### PR TITLE
feat(update-button): add rotating border beam animation

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.2",
   "identifier": "com.sunstory.openusage",
   "build": {
-    "beforeDevCommand": "bun run dev",
+    "beforeDevCommand": "bun run bundle:plugins && bun run dev",
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "bun run bundle:plugins && bun run build",
     "frontendDist": "../dist"

--- a/src/components/panel-footer.tsx
+++ b/src/components/panel-footer.tsx
@@ -39,6 +39,7 @@ function VersionDisplay({
         <Button
           variant="destructive"
           size="xs"
+          className="update-border-beam"
           onClick={onUpdateInstall}
         >
           Restart to update

--- a/src/index.css
+++ b/src/index.css
@@ -154,6 +154,39 @@ body,
   border-bottom: 6px solid var(--card);
 }
 
+/* Border beam for the update button */
+.update-border-beam {
+  position: relative;
+  isolation: isolate;
+}
+.update-border-beam::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: conic-gradient(
+    from var(--beam-angle),
+    transparent 70%,
+    var(--destructive) 90%,
+    transparent 100%
+  );
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: beam-rotate 2.5s linear infinite;
+}
+@property --beam-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+@keyframes beam-rotate {
+  to {
+    --beam-angle: 360deg;
+  }
+}
+
 /* Remove focus rings - this is a menu bar app, not keyboard-navigated */
 *:focus,
 *:focus-visible {


### PR DESCRIPTION
## Summary
- Adds a visually distinctive rotating border beam animation to the "Restart to update" button when an update is ready
- Beam travels around the button's edge using CSS mask-composite technique, no dependencies
- Also fixes dev build by running bundle:plugins before dev server starts

## Test plan
- [ ] App builds and runs in dev without errors
- [ ] When an update is ready, button displays with rotating border beam animation
- [ ] Animation is smooth and noticeable but not distracting
- [ ] Button functionality (clicking to restart with update) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to UI styling for the update-ready button and a dev-command tweak to run plugin bundling before starting the dev server.
> 
> **Overview**
> Adds a rotating “border beam” animation to the **update-ready** `Restart to update` button by applying a new `update-border-beam` class and associated CSS (conic-gradient + mask-composite + keyframed angle rotation).
> 
> Updates Tauri `beforeDevCommand` to run `bun run bundle:plugins` before `bun run dev`, aligning dev startup with the existing pre-build pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 000aee935aa46214cb240b1dd52ee890db2c6031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a rotating border beam to the “Restart to update” button to make updates more noticeable. Also fixes the dev build by bundling plugins before starting the dev server.

- **New Features**
  - CSS-only border beam using conic gradient and mask-composite.
  - Applied via class: update-border-beam with a smooth 2.5s rotation.

- **Bug Fixes**
  - Run bundle:plugins before bun run dev in Tauri beforeDevCommand.

<sup>Written for commit 000aee935aa46214cb240b1dd52ee890db2c6031. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

