### PR TITLE
fix(logging): improve log redaction and reduce noise

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -268,6 +268,8 @@ pub fn run() {
                 .level(log::LevelFilter::Trace) // Allow all levels; runtime filter via tray menu
                 .level_for("hyper", log::LevelFilter::Warn)
                 .level_for("reqwest", log::LevelFilter::Warn)
+                .level_for("tao", log::LevelFilter::Info)
+                .level_for("tauri_plugin_updater", log::LevelFilter::Info)
                 .build(),
         )
         .plugin(tauri_plugin_process::init())

--- a/src-tauri/src/plugin_engine/runtime.rs
+++ b/src-tauri/src/plugin_engine/runtime.rs
@@ -521,6 +521,7 @@ mod tests {
             limit: 100.0,
             format: ProgressFormat::Percent,
             resets_at: Some("2099-01-01T00:00:00.000Z".to_string()),
+            period_duration_ms: None,
             color: None,
         };
 


### PR DESCRIPTION
Tightens log sanitization based on audit of live output.

**Changes**
- Add `login` and `analytics_tracking_id` to sensitive key redaction in `redact_body()`
- Add `redact_log_message()` for defense-in-depth on plugin `host.log.*()` calls (catches JWTs + API keys)
- Truncate keychain error messages to first line (removes 20+ line `security` CLI help dump)
- Filter noisy `tao` TRACE and `tauri_plugin_updater` DEBUG logs to Info level
- Fix missing `period_duration_ms` field in runtime test

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes plus small test adjustments; low functional risk, with the main concern being accidental over/under-redaction of log content.
> 
> **Overview**
> Improves log privacy and signal by expanding `redact_body()` to also redact `login` and `analytics_tracking_id`, and by adding `redact_log_message()` so plugin `host.log.*()` output gets JWT/API-key scrubbing as defense-in-depth.
> 
> Reduces log noise by lowering `tao` and `tauri_plugin_updater` log levels, and truncates macOS keychain (`security` CLI) error messages to only the first line to avoid dumping verbose help text. Adds/updates unit tests for the new redaction behavior and fixes a runtime serialization test by setting `period_duration_ms: None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78e06ad47c5ca5656e3cffcf2a68608ee38f0830. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved log redaction and reduced noisy output to protect secrets and make logs easier to read.

- **Bug Fixes**
  - Redact JWTs and API keys in plugin host.log calls.
  - Add "login" and "analytics_tracking_id" to request body redaction.
  - Trim keychain error messages to the first line.
  - Set tao and tauri_plugin_updater logs to Info to cut noise.
  - Fix missing period_duration_ms in a runtime test.

<sup>Written for commit 78e06ad47c5ca5656e3cffcf2a68608ee38f0830. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

