### PR TITLE
feat(copilot): show raw request counts for premium interactions

### DIFF
--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -83,11 +83,12 @@ X-Github-Api-Version: 2025-04-01
 
 ## Displayed Lines
 
-| Line         | Tier | Description                              |
-|--------------|------|------------------------------------------|
-| Premium      | Paid | Premium interactions remaining (percent) |
-| Chat         | Both | Chat messages remaining                  |
-| Completions  | Free | Code completions remaining               |
+| Line           | Tier | Description                                          |
+|----------------|------|------------------------------------------------------|
+| Premium        | Paid | Premium interactions remaining (percent)             |
+| Requests Used  | Paid | Premium requests used vs. entitlement (e.g. 60 / 300)|
+| Chat           | Both | Chat messages remaining                              |
+| Completions    | Free | Code completions remaining                           |
 
 All progress lines include:
 - `resetsAt` — ISO timestamp of next quota reset

--- a/plugins/copilot/plugin.js
+++ b/plugins/copilot/plugin.js
@@ -225,6 +225,16 @@
       );
       if (premiumLine) lines.push(premiumLine);
 
+      // Show raw request counts for premium interactions
+      const pi = snapshots.premium_interactions;
+      if (pi && typeof pi.entitlement === "number" && typeof pi.remaining === "number" && pi.entitlement > 0) {
+        var used = pi.entitlement - pi.remaining;
+        lines.push(ctx.line.text({
+          label: "Requests Used",
+          value: String(Math.max(0, used)) + " / " + String(pi.entitlement),
+        }));
+      }
+
       const chatLine = makeProgressLine(
         ctx,
         "Chat",

--- a/plugins/copilot/plugin.json
+++ b/plugins/copilot/plugin.json
@@ -8,6 +8,7 @@
   "brandColor": "#A855F7",
   "lines": [
     { "type": "progress", "label": "Premium", "scope": "overview", "primaryOrder": 1 },
+    { "type": "text", "label": "Requests Used", "scope": "detail" },
     { "type": "progress", "label": "Chat", "scope": "overview", "primaryOrder": 2 },
     { "type": "progress", "label": "Completions", "scope": "overview" }
   ]

--- a/plugins/copilot/plugin.test.js
+++ b/plugins/copilot/plugin.test.js
@@ -179,6 +179,82 @@ describe("copilot plugin", () => {
     expect(chat.used).toBe(5); // 100 - 95
   });
 
+  it("shows Requests Used text line for paid tier", async () => {
+    const ctx = makePluginTestContext();
+    setKeychainToken(ctx, "tok");
+    mockUsageOk(ctx);
+    const plugin = await loadPlugin();
+    const result = plugin.probe(ctx);
+    const reqLine = result.lines.find((l) => l.label === "Requests Used");
+    expect(reqLine).toBeTruthy();
+    expect(reqLine.type).toBe("text");
+    expect(reqLine.value).toBe("60 / 300"); // 300 - 240 = 60
+  });
+
+  it("omits Requests Used when entitlement/remaining are missing", async () => {
+    const ctx = makePluginTestContext();
+    setKeychainToken(ctx, "tok");
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify(
+        makeUsageResponse({
+          quota_snapshots: {
+            premium_interactions: {
+              percent_remaining: 80,
+              quota_id: "premium",
+            },
+          },
+        }),
+      ),
+    });
+    const plugin = await loadPlugin();
+    const result = plugin.probe(ctx);
+    expect(result.lines.find((l) => l.label === "Requests Used")).toBeFalsy();
+  });
+
+  it("clamps Requests Used to 0 when remaining exceeds entitlement", async () => {
+    const ctx = makePluginTestContext();
+    setKeychainToken(ctx, "tok");
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify(
+        makeUsageResponse({
+          quota_snapshots: {
+            premium_interactions: {
+              percent_remaining: 120,
+              entitlement: 300,
+              remaining: 360,
+              quota_id: "premium",
+            },
+          },
+        }),
+      ),
+    });
+    const plugin = await loadPlugin();
+    const result = plugin.probe(ctx);
+    const reqLine = result.lines.find((l) => l.label === "Requests Used");
+    expect(reqLine).toBeTruthy();
+    expect(reqLine.value).toBe("0 / 300");
+  });
+
+  it("omits Requests Used for free tier", async () => {
+    const ctx = makePluginTestContext();
+    setKeychainToken(ctx, "tok");
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        copilot_plan: "individual",
+        access_type_sku: "free_limited_copilot",
+        limited_user_quotas: { chat: 410, completions: 4000 },
+        monthly_quotas: { chat: 500, completions: 4000 },
+        limited_user_reset_date: "2026-02-11",
+      }),
+    });
+    const plugin = await loadPlugin();
+    const result = plugin.probe(ctx);
+    expect(result.lines.find((l) => l.label === "Requests Used")).toBeFalsy();
+  });
+
   it("renders only Premium when Chat is missing", async () => {
     const ctx = makePluginTestContext();
     setKeychainToken(ctx, "tok");


### PR DESCRIPTION
## Description

Adds a **Requests Used** text line (e.g. `60 / 300`) to the Copilot plugin detail view. This gives users visibility into their exact premium request consumption alongside the existing percentage-based progress bar.

Copilot uses a request-based quota system, but the current plugin only shows "80% remaining" — which is ambiguous without knowing the total. This PR surfaces the raw counts already present in the API response (`entitlement` and `remaining` from `premium_interactions`), requiring no additional API calls.

**Scope:** Paid tier only. Free tier is unaffected. The line is scoped to `detail` in `plugin.json` so it doesn't clutter the overview.

## Related Issue

N/A — enhancement request.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass (935/935)
- [ ] I tested the change locally with `bun tauri dev`

4 new tests added:
- Verifies `Requests Used` text line present with value `60 / 300` for default paid-tier fixture
- Verifies absent when `entitlement`/`remaining` fields are missing from snapshot
- Verifies clamping when `remaining > entitlement` (shows `0 / N`)
- Verifies absent for free tier

## Screenshots

No UI changes — this is a plugin-only change. The frontend already renders `text` lines as label/value pairs.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Requests Used" text line to the Copilot plugin, showing exact premium request consumption (e.g., 60 / 300) alongside the Premium progress bar. This gives paid users clear usage numbers without extra API calls.

- **New Features**
  - Computes used = entitlement − remaining from `premium_interactions` and clamps at 0.
  - Shown only for paid tier and only in the detail view to avoid clutter.
  - Updated provider docs and added tests for presence, absence, clamping, and free tier exclusion.

<sup>Written for commit b90578d8dabbeaadaaf57e5032b523aaceb34261. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

