### PR TITLE
Filter control for what models on main tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,6 +158,7 @@ function App() {
   const {
     handleReorder,
     handleToggle,
+    handleToggleOverviewLabel,
   } = useSettingsPluginActions({
     pluginSettings,
     setPluginSettings,
@@ -241,6 +242,7 @@ function App() {
         onRetryPlugin: handleRetryPlugin,
         onReorder: handleReorder,
         onToggle: handleToggle,
+        onToggleOverviewLabel: handleToggleOverviewLabel,
         onAutoUpdateIntervalChange: handleAutoUpdateIntervalChange,
         onThemeModeChange: handleThemeModeChange,
         onDisplayModeChange: handleDisplayModeChange,

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -26,6 +26,7 @@ export type AppContentActionProps = {
   onRetryPlugin: (id: string) => void
   onReorder: (orderedIds: string[]) => void
   onToggle: (id: string) => void
+  onToggleOverviewLabel: (pluginId: string, label: string) => void
   onAutoUpdateIntervalChange: (value: AutoUpdateIntervalMinutes) => void
   onThemeModeChange: (mode: ThemeMode) => void
   onDisplayModeChange: (mode: DisplayMode) => void
@@ -46,6 +47,7 @@ export function AppContent({
   onRetryPlugin,
   onReorder,
   onToggle,
+  onToggleOverviewLabel,
   onAutoUpdateIntervalChange,
   onThemeModeChange,
   onDisplayModeChange,
@@ -100,6 +102,7 @@ export function AppContent({
         plugins={settingsPlugins}
         onReorder={onReorder}
         onToggle={onToggle}
+        onToggleOverviewLabel={onToggleOverviewLabel}
         autoUpdateInterval={autoUpdateInterval}
         onAutoUpdateIntervalChange={onAutoUpdateIntervalChange}
         themeMode={themeMode}

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -30,6 +30,7 @@ interface ProviderCardProps {
   onRetry?: () => void
   scopeFilter?: "overview" | "all"
   displayMode: DisplayMode
+  disabledOverviewLabels?: string[]
   resetTimerDisplayMode?: ResetTimerDisplayMode
   onResetTimerDisplayModeToggle?: () => void
 }
@@ -94,6 +95,7 @@ export function ProviderCard({
   displayMode,
   resetTimerDisplayMode = "relative",
   onResetTimerDisplayModeToggle,
+  disabledOverviewLabels = [],
 }: ProviderCardProps) {
   const cooldownRemainingMs = useMemo(() => {
     if (!lastManualRefreshAt) return 0
@@ -102,14 +104,15 @@ export function ProviderCard({
   }, [lastManualRefreshAt])
 
   // Filter lines based on scope - match by label since runtime lines can differ from manifest
+  const disabledSet = new Set(disabledOverviewLabels)
   const overviewLabels = new Set(
     skeletonLines
-      .filter(line => line.scope === "overview")
+      .filter(line => line.scope === "overview" && !disabledSet.has(line.label))
       .map(line => line.label)
   )
   const filteredSkeletonLines = scopeFilter === "all"
     ? skeletonLines
-    : skeletonLines.filter(line => line.scope === "overview")
+    : skeletonLines.filter(line => line.scope === "overview" && !disabledSet.has(line.label))
   const filteredLines = scopeFilter === "all"
     ? lines
     : lines.filter(line => overviewLabels.has(line.label))

--- a/src/hooks/app/use-app-plugin-views.ts
+++ b/src/hooks/app/use-app-plugin-views.ts
@@ -4,7 +4,7 @@ import type { PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 import type { PluginState } from "@/hooks/app/types"
 
-export type DisplayPluginState = { meta: PluginMeta } & PluginState
+export type DisplayPluginState = { meta: PluginMeta; disabledOverviewLabels: string[] } & PluginState
 
 type UseAppPluginViewsArgs = {
   activeView: ActiveView
@@ -33,7 +33,7 @@ export function useAppPluginViews({
         if (!meta) return null
         const state =
           pluginStates[id] ?? { data: null, loading: false, error: null, lastManualRefreshAt: null }
-        return { meta, ...state }
+        return { meta, ...state, disabledOverviewLabels: pluginSettings.disabledOverviewLabels?.[id] || [] }
       })
       .filter((plugin): plugin is DisplayPluginState => Boolean(plugin))
   }, [pluginSettings, pluginStates, pluginsMeta])

--- a/src/hooks/app/use-settings-plugin-actions.ts
+++ b/src/hooks/app/use-settings-plugin-actions.ts
@@ -91,8 +91,32 @@ export function useSettingsPluginActions({
     startBatch,
   ])
 
+  const handleToggleOverviewLabel = useCallback((pluginId: string, label: string) => {
+    if (!pluginSettings) return
+    const currentDisabled = pluginSettings.disabledOverviewLabels?.[pluginId] || []
+    const isCurrentlyDisabled = currentDisabled.includes(label)
+    
+    const nextDisabled = isCurrentlyDisabled
+      ? currentDisabled.filter((l) => l !== label)
+      : [...currentDisabled, label]
+
+    const nextSettings: PluginSettings = {
+      ...pluginSettings,
+      disabledOverviewLabels: {
+        ...pluginSettings.disabledOverviewLabels,
+        [pluginId]: nextDisabled,
+      },
+    }
+
+    setPluginSettings(nextSettings)
+    scheduleTrayIconUpdate("settings", TRAY_SETTINGS_DEBOUNCE_MS)
+    void savePluginSettings(nextSettings).catch((error) => {
+      console.error("Failed to save plugin overview label toggle:", error)
+    })
+  }, [pluginSettings, scheduleTrayIconUpdate, setPluginSettings])
   return {
     handleReorder,
     handleToggle,
+    handleToggleOverviewLabel,
   }
 }

--- a/src/hooks/app/use-settings-plugin-list.ts
+++ b/src/hooks/app/use-settings-plugin-list.ts
@@ -1,11 +1,13 @@
 import { useMemo } from "react"
-import type { PluginMeta } from "@/lib/plugin-types"
+import type { ManifestLine, PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 
 export type SettingsPluginState = {
   id: string
   name: string
   enabled: boolean
+  lines: ManifestLine[]
+  disabledOverviewLabels: string[]
 }
 
 type UseSettingsPluginListArgs = {
@@ -26,6 +28,8 @@ export function useSettingsPluginList({ pluginSettings, pluginsMeta }: UseSettin
           id,
           name: meta.name,
           enabled: !pluginSettings.disabled.includes(id),
+          lines: meta.lines,
+          disabledOverviewLabels: pluginSettings.disabledOverviewLabels?.[id] || [],
         }
       })
       .filter((plugin): plugin is SettingsPluginState => Boolean(plugin))

--- a/src/lib/plugin-types.ts
+++ b/src/lib/plugin-types.ts
@@ -53,4 +53,5 @@ export type PluginDisplayState = {
   loading: boolean
   error: string | null
   lastManualRefreshAt: number | null
+  disabledOverviewLabels?: string[]
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -8,6 +8,7 @@ export const REFRESH_COOLDOWN_MS = 300_000;
 export type PluginSettings = {
   order: string[];
   disabled: string[];
+  disabledOverviewLabels?: Record<string, string[]>;
 };
 
 export type AutoUpdateIntervalMinutes = 5 | 15 | 30 | 60;
@@ -83,6 +84,7 @@ const DEFAULT_ENABLED_PLUGINS = new Set(["claude", "codex", "cursor"]);
 export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   order: [],
   disabled: [],
+  disabledOverviewLabels: {},
 };
 
 export async function loadPluginSettings(): Promise<PluginSettings> {
@@ -91,6 +93,7 @@ export async function loadPluginSettings(): Promise<PluginSettings> {
   return {
     order: Array.isArray(stored.order) ? stored.order : [],
     disabled: Array.isArray(stored.disabled) ? stored.disabled : [],
+    disabledOverviewLabels: stored.disabledOverviewLabels || {},
   };
 }
 
@@ -148,7 +151,16 @@ export function normalizePluginSettings(
       disabled.push(id);
     }
   }
-  return { order, disabled };
+  const disabledOverviewLabels: Record<string, string[]> = {};
+  if (settings.disabledOverviewLabels) {
+    for (const [id, labels] of Object.entries(settings.disabledOverviewLabels)) {
+      if (knownSet.has(id) && Array.isArray(labels)) {
+        disabledOverviewLabels[id] = labels;
+      }
+    }
+  }
+
+  return { order, disabled, disabledOverviewLabels };
 }
 
 export function arePluginSettingsEqual(
@@ -162,6 +174,19 @@ export function arePluginSettingsEqual(
   }
   for (let i = 0; i < a.disabled.length; i += 1) {
     if (a.disabled[i] !== b.disabled[i]) return false;
+  }
+  const aLabels = a.disabledOverviewLabels || {};
+  const bLabels = b.disabledOverviewLabels || {};
+  const aKeys = Object.keys(aLabels);
+  const bKeys = Object.keys(bLabels);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    const aList = aLabels[key];
+    const bList = bLabels[key];
+    if (!bList || aList.length !== bList.length) return false;
+    for (let i = 0; i < aList.length; i += 1) {
+      if (aList[i] !== bList[i]) return false;
+    }
   }
   return true;
 }

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -43,6 +43,7 @@ export function OverviewPage({
           displayMode={displayMode}
           resetTimerDisplayMode={resetTimerDisplayMode}
           onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+          disabledOverviewLabels={plugin.disabledOverviewLabels}
         />
       ))}
     </div>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -40,6 +40,8 @@ interface PluginConfig {
   id: string;
   name: string;
   enabled: boolean;
+  lines: import("@/lib/plugin-types").ManifestLine[];
+  disabledOverviewLabels: string[];
 }
 
 const TRAY_PREVIEW_SIZE_PX = getTrayIconSizePx(1);
@@ -196,9 +198,11 @@ function MenubarIconStylePreview({
 function SortablePluginItem({
   plugin,
   onToggle,
+  onToggleOverviewLabel,
 }: {
   plugin: PluginConfig;
   onToggle: (id: string) => void;
+  onToggleOverviewLabel: (pluginId: string, label: string) => void;
 }) {
   const {
     attributes,
@@ -208,45 +212,61 @@ function SortablePluginItem({
     transition,
     isDragging,
   } = useSortable({ id: plugin.id });
-
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
   };
 
+  const overviewLines = plugin.lines ? plugin.lines.filter((l) => l.scope === "overview") : [];
   return (
     <div
       ref={setNodeRef}
       style={style}
       className={cn(
-        "flex items-center gap-3 px-3 py-2 rounded-md bg-card",
-        "border border-transparent",
+        "flex flex-col gap-2 px-3 py-2 rounded-md bg-card border border-transparent",
         isDragging && "opacity-50 border-border"
       )}
     >
-      <button
-        type="button"
-        className="touch-none cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground transition-colors"
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="h-4 w-4" />
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="touch-none cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground transition-colors"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-4 w-4" />
       </button>
-
-      <span
-        className={cn(
-          "flex-1 text-sm",
-          !plugin.enabled && "text-muted-foreground"
-        )}
-      >
-        {plugin.name}
-      </span>
-
-      <Checkbox
-        key={`${plugin.id}-${plugin.enabled}`}
-        checked={plugin.enabled}
-        onCheckedChange={() => onToggle(plugin.id)}
-      />
+        <span
+          className={cn(
+            "flex-1 text-sm",
+            !plugin.enabled && "text-muted-foreground"
+          )}
+        >
+          {plugin.name}
+        </span>
+        <Checkbox
+          key={`${plugin.id}-${plugin.enabled}`}
+          checked={plugin.enabled}
+          onCheckedChange={() => onToggle(plugin.id)}
+        />
+      </div>
+      {plugin.enabled && overviewLines.length > 0 && (
+        <div className="flex flex-col gap-1.5 pl-7 pr-1 pb-1">
+          {overviewLines.map((line) => {
+            const isLineEnabled = !plugin.disabledOverviewLabels.includes(line.label);
+            return (
+              <label key={line.label} className="flex items-center gap-2 text-xs select-none text-muted-foreground hover:text-foreground transition-colors cursor-pointer">
+                <Checkbox
+                  checked={isLineEnabled}
+                  onCheckedChange={() => onToggleOverviewLabel(plugin.id, line.label)}
+                  className="h-3.5 w-3.5"
+                />
+                {line.label}
+              </label>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }
@@ -255,6 +275,7 @@ interface SettingsPageProps {
   plugins: PluginConfig[];
   onReorder: (orderedIds: string[]) => void;
   onToggle: (id: string) => void;
+  onToggleOverviewLabel: (pluginId: string, label: string) => void;
   autoUpdateInterval: AutoUpdateIntervalMinutes;
   onAutoUpdateIntervalChange: (value: AutoUpdateIntervalMinutes) => void;
   themeMode: ThemeMode;
@@ -276,6 +297,7 @@ export function SettingsPage({
   plugins,
   onReorder,
   onToggle,
+  onToggleOverviewLabel,
   autoUpdateInterval,
   onAutoUpdateIntervalChange,
   themeMode,
@@ -504,6 +526,7 @@ export function SettingsPage({
                   key={plugin.id}
                   plugin={plugin}
                   onToggle={onToggle}
+                  onToggleOverviewLabel={onToggleOverviewLabel}
                 />
               ))}
             </SortableContext>


### PR DESCRIPTION
## Description

This allows you to exclude certain models from the main tab in order to help make it more concise.    You can still see all models on the individual provider's tab.

## Related Issue

<!-- Link to the issue this PR addresses: Fixes #123 -->

## Type of Change

- [ ] Bug fix
- [x ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [X] I ran `bun run build` and it succeeded
- [X] I ran `bun run test` and all tests pass
- [-] I tested the change locally with `bun tauri dev`
I am running windows so could only test with the https://github.com/Rana-Faraz/usage-tray-windows fork

## Screenshots

The main with filtered models:
<img width="200" height="446" alt="image" src="https://github.com/user-attachments/assets/d135ff69-d552-454d-84b3-fad876684598" />

The settings to pick what models (only shows the model selection when the provider is enabled):
<img width="270" height="382" alt="image" src="https://github.com/user-attachments/assets/9bd66abe-334c-4668-a39b-bbb58ca53df0" />


## Checklist

- [X] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My PR targets the `main` branch
- [X] I did not introduce new dependencies without justification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-provider controls to hide specific model lines on the Overview tab, making the main tab more concise. Settings are saved and do not affect provider-specific tabs.

- **New Features**
  - In Settings, enabled providers show checkboxes for each `scope: "overview"` line to include/exclude them on Overview.
  - Added `disabledOverviewLabels` to plugin settings with persistence, normalization, and equality checks.
  - Overview filters out disabled labels in `ProviderCard`; provider tabs remain unchanged. Wiring added via `onToggleOverviewLabel` through `App`, `AppContent`, and hooks.

<sup>Written for commit 7361b98f76a47dcaab2158aa4eb8953542653afa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

