### PR TITLE
fix(analytics): reduce noisy event volume

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -293,19 +293,6 @@ function App() {
       .map((p) => ({ id: p.id, name: p.name, iconUrl: p.iconUrl, brandColor: p.brandColor }))
   }, [pluginSettings, pluginsMeta])
 
-  // Track page views
-  useEffect(() => {
-    const page =
-      activeView === "home" ? "overview"
-        : activeView === "settings" ? "settings"
-          : "provider_detail"
-    const props: Record<string, string> =
-      activeView !== "home" && activeView !== "settings"
-        ? { page, provider_id: activeView }
-        : { page }
-    track("page_viewed", props)
-  }, [activeView])
-
   // If active view is a plugin that got disabled, switch to home
   useEffect(() => {
     if (activeView === "home" || activeView === "settings") return

--- a/src/hooks/use-app-update.test.ts
+++ b/src/hooks/use-app-update.test.ts
@@ -5,6 +5,9 @@ const { checkMock, relaunchMock } = vi.hoisted(() => ({
   checkMock: vi.fn(),
   relaunchMock: vi.fn(),
 }))
+const { trackMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+}))
 
 vi.mock("@tauri-apps/plugin-updater", () => ({
   check: checkMock,
@@ -12,6 +15,10 @@ vi.mock("@tauri-apps/plugin-updater", () => ({
 
 vi.mock("@tauri-apps/plugin-process", () => ({
   relaunch: relaunchMock,
+}))
+
+vi.mock("@/lib/analytics", () => ({
+  track: trackMock,
 }))
 
 import { useAppUpdate } from "@/hooks/use-app-update"
@@ -27,6 +34,7 @@ describe("useAppUpdate", () => {
   beforeEach(() => {
     checkMock.mockReset()
     relaunchMock.mockReset()
+    trackMock.mockReset()
     // `@tauri-apps/api/core` considers `globalThis.isTauri` the runtime flag.
     globalThis.isTauri = true
   })

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest"
+
+const state = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  isTauriMock: vi.fn(() => true),
+}))
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: state.invokeMock,
+  isTauri: state.isTauriMock,
+}))
+
+describe("analytics track", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-02-12T12:00:00.000Z"))
+    vi.resetModules()
+    state.invokeMock.mockReset()
+    state.isTauriMock.mockReset()
+    state.isTauriMock.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does nothing when not running in tauri", async () => {
+    state.isTauriMock.mockReturnValue(false)
+    const { track } = await import("./analytics")
+
+    track("provider_fetch_error", { provider_id: "codex", error: "network" })
+
+    expect(state.invokeMock).not.toHaveBeenCalled()
+  })
+
+  it("deduplicates provider_fetch_error for 60 minutes", async () => {
+    const { track } = await import("./analytics")
+
+    track("provider_fetch_error", { provider_id: "codex", error: "network" })
+    vi.advanceTimersByTime(59 * 60 * 1000)
+    track("provider_fetch_error", { provider_id: "codex", error: "network" })
+
+    expect(state.invokeMock).toHaveBeenCalledTimes(1)
+    expect(state.invokeMock).toHaveBeenCalledWith("plugin:aptabase|track_event", {
+      name: "provider_fetch_error",
+      props: { provider_id: "codex", error: "network" },
+    })
+  })
+
+  it("allows provider_fetch_error again after 60 minutes", async () => {
+    const { track } = await import("./analytics")
+
+    track("provider_fetch_error", { provider_id: "codex", error: "network" })
+    vi.advanceTimersByTime(60 * 60 * 1000)
+    track("provider_fetch_error", { provider_id: "codex", error: "network" })
+
+    expect(state.invokeMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not dedupe other event types", async () => {
+    const { track } = await import("./analytics")
+
+    track("setting_changed", { setting: "theme", value: "dark" })
+    track("setting_changed", { setting: "theme", value: "dark" })
+
+    expect(state.invokeMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -5,6 +5,31 @@ import { invoke, isTauri } from "@tauri-apps/api/core"
  * Aptabase only supports string and number property values.
  */
 const APTABASE_TRACK_EVENT_CMD = "plugin:aptabase|track_event"
+const PROVIDER_FETCH_ERROR_TTL_MS = 60 * 60 * 1000
+const providerFetchErrorLastSeenAt = new Map<string, number>()
+
+function getProviderFetchErrorKey(
+  props?: Record<string, string | number>,
+): string | null {
+  const providerId = props?.provider_id
+  const error = props?.error
+  if (providerId === undefined || error === undefined) return null
+  return `${String(providerId)}::${String(error)}`
+}
+
+function shouldDropProviderFetchError(
+  props?: Record<string, string | number>,
+): boolean {
+  const key = getProviderFetchErrorKey(props)
+  if (!key) return false
+  const now = Date.now()
+  const lastSeenAt = providerFetchErrorLastSeenAt.get(key)
+  if (lastSeenAt !== undefined && now - lastSeenAt < PROVIDER_FETCH_ERROR_TTL_MS) {
+    return true
+  }
+  providerFetchErrorLastSeenAt.set(key, now)
+  return false
+}
 
 export function track(
   event: string,
@@ -13,6 +38,10 @@ export function track(
   const tauriRuntime = isTauri()
 
   if (!tauriRuntime) {
+    return
+  }
+
+  if (event === "provider_fetch_error" && shouldDropProviderFetchError(props)) {
     return
   }
 


### PR DESCRIPTION
## Description

Reduce analytics spam to stay within free event limits while keeping useful product signals.

- Removed `page_viewed` tracking from app navigation.
- Added 60-minute dedupe for `provider_fetch_error` keyed by `provider_id + error`.
- Gated `app_started` to once per app version per UTC day using persisted store state.
- Added regression tests for all three behaviors, plus a test mock update to keep coverage runs clean.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [x] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [ ] I tested the change locally with `bun tauri dev`

Additional verification:
- `bun run test:coverage`
- `cargo test --lib tests::` (in `src-tauri`)

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics emission timing and adds persisted startup gating in the Tauri setup path, which could affect event reporting and involves store read/write on app launch.
> 
> **Overview**
> Reduces analytics noise by **removing `page_viewed` tracking** from app navigation and startup.
> 
> Adds a `track()` dedupe layer for `provider_fetch_error`, suppressing repeats for the same `provider_id`+`error` for 60 minutes, and gates backend `app_started` emission to **once per UTC day per app version** (persisted in the Tauri `settings.json` store on desktop).
> 
> Updates and adds tests to cover the new gating/dedupe behavior and adjusts mocks to keep existing test suites passing without unexpected analytics calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0429645e3dfeb3ebc09984955692e35c5f7c6783. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits analytics event volume to stay within free tier while keeping useful signals. Drops page_viewed, dedupes provider_fetch_error for 60 minutes, and tracks app_started once per app version per UTC day.

- **Bug Fixes**
  - Removed page_viewed tracking on startup and navigation.
  - Deduped provider_fetch_error (provider_id+error) for 60 minutes.
  - Tracked app_started once per app version per UTC day using a persisted store.

<sup>Written for commit 0429645e3dfeb3ebc09984955692e35c5f7c6783. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

