### PR TITLE
Fix env var lookup for GUI launches (fish/zsh)

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -112,6 +112,8 @@ Reads an environment variable by name.
 - Returns variable value as string when set
 - Returns `null` when missing
 - Variable must be whitelisted first in `src-tauri/src/plugin_engine/host_api.rs`
+- Resolution order: current process env first, then a login+interactive shell lookup (macOS)
+- Values may be cached for the app session; restart OpenUsage after changing shell config
 
 ### Example
 

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -18,10 +18,21 @@ Tracks [Z.ai](https://z.ai) (Zhipu AI) usage quotas for GLM coding plans.
 
 1. [Subscribe to a GLM Coding plan](https://z.ai/subscribe) and get your API key from
    the [Z.ai console](https://z.ai/manage-apikey/apikey-list)
-2. Set the environment variable `ZAI_API_KEY`
+2. Set `ZAI_API_KEY` (fallback: `GLM_API_KEY`)
+
+OpenUsage is a GUI app. A one-off `export ...` in a terminal session will not be visible when you launch OpenUsage from
+Spotlight/Launchpad. Persist it, then restart OpenUsage.
+
+zsh (`~/.zshrc`):
 
 ```bash
 export ZAI_API_KEY="YOUR_API_KEY"
+```
+
+fish (universal var):
+
+```fish
+set -Ux ZAI_API_KEY "YOUR_API_KEY"
 ```
 
 3. Enable the Z.ai plugin in OpenUsage settings


### PR DESCRIPTION
Fixes #181.

OpenUsage is launched as a GUI app (Spotlight/Launchpad), so it does not automatically inherit environment variables you `export` in a terminal session. The Z.ai plugin also only queried zsh, which made `ZAI_API_KEY` effectively impossible to pick up for fish users unless they launched OpenUsage from that same shell.

This PR makes env lookup behave the way people expect on macOS:
- `host.env.get(NAME)` first checks the app process env (launchctl / terminal-launch cases).
- If missing, it falls back to `printenv NAME` via a login+interactive shell (tries `$SHELL` when it's `zsh|bash|fish`, then `/bin/zsh`, `/bin/bash`, and common fish install paths). Shell-derived values are cached for the app session.
- Allowlist stays in place (`CODEX_HOME`, `ZAI_API_KEY`, `GLM_API_KEY`).

Docs:
- Updated Z.ai provider docs with persistent setup examples for zsh + fish, plus a restart note.

Tests:
- `bun run test`
- `bun run test:coverage`
- `cd src-tauri && cargo test plugin_engine::host_api -- --nocapture`
