### PR TITLE
fix(sqlite): use immutable=1 to prevent WAL false negatives after sleep

### DIFF
--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -787,7 +787,13 @@ fn inject_sqlite<'js>(ctx: &Ctx<'js>, host: &Object<'js>) -> rquickjs::Result<()
                 let expanded = expand_path(&db_path);
                 // Use immutable=1 to bypass WAL/SHM file access issues
                 // (WAL databases can fail with -readonly when shm is locked after macOS sleep)
-                let uri_path = format!("file:{}?immutable=1", expanded);
+                // Percent-encode special chars for valid URI (% must be first!)
+                let encoded = expanded
+                    .replace('%', "%25")
+                    .replace(' ', "%20")
+                    .replace('#', "%23")
+                    .replace('?', "%3F");
+                let uri_path = format!("file:{}?immutable=1", encoded);
                 let output = std::process::Command::new("sqlite3")
                     .args(["-readonly", "-json", &uri_path, &sql])
                     .output()


### PR DESCRIPTION
## Summary
- Use `immutable=1` URI parameter for SQLite queries to bypass WAL/SHM file access issues
- Fixes false "Not logged in" errors for Cursor plugin after macOS sleep/wake

## Description
SQLite `readonly` mode with WAL databases can fail after macOS sleep/wake when the `-shm` file is locked by another process (e.g., Cursor actively writing). This causes `sqlite3` to return empty results or errors, making valid tokens appear missing.

The `immutable=1` flag tells SQLite the database won't change, so it skips WAL/SHM access entirely. Trade-off: may return slightly stale data, which is acceptable for auth token reads.

## Test plan
- [ ] Build and run app locally
- [ ] Let Mac sleep for 30+ minutes with Cursor closed
- [ ] Wake and verify Cursor plugin shows usage (not "Not logged in")
- [ ] If issue persists, check logs for sqlite errors

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to how the `sqlite3` CLI is invoked for read-only JSON queries; main behavior change is potentially slightly stale reads due to `immutable=1` and new URI encoding edge cases.
> 
> **Overview**
> Updates the host SQLite `query` API to invoke `sqlite3` using a `file:` URI with `?immutable=1` (instead of a plain path) to avoid WAL/SHM access issues that can cause spurious read failures after macOS sleep.
> 
> Adds minimal percent-encoding for special characters in the database path before constructing the URI, while keeping `.dot` commands blocked and leaving `exec` behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db30c516fe3ce964dbe522780640d797c102282. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add immutable=1 to SQLite URIs for read-only queries. This bypasses WAL/SHM after macOS sleep and stops false "Not logged in" errors in the Cursor plugin.

- **Bug Fixes**
  - Pass file:{db}?immutable=1 to sqlite3 with -readonly -json.
  - Percent-encode %, spaces, #, ? for a valid URI.
  - Skips WAL/SHM access so reads succeed when -shm remains locked; may return slightly stale data (acceptable for auth token checks).

<sup>Written for commit 4db30c516fe3ce964dbe522780640d797c102282. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

