### PR TITLE
Fix Claude plugin auth compatibility across custom OAuth and keychain setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ tmpcov-gem
 # Agent working files
 docs/choices.md
 docs/breadcrumbs.md
+docs/superpowers/
 docs/specs/*
 plans/*
 package-lock.json

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -200,6 +200,35 @@
     return KEYCHAIN_SERVICE_PREFIX + getOauthConfig(ctx).oauthFileSuffix + "-credentials"
   }
 
+  function readKeychainCredentialText(ctx, service) {
+    const keychain = ctx.host.keychain
+    if (!keychain) return null
+
+    if (typeof keychain.readGenericPasswordForCurrentUser === "function") {
+      try {
+        const value = keychain.readGenericPasswordForCurrentUser(service)
+        if (value) {
+          return { value, source: "keychain-current-user" }
+        }
+      } catch (e) {
+        ctx.host.log.info("current-user keychain read failed, trying legacy lookup: " + String(e))
+      }
+    }
+
+    if (typeof keychain.readGenericPassword !== "function") return null
+
+    try {
+      const value = keychain.readGenericPassword(service)
+      if (value) {
+        return { value, source: "keychain-legacy" }
+      }
+    } catch (e) {
+      ctx.host.log.info("keychain read failed (may not exist): " + String(e))
+    }
+
+    return null
+  }
+
   function loadStoredCredentials(ctx, suppressMissingWarn) {
     const credFile = getClaudeCredentialsPath(ctx)
     // Try file first
@@ -221,21 +250,17 @@
     }
 
     // Try keychain fallback
-    try {
-      const keychainValue = ctx.host.keychain.readGenericPassword(getClaudeKeychainService(ctx))
-      if (keychainValue) {
-        const parsed = tryParseCredentialJSON(ctx, keychainValue)
-        if (parsed) {
-          const oauth = parsed.claudeAiOauth
-          if (oauth && oauth.accessToken) {
-            ctx.host.log.info("credentials loaded from keychain")
-            return { oauth, source: "keychain", fullData: parsed }
-          }
+    const keychainResult = readKeychainCredentialText(ctx, getClaudeKeychainService(ctx))
+    if (keychainResult && keychainResult.value) {
+      const parsed = tryParseCredentialJSON(ctx, keychainResult.value)
+      if (parsed) {
+        const oauth = parsed.claudeAiOauth
+        if (oauth && oauth.accessToken) {
+          ctx.host.log.info("credentials loaded from keychain")
+          return { oauth, source: keychainResult.source, fullData: parsed }
         }
-        ctx.host.log.warn("keychain has data but no valid oauth")
       }
-    } catch (e) {
-      ctx.host.log.info("keychain read failed (may not exist): " + String(e))
+      ctx.host.log.warn("keychain has data but no valid oauth")
     }
 
     if (!suppressMissingWarn) {
@@ -282,7 +307,17 @@
       } catch (e) {
         ctx.host.log.error("Failed to write Claude credentials file: " + String(e))
       }
-    } else if (source === "keychain") {
+    } else if (source === "keychain-current-user") {
+      try {
+        if (typeof ctx.host.keychain.writeGenericPasswordForCurrentUser === "function") {
+          ctx.host.keychain.writeGenericPasswordForCurrentUser(getClaudeKeychainService(ctx), text)
+        } else {
+          ctx.host.keychain.writeGenericPassword(getClaudeKeychainService(ctx), text)
+        }
+      } catch (e) {
+        ctx.host.log.error("Failed to write Claude credentials keychain: " + String(e))
+      }
+    } else if (source === "keychain-legacy" || source === "keychain") {
       try {
         ctx.host.keychain.writeGenericPassword(getClaudeKeychainService(ctx), text)
       } catch (e) {

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -1,10 +1,13 @@
 (function () {
-  const CRED_FILE = "~/.claude/.credentials.json"
-  const KEYCHAIN_SERVICE = "Claude Code-credentials"
-  const USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
-  const REFRESH_URL = "https://platform.claude.com/v1/oauth/token"
-  const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-  const SCOPES = "user:profile user:inference user:sessions:claude_code user:mcp_servers"
+  const DEFAULT_CLAUDE_HOME = "~/.claude"
+  const CRED_FILE_NAME = ".credentials.json"
+  const KEYCHAIN_SERVICE_PREFIX = "Claude Code"
+  const PROD_BASE_API_URL = "https://api.anthropic.com"
+  const PROD_REFRESH_URL = "https://platform.claude.com/v1/oauth/token"
+  const PROD_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+  const NON_PROD_CLIENT_ID = "22422756-60c9-4084-8eb7-27705fd5cf9a"
+  const SCOPES =
+    "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
   const REFRESH_BUFFER_MS = 5 * 60 * 1000 // refresh 5 minutes before expiration
 
   function utf8DecodeBytes(bytes) {
@@ -121,11 +124,88 @@
     return null
   }
 
-  function loadCredentials(ctx) {
+  function readEnvText(ctx, name) {
+    try {
+      const value = ctx.host.env.get(name)
+      if (value === null || value === undefined) return null
+      const text = String(value).trim()
+      return text || null
+    } catch {
+      return null
+    }
+  }
+
+  function readEnvFlag(ctx, name) {
+    const value = readEnvText(ctx, name)
+    if (!value) return false
+    const lower = value.toLowerCase()
+    return lower !== "0" && lower !== "false" && lower !== "no" && lower !== "off"
+  }
+
+  function getClaudeHomePath(ctx) {
+    return readEnvText(ctx, "CLAUDE_CONFIG_DIR") || DEFAULT_CLAUDE_HOME
+  }
+
+  function getClaudeHomeOverride(ctx) {
+    return readEnvText(ctx, "CLAUDE_CONFIG_DIR")
+  }
+
+  function getClaudeCredentialsPath(ctx) {
+    return getClaudeHomePath(ctx) + "/" + CRED_FILE_NAME
+  }
+
+  function getOauthConfig(ctx) {
+    let baseApiUrl = PROD_BASE_API_URL
+    let refreshUrl = PROD_REFRESH_URL
+    let clientId = PROD_CLIENT_ID
+    let oauthFileSuffix = ""
+
+    const isAntUser = readEnvText(ctx, "USER_TYPE") === "ant"
+    if (isAntUser && readEnvFlag(ctx, "USE_LOCAL_OAUTH")) {
+      const localApiBase = readEnvText(ctx, "CLAUDE_LOCAL_OAUTH_API_BASE")
+      baseApiUrl = (localApiBase || "http://localhost:8000").replace(/\/+$/, "")
+      refreshUrl = baseApiUrl + "/v1/oauth/token"
+      clientId = NON_PROD_CLIENT_ID
+      oauthFileSuffix = "-local-oauth"
+    } else if (isAntUser && readEnvFlag(ctx, "USE_STAGING_OAUTH")) {
+      baseApiUrl = "https://api-staging.anthropic.com"
+      refreshUrl = "https://platform.staging.ant.dev/v1/oauth/token"
+      clientId = NON_PROD_CLIENT_ID
+      oauthFileSuffix = "-staging-oauth"
+    }
+
+    const customOauthBase = readEnvText(ctx, "CLAUDE_CODE_CUSTOM_OAUTH_URL")
+    if (customOauthBase) {
+      const base = customOauthBase.replace(/\/+$/, "")
+      baseApiUrl = base
+      refreshUrl = base + "/v1/oauth/token"
+      oauthFileSuffix = "-custom-oauth"
+    }
+
+    const clientIdOverride = readEnvText(ctx, "CLAUDE_CODE_OAUTH_CLIENT_ID")
+    if (clientIdOverride) {
+      clientId = clientIdOverride
+    }
+
+    return {
+      baseApiUrl: baseApiUrl,
+      usageUrl: baseApiUrl + "/api/oauth/usage",
+      refreshUrl: refreshUrl,
+      clientId: clientId,
+      oauthFileSuffix: oauthFileSuffix,
+    }
+  }
+
+  function getClaudeKeychainService(ctx) {
+    return KEYCHAIN_SERVICE_PREFIX + getOauthConfig(ctx).oauthFileSuffix + "-credentials"
+  }
+
+  function loadStoredCredentials(ctx, suppressMissingWarn) {
+    const credFile = getClaudeCredentialsPath(ctx)
     // Try file first
-    if (ctx.host.fs.exists(CRED_FILE)) {
+    if (ctx.host.fs.exists(credFile)) {
       try {
-        const text = ctx.host.fs.readText(CRED_FILE)
+        const text = ctx.host.fs.readText(credFile)
         const parsed = tryParseCredentialJSON(ctx, text)
         if (parsed) {
           const oauth = parsed.claudeAiOauth
@@ -142,7 +222,7 @@
 
     // Try keychain fallback
     try {
-      const keychainValue = ctx.host.keychain.readGenericPassword(KEYCHAIN_SERVICE)
+      const keychainValue = ctx.host.keychain.readGenericPassword(getClaudeKeychainService(ctx))
       if (keychainValue) {
         const parsed = tryParseCredentialJSON(ctx, keychainValue)
         if (parsed) {
@@ -158,8 +238,38 @@
       ctx.host.log.info("keychain read failed (may not exist): " + String(e))
     }
 
-    ctx.host.log.warn("no credentials found")
+    if (!suppressMissingWarn) {
+      ctx.host.log.warn("no credentials found")
+    }
     return null
+  }
+
+  function loadCredentials(ctx) {
+    const envAccessToken = readEnvText(ctx, "CLAUDE_CODE_OAUTH_TOKEN")
+    const stored = loadStoredCredentials(ctx, !!envAccessToken)
+    if (!envAccessToken) {
+      return stored
+    }
+
+    const oauth = stored && stored.oauth ? Object.assign({}, stored.oauth) : {}
+    oauth.accessToken = envAccessToken
+    return {
+      oauth: oauth,
+      source: stored ? stored.source : null,
+      fullData: stored ? stored.fullData : null,
+      inferenceOnly: true,
+    }
+  }
+
+  function hasProfileScope(creds) {
+    if (!creds || creds.inferenceOnly) {
+      return false
+    }
+    const scopes = creds.oauth && creds.oauth.scopes
+    if (Array.isArray(scopes) && scopes.length > 0) {
+      return scopes.indexOf("user:profile") !== -1
+    }
+    return true
   }
 
   function saveCredentials(ctx, source, fullData) {
@@ -168,13 +278,13 @@
     const text = JSON.stringify(fullData)
     if (source === "file") {
       try {
-        ctx.host.fs.writeText(CRED_FILE, text)
+        ctx.host.fs.writeText(getClaudeCredentialsPath(ctx), text)
       } catch (e) {
         ctx.host.log.error("Failed to write Claude credentials file: " + String(e))
       }
     } else if (source === "keychain") {
       try {
-        ctx.host.keychain.writeGenericPassword(KEYCHAIN_SERVICE, text)
+        ctx.host.keychain.writeGenericPassword(getClaudeKeychainService(ctx), text)
       } catch (e) {
         ctx.host.log.error("Failed to write Claude credentials keychain: " + String(e))
       }
@@ -196,16 +306,17 @@
       return null
     }
 
+    const oauthConfig = getOauthConfig(ctx)
     ctx.host.log.info("attempting token refresh")
     try {
       const resp = ctx.util.request({
         method: "POST",
-        url: REFRESH_URL,
+        url: oauthConfig.refreshUrl,
         headers: { "Content-Type": "application/json" },
         bodyText: JSON.stringify({
           grant_type: "refresh_token",
           refresh_token: oauth.refreshToken,
-          client_id: CLIENT_ID,
+          client_id: oauthConfig.clientId,
           scope: SCOPES,
         }),
         timeoutMs: 15000,
@@ -258,9 +369,10 @@
   }
 
   function fetchUsage(ctx, accessToken) {
+    const oauthConfig = getOauthConfig(ctx)
     return ctx.util.request({
       method: "GET",
-      url: USAGE_URL,
+      url: oauthConfig.usageUrl,
       headers: {
         Authorization: "Bearer " + accessToken.trim(),
         Accept: "application/json",
@@ -272,7 +384,7 @@
     })
   }
 
-  function queryTokenUsage(ctx) {
+  function queryTokenUsage(ctx, homePath) {
     const since = new Date()
     // Inclusive range: today + previous 30 days = 31 calendar days.
     since.setDate(since.getDate() - 30)
@@ -281,7 +393,12 @@
     const d = since.getDate()
     const sinceStr = "" + y + (m < 10 ? "0" : "") + m + (d < 10 ? "0" : "") + d
 
-    const result = ctx.host.ccusage.query({ since: sinceStr })
+    const queryOpts = { since: sinceStr }
+    if (homePath) {
+      queryOpts.homePath = homePath
+    }
+
+    const result = ctx.host.ccusage.query(queryOpts)
     if (!result || typeof result !== "object" || typeof result.status !== "string") {
       return { status: "runner_failed", data: null }
     }
@@ -399,64 +516,70 @@
 
     const nowMs = Date.now()
     let accessToken = creds.oauth.accessToken
+    const homePath = getClaudeHomeOverride(ctx)
+    const canFetchLiveUsage = hasProfileScope(creds)
 
-    // Proactively refresh if token is expired or about to expire
-    if (needsRefresh(ctx, creds.oauth, nowMs)) {
-      ctx.host.log.info("token needs refresh (expired or expiring soon)")
-      const refreshed = refreshToken(ctx, creds)
-      if (refreshed) {
-        accessToken = refreshed
-      } else {
-        ctx.host.log.warn("proactive refresh failed, trying with existing token")
+    let data = null
+    let lines = []
+    if (canFetchLiveUsage) {
+      // Proactively refresh if token is expired or about to expire
+      if (needsRefresh(ctx, creds.oauth, nowMs)) {
+        ctx.host.log.info("token needs refresh (expired or expiring soon)")
+        const refreshed = refreshToken(ctx, creds)
+        if (refreshed) {
+          accessToken = refreshed
+        } else {
+          ctx.host.log.warn("proactive refresh failed, trying with existing token")
+        }
       }
-    }
 
-    let resp
-    let didRefresh = false
-    try {
-      resp = ctx.util.retryOnceOnAuth({
-        request: (token) => {
-          try {
-            return fetchUsage(ctx, token || accessToken)
-          } catch (e) {
-            ctx.host.log.error("usage request exception: " + String(e))
-            if (didRefresh) {
-              throw "Usage request failed after refresh. Try again."
+      let resp
+      let didRefresh = false
+      try {
+        resp = ctx.util.retryOnceOnAuth({
+          request: (token) => {
+            try {
+              return fetchUsage(ctx, token || accessToken)
+            } catch (e) {
+              ctx.host.log.error("usage request exception: " + String(e))
+              if (didRefresh) {
+                throw "Usage request failed after refresh. Try again."
+              }
+              throw "Usage request failed. Check your connection."
             }
-            throw "Usage request failed. Check your connection."
-          }
-        },
-        refresh: () => {
-          ctx.host.log.info("usage returned 401, attempting refresh")
-          didRefresh = true
-          return refreshToken(ctx, creds)
-        },
-      })
-    } catch (e) {
-      if (typeof e === "string") throw e
-      ctx.host.log.error("usage request failed: " + String(e))
-      throw "Usage request failed. Check your connection."
+          },
+          refresh: () => {
+            ctx.host.log.info("usage returned 401, attempting refresh")
+            didRefresh = true
+            return refreshToken(ctx, creds)
+          },
+        })
+      } catch (e) {
+        if (typeof e === "string") throw e
+        ctx.host.log.error("usage request failed: " + String(e))
+        throw "Usage request failed. Check your connection."
+      }
+
+      if (ctx.util.isAuthStatus(resp.status)) {
+        ctx.host.log.error("usage returned auth error after all retries: status=" + resp.status)
+        throw "Token expired. Run `claude` to log in again."
+      }
+
+      if (resp.status < 200 || resp.status >= 300) {
+        ctx.host.log.error("usage returned error: status=" + resp.status)
+        throw "Usage request failed (HTTP " + String(resp.status) + "). Try again later."
+      }
+
+      ctx.host.log.info("usage fetch succeeded")
+
+      data = ctx.util.tryParseJson(resp.bodyText)
+      if (data === null) {
+        throw "Usage response invalid. Try again later."
+      }
+    } else {
+      ctx.host.log.info("skipping live usage fetch for inference-only token")
     }
 
-    if (ctx.util.isAuthStatus(resp.status)) {
-      ctx.host.log.error("usage returned auth error after all retries: status=" + resp.status)
-      throw "Token expired. Run `claude` to log in again."
-    }
-
-    if (resp.status < 200 || resp.status >= 300) {
-      ctx.host.log.error("usage returned error: status=" + resp.status)
-      throw "Usage request failed (HTTP " + String(resp.status) + "). Try again later."
-    }
-    
-    ctx.host.log.info("usage fetch succeeded")
-
-    let data
-    data = ctx.util.tryParseJson(resp.bodyText)
-    if (data === null) {
-      throw "Usage response invalid. Try again later."
-    }
-
-    const lines = []
     let plan = null
     if (creds.oauth.subscriptionType) {
       const basePlan = ctx.fmt.planLabel(creds.oauth.subscriptionType)
@@ -471,53 +594,55 @@
       }
     }
 
-    if (data.five_hour && typeof data.five_hour.utilization === "number") {
-      lines.push(ctx.line.progress({
-        label: "Session",
-        used: data.five_hour.utilization,
-        limit: 100,
-        format: { kind: "percent" },
-        resetsAt: ctx.util.toIso(data.five_hour.resets_at),
-        periodDurationMs: 5 * 60 * 60 * 1000 // 5 hours
-      }))
-    }
-    if (data.seven_day && typeof data.seven_day.utilization === "number") {
-      lines.push(ctx.line.progress({
-        label: "Weekly",
-        used: data.seven_day.utilization,
-        limit: 100,
-        format: { kind: "percent" },
-        resetsAt: ctx.util.toIso(data.seven_day.resets_at),
-        periodDurationMs: 7 * 24 * 60 * 60 * 1000 // 7 days
-      }))
-    }
-    if (data.seven_day_sonnet && typeof data.seven_day_sonnet.utilization === "number") {
-      lines.push(ctx.line.progress({
-        label: "Sonnet",
-        used: data.seven_day_sonnet.utilization,
-        limit: 100,
-        format: { kind: "percent" },
-        resetsAt: ctx.util.toIso(data.seven_day_sonnet.resets_at),
-        periodDurationMs: 7 * 24 * 60 * 60 * 1000 // 7 days
-      }))
-    }
-
-    if (data.extra_usage && data.extra_usage.is_enabled) {
-      const used = data.extra_usage.used_credits
-      const limit = data.extra_usage.monthly_limit
-      if (typeof used === "number" && typeof limit === "number" && limit > 0) {
+    if (data) {
+      if (data.five_hour && typeof data.five_hour.utilization === "number") {
         lines.push(ctx.line.progress({
-          label: "Extra usage spent",
-          used: ctx.fmt.dollars(used),
-          limit: ctx.fmt.dollars(limit),
-          format: { kind: "dollars" }
+          label: "Session",
+          used: data.five_hour.utilization,
+          limit: 100,
+          format: { kind: "percent" },
+          resetsAt: ctx.util.toIso(data.five_hour.resets_at),
+          periodDurationMs: 5 * 60 * 60 * 1000 // 5 hours
         }))
-      } else if (typeof used === "number" && used > 0) {
-        lines.push(ctx.line.text({ label: "Extra usage spent", value: "$" + String(ctx.fmt.dollars(used)) }))
+      }
+      if (data.seven_day && typeof data.seven_day.utilization === "number") {
+        lines.push(ctx.line.progress({
+          label: "Weekly",
+          used: data.seven_day.utilization,
+          limit: 100,
+          format: { kind: "percent" },
+          resetsAt: ctx.util.toIso(data.seven_day.resets_at),
+          periodDurationMs: 7 * 24 * 60 * 60 * 1000 // 7 days
+        }))
+      }
+      if (data.seven_day_sonnet && typeof data.seven_day_sonnet.utilization === "number") {
+        lines.push(ctx.line.progress({
+          label: "Sonnet",
+          used: data.seven_day_sonnet.utilization,
+          limit: 100,
+          format: { kind: "percent" },
+          resetsAt: ctx.util.toIso(data.seven_day_sonnet.resets_at),
+          periodDurationMs: 7 * 24 * 60 * 60 * 1000 // 7 days
+        }))
+      }
+
+      if (data.extra_usage && data.extra_usage.is_enabled) {
+        const used = data.extra_usage.used_credits
+        const limit = data.extra_usage.monthly_limit
+        if (typeof used === "number" && typeof limit === "number" && limit > 0) {
+          lines.push(ctx.line.progress({
+            label: "Extra usage spent",
+            used: ctx.fmt.dollars(used),
+            limit: ctx.fmt.dollars(limit),
+            format: { kind: "dollars" }
+          }))
+        } else if (typeof used === "number" && used > 0) {
+          lines.push(ctx.line.text({ label: "Extra usage spent", value: "$" + String(ctx.fmt.dollars(used)) }))
+        }
       }
     }
 
-    const usageResult = queryTokenUsage(ctx)
+    const usageResult = queryTokenUsage(ctx, homePath)
     if (usageResult.status === "ok") {
       const usage = usageResult.data
       const now = new Date()

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -57,6 +57,50 @@ describe("claude plugin", () => {
     expect(ctx.host.log.info).toHaveBeenCalled()
   })
 
+  it("prefers current-user keychain credentials when available", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockReturnValue(
+      JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+    )
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
+      "Claude Code-credentials"
+    )
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+  })
+
+  it("falls back to legacy keychain lookup when current-user lookup misses", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation(() => {
+      throw new Error("keychain item not found")
+    })
+    ctx.host.keychain.readGenericPassword.mockReturnValue(
+      JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+    )
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Claude Code-credentials")
+  })
+
   it("falls back to keychain when credentials file is corrupt", async () => {
     const ctx = makeCtx()
     ctx.host.fs.exists = () => true
@@ -827,6 +871,69 @@ describe("claude plugin", () => {
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).not.toThrow()
     expect(ctx.host.log.error).toHaveBeenCalled()
+  })
+
+  it("writes refreshed credentials back to the current-user keychain source", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockReturnValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "old-token",
+          refreshToken: "refresh",
+          expiresAt: Date.now() - 1000,
+        },
+      })
+    )
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("/v1/oauth/token")) {
+        return { status: 200, bodyText: JSON.stringify({ access_token: "new-token", expires_in: 3600 }) }
+      }
+      return {
+        status: 200,
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).not.toThrow()
+    expect(ctx.host.keychain.writeGenericPasswordForCurrentUser).toHaveBeenCalled()
+    expect(ctx.host.keychain.writeGenericPassword).not.toHaveBeenCalled()
+  })
+
+  it("writes refreshed credentials back to the legacy keychain source after fallback", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation(() => {
+      throw new Error("keychain item not found")
+    })
+    ctx.host.keychain.readGenericPassword.mockReturnValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "old-token",
+          refreshToken: "refresh",
+          expiresAt: Date.now() - 1000,
+        },
+      })
+    )
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("/v1/oauth/token")) {
+        return { status: 200, bodyText: JSON.stringify({ access_token: "new-token", expires_in: 3600 }) }
+      }
+      return {
+        status: 200,
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).not.toThrow()
+    expect(ctx.host.keychain.writeGenericPassword).toHaveBeenCalled()
+    expect(ctx.host.keychain.writeGenericPasswordForCurrentUser).not.toHaveBeenCalled()
   })
 
   it("logs when saving credentials file fails", async () => {

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -1,15 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { makeCtx } from "../test-helpers.js"
 
+let pluginLoadNonce = 0
+
 const loadPlugin = async () => {
-  await import("./plugin.js")
+  await import(`./plugin.js?test=${pluginLoadNonce++}`)
   return globalThis.__openusage_plugin
 }
 
 describe("claude plugin", () => {
   beforeEach(() => {
     delete globalThis.__openusage_plugin
-    vi.resetModules()
   })
 
   it("throws when no credentials", async () => {
@@ -74,6 +75,110 @@ describe("claude plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+  })
+
+  it("reads credentials from CLAUDE_CONFIG_DIR and passes it to ccusage", async () => {
+    const ctx = makeCtx()
+    const configDir = "/tmp/custom-claude-home"
+    const configCredFile = configDir + "/.credentials.json"
+    const credsJson = JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+    ctx.host.env.get.mockImplementation((name) => (name === "CLAUDE_CONFIG_DIR" ? configDir : null))
+    ctx.host.fs.exists = vi.fn((path) => path === configCredFile)
+    ctx.host.fs.readText = vi.fn((path) => {
+      if (path !== configCredFile) {
+        throw new Error("unexpected readText path: " + path)
+      }
+      return credsJson
+    })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+    ctx.host.ccusage.query = vi.fn(() => ({ status: "ok", data: { daily: [] } }))
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.fs.readText).toHaveBeenCalledWith(configCredFile)
+    expect(ctx.host.ccusage.query).toHaveBeenCalledWith(
+      expect.objectContaining({ homePath: configDir })
+    )
+  })
+
+  it("looks up Claude Code-staging-oauth-credentials in keychain", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.env.get.mockImplementation((name) => {
+      if (name === "USER_TYPE") return "ant"
+      if (name === "USE_STAGING_OAUTH") return "1"
+      return null
+    })
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "Claude Code-staging-oauth-credentials") {
+        return JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+      }
+      if (service === "Claude Code-credentials") {
+        return JSON.stringify({ claudeAiOauth: { refreshToken: "fallback-only" } })
+      }
+      return null
+    })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith(
+      "Claude Code-staging-oauth-credentials"
+    )
+  })
+
+  it("uses env-injected OAuth tokens without hitting /api/oauth/usage", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.fs.readText = () => {
+      throw new Error("unexpected file read")
+    }
+    ctx.host.env.get.mockImplementation((name) =>
+      name === "CLAUDE_CODE_OAUTH_TOKEN" ? "env-oauth-token" : null
+    )
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+    ctx.host.ccusage.query = vi.fn(() => ({
+      status: "ok",
+      data: {
+        daily: [
+          {
+            date: "2024-01-01",
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            totalTokens: 150,
+            totalCost: 0.25,
+          },
+        ],
+      },
+    }))
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(
+      ctx.host.http.request.mock.calls.some((call) => String(call[0]?.url).includes("/api/oauth/usage"))
+    ).toBe(false)
+    expect(result.lines.find((line) => line.label === "Last 30 Days")?.value).toContain("150 tokens")
   })
 
   it("renders usage lines from response", async () => {
@@ -510,6 +615,42 @@ describe("claude plugin", () => {
     expect(ctx.host.fs.writeText).toHaveBeenCalled()
   })
 
+  it("includes user:file_upload in the OAuth refresh scope", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => true
+    ctx.host.fs.readText = () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "old-token",
+          refreshToken: "refresh",
+          expiresAt: Date.now() - 1000,
+          subscriptionType: "pro",
+        },
+      })
+
+    let refreshBody = null
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("/v1/oauth/token")) {
+        refreshBody = JSON.parse(opts.bodyText)
+        return {
+          status: 200,
+          bodyText: JSON.stringify({ access_token: "new-token", expires_in: 3600, refresh_token: "refresh2" }),
+        }
+      }
+      return {
+        status: 200,
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(refreshBody.scope).toContain("user:file_upload")
+  })
+
   it("refreshes keychain credentials and writes back to keychain", async () => {
     const ctx = makeCtx()
     ctx.host.fs.exists = () => false
@@ -800,8 +941,6 @@ describe("claude plugin", () => {
         }
       })
 
-      delete globalThis.__openusage_plugin
-      vi.resetModules()
       const plugin = await loadPlugin()
       const result = plugin.probe(ctx)
       expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -1,18 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeAll, describe, expect, it, vi } from "vitest"
 import { makeCtx } from "../test-helpers.js"
 
-let pluginLoadNonce = 0
+let plugin = null
 
-const loadPlugin = async () => {
-  await import(`./plugin.js?test=${pluginLoadNonce++}`)
-  return globalThis.__openusage_plugin
-}
+beforeAll(async () => {
+  await import("./plugin.js")
+  plugin = globalThis.__openusage_plugin
+})
+
+const loadPlugin = async () => plugin
 
 describe("claude plugin", () => {
-  beforeEach(() => {
-    delete globalThis.__openusage_plugin
-  })
-
   it("throws when no credentials", async () => {
     const ctx = makeCtx()
     const plugin = await loadPlugin()

--- a/plugins/test-helpers.js
+++ b/plugins/test-helpers.js
@@ -43,7 +43,9 @@ export const makeCtx = () => {
       },
       keychain: {
         readGenericPassword: vi.fn(),
+        readGenericPasswordForCurrentUser: vi.fn(),
         writeGenericPassword: vi.fn(),
+        writeGenericPasswordForCurrentUser: vi.fn(),
         deleteGenericPassword: vi.fn(),
       },
       crypto: {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -525,7 +525,7 @@ pub fn run() {
 
             let app_data_dir = app.path().app_data_dir().expect("no app data dir");
             let resource_dir = app.path().resource_dir().expect("no resource dir");
-            log::debug!("app_data_dir: {:?}", app_data_dir);
+            log::debug!("app_data_dir: [PATH]");
 
             let (_, plugins) = plugin_engine::initialize_plugins(&app_data_dir, &resource_dir);
             let known_plugin_ids: Vec<String> =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -525,7 +525,17 @@ pub fn run() {
 
             let app_data_dir = app.path().app_data_dir().expect("no app data dir");
             let resource_dir = app.path().resource_dir().expect("no resource dir");
-            log::debug!("app_data_dir: [PATH]");
+            let app_data_dir_tail = app_data_dir
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("unknown");
+            let redacted_app_data_dir =
+                plugin_engine::host_api::redact_log_message(&app_data_dir.display().to_string());
+            log::debug!(
+                "app_data_dir: tail={}, path={}",
+                app_data_dir_tail,
+                redacted_app_data_dir
+            );
 
             let (_, plugins) = plugin_engine::initialize_plugins(&app_data_dir, &resource_dir);
             let known_plugin_ids: Vec<String> =

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -11,8 +11,16 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
-const WHITELISTED_ENV_VARS: [&str; 6] = [
+const WHITELISTED_ENV_VARS: [&str; 14] = [
     "CODEX_HOME",
+    "CLAUDE_CONFIG_DIR",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "USER_TYPE",
+    "USE_STAGING_OAUTH",
+    "USE_LOCAL_OAUTH",
+    "CLAUDE_CODE_CUSTOM_OAUTH_URL",
+    "CLAUDE_CODE_OAUTH_CLIENT_ID",
+    "CLAUDE_LOCAL_OAUTH_API_BASE",
     "ZAI_API_KEY",
     "GLM_API_KEY",
     "MINIMAX_API_KEY",
@@ -45,6 +53,36 @@ fn read_env_value_via_command(program: &str, args: &[&str]) -> Option<String> {
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     last_non_empty_trimmed_line(&stdout)
+}
+
+fn current_macos_keychain_account() -> String {
+    read_env_from_process("USER")
+        .or_else(|| read_env_value_via_command("id", &["-un"]))
+        .unwrap_or_else(|| "openusage-user".to_string())
+}
+
+fn keychain_find_generic_password_args(service: &str, account: &str) -> Vec<OsString> {
+    vec![
+        OsString::from("find-generic-password"),
+        OsString::from("-a"),
+        OsString::from(account),
+        OsString::from("-s"),
+        OsString::from(service),
+        OsString::from("-w"),
+    ]
+}
+
+fn keychain_add_generic_password_args(service: &str, account: &str, value: &str) -> Vec<OsString> {
+    vec![
+        OsString::from("add-generic-password"),
+        OsString::from("-U"),
+        OsString::from("-a"),
+        OsString::from(account),
+        OsString::from("-s"),
+        OsString::from(service),
+        OsString::from("-w"),
+        OsString::from(value),
+    ]
 }
 
 fn terminal_env_cache() -> &'static Mutex<HashMap<String, Option<String>>> {
@@ -236,6 +274,10 @@ fn redact_body(body: &str) -> String {
         "userId",
         "account_id",
         "accountId",
+        "team_id",
+        "teamId",
+        "payment_id",
+        "paymentId",
         "email",
         "login",
         "analytics_tracking_id",
@@ -251,6 +293,12 @@ fn redact_body(body: &str) -> String {
                 })
                 .to_string();
         }
+    }
+
+    if let Ok(path_re) =
+        regex_lite::Regex::new(r#"(/(?:Users|home|opt|private|var|tmp|Applications)/[^\s"')]+)"#)
+    {
+        result = path_re.replace_all(&result, "[PATH]").to_string();
     }
 
     result
@@ -273,6 +321,18 @@ fn redact_log_message(msg: &str) -> String {
                 redact_value(&caps[0])
             })
             .to_string();
+    }
+    if let Ok(account_re) = regex_lite::Regex::new(r#"(account=)([^,\s]+)"#) {
+        result = account_re
+            .replace_all(&result, |caps: &regex_lite::Captures| {
+                format!("{}{}", &caps[1], redact_value(&caps[2]))
+            })
+            .to_string();
+    }
+    if let Ok(path_re) =
+        regex_lite::Regex::new(r#"(/(?:Users|home|opt|private|var|tmp|Applications)/[^\s"')]+)"#)
+    {
+        result = path_re.replace_all(&result, "[PATH]").to_string();
     }
     result
 }
@@ -403,7 +463,7 @@ pub fn inject_host_api<'js>(
     inject_crypto(ctx, &host)?;
     inject_env(ctx, &host, plugin_id)?;
     inject_http(ctx, &host, plugin_id)?;
-    inject_keychain(ctx, &host)?;
+    inject_keychain(ctx, &host, plugin_id)?;
     inject_sqlite(ctx, &host)?;
     inject_ls(ctx, &host, plugin_id)?;
     inject_ccusage(ctx, &host, plugin_id)?;
@@ -1888,8 +1948,13 @@ pub fn patch_ccusage_wrapper(ctx: &rquickjs::Ctx<'_>) -> rquickjs::Result<()> {
     )
 }
 
-fn inject_keychain<'js>(ctx: &Ctx<'js>, host: &Object<'js>) -> rquickjs::Result<()> {
+fn inject_keychain<'js>(
+    ctx: &Ctx<'js>,
+    host: &Object<'js>,
+    plugin_id: &str,
+) -> rquickjs::Result<()> {
     let keychain_obj = Object::new(ctx.clone())?;
+    let pid_read = plugin_id.to_string();
 
     keychain_obj.set(
         "readGenericPassword",
@@ -1902,8 +1967,17 @@ fn inject_keychain<'js>(ctx: &Ctx<'js>, host: &Object<'js>) -> rquickjs::Result<
                         "keychain API is only supported on macOS",
                     ));
                 }
+                let account = current_macos_keychain_account();
+                let args = keychain_find_generic_password_args(&service, &account);
+                let redacted_account = redact_value(&account);
+                log::info!(
+                    "[plugin:{}] keychain read: service={}, account={}",
+                    pid_read,
+                    service,
+                    redacted_account
+                );
                 let output = std::process::Command::new("security")
-                    .args(["find-generic-password", "-s", &service, "-w"])
+                    .args(&args)
                     .output()
                     .map_err(|e| {
                         Exception::throw_message(
@@ -1915,17 +1989,31 @@ fn inject_keychain<'js>(ctx: &Ctx<'js>, host: &Object<'js>) -> rquickjs::Result<
                 if !output.status.success() {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     let first_line = stderr.lines().next().unwrap_or("").trim();
+                    log::warn!(
+                        "[plugin:{}] keychain read miss: service={}, account={}, error={}",
+                        pid_read,
+                        service,
+                        redacted_account,
+                        first_line
+                    );
                     return Err(Exception::throw_message(
                         &ctx_inner,
                         &format!("keychain item not found: {}", first_line),
                     ));
                 }
 
+                log::info!(
+                    "[plugin:{}] keychain read hit: service={}, account={}",
+                    pid_read,
+                    service,
+                    redacted_account
+                );
                 Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
             },
         )?,
     )?;
 
+    let pid_write = plugin_id.to_string();
     keychain_obj.set(
         "writeGenericPassword",
         Function::new(
@@ -1937,61 +2025,44 @@ fn inject_keychain<'js>(ctx: &Ctx<'js>, host: &Object<'js>) -> rquickjs::Result<
                         "keychain API is only supported on macOS",
                     ));
                 }
-
-                // First, try to find existing entry and extract its account
-                let mut account_arg: Option<String> = None;
-                let find_output = std::process::Command::new("security")
-                    .args(["find-generic-password", "-s", &service])
-                    .output();
-
-                if let Ok(output) = find_output {
-                    if output.status.success() {
-                        // Parse account from output: "acct"<blob>="value"
-                        let stdout = String::from_utf8_lossy(&output.stdout);
-                        for line in stdout.lines() {
-                            if let Some(start) = line.find("\"acct\"<blob>=\"") {
-                                let rest = &line[start + 14..];
-                                if let Some(end) = rest.find('"') {
-                                    account_arg = Some(rest[..end].to_string());
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Build command with account if found
-                let output = if let Some(ref acct) = account_arg {
-                    std::process::Command::new("security")
-                        .args([
-                            "add-generic-password",
-                            "-s",
-                            &service,
-                            "-a",
-                            acct,
-                            "-w",
-                            &value,
-                            "-U",
-                        ])
-                        .output()
-                } else {
-                    std::process::Command::new("security")
-                        .args(["add-generic-password", "-s", &service, "-w", &value, "-U"])
-                        .output()
-                }
-                .map_err(|e| {
+                let account = current_macos_keychain_account();
+                let args = keychain_add_generic_password_args(&service, &account, &value);
+                let redacted_account = redact_value(&account);
+                log::info!(
+                    "[plugin:{}] keychain write: service={}, account={}",
+                    pid_write,
+                    service,
+                    redacted_account
+                );
+                let output = std::process::Command::new("security")
+                    .args(&args)
+                    .output()
+                    .map_err(|e| {
                     Exception::throw_message(&ctx_inner, &format!("keychain write failed: {}", e))
                 })?;
 
                 if !output.status.success() {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     let first_line = stderr.lines().next().unwrap_or("").trim();
+                    log::warn!(
+                        "[plugin:{}] keychain write failed: service={}, account={}, error={}",
+                        pid_write,
+                        service,
+                        redacted_account,
+                        first_line
+                    );
                     return Err(Exception::throw_message(
                         &ctx_inner,
                         &format!("keychain write failed: {}", first_line),
                     ));
                 }
 
+                log::info!(
+                    "[plugin:{}] keychain write succeeded: service={}, account={}",
+                    pid_write,
+                    service,
+                    redacted_account
+                );
                 Ok(())
             },
         )?,
@@ -2281,6 +2352,24 @@ mod tests {
 
     #[test]
     fn env_api_respects_allowlist_in_host_and_js() {
+        let claude_env_vars = [
+            "CLAUDE_CONFIG_DIR",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "USER_TYPE",
+            "USE_STAGING_OAUTH",
+            "USE_LOCAL_OAUTH",
+            "CLAUDE_CODE_CUSTOM_OAUTH_URL",
+            "CLAUDE_CODE_OAUTH_CLIENT_ID",
+            "CLAUDE_LOCAL_OAUTH_API_BASE",
+        ];
+
+        for name in claude_env_vars {
+            assert!(
+                WHITELISTED_ENV_VARS.contains(&name),
+                "{name} must be whitelisted for Claude auth compatibility"
+            );
+        }
+
         let rt = Runtime::new().expect("runtime");
         let ctx = Context::full(&rt).expect("context");
         ctx.with(|ctx| {
@@ -2376,6 +2465,83 @@ mod tests {
                 "process env should be preferred from JS"
             );
         });
+    }
+
+    #[test]
+    fn current_macos_keychain_account_prefers_user_env() {
+        struct RestoreEnvVar {
+            name: &'static str,
+            old: Option<String>,
+        }
+
+        impl Drop for RestoreEnvVar {
+            fn drop(&mut self) {
+                if let Some(value) = self.old.take() {
+                    // SAFETY: tests serialize env changes via this guard; value is restored on drop.
+                    unsafe { std::env::set_var(self.name, value) };
+                } else {
+                    // SAFETY: tests serialize env changes via this guard; var is restored/removed on drop.
+                    unsafe { std::env::remove_var(self.name) };
+                }
+            }
+        }
+
+        let name = "USER";
+        let old = std::env::var(name).ok();
+        let _restore = RestoreEnvVar { name, old };
+        // SAFETY: this test restores the previous value in `Drop`.
+        unsafe { std::env::set_var(name, "openusage-test-user") };
+
+        assert_eq!(current_macos_keychain_account(), "openusage-test-user");
+    }
+
+    #[test]
+    fn keychain_find_generic_password_args_include_account_and_service() {
+        let args =
+            keychain_find_generic_password_args("Claude Code-credentials", "openusage-test-user");
+        let rendered: Vec<String> = args
+            .into_iter()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            rendered,
+            vec![
+                "find-generic-password",
+                "-a",
+                "openusage-test-user",
+                "-s",
+                "Claude Code-credentials",
+                "-w",
+            ]
+        );
+    }
+
+    #[test]
+    fn keychain_add_generic_password_args_include_update_account_service_and_value() {
+        let args = keychain_add_generic_password_args(
+            "Claude Code-credentials",
+            "openusage-test-user",
+            "secret-value",
+        );
+        let rendered: Vec<String> = args
+            .into_iter()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            rendered,
+            vec![
+                "add-generic-password",
+                "-U",
+                "-a",
+                "openusage-test-user",
+                "-s",
+                "Claude Code-credentials",
+                "-w",
+                "secret-value",
+            ]
+        );
     }
 
     #[test]
@@ -2498,6 +2664,33 @@ mod tests {
     }
 
     #[test]
+    fn redact_body_redacts_team_id_payment_id_and_paths() {
+        let body = r#"{"teamId":"cc1ac023-9ff5-4c1f-a5a4-ae2a82df4243","paymentId":"cus_S5m1PGxjLWoc1c","binaryPath":"/opt/homebrew/bin/bunx","homePath":"/Users/rebers/.claude"}"#;
+        let redacted = redact_body(body);
+        assert!(
+            !redacted.contains("cc1ac023-9ff5-4c1f-a5a4-ae2a82df4243"),
+            "teamId should be redacted, got: {}",
+            redacted
+        );
+        assert!(
+            !redacted.contains("cus_S5m1PGxjLWoc1c"),
+            "paymentId should be redacted, got: {}",
+            redacted
+        );
+        assert!(
+            !redacted.contains("/opt/homebrew/bin/bunx"),
+            "path should be redacted, got: {}",
+            redacted
+        );
+        assert!(
+            !redacted.contains("/Users/rebers/.claude"),
+            "path should be redacted, got: {}",
+            redacted
+        );
+        assert!(redacted.contains("[PATH]"), "expected path marker, got: {}", redacted);
+    }
+
+    #[test]
     fn redact_log_message_redacts_jwt_and_api_key() {
         let msg = "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U key=sk-1234567890abcdef";
         let redacted = redact_log_message(msg);
@@ -2509,6 +2702,33 @@ mod tests {
             !redacted.contains("sk-1234567890abcdef"),
             "API key should be redacted"
         );
+    }
+
+    #[test]
+    fn redact_log_message_redacts_account_and_paths() {
+        let msg = "keychain read: service=Claude Code-credentials, account=rebers path=/opt/homebrew/bin/bunx home=/Users/rebers/.claude";
+        let redacted = redact_log_message(msg);
+        assert!(
+            !redacted.contains("account=rebers"),
+            "account should be redacted, got: {}",
+            redacted
+        );
+        assert!(
+            !redacted.contains("/opt/homebrew/bin/bunx"),
+            "path should be redacted, got: {}",
+            redacted
+        );
+        assert!(
+            !redacted.contains("/Users/rebers/.claude"),
+            "path should be redacted, got: {}",
+            redacted
+        );
+        assert!(
+            redacted.contains("account=[REDACTED]"),
+            "expected redacted account, got: {}",
+            redacted
+        );
+        assert!(redacted.contains("[PATH]"), "expected redacted path, got: {}", redacted);
     }
 
     #[test]

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -73,7 +73,16 @@ fn current_macos_keychain_account() -> String {
     current_macos_keychain_account_from_user_env(read_env_from_process("USER"))
 }
 
-fn keychain_find_generic_password_args(service: &str, account: &str) -> Vec<OsString> {
+fn keychain_find_generic_password_args(service: &str) -> Vec<OsString> {
+    vec![
+        OsString::from("find-generic-password"),
+        OsString::from("-s"),
+        OsString::from(service),
+        OsString::from("-w"),
+    ]
+}
+
+fn keychain_find_generic_password_args_for_account(service: &str, account: &str) -> Vec<OsString> {
     vec![
         OsString::from("find-generic-password"),
         OsString::from("-a"),
@@ -84,7 +93,22 @@ fn keychain_find_generic_password_args(service: &str, account: &str) -> Vec<OsSt
     ]
 }
 
-fn keychain_add_generic_password_args(service: &str, account: &str, value: &str) -> Vec<OsString> {
+fn keychain_add_generic_password_args(service: &str, value: &str) -> Vec<OsString> {
+    vec![
+        OsString::from("add-generic-password"),
+        OsString::from("-U"),
+        OsString::from("-s"),
+        OsString::from(service),
+        OsString::from("-w"),
+        OsString::from(value),
+    ]
+}
+
+fn keychain_add_generic_password_args_for_account(
+    service: &str,
+    account: &str,
+    value: &str,
+) -> Vec<OsString> {
     vec![
         OsString::from("add-generic-password"),
         OsString::from("-U"),
@@ -1981,12 +2005,60 @@ fn inject_keychain<'js>(
                         "keychain API is only supported on macOS",
                     ));
                 }
+                log::info!("[plugin:{}] keychain read: service={}", pid_read, service);
+                let output = std::process::Command::new("security")
+                    .args(keychain_find_generic_password_args(&service))
+                    .output()
+                    .map_err(|e| {
+                        Exception::throw_message(
+                            &ctx_inner,
+                            &format!("keychain read failed: {}", e),
+                        )
+                    })?;
+
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    let first_line = stderr.lines().next().unwrap_or("").trim();
+                    log::warn!(
+                        "[plugin:{}] keychain read miss: service={}, error={}",
+                        pid_read,
+                        service,
+                        first_line
+                    );
+                    return Err(Exception::throw_message(
+                        &ctx_inner,
+                        &format!("keychain item not found: {}", first_line),
+                    ));
+                }
+
+                log::info!(
+                    "[plugin:{}] keychain read hit: service={}",
+                    pid_read,
+                    service
+                );
+                Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            },
+        )?,
+    )?;
+
+    let pid_read_current_user = plugin_id.to_string();
+    keychain_obj.set(
+        "readGenericPasswordForCurrentUser",
+        Function::new(
+            ctx.clone(),
+            move |ctx_inner: Ctx<'_>, service: String| -> rquickjs::Result<String> {
+                if !cfg!(target_os = "macos") {
+                    return Err(Exception::throw_message(
+                        &ctx_inner,
+                        "keychain API is only supported on macOS",
+                    ));
+                }
                 let account = current_macos_keychain_account();
-                let args = keychain_find_generic_password_args(&service, &account);
+                let args = keychain_find_generic_password_args_for_account(&service, &account);
                 let redacted_account = redact_value(&account);
                 log::info!(
                     "[plugin:{}] keychain read: service={}, account={}",
-                    pid_read,
+                    pid_read_current_user,
                     service,
                     redacted_account
                 );
@@ -2005,7 +2077,7 @@ fn inject_keychain<'js>(
                     let first_line = stderr.lines().next().unwrap_or("").trim();
                     log::warn!(
                         "[plugin:{}] keychain read miss: service={}, account={}, error={}",
-                        pid_read,
+                        pid_read_current_user,
                         service,
                         redacted_account,
                         first_line
@@ -2018,7 +2090,7 @@ fn inject_keychain<'js>(
 
                 log::info!(
                     "[plugin:{}] keychain read hit: service={}, account={}",
-                    pid_read,
+                    pid_read_current_user,
                     service,
                     redacted_account
                 );
@@ -2039,12 +2111,87 @@ fn inject_keychain<'js>(
                         "keychain API is only supported on macOS",
                     ));
                 }
+                log::info!("[plugin:{}] keychain write: service={}", pid_write, service);
+
+                let mut account_arg: Option<String> = None;
+                let find_output = std::process::Command::new("security")
+                    .args(["find-generic-password", "-s", &service])
+                    .output();
+
+                if let Ok(output) = find_output {
+                    if output.status.success() {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        for line in stdout.lines() {
+                            if let Some(start) = line.find("\"acct\"<blob>=\"") {
+                                let rest = &line[start + 14..];
+                                if let Some(end) = rest.find('"') {
+                                    account_arg = Some(rest[..end].to_string());
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let output = if let Some(ref acct) = account_arg {
+                    std::process::Command::new("security")
+                        .args(keychain_add_generic_password_args_for_account(
+                            &service, acct, &value,
+                        ))
+                        .output()
+                } else {
+                    std::process::Command::new("security")
+                        .args(keychain_add_generic_password_args(&service, &value))
+                        .output()
+                }
+                .map_err(|e| {
+                    Exception::throw_message(&ctx_inner, &format!("keychain write failed: {}", e))
+                })?;
+
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    let first_line = stderr.lines().next().unwrap_or("").trim();
+                    log::warn!(
+                        "[plugin:{}] keychain write failed: service={}, error={}",
+                        pid_write,
+                        service,
+                        first_line
+                    );
+                    return Err(Exception::throw_message(
+                        &ctx_inner,
+                        &format!("keychain write failed: {}", first_line),
+                    ));
+                }
+
+                log::info!(
+                    "[plugin:{}] keychain write succeeded: service={}",
+                    pid_write,
+                    service
+                );
+                Ok(())
+            },
+        )?,
+    )?;
+
+    let pid_write_current_user = plugin_id.to_string();
+    keychain_obj.set(
+        "writeGenericPasswordForCurrentUser",
+        Function::new(
+            ctx.clone(),
+            move |ctx_inner: Ctx<'_>, service: String, value: String| -> rquickjs::Result<()> {
+                if !cfg!(target_os = "macos") {
+                    return Err(Exception::throw_message(
+                        &ctx_inner,
+                        "keychain API is only supported on macOS",
+                    ));
+                }
                 let account = current_macos_keychain_account();
-                let args = keychain_add_generic_password_args(&service, &account, &value);
+                let args =
+                    keychain_add_generic_password_args_for_account(&service, &account, &value);
                 let redacted_account = redact_value(&account);
                 log::info!(
                     "[plugin:{}] keychain write: service={}, account={}",
-                    pid_write,
+                    pid_write_current_user,
                     service,
                     redacted_account
                 );
@@ -2063,7 +2210,7 @@ fn inject_keychain<'js>(
                     let first_line = stderr.lines().next().unwrap_or("").trim();
                     log::warn!(
                         "[plugin:{}] keychain write failed: service={}, account={}, error={}",
-                        pid_write,
+                        pid_write_current_user,
                         service,
                         redacted_account,
                         first_line
@@ -2076,7 +2223,7 @@ fn inject_keychain<'js>(
 
                 log::info!(
                     "[plugin:{}] keychain write succeeded: service={}, account={}",
-                    pid_write,
+                    pid_write_current_user,
                     service,
                     redacted_account
                 );
@@ -2348,7 +2495,7 @@ mod tests {
     }
 
     #[test]
-    fn keychain_api_exposes_write() {
+    fn keychain_api_exposes_write_variants() {
         let rt = Runtime::new().expect("runtime");
         let ctx = Context::full(&rt).expect("context");
         ctx.with(|ctx| {
@@ -2361,9 +2508,15 @@ mod tests {
             let _read: Function = keychain
                 .get("readGenericPassword")
                 .expect("readGenericPassword");
+            let _read_current_user: Function = keychain
+                .get("readGenericPasswordForCurrentUser")
+                .expect("readGenericPasswordForCurrentUser");
             let _write: Function = keychain
                 .get("writeGenericPassword")
                 .expect("writeGenericPassword");
+            let _write_current_user: Function = keychain
+                .get("writeGenericPasswordForCurrentUser")
+                .expect("writeGenericPasswordForCurrentUser");
         });
     }
 
@@ -2501,9 +2654,30 @@ mod tests {
     }
 
     #[test]
-    fn keychain_find_generic_password_args_include_account_and_service() {
-        let args =
-            keychain_find_generic_password_args("Claude Code-credentials", "openusage-test-user");
+    fn keychain_find_generic_password_args_include_service_only_lookup() {
+        let args = keychain_find_generic_password_args("Claude Code-credentials");
+        let rendered: Vec<String> = args
+            .into_iter()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            rendered,
+            vec![
+                "find-generic-password",
+                "-s",
+                "Claude Code-credentials",
+                "-w",
+            ]
+        );
+    }
+
+    #[test]
+    fn keychain_find_generic_password_args_for_account_include_account_and_service() {
+        let args = keychain_find_generic_password_args_for_account(
+            "Claude Code-credentials",
+            "openusage-test-user",
+        );
         let rendered: Vec<String> = args
             .into_iter()
             .map(|value| value.to_string_lossy().into_owned())
@@ -2523,8 +2697,29 @@ mod tests {
     }
 
     #[test]
-    fn keychain_add_generic_password_args_include_update_account_service_and_value() {
-        let args = keychain_add_generic_password_args(
+    fn keychain_add_generic_password_args_include_service_only_write() {
+        let args = keychain_add_generic_password_args("Claude Code-credentials", "secret-value");
+        let rendered: Vec<String> = args
+            .into_iter()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            rendered,
+            vec![
+                "add-generic-password",
+                "-U",
+                "-s",
+                "Claude Code-credentials",
+                "-w",
+                "secret-value",
+            ]
+        );
+    }
+
+    #[test]
+    fn keychain_add_generic_password_args_for_account_include_update_account_service_and_value() {
+        let args = keychain_add_generic_password_args_for_account(
             "Claude Code-credentials",
             "openusage-test-user",
             "secret-value",

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -55,10 +55,22 @@ fn read_env_value_via_command(program: &str, args: &[&str]) -> Option<String> {
     last_non_empty_trimmed_line(&stdout)
 }
 
-fn current_macos_keychain_account() -> String {
-    read_env_from_process("USER")
+fn current_macos_keychain_account_from_user_env(user_env: Option<String>) -> String {
+    user_env
+        .and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
         .or_else(|| read_env_value_via_command("id", &["-un"]))
         .unwrap_or_else(|| "openusage-user".to_string())
+}
+
+fn current_macos_keychain_account() -> String {
+    current_macos_keychain_account_from_user_env(read_env_from_process("USER"))
 }
 
 fn keychain_find_generic_password_args(service: &str, account: &str) -> Vec<OsString> {
@@ -304,8 +316,8 @@ fn redact_body(body: &str) -> String {
     result
 }
 
-/// Lightweight redaction for plugin log messages (JWT + API key patterns only).
-fn redact_log_message(msg: &str) -> String {
+/// Lightweight redaction for log messages.
+pub(crate) fn redact_log_message(msg: &str) -> String {
     let mut result = msg.to_string();
     if let Ok(jwt_re) = regex_lite::Regex::new(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
     {
@@ -1763,14 +1775,16 @@ fn run_ccusage_with_runner(
 
     if let Some(home_path) = ccusage_home_override(opts, provider) {
         let config = ccusage_provider_config(provider);
-        command.env(config.home_env_var, home_path);
+        command.env(config.home_env_var, expand_path(&home_path));
     }
+
+    let redacted_program = redact_log_message(program);
 
     log::info!(
         "[plugin:{}] ccusage query via {} ({})",
         plugin_id,
         ccusage_runner_label(kind),
-        program
+        redacted_program
     );
 
     let mut child = match command.spawn() {
@@ -2038,8 +2052,11 @@ fn inject_keychain<'js>(
                     .args(&args)
                     .output()
                     .map_err(|e| {
-                    Exception::throw_message(&ctx_inner, &format!("keychain write failed: {}", e))
-                })?;
+                        Exception::throw_message(
+                            &ctx_inner,
+                            &format!("keychain write failed: {}", e),
+                        )
+                    })?;
 
                 if !output.status.success() {
                     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -2468,31 +2485,19 @@ mod tests {
     }
 
     #[test]
-    fn current_macos_keychain_account_prefers_user_env() {
-        struct RestoreEnvVar {
-            name: &'static str,
-            old: Option<String>,
-        }
+    fn current_macos_keychain_account_prefers_explicit_user_value() {
+        assert_eq!(
+            current_macos_keychain_account_from_user_env(Some("openusage-test-user".to_string())),
+            "openusage-test-user"
+        );
+    }
 
-        impl Drop for RestoreEnvVar {
-            fn drop(&mut self) {
-                if let Some(value) = self.old.take() {
-                    // SAFETY: tests serialize env changes via this guard; value is restored on drop.
-                    unsafe { std::env::set_var(self.name, value) };
-                } else {
-                    // SAFETY: tests serialize env changes via this guard; var is restored/removed on drop.
-                    unsafe { std::env::remove_var(self.name) };
-                }
-            }
-        }
+    #[test]
+    fn expand_path_expands_tilde_prefix() {
+        let home = dirs::home_dir().expect("home dir");
+        let expected = home.join(".claude-custom").to_string_lossy().to_string();
 
-        let name = "USER";
-        let old = std::env::var(name).ok();
-        let _restore = RestoreEnvVar { name, old };
-        // SAFETY: this test restores the previous value in `Drop`.
-        unsafe { std::env::set_var(name, "openusage-test-user") };
-
-        assert_eq!(current_macos_keychain_account(), "openusage-test-user");
+        assert_eq!(expand_path("~/.claude-custom"), expected);
     }
 
     #[test]
@@ -2687,7 +2692,11 @@ mod tests {
             "path should be redacted, got: {}",
             redacted
         );
-        assert!(redacted.contains("[PATH]"), "expected path marker, got: {}", redacted);
+        assert!(
+            redacted.contains("[PATH]"),
+            "expected path marker, got: {}",
+            redacted
+        );
     }
 
     #[test]
@@ -2728,7 +2737,11 @@ mod tests {
             "expected redacted account, got: {}",
             redacted
         );
-        assert!(redacted.contains("[PATH]"), "expected redacted path, got: {}", redacted);
+        assert!(
+            redacted.contains("[PATH]"),
+            "expected redacted path, got: {}",
+            redacted
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Claude auth compatibility for custom config dirs, custom OAuth endpoints, staging/local OAuth, and env-injected access tokens
- update Claude credential lookup and refresh behavior to use the correct keychain service, pass custom home paths to `ccusage`, and include the `user:file_upload` scope
- expand host API env allowlists and redaction coverage for Claude auth inputs, keychain logging, IDs, and filesystem paths
- add plugin and Rust regression tests covering the new Claude auth and redaction paths

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential loading/refresh, keychain access, and environment-variable handling; mistakes could break login/usage probing or leak sensitive values if redaction misses edge cases.
> 
> **Overview**
> Improves Claude plugin authentication portability by supporting custom Claude config directories (`CLAUDE_CONFIG_DIR`), env-injected access tokens (`CLAUDE_CODE_OAUTH_TOKEN`, treated as *inference-only*), and dynamic OAuth endpoints/client IDs (staging/local/custom URLs) with per-environment keychain service names.
> 
> The plugin now prefers a macOS *current-user* keychain entry with legacy fallback, writes refreshed tokens back to the same source, passes an optional home path through to `ccusage`, skips live `/api/oauth/usage` calls when tokens lack `user:profile`, and refreshes with the expanded scope including `user:file_upload`.
> 
> On the Tauri/Rust side, the host API expands the env var allowlist for Claude auth inputs, adds current-user keychain read/write bindings, expands redaction to cover filesystem paths and additional IDs, and redacts `app_data_dir`/`ccusage` logging. Tests were updated/added across JS and Rust to cover the new keychain/OAuth/redaction behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110bee64868396840d1f44e8c16f2c97d98bbe01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Claude plugin auth to work across custom config dirs and custom/staging/local OAuth setups, with current-user keychain support, env-injected tokens, and stronger redaction.

- **New Features**
  - Read creds from `CLAUDE_CONFIG_DIR`; pass expanded home path to `ccusage`.
  - Support staging/local/custom OAuth endpoints and client IDs; keychain service names include an OAuth suffix.
  - Accept `CLAUDE_CODE_OAUTH_TOKEN` for inference-only sessions; skip live usage when missing `user:profile`.
  - Include `user:file_upload` in OAuth refresh scope.

- **Bug Fixes**
  - macOS keychain prefers current-user entries with legacy fallback and writes back to the same source. Added `readGenericPasswordForCurrentUser`/`writeGenericPasswordForCurrentUser`.
  - Expanded host API env allowlist for Claude auth vars (`CLAUDE_CONFIG_DIR`, `CLAUDE_CODE_OAUTH_TOKEN`, `USER_TYPE`, `USE_STAGING_OAUTH`, `USE_LOCAL_OAUTH`, `CLAUDE_CODE_CUSTOM_OAUTH_URL`, `CLAUDE_CODE_OAUTH_CLIENT_ID`, `CLAUDE_LOCAL_OAUTH_API_BASE`).
  - Redaction covers team/payment IDs, account names, and filesystem paths; `app_data_dir` and `ccusage` paths masked as [PATH].
  - Expanded tilde path expansion for `ccusage` home and improved 401 retry handling. Added tests for keychain current-user/fallback, service suffixes, custom home, env tokens, scopes, usage-skip, and redaction.

<sup>Written for commit 110bee64868396840d1f44e8c16f2c97d98bbe01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

