### PR TITLE
fix(codex): map Codex plan labels to Pro 5x and Pro 10x

### DIFF
--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -272,6 +272,13 @@
     return Number.isFinite(n) ? n : null
   }
 
+  function formatCodexPlan(ctx, planType) {
+    const rawPlan = typeof planType === "string" ? planType.trim() : ""
+    if (!rawPlan) return null
+    if (rawPlan.toLowerCase() === "prolite") return "Pro 5x"
+    return ctx.fmt.planLabel(rawPlan) || null
+  }
+
   function getResetsAtIso(ctx, nowSec, window) {
     if (!window) return null
     if (typeof window.reset_at === "number") {
@@ -604,7 +611,7 @@
 
       let plan = null
       if (data.plan_type) {
-        const planLabel = ctx.fmt.planLabel(data.plan_type)
+        const planLabel = formatCodexPlan(ctx, data.plan_type)
         if (planLabel) {
           plan = planLabel
         }

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -276,6 +276,7 @@
     const rawPlan = typeof planType === "string" ? planType.trim() : ""
     if (!rawPlan) return null
     if (rawPlan.toLowerCase() === "prolite") return "Pro 5x"
+    if (rawPlan.toLowerCase() === "pro") return "Pro 10x"
     return ctx.fmt.planLabel(rawPlan) || null
   }
 

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -164,7 +164,39 @@ describe("codex plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.plan).toBeTruthy()
+    expect(result.plan).toBe("Pro")
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
+    const credits = result.lines.find((line) => line.label === "Credits")
+    expect(credits).toBeTruthy()
+    expect(credits.used).toBe(900)
+  })
+
+  it("maps prolite plan to Pro 5x", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {
+        "x-codex-primary-used-percent": "25",
+        "x-codex-secondary-used-percent": "50",
+        "x-codex-credits-balance": "100",
+      },
+      bodyText: JSON.stringify({
+        plan_type: "prolite",
+        rate_limit: {
+          primary_window: { reset_after_seconds: 60, used_percent: 10 },
+          secondary_window: { reset_after_seconds: 120, used_percent: 20 },
+        },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("Pro 5x")
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
     const credits = result.lines.find((line) => line.label === "Credits")

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -164,7 +164,7 @@ describe("codex plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.plan).toBe("Pro")
+    expect(result.plan).toBe("Pro 10x")
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
     const credits = result.lines.find((line) => line.label === "Credits")


### PR DESCRIPTION
## Description

Maps Codex raw upstream plan labels to user-facing tiers in the plan badge.

Current mappings:
- `prolite` -> `Pro 5x`
- `pro` -> `Pro 10x`

Keeps the change provider-specific and leaves shared plan formatting unchanged.

## Related Issue

Fixes #379 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [ ] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

Additional test notes:
Additional test notes:
- `bun run test plugins/codex/plugin.test.js` passes, including coverage for:
  - `prolite` -> `Pro 5x`
  - `pro` -> `Pro 10x`
- `Pro 5x` was verified locally in the app
- `Pro 10x` could not be verified locally because I do not have access to a standard Pro 10x account
- `bun run test` currently fails on an unrelated existing assertion in `src/App.test.tsx:785`
  - Failure: `expected "vi.fn()" to be called 2 times, but got 3 times`

## Screenshots
Before:
<img width="682" height="302" alt="CleanShot 2026-04-13 at 23 19 12@2x" src="https://github.com/user-attachments/assets/1c7a2c20-c557-4487-91b0-587404ea73d2" />

After:
<img width="698" height="304" alt="CleanShot 2026-04-13 at 23 16 34@2x" src="https://github.com/user-attachments/assets/ae0ccf2a-2632-4685-b9db-8f472992f55c" />


## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map Codex upstream plan_type "prolite" and "pro" to the user-facing "Pro 5x" and "Pro 10x" labels in the Codex provider. Keeps the change provider-specific and leaves shared plan formatting unchanged.

- **Bug Fixes**
  - Added a local formatter to map "prolite" → "Pro 5x" and "pro" → "Pro 10x", falling back to `ctx.fmt.planLabel`.
  - Updated tests to cover both mappings and validate plan and credit lines.

<sup>Written for commit 5e5715073b5f8d20d7922056a12fb92e7f5b3187. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



