### PR TITLE
fix(build): exclude test files from production tsc check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,6 @@
     }
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Prevents test-only type errors from breaking production builds. The build command runs `tsc && vite build`, and previously type-checked test files alongside source code. Test files are already type-checked independently by vitest.

Fixes #55

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects which files `tsc` validates during builds; main risk is inadvertently skipping a non-test file that matches the excluded patterns.
> 
> **Overview**
> Prevents production builds (`tsc && vite build`) from failing due to test-only TypeScript errors by excluding `*.test.ts`, `*.test.tsx`, and `src/test/**` from the root `tsconfig.json` typecheck.
> 
> Test files remain expected to be type-checked via the separate Vitest workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51fd422da3c45221dfa2571c1810e24ea4eeffe5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude *.test.ts, *.test.tsx, and src/test/** from the production TypeScript check so test and test-setup type errors no longer fail tsc && vite build. Tests continue to be type-checked by Vitest.

<sup>Written for commit 51fd422da3c45221dfa2571c1810e24ea4eeffe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

