### PR TITLE
Antigravity OPUS version display

### DIFF
--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -95,7 +95,7 @@ The CSRF token alone authenticates. When an API key is available from the local 
           "quotaInfo": { "remainingFraction": 1, "resetTime": "..." }
         },
         {
-          "label": "Claude Opus 4.5 (Thinking)",
+          "label": "Claude Opus 4.6 (Thinking)",
           "quotaInfo": { "remainingFraction": 1, "resetTime": "..." }
         },
         {
@@ -149,7 +149,7 @@ POST http://127.0.0.1:{port}/exa.language_server_pb.LanguageServerService/GetCom
 | Gemini 3 Pro (Low) | 1007 | Google |
 | Claude Sonnet 4.5 | 333 | Anthropic (proxied) |
 | Claude Sonnet 4.5 (Thinking) | 334 | Anthropic (proxied) |
-| Claude Opus 4.5 (Thinking) | 1012 | Anthropic (proxied) |
+| Claude Opus 4.6 (Thinking) | 1012 | Anthropic (proxied) |
 | GPT-OSS 120B (Medium) | 342 | OpenAI (proxied) |
 
 Models are dynamic — the list changes as Google adds/removes them. The plugin reads labels from the response, not a hardcoded list.

--- a/plugins/antigravity/plugin.json
+++ b/plugins/antigravity/plugin.json
@@ -9,6 +9,6 @@
   "lines": [
     { "type": "progress", "label": "Gemini 3 Pro", "scope": "overview", "primaryOrder": 1 },
     { "type": "progress", "label": "Gemini 3 Flash", "scope": "overview" },
-    { "type": "progress", "label": "Claude Opus 4.5", "scope": "overview" }
+    { "type": "progress", "label": "Claude Opus 4.6", "scope": "overview" }
   ]
 }

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -1,9 +1,14 @@
+import fs from "node:fs"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { makeCtx } from "../test-helpers.js"
 
 const loadPlugin = async () => {
   await import("./plugin.js")
   return globalThis.__openusage_plugin
+}
+
+function loadManifest() {
+  return JSON.parse(fs.readFileSync(new URL("./plugin.json", import.meta.url), "utf8"))
 }
 
 // --- Fixtures ---
@@ -52,7 +57,7 @@ function makeUserStatusResponse(overrides) {
             quotaInfo: { remainingFraction: 0.5, resetTime: "2026-02-08T09:10:56Z" },
           },
           {
-            label: "Claude Opus 4.5 (Thinking)",
+            label: "Claude Opus 4.6 (Thinking)",
             modelOrAlias: { model: "MODEL_1012" },
             quotaInfo: { remainingFraction: 0.8, resetTime: "2026-02-08T09:10:56Z" },
           },
@@ -156,6 +161,13 @@ describe("antigravity plugin", () => {
     vi.resetModules()
   })
 
+  it("keeps Claude Opus 4.6 as the overview label", () => {
+    const manifest = loadManifest()
+    const opus = manifest.lines.find((line) => line.label.includes("Claude Opus"))
+    expect(opus?.label).toBe("Claude Opus 4.6")
+    expect(opus?.scope).toBe("overview")
+  })
+
   it("throws when LS not found and no DB credentials", async () => {
     const ctx = makeCtx()
     ctx.host.ls.discover.mockReturnValue(null)
@@ -202,7 +214,7 @@ describe("antigravity plugin", () => {
     expect(labels).toContain("Gemini 3 Pro")
     expect(labels).toContain("Gemini 3 Flash")
     expect(labels).toContain("Claude Sonnet 4.5")
-    expect(labels).toContain("Claude Opus 4.5")
+    expect(labels).toContain("Claude Opus 4.6")
     expect(labels).toContain("GPT-OSS 120B")
   })
 
@@ -236,7 +248,7 @@ describe("antigravity plugin", () => {
     expect(labels).toEqual([
       "Gemini 3 Pro",
       "Gemini 3 Flash",
-      "Claude Opus 4.5",
+      "Claude Opus 4.6",
       "Claude Sonnet 4.5",
       "GPT-OSS 120B",
     ])
@@ -1165,8 +1177,8 @@ describe("antigravity plugin", () => {
                 model: "MODEL_PLACEHOLDER_M8",
                 quotaInfo: { remainingFraction: 0.7, resetTime: "2026-02-08T10:00:00Z" },
               },
-              "claude-opus-4-5-thinking": {
-                displayName: "Claude Opus 4.5 (Thinking)",
+              "claude-opus-4-6-thinking": {
+                displayName: "Claude Opus 4.6 (Thinking)",
                 model: "MODEL_PLACEHOLDER_M12",
                 quotaInfo: { remainingFraction: 1, resetTime: "2026-02-08T10:00:00Z" },
               },
@@ -1187,7 +1199,7 @@ describe("antigravity plugin", () => {
 
     const labels = result.lines.map((l) => l.label)
     expect(labels).toContain("Gemini 3 Pro")
-    expect(labels).toContain("Claude Opus 4.5")
+    expect(labels).toContain("Claude Opus 4.6")
     expect(labels).toContain("GPT-OSS 120B")
     expect(labels.length).toBe(3)
   })


### PR DESCRIPTION
## Description

Updates the Antigravity plugin to reflect "Claude Opus 4.6" across the dashboard overview, documentation, and tests. This ensures consistency with the latest model version.

## Related Issue

<!-- Link to the issue this PR addresses: Fixes #123 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

<!-- Required for UI changes. Remove this section if not applicable. -->

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

---
<p><a href="https://cursor.com/background-agent?bcId=bc-63db8438-84f1-45cb-a1e4-00d1f3806972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63db8438-84f1-45cb-a1e4-00d1f3806972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Antigravity to display “Claude Opus 4.6” instead of 4.5 across the dashboard overview, provider docs, and tests to keep model labeling consistent.

<sup>Written for commit f92c0b89c4f4c61c849120e7453c1dc171a91c4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

