### PR TITLE
fix(cursor): support Enterprise accounts with request-based usage

### DIFF
--- a/plugins/cursor/plugin.json
+++ b/plugins/cursor/plugin.json
@@ -9,6 +9,7 @@
   "lines": [
     { "type": "progress", "label": "Credits", "scope": "overview", "primaryOrder": 1 },
     { "type": "progress", "label": "Plan usage", "scope": "overview", "primaryOrder": 2 },
+    { "type": "progress", "label": "Included requests", "scope": "overview", "primaryOrder": 3 },
     { "type": "progress", "label": "On-demand", "scope": "detail" }
   ]
 }

--- a/plugins/cursor/plugin.test.js
+++ b/plugins/cursor/plugin.test.js
@@ -193,6 +193,131 @@ describe("cursor plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Usage response invalid")
   })
 
+  it("handles enterprise account with request-based usage", async () => {
+    const ctx = makeCtx()
+
+    // Build a JWT with a sub claim containing a user ID
+    const jwtPayload = Buffer.from(
+      JSON.stringify({ sub: "google-oauth2|user_abc123", exp: 9999999999 }),
+      "utf8"
+    )
+      .toString("base64")
+      .replace(/=+$/g, "")
+    const accessToken = `a.${jwtPayload}.c`
+
+    ctx.host.sqlite.query.mockReturnValue(
+      JSON.stringify([{ value: accessToken }])
+    )
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        // Enterprise returns no enabled/planUsage
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            billingCycleStart: "1770539602363",
+            billingCycleEnd: "1770539602363",
+            displayThreshold: 100,
+          }),
+        }
+      }
+      if (String(opts.url).includes("GetPlanInfo")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            planInfo: { planName: "Enterprise", price: "Custom" },
+          }),
+        }
+      }
+      if (String(opts.url).includes("cursor.com/api/usage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            "gpt-4": {
+              numRequests: 422,
+              numRequestsTotal: 422,
+              numTokens: 171664819,
+              maxRequestUsage: 500,
+              maxTokenUsage: null,
+            },
+            startOfMonth: "2026-02-01T06:12:57.000Z",
+          }),
+        }
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("Enterprise")
+    const reqLine = result.lines.find((l) => l.label === "Included requests")
+    expect(reqLine).toBeTruthy()
+    expect(reqLine.used).toBe(422)
+    expect(reqLine.limit).toBe(500)
+    expect(reqLine.format).toEqual({ kind: "count", suffix: "requests" })
+  })
+
+  it("throws when enterprise REST usage API fails", async () => {
+    const ctx = makeCtx()
+
+    const jwtPayload = Buffer.from(
+      JSON.stringify({ sub: "google-oauth2|user_abc123", exp: 9999999999 }),
+      "utf8"
+    )
+      .toString("base64")
+      .replace(/=+$/g, "")
+    const accessToken = `a.${jwtPayload}.c`
+
+    ctx.host.sqlite.query.mockReturnValue(
+      JSON.stringify([{ value: accessToken }])
+    )
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            billingCycleStart: "1770539602363",
+            billingCycleEnd: "1770539602363",
+          }),
+        }
+      }
+      if (String(opts.url).includes("GetPlanInfo")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            planInfo: { planName: "Enterprise" },
+          }),
+        }
+      }
+      if (String(opts.url).includes("cursor.com/api/usage")) {
+        return { status: 500, bodyText: "" }
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Enterprise usage data unavailable")
+  })
+
+  it("still throws no subscription for non-enterprise accounts without planUsage", async () => {
+    const ctx = makeCtx()
+    ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({ enabled: false }),
+        }
+      }
+      if (String(opts.url).includes("GetPlanInfo")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({ planInfo: { planName: "Pro" } }),
+        }
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("No active Cursor subscription.")
+  })
+
   it("handles plan fetch failure gracefully", async () => {
     const ctx = makeCtx()
     ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))


### PR DESCRIPTION
## Summary

Fixes #117 — Cursor Enterprise accounts show "No active Cursor subscription." despite active org usage.

<img width="349" height="641" alt="image" src="https://github.com/user-attachments/assets/17fff1d8-15c4-4dc4-b841-d532ad2f2003" />

### Root Cause

The Connect API (`GetCurrentPeriodUsage`) returns **no `enabled` or `planUsage` fields** for Enterprise accounts. The existing code gates all usage display on `!usage.enabled || !usage.planUsage`, which always evaluates to `true` for Enterprise.

**Enterprise Connect API response:**
```json
{
  "billingCycleStart": "1770539602363",
  "billingCycleEnd": "1770539602363",
  "displayThreshold": 100
}
```

### Solution

1. **Early plan detection** — Moved `GetPlanInfo` call before the subscription check to detect Enterprise accounts (`planName === "Enterprise"` + no `planUsage`).
2. **REST API fallback** — For Enterprise, calls `https://cursor.com/api/usage` (the same endpoint used by Cursor's billing dashboard) to fetch request-based usage metrics.
3. **Session token construction** — Extracts user ID from JWT `sub` claim to build the `WorkosCursorSessionToken` cookie required by the REST API.
4. **Request-based display** — Shows "Included requests" progress line (e.g., `422 / 500 requests`) using the `{ kind: "count", suffix: "requests" }` format.

### Changes

| File | Change |
|------|--------|
| `plugins/cursor/plugin.js` | Added `buildSessionToken()`, `fetchEnterpriseUsage()`, `buildEnterpriseResult()` functions; moved `GetPlanInfo` before subscription check; added Enterprise detection and fallback path |
| `plugins/cursor/plugin.json` | Added `"Included requests"` progress line to manifest |
| `plugins/cursor/plugin.test.js` | Added 3 test cases: Enterprise success, Enterprise REST API failure, non-Enterprise still throws |

### Test Results

All 357 tests pass (22 in cursor plugin, including 3 new Enterprise tests).

### Tested With

Cursor Enterprise account (organization billing, macOS Apple Silicon). Verified the REST API returns correct request-based usage data:
```json
{
  "gpt-4": {
    "numRequests": 422,
    "maxRequestUsage": 500,
    "numTokens": 171664819
  },
  "startOfMonth": "2026-02-01T06:12:57.000Z"
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Enterprise accounts incorrectly showing “No active Cursor subscription.” Detects Enterprise and uses request-based usage from Cursor’s REST API to show an “Included requests” progress line.

- **Bug Fixes**
  - Fetch plan info first to identify Enterprise when Connect usage omits enabled/planUsage.
  - For Enterprise, call https://cursor.com/api/usage using a WorkosCursorSessionToken built from the JWT sub.
  - Show Included requests (e.g., 422/500) with a monthly reset.
  - Added tests for Enterprise success, REST failure, and non-Enterprise behavior.

<sup>Written for commit e4b620518f6879ae935b2e76e3cdbe61727e4297. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

