### PR TITLE
fix(plugin): minify keychain JSON to prevent hex-encoding on read

### DIFF
--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -156,7 +156,9 @@
   }
 
   function saveCredentials(ctx, source, fullData) {
-    const text = JSON.stringify(fullData, null, 2)
+    // MUST use minified JSON - macOS `security -w` hex-encodes values with newlines,
+    // which Claude Code can't read back, causing it to invalidate the session.
+    const text = JSON.stringify(fullData)
     if (source === "file") {
       try {
         ctx.host.fs.writeText(CRED_FILE, text)


### PR DESCRIPTION
macOS security command hex-encodes credential values containing newlines. Pretty-printed JSON caused the keychain to store hex instead of readable JSON, breaking Claude Code's credential validation on read.

This change uses minified JSON when storing credentials to the keychain, ensuring values remain readable when retrieved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small serialization change that only affects how credentials are persisted, intended to avoid macOS keychain newline/hex-encoding issues.
> 
> **Overview**
> Updates the Claude plugin’s credential persistence to **write minified JSON** (no pretty-print/newlines) when saving `fullData`, to prevent macOS keychain `security -w` from hex-encoding newline-containing values and breaking subsequent credential reads/validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 019f4603592aeec9ed1afbdb20441fd33fc44f4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use minified JSON when saving credentials to prevent the macOS security command from hex-encoding values with newlines. This keeps keychain entries readable and fixes Claude Code credential validation on read.

<sup>Written for commit 019f4603592aeec9ed1afbdb20441fd33fc44f4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

