### PR TITLE
feat: add start on login setting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@tailwindcss/vite": "^4.1.18",
         "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-global-shortcut": "^2",
         "@tauri-apps/plugin-log": "^2.8.0",
         "@tauri-apps/plugin-opener": "^2",
@@ -305,6 +306,8 @@
     "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.10.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-EHyQ1iwrWy1CwMalEm9z2a6L5isQ121pe7FcA2xe4VWMJp+GHSDDGvbTv/OPdkt2Lyr7DAZBpZHM6nvlHXEc4A=="],
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NTpyQxkpzGmU6ceWBTY2xRIEaS0ZLbVx1HE1zTA3TY/pV3+cPoPPOs+7YScr4IMzXMtOw7tLw5LEXo5oIG3qaQ=="],
+
+    "@tauri-apps/plugin-autostart": ["@tauri-apps/plugin-autostart@2.5.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w=="],
 
     "@tauri-apps/plugin-global-shortcut": ["@tauri-apps/plugin-global-shortcut@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-vr40W2N6G63dmBPaha1TsBQLLURXG538RQbH5vAm0G/ovVZyXJrmZR1HF1W+WneNloQvwn4dm8xzwpEXRW560g=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@tailwindcss/vite": "^4.1.18",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -257,6 +257,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,11 +910,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -914,7 +945,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1021,7 +1052,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.11+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2923,7 +2954,7 @@ name = "openusage"
 version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "log",
  "objc2",
  "objc2-foundation",
@@ -2937,6 +2968,7 @@ dependencies = [
  "tauri-build",
  "tauri-nspanel",
  "tauri-plugin-aptabase",
+ "tauri-plugin-autostart",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -3637,6 +3669,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4688,7 +4731,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4739,7 +4782,7 @@ checksum = "ca7bd893329425df750813e95bd2b643d5369d929438da96d5bbb7cc2c918f74"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4843,6 +4886,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-global-shortcut"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4934,7 +4991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5421,7 +5478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -6309,6 +6366,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6339,7 +6405,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tauri-plugin-aptabase = { git = "https://github.com/aptabase/tauri-plugin-aptaba
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-autostart = "2.5.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 regex-lite = "0.1.9"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
     "aptabase:allow-track-event",
     "updater:default",
     "process:allow-restart",
-    "global-shortcut:default"
+    "global-shortcut:default",
+    "autostart:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -350,6 +350,7 @@ pub fn run() {
         )
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .plugin(tauri_plugin_autostart::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             init_panel,
             hide_panel,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,11 @@ import { getCurrentWindow, PhysicalSize, currentMonitor } from "@tauri-apps/api/
 import { getVersion } from "@tauri-apps/api/app"
 import { resolveResource } from "@tauri-apps/api/path"
 import { TrayIcon } from "@tauri-apps/api/tray"
+import {
+  disable as disableAutostart,
+  enable as enableAutostart,
+  isEnabled as isAutostartEnabled,
+} from "@tauri-apps/plugin-autostart"
 import { SideNav, type ActiveView } from "@/components/side-nav"
 import { PanelFooter } from "@/components/panel-footer"
 import { OverviewPage } from "@/pages/overview"
@@ -22,6 +27,7 @@ import {
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_RESET_TIMER_DISPLAY_MODE,
+  DEFAULT_START_ON_LOGIN,
   DEFAULT_TRAY_ICON_STYLE,
   DEFAULT_TRAY_SHOW_PERCENTAGE,
   DEFAULT_THEME_MODE,
@@ -33,6 +39,7 @@ import {
   loadGlobalShortcut,
   loadPluginSettings,
   loadResetTimerDisplayMode,
+  loadStartOnLogin,
   loadTrayShowPercentage,
   loadTrayIconStyle,
   loadThemeMode,
@@ -42,6 +49,7 @@ import {
   saveGlobalShortcut,
   savePluginSettings,
   saveResetTimerDisplayMode,
+  saveStartOnLogin,
   saveTrayShowPercentage,
   saveTrayIconStyle,
   saveThemeMode,
@@ -89,6 +97,7 @@ function App() {
   const [trayIconStyle, setTrayIconStyle] = useState<TrayIconStyle>(DEFAULT_TRAY_ICON_STYLE)
   const [trayShowPercentage, setTrayShowPercentage] = useState(DEFAULT_TRAY_SHOW_PERCENTAGE)
   const [globalShortcut, setGlobalShortcut] = useState<GlobalShortcut>(DEFAULT_GLOBAL_SHORTCUT)
+  const [startOnLogin, setStartOnLogin] = useState(DEFAULT_START_ON_LOGIN)
   const [maxPanelHeightPx, setMaxPanelHeightPx] = useState<number | null>(null)
   const maxPanelHeightPxRef = useRef<number | null>(null)
   const [appVersion, setAppVersion] = useState("...")
@@ -489,6 +498,18 @@ function App() {
     onBatchComplete: handleBatchComplete,
   })
 
+  const applyStartOnLogin = useCallback(async (value: boolean) => {
+    if (!isTauri()) return
+    const currentlyEnabled = await isAutostartEnabled()
+    if (currentlyEnabled === value) return
+
+    if (value) {
+      await enableAutostart()
+      return
+    }
+    await disableAutostart()
+  }, [])
+
   useEffect(() => {
     let isMounted = true
 
@@ -557,6 +578,19 @@ function App() {
           console.error("Failed to load global shortcut:", error)
         }
 
+        let storedStartOnLogin = DEFAULT_START_ON_LOGIN
+        try {
+          storedStartOnLogin = await loadStartOnLogin()
+        } catch (error) {
+          console.error("Failed to load start on login:", error)
+        }
+
+        try {
+          await applyStartOnLogin(storedStartOnLogin)
+        } catch (error) {
+          console.error("Failed to apply start on login setting:", error)
+        }
+
         const normalizedTrayShowPercentage = isTrayPercentageMandatory(storedTrayIconStyle)
           ? true
           : storedTrayShowPercentage
@@ -570,6 +604,7 @@ function App() {
           setTrayIconStyle(storedTrayIconStyle)
           setTrayShowPercentage(normalizedTrayShowPercentage)
           setGlobalShortcut(storedGlobalShortcut)
+          setStartOnLogin(storedStartOnLogin)
           const enabledIds = getEnabledPluginIds(normalized)
           setLoadingForPlugins(enabledIds)
           try {
@@ -600,7 +635,7 @@ function App() {
     return () => {
       isMounted = false
     }
-  }, [setLoadingForPlugins, setErrorForPlugins, startBatch])
+  }, [setLoadingForPlugins, setErrorForPlugins, startBatch, applyStartOnLogin])
 
   useEffect(() => {
     if (!pluginSettings) {
@@ -810,6 +845,17 @@ function App() {
     })
   }, [])
 
+  const handleStartOnLoginChange = useCallback((value: boolean) => {
+    track("setting_changed", { setting: "start_on_login", value: value ? "true" : "false" })
+    setStartOnLogin(value)
+    void saveStartOnLogin(value).catch((error) => {
+      console.error("Failed to save start on login:", error)
+    })
+    void applyStartOnLogin(value).catch((error) => {
+      console.error("Failed to update start on login:", error)
+    })
+  }, [applyStartOnLogin])
+
   const settingsPlugins = useMemo(() => {
     if (!pluginSettings) return []
     const pluginMap = new Map(pluginsMeta.map((plugin) => [plugin.id, plugin]))
@@ -931,6 +977,8 @@ function App() {
           onTrayShowPercentageChange={handleTrayShowPercentageChange}
           globalShortcut={globalShortcut}
           onGlobalShortcutChange={handleGlobalShortcutChange}
+          startOnLogin={startOnLogin}
+          onStartOnLoginChange={handleStartOnLoginChange}
           providerIconUrl={navPlugins[0]?.iconUrl}
         />
       )

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DISPLAY_MODE,
   DEFAULT_PLUGIN_SETTINGS,
   DEFAULT_RESET_TIMER_DISPLAY_MODE,
+  DEFAULT_START_ON_LOGIN,
   DEFAULT_TRAY_ICON_STYLE,
   DEFAULT_TRAY_SHOW_PERCENTAGE,
   DEFAULT_THEME_MODE,
@@ -13,6 +14,7 @@ import {
   loadDisplayMode,
   loadPluginSettings,
   loadResetTimerDisplayMode,
+  loadStartOnLogin,
   loadTrayIconStyle,
   loadTrayShowPercentage,
   loadThemeMode,
@@ -21,6 +23,7 @@ import {
   saveDisplayMode,
   savePluginSettings,
   saveResetTimerDisplayMode,
+  saveStartOnLogin,
   saveTrayIconStyle,
   saveTrayShowPercentage,
   saveThemeMode,
@@ -216,5 +219,24 @@ describe("settings", () => {
   it("falls back to default for invalid tray show percentage", async () => {
     storeState.set("trayShowPercentage", "invalid")
     await expect(loadTrayShowPercentage()).resolves.toBe(DEFAULT_TRAY_SHOW_PERCENTAGE)
+  })
+
+  it("loads default start on login when missing", async () => {
+    await expect(loadStartOnLogin()).resolves.toBe(DEFAULT_START_ON_LOGIN)
+  })
+
+  it("loads stored start on login value", async () => {
+    storeState.set("startOnLogin", true)
+    await expect(loadStartOnLogin()).resolves.toBe(true)
+  })
+
+  it("saves start on login value", async () => {
+    await saveStartOnLogin(true)
+    await expect(loadStartOnLogin()).resolves.toBe(true)
+  })
+
+  it("falls back to default for invalid start on login value", async () => {
+    storeState.set("startOnLogin", "invalid")
+    await expect(loadStartOnLogin()).resolves.toBe(DEFAULT_START_ON_LOGIN)
   })
 })

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -31,6 +31,7 @@ const RESET_TIMER_DISPLAY_MODE_KEY = "resetTimerDisplayMode";
 const TRAY_ICON_STYLE_KEY = "trayIconStyle";
 const TRAY_SHOW_PERCENTAGE_KEY = "trayShowPercentage";
 const GLOBAL_SHORTCUT_KEY = "globalShortcut";
+const START_ON_LOGIN_KEY = "startOnLogin";
 
 export const DEFAULT_AUTO_UPDATE_INTERVAL: AutoUpdateIntervalMinutes = 15;
 export const DEFAULT_THEME_MODE: ThemeMode = "system";
@@ -39,6 +40,7 @@ export const DEFAULT_RESET_TIMER_DISPLAY_MODE: ResetTimerDisplayMode = "relative
 export const DEFAULT_TRAY_ICON_STYLE: TrayIconStyle = "bars";
 export const DEFAULT_TRAY_SHOW_PERCENTAGE = false;
 export const DEFAULT_GLOBAL_SHORTCUT: GlobalShortcut = null;
+export const DEFAULT_START_ON_LOGIN = false;
 
 const AUTO_UPDATE_INTERVALS: AutoUpdateIntervalMinutes[] = [5, 15, 30, 60];
 const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
@@ -264,5 +266,16 @@ export async function loadGlobalShortcut(): Promise<GlobalShortcut> {
 
 export async function saveGlobalShortcut(shortcut: GlobalShortcut): Promise<void> {
   await store.set(GLOBAL_SHORTCUT_KEY, shortcut);
+  await store.save();
+}
+
+export async function loadStartOnLogin(): Promise<boolean> {
+  const stored = await store.get<unknown>(START_ON_LOGIN_KEY);
+  if (typeof stored === "boolean") return stored;
+  return DEFAULT_START_ON_LOGIN;
+}
+
+export async function saveStartOnLogin(value: boolean): Promise<void> {
+  await store.set(START_ON_LOGIN_KEY, value);
   await store.save();
 }

--- a/src/pages/settings.test.tsx
+++ b/src/pages/settings.test.tsx
@@ -59,6 +59,10 @@ const defaultProps = {
   onTrayIconStyleChange: vi.fn(),
   trayShowPercentage: false,
   onTrayShowPercentageChange: vi.fn(),
+  globalShortcut: null,
+  onGlobalShortcutChange: vi.fn(),
+  startOnLogin: false,
+  onStartOnLoginChange: vi.fn(),
 }
 
 afterEach(() => {
@@ -283,5 +287,17 @@ describe("SettingsPage", () => {
     await userEvent.click(screen.getByText("Show percentage"))
     expect(onTrayShowPercentageChange).toHaveBeenCalled()
     expect(onTrayShowPercentageChange.mock.calls[0]?.[0]).toBe(false)
+  })
+
+  it("toggles start on login checkbox", async () => {
+    const onStartOnLoginChange = vi.fn()
+    render(
+      <SettingsPage
+        {...defaultProps}
+        onStartOnLoginChange={onStartOnLoginChange}
+      />
+    )
+    await userEvent.click(screen.getByText("Start on login"))
+    expect(onStartOnLoginChange).toHaveBeenCalledWith(true)
   })
 })

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -277,6 +277,8 @@ interface SettingsPageProps {
   onTrayShowPercentageChange: (value: boolean) => void;
   globalShortcut: GlobalShortcut;
   onGlobalShortcutChange: (value: GlobalShortcut) => void;
+  startOnLogin: boolean;
+  onStartOnLoginChange: (value: boolean) => void;
   providerIconUrl?: string;
 }
 
@@ -298,6 +300,8 @@ export function SettingsPage({
   onTrayShowPercentageChange,
   globalShortcut,
   onGlobalShortcutChange,
+  startOnLogin,
+  onStartOnLoginChange,
   providerIconUrl,
 }: SettingsPageProps) {
   const percentageMandatory = isTrayPercentageMandatory(trayIconStyle);
@@ -502,6 +506,20 @@ export function SettingsPage({
         globalShortcut={globalShortcut}
         onGlobalShortcutChange={onGlobalShortcutChange}
       />
+      <section>
+        <h3 className="text-lg font-semibold mb-0">Start on Login</h3>
+        <p className="text-sm text-muted-foreground mb-2">
+          OpenUsage starts when you sign in
+        </p>
+        <label className="flex items-center gap-2 text-sm select-none text-foreground">
+          <Checkbox
+            key={`start-on-login-${startOnLogin}`}
+            checked={startOnLogin}
+            onCheckedChange={(checked) => onStartOnLoginChange(checked === true)}
+          />
+          Start on login
+        </label>
+      </section>
       <section>
         <h3 className="text-lg font-semibold mb-0">Plugins</h3>
         <p className="text-sm text-muted-foreground mb-2">


### PR DESCRIPTION
## Summary
- add a new **Start on login** toggle in Settings
- persist `startOnLogin` in the settings store
- apply OS autostart state on startup and when the toggle changes
- register Tauri autostart plugin and capability permission

## Testing
- `bun run test:coverage`
- `bun run build`
- `cd src-tauri && cargo check`

## Screenshot
<img width="800" height="2456" alt="CleanShot 2026-02-11 at 18 36 49@2x" src="https://github.com/user-attachments/assets/14478af3-c825-4aec-9fe3-e169e94cefc7" />


Closes #67
