### PR TITLE
tauri: nudge panel window up a few pixels

### DIFF
--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -121,7 +121,11 @@ pub fn position_panel_at_tray_icon(
     let icon_center_x_phys = icon_phys_x + (icon_width_phys / 2);
     let panel_x_phys = icon_center_x_phys - (window_width_phys / 2);
     let padding_phys = 0;
-    let panel_y_phys = icon_phys_y + icon_height_phys + padding_phys;
+    // Nudge the panel slightly upward so it visually aligns tighter to the tray.
+    // Use logical points (not physical px) so the offset looks consistent on Retina.
+    let nudge_up_points: f64 = 6.0;
+    let nudge_up_phys = (nudge_up_points * scale_factor).round() as i32;
+    let panel_y_phys = icon_phys_y + icon_height_phys + padding_phys - nudge_up_phys;
 
     let final_pos = tauri::PhysicalPosition::new(panel_x_phys, panel_y_phys);
 


### PR DESCRIPTION
Taura panel now sits slightly higher relative to the tray icon.

- Subtract a small Y offset when positioning the tray panel
- Offset is specified in logical points and scaled per-monitor for consistency

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 2fffe04b44604d037ddb5cc4b624aa929611f7f3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the tray panel slightly higher to sit tighter against the tray icon. Uses a 6 logical-point upward offset, scaled by the display’s scale factor for consistent spacing across monitors.

<sup>Written for commit 2fffe04b44604d037ddb5cc4b624aa929611f7f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

