### PR TITLE
feat(claude): show Max 5x/20x tier in plan badge

### DIFF
--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -459,11 +459,11 @@
     const lines = []
     let plan = null
     if (creds.oauth.subscriptionType) {
-      var basePlan = ctx.fmt.planLabel(creds.oauth.subscriptionType)
+      const basePlan = ctx.fmt.planLabel(creds.oauth.subscriptionType)
       if (basePlan) {
-        var tierSuffix = ""
-        var rlt = String(creds.oauth.rateLimitTier || "")
-        var tierMatch = rlt.match(/(\d+)x/)
+        let tierSuffix = ""
+        const rlt = String(creds.oauth.rateLimitTier || "")
+        const tierMatch = rlt.match(/(\d+)x/)
         if (tierMatch) {
           tierSuffix = " " + tierMatch[1] + "x"
         }

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -92,9 +92,37 @@ describe("claude plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.plan).toBeTruthy()
+    expect(result.plan).toBe("Pro")
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
+  })
+
+  it("appends max rate limit tier to the plan label when present", async () => {
+    const runCase = async (rateLimitTier, expectedPlan) => {
+      const ctx = makeCtx()
+      ctx.host.fs.exists = () => true
+      ctx.host.fs.readText = () =>
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: "token",
+            subscriptionType: "max",
+            rateLimitTier,
+          },
+        })
+      ctx.host.http.request.mockReturnValue({
+        status: 200,
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      })
+
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx)
+      expect(result.plan).toBe(expectedPlan)
+    }
+
+    await runCase("claude_max_subscription_20x", "Max 20x")
+    await runCase("claude_max_subscription_5x", "Max 5x")
   })
 
   it("omits resetsAt when resets_at is missing", async () => {


### PR DESCRIPTION
## Summary
- Extract the multiplier (e.g. `5x`, `20x`) from `rateLimitTier` in oauth credentials and append it to the plan badge
- Badge now shows "Max 20x" or "Max 5x" instead of just "Max", making it easy to distinguish between Claude Code Max tiers

## Test plan
- [x] All 65 existing plugin tests pass
- [x] Verify badge shows "Max 20x" for a 20x account
- [ ] Verify badge shows "Max 5x" for a 5x account
- [ ] Verify badge shows just "Pro" for a pro account (no `rateLimitTier` with multiplier)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Claude Max multiplier in the plan badge by parsing the `(\d+)x` from `creds.oauth.rateLimitTier`. Badges now display "Max 20x" or "Max 5x"; non-Max plans like Pro remain unchanged.

<sup>Written for commit 19975bf67616553a05bde5c44742dfd2db6eda25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

