### PR TITLE
fix: keep tray panel height stable when provider content changes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,6 +8,8 @@ const state = vi.hoisted(() => ({
   isTauriMock: vi.fn(() => false),
   trackMock: vi.fn(),
   setSizeMock: vi.fn(),
+  windowOnMovedMock: vi.fn(),
+  windowOnScaleChangedMock: vi.fn(),
   currentMonitorMock: vi.fn(),
   startBatchMock: vi.fn(),
   savePluginSettingsMock: vi.fn(),
@@ -172,7 +174,11 @@ vi.mock("@tauri-apps/api/path", () => ({
 }))
 
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({ setSize: state.setSizeMock }),
+  getCurrentWindow: () => ({
+    setSize: state.setSizeMock,
+    onMoved: state.windowOnMovedMock,
+    onScaleChanged: state.windowOnScaleChangedMock,
+  }),
   PhysicalSize: class {
     width: number
     height: number
@@ -259,6 +265,8 @@ describe("App", () => {
     state.isTauriMock.mockReturnValue(false)
     state.trackMock.mockReset()
     state.setSizeMock.mockReset()
+    state.windowOnMovedMock.mockReset()
+    state.windowOnScaleChangedMock.mockReset()
     state.currentMonitorMock.mockReset()
     state.startBatchMock.mockReset()
     state.savePluginSettingsMock.mockReset()
@@ -320,6 +328,8 @@ describe("App", () => {
     state.autostartDisableMock.mockResolvedValue(undefined)
     state.autostartIsEnabledMock.mockResolvedValue(false)
     state.renderTrayBarsIconMock.mockResolvedValue({})
+    state.windowOnMovedMock.mockResolvedValue(() => {})
+    state.windowOnScaleChangedMock.mockResolvedValue(() => {})
     Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
       configurable: true,
       get() {
@@ -1168,9 +1178,9 @@ describe("App", () => {
     await waitFor(() => expect(state.setSizeMock).toHaveBeenCalled())
   })
 
-  it("keeps a stable preferred panel height when content is shorter", async () => {
+  it("uses the preferred stable panel height on standard monitors", async () => {
     state.isTauriMock.mockReturnValue(true)
-    state.currentMonitorMock.mockResolvedValueOnce({ size: { height: 1000 } })
+    state.currentMonitorMock.mockResolvedValue({ size: { height: 1000 } })
     render(<App />)
 
     await waitFor(() =>
@@ -1182,7 +1192,7 @@ describe("App", () => {
 
   it("clamps the stable panel height to small monitors", async () => {
     state.isTauriMock.mockReturnValue(true)
-    state.currentMonitorMock.mockResolvedValueOnce({ size: { height: 500 } })
+    state.currentMonitorMock.mockResolvedValue({ size: { height: 500 } })
     render(<App />)
 
     await waitFor(() =>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1168,6 +1168,30 @@ describe("App", () => {
     await waitFor(() => expect(state.setSizeMock).toHaveBeenCalled())
   })
 
+  it("keeps a stable preferred panel height when content is shorter", async () => {
+    state.isTauriMock.mockReturnValue(true)
+    state.currentMonitorMock.mockResolvedValueOnce({ size: { height: 1000 } })
+    render(<App />)
+
+    await waitFor(() =>
+      expect(state.setSizeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ width: 400, height: 560 })
+      )
+    )
+  })
+
+  it("clamps the stable panel height to small monitors", async () => {
+    state.isTauriMock.mockReturnValue(true)
+    state.currentMonitorMock.mockResolvedValueOnce({ size: { height: 500 } })
+    render(<App />)
+
+    await waitFor(() =>
+      expect(state.setSizeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ width: 400, height: 400 })
+      )
+    )
+  })
+
   it("resizes again via ResizeObserver callback", async () => {
     state.isTauriMock.mockReturnValue(true)
     const OriginalResizeObserver = globalThis.ResizeObserver

--- a/src/components/app/app-shell.test.tsx
+++ b/src/components/app/app-shell.test.tsx
@@ -96,5 +96,8 @@ describe("AppShell", () => {
 
     expect(screen.getByTestId("app-content")).toBeInTheDocument()
     expect(container.querySelector(".panel-scroll")).toBeTruthy()
+    const contentWrapper = screen.getByTestId("panel-content-wrapper")
+    expect(contentWrapper).toBeTruthy()
+    expect(contentWrapper.querySelector("[data-testid='app-content']")).toBeTruthy()
   })
 })

--- a/src/components/app/app-shell.test.tsx
+++ b/src/components/app/app-shell.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const state = vi.hoisted(() => ({
+  usePanelMock: vi.fn(),
+  useAppVersionMock: vi.fn(),
+  useAppUpdateMock: vi.fn(),
+}))
+
+vi.mock("@/components/app/app-content", () => ({
+  AppContent: () => <div data-testid="app-content" />,
+}))
+
+vi.mock("@/components/panel-footer", () => ({
+  PanelFooter: () => <div data-testid="panel-footer" />,
+}))
+
+vi.mock("@/components/side-nav", () => ({
+  SideNav: () => <div data-testid="side-nav" />,
+}))
+
+vi.mock("@/hooks/app/use-panel", () => ({
+  usePanel: state.usePanelMock,
+}))
+
+vi.mock("@/hooks/app/use-app-version", () => ({
+  useAppVersion: state.useAppVersionMock,
+}))
+
+vi.mock("@/hooks/use-app-update", () => ({
+  useAppUpdate: state.useAppUpdateMock,
+}))
+
+vi.mock("@/stores/app-ui-store", () => ({
+  useAppUiStore: () => ({
+    activeView: "home",
+    setActiveView: vi.fn(),
+    showAbout: false,
+    setShowAbout: vi.fn(),
+  }),
+}))
+
+import { AppShell } from "@/components/app/app-shell"
+
+function createProps() {
+  return {
+    onRefreshAll: vi.fn(),
+    navPlugins: [],
+    displayPlugins: [],
+    settingsPlugins: [],
+    autoUpdateNextAt: null,
+    selectedPlugin: null,
+    onPluginContextAction: vi.fn(),
+    isPluginRefreshAvailable: vi.fn(),
+    onNavReorder: vi.fn(),
+    appContentProps: {
+      onRetryPlugin: vi.fn(),
+      onReorder: vi.fn(),
+      onToggle: vi.fn(),
+      onAutoUpdateIntervalChange: vi.fn(),
+      onThemeModeChange: vi.fn(),
+      onDisplayModeChange: vi.fn(),
+      onResetTimerDisplayModeChange: vi.fn(),
+      onResetTimerDisplayModeToggle: vi.fn(),
+      onMenubarIconStyleChange: vi.fn(),
+      traySettingsPreview: {
+        active: false,
+        bars: [],
+        iconUrl: null,
+        primaryLabel: null,
+      },
+      onGlobalShortcutChange: vi.fn(),
+      onStartOnLoginChange: vi.fn(),
+    },
+  }
+}
+
+describe("AppShell", () => {
+  beforeEach(() => {
+    state.usePanelMock.mockReturnValue({
+      containerRef: { current: null },
+      scrollRef: { current: null },
+      canScrollDown: false,
+      panelHeightPx: 560,
+    })
+    state.useAppVersionMock.mockReturnValue("0.0.0-test")
+    state.useAppUpdateMock.mockReturnValue({
+      updateStatus: { status: "idle" },
+      triggerInstall: vi.fn(),
+      checkForUpdates: vi.fn(),
+    })
+  })
+
+  it("uses the styled panel scrollbar class on the scroll region", () => {
+    const { container } = render(<AppShell {...createProps()} />)
+
+    expect(screen.getByTestId("app-content")).toBeInTheDocument()
+    expect(container.querySelector(".panel-scroll")).toBeTruthy()
+  })
+})

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -60,12 +60,11 @@ export function AppShell({
     setActiveView,
     showAbout,
     setShowAbout,
-    displayPlugins,
   })
 
   const appVersion = useAppVersion()
   const { updateStatus, triggerInstall, checkForUpdates } = useAppUpdate()
-  const cardHeightPx = panelHeightPx ? Math.max(1, panelHeightPx - ARROW_OVERHEAD_PX) : null
+  const cardHeightPx = panelHeightPx !== null ? Math.max(0, panelHeightPx - ARROW_OVERHEAD_PX) : null
 
   return (
     <div ref={containerRef} className="flex flex-col items-center p-6 pt-1.5 bg-transparent">
@@ -85,7 +84,7 @@ export function AppShell({
           />
           <div className="flex-1 flex flex-col px-3 pt-2 pb-1.5 min-w-0 bg-card dark:bg-muted/50">
             <div className="relative flex-1 min-h-0">
-              <div ref={scrollRef} className="h-full overflow-y-auto scrollbar-none">
+              <div ref={scrollRef} className="h-full overflow-y-auto">
                 <AppContent
                   {...appContentProps}
                   displayPlugins={displayPlugins}

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -84,7 +84,7 @@ export function AppShell({
           />
           <div className="flex-1 flex flex-col px-3 pt-2 pb-1.5 min-w-0 bg-card dark:bg-muted/50">
             <div className="relative flex-1 min-h-0">
-              <div ref={scrollRef} className="h-full overflow-y-auto">
+              <div ref={scrollRef} className="panel-scroll h-full overflow-y-auto pr-3">
                 <AppContent
                   {...appContentProps}
                   displayPlugins={displayPlugins}

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -82,15 +82,17 @@ export function AppShell({
             isPluginRefreshAvailable={isPluginRefreshAvailable}
             onReorder={onNavReorder}
           />
-          <div className="flex-1 flex flex-col px-3 pt-2 pb-1.5 min-w-0 bg-card dark:bg-muted/50">
+          <div className="flex-1 flex flex-col pl-3 pr-1 pt-2 pb-1.5 min-w-0 bg-card dark:bg-muted/50">
             <div className="relative flex-1 min-h-0">
-              <div ref={scrollRef} className="panel-scroll h-full overflow-y-auto pr-3">
-                <AppContent
-                  {...appContentProps}
-                  displayPlugins={displayPlugins}
-                  settingsPlugins={settingsPlugins}
-                  selectedPlugin={selectedPlugin}
-                />
+              <div ref={scrollRef} className="panel-scroll h-full overflow-y-auto">
+                <div className="pr-3">
+                  <AppContent
+                    {...appContentProps}
+                    displayPlugins={displayPlugins}
+                    settingsPlugins={settingsPlugins}
+                    selectedPlugin={selectedPlugin}
+                  />
+                </div>
               </div>
               <div
                 className={`pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-card dark:from-muted/50 to-transparent transition-opacity duration-200 ${canScrollDown ? "opacity-100" : "opacity-0"}`}

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -54,7 +54,7 @@ export function AppShell({
     containerRef,
     scrollRef,
     canScrollDown,
-    maxPanelHeightPx,
+    panelHeightPx,
   } = usePanel({
     activeView,
     setActiveView,
@@ -65,13 +65,14 @@ export function AppShell({
 
   const appVersion = useAppVersion()
   const { updateStatus, triggerInstall, checkForUpdates } = useAppUpdate()
+  const cardHeightPx = panelHeightPx ? Math.max(1, panelHeightPx - ARROW_OVERHEAD_PX) : null
 
   return (
     <div ref={containerRef} className="flex flex-col items-center p-6 pt-1.5 bg-transparent">
       <div className="tray-arrow" />
       <div
         className="relative bg-card rounded-xl overflow-hidden select-none w-full border shadow-lg flex flex-col"
-        style={maxPanelHeightPx ? { maxHeight: `${maxPanelHeightPx - ARROW_OVERHEAD_PX}px` } : undefined}
+        style={cardHeightPx ? { height: `${cardHeightPx}px`, maxHeight: `${cardHeightPx}px` } : undefined}
       >
         <div className="flex flex-1 min-h-0 flex-row">
           <SideNav

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -85,7 +85,7 @@ export function AppShell({
           <div className="flex-1 flex flex-col pl-3 pr-1 pt-2 pb-1.5 min-w-0 bg-card dark:bg-muted/50">
             <div className="relative flex-1 min-h-0">
               <div ref={scrollRef} className="panel-scroll h-full overflow-y-auto">
-                <div className="pr-3">
+                <div className="pr-4">
                   <AppContent
                     {...appContentProps}
                     displayPlugins={displayPlugins}

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -82,10 +82,10 @@ export function AppShell({
             isPluginRefreshAvailable={isPluginRefreshAvailable}
             onReorder={onNavReorder}
           />
-          <div className="flex-1 flex flex-col pl-3 pr-1 pt-2 pb-1.5 min-w-0 bg-card dark:bg-muted/50">
+          <div className="flex-1 flex flex-col pt-2 pb-1.5 min-w-0 bg-card dark:bg-muted/50">
             <div className="relative flex-1 min-h-0">
               <div ref={scrollRef} className="panel-scroll h-full overflow-y-auto">
-                <div className="pr-4">
+                <div data-testid="panel-content-wrapper" className="px-3">
                   <AppContent
                     {...appContentProps}
                     displayPlugins={displayPlugins}

--- a/src/components/panel-footer.tsx
+++ b/src/components/panel-footer.tsx
@@ -113,7 +113,7 @@ export function PanelFooter({
 
   return (
     <>
-      <div className="flex justify-between items-center h-8 pt-1.5 border-t">
+      <div className="flex justify-between items-center h-8 pt-1.5 pr-3 border-t">
         <VersionDisplay
           version={version}
           updateStatus={updateStatus}

--- a/src/components/panel-footer.tsx
+++ b/src/components/panel-footer.tsx
@@ -113,7 +113,7 @@ export function PanelFooter({
 
   return (
     <>
-      <div className="flex justify-between items-center h-8 pt-1.5 pr-3 border-t">
+      <div className="flex justify-between items-center h-8 pt-1.5 pr-4 border-t">
         <VersionDisplay
           version={version}
           updateStatus={updateStatus}

--- a/src/components/panel-footer.tsx
+++ b/src/components/panel-footer.tsx
@@ -113,7 +113,7 @@ export function PanelFooter({
 
   return (
     <>
-      <div className="flex justify-between items-center h-8 pt-1.5 pr-4 border-t">
+      <div className="flex justify-between items-center h-8 pt-1.5 px-3 border-t">
         <VersionDisplay
           version={version}
           updateStatus={updateStatus}

--- a/src/hooks/app/use-panel.test.ts
+++ b/src/hooks/app/use-panel.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { act, render, renderHook, waitFor } from "@testing-library/react"
+import { createElement } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
@@ -7,12 +8,16 @@ const {
   invokeMock,
   isTauriMock,
   listenMock,
+  onMovedMock,
+  onScaleChangedMock,
 } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   isTauriMock: vi.fn(),
   listenMock: vi.fn(),
   getCurrentWindowMock: vi.fn(),
   currentMonitorMock: vi.fn(),
+  onMovedMock: vi.fn(),
+  onScaleChangedMock: vi.fn(),
 }))
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -47,11 +52,20 @@ describe("usePanel", () => {
     listenMock.mockReset()
     getCurrentWindowMock.mockReset()
     currentMonitorMock.mockReset()
+    onMovedMock.mockReset()
+    onScaleChangedMock.mockReset()
 
     isTauriMock.mockReturnValue(true)
     invokeMock.mockResolvedValue(undefined)
+    listenMock.mockResolvedValue(vi.fn())
     currentMonitorMock.mockResolvedValue(null)
-    getCurrentWindowMock.mockReturnValue({ setSize: vi.fn().mockResolvedValue(undefined) })
+    onMovedMock.mockResolvedValue(vi.fn())
+    onScaleChangedMock.mockResolvedValue(vi.fn())
+    getCurrentWindowMock.mockReturnValue({
+      setSize: vi.fn().mockResolvedValue(undefined),
+      onMoved: onMovedMock,
+      onScaleChanged: onScaleChangedMock,
+    })
   })
 
   it("handles tray show-about event", async () => {
@@ -69,7 +83,6 @@ describe("usePanel", () => {
         setActiveView: vi.fn(),
         showAbout: false,
         setShowAbout,
-        displayPlugins: [],
       })
     )
 
@@ -103,7 +116,6 @@ describe("usePanel", () => {
         setActiveView: vi.fn(),
         showAbout: false,
         setShowAbout: vi.fn(),
-        displayPlugins: [],
       })
     )
 
@@ -135,7 +147,6 @@ describe("usePanel", () => {
         setActiveView: vi.fn(),
         showAbout: false,
         setShowAbout: vi.fn(),
-        displayPlugins: [],
       })
     )
 
@@ -148,6 +159,47 @@ describe("usePanel", () => {
 
     await waitFor(() => {
       expect(unlistenShowAbout).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("recalculates panel sizing when the window scale changes", async () => {
+    const setSize = vi.fn().mockResolvedValue(undefined)
+    let scaleChangedHandler: (() => void) | null = null
+
+    currentMonitorMock.mockResolvedValue({ size: { height: 1000 } })
+    onScaleChangedMock.mockImplementation(async (handler: () => void) => {
+      scaleChangedHandler = handler
+      return vi.fn()
+    })
+    getCurrentWindowMock.mockReturnValue({
+      setSize,
+      onMoved: onMovedMock,
+      onScaleChanged: onScaleChangedMock,
+    })
+
+    function Harness() {
+      const { containerRef, scrollRef } = usePanel({
+        activeView: "home",
+        setActiveView: vi.fn(),
+        showAbout: false,
+        setShowAbout: vi.fn(),
+      })
+
+      return createElement("div", { ref: containerRef }, createElement("div", { ref: scrollRef }))
+    }
+
+    render(createElement(Harness))
+
+    await waitFor(() => {
+      expect(setSize).toHaveBeenCalledTimes(1)
+    })
+
+    act(() => {
+      scaleChangedHandler?.()
+    })
+
+    await waitFor(() => {
+      expect(currentMonitorMock).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/src/hooks/app/use-panel.ts
+++ b/src/hooks/app/use-panel.ts
@@ -5,6 +5,8 @@ import { getCurrentWindow, PhysicalSize, currentMonitor } from "@tauri-apps/api/
 import type { ActiveView } from "@/components/side-nav"
 
 const PANEL_WIDTH = 400
+const PANEL_WINDOW_OVERHEAD_PX = 37
+const PANEL_MIN_CONTENT_HEIGHT_PX = 120
 // Keep the tray shell stable across short and long provider states; overflow should scroll inside the panel.
 const PANEL_PREFERRED_HEIGHT = 560
 const MAX_HEIGHT_FALLBACK_PX = 600
@@ -15,7 +17,6 @@ type UsePanelArgs = {
   setActiveView: (view: ActiveView) => void
   showAbout: boolean
   setShowAbout: (value: boolean) => void
-  displayPlugins: unknown[]
 }
 
 export function usePanel({
@@ -23,13 +24,13 @@ export function usePanel({
   setActiveView,
   showAbout,
   setShowAbout,
-  displayPlugins,
 }: UsePanelArgs) {
   const containerRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const [canScrollDown, setCanScrollDown] = useState(false)
   const [panelHeightPx, setPanelHeightPx] = useState<number | null>(null)
   const panelHeightPxRef = useRef<number | null>(null)
+  const lastWindowSizeRef = useRef<{ width: number; height: number } | null>(null)
 
   useEffect(() => {
     if (!isTauri()) return
@@ -87,6 +88,9 @@ export function usePanel({
     if (!isTauri()) return
     const container = containerRef.current
     if (!container) return
+    const currentWindow = getCurrentWindow()
+    let cancelled = false
+    const unlisteners: (() => void)[] = []
 
     const resizeWindow = async () => {
       const factor = window.devicePixelRatio
@@ -111,33 +115,78 @@ export function usePanel({
         maxHeightPhysical = Math.floor(maxHeightLogical * factor)
       }
 
+      const minPanelHeightLogical = Math.min(
+        maxHeightLogical,
+        PANEL_WINDOW_OVERHEAD_PX + PANEL_MIN_CONTENT_HEIGHT_PX
+      )
+
       // Keep the tray panel visually stable; scrolling should happen inside the shell.
-      const nextPanelHeightLogical = Math.max(1, Math.min(PANEL_PREFERRED_HEIGHT, maxHeightLogical))
+      const nextPanelHeightLogical = Math.max(
+        minPanelHeightLogical,
+        Math.min(PANEL_PREFERRED_HEIGHT, maxHeightLogical)
+      )
 
       if (panelHeightPxRef.current !== nextPanelHeightLogical) {
         panelHeightPxRef.current = nextPanelHeightLogical
         setPanelHeightPx(nextPanelHeightLogical)
       }
 
-      const height = Math.ceil(Math.min(nextPanelHeightLogical * factor, maxHeightPhysical!))
+      const nextWindowSize = {
+        width,
+        height: Math.ceil(Math.min(nextPanelHeightLogical * factor, maxHeightPhysical!)),
+      }
+
+      if (
+        lastWindowSizeRef.current?.width === nextWindowSize.width &&
+        lastWindowSizeRef.current?.height === nextWindowSize.height
+      ) {
+        return
+      }
+
+      lastWindowSizeRef.current = nextWindowSize
 
       try {
-        const currentWindow = getCurrentWindow()
-        await currentWindow.setSize(new PhysicalSize(width, height))
+        await currentWindow.setSize(new PhysicalSize(nextWindowSize.width, nextWindowSize.height))
       } catch (e) {
         console.error("Failed to resize window:", e)
       }
     }
 
-    resizeWindow()
+    void resizeWindow()
 
     const observer = new ResizeObserver(() => {
-      resizeWindow()
+      void resizeWindow()
     })
     observer.observe(container)
 
-    return () => observer.disconnect()
-  }, [activeView, displayPlugins])
+    async function setupWindowListeners() {
+      const unlistenMoved = await currentWindow.onMoved(() => {
+        void resizeWindow()
+      })
+      if (cancelled) {
+        unlistenMoved()
+        return
+      }
+      unlisteners.push(unlistenMoved)
+
+      const unlistenScaleChanged = await currentWindow.onScaleChanged(() => {
+        void resizeWindow()
+      })
+      if (cancelled) {
+        unlistenScaleChanged()
+        return
+      }
+      unlisteners.push(unlistenScaleChanged)
+    }
+
+    void setupWindowListeners()
+
+    return () => {
+      cancelled = true
+      observer.disconnect()
+      for (const fn of unlisteners) fn()
+    }
+  }, [])
 
   useEffect(() => {
     const el = scrollRef.current

--- a/src/hooks/app/use-panel.ts
+++ b/src/hooks/app/use-panel.ts
@@ -5,6 +5,7 @@ import { getCurrentWindow, PhysicalSize, currentMonitor } from "@tauri-apps/api/
 import type { ActiveView } from "@/components/side-nav"
 
 const PANEL_WIDTH = 400
+// Keep the tray shell stable across short and long provider states; overflow should scroll inside the panel.
 const PANEL_PREFERRED_HEIGHT = 560
 const MAX_HEIGHT_FALLBACK_PX = 600
 const MAX_HEIGHT_FRACTION_OF_MONITOR = 0.8

--- a/src/hooks/app/use-panel.ts
+++ b/src/hooks/app/use-panel.ts
@@ -5,6 +5,7 @@ import { getCurrentWindow, PhysicalSize, currentMonitor } from "@tauri-apps/api/
 import type { ActiveView } from "@/components/side-nav"
 
 const PANEL_WIDTH = 400
+const PANEL_PREFERRED_HEIGHT = 560
 const MAX_HEIGHT_FALLBACK_PX = 600
 const MAX_HEIGHT_FRACTION_OF_MONITOR = 0.8
 
@@ -26,8 +27,8 @@ export function usePanel({
   const containerRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const [canScrollDown, setCanScrollDown] = useState(false)
-  const [maxPanelHeightPx, setMaxPanelHeightPx] = useState<number | null>(null)
-  const maxPanelHeightPxRef = useRef<number | null>(null)
+  const [panelHeightPx, setPanelHeightPx] = useState<number | null>(null)
+  const panelHeightPxRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (!isTauri()) return
@@ -89,7 +90,6 @@ export function usePanel({
     const resizeWindow = async () => {
       const factor = window.devicePixelRatio
       const width = Math.ceil(PANEL_WIDTH * factor)
-      const desiredHeightLogical = Math.max(1, container.scrollHeight)
 
       let maxHeightPhysical: number | null = null
       let maxHeightLogical: number | null = null
@@ -110,13 +110,15 @@ export function usePanel({
         maxHeightPhysical = Math.floor(maxHeightLogical * factor)
       }
 
-      if (maxPanelHeightPxRef.current !== maxHeightLogical) {
-        maxPanelHeightPxRef.current = maxHeightLogical
-        setMaxPanelHeightPx(maxHeightLogical)
+      // Keep the tray panel visually stable; scrolling should happen inside the shell.
+      const nextPanelHeightLogical = Math.max(1, Math.min(PANEL_PREFERRED_HEIGHT, maxHeightLogical))
+
+      if (panelHeightPxRef.current !== nextPanelHeightLogical) {
+        panelHeightPxRef.current = nextPanelHeightLogical
+        setPanelHeightPx(nextPanelHeightLogical)
       }
 
-      const desiredHeightPhysical = Math.ceil(desiredHeightLogical * factor)
-      const height = Math.ceil(Math.min(desiredHeightPhysical, maxHeightPhysical!))
+      const height = Math.ceil(Math.min(nextPanelHeightLogical * factor, maxHeightPhysical!))
 
       try {
         const currentWindow = getCurrentWindow()
@@ -164,6 +166,6 @@ export function usePanel({
     containerRef,
     scrollRef,
     canScrollDown,
-    maxPanelHeightPx,
+    panelHeightPx,
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -158,6 +158,30 @@ body,
   display: none;                  /* Chrome / Safari / WebKit */
 }
 
+/* Slim in-panel scrollbar with a reserved gutter so it doesn't sit on top of content. */
+.panel-scroll {
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--muted-foreground) 58%, transparent) transparent;
+}
+.panel-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+.panel-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.panel-scroll::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--muted-foreground) 42%, transparent);
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+.panel-scroll::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--foreground) 36%, transparent);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
 /* Arrow pointing up toward the tray icon */
 .tray-arrow {
   width: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -158,28 +158,18 @@ body,
   display: none;                  /* Chrome / Safari / WebKit */
 }
 
-/* Slim in-panel scrollbar with a reserved gutter so it doesn't sit on top of content. */
+/* In-panel scrollbar: thin, no reserved idle gutter. */
 .panel-scroll {
-  scrollbar-gutter: stable;
+  --scrollbar-thumb: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
   scrollbar-width: thin;
-  scrollbar-color: color-mix(in oklch, var(--muted-foreground) 58%, transparent) transparent;
-}
-.panel-scroll::-webkit-scrollbar {
-  width: 10px;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 .panel-scroll::-webkit-scrollbar-track {
   background: transparent;
 }
 .panel-scroll::-webkit-scrollbar-thumb {
-  background: color-mix(in oklch, var(--muted-foreground) 42%, transparent);
-  border: 2px solid transparent;
+  background: var(--scrollbar-thumb);
   border-radius: 999px;
-  background-clip: padding-box;
-}
-.panel-scroll::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in oklch, var(--foreground) 36%, transparent);
-  border: 2px solid transparent;
-  background-clip: padding-box;
 }
 
 /* Arrow pointing up toward the tray icon */


### PR DESCRIPTION
## Description

Fixes the tray panel resizing vertically when switching between providers or views with different amounts of content.

Before this change, the window height followed the current content height, so short states and longer states made the whole panel jump up and down.

This change keeps a stable preferred panel height and lets the content scroll inside the panel when needed.

## Related Issue

N/A

Related to the general sizing/compactness discussion in #106, but this specifically fixes panel height jitter rather than adding a compact mode.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I added regression tests for stable panel height and small-screen clamping

## Screenshots

- Before: panel height changes depending on which provider state is visible
<img width="494" height="913" alt="image" src="https://github.com/user-attachments/assets/a0a921a9-c9cd-41be-9eeb-afd9b9177ebd" />

<img width="508" height="710" alt="image" src="https://github.com/user-attachments/assets/1a633a7d-1dca-4fa3-b479-d0125c6bf669" />


- After: panel height stays stable and only the inner content scrolls

<img width="596" height="804" alt="image" src="https://github.com/user-attachments/assets/5f44c03a-9a16-4ee1-a66c-db1bb685fc07" />


![newosu](https://github.com/user-attachments/assets/e2cb2ae5-1baa-409f-a458-b2d378f3eed9)

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the tray panel height stable across provider/view changes so the window stops jumping. Uses a preferred 560px height with in-panel scrolling, clamps for small monitors, and refines the scrollbar and layout for better spacing.

- **Bug Fixes**
  - Stable `panelHeightPx` with a fixed card height in `AppShell`; dedup window resizes; recalc on DPI/scale changes and window moves.
  - Clamp height to monitor bounds with a small minimum; content scrolls inside the panel.
  - Thin `.panel-scroll` on the outer edge; padding moved to an inner content wrapper; footer now has `px-3` to match the gutter; updated styles and tests.

<sup>Written for commit 4410fb492a13bcdb8cd9b080541a2d66115b0147. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



