### PR TITLE
fix(ccusage): bump to v18.0.10

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -490,7 +490,7 @@ Returns a status envelope:
 
 ### Behavior
 
-- **Runtime runners**: Executes pinned `ccusage@18.0.8` (Claude) or `@ccusage/codex@18.0.8` (Codex) via fallback chain `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx`
+- **Runtime runners**: Executes pinned `ccusage@18.0.10` (Claude) or `@ccusage/codex@18.0.10` (Codex) via fallback chain `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx`
 - **Provider-aware**: Resolves provider from `opts.provider` or plugin id (`claude`/`codex`)
 - **No provider API calls**: Usage is computed from local JSONL session files; the host does not call Claude/Codex (or other provider) APIs, but package runners may contact a package registry to download the `ccusage` CLI if it is not already available locally
 - **Graceful degradation**: returns `no_runner` when no runner exists, `runner_failed` when execution fails

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -1166,7 +1166,7 @@ fn ls_parse_listening_ports(output: &str) -> Vec<i32> {
     ports.into_iter().collect()
 }
 
-const CCUSAGE_VERSION: &str = "18.0.8";
+const CCUSAGE_VERSION: &str = "18.0.10";
 const CCUSAGE_CLAUDE_PACKAGE_NAME: &str = "ccusage";
 const CCUSAGE_CODEX_PACKAGE_NAME: &str = "@ccusage/codex";
 const CCUSAGE_TIMEOUT_SECS: u64 = 15;


### PR DESCRIPTION
## Summary
- Bump pinned ccusage version from 18.0.8 to 18.0.10 (both `ccusage` and `@ccusage/codex`)
- Updates `CCUSAGE_VERSION` in `host_api.rs` and version pins in `docs/plugins/api.md`

## Test plan
- [x] All 890 tests pass
- [x] Coverage threshold miss (branches 89.83% < 90%) is pre-existing on main


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-pin change that only affects which `ccusage`/`@ccusage/codex` CLI release is executed for local usage queries; behavior depends on upstream CLI changes.
> 
> **Overview**
> Bumps the pinned `ccusage` and `@ccusage/codex` runtime CLI version from `18.0.8` to `18.0.10` for `host.ccusage.query` execution, and updates the corresponding version reference in the plugin Host API docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e62612ef6c6b94f73aac715a78c1285a3f7e3e84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump pinned `ccusage` and `@ccusage/codex` to v18.0.10 so runtime runners use the latest CLI and fixes.

Updates `CCUSAGE_VERSION` in `src-tauri/src/plugin_engine/host_api.rs` and the version reference in `docs/plugins/api.md`.

<sup>Written for commit e62612ef6c6b94f73aac715a78c1285a3f7e3e84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

