### PR TITLE
feat: add UI scale setting (Normal / Small / Compact)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,8 +59,8 @@ function App() {
     setResetTimerDisplayMode,
     setGlobalShortcut,
     setStartOnLogin,
-    compactMode,
-    setCompactMode,
+    uiScale,
+    setUIScale,
   } = useAppPreferencesStore(
     useShallow((state) => ({
       autoUpdateInterval: state.autoUpdateInterval,
@@ -75,8 +75,8 @@ function App() {
       setResetTimerDisplayMode: state.setResetTimerDisplayMode,
       setGlobalShortcut: state.setGlobalShortcut,
       setStartOnLogin: state.setStartOnLogin,
-      compactMode: state.compactMode,
-      setCompactMode: state.setCompactMode,
+      uiScale: state.uiScale,
+      setUIScale: state.setUIScale,
     }))
   )
 
@@ -125,14 +125,14 @@ function App() {
     setResetTimerDisplayMode,
     setGlobalShortcut,
     setStartOnLogin,
-    setCompactMode,
+    setUIScale,
     setLoadingForPlugins,
     setErrorForPlugins,
     startBatch,
   })
 
   useSettingsTheme(themeMode)
-  useSettingsCompact(compactMode)
+  useSettingsCompact(uiScale)
 
   const {
     handleThemeModeChange,
@@ -140,14 +140,14 @@ function App() {
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleMenubarIconStyleChange,
-    handleCompactModeChange,
+    handleUIScaleChange,
   } = useSettingsDisplayActions({
     setThemeMode,
     setDisplayMode,
     resetTimerDisplayMode,
     setResetTimerDisplayMode,
     setMenubarIconStyle,
-    setCompactMode,
+    setUIScale,
     scheduleTrayIconUpdate,
   })
 
@@ -259,7 +259,7 @@ function App() {
         traySettingsPreview,
         onGlobalShortcutChange: handleGlobalShortcutChange,
         onStartOnLoginChange: handleStartOnLoginChange,
-        onCompactModeChange: handleCompactModeChange,
+        onUIScaleChange: handleUIScaleChange,
       }}
     />
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { useSettingsPluginActions } from "@/hooks/app/use-settings-plugin-action
 import { useSettingsPluginList } from "@/hooks/app/use-settings-plugin-list"
 import { useSettingsSystemActions } from "@/hooks/app/use-settings-system-actions"
 import { useSettingsTheme } from "@/hooks/app/use-settings-theme"
-import { useSettingsCompact } from "@/hooks/app/use-settings-compact"
+import { useSettingsUIScale } from "@/hooks/app/use-settings-ui-scale"
 import { useTrayIcon } from "@/hooks/app/use-tray-icon"
 import { track } from "@/lib/analytics"
 import { REFRESH_COOLDOWN_MS, savePluginSettings } from "@/lib/settings"
@@ -132,7 +132,7 @@ function App() {
   })
 
   useSettingsTheme(themeMode)
-  useSettingsCompact(uiScale)
+  useSettingsUIScale(uiScale)
 
   const {
     handleThemeModeChange,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { useSettingsPluginActions } from "@/hooks/app/use-settings-plugin-action
 import { useSettingsPluginList } from "@/hooks/app/use-settings-plugin-list"
 import { useSettingsSystemActions } from "@/hooks/app/use-settings-system-actions"
 import { useSettingsTheme } from "@/hooks/app/use-settings-theme"
+import { useSettingsCompact } from "@/hooks/app/use-settings-compact"
 import { useTrayIcon } from "@/hooks/app/use-tray-icon"
 import { track } from "@/lib/analytics"
 import { REFRESH_COOLDOWN_MS, savePluginSettings } from "@/lib/settings"
@@ -58,6 +59,8 @@ function App() {
     setResetTimerDisplayMode,
     setGlobalShortcut,
     setStartOnLogin,
+    compactMode,
+    setCompactMode,
   } = useAppPreferencesStore(
     useShallow((state) => ({
       autoUpdateInterval: state.autoUpdateInterval,
@@ -72,6 +75,8 @@ function App() {
       setResetTimerDisplayMode: state.setResetTimerDisplayMode,
       setGlobalShortcut: state.setGlobalShortcut,
       setStartOnLogin: state.setStartOnLogin,
+      compactMode: state.compactMode,
+      setCompactMode: state.setCompactMode,
     }))
   )
 
@@ -120,12 +125,14 @@ function App() {
     setResetTimerDisplayMode,
     setGlobalShortcut,
     setStartOnLogin,
+    setCompactMode,
     setLoadingForPlugins,
     setErrorForPlugins,
     startBatch,
   })
 
   useSettingsTheme(themeMode)
+  useSettingsCompact(compactMode)
 
   const {
     handleThemeModeChange,
@@ -133,12 +140,14 @@ function App() {
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleMenubarIconStyleChange,
+    handleCompactModeChange,
   } = useSettingsDisplayActions({
     setThemeMode,
     setDisplayMode,
     resetTimerDisplayMode,
     setResetTimerDisplayMode,
     setMenubarIconStyle,
+    setCompactMode,
     scheduleTrayIconUpdate,
   })
 
@@ -250,6 +259,7 @@ function App() {
         traySettingsPreview,
         onGlobalShortcutChange: handleGlobalShortcutChange,
         onStartOnLoginChange: handleStartOnLoginChange,
+        onCompactModeChange: handleCompactModeChange,
       }}
     />
   )

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -14,6 +14,7 @@ import type {
   MenubarIconStyle,
   ResetTimerDisplayMode,
   ThemeMode,
+  UIScale,
 } from "@/lib/settings"
 
 type AppContentDerivedProps = {
@@ -35,7 +36,7 @@ export type AppContentActionProps = {
   traySettingsPreview: TraySettingsPreview
   onGlobalShortcutChange: (value: GlobalShortcut) => void
   onStartOnLoginChange: (value: boolean) => void
-  onCompactModeChange: (value: boolean) => void
+  onUIScaleChange: (value: UIScale) => void
 }
 
 export type AppContentProps = AppContentDerivedProps & AppContentActionProps
@@ -56,7 +57,7 @@ export function AppContent({
   traySettingsPreview,
   onGlobalShortcutChange,
   onStartOnLoginChange,
-  onCompactModeChange,
+  onUIScaleChange,
 }: AppContentProps) {
   const { activeView } = useAppUiStore(
     useShallow((state) => ({
@@ -72,7 +73,7 @@ export function AppContent({
     globalShortcut,
     themeMode,
     startOnLogin,
-    compactMode,
+    uiScale,
   } = useAppPreferencesStore(
     useShallow((state) => ({
       displayMode: state.displayMode,
@@ -82,7 +83,7 @@ export function AppContent({
       globalShortcut: state.globalShortcut,
       themeMode: state.themeMode,
       startOnLogin: state.startOnLogin,
-      compactMode: state.compactMode,
+      uiScale: state.uiScale,
     }))
   )
 
@@ -119,8 +120,8 @@ export function AppContent({
         onGlobalShortcutChange={onGlobalShortcutChange}
         startOnLogin={startOnLogin}
         onStartOnLoginChange={onStartOnLoginChange}
-        compactMode={compactMode}
-        onCompactModeChange={onCompactModeChange}
+        uiScale={uiScale}
+        onUIScaleChange={onUIScaleChange}
       />
     )
   }

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -35,6 +35,7 @@ export type AppContentActionProps = {
   traySettingsPreview: TraySettingsPreview
   onGlobalShortcutChange: (value: GlobalShortcut) => void
   onStartOnLoginChange: (value: boolean) => void
+  onCompactModeChange: (value: boolean) => void
 }
 
 export type AppContentProps = AppContentDerivedProps & AppContentActionProps
@@ -55,6 +56,7 @@ export function AppContent({
   traySettingsPreview,
   onGlobalShortcutChange,
   onStartOnLoginChange,
+  onCompactModeChange,
 }: AppContentProps) {
   const { activeView } = useAppUiStore(
     useShallow((state) => ({
@@ -70,6 +72,7 @@ export function AppContent({
     globalShortcut,
     themeMode,
     startOnLogin,
+    compactMode,
   } = useAppPreferencesStore(
     useShallow((state) => ({
       displayMode: state.displayMode,
@@ -79,6 +82,7 @@ export function AppContent({
       globalShortcut: state.globalShortcut,
       themeMode: state.themeMode,
       startOnLogin: state.startOnLogin,
+      compactMode: state.compactMode,
     }))
   )
 
@@ -115,6 +119,8 @@ export function AppContent({
         onGlobalShortcutChange={onGlobalShortcutChange}
         startOnLogin={startOnLogin}
         onStartOnLoginChange={onStartOnLoginChange}
+        compactMode={compactMode}
+        onCompactModeChange={onCompactModeChange}
       />
     )
   }

--- a/src/hooks/app/use-settings-bootstrap.test.ts
+++ b/src/hooks/app/use-settings-bootstrap.test.ts
@@ -17,6 +17,7 @@ const {
   loadResetTimerDisplayModeMock,
   loadStartOnLoginMock,
   loadThemeModeMock,
+  loadUIScaleMock,
   migrateLegacyTraySettingsMock,
   normalizePluginSettingsMock,
   savePluginSettingsMock,
@@ -36,6 +37,7 @@ const {
   loadResetTimerDisplayModeMock: vi.fn(),
   loadStartOnLoginMock: vi.fn(),
   loadThemeModeMock: vi.fn(),
+  loadUIScaleMock: vi.fn(),
   migrateLegacyTraySettingsMock: vi.fn(),
   normalizePluginSettingsMock: vi.fn(),
   savePluginSettingsMock: vi.fn(),
@@ -61,6 +63,7 @@ vi.mock("@/lib/settings", () => ({
   DEFAULT_RESET_TIMER_DISPLAY_MODE: "relative",
   DEFAULT_START_ON_LOGIN: false,
   DEFAULT_THEME_MODE: "system",
+  DEFAULT_UI_SCALE: "normal",
   getEnabledPluginIds: getEnabledPluginIdsMock,
   loadAutoUpdateInterval: loadAutoUpdateIntervalMock,
   loadDisplayMode: loadDisplayModeMock,
@@ -70,6 +73,7 @@ vi.mock("@/lib/settings", () => ({
   loadResetTimerDisplayMode: loadResetTimerDisplayModeMock,
   loadStartOnLogin: loadStartOnLoginMock,
   loadThemeMode: loadThemeModeMock,
+  loadUIScale: loadUIScaleMock,
   migrateLegacyTraySettings: migrateLegacyTraySettingsMock,
   normalizePluginSettings: normalizePluginSettingsMock,
   savePluginSettings: savePluginSettingsMock,
@@ -88,6 +92,7 @@ function createArgs() {
     setGlobalShortcut: vi.fn(),
     setStartOnLogin: vi.fn(),
     setMenubarIconStyle: vi.fn(),
+    setUIScale: vi.fn(),
     setLoadingForPlugins: vi.fn(),
     setErrorForPlugins: vi.fn(),
     startBatch: vi.fn().mockResolvedValue(undefined),
@@ -111,6 +116,7 @@ describe("useSettingsBootstrap", () => {
     loadResetTimerDisplayModeMock.mockReset()
     loadStartOnLoginMock.mockReset()
     loadThemeModeMock.mockReset()
+    loadUIScaleMock.mockReset()
     migrateLegacyTraySettingsMock.mockReset()
     normalizePluginSettingsMock.mockReset()
     savePluginSettingsMock.mockReset()
@@ -137,6 +143,7 @@ describe("useSettingsBootstrap", () => {
     loadGlobalShortcutMock.mockResolvedValue("CommandOrControl+Shift+O")
     loadMenubarIconStyleMock.mockResolvedValue("provider")
     loadStartOnLoginMock.mockResolvedValue(true)
+    loadUIScaleMock.mockResolvedValue("normal")
     migrateLegacyTraySettingsMock.mockResolvedValue(undefined)
     savePluginSettingsMock.mockResolvedValue(undefined)
     getEnabledPluginIdsMock.mockReturnValue(["codex"])
@@ -150,6 +157,25 @@ describe("useSettingsBootstrap", () => {
 
     expect(disableAutostartMock).toHaveBeenCalledTimes(1)
     expect(enableAutostartMock).not.toHaveBeenCalled()
+  })
+
+  it("falls back to default UI scale when loading fails", async () => {
+    const uiScaleError = new Error("ui scale unavailable")
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    loadUIScaleMock.mockRejectedValueOnce(uiScaleError)
+    const args = createArgs()
+
+    renderHook(() => useSettingsBootstrap(args))
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to load UI scale:",
+        uiScaleError
+      )
+      expect(args.setUIScale).toHaveBeenCalledWith("normal")
+    })
+
+    errorSpy.mockRestore()
   })
 
   it("falls back to default reset timer mode when loading fails", async () => {

--- a/src/hooks/app/use-settings-bootstrap.ts
+++ b/src/hooks/app/use-settings-bootstrap.ts
@@ -9,6 +9,7 @@ import type { PluginMeta } from "@/lib/plugin-types"
 import {
   arePluginSettingsEqual,
   DEFAULT_AUTO_UPDATE_INTERVAL,
+  DEFAULT_COMPACT_MODE,
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
@@ -17,6 +18,7 @@ import {
   DEFAULT_THEME_MODE,
   getEnabledPluginIds,
   loadAutoUpdateInterval,
+  loadCompactMode,
   loadDisplayMode,
   loadGlobalShortcut,
   loadMenubarIconStyle,
@@ -46,6 +48,7 @@ type UseSettingsBootstrapArgs = {
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setCompactMode: (value: boolean) => void
   setLoadingForPlugins: (ids: string[]) => void
   setErrorForPlugins: (ids: string[], error: string) => void
   startBatch: (pluginIds?: string[]) => Promise<string[] | undefined>
@@ -61,6 +64,7 @@ export function useSettingsBootstrap({
   setGlobalShortcut,
   setStartOnLogin,
   setMenubarIconStyle,
+  setCompactMode,
   setLoadingForPlugins,
   setErrorForPlugins,
   startBatch,
@@ -153,6 +157,13 @@ export function useSettingsBootstrap({
           console.error("Failed to load menubar icon style:", error)
         }
 
+        let storedCompactMode = DEFAULT_COMPACT_MODE
+        try {
+          storedCompactMode = await loadCompactMode()
+        } catch (error) {
+          console.error("Failed to load compact mode:", error)
+        }
+
         if (isMounted) {
           setPluginSettings(normalized)
           setAutoUpdateInterval(storedInterval)
@@ -162,6 +173,7 @@ export function useSettingsBootstrap({
           setGlobalShortcut(storedGlobalShortcut)
           setStartOnLogin(storedStartOnLogin)
           setMenubarIconStyle(storedMenubarIconStyle)
+          setCompactMode(storedCompactMode)
 
           const enabledIds = getEnabledPluginIds(normalized)
           setLoadingForPlugins(enabledIds)
@@ -187,6 +199,7 @@ export function useSettingsBootstrap({
   }, [
     applyStartOnLogin,
     setAutoUpdateInterval,
+    setCompactMode,
     setDisplayMode,
     setErrorForPlugins,
     setGlobalShortcut,

--- a/src/hooks/app/use-settings-bootstrap.ts
+++ b/src/hooks/app/use-settings-bootstrap.ts
@@ -9,7 +9,7 @@ import type { PluginMeta } from "@/lib/plugin-types"
 import {
   arePluginSettingsEqual,
   DEFAULT_AUTO_UPDATE_INTERVAL,
-  DEFAULT_COMPACT_MODE,
+  DEFAULT_UI_SCALE,
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
@@ -18,7 +18,7 @@ import {
   DEFAULT_THEME_MODE,
   getEnabledPluginIds,
   loadAutoUpdateInterval,
-  loadCompactMode,
+  loadUIScale,
   loadDisplayMode,
   loadGlobalShortcut,
   loadMenubarIconStyle,
@@ -36,6 +36,7 @@ import {
   type PluginSettings,
   type ResetTimerDisplayMode,
   type ThemeMode,
+  type UIScale,
 } from "@/lib/settings"
 
 type UseSettingsBootstrapArgs = {
@@ -48,7 +49,7 @@ type UseSettingsBootstrapArgs = {
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
-  setCompactMode: (value: boolean) => void
+  setUIScale: (value: UIScale) => void
   setLoadingForPlugins: (ids: string[]) => void
   setErrorForPlugins: (ids: string[], error: string) => void
   startBatch: (pluginIds?: string[]) => Promise<string[] | undefined>
@@ -64,7 +65,7 @@ export function useSettingsBootstrap({
   setGlobalShortcut,
   setStartOnLogin,
   setMenubarIconStyle,
-  setCompactMode,
+  setUIScale,
   setLoadingForPlugins,
   setErrorForPlugins,
   startBatch,
@@ -157,11 +158,11 @@ export function useSettingsBootstrap({
           console.error("Failed to load menubar icon style:", error)
         }
 
-        let storedCompactMode = DEFAULT_COMPACT_MODE
+        let storedUIScale = DEFAULT_UI_SCALE
         try {
-          storedCompactMode = await loadCompactMode()
+          storedUIScale = await loadUIScale()
         } catch (error) {
-          console.error("Failed to load compact mode:", error)
+          console.error("Failed to load UI scale:", error)
         }
 
         if (isMounted) {
@@ -173,7 +174,7 @@ export function useSettingsBootstrap({
           setGlobalShortcut(storedGlobalShortcut)
           setStartOnLogin(storedStartOnLogin)
           setMenubarIconStyle(storedMenubarIconStyle)
-          setCompactMode(storedCompactMode)
+          setUIScale(storedUIScale)
 
           const enabledIds = getEnabledPluginIds(normalized)
           setLoadingForPlugins(enabledIds)
@@ -199,7 +200,7 @@ export function useSettingsBootstrap({
   }, [
     applyStartOnLogin,
     setAutoUpdateInterval,
-    setCompactMode,
+    setUIScale,
     setDisplayMode,
     setErrorForPlugins,
     setGlobalShortcut,

--- a/src/hooks/app/use-settings-compact.ts
+++ b/src/hooks/app/use-settings-compact.ts
@@ -1,7 +1,10 @@
 import { useEffect } from "react"
+import type { UIScale } from "@/lib/settings"
 
-export function useSettingsCompact(compactMode: boolean) {
+export function useSettingsCompact(uiScale: UIScale) {
   useEffect(() => {
-    document.documentElement.classList.toggle("compact", compactMode)
-  }, [compactMode])
+    const root = document.documentElement
+    root.classList.remove("small", "compact")
+    if (uiScale !== "normal") root.classList.add(uiScale)
+  }, [uiScale])
 }

--- a/src/hooks/app/use-settings-compact.ts
+++ b/src/hooks/app/use-settings-compact.ts
@@ -1,0 +1,7 @@
+import { useEffect } from "react"
+
+export function useSettingsCompact(compactMode: boolean) {
+  useEffect(() => {
+    document.documentElement.classList.toggle("compact", compactMode)
+  }, [compactMode])
+}

--- a/src/hooks/app/use-settings-display-actions.test.ts
+++ b/src/hooks/app/use-settings-display-actions.test.ts
@@ -6,11 +6,13 @@ const {
   saveDisplayModeMock,
   saveResetTimerDisplayModeMock,
   saveThemeModeMock,
+  saveUIScaleMock,
 } = vi.hoisted(() => ({
   trackMock: vi.fn(),
   saveThemeModeMock: vi.fn(),
   saveDisplayModeMock: vi.fn(),
   saveResetTimerDisplayModeMock: vi.fn(),
+  saveUIScaleMock: vi.fn(),
 }))
 
 vi.mock("@/lib/analytics", () => ({
@@ -21,6 +23,7 @@ vi.mock("@/lib/settings", () => ({
   saveThemeMode: saveThemeModeMock,
   saveDisplayMode: saveDisplayModeMock,
   saveResetTimerDisplayMode: saveResetTimerDisplayModeMock,
+  saveUIScale: saveUIScaleMock,
 }))
 
 import { useSettingsDisplayActions } from "@/hooks/app/use-settings-display-actions"
@@ -31,15 +34,18 @@ describe("useSettingsDisplayActions", () => {
     saveThemeModeMock.mockReset()
     saveDisplayModeMock.mockReset()
     saveResetTimerDisplayModeMock.mockReset()
+    saveUIScaleMock.mockReset()
     saveThemeModeMock.mockResolvedValue(undefined)
     saveDisplayModeMock.mockResolvedValue(undefined)
     saveResetTimerDisplayModeMock.mockResolvedValue(undefined)
+    saveUIScaleMock.mockResolvedValue(undefined)
   })
 
   it("tracks and applies display-related setting changes", () => {
     const setThemeMode = vi.fn()
     const setDisplayMode = vi.fn()
     const setResetTimerDisplayMode = vi.fn()
+    const setUIScale = vi.fn()
     const scheduleTrayIconUpdate = vi.fn()
 
     const { result } = renderHook(() =>
@@ -48,6 +54,7 @@ describe("useSettingsDisplayActions", () => {
         setDisplayMode,
         resetTimerDisplayMode: "relative",
         setResetTimerDisplayMode,
+        setUIScale,
         scheduleTrayIconUpdate,
       })
     )
@@ -88,6 +95,7 @@ describe("useSettingsDisplayActions", () => {
           setDisplayMode: vi.fn(),
           resetTimerDisplayMode: mode,
           setResetTimerDisplayMode,
+          setUIScale: vi.fn(),
           scheduleTrayIconUpdate: vi.fn(),
         }),
       { initialProps: { mode: "relative" as const } }
@@ -120,6 +128,7 @@ describe("useSettingsDisplayActions", () => {
         setDisplayMode: vi.fn(),
         resetTimerDisplayMode: "relative",
         setResetTimerDisplayMode: vi.fn(),
+        setUIScale: vi.fn(),
         scheduleTrayIconUpdate: vi.fn(),
       })
     )
@@ -137,5 +146,31 @@ describe("useSettingsDisplayActions", () => {
     })
 
     errorSpy.mockRestore()
+  })
+
+  it("tracks and persists UI scale change", async () => {
+    const setUIScale = vi.fn()
+
+    const { result } = renderHook(() =>
+      useSettingsDisplayActions({
+        setThemeMode: vi.fn(),
+        setDisplayMode: vi.fn(),
+        resetTimerDisplayMode: "relative",
+        setResetTimerDisplayMode: vi.fn(),
+        setUIScale,
+        scheduleTrayIconUpdate: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.handleUIScaleChange("compact")
+    })
+
+    expect(trackMock).toHaveBeenCalledWith("setting_changed", { setting: "ui_scale", value: "compact" })
+    expect(setUIScale).toHaveBeenCalledWith("compact")
+
+    await waitFor(() => {
+      expect(saveUIScaleMock).toHaveBeenCalledWith("compact")
+    })
   })
 })

--- a/src/hooks/app/use-settings-display-actions.ts
+++ b/src/hooks/app/use-settings-display-actions.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react"
 import { track } from "@/lib/analytics"
 import {
+  saveCompactMode,
   saveDisplayMode,
   saveMenubarIconStyle,
   saveResetTimerDisplayMode,
@@ -19,6 +20,7 @@ type UseSettingsDisplayActionsArgs = {
   resetTimerDisplayMode: ResetTimerDisplayMode
   setResetTimerDisplayMode: (value: ResetTimerDisplayMode) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setCompactMode: (value: boolean) => void
   scheduleTrayIconUpdate: ScheduleTrayIconUpdate
 }
 
@@ -28,6 +30,7 @@ export function useSettingsDisplayActions({
   resetTimerDisplayMode,
   setResetTimerDisplayMode,
   setMenubarIconStyle,
+  setCompactMode,
   scheduleTrayIconUpdate,
 }: UseSettingsDisplayActionsArgs) {
   const handleThemeModeChange = useCallback((mode: ThemeMode) => {
@@ -69,11 +72,20 @@ export function useSettingsDisplayActions({
     })
   }, [scheduleTrayIconUpdate, setMenubarIconStyle])
 
+  const handleCompactModeChange = useCallback((value: boolean) => {
+    track("setting_changed", { setting: "compact_mode", value: String(value) })
+    setCompactMode(value)
+    void saveCompactMode(value).catch((error) => {
+      console.error("Failed to save compact mode:", error)
+    })
+  }, [setCompactMode])
+
   return {
     handleThemeModeChange,
     handleDisplayModeChange,
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleMenubarIconStyleChange,
+    handleCompactModeChange,
   }
 }

--- a/src/hooks/app/use-settings-display-actions.ts
+++ b/src/hooks/app/use-settings-display-actions.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react"
 import { track } from "@/lib/analytics"
 import {
-  saveCompactMode,
+  saveUIScale,
   saveDisplayMode,
   saveMenubarIconStyle,
   saveResetTimerDisplayMode,
@@ -10,6 +10,7 @@ import {
   type MenubarIconStyle,
   type ResetTimerDisplayMode,
   type ThemeMode,
+  type UIScale,
 } from "@/lib/settings"
 
 type ScheduleTrayIconUpdate = (reason: "probe" | "settings" | "init", delayMs?: number) => void
@@ -20,7 +21,7 @@ type UseSettingsDisplayActionsArgs = {
   resetTimerDisplayMode: ResetTimerDisplayMode
   setResetTimerDisplayMode: (value: ResetTimerDisplayMode) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
-  setCompactMode: (value: boolean) => void
+  setUIScale: (value: UIScale) => void
   scheduleTrayIconUpdate: ScheduleTrayIconUpdate
 }
 
@@ -30,7 +31,7 @@ export function useSettingsDisplayActions({
   resetTimerDisplayMode,
   setResetTimerDisplayMode,
   setMenubarIconStyle,
-  setCompactMode,
+  setUIScale,
   scheduleTrayIconUpdate,
 }: UseSettingsDisplayActionsArgs) {
   const handleThemeModeChange = useCallback((mode: ThemeMode) => {
@@ -72,13 +73,13 @@ export function useSettingsDisplayActions({
     })
   }, [scheduleTrayIconUpdate, setMenubarIconStyle])
 
-  const handleCompactModeChange = useCallback((value: boolean) => {
-    track("setting_changed", { setting: "compact_mode", value: String(value) })
-    setCompactMode(value)
-    void saveCompactMode(value).catch((error) => {
-      console.error("Failed to save compact mode:", error)
+  const handleUIScaleChange = useCallback((value: UIScale) => {
+    track("setting_changed", { setting: "ui_scale", value })
+    setUIScale(value)
+    void saveUIScale(value).catch((error) => {
+      console.error("Failed to save UI scale:", error)
     })
-  }, [setCompactMode])
+  }, [setUIScale])
 
   return {
     handleThemeModeChange,
@@ -86,6 +87,6 @@ export function useSettingsDisplayActions({
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleMenubarIconStyleChange,
-    handleCompactModeChange,
+    handleUIScaleChange,
   }
 }

--- a/src/hooks/app/use-settings-ui-scale.ts
+++ b/src/hooks/app/use-settings-ui-scale.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react"
 import type { UIScale } from "@/lib/settings"
 
-export function useSettingsCompact(uiScale: UIScale) {
+export function useSettingsUIScale(uiScale: UIScale) {
   useEffect(() => {
     const root = document.documentElement
     root.classList.remove("small", "compact")

--- a/src/index.css
+++ b/src/index.css
@@ -140,6 +140,11 @@
   }
 }
 
+/* Compact mode: reduce font size and spacing globally */
+html.compact {
+  font-size: 13px;
+}
+
 /* Panel-specific styles for transparent Tauri window */
 html,
 body,

--- a/src/index.css
+++ b/src/index.css
@@ -140,9 +140,12 @@
   }
 }
 
-/* Compact mode: reduce font size and spacing globally */
+/* UI scale: reduce font size and spacing globally */
+html.small {
+  font-size: 14px;
+}
 html.compact {
-  font-size: 13px;
+  font-size: 11px;
 }
 
 /* Panel-specific styles for transparent Tauri window */

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -33,6 +33,7 @@ const LEGACY_TRAY_ICON_STYLE_KEY = "trayIconStyle";
 const LEGACY_TRAY_SHOW_PERCENTAGE_KEY = "trayShowPercentage";
 const GLOBAL_SHORTCUT_KEY = "globalShortcut";
 const START_ON_LOGIN_KEY = "startOnLogin";
+const COMPACT_MODE_KEY = "compactMode";
 
 export const DEFAULT_AUTO_UPDATE_INTERVAL: AutoUpdateIntervalMinutes = 15;
 export const DEFAULT_THEME_MODE: ThemeMode = "system";
@@ -41,6 +42,7 @@ export const DEFAULT_RESET_TIMER_DISPLAY_MODE: ResetTimerDisplayMode = "relative
 export const DEFAULT_MENUBAR_ICON_STYLE: MenubarIconStyle = "provider";
 export const DEFAULT_GLOBAL_SHORTCUT: GlobalShortcut = null;
 export const DEFAULT_START_ON_LOGIN = false;
+export const DEFAULT_COMPACT_MODE = false;
 
 const AUTO_UPDATE_INTERVALS: AutoUpdateIntervalMinutes[] = [5, 15, 30, 60];
 const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
@@ -301,5 +303,16 @@ export async function loadStartOnLogin(): Promise<boolean> {
 
 export async function saveStartOnLogin(value: boolean): Promise<void> {
   await store.set(START_ON_LOGIN_KEY, value);
+  await store.save();
+}
+
+export async function loadCompactMode(): Promise<boolean> {
+  const stored = await store.get<unknown>(COMPACT_MODE_KEY);
+  if (typeof stored === "boolean") return stored;
+  return DEFAULT_COMPACT_MODE;
+}
+
+export async function saveCompactMode(value: boolean): Promise<void> {
+  await store.set(COMPACT_MODE_KEY, value);
   await store.save();
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -33,7 +33,7 @@ const LEGACY_TRAY_ICON_STYLE_KEY = "trayIconStyle";
 const LEGACY_TRAY_SHOW_PERCENTAGE_KEY = "trayShowPercentage";
 const GLOBAL_SHORTCUT_KEY = "globalShortcut";
 const START_ON_LOGIN_KEY = "startOnLogin";
-const COMPACT_MODE_KEY = "compactMode";
+const UI_SCALE_KEY = "uiScale";
 
 export const DEFAULT_AUTO_UPDATE_INTERVAL: AutoUpdateIntervalMinutes = 15;
 export const DEFAULT_THEME_MODE: ThemeMode = "system";
@@ -42,7 +42,14 @@ export const DEFAULT_RESET_TIMER_DISPLAY_MODE: ResetTimerDisplayMode = "relative
 export const DEFAULT_MENUBAR_ICON_STYLE: MenubarIconStyle = "provider";
 export const DEFAULT_GLOBAL_SHORTCUT: GlobalShortcut = null;
 export const DEFAULT_START_ON_LOGIN = false;
-export const DEFAULT_COMPACT_MODE = false;
+export type UIScale = "normal" | "small" | "compact";
+export const DEFAULT_UI_SCALE: UIScale = "normal";
+const UI_SCALE_VALUES: UIScale[] = ["normal", "small", "compact"];
+export const UI_SCALE_OPTIONS: { value: UIScale; label: string }[] = [
+  { value: "normal", label: "Normal" },
+  { value: "small", label: "Small" },
+  { value: "compact", label: "Compact" },
+];
 
 const AUTO_UPDATE_INTERVALS: AutoUpdateIntervalMinutes[] = [5, 15, 30, 60];
 const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
@@ -306,13 +313,13 @@ export async function saveStartOnLogin(value: boolean): Promise<void> {
   await store.save();
 }
 
-export async function loadCompactMode(): Promise<boolean> {
-  const stored = await store.get<unknown>(COMPACT_MODE_KEY);
-  if (typeof stored === "boolean") return stored;
-  return DEFAULT_COMPACT_MODE;
+export async function loadUIScale(): Promise<UIScale> {
+  const stored = await store.get<unknown>(UI_SCALE_KEY);
+  if (typeof stored === "string" && UI_SCALE_VALUES.includes(stored as UIScale)) return stored as UIScale;
+  return DEFAULT_UI_SCALE;
 }
 
-export async function saveCompactMode(value: boolean): Promise<void> {
-  await store.set(COMPACT_MODE_KEY, value);
+export async function saveUIScale(value: UIScale): Promise<void> {
+  await store.set(UI_SCALE_KEY, value);
   await store.save();
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -313,9 +313,13 @@ export async function saveStartOnLogin(value: boolean): Promise<void> {
   await store.save();
 }
 
+export function isUIScale(value: unknown): value is UIScale {
+  return typeof value === "string" && UI_SCALE_VALUES.includes(value as UIScale);
+}
+
 export async function loadUIScale(): Promise<UIScale> {
   const stored = await store.get<unknown>(UI_SCALE_KEY);
-  if (typeof stored === "string" && UI_SCALE_VALUES.includes(stored as UIScale)) return stored as UIScale;
+  if (isUIScale(stored)) return stored;
   return DEFAULT_UI_SCALE;
 }
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -270,6 +270,8 @@ interface SettingsPageProps {
   onGlobalShortcutChange: (value: GlobalShortcut) => void;
   startOnLogin: boolean;
   onStartOnLoginChange: (value: boolean) => void;
+  compactMode: boolean;
+  onCompactModeChange: (value: boolean) => void;
 }
 
 export function SettingsPage({
@@ -291,6 +293,8 @@ export function SettingsPage({
   onGlobalShortcutChange,
   startOnLogin,
   onStartOnLoginChange,
+  compactMode,
+  onCompactModeChange,
 }: SettingsPageProps) {
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -482,6 +486,20 @@ export function SettingsPage({
             onCheckedChange={(checked) => onStartOnLoginChange(checked === true)}
           />
           Start on login
+        </label>
+      </section>
+      <section>
+        <h3 className="text-lg font-semibold mb-0">Compact Mode</h3>
+        <p className="text-sm text-muted-foreground mb-2">
+          Smaller text and tighter spacing
+        </p>
+        <label className="flex items-center gap-2 text-sm select-none text-foreground">
+          <Checkbox
+            key={`compact-mode-${compactMode}`}
+            checked={compactMode}
+            onCheckedChange={(checked) => onCompactModeChange(checked === true)}
+          />
+          Compact mode
         </label>
       </section>
       <section>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -26,12 +26,14 @@ import {
   MENUBAR_ICON_STYLE_OPTIONS,
   RESET_TIMER_DISPLAY_OPTIONS,
   THEME_OPTIONS,
+  UI_SCALE_OPTIONS,
   type AutoUpdateIntervalMinutes,
   type DisplayMode,
   type GlobalShortcut,
   type MenubarIconStyle,
   type ResetTimerDisplayMode,
   type ThemeMode,
+  type UIScale,
 } from "@/lib/settings";
 import type { TraySettingsPreview } from "@/hooks/app/use-tray-icon";
 import { cn } from "@/lib/utils";
@@ -270,8 +272,8 @@ interface SettingsPageProps {
   onGlobalShortcutChange: (value: GlobalShortcut) => void;
   startOnLogin: boolean;
   onStartOnLoginChange: (value: boolean) => void;
-  compactMode: boolean;
-  onCompactModeChange: (value: boolean) => void;
+  uiScale: UIScale;
+  onUIScaleChange: (value: UIScale) => void;
 }
 
 export function SettingsPage({
@@ -293,8 +295,8 @@ export function SettingsPage({
   onGlobalShortcutChange,
   startOnLogin,
   onStartOnLoginChange,
-  compactMode,
-  onCompactModeChange,
+  uiScale,
+  onUIScaleChange,
 }: SettingsPageProps) {
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -489,18 +491,31 @@ export function SettingsPage({
         </label>
       </section>
       <section>
-        <h3 className="text-lg font-semibold mb-0">Compact Mode</h3>
+        <h3 className="text-lg font-semibold mb-0">UI Scale</h3>
         <p className="text-sm text-muted-foreground mb-2">
-          Smaller text and tighter spacing
+          Adjust text size and spacing
         </p>
-        <label className="flex items-center gap-2 text-sm select-none text-foreground">
-          <Checkbox
-            key={`compact-mode-${compactMode}`}
-            checked={compactMode}
-            onCheckedChange={(checked) => onCompactModeChange(checked === true)}
-          />
-          Compact mode
-        </label>
+        <div className="bg-muted/50 rounded-lg p-1">
+          <div className="flex gap-1" role="radiogroup" aria-label="UI scale">
+            {UI_SCALE_OPTIONS.map((option) => {
+              const isActive = option.value === uiScale;
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  variant={isActive ? "default" : "outline"}
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => onUIScaleChange(option.value)}
+                >
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
       </section>
       <section>
         <h3 className="text-lg font-semibold mb-0">Plugins</h3>

--- a/src/stores/app-preferences-store.ts
+++ b/src/stores/app-preferences-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand"
 import {
   DEFAULT_AUTO_UPDATE_INTERVAL,
+  DEFAULT_COMPACT_MODE,
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
@@ -23,6 +24,7 @@ type AppPreferencesStore = {
   globalShortcut: GlobalShortcut
   startOnLogin: boolean
   menubarIconStyle: MenubarIconStyle
+  compactMode: boolean
   setAutoUpdateInterval: (value: AutoUpdateIntervalMinutes) => void
   setThemeMode: (value: ThemeMode) => void
   setDisplayMode: (value: DisplayMode) => void
@@ -30,6 +32,7 @@ type AppPreferencesStore = {
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setCompactMode: (value: boolean) => void
   resetState: () => void
 }
 
@@ -41,6 +44,7 @@ const initialState = {
   globalShortcut: DEFAULT_GLOBAL_SHORTCUT,
   startOnLogin: DEFAULT_START_ON_LOGIN,
   menubarIconStyle: DEFAULT_MENUBAR_ICON_STYLE,
+  compactMode: DEFAULT_COMPACT_MODE,
 }
 
 export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
@@ -52,5 +56,6 @@ export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
   setGlobalShortcut: (value) => set({ globalShortcut: value }),
   setStartOnLogin: (value) => set({ startOnLogin: value }),
   setMenubarIconStyle: (value) => set({ menubarIconStyle: value }),
+  setCompactMode: (value) => set({ compactMode: value }),
   resetState: () => set(initialState),
 }))

--- a/src/stores/app-preferences-store.ts
+++ b/src/stores/app-preferences-store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand"
 import {
   DEFAULT_AUTO_UPDATE_INTERVAL,
-  DEFAULT_COMPACT_MODE,
+  DEFAULT_UI_SCALE,
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
@@ -10,6 +10,7 @@ import {
   DEFAULT_THEME_MODE,
   type AutoUpdateIntervalMinutes,
   type DisplayMode,
+  type UIScale,
   type GlobalShortcut,
   type MenubarIconStyle,
   type ResetTimerDisplayMode,
@@ -24,7 +25,7 @@ type AppPreferencesStore = {
   globalShortcut: GlobalShortcut
   startOnLogin: boolean
   menubarIconStyle: MenubarIconStyle
-  compactMode: boolean
+  uiScale: UIScale
   setAutoUpdateInterval: (value: AutoUpdateIntervalMinutes) => void
   setThemeMode: (value: ThemeMode) => void
   setDisplayMode: (value: DisplayMode) => void
@@ -32,7 +33,7 @@ type AppPreferencesStore = {
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
-  setCompactMode: (value: boolean) => void
+  setUIScale: (value: UIScale) => void
   resetState: () => void
 }
 
@@ -44,7 +45,7 @@ const initialState = {
   globalShortcut: DEFAULT_GLOBAL_SHORTCUT,
   startOnLogin: DEFAULT_START_ON_LOGIN,
   menubarIconStyle: DEFAULT_MENUBAR_ICON_STYLE,
-  compactMode: DEFAULT_COMPACT_MODE,
+  uiScale: DEFAULT_UI_SCALE,
 }
 
 export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
@@ -56,6 +57,6 @@ export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
   setGlobalShortcut: (value) => set({ globalShortcut: value }),
   setStartOnLogin: (value) => set({ startOnLogin: value }),
   setMenubarIconStyle: (value) => set({ menubarIconStyle: value }),
-  setCompactMode: (value) => set({ compactMode: value }),
+  setUIScale: (value) => set({ uiScale: value }),
   resetState: () => set(initialState),
 }))


### PR DESCRIPTION
## Summary

Adds a **UI Scale** setting with three options — Normal, Small, and Compact — that adjusts font size and spacing across the entire UI.

- Setting lives in **Settings → UI Scale** as a radio button group (matching existing settings style)
- Preference persists across restarts via Tauri's `LazyStore`
- Scales all `rem`-based font sizes and spacing proportionally via a single CSS rule:
  - **Normal** — default (16px)
  - **Small** — 14px
  - **Compact** — 11px

## Screenshots

| Normal | Small | Compact |
|:---:|:---:|:---:|
| <img width="400" height="764" alt="Normal" src="https://github.com/user-attachments/assets/21ab78c6-0599-4bf9-bcff-9ecfe04e8000" /> | <img width="400" height="760" alt="Small" src="https://github.com/user-attachments/assets/c76c95fb-73a8-40f1-920a-c4a630687625" /> | <img width="400" height="755" alt="Compact" src="https://github.com/user-attachments/assets/d15cb6c6-5ba9-4dcf-a63f-6677852e74f7" /> |

## Implementation

- `src/lib/settings.ts` — `UIScale` type, `UI_SCALE_OPTIONS`, `loadUIScale` / `saveUIScale`
- `src/stores/app-preferences-store.ts` — `uiScale` state + `setUIScale`
- `src/hooks/app/use-settings-compact.ts` — applies `small` or `compact` class on `<html>`
- `src/hooks/app/use-settings-bootstrap.ts` — loads setting on startup
- `src/hooks/app/use-settings-display-actions.ts` — `handleUIScaleChange`
- `src/index.css` — `html.small { font-size: 14px }`, `html.compact { font-size: 11px }`
- `src/pages/settings.tsx` — UI Scale section with Normal / Small / Compact radio buttons

## Test plan

- [x] Select Small — UI immediately scales down slightly
- [x] Select Compact — UI scales down more noticeably
- [x] Select Normal — UI returns to default
- [x] Restart app — preference persists