### PR TITLE
fix: guard WKPreferences.inactiveSchedulingPolicy behind macOS 14.0+ runtime check

### DIFF
--- a/src-tauri/src/webkit_config.rs
+++ b/src-tauri/src/webkit_config.rs
@@ -5,11 +5,23 @@
 
 use tauri::Manager;
 
+/// Returns true if the running macOS version is at least `major.minor`.
+fn macos_at_least(major: u64, minor: u64) -> bool {
+    let info = objc2_foundation::NSProcessInfo::processInfo();
+    let version = info.operatingSystemVersion();
+    (version.majorVersion as u64, version.minorVersion as u64) >= (major, minor)
+}
+
 pub fn disable_webview_suspension(app_handle: &tauri::AppHandle) {
     let Some(window) = app_handle.get_webview_window("main") else {
         log::warn!("webkit_config: main window not found");
         return;
     };
+
+    if !macos_at_least(14, 0) {
+        log::info!("WebKit inactiveSchedulingPolicy requires macOS 14.0+; skipping on this system");
+        return;
+    }
 
     if let Err(e) = window.with_webview(|webview| {
         unsafe {


### PR DESCRIPTION
## Summary

OpenUsage crashes on launch on macOS 13.x (Ventura) with:

```
[WKPreferences setInactiveSchedulingPolicy:]: unrecognized selector sent to instance
```

`WKPreferences.setInactiveSchedulingPolicy` was introduced in macOS 14.0 (Sonoma). The current code in `webkit_config.rs` calls it unconditionally, which sends an unrecognized selector on older systems and causes an immediate abort.

## Changes

- Added a lightweight runtime version check using `NSProcessInfo.operatingSystemVersion` (already available via the `objc2-foundation` dependency)
- On macOS 14.0+: behavior is **completely unchanged** — `setInactiveSchedulingPolicy(.none)` is called as before
- On macOS <14.0: the call is skipped with an informational log message
- App Nap prevention (`app_nap.rs`) is unaffected and continues to work on all macOS versions

The change is minimal (12 lines added, 0 removed from the original logic) and introduces no new dependencies.

## Test plan

- [x] Verified the app launches and runs correctly on macOS 13.7 Ventura (Darwin 22.6.0, Intel x86_64)
- [x] Confirmed `cargo build --release` compiles without warnings
- [ ] Verify no regression on macOS 14.x / 15.x (the guarded path preserves original behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch crash on macOS 13 by guarding `WKPreferences.setInactiveSchedulingPolicy` behind a macOS 14.0+ runtime check. macOS 14+ behavior is unchanged.

- **Bug Fixes**
  - Added a runtime check via `NSProcessInfo.operatingSystemVersion` (from `objc2-foundation`).
  - Skip the call and log on macOS <14 to avoid the "unrecognized selector" crash.
  - App Nap prevention remains unchanged.
  - No new dependencies; change limited to `src-tauri/src/webkit_config.rs`.

<sup>Written for commit e8c6647e5ad30642c5efc9c913f81ddb4752f1c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

