### PR TITLE
Add Cmd+Arrow tab navigation in panel

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1240,6 +1240,67 @@ describe("App", () => {
     await screen.findByText("Now")
   })
 
+  it("switches sidebar tabs with Cmd+Up and Cmd+Down immediately after focus", async () => {
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "list_plugins") {
+        return [
+          { id: "a", name: "Alpha", iconUrl: "icon-a", primaryProgressLabel: null, lines: [{ type: "text", label: "Alpha line", scope: "overview" }] },
+          { id: "b", name: "Beta", iconUrl: "icon-b", primaryProgressLabel: null, lines: [{ type: "text", label: "Beta line", scope: "overview" }] },
+        ]
+      }
+      return null
+    })
+
+    render(<App />)
+    await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
+
+    state.probeHandlers?.onResult({
+      providerId: "a",
+      displayName: "Alpha",
+      iconUrl: "icon-a",
+      lines: [{ type: "text", label: "Alpha line", value: "A" }],
+    })
+    state.probeHandlers?.onResult({
+      providerId: "b",
+      displayName: "Beta",
+      iconUrl: "icon-b",
+      lines: [{ type: "text", label: "Beta line", value: "B" }],
+    })
+
+    await screen.findByText("Alpha line")
+    await screen.findByText("Beta line")
+
+    window.dispatchEvent(new Event("focus"))
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", metaKey: true }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha line")).toBeInTheDocument()
+      expect(screen.queryByText("Beta line")).not.toBeInTheDocument()
+    })
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", metaKey: true }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Beta line")).toBeInTheDocument()
+      expect(screen.queryByText("Alpha line")).not.toBeInTheDocument()
+    })
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", metaKey: true }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha line")).toBeInTheDocument()
+      expect(screen.queryByText("Beta line")).not.toBeInTheDocument()
+    })
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", metaKey: true }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha line")).toBeInTheDocument()
+      expect(screen.getByText("Beta line")).toBeInTheDocument()
+    })
+  })
+
   it("coalesces pending tray icon timers on multiple settings changes", async () => {
     state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
     render(<App />)

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -67,7 +67,11 @@ export function AppShell({
   const { updateStatus, triggerInstall, checkForUpdates } = useAppUpdate()
 
   return (
-    <div ref={containerRef} className="flex flex-col items-center p-6 pt-1.5 bg-transparent">
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      className="flex flex-col items-center p-6 pt-1.5 bg-transparent outline-none"
+    >
       <div className="tray-arrow" />
       <div
         className="relative bg-card rounded-xl overflow-hidden select-none w-full border shadow-lg flex flex-col"

--- a/src/hooks/app/use-panel.test.ts
+++ b/src/hooks/app/use-panel.test.ts
@@ -50,6 +50,7 @@ describe("usePanel", () => {
 
     isTauriMock.mockReturnValue(true)
     invokeMock.mockResolvedValue(undefined)
+    listenMock.mockResolvedValue(vi.fn())
     currentMonitorMock.mockResolvedValue(null)
     getCurrentWindowMock.mockReturnValue({ setSize: vi.fn().mockResolvedValue(undefined) })
   })
@@ -149,5 +150,195 @@ describe("usePanel", () => {
     await waitFor(() => {
       expect(unlistenShowAbout).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it("switches views with Cmd+Arrow navigation", () => {
+    const setActiveView = vi.fn()
+
+    const firstHook = renderHook(() =>
+      usePanel({
+        activeView: "home",
+        setActiveView,
+        showAbout: false,
+        setShowAbout: vi.fn(),
+        displayPlugins: [
+          {
+            meta: { id: "a" },
+            data: null,
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+          } as any,
+          {
+            meta: { id: "b" },
+            data: null,
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+          } as any,
+        ],
+      })
+    )
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", metaKey: true }))
+    })
+
+    expect(setActiveView).toHaveBeenCalledWith("a")
+
+    firstHook.unmount()
+    setActiveView.mockClear()
+
+    const secondHook = renderHook(() =>
+      usePanel({
+        activeView: "b",
+        setActiveView,
+        showAbout: false,
+        setShowAbout: vi.fn(),
+        displayPlugins: [
+          {
+            meta: { id: "a" },
+            data: null,
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+          } as any,
+          {
+            meta: { id: "b" },
+            data: null,
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+          } as any,
+        ],
+      })
+    )
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", metaKey: true }))
+    })
+
+    expect(setActiveView).toHaveBeenCalledWith("home")
+    secondHook.unmount()
+  })
+
+  it("ignores Cmd+Arrow navigation from editable targets", () => {
+    const setActiveView = vi.fn()
+    const { result } = renderHook(() =>
+      usePanel({
+        activeView: "a",
+        setActiveView,
+        showAbout: false,
+        setShowAbout: vi.fn(),
+        displayPlugins: [
+          {
+            meta: { id: "a" },
+            data: null,
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+          } as any,
+        ],
+      })
+    )
+
+    const textbox = document.createElement("div")
+    textbox.setAttribute("role", "textbox")
+    document.body.appendChild(textbox)
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", metaKey: true, bubbles: true }))
+    })
+
+    expect(setActiveView).toHaveBeenCalledWith("home")
+
+    setActiveView.mockClear()
+
+    act(() => {
+      textbox.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", metaKey: true, bubbles: true }))
+    })
+
+    expect(setActiveView).not.toHaveBeenCalled()
+    document.body.removeChild(textbox)
+    expect(result.current.containerRef.current).toBeNull()
+  })
+
+  it("skips settings when navigating with Cmd+Arrow", () => {
+    const setActiveView = vi.fn()
+
+    renderHook(() =>
+      usePanel({
+        activeView: "settings",
+        setActiveView,
+        showAbout: false,
+        setShowAbout: vi.fn(),
+        displayPlugins: [
+          {
+            meta: { id: "a" },
+            data: null,
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+          } as any,
+          {
+            meta: { id: "b" },
+            data: null,
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+          } as any,
+        ],
+      })
+    )
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", metaKey: true }))
+    })
+
+    expect(setActiveView).toHaveBeenCalledWith("home")
+
+    setActiveView.mockClear()
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", metaKey: true }))
+    })
+
+    expect(setActiveView).toHaveBeenCalledWith("b")
+  })
+
+  it("focuses the panel container when the window regains focus", () => {
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback: FrameRequestCallback) => {
+        callback(0)
+        return 0
+      })
+
+    const { result } = renderHook(() =>
+      usePanel({
+        activeView: "home",
+        setActiveView: vi.fn(),
+        showAbout: false,
+        setShowAbout: vi.fn(),
+        displayPlugins: [],
+      })
+    )
+
+    const container = document.createElement("div")
+    container.tabIndex = -1
+    document.body.appendChild(container)
+
+    act(() => {
+      result.current.containerRef.current = container
+    })
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"))
+    })
+
+    expect(container).toHaveFocus()
+
+    document.body.removeChild(container)
+    requestAnimationFrameSpy.mockRestore()
   })
 })

--- a/src/hooks/app/use-panel.ts
+++ b/src/hooks/app/use-panel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { invoke, isTauri } from "@tauri-apps/api/core"
 import { listen } from "@tauri-apps/api/event"
 import { getCurrentWindow, PhysicalSize, currentMonitor } from "@tauri-apps/api/window"
@@ -40,14 +40,13 @@ export function usePanel({
   const [canScrollDown, setCanScrollDown] = useState(false)
   const [maxPanelHeightPx, setMaxPanelHeightPx] = useState<number | null>(null)
   const maxPanelHeightPxRef = useRef<number | null>(null)
+  const focusContainer = useCallback(() => {
+    window.requestAnimationFrame(() => {
+      containerRef.current?.focus({ preventScroll: true })
+    })
+  }, [])
 
   useEffect(() => {
-    const focusContainer = () => {
-      window.requestAnimationFrame(() => {
-        containerRef.current?.focus({ preventScroll: true })
-      })
-    }
-
     const handleVisibilityChange = () => {
       if (!document.hidden) {
         focusContainer()
@@ -61,7 +60,7 @@ export function usePanel({
       window.removeEventListener("focus", focusContainer)
       document.removeEventListener("visibilitychange", handleVisibilityChange)
     }
-  }, [])
+  }, [focusContainer])
 
   useEffect(() => {
     if (!isTauri()) return
@@ -86,12 +85,6 @@ export function usePanel({
     if (!isTauri()) return
     let cancelled = false
     const unlisteners: (() => void)[] = []
-
-    const focusContainer = () => {
-      window.requestAnimationFrame(() => {
-        containerRef.current?.focus({ preventScroll: true })
-      })
-    }
 
     async function setup() {
       const u1 = await listen<string>("tray:navigate", (event) => {
@@ -121,7 +114,7 @@ export function usePanel({
       cancelled = true
       for (const fn of unlisteners) fn()
     }
-  }, [setActiveView, setShowAbout])
+  }, [focusContainer, setActiveView, setShowAbout])
 
   useEffect(() => {
     if (showAbout) return

--- a/src/hooks/app/use-panel.ts
+++ b/src/hooks/app/use-panel.ts
@@ -3,6 +3,7 @@ import { invoke, isTauri } from "@tauri-apps/api/core"
 import { listen } from "@tauri-apps/api/event"
 import { getCurrentWindow, PhysicalSize, currentMonitor } from "@tauri-apps/api/window"
 import type { ActiveView } from "@/components/side-nav"
+import type { DisplayPluginState } from "@/hooks/app/use-app-plugin-views"
 
 const PANEL_WIDTH = 400
 const MAX_HEIGHT_FALLBACK_PX = 600
@@ -13,7 +14,18 @@ type UsePanelArgs = {
   setActiveView: (view: ActiveView) => void
   showAbout: boolean
   setShowAbout: (value: boolean) => void
-  displayPlugins: unknown[]
+  displayPlugins: DisplayPluginState[]
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+
+  if (target.isContentEditable) return true
+  if (target.closest("input, textarea, select, [contenteditable='true'], [role='textbox']")) {
+    return true
+  }
+
+  return false
 }
 
 export function usePanel({
@@ -28,6 +40,28 @@ export function usePanel({
   const [canScrollDown, setCanScrollDown] = useState(false)
   const [maxPanelHeightPx, setMaxPanelHeightPx] = useState<number | null>(null)
   const maxPanelHeightPxRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const focusContainer = () => {
+      window.requestAnimationFrame(() => {
+        containerRef.current?.focus({ preventScroll: true })
+      })
+    }
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        focusContainer()
+      }
+    }
+
+    window.addEventListener("focus", focusContainer)
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+
+    return () => {
+      window.removeEventListener("focus", focusContainer)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [])
 
   useEffect(() => {
     if (!isTauri()) return
@@ -53,9 +87,16 @@ export function usePanel({
     let cancelled = false
     const unlisteners: (() => void)[] = []
 
+    const focusContainer = () => {
+      window.requestAnimationFrame(() => {
+        containerRef.current?.focus({ preventScroll: true })
+      })
+    }
+
     async function setup() {
       const u1 = await listen<string>("tray:navigate", (event) => {
         setActiveView(event.payload as ActiveView)
+        focusContainer()
       })
       if (cancelled) {
         u1()
@@ -65,6 +106,7 @@ export function usePanel({
 
       const u2 = await listen("tray:show-about", () => {
         setShowAbout(true)
+        focusContainer()
       })
       if (cancelled) {
         u2()
@@ -80,6 +122,39 @@ export function usePanel({
       for (const fn of unlisteners) fn()
     }
   }, [setActiveView, setShowAbout])
+
+  useEffect(() => {
+    if (showAbout) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return
+      if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
+      if (isEditableTarget(event.target)) return
+
+      const views: ActiveView[] = ["home", ...displayPlugins.map((plugin) => plugin.meta.id)]
+      if (views.length === 0) return
+
+      let nextView: ActiveView | undefined
+
+      if (activeView === "settings") {
+        nextView = event.key === "ArrowUp" ? views[views.length - 1] : views[0]
+      } else {
+        const currentIndex = views.indexOf(activeView)
+        if (currentIndex === -1) return
+        const offset = event.key === "ArrowUp" ? -1 : 1
+        nextView = views[(currentIndex + offset + views.length) % views.length]
+      }
+
+      if (!nextView || nextView === activeView) return
+
+      event.preventDefault()
+      setActiveView(nextView)
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [activeView, displayPlugins, setActiveView, showAbout])
 
   useEffect(() => {
     if (!isTauri()) return


### PR DESCRIPTION
## Description

Add `Cmd+Up` / `Cmd+Down` navigation for the open panel so the user can switch between Home and enabled provider tabs without reordering anything.
The shortcut works immediately after opening from either the tray icon or the global shortcut because the panel now reclaims focus when it becomes visible.
The cycle wraps at the ends and skips Settings, and the change is covered with focused panel and app regression tests.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [ ] I ran `bun run build` and it succeeded
- [ ] I ran `bun run test` and all tests pass
- [ ] I tested the change locally with `bun tauri dev`
- Ran `bunx vitest run src/hooks/app/use-panel.test.ts src/App.test.tsx`

## Screenshots

Keyboard-only change; no screenshot attached.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds client-side keyboard/focus handling with comprehensive tests; low risk aside from potential UX regressions from globally listening to `keydown` and changing focus behavior.
> 
> **Overview**
> Adds **Cmd+ArrowUp/ArrowDown** keyboard navigation to cycle the panel sidebar between `home` and provider views (wrapping at ends), while *skipping* `settings` and ignoring key events originating from editable elements.
> 
> Ensures the shortcut works immediately after the panel is shown by making the panel container focusable (`tabIndex={-1}`) and auto-focusing it on window focus/visibility regain and after tray navigation/about events. Updates and expands hook/app tests to cover focus behavior and view-cycling edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6e0ed70d776bfa3437872e2c40203f14401d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cmd+Up/Down navigation to switch between Home and provider tabs in the panel. The panel now reclaims focus on window focus/visibility and after tray/about actions so the shortcut works immediately.

- **New Features**
  - Cmd+Up/Down cycles through Home and enabled provider tabs; wraps at ends and skips Settings.
  - Auto-focus on window focus and visibility change, and after tray navigation/about; `AppShell` container is focusable (`tabIndex={-1}`).
  - Shortcut is ignored when typing in inputs or contenteditable areas; tests added for navigation, focus, and editable targets.

- **Refactors**
  - Consolidated focus logic into a single helper used by window, visibility, and tray listeners.

<sup>Written for commit 0d6e0ed70d776bfa3437872e2c40203f14401d6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

