### PR TITLE
fix(antigravity): prefer userTier.name over legacy planInfo.planName

### DIFF
--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -428,9 +428,17 @@
 
     var plan = null
     if (hasUserStatus) {
-      var ps = data.userStatus.planStatus || {}
-      var pi = ps.planInfo || {}
-      plan = pi.planName || null
+      // Prefer userTier.name (Google's own subscription system) over the legacy
+      // planInfo.planName field inherited from Windsurf/Codeium, which always
+      // returns "Pro" for all paid tiers including Google AI Ultra.
+      var ut = data.userStatus.userTier
+      if (ut && ut.name) {
+        plan = ut.name
+      } else {
+        var ps = data.userStatus.planStatus || {}
+        var pi = ps.planInfo || {}
+        plan = pi.planName || null
+      }
     }
 
     return { plan: plan, lines: lines }

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -432,12 +432,15 @@
       // planInfo.planName field inherited from Windsurf/Codeium, which always
       // returns "Pro" for all paid tiers including Google AI Ultra.
       var ut = data.userStatus.userTier
-      if (ut && ut.name) {
-        plan = ut.name
+      var userTierName =
+        ut && typeof ut.name === "string" && ut.name.trim() ? ut.name.trim() : null
+      if (userTierName) {
+        plan = userTierName
       } else {
         var ps = data.userStatus.planStatus || {}
         var pi = ps.planInfo || {}
-        plan = pi.planName || null
+        plan =
+          typeof pi.planName === "string" && pi.planName.trim() ? pi.planName.trim() : null
       }
     }
 

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -69,6 +69,7 @@ function makeUserStatusResponse(overrides) {
     if (overrides.planName !== undefined) base.userStatus.planStatus.planInfo.planName = overrides.planName
     if (overrides.configs !== undefined) base.userStatus.cascadeModelConfigData.clientModelConfigs = overrides.configs
     if (overrides.planStatus !== undefined) base.userStatus.planStatus = overrides.planStatus
+    if (overrides.userTier !== undefined) base.userStatus.userTier = overrides.userTier
   }
   return base
 }
@@ -195,6 +196,9 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
+    expect(result.plan).toBe("Pro")
+
+    // No userTier in default fixture → falls back to planInfo.planName
     expect(result.plan).toBe("Pro")
 
     // Model lines exist — 3 pool lines
@@ -654,6 +658,7 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
+    // No userTier in default fixture → falls back to planInfo.planName
     expect(result.plan).toBe("Pro")
     const calls = ctx.host.http.request.mock.calls.map((c) => String(c[0].url))
     const ccCalls = calls.filter((u) => u.includes("fetchAvailableModels"))
@@ -1286,6 +1291,7 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
+    // No userTier in default fixture → falls back to planInfo.planName
     expect(result.plan).toBe("Pro")
     const calls = ctx.host.http.request.mock.calls.map((c) => String(c[0].url))
     expect(calls.filter((u) => u.includes("fetchAvailableModels")).length).toBe(0)
@@ -1352,5 +1358,52 @@ describe("antigravity plugin", () => {
     const result = plugin.probe(ctx)
     expect(result.lines.length).toBeGreaterThan(0)
     expect(ccCalls).toBe(2)
+  })
+
+  it("prefers userTier.name over legacy planInfo.planName for Ultra subscribers", async () => {
+    const ctx = makeCtx()
+    const discovery = makeDiscovery()
+    const response = makeUserStatusResponse({
+      userTier: {
+        id: "g1-ultra-tier",
+        name: "Google AI Ultra",
+        description: "Google AI Ultra",
+        upgradeSubscriptionText: "You are subscribed to the best plan.",
+      },
+    })
+    setupLsMock(ctx, discovery, response)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Google AI Ultra")
+    const labels = result.lines.map((l) => l.label)
+    expect(labels).toEqual(["Gemini Pro", "Gemini Flash", "Claude"])
+  })
+
+  it("falls back to planInfo.planName when userTier is absent", async () => {
+    const ctx = makeCtx()
+    const discovery = makeDiscovery()
+    const response = makeUserStatusResponse()  // no userTier override
+    setupLsMock(ctx, discovery, response)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Pro")
+  })
+
+  it("falls back to planInfo.planName when userTier.name is empty", async () => {
+    const ctx = makeCtx()
+    const discovery = makeDiscovery()
+    const response = makeUserStatusResponse({
+      userTier: { id: "g1-pro-tier", name: "" },
+    })
+    setupLsMock(ctx, discovery, response)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Pro")
   })
 })

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -196,8 +196,6 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
 
-    expect(result.plan).toBe("Pro")
-
     // No userTier in default fixture → falls back to planInfo.planName
     expect(result.plan).toBe("Pro")
 


### PR DESCRIPTION
## Summary

Fixes #368 — Ultra subscribers are incorrectly displayed as "Pro" in the Antigravity plugin.

## Problem

The `GetUserStatus` response contains two separate tier identifiers:

| Field | Ultra subscriber value | Source |
|---|---|---|
| `planStatus.planInfo.planName` | `"Pro"` ❌ | Windsurf/Codeium legacy |
| `userTier.name` | `"Google AI Ultra"` ✅ | Google subscription system |

The plugin was reading `planInfo.planName`, which always returns `"Pro"` for all paid tiers regardless of whether the user is on Pro or Ultra.

## Fix

Prefer `userTier.name` when available, falling back to `planInfo.planName` for backward compatibility:

```js
var ut = data.userStatus.userTier
if (ut && ut.name) {
  plan = ut.name
} else {
  var ps = data.userStatus.planStatus || {}
  var pi = ps.planInfo || {}
  plan = pi.planName || null
}
```

## Tests

- ✅ Added: "prefers userTier.name over legacy planInfo.planName for Ultra subscribers"
- ✅ Added: "falls back to planInfo.planName when userTier is absent"
- ✅ Added: "falls back to planInfo.planName when userTier.name is empty"
- ✅ All 53 existing tests pass without modification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect plan labels in the Antigravity plugin by preferring `userTier.name` over the legacy `planInfo.planName`. Ultra subscribers now display as "Google AI Ultra" instead of "Pro", with guards for empty or non-string values.

- **Bug Fixes**
  - Prefer `userTier.name`; fall back to `planStatus.planInfo.planName` for backward compatibility.
  - Add typeof/trim guards to ignore invalid labels; add tests for Ultra, missing `userTier`, and empty `userTier.name`.

<sup>Written for commit cb63b20fa59152a4432220d95942c9a610b4e039. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

