### PR TITLE
fix(windsurf): stop showing billing cycle pacing for flex credits

### DIFF
--- a/plugins/windsurf/plugin.js
+++ b/plugins/windsurf/plugin.js
@@ -190,7 +190,7 @@
     var flexTotal = ps.availableFlexCredits
     var flexUsed = ps.usedFlexCredits || 0
     if (typeof flexTotal === "number" && flexTotal > 0) {
-      var xl = creditLine(ctx, "Flex credits", flexUsed / 100, flexTotal / 100, planEnd, periodMs)
+      var xl = creditLine(ctx, "Flex credits", flexUsed / 100, flexTotal / 100, null, null)
       if (xl) lines.push(xl)
     }
 

--- a/plugins/windsurf/plugin.test.js
+++ b/plugins/windsurf/plugin.test.js
@@ -103,6 +103,24 @@ describe("windsurf plugin", () => {
     expect(flex).toBeTruthy()
     expect(flex.used).toBe(1755.5)     // 175550 / 100
     expect(flex.limit).toBe(26750)     // 2675000 / 100
+    expect(flex.resetsAt).toBeUndefined()
+    expect(flex.periodDurationMs).toBeUndefined()
+  })
+
+  it("flex credits have no billing cycle (non-renewing)", async () => {
+    const ctx = makeCtx()
+    setupLsMock(ctx, makeDiscovery(), "sk-ws-01-test", makeLsResponse())
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    const prompt = result.lines.find((l) => l.label === "Prompt credits")
+    expect(prompt.resetsAt).toBe("2026-02-18T09:07:17Z")
+    expect(prompt.periodDurationMs).toBeGreaterThan(0)
+
+    const flex = result.lines.find((l) => l.label === "Flex credits")
+    expect(flex.resetsAt).toBeUndefined()
+    expect(flex.periodDurationMs).toBeUndefined()
   })
 
   it("skips credit lines with negative available (unlimited)", async () => {


### PR DESCRIPTION
fix(windsurf): Stop showing billing cycle pacing for flex credits

Flex credits are purchased once and deplete — no monthly reset, no renewal.

**Changes**
- Pass `null, null` for `resetsAt`/`periodDurationMs` on the flex credit line so the UI no longer shows "Resets in X" or pace indicator dots
- Add test assertions that flex credits have no billing cycle data while prompt credits still do


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to UI-facing credit-line metadata plus test coverage; no auth, persistence, or protocol changes.
> 
> **Overview**
> Updates the Windsurf plugin to treat **Flex credits as non-renewing** by no longer passing `resetsAt`/`periodDurationMs` into the Flex credit progress line, preventing “resets in …”/pacing indicators from showing.
> 
> Extends unit tests to assert Flex credit lines do **not** include billing-cycle fields while Prompt credits still do.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd5a521815d6f454955cc5d66638aca2894ecde7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing billing cycle pacing for flex credits in Windsurf. Flex credits are one-time, so the UI no longer shows a reset time or pacing dots.

- **Bug Fixes**
  - Pass null for resetsAt and periodDurationMs on the flex credit line to disable pacing/“Resets in X”.
  - Add tests confirming flex credits omit billing cycle fields while prompt credits keep them.

<sup>Written for commit fd5a521815d6f454955cc5d66638aca2894ecde7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

