### PR TITLE
feat: add SOCKS5/HTTP proxy support for all provider requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ OpenUsage lives in your menu bar and shows you how much of your AI coding subscr
 - **Lightweight.** Opens instantly, stays out of your way.
 - **Plugin-based.** New providers get added without updating the whole app.
 - **[Local HTTP API](docs/local-http-api.md).** Other apps can read your usage data from `127.0.0.1:6736`.
+- **[Proxy support](docs/proxy.md).** Route provider HTTP requests through a SOCKS5 or HTTP proxy.
 
 ## Supported Providers
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,46 @@
+# Proxy Configuration
+
+OpenUsage can route provider and plugin HTTP requests through an optional proxy.
+
+- Supported proxy types: `socks5://`, `http://`, `https://`
+- Config file: `~/.openusage/config.json`
+- Default: off
+- UI: none
+
+## Config File
+
+Create `~/.openusage/config.json`:
+
+```json
+{
+  "proxy": {
+    "enabled": true,
+    "url": "socks5://127.0.0.1:10808"
+  }
+}
+```
+
+You can also use an authenticated proxy URL:
+
+```json
+{
+  "proxy": {
+    "enabled": true,
+    "url": "http://user:pass@proxy.example.com:8080"
+  }
+}
+```
+
+## Behavior
+
+- Config is loaded once when the app starts.
+- Restart OpenUsage after changing the file.
+- `localhost`, `127.0.0.1`, and `::1` always bypass the proxy.
+- Missing, disabled, invalid, or unreadable config leaves proxying off.
+- Proxy credentials are redacted in logs.
+
+## Scope
+
+This applies to provider and plugin HTTP requests that go through OpenUsage's built-in HTTP client.
+
+It is not a general macOS system proxy setting and does not automatically proxy unrelated subprocess network traffic.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.
 time = { version = "0.3.47", features = ["formatting"] }
 dirs = "6"
 log = "0.4"
-reqwest = { version = "0.13", features = ["blocking"] }
+reqwest = { version = "0.13", features = ["blocking", "socks"] }
 rquickjs = { version = "0.11", features = ["bindgen"] }
 tauri-plugin-store = "2.4.2"
 base64 = "0.22"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -86,7 +86,7 @@ pub fn redact_proxy_url(url: &str) -> String {
     if let Some(at_pos) = url.find('@') {
         if let Some(scheme_end) = url.find("://") {
             let userinfo_start = scheme_end + 3;
-            format!("{}://***@{}", &url[..userinfo_start], &url[at_pos + 1..])
+            format!("{}***@{}", &url[..userinfo_start], &url[at_pos + 1..])
         } else {
             format!("***@{}", &url[at_pos + 1..])
         }
@@ -103,7 +103,7 @@ mod tests {
     fn redact_proxy_url_with_credentials() {
         let url = "http://user:pass@127.0.0.1:10808";
         let redacted = redact_proxy_url(url);
-        assert!(redacted.contains("***"));
+        assert_eq!(redacted, "http://***@127.0.0.1:10808");
         assert!(!redacted.contains("user"));
         assert!(!redacted.contains("pass"));
     }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,0 +1,139 @@
+use reqwest::Proxy;
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+/// Proxy configuration loaded from ~/.openusage/config.json
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProxyConfig {
+    pub enabled: bool,
+    pub url: String,
+}
+
+/// Top-level application config
+#[derive(Debug, Clone, Deserialize)]
+pub struct AppConfig {
+    pub proxy: Option<ProxyConfig>,
+}
+
+/// Resolved proxy state — computed once at startup, used per-request.
+/// This avoids re-parsing or re-validating on every HTTP call.
+#[derive(Debug, Clone)]
+pub struct ResolvedProxy {
+    pub proxy: Proxy,
+}
+
+/// Global resolved proxy: Some(active) or None(disabled).
+static RESOLVED_PROXY: OnceLock<Option<ResolvedProxy>> = OnceLock::new();
+
+/// Returns the resolved proxy, or None if disabled/invalid/missing.
+/// Loaded once from disk on first call; subsequent calls are zero-cost.
+pub fn get_resolved_proxy() -> Option<&'static ResolvedProxy> {
+    RESOLVED_PROXY.get_or_init(|| load_and_resolve_proxy()).as_ref()
+}
+
+/// Config file path: ~/.openusage/config.json
+fn config_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".openusage")
+        .join("config.json")
+}
+
+/// Loads config from disk, resolves proxy, logs result.
+fn load_and_resolve_proxy() -> Option<ResolvedProxy> {
+    let path = config_path();
+    let config = match std::fs::read_to_string(&path) {
+        Ok(contents) => match serde_json::from_str::<AppConfig>(&contents) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                log::warn!("[config] failed to parse {}: {}, using defaults", path.display(), e);
+                return None;
+            }
+        },
+        Err(_) => {
+            log::debug!("[config] no config file at {}, using defaults", path.display());
+            return None;
+        }
+    };
+
+    let Some(proxy_cfg) = config.proxy.as_ref().filter(|p| p.enabled) else {
+        log::debug!("[config] proxy disabled");
+        return None;
+    };
+
+    match Proxy::all(&proxy_cfg.url) {
+        Ok(proxy) => {
+            let redacted = redact_proxy_url(&proxy_cfg.url);
+            log::debug!("[config] proxy enabled: {}", redacted);
+
+            // Build no-proxy bypass for localhost
+            let no_proxy = reqwest::NoProxy::from_string("localhost,127.0.0.1,::1");
+            let proxy = proxy.no_proxy(no_proxy);
+
+            Some(ResolvedProxy { proxy })
+        }
+        Err(e) => {
+            log::warn!("[config] proxy disabled due to invalid URL: {}", e);
+            None
+        }
+    }
+}
+
+/// Redacts user info from a proxy URL for safe logging.
+pub fn redact_proxy_url(url: &str) -> String {
+    // Simple redaction: look for ://user:pass@ pattern
+    if let Some(at_pos) = url.find('@') {
+        if let Some(scheme_end) = url.find("://") {
+            let userinfo_start = scheme_end + 3;
+            format!("{}://***@{}", &url[..userinfo_start], &url[at_pos + 1..])
+        } else {
+            format!("***@{}", &url[at_pos + 1..])
+        }
+    } else {
+        url.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_proxy_url_with_credentials() {
+        let url = "http://user:pass@127.0.0.1:10808";
+        let redacted = redact_proxy_url(url);
+        assert!(redacted.contains("***"));
+        assert!(!redacted.contains("user"));
+        assert!(!redacted.contains("pass"));
+    }
+
+    #[test]
+    fn redact_proxy_url_without_credentials() {
+        let url = "http://127.0.0.1:10808";
+        let redacted = redact_proxy_url(url);
+        assert_eq!(redacted, "http://127.0.0.1:10808");
+    }
+
+    #[test]
+    fn proxy_disabled_when_enabled_false() {
+        let config = AppConfig {
+            proxy: Some(ProxyConfig {
+                enabled: false,
+                url: "http://127.0.0.1:10808".to_string(),
+            }),
+        };
+        assert!(config.proxy.as_ref().filter(|p| p.enabled).is_none());
+    }
+
+    #[test]
+    fn proxy_enabled_when_enabled_true() {
+        let config = AppConfig {
+            proxy: Some(ProxyConfig {
+                enabled: true,
+                url: "http://127.0.0.1:10808".to_string(),
+            }),
+        };
+        assert!(config.proxy.as_ref().filter(|p| p.enabled).is_some());
+    }
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -33,16 +33,16 @@ pub fn get_resolved_proxy() -> Option<&'static ResolvedProxy> {
 }
 
 /// Config file path: ~/.openusage/config.json
-fn config_path() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_default()
-        .join(".openusage")
-        .join("config.json")
+fn config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".openusage").join("config.json"))
 }
 
 /// Loads config from disk, resolves proxy, logs result.
 fn load_and_resolve_proxy() -> Option<ResolvedProxy> {
-    let path = config_path();
+    let Some(path) = config_path() else {
+        log::debug!("[config] no home directory, proxy disabled");
+        return None;
+    };
     let config = match std::fs::read_to_string(&path) {
         Ok(contents) => match serde_json::from_str::<AppConfig>(&contents) {
             Ok(cfg) => cfg,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "macos")]
 mod app_nap;
+mod config;
 mod local_http_api;
 mod panel;
 mod plugin_engine;
@@ -514,6 +515,9 @@ pub fn run() {
 
             let version = app.package_info().version.to_string();
             log::info!("OpenUsage v{} starting", version);
+
+            // Load config early (lazy init via OnceLock, zero-cost after)
+            let _proxy = config::get_resolved_proxy();
 
             track_daily_active_if_needed(app.handle());
             #[cfg(desktop)]

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -602,7 +602,17 @@ fn inject_http<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rqui
                 let timeout_ms = req.timeout_ms.unwrap_or(10_000);
                 let mut builder = reqwest::blocking::Client::builder()
                     .timeout(std::time::Duration::from_millis(timeout_ms))
+                    .connect_timeout(std::time::Duration::from_millis(timeout_ms))
                     .redirect(reqwest::redirect::Policy::none());
+
+                // Apply pre-resolved proxy (localhost bypass already configured)
+                if let Some(resolved) = crate::config::get_resolved_proxy() {
+                    builder = builder.proxy(resolved.proxy.clone());
+                    log::debug!("[http] proxy active");
+                } else {
+                    log::debug!("[http] proxy not used");
+                }
+
                 if req.dangerously_ignore_tls.unwrap_or(false) {
                     builder = builder.danger_accept_invalid_certs(true);
                 }


### PR DESCRIPTION
## Summary

Add minimal proxy support for personal use — all outgoing HTTP requests from providers/plugins can now be routed through a SOCKS5 or HTTP proxy.

## Configuration

Create `~/.openusage/config.json`:

```json
{
  "proxy": {
    "enabled": true,
    "url": "socks5://127.0.0.1:10808"
  }
}
```

## Details

- **Zero overhead** — config loaded once at startup via `OnceLock`, cached as pre-resolved `reqwest::Proxy`
- **Localhost bypass** — `localhost`, `127.0.0.1`, `::1` always bypass the proxy (via `reqwest::NoProxy`)
- **Graceful fallback** — missing file, invalid JSON, or invalid URL → app continues without proxy
- **SOCKS5 + HTTP/HTTPS** — supported natively by reqwest
- **No UI changes** — file-only config
- **No env vars** — hardcoded path `~/.openusage/config.json`

## Changes

| File | What |
|---|---|
| `src-tauri/src/config.rs` | New — config loader with `OnceLock` caching, `NoProxy` bypass, URL redaction |
| `src-tauri/Cargo.toml` | Added `socks` feature to reqwest |
| `src-tauri/src/lib.rs` | Early config load during app setup |
| `src-tauri/src/plugin_engine/host_api.rs` | Proxy applied to the single `Client::builder()` + `connect_timeout`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional SOCKS5/HTTP proxy support for all provider/plugin HTTP requests, configurable via ~/.openusage/config.json. Defaults off; when enabled, requests use the proxy with a localhost bypass, and setup is documented in docs/proxy.md (linked from README).

- **New Features**
  - Apply a pre-resolved `reqwest::Proxy` to the shared HTTP client (`OnceLock`; supports SOCKS5/HTTP).
  - Bypass proxy for localhost addresses.
  - Add `connect_timeout` aligned with the request timeout.
  - Add proxy setup guide in docs/proxy.md and link from README.

- **Bug Fixes**
  - Avoid relative config path when the home directory is unavailable; proxy stays disabled in that case.
  - Correct proxy URL redaction to reliably mask credentials in logs.

<sup>Written for commit a0b7b1abd1161438c343dd09539bc91fa8803f48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

