### PR TITLE
feat: auto update interval setting

### DIFF
--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -5,3 +5,9 @@
 - Adjusted mock/cursor plugin helpers/config handling to raise branch coverage; coverage run passes.
 - Committing coverage output per explicit user request.
 - Removed generated coverage output and added `coverage/` to `.gitignore`.
+- Added spec + auto-update interval setting flow (store/load, app interval effect, settings UI/tests).
+- Added auto-update header helper text + live countdown display in settings.
+- Updated auto-update header label, helper text, and countdown format.
+- Aligned Auto Update header size with other section headers; helper text now standard size + foreground color.
+- Manual refresh now resets auto-update schedule; added test coverage.
+- Ran `bun run test:coverage`; 8 failed files, 25 failed tests; coverage not met.

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -8,3 +8,5 @@
 - Mock/cursor lineProgress now always include unit/color fields to remove branchy conditionals (no change when values are defined).
 - Mock plugin treats non-string mode as unknown; display uses safeString for visibility in warnings.
 - Committed generated `coverage/` output per user request.
+- Auto-update interval picker placed above Plugins in settings for visibility.
+- Auto-update countdown label format: "Next in Xm Ys"; shows "Paused" when no schedule.

--- a/docs/specs/2026-02-02-auto-update-interval.md
+++ b/docs/specs/2026-02-02-auto-update-interval.md
@@ -1,0 +1,29 @@
+# Spec: Probe Auto-Update Interval
+
+## Summary
+Persisted setting for probe auto-update frequency (5/15/30/60 minutes). Interval change resets timer. Auto-updates do not trigger manual cooldown. Settings shows live countdown + helper text.
+
+## Goals
+- Persist interval setting with default 15 minutes.
+- Auto-update loop uses enabled plugins; resets on interval or plugin changes.
+- Auto-update does not set manual cooldown timestamps.
+- Settings UI exposes 4 radio-style options.
+- Settings UI shows next auto-update countdown and description.
+- Manual refresh resets auto-update schedule.
+
+## Non-goals
+- Per-plugin intervals.
+- Manual refresh behavior changes beyond timer reset.
+
+## Plan
+- Add load/save helpers and type in `src/lib/settings.ts` + tests.
+- Load interval in `src/App.tsx`, store in state, add interval effect.
+- Reset auto-update schedule on manual refresh.
+- Add settings UI section with buttons, countdown, and helper text.
+
+## Acceptance
+- Interval persists across restart.
+- Changing interval clears prior timer and starts new schedule.
+- Auto-updates show loading state without manual cooldown.
+- Countdown updates live and resets when interval changes.
+- Manual refresh resets the countdown schedule.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,15 @@ import type { PluginMeta, PluginOutput } from "@/lib/plugin-types"
 import { useProbeEvents } from "@/hooks/use-probe-events"
 import {
   arePluginSettingsEqual,
+  DEFAULT_AUTO_UPDATE_INTERVAL,
   getEnabledPluginIds,
+  loadAutoUpdateInterval,
   loadPluginSettings,
   normalizePluginSettings,
   REFRESH_COOLDOWN_MS,
+  saveAutoUpdateInterval,
   savePluginSettings,
+  type AutoUpdateIntervalMinutes,
   type PluginSettings,
 } from "@/lib/settings"
 
@@ -37,6 +41,11 @@ function App() {
   const [pluginStates, setPluginStates] = useState<Record<string, PluginState>>({})
   const [pluginsMeta, setPluginsMeta] = useState<PluginMeta[]>([])
   const [pluginSettings, setPluginSettings] = useState<PluginSettings | null>(null)
+  const [autoUpdateInterval, setAutoUpdateInterval] = useState<AutoUpdateIntervalMinutes>(
+    DEFAULT_AUTO_UPDATE_INTERVAL
+  )
+  const [autoUpdateNextAt, setAutoUpdateNextAt] = useState<number | null>(null)
+  const [autoUpdateResetToken, setAutoUpdateResetToken] = useState(0)
   const [maxPanelHeightPx, setMaxPanelHeightPx] = useState<number | null>(null)
   const maxPanelHeightPxRef = useRef<number | null>(null)
 
@@ -259,8 +268,16 @@ function App() {
           await savePluginSettings(normalized)
         }
 
+        let storedInterval = DEFAULT_AUTO_UPDATE_INTERVAL
+        try {
+          storedInterval = await loadAutoUpdateInterval()
+        } catch (error) {
+          console.error("Failed to load auto-update interval:", error)
+        }
+
         if (isMounted) {
           setPluginSettings(normalized)
+          setAutoUpdateInterval(storedInterval)
           const enabledIds = getEnabledPluginIds(normalized)
           setLoadingForPlugins(enabledIds)
           try {
@@ -284,6 +301,48 @@ function App() {
     }
   }, [setLoadingForPlugins, setErrorForPlugins, startBatch])
 
+  useEffect(() => {
+    if (!pluginSettings) {
+      setAutoUpdateNextAt(null)
+      return
+    }
+    const enabledIds = getEnabledPluginIds(pluginSettings)
+    if (enabledIds.length === 0) {
+      setAutoUpdateNextAt(null)
+      return
+    }
+    const intervalMs = autoUpdateInterval * 60_000
+    const scheduleNext = () => setAutoUpdateNextAt(Date.now() + intervalMs)
+    scheduleNext()
+    const interval = setInterval(() => {
+      setLoadingForPlugins(enabledIds)
+      startBatch(enabledIds).catch((error) => {
+        console.error("Failed to start auto-update batch:", error)
+        setErrorForPlugins(enabledIds, "Failed to start probe")
+      })
+      scheduleNext()
+    }, intervalMs)
+    return () => clearInterval(interval)
+  }, [
+    autoUpdateInterval,
+    autoUpdateResetToken,
+    pluginSettings,
+    setLoadingForPlugins,
+    setErrorForPlugins,
+    startBatch,
+  ])
+
+  const resetAutoUpdateSchedule = useCallback(() => {
+    if (!pluginSettings) return
+    const enabledIds = getEnabledPluginIds(pluginSettings)
+    if (enabledIds.length === 0) {
+      setAutoUpdateNextAt(null)
+      return
+    }
+    setAutoUpdateNextAt(Date.now() + autoUpdateInterval * 60_000)
+    setAutoUpdateResetToken((value) => value + 1)
+  }, [autoUpdateInterval, pluginSettings])
+
   const handleRefresh = useCallback(() => {
     if (!pluginSettings) return
     const enabledIds = getEnabledPluginIds(pluginSettings)
@@ -294,6 +353,7 @@ function App() {
       return !lastManual || now - lastManual >= REFRESH_COOLDOWN_MS
     })
     if (refreshableIds.length === 0) return
+    resetAutoUpdateSchedule()
     // Mark as manual refresh
     for (const id of refreshableIds) {
       manualRefreshIdsRef.current.add(id)
@@ -303,10 +363,18 @@ function App() {
       console.error("Failed to refresh plugins:", error)
       setErrorForPlugins(refreshableIds, "Failed to start probe")
     })
-  }, [pluginSettings, pluginStates, setLoadingForPlugins, setErrorForPlugins, startBatch])
+  }, [
+    pluginSettings,
+    pluginStates,
+    resetAutoUpdateSchedule,
+    setLoadingForPlugins,
+    setErrorForPlugins,
+    startBatch,
+  ])
 
   const handleRetryPlugin = useCallback(
     (id: string) => {
+      resetAutoUpdateSchedule()
       // Mark as manual refresh
       manualRefreshIdsRef.current.add(id)
       setLoadingForPlugins([id])
@@ -315,8 +383,23 @@ function App() {
         setErrorForPlugins([id], "Failed to start probe")
       })
     },
-    [setLoadingForPlugins, setErrorForPlugins, startBatch]
+    [resetAutoUpdateSchedule, setLoadingForPlugins, setErrorForPlugins, startBatch]
   )
+
+  const handleAutoUpdateIntervalChange = useCallback((value: AutoUpdateIntervalMinutes) => {
+    setAutoUpdateInterval(value)
+    if (pluginSettings) {
+      const enabledIds = getEnabledPluginIds(pluginSettings)
+      if (enabledIds.length > 0) {
+        setAutoUpdateNextAt(Date.now() + value * 60_000)
+      } else {
+        setAutoUpdateNextAt(null)
+      }
+    }
+    void saveAutoUpdateInterval(value).catch((error) => {
+      console.error("Failed to save auto-update interval:", error)
+    })
+  }, [pluginSettings])
 
   const settingsPlugins = useMemo(() => {
     if (!pluginSettings) return []
@@ -397,6 +480,9 @@ function App() {
           plugins={settingsPlugins}
           onReorder={handleReorder}
           onToggle={handleToggle}
+          autoUpdateInterval={autoUpdateInterval}
+          onAutoUpdateIntervalChange={handleAutoUpdateIntervalChange}
+          autoUpdateNextAt={autoUpdateNextAt}
         />
       )
     }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
+  DEFAULT_AUTO_UPDATE_INTERVAL,
   DEFAULT_PLUGIN_SETTINGS,
   arePluginSettingsEqual,
   getEnabledPluginIds,
+  loadAutoUpdateInterval,
   loadPluginSettings,
   normalizePluginSettings,
+  saveAutoUpdateInterval,
   savePluginSettings,
 } from "@/lib/settings"
 import type { PluginMeta } from "@/lib/plugin-types"
@@ -68,5 +71,19 @@ describe("settings", () => {
 
   it("returns enabled plugin ids", () => {
     expect(getEnabledPluginIds({ order: ["a", "b"], disabled: ["b"] })).toEqual(["a"])
+  })
+
+  it("loads default auto-update interval when missing", async () => {
+    await expect(loadAutoUpdateInterval()).resolves.toBe(DEFAULT_AUTO_UPDATE_INTERVAL)
+  })
+
+  it("loads stored auto-update interval", async () => {
+    storeState.set("autoUpdateInterval", 30)
+    await expect(loadAutoUpdateInterval()).resolves.toBe(30)
+  })
+
+  it("saves auto-update interval", async () => {
+    await saveAutoUpdateInterval(5)
+    await expect(loadAutoUpdateInterval()).resolves.toBe(5)
   })
 })

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -10,8 +10,15 @@ export type PluginSettings = {
   disabled: string[];
 };
 
+export type AutoUpdateIntervalMinutes = 5 | 15 | 30 | 60;
+
 const SETTINGS_STORE_PATH = "settings.json";
 const PLUGIN_SETTINGS_KEY = "plugins";
+const AUTO_UPDATE_SETTINGS_KEY = "autoUpdateInterval";
+
+export const DEFAULT_AUTO_UPDATE_INTERVAL: AutoUpdateIntervalMinutes = 15;
+
+const AUTO_UPDATE_INTERVALS: AutoUpdateIntervalMinutes[] = [5, 15, 30, 60];
 
 const store = new LazyStore(SETTINGS_STORE_PATH);
 
@@ -31,6 +38,26 @@ export async function loadPluginSettings(): Promise<PluginSettings> {
 
 export async function savePluginSettings(settings: PluginSettings): Promise<void> {
   await store.set(PLUGIN_SETTINGS_KEY, settings);
+  await store.save();
+}
+
+function isAutoUpdateInterval(value: unknown): value is AutoUpdateIntervalMinutes {
+  return (
+    typeof value === "number" &&
+    AUTO_UPDATE_INTERVALS.includes(value as AutoUpdateIntervalMinutes)
+  );
+}
+
+export async function loadAutoUpdateInterval(): Promise<AutoUpdateIntervalMinutes> {
+  const stored = await store.get<unknown>(AUTO_UPDATE_SETTINGS_KEY);
+  if (isAutoUpdateInterval(stored)) return stored;
+  return DEFAULT_AUTO_UPDATE_INTERVAL;
+}
+
+export async function saveAutoUpdateInterval(
+  interval: AutoUpdateIntervalMinutes
+): Promise<void> {
+  await store.set(AUTO_UPDATE_SETTINGS_KEY, interval);
   await store.save();
 }
 

--- a/src/pages/settings.test.tsx
+++ b/src/pages/settings.test.tsx
@@ -47,6 +47,7 @@ describe("SettingsPage", () => {
   it("toggles plugins", async () => {
     const onToggle = vi.fn()
     const onReorder = vi.fn()
+    const onAutoUpdateIntervalChange = vi.fn()
     render(
       <SettingsPage
         plugins={[
@@ -55,6 +56,9 @@ describe("SettingsPage", () => {
         ]}
         onReorder={onReorder}
         onToggle={onToggle}
+        autoUpdateInterval={15}
+        onAutoUpdateIntervalChange={onAutoUpdateIntervalChange}
+        autoUpdateNextAt={Date.now() + 60_000}
       />
     )
     const checkboxes = screen.getAllByRole("checkbox")
@@ -65,6 +69,7 @@ describe("SettingsPage", () => {
   it("reorders plugins on drag end", () => {
     const onToggle = vi.fn()
     const onReorder = vi.fn()
+    const onAutoUpdateIntervalChange = vi.fn()
     render(
       <SettingsPage
         plugins={[
@@ -73,6 +78,9 @@ describe("SettingsPage", () => {
         ]}
         onReorder={onReorder}
         onToggle={onToggle}
+        autoUpdateInterval={15}
+        onAutoUpdateIntervalChange={onAutoUpdateIntervalChange}
+        autoUpdateNextAt={Date.now() + 60_000}
       />
     )
     latestOnDragEnd?.({ active: { id: "a" }, over: { id: "b" } })
@@ -82,15 +90,55 @@ describe("SettingsPage", () => {
   it("ignores invalid drag end", () => {
     const onToggle = vi.fn()
     const onReorder = vi.fn()
+    const onAutoUpdateIntervalChange = vi.fn()
     render(
       <SettingsPage
         plugins={[{ id: "a", name: "Alpha", enabled: true }]}
         onReorder={onReorder}
         onToggle={onToggle}
+        autoUpdateInterval={15}
+        onAutoUpdateIntervalChange={onAutoUpdateIntervalChange}
+        autoUpdateNextAt={Date.now() + 60_000}
       />
     )
     latestOnDragEnd?.({ active: { id: "a" }, over: null })
     latestOnDragEnd?.({ active: { id: "a" }, over: { id: "a" } })
     expect(onReorder).not.toHaveBeenCalled()
+  })
+
+  it("updates auto-update interval", async () => {
+    const onToggle = vi.fn()
+    const onReorder = vi.fn()
+    const onAutoUpdateIntervalChange = vi.fn()
+    render(
+      <SettingsPage
+        plugins={[{ id: "a", name: "Alpha", enabled: true }]}
+        onReorder={onReorder}
+        onToggle={onToggle}
+        autoUpdateInterval={15}
+        onAutoUpdateIntervalChange={onAutoUpdateIntervalChange}
+        autoUpdateNextAt={Date.now() + 60_000}
+      />
+    )
+    await userEvent.click(screen.getByRole("radio", { name: "30 min" }))
+    expect(onAutoUpdateIntervalChange).toHaveBeenCalledWith(30)
+  })
+
+  it("shows auto-update helper text and countdown", () => {
+    const onToggle = vi.fn()
+    const onReorder = vi.fn()
+    const onAutoUpdateIntervalChange = vi.fn()
+    render(
+      <SettingsPage
+        plugins={[{ id: "a", name: "Alpha", enabled: true }]}
+        onReorder={onReorder}
+        onToggle={onToggle}
+        autoUpdateInterval={15}
+        onAutoUpdateIntervalChange={onAutoUpdateIntervalChange}
+        autoUpdateNextAt={Date.now() + 60_000}
+      />
+    )
+    expect(screen.getByText("How we update your usage")).toBeInTheDocument()
+    expect(screen.getByText(/Next in/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Adds persisted auto update interval with live countdown and settings UI.\nResets the auto update schedule on manual refresh and retry.\nTests: bun run test:coverage (fails: existing plugin/app test failures).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new timed auto-refresh loop and persisted setting, which can introduce subtle scheduling/cleanup issues and affects app-side polling behavior. Coverage/tests were updated for the new flow, but the PR notes the overall coverage run is currently failing in the repo.
> 
> **Overview**
> Adds a **persisted auto-update interval** (5/15/30/60 min, default 15) via new `loadAutoUpdateInterval`/`saveAutoUpdateInterval` helpers in `src/lib/settings.ts`.
> 
> `App` now runs a periodic auto-refresh for enabled plugins based on that interval, tracks the next scheduled run, and **resets the auto-update schedule** when the user manually refreshes or retries a plugin.
> 
> `SettingsPage` introduces an **Auto Update** section with interval selection and a live “Next in Xm Ys” countdown (or “Paused”), with accompanying unit tests and updated app tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 216d848a6f536fe2c1ceee0f565fe345ba105130. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persisted auto‑update interval for probes (5/15/30/60 min) with a settings UI and live countdown. Auto‑updates run for enabled plugins, and the schedule resets on manual refresh and retry.

- **New Features**
  - Persist interval in settings.json as autoUpdateInterval; default 15 minutes.
  - App schedules background auto‑updates for enabled plugins; does not set manual cooldown; resets on interval/setting change.
  - Settings page adds a radio group above Plugins with helper text and a live “Next in …” countdown; shows “Paused” when no schedule.
  - Manual “Refresh all” and per‑plugin “Retry” reset the next run; spec and tests included.

<sup>Written for commit 216d848a6f536fe2c1ceee0f565fe345ba105130. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

