### PR TITLE
Ccusage pricing fix

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -476,7 +476,7 @@ Returns a status envelope:
 
 ### Behavior
 
-- **Runtime runners**: Executes pinned `ccusage@18.0.5` (Claude) or `@ccusage/codex@18.0.5` (Codex) via fallback chain `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx`
+- **Runtime runners**: Executes pinned `ccusage@18.0.6` (Claude) or `@ccusage/codex@18.0.6` (Codex) via fallback chain `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx`
 - **Provider-aware**: Resolves provider from `opts.provider` or plugin id (`claude`/`codex`)
 - **No provider API calls**: Usage is computed from local JSONL session files; the host does not call Claude/Codex (or other provider) APIs, but package runners may contact a package registry to download the `ccusage` CLI if it is not already available locally
 - **Graceful degradation**: returns `no_runner` when no runner exists, `runner_failed` when execution fails

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -1137,8 +1137,8 @@ fn ls_parse_listening_ports(output: &str) -> Vec<i32> {
     ports.into_iter().collect()
 }
 
-const CCUSAGE_CLAUDE_PACKAGE: &str = "ccusage@18.0.5";
-const CCUSAGE_CODEX_PACKAGE: &str = "@ccusage/codex@18.0.5";
+const CCUSAGE_CLAUDE_PACKAGE: &str = "ccusage@18.0.6";
+const CCUSAGE_CODEX_PACKAGE: &str = "@ccusage/codex@18.0.6";
 const CCUSAGE_TIMEOUT_SECS: u64 = 15;
 const CCUSAGE_POLL_INTERVAL_MS: u64 = 100;
 
@@ -2233,7 +2233,7 @@ mod tests {
             bunx,
             vec![
                 "--silent",
-                "ccusage@18.0.5",
+                "ccusage@18.0.6",
                 "daily",
                 "--json",
                 "--order",
@@ -2251,7 +2251,7 @@ mod tests {
             vec![
                 "-s",
                 "dlx",
-                "ccusage@18.0.5",
+                "ccusage@18.0.6",
                 "daily",
                 "--json",
                 "--order",
@@ -2269,7 +2269,7 @@ mod tests {
             vec![
                 "dlx",
                 "-q",
-                "ccusage@18.0.5",
+                "ccusage@18.0.6",
                 "daily",
                 "--json",
                 "--order",
@@ -2288,7 +2288,7 @@ mod tests {
             vec![
                 "exec",
                 "--yes",
-                "--package=ccusage@18.0.5",
+                "--package=ccusage@18.0.6",
                 "--",
                 "ccusage",
                 "daily",
@@ -2307,7 +2307,7 @@ mod tests {
             npx,
             vec![
                 "--yes",
-                "ccusage@18.0.5",
+                "ccusage@18.0.6",
                 "daily",
                 "--json",
                 "--order",
@@ -2336,7 +2336,7 @@ mod tests {
             vec![
                 "exec",
                 "--yes",
-                "--package=@ccusage/codex@18.0.5",
+                "--package=@ccusage/codex@18.0.6",
                 "--",
                 "ccusage-codex",
                 "daily",
@@ -2355,7 +2355,7 @@ mod tests {
             npx,
             vec![
                 "--yes",
-                "@ccusage/codex@18.0.5",
+                "@ccusage/codex@18.0.6",
                 "daily",
                 "--json",
                 "--order",


### PR DESCRIPTION
## Description

Updates the `ccusage` version used in the plugin engine to `v18.0.6`. This version includes a fix for GPT 5.3 Codex pricing calculations. The `CCUSAGE_CLAUDE_PACKAGE` and `CCUSAGE_CODEX_PACKAGE` constants, along with related test assertions and documentation, have been updated to reflect this change.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [ ] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass (specifically `bun vitest run`)
- [ ] I tested the change locally with `bun tauri dev`

## Screenshots

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

---
<p><a href="https://cursor.com/agents/bc-f6ca19ad-9815-4931-a535-ba44f98bea9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ca19ad-9815-4931-a535-ba44f98bea9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped ccusage to v18.0.6 to fix GPT 5.3 Codex pricing and keep docs/tests in sync.

- **Bug Fixes**
  - Use ccusage v18.0.6 to correct Codex pricing.
  - Update CCUSAGE_CLAUDE_PACKAGE and CCUSAGE_CODEX_PACKAGE to 18.0.6 with matching test updates.
  - Update plugin API docs to reflect the new pinned versions.

<sup>Written for commit 71fd3dc59cdd00fcc5c002b298de9a73f91ea092. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bump plus doc/test sync; behavior change is limited to which external CLI version is executed, with minimal impact on host logic.
> 
> **Overview**
> Updates the plugin engine’s pinned `ccusage` CLIs from `18.0.5` to `18.0.6` for both Claude (`ccusage`) and Codex (`@ccusage/codex`) when executing usage queries via package runners.
> 
> Adjusts the associated unit test expectations for runner arguments and updates the Host API docs to reflect the new pinned versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71fd3dc59cdd00fcc5c002b298de9a73f91ea092. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->