### PR TITLE
feat: preserve usage data during refresh (stale-while-revalidate)

### DIFF
--- a/src/components/app/app-content.test.tsx
+++ b/src/components/app/app-content.test.tsx
@@ -53,6 +53,7 @@ function createProps(): AppContentProps {
       loading: false,
       error: null,
       lastManualRefreshAt: null,
+      lastUpdatedAt: null,
     },
     onRetryPlugin: vi.fn(),
     onReorder: vi.fn(),

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -815,6 +815,7 @@ describe("ProviderCard", () => {
         name="SWR"
         displayMode="used"
         loading
+        lastUpdatedAt={Date.now() - 60_000}
         lines={[
           { type: "text", label: "Label", value: "Value" },
           { type: "progress", label: "Session", used: 32, limit: 100, format: { kind: "percent" } },
@@ -830,6 +831,28 @@ describe("ProviderCard", () => {
     expect(screen.getByText("32%")).toBeInTheDocument()
     // Progress bar shows shimmer overlay
     expect(document.querySelector('[data-slot="progress-refreshing"]')).toBeTruthy()
+  })
+
+  it("skips skeleton on refresh when lastUpdatedAt set even if filtered lines are empty", () => {
+    render(
+      <ProviderCard
+        name="FilteredEmpty"
+        displayMode="used"
+        loading
+        lastUpdatedAt={Date.now() - 60_000}
+        scopeFilter="overview"
+        skeletonLines={[
+          { type: "progress", label: "Session", scope: "overview" },
+        ]}
+        lines={[
+          { type: "text", label: "DetailOnly", value: "Hidden" },
+        ]}
+      />
+    )
+    // skeleton label for "Session" should not render because we have prior data (lastUpdatedAt set)
+    expect(screen.queryByText("Session")).toBeNull()
+    // and the detail-scoped line stays filtered out
+    expect(screen.queryByText("DetailOnly")).toBeNull()
   })
 
   it("renders skeleton on first load when no stale data exists", () => {
@@ -851,6 +874,7 @@ describe("ProviderCard", () => {
         name="StaleErr"
         displayMode="used"
         error="Couldn't update data. Try again?"
+        lastUpdatedAt={Date.now() - 60_000}
         lines={[
           { type: "progress", label: "Session", used: 40, limit: 100, format: { kind: "percent" } },
         ]}
@@ -877,7 +901,7 @@ describe("ProviderCard", () => {
     expect(screen.getByText("Nope")).toBeInTheDocument()
   })
 
-  it("shows relative last-updated timestamp", () => {
+  it("shows relative last-updated timestamp in retry tooltip", () => {
     vi.useFakeTimers()
     const now = new Date("2026-02-02T00:05:00.000Z")
     vi.setSystemTime(now)
@@ -885,6 +909,7 @@ describe("ProviderCard", () => {
       <ProviderCard
         name="Updated"
         displayMode="used"
+        onRetry={() => {}}
         lastUpdatedAt={now.getTime() - 120_000}
         lines={[{ type: "text", label: "Label", value: "Value" }]}
       />
@@ -901,6 +926,7 @@ describe("ProviderCard", () => {
       <ProviderCard
         name="Fresh"
         displayMode="used"
+        onRetry={() => {}}
         lastUpdatedAt={now.getTime() - 5_000}
         lines={[{ type: "text", label: "Label", value: "Value" }]}
       />
@@ -917,12 +943,25 @@ describe("ProviderCard", () => {
       <ProviderCard
         name="Skew"
         displayMode="used"
+        onRetry={() => {}}
         lastUpdatedAt={now.getTime() + 60_000}
         lines={[{ type: "text", label: "Label", value: "Value" }]}
       />
     )
     expect(screen.getByText(/Updated just now/)).toBeInTheDocument()
     vi.useRealTimers()
+  })
+
+  it("omits retry tooltip content when lastUpdatedAt is null", () => {
+    render(
+      <ProviderCard
+        name="NoTimestamp"
+        displayMode="used"
+        onRetry={() => {}}
+        lines={[{ type: "text", label: "Label", value: "Value" }]}
+      />
+    )
+    expect(screen.queryByText(/Updated/)).toBeNull()
   })
 })
 

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -808,6 +808,122 @@ describe("ProviderCard", () => {
     expect(screen.getByText("Session")).toBeInTheDocument()
     expect(screen.queryByText("Extra")).not.toBeInTheDocument()
   })
+
+  it("keeps stale data visible while loading (stale-while-revalidate)", () => {
+    render(
+      <ProviderCard
+        name="SWR"
+        displayMode="used"
+        loading
+        lines={[
+          { type: "text", label: "Label", value: "Value" },
+          { type: "progress", label: "Session", used: 32, limit: 100, format: { kind: "percent" } },
+        ]}
+        skeletonLines={[
+          { type: "text", label: "Label", scope: "overview" },
+          { type: "progress", label: "Session", scope: "overview" },
+        ]}
+      />
+    )
+    // Real data stays on screen — no skeleton swap
+    expect(screen.getByText("Value")).toBeInTheDocument()
+    expect(screen.getByText("32%")).toBeInTheDocument()
+    // Progress bar shows shimmer overlay
+    expect(document.querySelector('[data-slot="progress-refreshing"]')).toBeTruthy()
+  })
+
+  it("renders skeleton on first load when no stale data exists", () => {
+    render(
+      <ProviderCard
+        name="Cold"
+        displayMode="used"
+        loading
+        skeletonLines={[{ type: "progress", label: "Session", scope: "overview" }]}
+      />
+    )
+    expect(screen.getByText("Session")).toBeInTheDocument()
+    expect(document.querySelector('[data-slot="progress-refreshing"]')).toBeNull()
+  })
+
+  it("shows inline warning with stale data on refresh error", () => {
+    render(
+      <ProviderCard
+        name="StaleErr"
+        displayMode="used"
+        error="Couldn't update data. Try again?"
+        lines={[
+          { type: "progress", label: "Session", used: 40, limit: 100, format: { kind: "percent" } },
+        ]}
+      />
+    )
+    // Stale data still visible
+    expect(screen.getByText("40%")).toBeInTheDocument()
+    // Inline warning shown (not the full PluginError alert) — error text appears
+    // in both the trigger and the tooltip content via our mocked Tooltip
+    expect(screen.getAllByText("Couldn't update data. Try again?").length).toBeGreaterThan(0)
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("shows full PluginError when errored without stale data", () => {
+    render(
+      <ProviderCard
+        name="ColdErr"
+        displayMode="used"
+        error="Nope"
+        onRetry={() => {}}
+      />
+    )
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+    expect(screen.getByText("Nope")).toBeInTheDocument()
+  })
+
+  it("shows relative last-updated timestamp", () => {
+    vi.useFakeTimers()
+    const now = new Date("2026-02-02T00:05:00.000Z")
+    vi.setSystemTime(now)
+    render(
+      <ProviderCard
+        name="Updated"
+        displayMode="used"
+        lastUpdatedAt={now.getTime() - 120_000}
+        lines={[{ type: "text", label: "Label", value: "Value" }]}
+      />
+    )
+    expect(screen.getByText(/Updated 2m ago/)).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it("shows 'just now' for very recent last-updated timestamps", () => {
+    vi.useFakeTimers()
+    const now = new Date("2026-02-02T00:05:00.000Z")
+    vi.setSystemTime(now)
+    render(
+      <ProviderCard
+        name="Fresh"
+        displayMode="used"
+        lastUpdatedAt={now.getTime() - 5_000}
+        lines={[{ type: "text", label: "Label", value: "Value" }]}
+      />
+    )
+    expect(screen.getByText(/Updated just now/)).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it("clamps negative time deltas to 'just now' (clock skew)", () => {
+    vi.useFakeTimers()
+    const now = new Date("2026-02-02T00:05:00.000Z")
+    vi.setSystemTime(now)
+    render(
+      <ProviderCard
+        name="Skew"
+        displayMode="used"
+        lastUpdatedAt={now.getTime() + 60_000}
+        lines={[{ type: "text", label: "Label", value: "Value" }]}
+      />
+    )
+    expect(screen.getByText(/Updated just now/)).toBeInTheDocument()
+    vi.useRealTimers()
+  })
 })
 
 describe("groupLinesByType", () => {

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo } from "react"
-import { ExternalLink, Hourglass, RefreshCw } from "lucide-react"
+import { AlertCircle, ExternalLink, Hourglass, RefreshCw } from "lucide-react"
 import { openUrl } from "@tauri-apps/plugin-opener"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -27,6 +27,7 @@ interface ProviderCardProps {
   lines?: MetricLine[]
   skeletonLines?: ManifestLine[]
   lastManualRefreshAt?: number | null
+  lastUpdatedAt?: number | null
   onRetry?: () => void
   scopeFilter?: "overview" | "all"
   displayMode: DisplayMode
@@ -79,6 +80,17 @@ function PaceIndicator({
   )
 }
 
+function formatRelativeTime(diffMs: number): string {
+  const seconds = Math.floor(diffMs / 1000)
+  if (seconds < 60) return "just now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
 export function ProviderCard({
   name,
   plan,
@@ -89,6 +101,7 @@ export function ProviderCard({
   lines = [],
   skeletonLines = [],
   lastManualRefreshAt,
+  lastUpdatedAt,
   onRetry,
   scopeFilter = "all",
   displayMode,
@@ -118,10 +131,13 @@ export function ProviderCard({
     (line) => line.type === "progress" && Boolean(line.resetsAt)
   )
 
+  const hasStaleData = filteredLines.length > 0
+  const isRefreshingWithData = loading && hasStaleData
+
   const now = useNowTicker({
-    enabled: cooldownRemainingMs > 0 || hasResetCountdown,
+    enabled: cooldownRemainingMs > 0 || hasResetCountdown || Boolean(lastUpdatedAt),
     intervalMs: cooldownRemainingMs > 0 ? 1000 : 30_000,
-    stopAfterMs: cooldownRemainingMs > 0 && !hasResetCountdown ? cooldownRemainingMs : null,
+    stopAfterMs: cooldownRemainingMs > 0 && !hasResetCountdown && !lastUpdatedAt ? cooldownRemainingMs : null,
   })
 
   const inCooldown = lastManualRefreshAt
@@ -242,13 +258,20 @@ export function ProviderCard({
             ))}
           </div>
         )}
-        {error && <PluginError message={error} />}
+        {error && !hasStaleData && <PluginError message={error} />}
 
-        {loading && !error && (
+        {error && hasStaleData && (
+          <div className="flex items-center gap-1.5 mb-2 text-xs text-destructive">
+            <AlertCircle className="h-3 w-3 flex-shrink-0" />
+            <span className="truncate">{error}</span>
+          </div>
+        )}
+
+        {loading && !hasStaleData && !error && (
           <SkeletonLines lines={filteredSkeletonLines} />
         )}
 
-        {!loading && !error && (
+        {hasStaleData && (
           <div className="space-y-4">
             {groupLinesByType(filteredLines).map((group, gi) =>
               group.kind === "text" ? (
@@ -261,6 +284,7 @@ export function ProviderCard({
                       resetTimerDisplayMode={resetTimerDisplayMode}
                       onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
                       now={now}
+                      refreshing={isRefreshingWithData}
                     />
                   ))}
                 </div>
@@ -274,11 +298,23 @@ export function ProviderCard({
                       resetTimerDisplayMode={resetTimerDisplayMode}
                       onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
                       now={now}
+                      refreshing={isRefreshingWithData}
                     />
                   ))}
                 </Fragment>
               )
             )}
+          </div>
+        )}
+
+        {lastUpdatedAt && (
+          <div className="mt-2 text-[10px] text-muted-foreground text-right">
+            <time
+              dateTime={new Date(lastUpdatedAt).toISOString()}
+              title={new Date(lastUpdatedAt).toLocaleString()}
+            >
+              Updated {formatRelativeTime(now - lastUpdatedAt)}
+            </time>
           </div>
         )}
       </div>
@@ -293,12 +329,14 @@ function MetricLineRenderer({
   resetTimerDisplayMode,
   onResetTimerDisplayModeToggle,
   now,
+  refreshing,
 }: {
   line: MetricLine
   displayMode: DisplayMode
   resetTimerDisplayMode: ResetTimerDisplayMode
   onResetTimerDisplayModeToggle?: () => void
   now: number
+  refreshing?: boolean
 }) {
   if (line.type === "text") {
     return (
@@ -441,6 +479,7 @@ function MetricLineRenderer({
           value={percent}
           indicatorColor={line.color}
           markerValue={paceMarkerValue}
+          refreshing={refreshing}
         />
         <div className="flex justify-between items-center mt-1.5">
           <span className="text-xs text-muted-foreground tabular-nums">

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -131,30 +131,17 @@ export function ProviderCard({
     (line) => line.type === "progress" && Boolean(line.resetsAt)
   )
 
-  const hasStaleData = filteredLines.length > 0
+  // "has ever loaded" — true if either we have a prior success timestamp,
+  // or the parent is passing lines directly (tests + legacy state paths).
+  const hasStaleData = lastUpdatedAt != null || filteredLines.length > 0
   const isRefreshingWithData = loading && hasStaleData
 
-  // Pick tick rate for "Updated Xm ago" based on age: minute-granular while <1h,
-  // hourly while <1d, daily beyond. Avoids a per-card 30s interval running forever.
-  const lastUpdatedTickMs = useMemo(() => {
-    if (!lastUpdatedAt) return null
-    const age = Math.max(0, Date.now() - lastUpdatedAt)
-    if (age < 60 * 60 * 1000) return 60_000
-    if (age < 24 * 60 * 60 * 1000) return 60 * 60 * 1000
-    return 24 * 60 * 60 * 1000
-  }, [lastUpdatedAt])
-
-  const tickerIntervalMs =
-    cooldownRemainingMs > 0
-      ? 1000
-      : hasResetCountdown
-        ? 30_000
-        : lastUpdatedTickMs ?? 30_000
+  const tickerIntervalMs = cooldownRemainingMs > 0 ? 1000 : 30_000
 
   const now = useNowTicker({
-    enabled: cooldownRemainingMs > 0 || hasResetCountdown || Boolean(lastUpdatedAt),
+    enabled: cooldownRemainingMs > 0 || hasResetCountdown,
     intervalMs: tickerIntervalMs,
-    stopAfterMs: cooldownRemainingMs > 0 && !hasResetCountdown && !lastUpdatedAt ? cooldownRemainingMs : null,
+    stopAfterMs: cooldownRemainingMs > 0 && !hasResetCountdown ? cooldownRemainingMs : null,
   })
 
   const inCooldown = lastManualRefreshAt
@@ -231,19 +218,32 @@ export function ProviderCard({
                   </TooltipContent>
                 </Tooltip>
               ) : (
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="Retry"
-                  onClick={(e) => {
-                    e.currentTarget.blur()
-                    onRetry()
-                  }}
-                  className="ml-1 opacity-0 hover:opacity-100 focus-visible:opacity-100"
-                  style={{ transform: "translateZ(0)", backfaceVisibility: "hidden" }}
-                >
-                  <RefreshCw className="h-3 w-3" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    className="ml-1"
+                    render={(props) => (
+                      <Button
+                        {...props}
+                        variant="ghost"
+                        size="icon-xs"
+                        aria-label="Retry"
+                        onClick={(e) => {
+                          e.currentTarget.blur()
+                          onRetry()
+                        }}
+                        className="opacity-0 hover:opacity-100 focus-visible:opacity-100"
+                        style={{ transform: "translateZ(0)", backfaceVisibility: "hidden" }}
+                      >
+                        <RefreshCw className="h-3 w-3" />
+                      </Button>
+                    )}
+                  />
+                  {lastUpdatedAt != null && (
+                    <TooltipContent side="top">
+                      Updated {formatRelativeTime(Date.now() - lastUpdatedAt)}
+                    </TooltipContent>
+                  )}
+                </Tooltip>
               )
             )}
           </div>
@@ -336,26 +336,6 @@ export function ProviderCard({
           </div>
         )}
 
-        {lastUpdatedAt && (
-          <div className="mt-2 text-[10px] text-muted-foreground text-right">
-            <Tooltip>
-              <TooltipTrigger
-                render={(props) => (
-                  <time
-                    {...props}
-                    dateTime={new Date(lastUpdatedAt).toISOString()}
-                    aria-label={`Updated ${formatRelativeTime(now - lastUpdatedAt)} (${new Date(lastUpdatedAt).toLocaleString()})`}
-                  >
-                    Updated {formatRelativeTime(now - lastUpdatedAt)}
-                  </time>
-                )}
-              />
-              <TooltipContent side="top">
-                {new Date(lastUpdatedAt).toLocaleString()}
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        )}
       </div>
       {showSeparator && <Separator />}
     </div>

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -81,7 +81,7 @@ function PaceIndicator({
 }
 
 function formatRelativeTime(diffMs: number): string {
-  const seconds = Math.floor(diffMs / 1000)
+  const seconds = Math.floor(Math.max(0, diffMs) / 1000)
   if (seconds < 60) return "just now"
   const minutes = Math.floor(seconds / 60)
   if (minutes < 60) return `${minutes}m ago`
@@ -134,9 +134,26 @@ export function ProviderCard({
   const hasStaleData = filteredLines.length > 0
   const isRefreshingWithData = loading && hasStaleData
 
+  // Pick tick rate for "Updated Xm ago" based on age: minute-granular while <1h,
+  // hourly while <1d, daily beyond. Avoids a per-card 30s interval running forever.
+  const lastUpdatedTickMs = useMemo(() => {
+    if (!lastUpdatedAt) return null
+    const age = Math.max(0, Date.now() - lastUpdatedAt)
+    if (age < 60 * 60 * 1000) return 60_000
+    if (age < 24 * 60 * 60 * 1000) return 60 * 60 * 1000
+    return 24 * 60 * 60 * 1000
+  }, [lastUpdatedAt])
+
+  const tickerIntervalMs =
+    cooldownRemainingMs > 0
+      ? 1000
+      : hasResetCountdown
+        ? 30_000
+        : lastUpdatedTickMs ?? 30_000
+
   const now = useNowTicker({
     enabled: cooldownRemainingMs > 0 || hasResetCountdown || Boolean(lastUpdatedAt),
-    intervalMs: cooldownRemainingMs > 0 ? 1000 : 30_000,
+    intervalMs: tickerIntervalMs,
     stopAfterMs: cooldownRemainingMs > 0 && !hasResetCountdown && !lastUpdatedAt ? cooldownRemainingMs : null,
   })
 
@@ -261,10 +278,22 @@ export function ProviderCard({
         {error && !hasStaleData && <PluginError message={error} />}
 
         {error && hasStaleData && (
-          <div className="flex items-center gap-1.5 mb-2 text-xs text-destructive">
-            <AlertCircle className="h-3 w-3 flex-shrink-0" />
-            <span className="truncate">{error}</span>
-          </div>
+          <Tooltip>
+            <TooltipTrigger
+              render={(props) => (
+                <div
+                  {...props}
+                  className="flex items-center gap-1.5 mb-2 text-xs text-destructive"
+                >
+                  <AlertCircle className="h-3 w-3 flex-shrink-0" />
+                  <span className="truncate">{error}</span>
+                </div>
+              )}
+            />
+            <TooltipContent side="top" className="max-w-xs break-words text-xs">
+              {error}
+            </TooltipContent>
+          </Tooltip>
         )}
 
         {loading && !hasStaleData && !error && (
@@ -309,12 +338,22 @@ export function ProviderCard({
 
         {lastUpdatedAt && (
           <div className="mt-2 text-[10px] text-muted-foreground text-right">
-            <time
-              dateTime={new Date(lastUpdatedAt).toISOString()}
-              title={new Date(lastUpdatedAt).toLocaleString()}
-            >
-              Updated {formatRelativeTime(now - lastUpdatedAt)}
-            </time>
+            <Tooltip>
+              <TooltipTrigger
+                render={(props) => (
+                  <time
+                    {...props}
+                    dateTime={new Date(lastUpdatedAt).toISOString()}
+                    aria-label={`Updated ${formatRelativeTime(now - lastUpdatedAt)} (${new Date(lastUpdatedAt).toLocaleString()})`}
+                  >
+                    Updated {formatRelativeTime(now - lastUpdatedAt)}
+                  </time>
+                )}
+              />
+              <TooltipContent side="top">
+                {new Date(lastUpdatedAt).toLocaleString()}
+              </TooltipContent>
+            </Tooltip>
           </div>
         )}
       </div>

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -6,10 +6,11 @@ interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
   value?: number
   indicatorColor?: string
   markerValue?: number
+  refreshing?: boolean
 }
 
 const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
-  ({ className, value = 0, indicatorColor, markerValue, ...props }, ref) => {
+  ({ className, value = 0, indicatorColor, markerValue, refreshing, ...props }, ref) => {
     const clamped = Math.min(100, Math.max(0, value))
     const clampedMarker =
       typeof markerValue === "number" && Number.isFinite(markerValue)
@@ -55,6 +56,15 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
             className="absolute top-0 bottom-0 w-[2px] z-10 pointer-events-none bg-muted-foreground opacity-50"
             style={markerStyle}
           />
+        )}
+        {refreshing && (
+          <div
+            data-slot="progress-refreshing"
+            aria-hidden="true"
+            className="absolute inset-0 overflow-hidden rounded-full"
+          >
+            <div className="h-full w-full animate-shimmer bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+          </div>
         )}
       </div>
     )

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -99,6 +99,17 @@ describe("ui components", () => {
     expect(marker).toBeNull()
   })
 
+  it("renders shimmer overlay only when refreshing", () => {
+    const { container, rerender } = render(<Progress value={40} />)
+    expect(container.querySelector('[data-slot="progress-refreshing"]')).toBeNull()
+
+    rerender(<Progress value={40} refreshing />)
+    expect(container.querySelector('[data-slot="progress-refreshing"]')).toBeTruthy()
+
+    rerender(<Progress value={40} refreshing={false} />)
+    expect(container.querySelector('[data-slot="progress-refreshing"]')).toBeNull()
+  })
+
   it("renders separator orientations", () => {
     const { rerender } = render(<Separator />)
     expect(screen.getByRole("separator")).toBeInTheDocument()

--- a/src/hooks/app/types.ts
+++ b/src/hooks/app/types.ts
@@ -5,4 +5,5 @@ export type PluginState = {
   loading: boolean
   error: string | null
   lastManualRefreshAt: number | null
+  lastUpdatedAt: number | null
 }

--- a/src/hooks/app/use-app-plugin-views.test.ts
+++ b/src/hooks/app/use-app-plugin-views.test.ts
@@ -39,6 +39,7 @@ describe("useAppPluginViews", () => {
             loading: true,
             error: null,
             lastManualRefreshAt: null,
+            lastUpdatedAt: null,
           },
         },
       })

--- a/src/hooks/app/use-app-plugin-views.ts
+++ b/src/hooks/app/use-app-plugin-views.ts
@@ -32,7 +32,7 @@ export function useAppPluginViews({
         const meta = metaById.get(id)
         if (!meta) return null
         const state =
-          pluginStates[id] ?? { data: null, loading: false, error: null, lastManualRefreshAt: null }
+          pluginStates[id] ?? { data: null, loading: false, error: null, lastManualRefreshAt: null, lastUpdatedAt: null }
         return { meta, ...state }
       })
       .filter((plugin): plugin is DisplayPluginState => Boolean(plugin))

--- a/src/hooks/app/use-probe-refresh-actions.test.ts
+++ b/src/hooks/app/use-probe-refresh-actions.test.ts
@@ -63,9 +63,9 @@ describe("useProbeRefreshActions", () => {
         pluginSettings: { order: ["a", "b", "c"], disabled: [] },
         pluginStatesRef: {
           current: {
-            a: { data: null, loading: true, error: null, lastManualRefreshAt: null },
-            b: { data: null, loading: false, error: null, lastManualRefreshAt: 900_001 },
-            c: { data: null, loading: false, error: null, lastManualRefreshAt: null },
+            a: { data: null, loading: true, error: null, lastManualRefreshAt: null, lastUpdatedAt: null },
+            b: { data: null, loading: false, error: null, lastManualRefreshAt: 900_001, lastUpdatedAt: null },
+            c: { data: null, loading: false, error: null, lastManualRefreshAt: null, lastUpdatedAt: null },
           },
         },
         manualRefreshIdsRef: { current: new Set<string>(["b"]) },
@@ -95,7 +95,7 @@ describe("useProbeRefreshActions", () => {
           pluginSettings: settings,
           pluginStatesRef: {
             current: {
-              codex: { data: null, loading: true, error: null, lastManualRefreshAt: null },
+              codex: { data: null, loading: true, error: null, lastManualRefreshAt: null, lastUpdatedAt: null },
             },
           },
           manualRefreshIdsRef: { current: new Set<string>() },

--- a/src/hooks/app/use-probe-state.ts
+++ b/src/hooks/app/use-probe-state.ts
@@ -31,10 +31,11 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
       for (const id of ids) {
         const existing = prev[id]
         next[id] = {
-          data: null,
+          data: existing?.data ?? null,
           loading: true,
           error: null,
           lastManualRefreshAt: existing?.lastManualRefreshAt ?? null,
+          lastUpdatedAt: existing?.lastUpdatedAt ?? null,
         }
       }
       return next
@@ -47,10 +48,11 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
       for (const id of ids) {
         const existing = prev[id]
         next[id] = {
-          data: null,
+          data: existing?.data ?? null,
           loading: false,
           error,
           lastManualRefreshAt: existing?.lastManualRefreshAt ?? null,
+          lastUpdatedAt: existing?.lastUpdatedAt ?? null,
         }
       }
       return next
@@ -65,17 +67,22 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
         manualRefreshIdsRef.current.delete(output.providerId)
       }
 
-      setPluginStates((prev) => ({
-        ...prev,
-        [output.providerId]: {
-          data: errorMessage ? null : output,
-          loading: false,
-          error: errorMessage,
-          lastManualRefreshAt: !errorMessage && isManual
-            ? Date.now()
-            : prev[output.providerId]?.lastManualRefreshAt ?? null,
-        },
-      }))
+      const now = Date.now()
+      setPluginStates((prev) => {
+        const existing = prev[output.providerId]
+        return {
+          ...prev,
+          [output.providerId]: {
+            data: errorMessage ? (existing?.data ?? null) : output,
+            loading: false,
+            error: errorMessage,
+            lastManualRefreshAt: !errorMessage && isManual
+              ? now
+              : existing?.lastManualRefreshAt ?? null,
+            lastUpdatedAt: errorMessage ? (existing?.lastUpdatedAt ?? null) : now,
+          },
+        }
+      })
 
       onProbeResult?.()
     },

--- a/src/index.css
+++ b/src/index.css
@@ -213,6 +213,19 @@ body,
   }
 }
 
+/* Shimmer animation for progress bars refreshing with stale data */
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+.animate-shimmer {
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
 /* Remove focus rings - this is a menu bar app, not keyboard-navigated */
 *:focus,
 *:focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -225,6 +225,11 @@ body,
 .animate-shimmer {
   animation: shimmer 1.5s ease-in-out infinite;
 }
+@media (prefers-reduced-motion: reduce) {
+  .animate-shimmer {
+    animation: none;
+  }
+}
 
 /* Remove focus rings - this is a menu bar app, not keyboard-navigated */
 *:focus,

--- a/src/lib/plugin-types.ts
+++ b/src/lib/plugin-types.ts
@@ -53,4 +53,5 @@ export type PluginDisplayState = {
   loading: boolean
   error: string | null
   lastManualRefreshAt: number | null
+  lastUpdatedAt: number | null
 }

--- a/src/pages/overview.test.tsx
+++ b/src/pages/overview.test.tsx
@@ -16,6 +16,7 @@ describe("OverviewPage", () => {
         loading: false,
         error: null,
         lastManualRefreshAt: null,
+        lastUpdatedAt: null,
       },
     ]
     render(<OverviewPage plugins={plugins} displayMode="used" resetTimerDisplayMode="relative" />)
@@ -46,6 +47,7 @@ describe("OverviewPage", () => {
         loading: false,
         error: null,
         lastManualRefreshAt: null,
+        lastUpdatedAt: null,
       },
     ]
     render(<OverviewPage plugins={plugins} displayMode="used" resetTimerDisplayMode="relative" />)
@@ -69,6 +71,7 @@ describe("OverviewPage", () => {
         loading: false,
         error: null,
         lastManualRefreshAt: null,
+        lastUpdatedAt: null,
       },
     ]
 

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -38,6 +38,7 @@ export function OverviewPage({
           lines={plugin.data?.lines ?? []}
           skeletonLines={plugin.meta.lines}
           lastManualRefreshAt={plugin.lastManualRefreshAt}
+          lastUpdatedAt={plugin.lastUpdatedAt}
           onRetry={onRetryPlugin ? () => onRetryPlugin(plugin.meta.id) : undefined}
           scopeFilter="overview"
           displayMode={displayMode}

--- a/src/pages/provider-detail.test.tsx
+++ b/src/pages/provider-detail.test.tsx
@@ -20,6 +20,7 @@ describe("ProviderDetailPage", () => {
           loading: false,
           error: null,
           lastManualRefreshAt: null,
+          lastUpdatedAt: null,
         }}
       />
     )
@@ -37,6 +38,7 @@ describe("ProviderDetailPage", () => {
           loading: false,
           error: null,
           lastManualRefreshAt: null,
+          lastUpdatedAt: null,
         }}
       />
     )
@@ -60,6 +62,7 @@ describe("ProviderDetailPage", () => {
           loading: false,
           error: null,
           lastManualRefreshAt: null,
+          lastUpdatedAt: null,
         }}
       />
     )

--- a/src/pages/provider-detail.tsx
+++ b/src/pages/provider-detail.tsx
@@ -36,6 +36,7 @@ export function ProviderDetailPage({
       lines={plugin.data?.lines ?? []}
       skeletonLines={plugin.meta.lines}
       lastManualRefreshAt={plugin.lastManualRefreshAt}
+      lastUpdatedAt={plugin.lastUpdatedAt}
       onRetry={onRetry}
       scopeFilter="all"
       displayMode={displayMode}


### PR DESCRIPTION
Stop clearing provider data when a refresh starts. Instead of replacing content with skeleton loaders on every refresh, keep the existing values visible and show a subtle shimmer overlay on progress bars. This avoids the jarring flash-to-skeleton UX on subsequent refreshes while keeping skeletons for first-time loads when no data exists.

Changes:
- setLoadingForPlugins preserves existing data instead of nulling it
- setErrorForPlugins preserves stale data on transient failures
- handleProbeResult preserves stale data on error responses
- Added lastUpdatedAt field to PluginState, shown as relative timestamp
- Progress bar gains a shimmer overlay when refreshing with stale data
- Error during refresh shows inline warning instead of replacing content

Closes robinebers/openusage#385

https://claude.ai/code/session_01F1GBhgCyfdf36cqnq5Lurd

## Description

<!-- What does this PR do and why? -->

## Related Issue

<!-- Link to the issue this PR addresses: Fixes #123 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [ ] I ran `bun run build` and it succeeded
- [ ] I ran `bun run test` and all tests pass
- [ ] I tested the change locally with `bun tauri dev`

## Screenshots

<!-- Required for UI changes. Remove this section if not applicable. -->

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves usage data during refresh to remove the flash-to-skeleton effect. Progress bars shimmer while refreshing; errors show inline with stale data, and an “Updated X ago” tooltip appears on the refresh icon.

- **New Features**
  - Keep existing provider data during refresh and transient errors; skeletons only on first load.
  - Add `lastUpdatedAt`; show “Updated X ago” only as a tooltip on the refresh button; clamp negative deltas to “just now”.
  - Add a shimmer overlay to progress bars when refreshing; respects reduced motion.
  - Show an inline warning with a tooltip when refresh fails and stale data exists; show the full error only when no data.
  - Remove periodic timestamp updates; tooltip computes freshness on open to avoid background timers.

<sup>Written for commit 7afc4fe71aa8e7217167614c10c4823bac2328a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

