### PR TITLE
macOS DMG: add Applications drag target

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,6 +30,22 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "macOS": {
+      "dmg": {
+        "appPosition": {
+          "x": 180,
+          "y": 170
+        },
+        "applicationFolderPosition": {
+          "x": 480,
+          "y": 170
+        },
+        "windowSize": {
+          "width": 660,
+          "height": 400
+        }
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Why
The macOS DMG installer currently does not include a visible `Applications` drag target (folder/link), which makes the install UX incomplete.

## What changed
- Updated `src-tauri/tauri.conf.json`
- Added `bundle.macOS.dmg` layout config:
  - `appPosition`
  - `applicationFolderPosition`
  - `windowSize`

## Before
[Before screenshot](https://drive.google.com/file/d/1gf7AoKBuHcQjtghcunf8yfcbiQVHhxjj/view?usp=share_link)

## After
[After screenshot](https://drive.google.com/file/d/12ZLUlP7Ik4uZfW6ST8WQbuibBPQNUV8I/view?usp=share_link)

## Validation
- Built DMG locally: `bun run tauri build --bundles dmg`
- Mounted DMG and verified it contains:
  - OpenUsage.app
  - Applications -> /Applications
