### PR TITLE
feat(cursor): align individual-account usage metric layout

### DIFF
--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -103,6 +103,47 @@ Returns whether user is in slow pool, feature gates, and allowed models. Respons
 
 Returns limit policy status plus any active credit grants. Response undocumented.
 
+### GET /api/usage?user=<id>
+
+Returns per-model request/token counters. OpenUsage currently uses this endpoint for the `Requests` metric only.
+
+Auth:
+- Requires `WorkosCursorSessionToken` cookie (derived from `user_id::access_token`).
+
+### GET /api/usage-summary
+
+Returns a higher-level usage summary for dashboard pages. Endpoint is cookie-authenticated and currently optional in OpenUsage for Cursor.
+
+### GET/POST /api/dashboard/get-current-period-usage
+
+Not used by OpenUsage. In local probing this endpoint is not reliably compatible with plugin auth flow (`500`/`403`).
+
+## Rendered Metrics (Individual Accounts)
+
+OpenUsage intentionally renders the following Cursor lines:
+
+- **Overview tab:** `Credits`, `Total usage`, `Requests`
+- **Detail tab adds:** `Auto + Composer`, `API`, `On-demand`
+
+### Endpoint-to-Metric Mapping
+
+| Metric label | Source endpoint | Source fields | Output format |
+|---|---|---|---|
+| `Credits` | `GetCreditGrantsBalance` | `usedCents`, `totalCents` | dollars progress |
+| `Total usage` | `GetCurrentPeriodUsage` | `planUsage.totalPercentUsed` (fallback: derived from `limit`/`remaining`) | percent progress |
+| `Requests` | `/api/usage?user=<id>` | aggregated `numRequestsTotal`/`numRequests` + `maxRequestUsage` | count progress (or text fallback if cap missing) |
+| `Auto + Composer` | `GetCurrentPeriodUsage` | `planUsage.autoPercentUsed` | percent progress |
+| `API` | `GetCurrentPeriodUsage` | `planUsage.apiPercentUsed` | percent progress |
+| `On-demand` | `GetCurrentPeriodUsage` | `spendLimitUsage.individualLimit`/`individualRemaining` (fallback pooled) | dollars progress |
+
+### Intentionally Excluded From UI
+
+The Cursor plugin currently does **not** render UI lines for:
+
+- `limitType`
+- `autoBucketModels`
+- per-model usage breakdown text (token/request model detail lines)
+
 ## Authentication
 
 ### Token Sources

--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -220,10 +220,10 @@
     return { userId: userId, sessionToken: userId + "%3A%3A" + accessToken }
   }
 
-  function fetchEnterpriseUsage(ctx, accessToken) {
+  function fetchRequestUsage(ctx, accessToken, logPrefix) {
     var session = buildSessionToken(ctx, accessToken)
     if (!session) {
-      ctx.host.log.warn("enterprise: cannot build session token")
+      ctx.host.log.warn(logPrefix + ": cannot build session token")
       return null
     }
     try {
@@ -236,41 +236,76 @@
         timeoutMs: 10000,
       })
       if (resp.status < 200 || resp.status >= 300) {
-        ctx.host.log.warn("enterprise usage returned status=" + resp.status)
+        ctx.host.log.warn(logPrefix + " request usage returned status=" + resp.status)
         return null
       }
       return ctx.util.tryParseJson(resp.bodyText)
     } catch (e) {
-      ctx.host.log.warn("enterprise usage fetch failed: " + String(e))
+      ctx.host.log.warn(logPrefix + " request usage fetch failed: " + String(e))
       return null
     }
   }
 
+  function summarizeRequestUsage(ctx, requestUsage) {
+    if (!requestUsage || typeof requestUsage !== "object") return null
+    var used = 0
+    var limit = 0
+    var hasUsage = false
+    var hasLimit = false
+
+    for (var key in requestUsage) {
+      if (!Object.prototype.hasOwnProperty.call(requestUsage, key)) continue
+      if (key === "startOfMonth") continue
+      var model = requestUsage[key]
+      if (!model || typeof model !== "object") continue
+
+      var modelUsed = null
+      if (typeof model.numRequestsTotal === "number" && Number.isFinite(model.numRequestsTotal)) {
+        modelUsed = model.numRequestsTotal
+      } else if (typeof model.numRequests === "number" && Number.isFinite(model.numRequests)) {
+        modelUsed = model.numRequests
+      }
+      if (typeof modelUsed === "number" && modelUsed >= 0) {
+        used += modelUsed
+        hasUsage = true
+      }
+
+      if (typeof model.maxRequestUsage === "number" && Number.isFinite(model.maxRequestUsage) && model.maxRequestUsage > 0) {
+        limit += model.maxRequestUsage
+        hasLimit = true
+      }
+    }
+
+    if (!hasUsage && !hasLimit) return null
+
+    var billingPeriodMs = 30 * 24 * 60 * 60 * 1000
+    var cycleStart = requestUsage.startOfMonth
+      ? ctx.util.parseDateMs(requestUsage.startOfMonth)
+      : null
+    var cycleEndMs = cycleStart ? cycleStart + billingPeriodMs : null
+
+    return {
+      used: used,
+      limit: hasLimit ? limit : null,
+      billingPeriodMs: billingPeriodMs,
+      cycleEndMs: cycleEndMs,
+    }
+  }
+
   function buildEnterpriseResult(ctx, accessToken, planName, usage) {
-    var requestUsage = fetchEnterpriseUsage(ctx, accessToken)
+    var requestUsage = fetchRequestUsage(ctx, accessToken, "enterprise")
+    var requestTotals = summarizeRequestUsage(ctx, requestUsage)
     var lines = []
 
-    if (requestUsage) {
-      var gpt4 = requestUsage["gpt-4"]
-      if (gpt4 && typeof gpt4.maxRequestUsage === "number" && gpt4.maxRequestUsage > 0) {
-        var used = gpt4.numRequests || 0
-        var limit = gpt4.maxRequestUsage
-
-        var billingPeriodMs = 30 * 24 * 60 * 60 * 1000
-        var cycleStart = requestUsage.startOfMonth
-          ? ctx.util.parseDateMs(requestUsage.startOfMonth)
-          : null
-        var cycleEndMs = cycleStart ? cycleStart + billingPeriodMs : null
-
-        lines.push(ctx.line.progress({
-          label: "Included requests",
-          used: used,
-          limit: limit,
-          format: { kind: "count", suffix: "requests" },
-          resetsAt: ctx.util.toIso(cycleEndMs),
-          periodDurationMs: billingPeriodMs,
-        }))
-      }
+    if (requestTotals && typeof requestTotals.limit === "number" && requestTotals.limit > 0) {
+      lines.push(ctx.line.progress({
+        label: "Requests",
+        used: requestTotals.used,
+        limit: requestTotals.limit,
+        format: { kind: "count", suffix: "requests" },
+        resetsAt: ctx.util.toIso(requestTotals.cycleEndMs),
+        periodDurationMs: requestTotals.billingPeriodMs,
+      }))
     }
 
     if (lines.length === 0) {
@@ -429,14 +464,19 @@
       }
     }
 
-    // Plan usage (always present) - fallback primary metric
-    // API may return totalSpend directly, or we calculate from limit - remaining
+    // Total usage (always present) - fallback primary metric
     if (typeof pu.limit !== "number") {
-      throw "Plan usage limit missing from API response."
+      throw "Total usage limit missing from API response."
     }
     const planUsed = typeof pu.totalSpend === "number"
       ? pu.totalSpend
       : pu.limit - (pu.remaining ?? 0)
+    const computedPercentUsed = pu.limit > 0
+      ? (planUsed / pu.limit) * 100
+      : 0
+    const totalUsagePercent = typeof pu.totalPercentUsed === "number"
+      ? pu.totalPercentUsed
+      : computedPercentUsed
 
     // Calculate billing cycle period duration
     // API returns timestamps as strings in milliseconds
@@ -448,16 +488,56 @@
     }
 
     lines.push(ctx.line.progress({
-      label: "Plan usage",
-      used: ctx.fmt.dollars(planUsed),
-      limit: ctx.fmt.dollars(pu.limit),
-      format: { kind: "dollars" },
+      label: "Total usage",
+      used: totalUsagePercent,
+      limit: 100,
+      format: { kind: "percent" },
       resetsAt: ctx.util.toIso(usage.billingCycleEnd),
       periodDurationMs: billingPeriodMs
     }))
 
-    if (typeof pu.bonusSpend === "number" && pu.bonusSpend > 0) {
-      lines.push(ctx.line.text({ label: "Bonus spend", value: "$" + String(ctx.fmt.dollars(pu.bonusSpend)) }))
+    // Requests (overview) - cap-aware progress when available, otherwise a text fallback.
+    var requestUsage = fetchRequestUsage(ctx, accessToken, "individual")
+    var requestTotals = summarizeRequestUsage(ctx, requestUsage)
+    if (requestTotals) {
+      if (typeof requestTotals.limit === "number" && requestTotals.limit > 0) {
+        lines.push(ctx.line.progress({
+          label: "Requests",
+          used: requestTotals.used,
+          limit: requestTotals.limit,
+          format: { kind: "count", suffix: "requests" },
+          resetsAt: ctx.util.toIso(requestTotals.cycleEndMs),
+          periodDurationMs: requestTotals.billingPeriodMs,
+        }))
+      } else {
+        lines.push(ctx.line.text({
+          label: "Requests",
+          value: String(Math.round(requestTotals.used)) + " requests"
+        }))
+      }
+    }
+
+    // Detail breakdown percentages
+    if (typeof pu.autoPercentUsed === "number" && Number.isFinite(pu.autoPercentUsed)) {
+      lines.push(ctx.line.progress({
+        label: "Auto + Composer",
+        used: pu.autoPercentUsed,
+        limit: 100,
+        format: { kind: "percent" },
+        resetsAt: ctx.util.toIso(usage.billingCycleEnd),
+        periodDurationMs: billingPeriodMs
+      }))
+    }
+
+    if (typeof pu.apiPercentUsed === "number" && Number.isFinite(pu.apiPercentUsed)) {
+      lines.push(ctx.line.progress({
+        label: "API",
+        used: pu.apiPercentUsed,
+        limit: 100,
+        format: { kind: "percent" },
+        resetsAt: ctx.util.toIso(usage.billingCycleEnd),
+        periodDurationMs: billingPeriodMs
+      }))
     }
 
     // On-demand (if available) - not a primary candidate

--- a/plugins/cursor/plugin.json
+++ b/plugins/cursor/plugin.json
@@ -12,8 +12,10 @@
   ],
   "lines": [
     { "type": "progress", "label": "Credits", "scope": "overview", "primaryOrder": 1 },
-    { "type": "progress", "label": "Plan usage", "scope": "overview", "primaryOrder": 2 },
-    { "type": "progress", "label": "Included requests", "scope": "overview", "primaryOrder": 3 },
+    { "type": "progress", "label": "Total usage", "scope": "overview", "primaryOrder": 2 },
+    { "type": "progress", "label": "Requests", "scope": "overview", "primaryOrder": 3 },
+    { "type": "progress", "label": "Auto + Composer", "scope": "detail" },
+    { "type": "progress", "label": "API", "scope": "detail" },
     { "type": "progress", "label": "On-demand", "scope": "detail" }
   ]
 }

--- a/plugins/cursor/plugin.test.js
+++ b/plugins/cursor/plugin.test.js
@@ -45,7 +45,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
     expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("cursor-access-token")
     expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("cursor-refresh-token")
   })
@@ -86,7 +86,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
     expect(ctx.host.keychain.writeGenericPassword).toHaveBeenCalledWith(
       "cursor-access-token",
       refreshedAccessToken
@@ -135,7 +135,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
     expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
 
@@ -200,7 +200,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.plan).toBe("Team")
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
   })
 
   it("throws on missing plan usage limit", async () => {
@@ -214,10 +214,10 @@ describe("cursor plugin", () => {
       }),
     })
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Plan usage limit missing")
+    expect(() => plugin.probe(ctx)).toThrow("Total usage limit missing")
   })
 
-  it("calculates planUsed from limit - remaining when totalSpend missing", async () => {
+  it("falls back to calculated total usage percent when totalPercentUsed missing", async () => {
     const ctx = makeCtx()
     ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
     ctx.host.http.request.mockReturnValue({
@@ -229,10 +229,10 @@ describe("cursor plugin", () => {
     })
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    const planLine = result.lines.find((l) => l.label === "Plan usage")
+    const planLine = result.lines.find((l) => l.label === "Total usage")
     expect(planLine).toBeTruthy()
-    // used = limit - remaining = 2400 - 1200 = 1200
-    expect(planLine.used).toBe(12) // ctx.fmt.dollars divides by 100
+    // used percent = (2400 - 1200) / 2400 * 100 = 50
+    expect(planLine.used).toBe(50)
   })
 
   it("renders usage + plan info", async () => {
@@ -258,7 +258,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.plan).toBeTruthy()
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
   })
 
   it("omits plan badge for blank plan names", async () => {
@@ -400,7 +400,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.plan).toBe("Enterprise")
-    const reqLine = result.lines.find((l) => l.label === "Included requests")
+    const reqLine = result.lines.find((l) => l.label === "Requests")
     expect(reqLine).toBeTruthy()
     expect(reqLine.used).toBe(422)
     expect(reqLine.limit).toBe(500)
@@ -488,7 +488,7 @@ describe("cursor plugin", () => {
     })
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
   })
 
   it("outputs Credits first when available", async () => {
@@ -522,13 +522,13 @@ describe("cursor plugin", () => {
     
     // Credits should be first in the lines array
     expect(result.lines[0].label).toBe("Credits")
-    expect(result.lines[1].label).toBe("Plan usage")
+    expect(result.lines[1].label).toBe("Total usage")
     // On-demand should come after
     const onDemandIndex = result.lines.findIndex((l) => l.label === "On-demand")
     expect(onDemandIndex).toBeGreaterThan(1)
   })
 
-  it("outputs Plan usage first when Credits not available", async () => {
+  it("outputs Total usage first when Credits not available", async () => {
     const ctx = makeCtx()
     ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
     ctx.host.http.request.mockImplementation((opts) => {
@@ -552,8 +552,83 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     
-    // Plan usage should be first when Credits not available
-    expect(result.lines[0].label).toBe("Plan usage")
+    // Total usage should be first when Credits not available
+    expect(result.lines[0].label).toBe("Total usage")
+  })
+
+  it("emits Auto + Composer and API percent lines when available", async () => {
+    const ctx = makeCtx()
+    ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            enabled: true,
+            billingCycleEnd: Date.now(),
+            planUsage: {
+              limit: 40000,
+              remaining: 32000,
+              totalPercentUsed: 20,
+              autoPercentUsed: 12.5,
+              apiPercentUsed: 7.5,
+            },
+          }),
+        }
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const totalLine = result.lines.find((line) => line.label === "Total usage")
+    const autoLine = result.lines.find((line) => line.label === "Auto + Composer")
+    const apiLine = result.lines.find((line) => line.label === "API")
+
+    expect(totalLine).toBeTruthy()
+    expect(totalLine.used).toBe(20)
+    expect(autoLine).toBeTruthy()
+    expect(autoLine.used).toBe(12.5)
+    expect(apiLine).toBeTruthy()
+    expect(apiLine.used).toBe(7.5)
+  })
+
+  it("falls back to text Requests line when request cap is unavailable", async () => {
+    const ctx = makeCtx()
+    const accessToken = makeJwt({ sub: "google-oauth2|user_abc123", exp: 9999999999 })
+    ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: accessToken }]))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            enabled: true,
+            billingCycleEnd: Date.now(),
+            planUsage: { limit: 40000, remaining: 36000, totalPercentUsed: 10 },
+          }),
+        }
+      }
+      if (String(opts.url).includes("cursor.com/api/usage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            "gpt-4": {
+              numRequestsTotal: 7,
+              maxRequestUsage: null,
+            },
+            startOfMonth: "2026-02-01T00:00:00.000Z",
+          }),
+        }
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const requestsLine = result.lines.find((line) => line.label === "Requests")
+    expect(requestsLine).toBeTruthy()
+    expect(requestsLine.type).toBe("text")
+    expect(requestsLine.value).toBe("7 requests")
   })
 
   it("refreshes token when expired and persists new access token", async () => {
@@ -591,7 +666,7 @@ describe("cursor plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
     expect(ctx.host.sqlite.exec).toHaveBeenCalled()
   })
 
@@ -671,7 +746,7 @@ describe("cursor plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
   })
 
   it("throws not logged in when only refresh token exists but refresh returns no access token", async () => {
@@ -803,7 +878,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.plan).toBe("Enterprise")
-    const reqLine = result.lines.find((l) => l.label === "Included requests")
+    const reqLine = result.lines.find((l) => l.label === "Requests")
     expect(reqLine).toBeTruthy()
     expect(reqLine.used).toBe(3)
     expect(reqLine.limit).toBe(10)
@@ -828,9 +903,9 @@ describe("cursor plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    const planLine = result.lines.find((line) => line.label === "Plan usage")
+    const planLine = result.lines.find((line) => line.label === "Total usage")
     expect(planLine).toBeTruthy()
-    expect(planLine.used).toBe(24)
+    expect(planLine.used).toBe(100)
     expect(result.lines.find((line) => line.label === "On-demand")).toBeUndefined()
   })
 
@@ -845,7 +920,7 @@ describe("cursor plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("retry failed")
   })
 
-  it("skips malformed credit grants payload and still returns plan usage", async () => {
+  it("skips malformed credit grants payload and still returns total usage", async () => {
     const ctx = makeCtx()
     ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
     ctx.host.http.request.mockImplementation((opts) => {
@@ -874,7 +949,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Credits")).toBeUndefined()
-    expect(result.lines.find((line) => line.label === "Plan usage")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
   })
 
   it("uses expired access token when refresh token is missing", async () => {
@@ -959,7 +1034,7 @@ describe("cursor plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    const reqLine = result.lines.find((line) => line.label === "Included requests")
+    const reqLine = result.lines.find((line) => line.label === "Requests")
     expect(reqLine).toBeTruthy()
     expect(reqLine.used).toBe(0)
     expect(reqLine.limit).toBe(10)
@@ -1045,7 +1120,7 @@ describe("cursor plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.plan).toBeNull()
-    expect(result.lines.find((line) => line.label === "Included requests")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Requests")).toBeTruthy()
   })
 
   it("wraps non-string retry wrapper errors as usage request failure", async () => {


### PR DESCRIPTION
## Description

- Align Cursor plugin metric output to the requested individual-account layout: Overview now surfaces `Credits`, `Total usage`, and `Requests`, while Detail adds `Auto + Composer`, `API`, and `On-demand`.
- Update Cursor runtime mapping to use `planUsage.totalPercentUsed` (with fallback), map auto/API percent fields, and render `Requests` from `usage?user` with a count-progress line when a cap is available and a text fallback otherwise.
- Refresh Cursor provider docs with endpoint compatibility, endpoint-to-metric mapping, and explicitly excluded fields (`limitType`, `autoBucketModels`, per-model stats).

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New provider plugin
- [x] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [ ] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [ ] I tested the change locally with `bun tauri dev`

Additional validation run:
- `bun run test "plugins/cursor/plugin.test.js"` passed (43/43).
- `bun run test:coverage` was executed; suite passed but command exits non-zero due existing repository coverage thresholds in unrelated files under `src/hooks/app/*` and `src/components/app/*`.

## Screenshots

Not applicable (no UI layout or visual component changes).

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches usage calculation and metric rendering for Cursor, including a new cookie-authenticated REST call and aggregation logic that could change displayed totals if the upstream payload format varies.
> 
> **Overview**
> Aligns Cursor individual-account output to a new layout: overview now shows **`Credits`**, **`Total usage`**, and **`Requests`**, while detail adds **`Auto + Composer`** and **`API`** (alongside `On-demand`).
> 
> Changes `Total usage` to render as a percent progress line sourced from `planUsage.totalPercentUsed` (with a computed fallback), and reworks `Requests` to pull from `/api/usage?user=<id>` by aggregating per-model request counts and optionally summing caps; if no cap is available it falls back to a text line. Updates docs to document the new REST endpoints, endpoint-to-metric mapping, and explicitly excluded fields, and adjusts tests/config (`plugin.json`) to match the renamed/added metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73fdc4c9933646a3eec745bbe8a2fb3374179489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Cursor plugin to the individual-account layout. Overview now shows Credits, Total usage, and Requests; Detail adds Auto + Composer and API, improving clarity and cap visibility.

- New Features
  - Render Total usage as a percent using planUsage.totalPercentUsed (fallback to computed percent).
  - Add Auto + Composer and API percent lines; keep On-demand in Detail.
  - Compute Requests from /api/usage?user by summing requests and caps; show count progress when a cap exists, else a simple “N requests” text.
  - Update Enterprise to use the same Requests label and logic.
  - Refresh provider docs with endpoint compatibility, metric mapping, and excluded fields.

<sup>Written for commit 73fdc4c9933646a3eec745bbe8a2fb3374179489. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

