### PR TITLE
fix(claude): handle hex-encoded keychain credentials

### DIFF
--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -7,6 +7,95 @@
   const SCOPES = "user:profile user:inference user:sessions:claude_code user:mcp_servers"
   const REFRESH_BUFFER_MS = 5 * 60 * 1000 // refresh 5 minutes before expiration
 
+  function utf8DecodeBytes(bytes) {
+    // Prefer native TextDecoder when available (QuickJS may not expose it).
+    if (typeof TextDecoder !== "undefined") {
+      try {
+        return new TextDecoder("utf-8", { fatal: false }).decode(new Uint8Array(bytes))
+      } catch {}
+    }
+
+    // Minimal UTF-8 decoder (replacement char on invalid sequences).
+    let out = ""
+    for (let i = 0; i < bytes.length; ) {
+      const b0 = bytes[i] & 0xff
+      if (b0 < 0x80) {
+        out += String.fromCharCode(b0)
+        i += 1
+        continue
+      }
+
+      // 2-byte
+      if (b0 >= 0xc2 && b0 <= 0xdf) {
+        if (i + 1 >= bytes.length) {
+          out += "\ufffd"
+          break
+        }
+        const b1 = bytes[i + 1] & 0xff
+        if ((b1 & 0xc0) !== 0x80) {
+          out += "\ufffd"
+          i += 1
+          continue
+        }
+        const cp = ((b0 & 0x1f) << 6) | (b1 & 0x3f)
+        out += String.fromCharCode(cp)
+        i += 2
+        continue
+      }
+
+      // 3-byte
+      if (b0 >= 0xe0 && b0 <= 0xef) {
+        if (i + 2 >= bytes.length) {
+          out += "\ufffd"
+          break
+        }
+        const b1 = bytes[i + 1] & 0xff
+        const b2 = bytes[i + 2] & 0xff
+        const validCont = (b1 & 0xc0) === 0x80 && (b2 & 0xc0) === 0x80
+        const notOverlong = !(b0 === 0xe0 && b1 < 0xa0)
+        const notSurrogate = !(b0 === 0xed && b1 >= 0xa0)
+        if (!validCont || !notOverlong || !notSurrogate) {
+          out += "\ufffd"
+          i += 1
+          continue
+        }
+        const cp = ((b0 & 0x0f) << 12) | ((b1 & 0x3f) << 6) | (b2 & 0x3f)
+        out += String.fromCharCode(cp)
+        i += 3
+        continue
+      }
+
+      // 4-byte
+      if (b0 >= 0xf0 && b0 <= 0xf4) {
+        if (i + 3 >= bytes.length) {
+          out += "\ufffd"
+          break
+        }
+        const b1 = bytes[i + 1] & 0xff
+        const b2 = bytes[i + 2] & 0xff
+        const b3 = bytes[i + 3] & 0xff
+        const validCont = (b1 & 0xc0) === 0x80 && (b2 & 0xc0) === 0x80 && (b3 & 0xc0) === 0x80
+        const notOverlong = !(b0 === 0xf0 && b1 < 0x90)
+        const notTooHigh = !(b0 === 0xf4 && b1 > 0x8f)
+        if (!validCont || !notOverlong || !notTooHigh) {
+          out += "\ufffd"
+          i += 1
+          continue
+        }
+        const cp =
+          ((b0 & 0x07) << 18) | ((b1 & 0x3f) << 12) | ((b2 & 0x3f) << 6) | (b3 & 0x3f)
+        const n = cp - 0x10000
+        out += String.fromCharCode(0xd800 + ((n >> 10) & 0x3ff), 0xdc00 + (n & 0x3ff))
+        i += 4
+        continue
+      }
+
+      out += "\ufffd"
+      i += 1
+    }
+    return out
+  }
+
   function tryParseCredentialJSON(text) {
     if (!text) return null
     const trimmed = String(text).trim()
@@ -23,10 +112,11 @@
     if (!hex || hex.length % 2 !== 0) return null
     if (!/^[0-9a-fA-F]+$/.test(hex)) return null
     try {
-      let decoded = ""
+      const bytes = []
       for (let i = 0; i < hex.length; i += 2) {
-        decoded += String.fromCharCode(parseInt(hex.slice(i, i + 2), 16))
+        bytes.push(parseInt(hex.slice(i, i + 2), 16))
       }
+      const decoded = utf8DecodeBytes(bytes)
       return JSON.parse(decoded)
     } catch {}
 
@@ -39,10 +129,11 @@
       try {
         const text = ctx.host.fs.readText(CRED_FILE)
         const parsed = tryParseCredentialJSON(text)
-        if (!parsed) return null
-        const oauth = parsed.claudeAiOauth
-        if (oauth && oauth.accessToken) {
-          return { oauth, source: "file", fullData: parsed }
+        if (parsed) {
+          const oauth = parsed.claudeAiOauth
+          if (oauth && oauth.accessToken) {
+            return { oauth, source: "file", fullData: parsed }
+          }
         }
       } catch (e) {
       }
@@ -53,10 +144,11 @@
       const keychainValue = ctx.host.keychain.readGenericPassword(KEYCHAIN_SERVICE)
       if (keychainValue) {
         const parsed = tryParseCredentialJSON(keychainValue)
-        if (!parsed) return null
-        const oauth = parsed.claudeAiOauth
-        if (oauth && oauth.accessToken) {
-          return { oauth, source: "keychain", fullData: parsed }
+        if (parsed) {
+          const oauth = parsed.claudeAiOauth
+          if (oauth && oauth.accessToken) {
+            return { oauth, source: "keychain", fullData: parsed }
+          }
         }
       }
     } catch (e) {

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -90,6 +90,24 @@ describe("claude plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Not logged in")
   })
 
+  it("falls back to keychain when credentials file is corrupt", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => true
+    ctx.host.fs.readText = () => "{bad json"
+    ctx.host.keychain.readGenericPassword.mockReturnValue(
+      JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+    )
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+  })
+
   it("renders usage lines from response", async () => {
     const ctx = makeCtx()
     ctx.host.fs.readText = () =>
@@ -154,6 +172,22 @@ describe("claude plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+  })
+
+  it("decodes hex-encoded UTF-8 correctly (non-ascii json)", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    const json = JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pró" } }, null, 2)
+    const hex = Buffer.from(json, "utf8").toString("hex")
+    ctx.host.keychain.readGenericPassword.mockReturnValue(hex)
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 1, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).not.toThrow()
   })
 
   it("throws on http errors and parse failures", async () => {


### PR DESCRIPTION
Fixes credential loading when macOS keychain returns hex-encoded UTF-8 bytes instead of plain JSON.

**TLDR**: Some macOS keychain items are returned by `security ... -w` as hex-encoded strings (e.g., `7b0a...` for `{\n...`). This PR adds support for decoding them.

**Changes**
- Add `tryParseCredentialJSON()` helper that attempts plain JSON parse first, then falls back to hex decoding
- Apply the helper to both file and keychain credential loading paths
- Add test for hex-encoded keychain credentials

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to credential parsing in the Claude plugin, adding a safe fallback decoder plus tests; main risk is edge-case parsing behavior for unexpected keychain/file contents.
> 
> **Overview**
> Fixes Claude credential loading when stored data isn’t plain JSON by adding `tryParseCredentialJSON()` with a hex-to-UTF8 decode fallback (using `TextDecoder` when available, otherwise a minimal UTF-8 decoder).
> 
> `loadCredentials()` now uses this parser for both the credentials file and keychain paths, and tests cover file-corruption fallback to keychain plus hex-encoded (including non-ASCII) keychain values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 159cffa8f5460595e631d4f6b23eb27abc93fc2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes credential parsing in the Claude plugin when macOS Keychain returns hex-encoded JSON, including non-ASCII, so OAuth tokens load reliably from both file and keychain. Prevents auth failures when `security ... -w` outputs hex (e.g., "7b0a...").

- **Bug Fixes**
  - Added tryParseCredentialJSON that parses JSON or falls back to hex→UTF-8 decoding (supports 0x-prefixed hex and non-ASCII).
  - Applied the helper to both file and keychain paths; added tests for hex-encoded values, non-ASCII, and corrupt-file fallback.

<sup>Written for commit 159cffa8f5460595e631d4f6b23eb27abc93fc2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

