### PR TITLE
fix(plugins): improve subtitles and polish about dialog

### DIFF
--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -324,7 +324,7 @@
         value: data.five_hour.utilization,
         max: 100,
         unit: "percent",
-        subtitle: resetIn ? "Resets in " + resetIn : null
+        subtitle: resetIn ? "Resets in " + resetIn : "No active session"
       }))
     }
     if (data.seven_day && typeof data.seven_day.utilization === "number") {

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -66,6 +66,25 @@ describe("claude plugin", () => {
     expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
   })
 
+  it("shows fallback subtitle when resets_at is missing", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.readText = () =>
+      JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+    ctx.host.fs.exists = () => true
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 0 },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const sessionLine = result.lines.find((line) => line.label === "Session")
+    expect(sessionLine).toBeTruthy()
+    expect(sessionLine.subtitle).toBe("No active session")
+  })
+
   it("throws token expired on 401", async () => {
     const ctx = makeCtx()
     ctx.host.fs.readText = () => JSON.stringify({ claudeAiOauth: { accessToken: "token" } })

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -188,7 +188,7 @@
           value: headerPrimary,
           max: 100,
           unit: "percent",
-          subtitle: resetIn ? "Resets in " + resetIn : null
+          subtitle: resetIn ? "Resets in " + resetIn : "No active session"
         }))
       }
       if (headerSecondary !== null) {
@@ -210,7 +210,7 @@
             value: data.rate_limit.primary_window.used_percent,
             max: 100,
             unit: "percent",
-            subtitle: resetIn ? "Resets in " + resetIn : null
+            subtitle: resetIn ? "Resets in " + resetIn : "No active session"
           }))
         }
         if (data.rate_limit.secondary_window && typeof data.rate_limit.secondary_window.used_percent === "number") {
@@ -243,9 +243,9 @@
       const creditsHeader = readNumber(creditsBalance)
       const creditsData = data.credits ? readNumber(data.credits.balance) : null
       if (creditsHeader !== null) {
-        lines.push(ctx.line.progress({ label: "Credits", value: creditsHeader, max: 1000 }))
+        lines.push(ctx.line.progress({ label: "Credits", value: creditsHeader, max: 1000, subtitle: "1,000 credits limit" }))
       } else if (creditsData !== null) {
-        lines.push(ctx.line.progress({ label: "Credits", value: creditsData, max: 1000 }))
+        lines.push(ctx.line.progress({ label: "Credits", value: creditsData, max: 1000, subtitle: "1,000 credits limit" }))
       }
 
       let plan = null

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -129,7 +129,7 @@ describe("codex plugin", () => {
     expect(result.lines.find((line) => line.label === "Credits")).toBeTruthy()
   })
 
-  it("skips reset lines when window lacks reset info", async () => {
+  it("shows fallback subtitle when window lacks reset info", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
       tokens: { access_token: "token" },
@@ -146,8 +146,9 @@ describe("codex plugin", () => {
     })
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
-    expect(result.lines.every((line) => !line.subtitle)).toBe(true)
+    const sessionLine = result.lines.find((line) => line.label === "Session")
+    expect(sessionLine).toBeTruthy()
+    expect(sessionLine.subtitle).toBe("No active session")
   })
 
   it("uses reset_at when present for subtitles", async () => {

--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -244,7 +244,8 @@
           label: "On-demand",
           value: ctx.fmt.dollars(used),
           max: ctx.fmt.dollars(limit),
-          unit: "dollars"
+          unit: "dollars",
+          subtitle: "$" + String(ctx.fmt.dollars(limit)) + " limit"
         }))
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -646,7 +646,7 @@ function App() {
     <div ref={containerRef} className="flex flex-col items-center p-6 pt-1.5 bg-transparent">
       <div className="tray-arrow" />
       <div
-        className="bg-card rounded-xl overflow-hidden select-none w-full border shadow-lg"
+        className="relative bg-card rounded-xl overflow-hidden select-none w-full border shadow-lg"
         style={maxPanelHeightPx ? { maxHeight: `${maxPanelHeightPx - ARROW_OVERHEAD_PX}px` } : undefined}
       >
         <div className="flex h-full min-h-0 flex-row">

--- a/src/components/about-dialog.tsx
+++ b/src/components/about-dialog.tsx
@@ -33,6 +33,7 @@ export function AboutDialog({ version, onClose }: AboutDialogProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        e.preventDefault();
         onClose();
       }
     };
@@ -60,7 +61,7 @@ export function AboutDialog({ version, onClose }: AboutDialogProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm rounded-xl"
       onClick={handleBackdropClick}
     >
       <div className="bg-card rounded-lg border shadow-xl p-6 max-w-xs w-full mx-4 text-center animate-in fade-in zoom-in-95 duration-200">
@@ -80,10 +81,6 @@ export function AboutDialog({ version, onClose }: AboutDialogProps) {
           <p>
             Built by{" "}
             <ExternalLink href="https://itsbyrob.in/x">Robin Ebers</ExternalLink>
-          </p>
-          <p>
-            Tray icon can show up to 4 usage bars. Plugins may declare one
-            primary progress metric.
           </p>
           <p>
             Open source on{" "}

--- a/src/components/side-nav.tsx
+++ b/src/components/side-nav.tsx
@@ -1,4 +1,12 @@
-import { Home, Settings } from "lucide-react"
+import { Settings } from "lucide-react"
+
+function GaugeIcon({ className }: { className?: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4ZM15.8329 7.33748C16.0697 7.17128 16.3916 7.19926 16.5962 7.40381C16.8002 7.60784 16.8267 7.92955 16.6587 8.16418C14.479 11.2095 13.2796 12.8417 13.0607 13.0607C12.4749 13.6464 11.5251 13.6464 10.9393 13.0607C10.3536 12.4749 10.3536 11.5251 10.9393 10.9393C11.3126 10.5661 12.9438 9.36549 15.8329 7.33748ZM17.5 11C18.0523 11 18.5 11.4477 18.5 12C18.5 12.5523 18.0523 13 17.5 13C16.9477 13 16.5 12.5523 16.5 12C16.5 11.4477 16.9477 11 17.5 11ZM6.5 11C7.05228 11 7.5 11.4477 7.5 12C7.5 12.5523 7.05228 13 6.5 13C5.94772 13 5.5 12.5523 5.5 12C5.5 11.4477 5.94772 11 6.5 11ZM8.81802 7.40381C9.20854 7.79433 9.20854 8.4275 8.81802 8.81802C8.4275 9.20854 7.79433 9.20854 7.40381 8.81802C7.01328 8.4275 7.01328 7.79433 7.40381 7.40381C7.79433 7.01328 8.4275 7.01328 8.81802 7.40381ZM12 5.5C12.5523 5.5 13 5.94772 13 6.5C13 7.05228 12.5523 7.5 12 7.5C11.4477 7.5 11 7.05228 11 6.5C11 5.94772 11.4477 5.5 12 5.5Z" />
+    </svg>
+  )
+}
 import { cn } from "@/lib/utils"
 import { getRelativeLuminance } from "@/lib/color"
 import { useDarkMode } from "@/hooks/use-dark-mode"
@@ -63,7 +71,7 @@ export function SideNav({ activeView, onViewChange, plugins }: SideNavProps) {
         onClick={() => onViewChange("home")}
         aria-label="Home"
       >
-        <Home className="size-6" />
+        <GaugeIcon className="size-6" />
       </NavButton>
 
       {/* Plugin icons */}


### PR DESCRIPTION
Adds fallback subtitles for session/credits lines and fixes several UI polish issues.

## Changes
- Show "No active session" subtitle when Claude/Codex session has no reset time (0% usage)
- Add limit subtitles for Cursor on-demand ("$250 limit") and Codex credits ("1,000 credits limit")
- Fix about dialog: remove extra tray text, contain blur within panel bounds, prevent macOS beep on ESC
- Replace home icon with OpenUsage gauge icon
- Remove separators from overview page

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/wording changes plus small plugin output tweaks; main risk is minor regressions in how usage subtitles render when reset metadata is missing.
> 
> **Overview**
> **Improves usage line clarity across plugins.** Claude and Codex now show a `"No active session"` subtitle for the Session bar when reset timing is missing, and Codex adds a `"1,000 credits limit"` subtitle to the Credits bar; Cursor’s on-demand spend bar now includes a `$X limit` subtitle.
> 
> **Polishes panel UI.** The About dialog is now contained within the panel bounds (using absolute positioning within a `relative` panel), suppresses the ESC key default behavior, and removes extra explanatory text; the SideNav home icon is replaced with an inline gauge SVG.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0346b24ff380c00c5c41bf6e24d6769a3098434b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved plugin subtitles for clearer session and limit info, and polished the About dialog to contain blur and stop the Escape key beep.

- **New Features**
  - Show "No active session" when reset info is missing in Claude and Codex.
  - Add limit subtitles: Cursor on-demand ("$<limit> limit") and Codex credits ("1,000 credits limit").

- **Bug Fixes**
  - About dialog: contain blur within the panel, remove extra tray text, and prevent macOS beep on Escape.

<sup>Written for commit 0346b24ff380c00c5c41bf6e24d6769a3098434b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

