### PR TITLE
fix(gemini): session expired

### DIFF
--- a/plugins/gemini/plugin.js
+++ b/plugins/gemini/plugin.js
@@ -1,13 +1,62 @@
 (function () {
   const SETTINGS_PATH = "~/.gemini/settings.json"
   const CREDS_PATH = "~/.gemini/oauth_creds.json"
-  const OAUTH2_JS_PATHS = [
-    "~/.bun/install/global/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js",
-    "~/.npm-global/lib/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js",
-    "~/.nvm/versions/node/current/lib/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js",
-    "/opt/homebrew/opt/gemini-cli/libexec/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js",
-    "/usr/local/opt/gemini-cli/libexec/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js",
+  const OAUTH2_SUFFIX_FLAT = "/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
+  const OAUTH2_SUFFIX_NESTED = "/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
+
+  const STATIC_MODULE_ROOTS = [
+    "~/.bun/install/global/node_modules",
+    "~/.npm-global/lib/node_modules",
+    "/usr/local/lib/node_modules",
+    "~/Library/pnpm/global/5/node_modules",
   ]
+
+  const STATIC_NESTED_ONLY = [
+    "/opt/homebrew/opt/gemini-cli/libexec/lib/node_modules",
+    "/usr/local/opt/gemini-cli/libexec/lib/node_modules",
+  ]
+
+  const VERSION_MANAGER_ROOTS = [
+    "~/.nvm/versions/node",
+    "~/Library/Application Support/fnm/node-versions",
+  ]
+
+  function listDirSafe(ctx, path) {
+    try {
+      return ctx.host.fs.listDir(path)
+    } catch (e) {
+      return []
+    }
+  }
+
+  function buildOauthCandidatePaths(ctx) {
+    var paths = []
+
+    for (var i = 0; i < STATIC_MODULE_ROOTS.length; i += 1) {
+      paths.push(STATIC_MODULE_ROOTS[i] + OAUTH2_SUFFIX_FLAT)
+      paths.push(STATIC_MODULE_ROOTS[i] + OAUTH2_SUFFIX_NESTED)
+    }
+
+    for (var i = 0; i < STATIC_NESTED_ONLY.length; i += 1) {
+      paths.push(STATIC_NESTED_ONLY[i] + OAUTH2_SUFFIX_NESTED)
+    }
+
+    for (var i = 0; i < VERSION_MANAGER_ROOTS.length; i += 1) {
+      var root = VERSION_MANAGER_ROOTS[i]
+      var versions = listDirSafe(ctx, root)
+      for (var j = 0; j < versions.length; j += 1) {
+        var base = root + "/" + versions[j] + "/lib/node_modules"
+        paths.push(base + OAUTH2_SUFFIX_FLAT)
+        paths.push(base + OAUTH2_SUFFIX_NESTED)
+      }
+    }
+
+    // volta stores packages differently
+    paths.push("~/.volta/tools/image/packages/@google/gemini-cli/lib/node_modules" + OAUTH2_SUFFIX_NESTED)
+    paths.push("~/.volta/tools/image/packages/@google/gemini-cli/lib/node_modules" + OAUTH2_SUFFIX_FLAT)
+
+    return paths
+  }
 
   const LOAD_CODE_ASSIST_URL = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"
   const QUOTA_URL = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota"
@@ -77,16 +126,18 @@
   }
 
   function loadOauthClientCreds(ctx) {
-    for (let i = 0; i < OAUTH2_JS_PATHS.length; i += 1) {
-      const path = OAUTH2_JS_PATHS[i]
+    const candidates = buildOauthCandidatePaths(ctx)
+    for (let i = 0; i < candidates.length; i += 1) {
+      const path = candidates[i]
       if (!ctx.host.fs.exists(path)) continue
       try {
         const parsed = parseOauthClientCreds(ctx.host.fs.readText(path))
         if (parsed) return parsed
       } catch (e) {
-        ctx.host.log.warn("failed reading oauth2.js: " + String(e))
+        ctx.host.log.warn("failed reading oauth2.js at " + path + ": " + String(e))
       }
     }
+    ctx.host.log.warn("Gemini OAuth client credentials not found in any known install path")
     return null
   }
 

--- a/plugins/gemini/plugin.js
+++ b/plugins/gemini/plugin.js
@@ -17,8 +17,8 @@
   ]
 
   const VERSION_MANAGER_ROOTS = [
-    "~/.nvm/versions/node",
-    "~/Library/Application Support/fnm/node-versions",
+    { root: "~/.nvm/versions/node", modulePath: "/lib/node_modules" },
+    { root: "~/Library/Application Support/fnm/node-versions", modulePath: "/installation/lib/node_modules" },
   ]
 
   function listDirSafe(ctx, path) {
@@ -42,10 +42,11 @@
     }
 
     for (var i = 0; i < VERSION_MANAGER_ROOTS.length; i += 1) {
-      var root = VERSION_MANAGER_ROOTS[i]
+      var versionManager = VERSION_MANAGER_ROOTS[i]
+      var root = versionManager.root
       var versions = listDirSafe(ctx, root)
       for (var j = 0; j < versions.length; j += 1) {
-        var base = root + "/" + versions[j] + "/lib/node_modules"
+        var base = root + "/" + versions[j] + versionManager.modulePath
         paths.push(base + OAUTH2_SUFFIX_FLAT)
         paths.push(base + OAUTH2_SUFFIX_NESTED)
       }

--- a/plugins/gemini/plugin.test.js
+++ b/plugins/gemini/plugin.test.js
@@ -746,6 +746,58 @@ describe("gemini plugin", () => {
     expect(persisted.access_token).toBe("refreshed-token")
   })
 
+  it("discovers oauth2.js via dynamic fnm version scanning", async () => {
+    const ctx = makeCtx()
+    const nowMs = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(nowMs)
+
+    const fnmOauth2Path =
+      "~/Library/Application Support/fnm/node-versions/v22.0.0/installation/lib/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
+
+    ctx.host.fs.writeText(
+      CREDS_PATH,
+      JSON.stringify({
+        access_token: "old-token",
+        refresh_token: "refresh-token",
+        expiry_date: nowMs - 1000,
+      })
+    )
+    ctx.host.fs.writeText(
+      fnmOauth2Path,
+      "const OAUTH_CLIENT_ID='fnm-client-id'; const OAUTH_CLIENT_SECRET='fnm-client-secret';"
+    )
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url === TOKEN_URL) {
+        return { status: 200, bodyText: JSON.stringify({ access_token: "fnm-token", expires_in: 3600 }) }
+      }
+      if (url === LOAD_CODE_ASSIST_URL) {
+        return { status: 200, bodyText: JSON.stringify({ tier: "standard-tier" }) }
+      }
+      if (url === PROJECTS_URL) {
+        return { status: 200, bodyText: JSON.stringify({ projects: [{ projectId: "gen-lang-client-fnm" }] }) }
+      }
+      if (url === QUOTA_URL) {
+        expect(opts.headers.Authorization).toBe("Bearer fnm-token")
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            quotaBuckets: [{ modelId: "gemini-2.5-pro", remainingFraction: 0.5, resetTime: "2099-01-01T00:00:00Z" }],
+          }),
+        }
+      }
+      throw new Error("unexpected url: " + url)
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Pro")).toBeTruthy()
+
+    const persisted = JSON.parse(ctx.host.fs.readText(CREDS_PATH))
+    expect(persisted.access_token).toBe("fnm-token")
+  })
+
   it("discovers oauth2.js via nested package structure", async () => {
     const ctx = makeCtx()
     const nowMs = 1_700_000_000_000

--- a/plugins/gemini/plugin.test.js
+++ b/plugins/gemini/plugin.test.js
@@ -695,6 +695,138 @@ describe("gemini plugin", () => {
     expect(result.lines.find((line) => line.label === "Flash")).toBeTruthy()
   })
 
+  it("discovers oauth2.js via dynamic NVM version scanning", async () => {
+    const ctx = makeCtx()
+    const nowMs = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(nowMs)
+
+    const nvmOauth2Path =
+      "~/.nvm/versions/node/v22.0.0/lib/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
+
+    ctx.host.fs.writeText(
+      CREDS_PATH,
+      JSON.stringify({
+        access_token: "old-token",
+        refresh_token: "refresh-token",
+        expiry_date: nowMs - 1000,
+      })
+    )
+    ctx.host.fs.writeText(
+      nvmOauth2Path,
+      "const OAUTH_CLIENT_ID='nvm-client-id'; const OAUTH_CLIENT_SECRET='nvm-client-secret';"
+    )
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url === TOKEN_URL) {
+        return { status: 200, bodyText: JSON.stringify({ access_token: "refreshed-token", expires_in: 3600 }) }
+      }
+      if (url === LOAD_CODE_ASSIST_URL) {
+        return { status: 200, bodyText: JSON.stringify({ tier: "standard-tier" }) }
+      }
+      if (url === PROJECTS_URL) {
+        return { status: 200, bodyText: JSON.stringify({ projects: [{ projectId: "gen-lang-client-nvm" }] }) }
+      }
+      if (url === QUOTA_URL) {
+        expect(opts.headers.Authorization).toBe("Bearer refreshed-token")
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            quotaBuckets: [{ modelId: "gemini-2.5-pro", remainingFraction: 0.5, resetTime: "2099-01-01T00:00:00Z" }],
+          }),
+        }
+      }
+      throw new Error("unexpected url: " + url)
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Pro")).toBeTruthy()
+    const persisted = JSON.parse(ctx.host.fs.readText(CREDS_PATH))
+    expect(persisted.access_token).toBe("refreshed-token")
+  })
+
+  it("discovers oauth2.js via nested package structure", async () => {
+    const ctx = makeCtx()
+    const nowMs = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(nowMs)
+
+    const nestedPath =
+      "~/.npm-global/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
+
+    ctx.host.fs.writeText(
+      CREDS_PATH,
+      JSON.stringify({
+        access_token: "old-token",
+        refresh_token: "refresh-token",
+        expiry_date: nowMs - 1000,
+      })
+    )
+    ctx.host.fs.writeText(
+      nestedPath,
+      "const OAUTH_CLIENT_ID='nested-id'; const OAUTH_CLIENT_SECRET='nested-secret';"
+    )
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url === TOKEN_URL) {
+        return { status: 200, bodyText: JSON.stringify({ access_token: "nested-token", expires_in: 3600 }) }
+      }
+      if (url === LOAD_CODE_ASSIST_URL) return { status: 200, bodyText: JSON.stringify({ tier: "standard-tier" }) }
+      if (url === PROJECTS_URL) return { status: 200, bodyText: JSON.stringify({ projects: [{ projectId: "gen-lang-client-nested" }] }) }
+      if (url === QUOTA_URL) {
+        expect(opts.headers.Authorization).toBe("Bearer nested-token")
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            quotaBuckets: [{ modelId: "gemini-2.5-pro", remainingFraction: 0.3, resetTime: "2099-01-01T00:00:00Z" }],
+          }),
+        }
+      }
+      throw new Error("unexpected url: " + url)
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Pro")).toBeTruthy()
+  })
+
+  it("logs warning when no oauth2.js is found at any path", async () => {
+    const ctx = makeCtx()
+    const nowMs = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(nowMs)
+
+    ctx.host.fs.writeText(
+      CREDS_PATH,
+      JSON.stringify({
+        access_token: "existing-token",
+        refresh_token: "refresh-token",
+        expiry_date: nowMs - 1000,
+      })
+    )
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url === LOAD_CODE_ASSIST_URL) return { status: 200, bodyText: JSON.stringify({ tier: "standard-tier" }) }
+      if (url === PROJECTS_URL) return { status: 200, bodyText: JSON.stringify({ projects: [{ projectId: "gen-lang-client-warn" }] }) }
+      if (url === QUOTA_URL) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            quotaBuckets: [{ modelId: "gemini-2.5-pro", remainingFraction: 0.5, resetTime: "2099-01-01T00:00:00Z" }],
+          }),
+        }
+      }
+      throw new Error("unexpected url: " + url)
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    const warnCalls = ctx.host.log.warn.mock.calls.map((c) => c[0])
+    expect(warnCalls.some((msg) => msg.includes("not found in any known install path"))).toBe(true)
+  })
+
   it("uses snake_case quota fields and still renders lines", async () => {
     const ctx = makeCtx()
     const nowMs = 1_700_000_000_000


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->
Fixes Gemini session expired issue

## Related Issue

<!-- Link to the issue this PR addresses: Fixes #123 -->
Fixes #357 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Gemini “session expired” by reliably finding OAuth client credentials and refreshing tokens across common install paths. Adds clear warnings when none are found; fixes #357.

- **Bug Fixes**
  - Dynamically scans for `@google/gemini-cli-core`/`@google/gemini-cli` oauth2.js in flat and nested layouts (NVM, FNM with corrected `~/Library/Application Support/fnm/.../installation` path, Volta, npm/pnpm globals, Homebrew, `/usr/local`).
  - Refreshes tokens with discovered client ID/secret and persists to `~/.gemini/oauth_creds.json`.
  - Logs a single warning when OAuth creds are not found; read errors include the file path.

<sup>Written for commit 7735d12d86589d75dd81aa5b48d07e22bee84e07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

