### PR TITLE
fix(cursor): prefer enterprise auth and handle missing limits

### DIFF
--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -503,6 +503,7 @@
 
     const needsFallbackWithoutPlanInfo = usage.enabled !== false &&
       (!hasPlanUsage || planUsageLimitMissing) &&
+      !hasTotalUsagePercent &&
       !normalizedPlanName &&
       planInfoUnavailable
     if (needsFallbackWithoutPlanInfo) {

--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -82,7 +82,29 @@
   function loadAuthState(ctx) {
     const sqliteAccessToken = readStateValue(ctx, "cursorAuth/accessToken")
     const sqliteRefreshToken = readStateValue(ctx, "cursorAuth/refreshToken")
+    const sqliteMembershipTypeRaw = readStateValue(ctx, "cursorAuth/stripeMembershipType")
+    const sqliteMembershipType = typeof sqliteMembershipTypeRaw === "string"
+      ? sqliteMembershipTypeRaw.trim().toLowerCase()
+      : null
+
+    const keychainAccessToken = readKeychainValue(ctx, KEYCHAIN_ACCESS_TOKEN_SERVICE)
+    const keychainRefreshToken = readKeychainValue(ctx, KEYCHAIN_REFRESH_TOKEN_SERVICE)
+
+    const sqliteSubject = getTokenSubject(ctx, sqliteAccessToken)
+    const keychainSubject = getTokenSubject(ctx, keychainAccessToken)
+    const hasDifferentSubjects = !!sqliteSubject && !!keychainSubject && sqliteSubject !== keychainSubject
+    const sqliteLooksFree = sqliteMembershipType === "free"
+
     if (sqliteAccessToken || sqliteRefreshToken) {
+      if ((keychainAccessToken || keychainRefreshToken) && sqliteLooksFree && hasDifferentSubjects) {
+        ctx.host.log.info("sqlite auth looks free and differs from keychain account; preferring keychain token")
+        return {
+          accessToken: keychainAccessToken,
+          refreshToken: keychainRefreshToken,
+          source: "keychain",
+        }
+      }
+
       return {
         accessToken: sqliteAccessToken,
         refreshToken: sqliteRefreshToken,
@@ -90,8 +112,6 @@
       }
     }
 
-    const keychainAccessToken = readKeychainValue(ctx, KEYCHAIN_ACCESS_TOKEN_SERVICE)
-    const keychainRefreshToken = readKeychainValue(ctx, KEYCHAIN_REFRESH_TOKEN_SERVICE)
     if (keychainAccessToken || keychainRefreshToken) {
       return {
         accessToken: keychainAccessToken,
@@ -105,6 +125,14 @@
       refreshToken: null,
       source: null,
     }
+  }
+
+  function getTokenSubject(ctx, token) {
+    if (!token) return null
+    const payload = ctx.jwt.decodePayload(token)
+    if (!payload || typeof payload.sub !== "string") return null
+    const subject = payload.sub.trim()
+    return subject || null
   }
 
   function persistAccessToken(ctx, source, accessToken) {
@@ -449,9 +477,18 @@
       ? planName.toLowerCase()
       : ""
 
-    // Enterprise and some Team request-based accounts return no planUsage from
-    // the Connect API. Detect them and use the REST usage API instead.
-    const needsRequestBasedFallback = usage.enabled !== false && !usage.planUsage && (
+    const hasPlanUsage = !!usage.planUsage
+    const hasPlanUsageLimit = hasPlanUsage &&
+      typeof usage.planUsage.limit === "number" &&
+      Number.isFinite(usage.planUsage.limit)
+    const planUsageLimitMissing = hasPlanUsage && !hasPlanUsageLimit
+    const hasTotalUsagePercent = hasPlanUsage &&
+      typeof usage.planUsage.totalPercentUsed === "number" &&
+      Number.isFinite(usage.planUsage.totalPercentUsed)
+
+    // Enterprise and some Team request-based accounts can return no planUsage
+    // or a planUsage object without limit from the Connect API.
+    const needsRequestBasedFallback = usage.enabled !== false && (!hasPlanUsage || planUsageLimitMissing) && (
       normalizedPlanName === "enterprise" ||
       normalizedPlanName === "team"
     )
@@ -465,12 +502,21 @@
     }
 
     const needsFallbackWithoutPlanInfo = usage.enabled !== false &&
-      !usage.planUsage &&
+      (!hasPlanUsage || planUsageLimitMissing) &&
       !normalizedPlanName &&
       planInfoUnavailable
     if (needsFallbackWithoutPlanInfo) {
       ctx.host.log.info("plan info unavailable with missing planUsage, attempting REST usage API fallback")
       return buildUnknownRequestBasedResult(ctx, accessToken, planName)
+    }
+
+    if (usage.enabled !== false && planUsageLimitMissing && !hasTotalUsagePercent) {
+      ctx.host.log.warn("planUsage.limit missing, attempting REST usage API fallback")
+      try {
+        return buildUnknownRequestBasedResult(ctx, accessToken, planName)
+      } catch (e) {
+        ctx.host.log.warn("REST usage fallback unavailable: " + String(e))
+      }
     }
 
     // Team plans may omit `enabled` even with valid plan usage data.
@@ -520,36 +566,21 @@
       }))
     }
 
-    const su = usage.spendLimitUsage
-    const isTeamAccount = (
-      normalizedPlanName === "team" ||
-      (su && su.limitType === "team") ||
-      (su && typeof su.pooledLimit === "number")
-    )
-    const hasFiniteLimit = typeof pu.limit === "number" && Number.isFinite(pu.limit)
-    const hasFinitePercent = Number.isFinite(pu.totalPercentUsed)
-
-    // Free/individual plans can be percent-only; team rendering still needs dollars.
-    if (isTeamAccount && !hasFiniteLimit) {
+    // Total usage (always present) - fallback primary metric
+    if (!hasPlanUsageLimit && !hasTotalUsagePercent) {
       throw "Total usage limit missing from API response."
     }
-    if (!isTeamAccount && !hasFiniteLimit && !hasFinitePercent) {
-      throw "Total usage limit missing from API response."
-    }
-
-    const planUsed = hasFiniteLimit
-      ? (typeof pu.totalSpend === "number" ? pu.totalSpend : pu.limit - (pu.remaining ?? 0))
-      : null
-    const computedPercentUsed = hasFiniteLimit
-      ? (pu.limit > 0 ? (planUsed / pu.limit) * 100 : 0)
-      : null
-    const totalUsagePercent = hasFinitePercent
+    const planUsed = hasPlanUsageLimit
+      ? (typeof pu.totalSpend === "number"
+        ? pu.totalSpend
+        : pu.limit - (pu.remaining ?? 0))
+      : 0
+    const computedPercentUsed = hasPlanUsageLimit && pu.limit > 0
+      ? (planUsed / pu.limit) * 100
+      : 0
+    const totalUsagePercent = hasTotalUsagePercent
       ? pu.totalPercentUsed
       : computedPercentUsed
-
-    if (!isTeamAccount && !hasFiniteLimit && hasFinitePercent) {
-      ctx.host.log.info("total usage limit missing; using totalPercentUsed for individual account")
-    }
 
     // Calculate billing cycle period duration
     var billingPeriodMs = 30 * 24 * 60 * 60 * 1000 // 30 days default
@@ -559,7 +590,18 @@
       billingPeriodMs = cycleEnd - cycleStart // already in ms
     }
 
+    const su = usage.spendLimitUsage
+    const isTeamAccount = (
+      normalizedPlanName === "team" ||
+      (su && su.limitType === "team") ||
+      (su && typeof su.pooledLimit === "number")
+    )
+
     if (isTeamAccount) {
+      if (!hasPlanUsageLimit) {
+        ctx.host.log.warn("team-inferred account missing planUsage.limit, attempting REST usage API fallback")
+        return buildUnknownRequestBasedResult(ctx, accessToken, planName)
+      }
       lines.push(ctx.line.progress({
         label: "Total usage",
         used: ctx.fmt.dollars(planUsed),

--- a/plugins/cursor/plugin.test.js
+++ b/plugins/cursor/plugin.test.js
@@ -319,6 +319,42 @@ describe("cursor plugin", () => {
     expect(totalLine.limit).toBe(100)
   })
 
+  it("renders percent-only usage when plan info is unavailable", async () => {
+    const ctx = makeCtx()
+    ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            enabled: true,
+            billingCycleStart: "1772556293029",
+            billingCycleEnd: "1775234693029",
+            planUsage: {
+              totalPercentUsed: 42,
+            },
+          }),
+        }
+      }
+      if (String(opts.url).includes("GetPlanInfo")) {
+        return { status: 503, bodyText: "" }
+      }
+      if (String(opts.url).includes("cursor.com/api/usage")) {
+        throw new Error("unexpected REST usage fallback")
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBeNull()
+    const totalLine = result.lines.find((line) => line.label === "Total usage")
+    expect(totalLine).toBeTruthy()
+    expect(totalLine.format).toEqual({ kind: "percent" })
+    expect(totalLine.used).toBe(42)
+    expect(totalLine.limit).toBe(100)
+  })
+
   it("falls back to computed percent when totalSpend missing and no totalPercentUsed", async () => {
     const ctx = makeCtx()
     ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))

--- a/plugins/cursor/plugin.test.js
+++ b/plugins/cursor/plugin.test.js
@@ -598,6 +598,56 @@ describe("cursor plugin", () => {
     expect(reqLine.limit).toBe(500)
   })
 
+  it("falls back to REST usage for team-inferred account with percent-only and unavailable plan info", async () => {
+    const ctx = makeCtx()
+    const accessToken = makeJwt({ sub: "google-oauth2|user_abc123", exp: 9999999999 })
+
+    ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: accessToken }]))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            enabled: true,
+            billingCycleStart: "1772556293029",
+            billingCycleEnd: "1775234693029",
+            planUsage: {
+              totalPercentUsed: 35,
+            },
+            spendLimitUsage: {
+              limitType: "team",
+              pooledLimit: 5000,
+            },
+          }),
+        }
+      }
+      if (String(opts.url).includes("GetPlanInfo")) {
+        return { status: 503, bodyText: "" }
+      }
+      if (String(opts.url).includes("cursor.com/api/usage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            "gpt-4": {
+              numRequests: 150,
+              maxRequestUsage: 500,
+            },
+            startOfMonth: "2026-02-01T06:12:57.000Z",
+          }),
+        }
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const reqLine = result.lines.find((l) => l.label === "Requests")
+    expect(reqLine).toBeTruthy()
+    expect(reqLine.used).toBe(150)
+    expect(reqLine.limit).toBe(500)
+    expect(reqLine.format).toEqual({ kind: "count", suffix: "requests" })
+  })
+
   it("handles team account with request-based usage", async () => {
     const ctx = makeCtx()
     const accessToken = makeJwt({ sub: "google-oauth2|user_abc123", exp: 9999999999 })

--- a/plugins/cursor/plugin.test.js
+++ b/plugins/cursor/plugin.test.js
@@ -136,7 +136,61 @@ describe("cursor plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
-    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("cursor-access-token")
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("cursor-refresh-token")
+  })
+
+  it("prefers keychain when sqlite looks free and token subjects differ", async () => {
+    const ctx = makeCtx()
+    const sqlitePayload = Buffer.from(
+      JSON.stringify({ exp: 9999999999, sub: "google-oauth2|sqlite-user" }),
+      "utf8"
+    )
+      .toString("base64")
+      .replace(/=+$/g, "")
+    const sqliteToken = `a.${sqlitePayload}.c`
+
+    const keychainPayload = Buffer.from(
+      JSON.stringify({ exp: 9999999999, sub: "auth0|keychain-user" }),
+      "utf8"
+    )
+      .toString("base64")
+      .replace(/=+$/g, "")
+    const keychainToken = `a.${keychainPayload}.c`
+
+    ctx.host.sqlite.query.mockImplementation((db, sql) => {
+      if (String(sql).includes("cursorAuth/accessToken")) {
+        return JSON.stringify([{ value: sqliteToken }])
+      }
+      if (String(sql).includes("cursorAuth/refreshToken")) {
+        return JSON.stringify([{ value: "sqlite-refresh-token" }])
+      }
+      if (String(sql).includes("cursorAuth/stripeMembershipType")) {
+        return JSON.stringify([{ value: "free" }])
+      }
+      return JSON.stringify([])
+    })
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "cursor-access-token") return keychainToken
+      if (service === "cursor-refresh-token") return "keychain-refresh-token"
+      return null
+    })
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        expect(opts.headers.Authorization).toBe("Bearer " + keychainToken)
+      }
+      return {
+        status: 200,
+        bodyText: JSON.stringify({
+          enabled: true,
+          planUsage: { totalSpend: 1200, limit: 2400 },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Total usage")).toBeTruthy()
   })
 
   it("throws on sqlite errors when reading token", async () => {
@@ -222,7 +276,7 @@ describe("cursor plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Total usage limit missing")
   })
 
-  it("accepts percent-only free plan usage when limit is omitted", async () => {
+  it("uses percent-only usage when totalPercentUsed exists but limit is missing", async () => {
     const ctx = makeCtx()
     ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
     ctx.host.http.request.mockImplementation((opts) => {
@@ -231,16 +285,12 @@ describe("cursor plugin", () => {
           status: 200,
           bodyText: JSON.stringify({
             enabled: true,
-            billingCycleStart: "1772707936000",
-            billingCycleEnd: "1775386336000",
+            billingCycleStart: "1772556293029",
+            billingCycleEnd: "1775234693029",
             planUsage: {
-              remainingBonus: false,
               autoPercentUsed: 0,
               apiPercentUsed: 0,
               totalPercentUsed: 0,
-            },
-            spendLimitUsage: {
-              limitType: "user",
             },
           }),
         }
@@ -249,74 +299,24 @@ describe("cursor plugin", () => {
         return {
           status: 200,
           bodyText: JSON.stringify({
-            planInfo: {
-              planName: "Free",
-              price: "Free",
-              billingCycleEnd: "1775386336000",
-            },
+            planInfo: { planName: "Free" },
           }),
         }
       }
-      if (String(opts.url).includes("GetCreditGrantsBalance")) {
-        return { status: 200, bodyText: "{}" }
-      }
-      if (String(opts.url).includes("cursor.com/api/auth/stripe")) {
-        return {
-          status: 200,
-          bodyText: JSON.stringify({
-            membershipType: "free",
-            customerBalance: 0,
-          }),
-        }
+      if (String(opts.url).includes("cursor.com/api/usage")) {
+        throw new Error("unexpected REST usage fallback")
       }
       return { status: 200, bodyText: "{}" }
     })
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    const totalLine = result.lines.find((line) => line.label === "Total usage")
     expect(result.plan).toBe("Free")
+    const totalLine = result.lines.find((line) => line.label === "Total usage")
     expect(totalLine).toBeTruthy()
     expect(totalLine.format).toEqual({ kind: "percent" })
     expect(totalLine.used).toBe(0)
     expect(totalLine.limit).toBe(100)
-  })
-
-  it("still throws for team usage when limit is omitted even if totalPercentUsed exists", async () => {
-    const ctx = makeCtx()
-    ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
-    ctx.host.http.request.mockImplementation((opts) => {
-      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
-        return {
-          status: 200,
-          bodyText: JSON.stringify({
-            billingCycleStart: "1772707936000",
-            billingCycleEnd: "1775386336000",
-            planUsage: {
-              totalPercentUsed: 42,
-            },
-            spendLimitUsage: {
-              limitType: "team",
-              pooledRemaining: 1000,
-            },
-          }),
-        }
-      }
-      if (String(opts.url).includes("GetPlanInfo")) {
-        return {
-          status: 200,
-          bodyText: JSON.stringify({
-            planInfo: {
-              planName: "Team",
-            },
-          }),
-        }
-      }
-      return { status: 200, bodyText: "{}" }
-    })
-
-    const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Total usage limit missing")
   })
 
   it("falls back to computed percent when totalSpend missing and no totalPercentUsed", async () => {
@@ -508,6 +508,58 @@ describe("cursor plugin", () => {
     expect(reqLine.used).toBe(422)
     expect(reqLine.limit).toBe(500)
     expect(reqLine.format).toEqual({ kind: "count", suffix: "requests" })
+  })
+
+  it("falls back to enterprise request-based usage when planUsage.limit is missing", async () => {
+    const ctx = makeCtx()
+    const accessToken = makeJwt({ sub: "google-oauth2|user_abc123", exp: 9999999999 })
+
+    ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: accessToken }]))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            enabled: true,
+            billingCycleStart: "1770539602363",
+            billingCycleEnd: "1770539602363",
+            planUsage: {
+              totalSpend: 1234,
+              totalPercentUsed: 12,
+            },
+          }),
+        }
+      }
+      if (String(opts.url).includes("GetPlanInfo")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            planInfo: { planName: "Enterprise" },
+          }),
+        }
+      }
+      if (String(opts.url).includes("cursor.com/api/usage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            "gpt-4": {
+              numRequests: 211,
+              maxRequestUsage: 500,
+            },
+            startOfMonth: "2026-02-01T06:12:57.000Z",
+          }),
+        }
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("Enterprise")
+    const reqLine = result.lines.find((line) => line.label === "Requests")
+    expect(reqLine).toBeTruthy()
+    expect(reqLine.used).toBe(211)
+    expect(reqLine.limit).toBe(500)
   })
 
   it("handles team account with request-based usage", async () => {


### PR DESCRIPTION
    This change fixes a multi-account Cursor edge case by preferring
    keychain auth when SQLite indicates a free account and the token
    subjects differ, ensuring enterprise usage is attributed to the
    correct account. It also handles percent-only usage payloads when
    planUsage.limit is missing, avoiding false errors while still
    rendering valid usage lines.

    Regression tests were added for both auth-source selection and
    missing-limit percent usage.

## Description

<!-- What does this PR do and why? -->

## Related Issue

<!-- Link to the issue this PR addresses: Fixes #123 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

<img width="303" height="137" alt="image" src="https://github.com/user-attachments/assets/93973ccd-fe96-4d9c-9670-33c2509dcd9a" />


## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My PR targets the `main` branch
- [ ] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a multi-account auth edge case by preferring keychain tokens when SQLite looks free and JWT subjects differ, so enterprise usage is attributed to the right account. Also handles Connect responses that omit `planUsage.limit` by using percent-only data when available and falling back to request-based metrics when needed, including team-inferred accounts.

- **Bug Fixes**
  - Prefer keychain auth when SQLite shows "free" and JWT subjects differ.
  - When `planUsage.limit` is missing: render percent usage if `totalPercentUsed` exists; otherwise fall back to REST request-based usage (Enterprise/Team, including team-inferred when plan info is unavailable).
  - Add regression tests for auth selection, percent-only handling (including missing plan info), enterprise missing-limit fallback, and team-inferred fallback.

<sup>Written for commit b821f34bd3a1b09153ec7d33a51399953105c1a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

