### PR TITLE
fix: filter opus 4.5 from antigravity and use same maintained list for ls probe to block models

### DIFF
--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -149,7 +149,7 @@ POST http://127.0.0.1:{port}/exa.language_server_pb.LanguageServerService/GetCom
 | Gemini 3 Pro (Low) | 1007 | Google |
 | Claude Sonnet 4.5 | 333 | Anthropic (proxied) |
 | Claude Sonnet 4.5 (Thinking) | 334 | Anthropic (proxied) |
-| Claude Opus 4.5 (Thinking) | 1012 | Anthropic (proxied) |
+| Claude Opus 4.6 (Thinking) | MODEL_PLACEHOLDER_M26 | Anthropic (proxied) |
 | GPT-OSS 120B (Medium) | 342 | OpenAI (proxied) |
 
 Models are dynamic — the list changes as Google adds/removes them. The plugin reads labels from the response, not a hardcoded list.

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -18,6 +18,7 @@
     "MODEL_GOOGLE_GEMINI_2_5_PRO": true,
     "MODEL_PLACEHOLDER_M19": true,
     "MODEL_PLACEHOLDER_M9": true,
+    "MODEL_PLACEHOLDER_M12": true,
   }
   // --- Protobuf wire-format decoder ---
 
@@ -403,7 +404,14 @@
       return null
     }
 
-    var lines = buildModelLines(ctx, configs)
+    var filtered = []
+    for (var j = 0; j < configs.length; j++) {
+      var mid = configs[j].modelOrAlias && configs[j].modelOrAlias.model
+      if (mid && CC_MODEL_BLACKLIST[mid]) continue
+      filtered.push(configs[j])
+    }
+
+    var lines = buildModelLines(ctx, filtered)
     if (lines.length === 0) return null
 
     var plan = null

--- a/plugins/antigravity/plugin.json
+++ b/plugins/antigravity/plugin.json
@@ -9,6 +9,6 @@
   "lines": [
     { "type": "progress", "label": "Gemini 3 Pro", "scope": "overview", "primaryOrder": 1 },
     { "type": "progress", "label": "Gemini 3 Flash", "scope": "overview" },
-    { "type": "progress", "label": "Claude Opus 4.5", "scope": "overview" }
+    { "type": "progress", "label": "Claude Opus 4.6", "scope": "overview" }
   ]
 }


### PR DESCRIPTION


## Description

Precedes the attempted PR https://github.com/robinebers/openusage/pull/157.

This pull request updates the Antigravity plugin to replace support for "Claude Opus 4.5" with "Claude Opus 4.6", including updating all references, tests, and model IDs. It also introduces logic to filter out blacklisted model IDs (specifically excluding "Claude Opus 4.5") from the available models, and adds corresponding test coverage to ensure correct filtering behavior.

**Model Updates and Filtering:**

* Replaced all references to "Claude Opus 4.5" with "Claude Opus 4.6" in user-facing labels, model IDs, and test fixtures across `plugin.js`, `plugin.json`, `plugin.test.js`, and documentation. [[1]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L152-R152) [[2]](diffhunk://#diff-0f44acb071bb07fe9867e8c4cf4b1f8d3c5dce1392802482c8d326a370164db4L12-R12) [[3]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L36-R61) [[4]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L205-R205) [[5]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L239-R239) [[6]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L1168-R1170) [[7]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L1190-R1227)
* Added "MODEL_PLACEHOLDER_M12" to the model allowlist in `plugin.js` and updated test fixtures to use new model IDs. [[1]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8R21) [[2]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L36-R61)
* Updated the plugin logic in `plugin.js` to filter out blacklisted model IDs (e.g., "Claude Opus 4.5") when building the list of available models.

**Test Enhancements:**

* Added a new test to `plugin.test.js` to verify that blacklisted models (such as "Claude Opus 4.5") are excluded from the available models list, while "Claude Opus 4.6" remains available.

## Related Issue

None

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots
<img width="1152" height="1360" alt="CleanShot 2026-02-16 at 12 27 59@2x" src="https://github.com/user-attachments/assets/a2ab6c41-1f75-46ad-8545-2db8f341da7f" />

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Claude Opus 4.5 with 4.6 across the Antigravity plugin and added filtering so blacklisted models (like 4.5) are not shown. Updated docs, labels, and tests to match the new model IDs.

- **Bug Fixes**
  - Filter blacklisted model IDs when building available models.
  - Switch docs and plugin config to “Claude Opus 4.6 (Thinking)” (MODEL_PLACEHOLDER_M26).
  - Update tests and add coverage to confirm 4.5 is excluded and 4.6 remains available.

<sup>Written for commit 5ac0a9417fe7b871ab5c29386a5fc94b7047bdc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

