### PR TITLE
fix(cursor): support team usage when enabled flag is omitted

### DIFF
--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -320,7 +320,8 @@
       return buildEnterpriseResult(ctx, accessToken, planName, usage)
     }
 
-    if (!usage.enabled || !usage.planUsage) {
+    // Team plans may omit `enabled` even with valid plan usage data.
+    if (usage.enabled === false || !usage.planUsage) {
       throw "No active Cursor subscription."
     }
 


### PR DESCRIPTION
## Summary
- fix Cursor subscription guard to treat `enabled` as optional
- only show "No active Cursor subscription" when `enabled === false` or `planUsage` is missing
- add regression test for Team payloads where `planUsage` exists but `enabled` is absent

## Root cause
Cursor Team responses can omit `enabled`. Existing code used `!usage.enabled`, which treated `undefined` as disabled and incorrectly errored.

## Validation
- bun run test plugins/cursor/plugin.test.js
- bun run test:coverage

Closes #187

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cursor subscription checks to accept Team payloads that omit the enabled flag, preventing false “No active Cursor subscription.” errors. Adds a regression test that verifies Team plan and usage output.

- **Bug Fixes**
  - Guard now throws only when enabled === false or planUsage is missing.
  - Test covers Team payloads without enabled and asserts plan "Team" and usage are returned.

<sup>Written for commit a05e7fab60faf6b163c00ba3d935cb9c1577ec29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

