### PR TITLE
fix(factory): support Droid encrypted/keychain auth storage

### DIFF
--- a/docs/providers/factory.md
+++ b/docs/providers/factory.md
@@ -81,7 +81,9 @@ Premium tokens (`premium.totalAllowance > 0`) are only available on Max/Enterpri
 
 ### Token Location
 
-`~/.factory/auth.json` (droid CLI auth file)
+- `~/.factory/auth.json` (legacy droid auth file)
+- `~/.factory/auth.encrypted` (current droid auth file)
+- macOS keychain entry (when droid uses keyring-backed storage)
 
 ```jsonc
 {
@@ -138,4 +140,4 @@ droid
 # Follow OAuth flow in browser
 ```
 
-This creates `~/.factory/auth.json` with the tokens needed by this plugin.
+This creates auth data in the droid auth store (file and/or keychain, depending on droid version/configuration).


### PR DESCRIPTION
## Summary
- fix Factory plugin auth loading to support current Droid auth storage
- add fallback order: ~/.factory/auth.json -> ~/.factory/auth.encrypted -> macOS keychain
- persist refreshed auth back to source (file or keychain)
- add regression tests for encrypted file, keychain, hex-encoded keychain payloads, refresh writeback, and retry/fallback paths
- update Factory provider docs for current auth locations

## Validation
- bun run test -- plugins/factory/plugin.test.js
- bun run test:coverage

Closes #158

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Factory plugin now loads auth from Droid's encrypted file and macOS keychain, falling back from legacy auth.json. Refresh writes back to the original store and fixes login failures across Droid versions (closes #158).

- **Bug Fixes**
  - Fallback order: ~/.factory/auth.json → ~/.factory/auth.encrypted → macOS keychain (supports multiple service names and hex-encoded payloads).
  - Normalizes token shapes; proactive refresh within 24h; retries usage once on 401 with clearer errors.
  - Persists refreshed tokens back to the original source (file or keychain).
  - Docs updated; regression tests added for encrypted/keychain paths, hex payloads, write-back, and fallback.

<sup>Written for commit 7c7d859f993ce8b2cbebf1076a8d9a6569c5e235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

