### PR TITLE
fix: suppress zero-formatted deficit text

### DIFF
--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -558,6 +558,35 @@ describe("ProviderCard", () => {
     vi.useRealTimers()
   })
 
+  it("hides tiny positive deficit text that would round to zero", () => {
+    vi.useFakeTimers()
+    const now = new Date("2026-02-02T12:00:00.000Z")
+    vi.setSystemTime(now)
+    render(
+      <ProviderCard
+        name="Pace"
+        displayMode="used"
+        lines={[
+          {
+            type: "progress",
+            label: "Behind",
+            used: 50.3,
+            limit: 100,
+            format: { kind: "percent" },
+            resetsAt: "2026-02-03T00:00:00.000Z",
+            periodDurationMs: 24 * 60 * 60 * 1000,
+          },
+        ]}
+      />
+    )
+    expect(screen.getByLabelText("Will run out")).toBeInTheDocument()
+    expect(screen.getByText(/^Runs out in /)).toBeInTheDocument()
+    expect(screen.queryByText("0% in deficit")).not.toBeInTheDocument()
+    expect(screen.queryByText("0% short")).not.toBeInTheDocument()
+    expect(screen.queryByText(/in deficit/i)).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
   it("keeps status-only tooltip when pace projection is not yet available", () => {
     vi.useFakeTimers()
     const now = new Date("2026-02-02T00:45:00.000Z")

--- a/src/lib/pace-tooltip.test.ts
+++ b/src/lib/pace-tooltip.test.ts
@@ -272,4 +272,29 @@ describe("formatDeficitText", () => {
   it("rounds percent deficit", () => {
     expect(formatDeficitText(4.7, { kind: "percent" }, "used")).toBe("5% in deficit")
   })
+
+  it("returns null for tiny percent deficits that round to zero", () => {
+    expect(formatDeficitText(0.3, { kind: "percent" }, "used")).toBeNull()
+    expect(formatDeficitText(0.3, { kind: "percent" }, "left")).toBeNull()
+  })
+
+  it("returns null for tiny dollar deficits that round to zero", () => {
+    expect(formatDeficitText(0.004, { kind: "dollars" }, "used")).toBeNull()
+  })
+
+  it("returns null for tiny count deficits that round to zero", () => {
+    expect(formatDeficitText(0.004, { kind: "count", suffix: "requests" }, "used")).toBeNull()
+  })
+
+  it("shows the first displayable percent deficit", () => {
+    expect(formatDeficitText(0.5, { kind: "percent" }, "used")).toBe("1% in deficit")
+  })
+
+  it("shows the first displayable dollar deficit", () => {
+    expect(formatDeficitText(0.005, { kind: "dollars" }, "used")).toBe("$0.01 in deficit")
+  })
+
+  it("shows the first displayable count deficit", () => {
+    expect(formatDeficitText(0.005, { kind: "count", suffix: "requests" }, "used")).toBe("0.01 requests in deficit")
+  })
 })

--- a/src/lib/pace-tooltip.ts
+++ b/src/lib/pace-tooltip.ts
@@ -104,9 +104,18 @@ export function formatDeficitText(
   deficit: number,
   format: ProgressFormat,
   displayMode: DisplayMode
-): string {
+): string | null {
+  if (!Number.isFinite(deficit) || deficit <= 0) return null
+
   const suffix = displayMode === "left" ? "short" : "in deficit"
-  if (format.kind === "percent") return `${Math.round(deficit)}% ${suffix}`
-  if (format.kind === "dollars") return `$${formatFixedPrecisionNumber(deficit)} ${suffix}`
-  return `${formatCountNumber(deficit)} ${format.suffix} ${suffix}`
+  if (format.kind === "percent") {
+    const roundedPercent = Math.round(deficit)
+    return roundedPercent > 0 ? `${roundedPercent}% ${suffix}` : null
+  }
+
+  const roundedToCents = Math.round(deficit * 100) / 100
+  if (roundedToCents <= 0) return null
+
+  if (format.kind === "dollars") return `$${formatFixedPrecisionNumber(roundedToCents)} ${suffix}`
+  return `${formatCountNumber(roundedToCents)} ${format.suffix} ${suffix}`
 }


### PR DESCRIPTION
## Summary
- prevent contradictory deficit text by returning `null` when a positive deficit rounds to zero at display precision
- keep existing deficit phrasing for displayable values and preserve behind-pace runs-out behavior
- add regression tests in `pace-tooltip` and `provider-card` for tiny-deficit and first-displayable boundary cases

## Test plan
- [x] `bunx vitest run src/lib/pace-tooltip.test.ts src/components/provider-card.test.tsx`
- [ ] `bun run test:coverage` *(fails on pre-existing coverage thresholds in unrelated `src/hooks/app/*` files on current `main`)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses contradictory deficit text by hiding values that round to zero, while keeping normal deficit phrasing and “Runs out” behavior intact.

- **Bug Fixes**
  - formatDeficitText returns null for tiny percent, dollar, and count deficits that round to zero.
  - Preserves existing phrasing for displayable deficits and behind-pace run-out messaging.
  - Adds regression tests for tiny-deficit and first-displayable boundary cases in pace-tooltip and provider-card.

<sup>Written for commit 9c679d2060493b8ccb226e0d34ea75a1c537afd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

