### PR TITLE
feat(claude): integrate peak/off-peak status via external API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ OpenUsage lives in your menu bar and shows you how much of your AI coding subscr
 
 - [**Amp**](docs/providers/amp.md) / free tier, bonus, credits
 - [**Antigravity**](docs/providers/antigravity.md) / all models
-- [**Claude**](docs/providers/claude.md) / session, weekly, extra usage, local token usage (ccusage)
+- [**Claude**](docs/providers/claude.md) / session, weekly, peak/off-peak, extra usage, local token usage (ccusage)
 - [**Codex**](docs/providers/codex.md) / session, weekly, reviews, credits
 - [**Copilot**](docs/providers/copilot.md) / premium, chat, completions
 - [**Cursor**](docs/providers/cursor.md) / credits, total usage, auto usage, API usage, on-demand, CLI auth

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -12,6 +12,7 @@
 - **Utilization:** integer percentage (0-100)
 - **Credits:** cents (divide by 100 for dollars)
 - **Timestamps:** ISO 8601 (response), unix milliseconds (credentials file)
+- **Peak hours status:** supplemental best-effort data from PromoClock's public API; does not affect Claude usage math
 
 ## Endpoints
 
@@ -54,6 +55,18 @@ Returns rate limit windows and optional extra credits.
 ```
 
 All windows are enforced simultaneously — hitting any limit throttles the user.
+
+## Supplemental Peak Hours Status
+
+OpenUsage also augments the Claude card with PromoClock peak/off-peak status:
+
+- **Endpoint:** `GET https://promoclock.co/api/status`
+- **Auth:** none
+- **Fields used:** `isPeak`, `isOffPeak`, `isWeekend`, `status` (fallback)
+- **UI mapping:** binary Peak / Off-Peak badge (weekend is treated as off-peak)
+- **Failure mode:** ignored on network, HTTP, or payload errors; Claude usage lines still render normally
+
+This is informational only. PromoClock is an independent public service, not an official Anthropic API.
 
 ## Authentication
 

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -6,6 +6,9 @@
   const PROD_REFRESH_URL = "https://platform.claude.com/v1/oauth/token"
   const PROD_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
   const NON_PROD_CLIENT_ID = "22422756-60c9-4084-8eb7-27705fd5cf9a"
+  const PROMOCLOCK_STATUS_URL = "https://promoclock.co/api/status"
+  const PROMOCLOCK_PEAK_COLOR = "#ef4444"
+  const PROMOCLOCK_OFF_PEAK_COLOR = "#22c55e"
   const SCOPES =
     "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
   const REFRESH_BUFFER_MS = 5 * 60 * 1000 // refresh 5 minutes before expiration
@@ -542,6 +545,66 @@
     }))
   }
 
+  function getPromoClockBadgeText(data) {
+    if (!data || typeof data !== "object") return null
+    if (data.isPeak === true) return "Peak"
+    if (data.isOffPeak === true || data.isWeekend === true) return "Off-Peak"
+
+    const status = typeof data.status === "string" ? data.status.trim().toLowerCase() : ""
+    if (status === "peak") return "Peak"
+    if (status === "off_peak" || status === "off-peak" || status === "weekend") return "Off-Peak"
+    return null
+  }
+
+  function getPromoClockColor(badgeText) {
+    if (badgeText === "Peak") return PROMOCLOCK_PEAK_COLOR
+    if (badgeText === "Off-Peak") return PROMOCLOCK_OFF_PEAK_COLOR
+    return null
+  }
+
+  function fetchPromoClockLine(ctx) {
+    let resp
+    let json
+    try {
+      const result = ctx.util.requestJson({
+        method: "GET",
+        url: PROMOCLOCK_STATUS_URL,
+        headers: {
+          Accept: "application/json",
+        },
+        timeoutMs: 2000,
+      })
+      resp = result.resp
+      json = result.json
+    } catch (e) {
+      ctx.host.log.warn("promoclock request failed: " + String(e))
+      return null
+    }
+
+    if (!resp || resp.status < 200 || resp.status >= 300) {
+      ctx.host.log.warn("promoclock returned unexpected status: " + String(resp && resp.status))
+      return null
+    }
+
+    if (!json || typeof json !== "object") {
+      ctx.host.log.warn("promoclock response invalid")
+      return null
+    }
+
+    const badgeText = getPromoClockBadgeText(json)
+
+    if (!badgeText) {
+      ctx.host.log.warn("promoclock response missing expected fields")
+      return null
+    }
+
+    return ctx.line.badge({
+      label: "Peak Hours",
+      text: badgeText,
+      color: getPromoClockColor(badgeText),
+    })
+  }
+
   function probe(ctx) {
     const creds = loadCredentials(ctx)
     if (!creds || !creds.oauth || !creds.oauth.accessToken || !creds.oauth.accessToken.trim()) {
@@ -725,9 +788,13 @@
       }
     }
 
+    const promoClockLine = fetchPromoClockLine(ctx)
+
     if (lines.length === 0) {
       lines.push(ctx.line.badge({ label: "Status", text: "No usage data", color: "#a3a3a3" }))
     }
+
+    if (promoClockLine) lines.push(promoClockLine)
 
     return { plan: plan, lines: lines }
   }

--- a/plugins/claude/plugin.json
+++ b/plugins/claude/plugin.json
@@ -13,6 +13,7 @@
   "lines": [
     { "type": "progress", "label": "Session", "scope": "overview", "primaryOrder": 1 },
     { "type": "progress", "label": "Weekly", "scope": "overview" },
+    { "type": "badge", "label": "Peak Hours", "scope": "overview" },
     { "type": "progress", "label": "Sonnet", "scope": "detail" },
     { "type": "progress", "label": "Extra usage spent", "scope": "detail" },
     { "type": "text", "label": "Today", "scope": "detail" },

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -10,6 +10,60 @@ beforeAll(async () => {
 
 const loadPlugin = async () => plugin
 
+const SAMPLE_PROMOCLOCK_RESPONSE = {
+  status: "off_peak",
+  isPeak: false,
+  isOffPeak: true,
+  isWeekend: false,
+  sessionLimitSpeed: "normal",
+  emoji: "🟢",
+  label: "Off-Peak — Normal Speed",
+  peakHours: "Weekdays 1pm–7pm UTC / 1:00 PM–7:00 PM GMT",
+  nextChange: "2026-04-09T13:00:00.000Z",
+  minutesUntilChange: 720,
+  timestamp: "2026-04-09T01:00:00.000Z",
+  utcHour: 1,
+  utcDay: 4,
+  note: "No known end date for peak hours adjustment. Weekly limits unchanged.",
+}
+
+function mockClaudeUsageAndPromoClock(
+  ctx,
+  {
+    usageBody = {
+      five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      seven_day: { utilization: 20, resets_at: "2099-01-01T00:00:00.000Z" },
+    },
+    usageStatus = 200,
+    promoClockBody = SAMPLE_PROMOCLOCK_RESPONSE,
+    promoClockStatus = 200,
+    promoClockBodyText,
+  } = {}
+) {
+  ctx.host.http.request.mockImplementation((opts) => {
+    const url = String(opts && opts.url ? opts.url : "")
+    if (url === "https://promoclock.co/api/status") {
+      return {
+        status: promoClockStatus,
+        headers: {},
+        bodyText:
+          promoClockBodyText !== undefined
+            ? promoClockBodyText
+            : JSON.stringify(promoClockBody),
+      }
+    }
+
+    return {
+      status: usageStatus,
+      headers: {},
+      bodyText:
+        typeof usageBody === "string"
+          ? usageBody
+          : JSON.stringify(usageBody),
+    }
+  })
+}
+
 describe("claude plugin", () => {
   it("throws when no credentials", async () => {
     const ctx = makeCtx()
@@ -242,6 +296,120 @@ describe("claude plugin", () => {
     expect(result.plan).toBe("Pro")
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
+  })
+
+  describe("PromoClock integration", () => {
+    it("maps the real off-peak endpoint payload to the compact badge", async () => {
+      const ctx = makeCtx()
+      ctx.host.fs.readText = () =>
+        JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+      ctx.host.fs.exists = () => true
+      mockClaudeUsageAndPromoClock(ctx)
+
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx)
+
+      expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+      expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
+      expect(result.lines.find((line) => line.label === "Peak Hours")).toEqual({
+        type: "badge",
+        label: "Peak Hours",
+        text: "Off-Peak",
+        color: "#22c55e",
+      })
+      expect(result.lines.find((line) => line.label === "Next change")).toBeUndefined()
+    })
+
+    it("maps peak PromoClock responses into the badge-only UI", async () => {
+      const ctx = makeCtx()
+      ctx.host.fs.readText = () =>
+        JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+      ctx.host.fs.exists = () => true
+      mockClaudeUsageAndPromoClock(ctx, {
+        promoClockBody: {
+          ...SAMPLE_PROMOCLOCK_RESPONSE,
+          status: "peak",
+          isPeak: true,
+          isOffPeak: false,
+          emoji: "🔴",
+          label: "Peak Hours — Limits Drain Faster",
+          nextChange: "2026-04-08T19:00:00.000Z",
+          minutesUntilChange: 111,
+          timestamp: "2026-04-08T17:08:33.089Z",
+          utcHour: 17,
+        },
+      })
+
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx)
+
+      expect(result.lines.find((line) => line.label === "Peak Hours")?.text).toBe("Peak")
+      expect(result.lines.find((line) => line.label === "Peak Hours")?.color).toBe("#ef4444")
+    })
+
+    it("treats weekend as off-peak", async () => {
+      const ctx = makeCtx()
+      ctx.host.fs.readText = () =>
+        JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+      ctx.host.fs.exists = () => true
+      mockClaudeUsageAndPromoClock(ctx, {
+        promoClockBody: {
+          ...SAMPLE_PROMOCLOCK_RESPONSE,
+          status: "weekend",
+          isPeak: false,
+          isOffPeak: false,
+          isWeekend: true,
+          label: "Weekend — Normal Speed",
+        },
+      })
+
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx)
+
+      expect(result.lines.find((line) => line.label === "Peak Hours")?.text).toBe("Off-Peak")
+      expect(result.lines.find((line) => line.label === "Peak Hours")?.color).toBe("#22c55e")
+    })
+
+    it("ignores PromoClock failures and still returns Claude usage lines", async () => {
+      const ctx = makeCtx()
+      ctx.host.fs.readText = () =>
+        JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+      ctx.host.fs.exists = () => true
+      mockClaudeUsageAndPromoClock(ctx, {
+        promoClockStatus: 503,
+        promoClockBody: { error: "temporarily unavailable" },
+      })
+
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx)
+
+      expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+      expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
+      expect(result.lines.find((line) => line.label === "Peak Hours")).toBeUndefined()
+      expect(result.lines.find((line) => line.label === "Next change")).toBeUndefined()
+    })
+
+    it("falls back to status string when boolean flags are absent", async () => {
+      const ctx = makeCtx()
+      ctx.host.fs.readText = () =>
+        JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+      ctx.host.fs.exists = () => true
+      mockClaudeUsageAndPromoClock(ctx, {
+        promoClockBody: {
+          ...SAMPLE_PROMOCLOCK_RESPONSE,
+          status: "off_peak",
+          isPeak: undefined,
+          isOffPeak: undefined,
+          isWeekend: undefined,
+        },
+      })
+
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx)
+
+      expect(result.lines.find((line) => line.label === "Peak Hours")?.text).toBe("Off-Peak")
+      expect(result.lines.find((line) => line.label === "Peak Hours")?.color).toBe("#22c55e")
+    })
   })
 
   it("appends max rate limit tier to the plan label when present", async () => {


### PR DESCRIPTION
## Description

This pull request adds support for displaying Claude's current peak/off-peak status in the UI by integrating with PromoClock's public API. The change is informational only and does not affect usage calculations. It includes updates to the plugin logic, UI, documentation, and comprehensive tests for the new feature.

**Claude Plugin: Peak/Off-Peak Hours Integration**

*Plugin logic and UI:*
- Added logic to fetch peak/off-peak status from PromoClock's API (`https://promoclock.co/api/status`), interpret the response, and display a "Peak" or "Off-Peak" badge in the Claude plugin UI. Weekend is treated as off-peak, and the badge color reflects the status. Failures to fetch or parse the data are handled gracefully and do not affect other usage lines. (`[[1]](diffhunk://#diff-bbf9e1ee8073a9ec48cfe0f640517ab851868ecf255ede50d12e941df1dd1413R9-R11)`, `[[2]](diffhunk://#diff-bbf9e1ee8073a9ec48cfe0f640517ab851868ecf255ede50d12e941df1dd1413R548-R607)`, `[[3]](diffhunk://#diff-bbf9e1ee8073a9ec48cfe0f640517ab851868ecf255ede50d12e941df1dd1413R791-R798)`)
- Updated `plugin.json` to include the new "Peak Hours" badge line in the overview scope. (`[plugins/claude/plugin.jsonR16](diffhunk://#diff-09937f32dcee14bad5ff851487d40126ee65a298011a5d597df15e5e6a6d336dR16)`)

*Documentation:*
- Updated `README.md` and `docs/providers/claude.md` to document the new peak/off-peak badge, its source, and its informational nature. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R29)`, `[[2]](diffhunk://#diff-c90a552739431087015dcbcb584e52be85990ba0b01f0f1b0d086243d3b51aebR15)`, `[[3]](diffhunk://#diff-c90a552739431087015dcbcb584e52be85990ba0b01f0f1b0d086243d3b51aebR59-R70)`)

*Testing:*
- Added comprehensive tests for the PromoClock integration, including normal, peak, off-peak, weekend, fallback, and failure scenarios. (`[[1]](diffhunk://#diff-45842f7a680d33ed96cdafb4a241396028788710380cfc08c15a60496962e90dR13-R66)`, `[[2]](diffhunk://#diff-45842f7a680d33ed96cdafb4a241396028788710380cfc08c15a60496962e90dR301-R414)`)


## Type of Change

- [x] New feature

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

<img width="1120" height="954" alt="CleanShot 2026-04-10 at 11 40 38@2x" src="https://github.com/user-attachments/assets/2f95d05b-87a1-4e47-9d32-bec239c37006" />

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
