### PR TITLE
feat: improve Linux compatibility and Copilot auth fallback handling

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,6 @@ tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-pn
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 time = { version = "0.3.47", features = ["formatting"] }
 dirs = "6"
 log = "0.4"
@@ -41,6 +40,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 regex-lite = "0.1.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSProcessInfo", "NSString"] }
 objc2-web-kit = { version = "0.3", features = ["WKPreferences", "WKWebView", "WKWebViewConfiguration"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "macos")]
 mod app_nap;
+#[cfg(target_os = "macos")]
 mod panel;
 mod plugin_engine;
 mod tray;
@@ -33,7 +34,20 @@ fn managed_shortcut_slot() -> &'static Mutex<Option<String>> {
 fn handle_global_shortcut(app: &tauri::AppHandle, event: tauri_plugin_global_shortcut::ShortcutEvent) {
     if event.state == ShortcutState::Pressed {
         log::debug!("Global shortcut triggered");
+        #[cfg(target_os = "macos")]
         panel::toggle_panel(app);
+        #[cfg(not(target_os = "macos"))]
+        {
+            use tauri::Manager;
+            if let Some(window) = app.get_webview_window("main") {
+                if window.is_visible().unwrap_or(false) {
+                    let _ = window.hide();
+                } else {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            }
+        }
     }
 }
 
@@ -95,14 +109,32 @@ pub struct ProbeBatchComplete {
 
 #[tauri::command]
 fn init_panel(app_handle: tauri::AppHandle) {
-    panel::init(&app_handle).expect("Failed to initialize panel");
+    #[cfg(target_os = "macos")]
+    {
+        panel::init(&app_handle).expect("Failed to initialize panel");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // On non-macOS, the main window is a regular WebviewWindow – no panel init needed.
+        let _ = &app_handle;
+    }
 }
 
 #[tauri::command]
 fn hide_panel(app_handle: tauri::AppHandle) {
-    use tauri_nspanel::ManagerExt;
-    if let Ok(panel) = app_handle.get_webview_panel("main") {
-        panel.hide();
+    #[cfg(target_os = "macos")]
+    {
+        use tauri_nspanel::ManagerExt;
+        if let Ok(panel) = app_handle.get_webview_panel("main") {
+            panel.hide();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        use tauri::Manager;
+        if let Some(window) = app_handle.get_webview_window("main") {
+            let _ = window.hide();
+        }
     }
 }
 
@@ -229,10 +261,11 @@ async fn start_probe_batch(
 
 #[tauri::command]
 fn get_log_path(app_handle: tauri::AppHandle) -> Result<String, String> {
-    // macOS log directory: ~/Library/Logs/{bundleIdentifier}
-    let home = dirs::home_dir().ok_or("no home dir")?;
-    let bundle_id = app_handle.config().identifier.clone();
-    let log_dir = home.join("Library").join("Logs").join(&bundle_id);
+    use tauri::Manager;
+    let log_dir = app_handle
+        .path()
+        .app_log_dir()
+        .map_err(|e: tauri::Error| e.to_string())?;
     let log_file = log_dir.join(format!("{}.log", app_handle.package_info().name));
     Ok(log_file.to_string_lossy().to_string())
 }
@@ -350,7 +383,17 @@ pub fn run() {
         .plugin(tauri_plugin_aptabase::Builder::new("A-US-6435241436").build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
-        .plugin(tauri_nspanel::init())
+        .plugin({
+            #[cfg(target_os = "macos")]
+            {
+                tauri_nspanel::init()
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                // No-op plugin: tauri-nspanel is macOS-only.
+                tauri::plugin::Builder::<tauri::Wry, ()>::new("nspanel-stub").build()
+            }
+        })
         .plugin(
             tauri_plugin_log::Builder::new()
                 .targets([


### PR DESCRIPTION
## Summary
- improve Linux compatibility by making `tauri-nspanel` macOS-only and adding non-macOS window handling for tray/shortcut/panel actions.
- make Copilot authentication more resilient on Linux by adding token fallbacks in this order: OpenUsage cache/keychain, gh keychain entry, `gh` hosts file, and `gh auth token` command.
- persist recovered GitHub tokens into OpenUsage auth cache so subsequent probes work without re-authentication prompts.
- add comprehensive tests for new Copilot auth fallback paths and stale-token retry behavior.
- allow plugins to read `HOME`, `XDG_CONFIG_HOME`, and `GH_CONFIG_DIR` from the host env so gh config paths can be resolved correctly.

## Why
On Linux, users could be logged in with `gh` but Copilot still showed `Not logged in. Run gh auth login first.` because token discovery depended on storage assumptions that do not always hold across environments.

## Validation
- `bun run test -- plugins/copilot/plugin.test.js` (pass: 36 tests)
- `cargo check --manifest-path src-tauri/Cargo.toml` (pass)
- `bun run test:coverage` (tests and coverage completed; command exits non-zero due 3 pre-existing unhandled rejections in `src/hooks/use-app-update.test.ts` not introduced by this change)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Linux compatibility by making the panel macOS-only and adding cross-platform tray/shortcut toggling for the main window. Fixes Copilot login issues on Linux with robust token discovery and persistence.

- **New Features**
  - macOS-only panel plugin; on non-macOS, tray clicks and the global shortcut toggle the main window (show/hide/focus structures updated).
  - Cross-platform log file path via app_log_dir.
  - Plugins can read HOME, XDG_CONFIG_HOME, and GH_CONFIG_DIR from the host env.

- **Bug Fixes**
  - Resolve Copilot sign-in on Linux by adding token fallbacks: OpenUsage cache/keychain → gh keychain → hosts.yml → gh auth token.
  - Persist recovered tokens to the OpenUsage keychain and retry on 401 for stale tokens; added tests covering fallbacks and stale-token behavior.

<sup>Written for commit f05718cab0d317ed71d2ae49f7bc5557b0afe44c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

