### PR TITLE
feat: add System/Light/Dark appearance setting

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -12,6 +12,8 @@ const state = vi.hoisted(() => ({
   loadPluginSettingsMock: vi.fn(),
   loadAutoUpdateIntervalMock: vi.fn(),
   saveAutoUpdateIntervalMock: vi.fn(),
+  loadThemeModeMock: vi.fn(),
+  saveThemeModeMock: vi.fn(),
   probeHandlers: null as null | { onResult: (output: any) => void; onBatchComplete: () => void },
 }))
 
@@ -87,6 +89,8 @@ vi.mock("@/lib/settings", async () => {
     savePluginSettings: state.savePluginSettingsMock,
     loadAutoUpdateInterval: state.loadAutoUpdateIntervalMock,
     saveAutoUpdateInterval: state.saveAutoUpdateIntervalMock,
+    loadThemeMode: state.loadThemeModeMock,
+    saveThemeMode: state.saveThemeModeMock,
   }
 })
 
@@ -103,8 +107,12 @@ describe("App", () => {
     state.loadPluginSettingsMock.mockReset()
     state.loadAutoUpdateIntervalMock.mockReset()
     state.saveAutoUpdateIntervalMock.mockReset()
+    state.loadThemeModeMock.mockReset()
+    state.saveThemeModeMock.mockReset()
     state.savePluginSettingsMock.mockResolvedValue(undefined)
     state.saveAutoUpdateIntervalMock.mockResolvedValue(undefined)
+    state.loadThemeModeMock.mockResolvedValue("system")
+    state.saveThemeModeMock.mockResolvedValue(undefined)
     Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
       configurable: true,
       get() {

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (@media (prefers-color-scheme: dark));
+@custom-variant dark (&:is(.dark *));
 
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
@@ -79,40 +79,38 @@
   --sidebar-ring: oklch(0.707 0.022 261.325);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: oklch(0.13 0.028 261.692);
-    --foreground: oklch(0.985 0.002 247.839);
-    --card: oklch(0.21 0.034 264.665);
-    --card-foreground: oklch(0.985 0.002 247.839);
-    --popover: oklch(0.21 0.034 264.665);
-    --popover-foreground: oklch(0.985 0.002 247.839);
-    --primary: oklch(0.928 0.006 264.531);
-    --primary-foreground: oklch(0.21 0.034 264.665);
-    --secondary: oklch(0.278 0.033 256.848);
-    --secondary-foreground: oklch(0.985 0.002 247.839);
-    --muted: oklch(0.278 0.033 256.848);
-    --muted-foreground: oklch(0.707 0.022 261.325);
-    --accent: oklch(0.278 0.033 256.848);
-    --accent-foreground: oklch(0.985 0.002 247.839);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.551 0.027 264.364);
-    --chart-1: oklch(0.488 0.243 264.376);
-    --chart-2: oklch(0.696 0.17 162.48);
-    --chart-3: oklch(0.769 0.188 70.08);
-    --chart-4: oklch(0.627 0.265 303.9);
-    --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.21 0.034 264.665);
-    --sidebar-foreground: oklch(0.985 0.002 247.839);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0.002 247.839);
-    --sidebar-accent: oklch(0.278 0.033 256.848);
-    --sidebar-accent-foreground: oklch(0.985 0.002 247.839);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.551 0.027 264.364);
-  }
+:root.dark {
+  --background: oklch(0.13 0.028 261.692);
+  --foreground: oklch(0.985 0.002 247.839);
+  --card: oklch(0.21 0.034 264.665);
+  --card-foreground: oklch(0.985 0.002 247.839);
+  --popover: oklch(0.21 0.034 264.665);
+  --popover-foreground: oklch(0.985 0.002 247.839);
+  --primary: oklch(0.928 0.006 264.531);
+  --primary-foreground: oklch(0.21 0.034 264.665);
+  --secondary: oklch(0.278 0.033 256.848);
+  --secondary-foreground: oklch(0.985 0.002 247.839);
+  --muted: oklch(0.278 0.033 256.848);
+  --muted-foreground: oklch(0.707 0.022 261.325);
+  --accent: oklch(0.278 0.033 256.848);
+  --accent-foreground: oklch(0.985 0.002 247.839);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.551 0.027 264.364);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.034 264.665);
+  --sidebar-foreground: oklch(0.985 0.002 247.839);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0.002 247.839);
+  --sidebar-accent: oklch(0.278 0.033 256.848);
+  --sidebar-accent-foreground: oklch(0.985 0.002 247.839);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.551 0.027 264.364);
 }
 
 @layer base {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -2,13 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   DEFAULT_AUTO_UPDATE_INTERVAL,
   DEFAULT_PLUGIN_SETTINGS,
+  DEFAULT_THEME_MODE,
   arePluginSettingsEqual,
   getEnabledPluginIds,
   loadAutoUpdateInterval,
   loadPluginSettings,
+  loadThemeMode,
   normalizePluginSettings,
   saveAutoUpdateInterval,
   savePluginSettings,
+  saveThemeMode,
 } from "@/lib/settings"
 import type { PluginMeta } from "@/lib/plugin-types"
 
@@ -85,5 +88,24 @@ describe("settings", () => {
   it("saves auto-update interval", async () => {
     await saveAutoUpdateInterval(5)
     await expect(loadAutoUpdateInterval()).resolves.toBe(5)
+  })
+
+  it("loads default theme mode when missing", async () => {
+    await expect(loadThemeMode()).resolves.toBe(DEFAULT_THEME_MODE)
+  })
+
+  it("loads stored theme mode", async () => {
+    storeState.set("themeMode", "dark")
+    await expect(loadThemeMode()).resolves.toBe("dark")
+  })
+
+  it("saves theme mode", async () => {
+    await saveThemeMode("light")
+    await expect(loadThemeMode()).resolves.toBe("light")
+  })
+
+  it("falls back to default for invalid theme mode", async () => {
+    storeState.set("themeMode", "invalid")
+    await expect(loadThemeMode()).resolves.toBe(DEFAULT_THEME_MODE)
   })
 })

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -12,13 +12,18 @@ export type PluginSettings = {
 
 export type AutoUpdateIntervalMinutes = 5 | 15 | 30 | 60;
 
+export type ThemeMode = "system" | "light" | "dark";
+
 const SETTINGS_STORE_PATH = "settings.json";
 const PLUGIN_SETTINGS_KEY = "plugins";
 const AUTO_UPDATE_SETTINGS_KEY = "autoUpdateInterval";
+const THEME_MODE_KEY = "themeMode";
 
 export const DEFAULT_AUTO_UPDATE_INTERVAL: AutoUpdateIntervalMinutes = 15;
+export const DEFAULT_THEME_MODE: ThemeMode = "system";
 
 const AUTO_UPDATE_INTERVALS: AutoUpdateIntervalMinutes[] = [5, 15, 30, 60];
+const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
 
 const store = new LazyStore(SETTINGS_STORE_PATH);
 
@@ -99,6 +104,21 @@ export function arePluginSettingsEqual(
     if (a.disabled[i] !== b.disabled[i]) return false;
   }
   return true;
+}
+
+function isThemeMode(value: unknown): value is ThemeMode {
+  return typeof value === "string" && THEME_MODES.includes(value as ThemeMode);
+}
+
+export async function loadThemeMode(): Promise<ThemeMode> {
+  const stored = await store.get<unknown>(THEME_MODE_KEY);
+  if (isThemeMode(stored)) return stored;
+  return DEFAULT_THEME_MODE;
+}
+
+export async function saveThemeMode(mode: ThemeMode): Promise<void> {
+  await store.set(THEME_MODE_KEY, mode);
+  await store.save();
 }
 
 export function getEnabledPluginIds(settings: PluginSettings): string[] {

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -19,7 +19,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { GripVertical } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
-import type { AutoUpdateIntervalMinutes } from "@/lib/settings";
+import type { AutoUpdateIntervalMinutes, ThemeMode } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 
 interface PluginConfig {
@@ -33,6 +33,12 @@ const AUTO_UPDATE_OPTIONS: { value: AutoUpdateIntervalMinutes; label: string }[]
   { value: 15, label: "15 min" },
   { value: 30, label: "30 min" },
   { value: 60, label: "1 hour" },
+];
+
+const THEME_OPTIONS: { value: ThemeMode; label: string }[] = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
 ];
 
 function SortablePluginItem({
@@ -100,6 +106,8 @@ interface SettingsPageProps {
   autoUpdateInterval: AutoUpdateIntervalMinutes;
   onAutoUpdateIntervalChange: (value: AutoUpdateIntervalMinutes) => void;
   autoUpdateNextAt: number | null;
+  themeMode: ThemeMode;
+  onThemeModeChange: (value: ThemeMode) => void;
 }
 
 export function SettingsPage({
@@ -109,6 +117,8 @@ export function SettingsPage({
   autoUpdateInterval,
   onAutoUpdateIntervalChange,
   autoUpdateNextAt,
+  themeMode,
+  onThemeModeChange,
 }: SettingsPageProps) {
   const [now, setNow] = useState(() => Date.now());
   const sensors = useSensors(
@@ -151,6 +161,33 @@ export function SettingsPage({
 
   return (
     <div className="py-3 space-y-4">
+      <section>
+        <h3 className="text-lg font-semibold mb-1">Appearance</h3>
+        <p className="text-sm text-foreground mb-2">
+          Choose your color theme
+        </p>
+        <div className="bg-muted/50 rounded-lg p-1">
+          <div className="flex gap-1" role="radiogroup" aria-label="Theme mode">
+            {THEME_OPTIONS.map((option) => {
+              const isActive = option.value === themeMode;
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  variant={isActive ? "default" : "outline"}
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => onThemeModeChange(option.value)}
+                >
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
       <section>
         <div className="flex items-center justify-between mb-1">
           <h3 className="text-lg font-semibold">Auto Update</h3>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -9,3 +9,19 @@ class ResizeObserverMock {
 if (!globalThis.ResizeObserver) {
   globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver
 }
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+}


### PR DESCRIPTION
Add a new Appearance section to the settings page with three radio button options: System, Light, and Dark. The selection persists to the same LazyStore as other app settings. System mode automatically respects the OS dark/light preference via matchMedia.

Switched CSS dark mode from media query-based (@media prefers-color-scheme) to class-based (.dark on the html element) to enable JavaScript control. All 20 tests pass and the build succeeds.

Tests added:
- Theme mode persistence (load/save/validate)
- Appearance section rendering and interaction

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes global theming behavior by switching from OS media-query dark mode to a JS-controlled `.dark` class, which could affect styling across the app and requires `matchMedia` support in runtime/tests.
> 
> **Overview**
> Adds an **Appearance** section to `SettingsPage` with `ThemeMode` options (*System/Light/Dark*) and wires it through `App` so user selection is persisted via new `loadThemeMode`/`saveThemeMode` helpers.
> 
> Switches dark mode styling in `index.css` from `prefers-color-scheme` media queries to a `:root.dark` + Tailwind `dark` variant driven by `document.documentElement.classList`, with `system` mode following OS changes via `matchMedia` listeners.
> 
> Updates tests to cover theme persistence and UI interaction, and extends the test setup with a `window.matchMedia` shim.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75711851a658457cb6f3bd361ab379ea21b9800a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Appearance setting with System, Light, and Dark options. The app now controls theme via a .dark class and follows the OS when set to System.

- **New Features**
  - Appearance section in Settings with System/Light/Dark.
  - Selection persists in LazyStore and loads on startup.
  - System mode follows OS preference via matchMedia.

- **Refactors**
  - Switched from prefers-color-scheme media queries to class-based dark mode (.dark on html).
  - App loads/saves theme mode and applies it via an effect.
  - Added tests for persistence and settings UI; test setup includes a matchMedia stub.

<sup>Written for commit 75711851a658457cb6f3bd361ab379ea21b9800a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

