### PR TITLE
fix(ccusage): centralize version pinning and add bump command

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -476,7 +476,7 @@ Returns a status envelope:
 
 ### Behavior
 
-- **Runtime runners**: Executes pinned `ccusage@18.0.6` (Claude) or `@ccusage/codex@18.0.6` (Codex) via fallback chain `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx`
+- **Runtime runners**: Executes pinned `ccusage@18.0.8` (Claude) or `@ccusage/codex@18.0.8` (Codex) via fallback chain `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx`
 - **Provider-aware**: Resolves provider from `opts.provider` or plugin id (`claude`/`codex`)
 - **No provider API calls**: Usage is computed from local JSONL session files; the host does not call Claude/Codex (or other provider) APIs, but package runners may contact a package registry to download the `ccusage` CLI if it is not already available locally
 - **Graceful degradation**: returns `no_runner` when no runner exists, `runner_failed` when execution fails

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:release": "./scripts/build-release.sh",
+    "ccusage:bump": "node ./scripts/bump-ccusage-version.mjs",
     "bundle:plugins": "bun copy-bundled.cjs",
     "preview": "vite preview",
     "test": "vitest",

--- a/scripts/bump-ccusage-version.mjs
+++ b/scripts/bump-ccusage-version.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const VERSION_RE = /^\d+\.\d+\.\d+$/;
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+const version = process.argv[2];
+if (!version) {
+  fail("missing version argument. Usage: bun run ccusage:bump -- <x.y.z>");
+}
+if (!VERSION_RE.test(version)) {
+  fail(`invalid version "${version}", expected x.y.z`);
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+
+const hostApiPath = path.join(repoRoot, "src-tauri/src/plugin_engine/host_api.rs");
+const docsPath = path.join(repoRoot, "docs/plugins/api.md");
+
+function replaceOnce(content, regex, replacement, missingMessage) {
+  if (!regex.test(content)) {
+    fail(missingMessage);
+  }
+  return content.replace(regex, replacement);
+}
+
+const hostApiSource = readFileSync(hostApiPath, "utf8");
+const updatedHostApiSource = replaceOnce(
+  hostApiSource,
+  /const CCUSAGE_VERSION: &str = "\d+\.\d+\.\d+";/,
+  `const CCUSAGE_VERSION: &str = "${version}";`,
+  "could not find CCUSAGE_VERSION constant in host_api.rs",
+);
+writeFileSync(hostApiPath, updatedHostApiSource);
+
+const docsSource = readFileSync(docsPath, "utf8");
+const docsAfterClaude = replaceOnce(
+  docsSource,
+  /ccusage@\d+\.\d+\.\d+/,
+  `ccusage@${version}`,
+  "could not find Claude ccusage pin in docs/plugins/api.md",
+);
+const docsAfterCodex = replaceOnce(
+  docsAfterClaude,
+  /@ccusage\/codex@\d+\.\d+\.\d+/,
+  `@ccusage/codex@${version}`,
+  "could not find Codex ccusage pin in docs/plugins/api.md",
+);
+writeFileSync(docsPath, docsAfterCodex);
+
+console.log(`Updated ccusage version to ${version}`);
+console.log(`- ${path.relative(repoRoot, hostApiPath)}`);
+console.log(`- ${path.relative(repoRoot, docsPath)}`);


### PR DESCRIPTION
## Description

Centralizes ccusage version management behind a single runtime constant and removes duplicated hardcoded pins across runner arg tests.
Also adds a one-command bump workflow and updates the pinned runtime version to 18.0.8.

- Add `CCUSAGE_VERSION` as the source of truth in `src-tauri/src/plugin_engine/host_api.rs` and derive provider package specs from it.
- Replace hardcoded version literals in ccusage runner-arg tests with expectations derived from shared package-spec helpers.
- Add `scripts/bump-ccusage-version.mjs` plus `bun run ccusage:bump -- <x.y.z>` to update runtime/docs pins together.
- Update docs runtime runner pin line to `ccusage@18.0.8` / `@ccusage/codex@18.0.8`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [x] Documentation
- [ ] Performance improvement
- [x] Other (describe below)

Other: maintenance ergonomics for future ccusage version bumps.

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [ ] I tested the change locally with `bun tauri dev`

## Screenshots

N/A (non-UI change)

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly maintenance/refactor and docs/script additions; runtime behavior change is limited to bumping the executed `ccusage`/`@ccusage/codex` version and how the package spec string is constructed.
> 
> **Overview**
> Updates the pinned runtime `ccusage` CLI version to `18.0.8` and centralizes package spec construction in `host_api.rs` via a single `CCUSAGE_VERSION` constant (deriving `ccusage@<ver>` / `@ccusage/codex@<ver>` at runtime instead of hardcoding per-provider strings).
> 
> Refactors ccusage runner-arg tests to build expected package specs from the shared helper, and adds a `ccusage:bump` script (`scripts/bump-ccusage-version.mjs`) to update both the Rust constant and the docs pin in one command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56badfea3e59c5108d4862fcbdb25d9c3a590cfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized ccusage version pinning behind a single constant and added a one-command bump workflow. Bumps the runtime to 18.0.8 and updates docs to prevent drift.

- **Refactors**
  - Introduced CCUSAGE_VERSION in host_api.rs and derive provider package specs from it.
  - Updated runner-arg tests to use shared package-spec helpers instead of hardcoded versions.

- **New Features**
  - Added scripts/bump-ccusage-version.mjs and package.json script ccusage:bump.
  - Usage: bun run ccusage:bump -- <x.y.z> updates both runtime and docs pins.

<sup>Written for commit 56badfea3e59c5108d4862fcbdb25d9c3a590cfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

