### PR TITLE
refactor(settings): enhance auto-update interval handling

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -10,7 +10,11 @@ export type PluginSettings = {
   disabled: string[];
 };
 
-export type AutoUpdateIntervalMinutes = 5 | 15 | 30 | 60;
+/**
+ * Auto-update interval stored in minutes.
+ * Preset values: 5, 15, 30, 60. Custom values allowed (minimum 0.5 = 30 seconds).
+ */
+export type AutoUpdateIntervalMinutes = number;
 
 export type ThemeMode = "system" | "light" | "dark";
 
@@ -42,7 +46,9 @@ export const DEFAULT_MENUBAR_ICON_STYLE: MenubarIconStyle = "provider";
 export const DEFAULT_GLOBAL_SHORTCUT: GlobalShortcut = null;
 export const DEFAULT_START_ON_LOGIN = false;
 
-const AUTO_UPDATE_INTERVALS: AutoUpdateIntervalMinutes[] = [5, 15, 30, 60];
+const AUTO_UPDATE_PRESET_VALUES: number[] = [5, 15, 30, 60];
+export const MIN_CUSTOM_INTERVAL_MINUTES = 0.5; // 30 seconds
+export const MAX_CUSTOM_INTERVAL_MINUTES = 1440; // 24 hours
 const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
 const DISPLAY_MODES: DisplayMode[] = ["used", "left"];
 const RESET_TIMER_DISPLAY_MODES: ResetTimerDisplayMode[] = ["relative", "absolute"];
@@ -55,10 +61,27 @@ export const MENUBAR_ICON_STYLE_OPTIONS: { value: MenubarIconStyle; label: strin
 ];
 
 export const AUTO_UPDATE_OPTIONS: { value: AutoUpdateIntervalMinutes; label: string }[] =
-  AUTO_UPDATE_INTERVALS.map((value) => ({
+  AUTO_UPDATE_PRESET_VALUES.map((value) => ({
     value,
     label: value === 60 ? "1 hour" : `${value} min`,
   }));
+
+export function isPresetInterval(value: number): boolean {
+  return AUTO_UPDATE_PRESET_VALUES.includes(value);
+}
+
+export function clampCustomInterval(minutes: number): number {
+  return Math.min(MAX_CUSTOM_INTERVAL_MINUTES, Math.max(MIN_CUSTOM_INTERVAL_MINUTES, minutes));
+}
+
+export function formatIntervalLabel(minutes: number): string {
+  const totalSeconds = Math.round(minutes * 60);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  if (minutes < 60) return Number.isInteger(minutes) ? `${minutes} min` : `${totalSeconds}s`;
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
 
 export const THEME_OPTIONS: { value: ThemeMode; label: string }[] =
   THEME_MODES.map((value) => ({
@@ -102,7 +125,9 @@ export async function savePluginSettings(settings: PluginSettings): Promise<void
 function isAutoUpdateInterval(value: unknown): value is AutoUpdateIntervalMinutes {
   return (
     typeof value === "number" &&
-    AUTO_UPDATE_INTERVALS.includes(value as AutoUpdateIntervalMinutes)
+    Number.isFinite(value) &&
+    value >= MIN_CUSTOM_INTERVAL_MINUTES &&
+    value <= MAX_CUSTOM_INTERVAL_MINUTES
   );
 }
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -20,12 +20,18 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { GlobalShortcutSection } from "@/components/global-shortcut-section";
 import { getBarFillLayout, getTrayIconSizePx } from "@/lib/tray-bars-icon";
+import { useState, useRef, useEffect, useCallback } from "react";
 import {
   AUTO_UPDATE_OPTIONS,
   DISPLAY_MODE_OPTIONS,
   MENUBAR_ICON_STYLE_OPTIONS,
   RESET_TIMER_DISPLAY_OPTIONS,
   THEME_OPTIONS,
+  isPresetInterval,
+  clampCustomInterval,
+  formatIntervalLabel,
+  MIN_CUSTOM_INTERVAL_MINUTES,
+  MAX_CUSTOM_INTERVAL_MINUTES,
   type AutoUpdateIntervalMinutes,
   type DisplayMode,
   type GlobalShortcut,
@@ -252,6 +258,175 @@ function SortablePluginItem({
   );
 }
 
+type IntervalUnit = "sec" | "min";
+
+function minutesToUnitValue(minutes: number): { value: number; unit: IntervalUnit } {
+  const totalSeconds = Math.round(minutes * 60);
+  if (totalSeconds < 60 || totalSeconds % 60 !== 0) {
+    return { value: totalSeconds, unit: "sec" };
+  }
+  return { value: minutes, unit: "min" };
+}
+
+function unitValueToMinutes(value: number, unit: IntervalUnit): number {
+  return unit === "sec" ? value / 60 : value;
+}
+
+function CustomIntervalEditor({
+  currentInterval,
+  onIntervalChange,
+}: {
+  currentInterval: AutoUpdateIntervalMinutes;
+  onIntervalChange: (value: AutoUpdateIntervalMinutes) => void;
+}) {
+  const initial = minutesToUnitValue(currentInterval);
+  const [unit, setUnit] = useState<IntervalUnit>(initial.unit);
+  const [inputValue, setInputValue] = useState(String(initial.value));
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const commit = useCallback(() => {
+    const parsed = Number(inputValue);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+    const minutes = clampCustomInterval(unitValueToMinutes(parsed, unit));
+    onIntervalChange(minutes);
+  }, [inputValue, unit, onIntervalChange]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit();
+    }
+  };
+
+  const minValue = unit === "sec" ? Math.round(MIN_CUSTOM_INTERVAL_MINUTES * 60) : MIN_CUSTOM_INTERVAL_MINUTES;
+  const maxValue = unit === "sec" ? Math.round(MAX_CUSTOM_INTERVAL_MINUTES * 60) : MAX_CUSTOM_INTERVAL_MINUTES;
+
+  return (
+    <div className="flex items-center gap-1.5 mt-2">
+      <input
+        ref={inputRef}
+        type="number"
+        min={minValue}
+        max={maxValue}
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={commit}
+        className={cn(
+          "h-8 w-20 rounded-md border border-border bg-background px-2 text-sm text-foreground",
+          "placeholder:text-muted-foreground",
+          "focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent",
+          "dark:bg-input/30 dark:border-input",
+          "[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        )}
+        placeholder={String(minValue)}
+      />
+      <div className="flex rounded-md border border-border dark:border-input overflow-hidden">
+        {(["sec", "min"] as const).map((u) => (
+          <button
+            key={u}
+            type="button"
+            onClick={() => {
+              if (u === unit) return;
+              const parsed = Number(inputValue);
+              if (Number.isFinite(parsed) && parsed > 0) {
+                const converted = u === "sec" ? Math.round(parsed * 60) : +(parsed / 60).toFixed(1);
+                setInputValue(String(converted));
+              }
+              setUnit(u);
+            }}
+            className={cn(
+              "px-2 h-8 text-xs font-medium transition-colors",
+              u === unit
+                ? "bg-primary text-primary-foreground"
+                : "bg-background text-muted-foreground hover:text-foreground hover:bg-muted dark:bg-input/30 dark:hover:bg-input/50"
+            )}
+          >
+            {u}
+          </button>
+        ))}
+      </div>
+      <Button
+        type="button"
+        variant="default"
+        size="sm"
+        className="h-8 px-3 text-xs"
+        onClick={commit}
+      >
+        Set
+      </Button>
+    </div>
+  );
+}
+
+function AutoRefreshSection({
+  autoUpdateInterval,
+  onAutoUpdateIntervalChange,
+}: {
+  autoUpdateInterval: AutoUpdateIntervalMinutes;
+  onAutoUpdateIntervalChange: (value: AutoUpdateIntervalMinutes) => void;
+}) {
+  const isCustom = !isPresetInterval(autoUpdateInterval);
+  const [showCustomEditor, setShowCustomEditor] = useState(isCustom);
+
+  return (
+    <section>
+      <h3 className="text-lg font-semibold mb-0">Auto Refresh</h3>
+      <p className="text-sm text-muted-foreground mb-2">
+        How obsessive are you
+      </p>
+      <div className="bg-muted/50 rounded-lg p-1 space-y-1">
+        <div className="flex gap-1" role="radiogroup" aria-label="Auto-update interval">
+          {AUTO_UPDATE_OPTIONS.map((option) => {
+            const isActive = !showCustomEditor && option.value === autoUpdateInterval;
+            return (
+              <Button
+                key={option.value}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                variant={isActive ? "default" : "outline"}
+                size="sm"
+                className="flex-1"
+                onClick={() => {
+                  setShowCustomEditor(false);
+                  onAutoUpdateIntervalChange(option.value);
+                }}
+              >
+                {option.label}
+              </Button>
+            );
+          })}
+        </div>
+        <Button
+          type="button"
+          role="radio"
+          aria-checked={showCustomEditor}
+          variant={showCustomEditor ? "default" : "outline"}
+          size="sm"
+          className="w-full"
+          onClick={() => setShowCustomEditor(true)}
+        >
+          {showCustomEditor && isCustom ? `Custom (${formatIntervalLabel(autoUpdateInterval)})` : "Custom"}
+        </Button>
+        {showCustomEditor && (
+          <CustomIntervalEditor
+            currentInterval={autoUpdateInterval}
+            onIntervalChange={(value) => {
+              onAutoUpdateIntervalChange(value);
+            }}
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
 interface SettingsPageProps {
   plugins: PluginConfig[];
   onReorder: (orderedIds: string[]) => void;
@@ -314,33 +489,10 @@ export function SettingsPage({
 
   return (
     <div className="py-3 space-y-4">
-      <section>
-        <h3 className="text-lg font-semibold mb-0">Auto Refresh</h3>
-        <p className="text-sm text-muted-foreground mb-2">
-          How obsessive are you
-        </p>
-        <div className="bg-muted/50 rounded-lg p-1">
-          <div className="flex gap-1" role="radiogroup" aria-label="Auto-update interval">
-            {AUTO_UPDATE_OPTIONS.map((option) => {
-              const isActive = option.value === autoUpdateInterval;
-              return (
-                <Button
-                  key={option.value}
-                  type="button"
-                  role="radio"
-                  aria-checked={isActive}
-                  variant={isActive ? "default" : "outline"}
-                  size="sm"
-                  className="flex-1"
-                  onClick={() => onAutoUpdateIntervalChange(option.value)}
-                >
-                  {option.label}
-                </Button>
-              );
-            })}
-          </div>
-        </div>
-      </section>
+      <AutoRefreshSection
+        autoUpdateInterval={autoUpdateInterval}
+        onAutoUpdateIntervalChange={onAutoUpdateIntervalChange}
+      />
       <section>
         <h3 className="text-lg font-semibold mb-0">Usage Mode</h3>
         <p className="text-sm text-muted-foreground mb-2">


### PR DESCRIPTION
- Updated AutoUpdateIntervalMinutes type to allow custom values with a minimum of 0.5 minutes.
- Introduced new constants for minimum and maximum custom interval limits.
- Added utility functions for clamping intervals and formatting labels.
- Refactored settings page to include a custom interval editor for user-defined intervals.
- Improved user interface for selecting auto-update intervals, including preset options and custom input handling.

## Description

Adds a "Custom" auto-refresh interval option so users can define their own polling frequency (down to 30 seconds) instead of being limited to the four fixed presets (5 min, 15 min, 30 min, 1 hour).

Changes:
- src/lib/settings.ts: Widened AutoUpdateIntervalMinutes from 5 | 15 | 30 | 60 to number (still stored in minutes, supporting      fractional values like 0.5 for 30s). Updated isAutoUpdateInterval validator to accept any finite number within bounds. Added   MIN_CUSTOM_INTERVAL_MINUTES (0.5), MAX_CUSTOM_INTERVAL_MINUTES (1440), and utility functions isPresetInterval(), clampCustomInterval(), formatIntervalLabel().

- src/pages/settings.tsx: Extracted AutoRefreshSection component with a two-row layout (presets on top, full-width Custom button below) to fit the 400px panel. Added CustomIntervalEditor with a number input, sec/min unit toggle (auto-converts values when switching), and a Set button. Supports Enter-to-confirm and blur-to-commit. Theme-aware styling for both light and dark modes. The type widening is fully backward-compatible — no changes needed in the Zustand store, hooks, bootstrap, or app-content layers.


## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [X] I ran `bun run build` and it succeeded
- [X] I ran `bun run test` and all tests pass
- [X] I tested the change locally with `bun tauri dev`

## Screenshots

<!-- Required for UI changes. Remove this section if not applicable. -->

## Checklist

- [X] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My PR targets the `main` branch
- [X] I did not introduce new dependencies without justification
