### PR TITLE
[FIX] Cursor pace marker

### DIFF
--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -551,13 +551,15 @@ describe("ProviderCard", () => {
     expect(screen.getByText("90% used at reset")).toBeInTheDocument()
     expect(screen.getByText("Limit in 8h 0m")).toBeInTheDocument()
 
-    // On-track hides the marker (like CodexBar); only ahead + behind show it
+    // All three bars show the pace marker (always visible when hasPaceContext)
     const markers = document.querySelectorAll<HTMLElement>('[data-slot="progress-marker"]')
-    expect(markers).toHaveLength(2)
+    expect(markers).toHaveLength(3)
     expect(markers[0]?.style.left).toBe("50%")
     expect(markers[1]?.style.left).toBe("50%")
+    expect(markers[2]?.style.left).toBe("50%")
     expect(markers[0]).toHaveClass("bg-muted-foreground")
     expect(markers[1]).toHaveClass("bg-muted-foreground")
+    expect(markers[2]).toHaveClass("bg-muted-foreground")
     vi.useRealTimers()
   })
 
@@ -666,7 +668,8 @@ describe("ProviderCard", () => {
       />
     )
     expect(screen.queryByLabelText("Plenty of room")).not.toBeInTheDocument()
-    expect(document.querySelector('[data-slot="progress-marker"]')).toBeNull()
+    // Marker always shows when hasPaceContext (resetsAt + periodDurationMs > 0), even early in period
+    expect(document.querySelector('[data-slot="progress-marker"]')).not.toBeNull()
     vi.useRealTimers()
   })
 

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -348,8 +348,7 @@ function MetricLineRenderer({
   if (line.type === "progress") {
     const resetsAtMs = line.resetsAt ? Date.parse(line.resetsAt) : Number.NaN
     const periodDurationMs = line.periodDurationMs
-    const hasPaceContext = Number.isFinite(resetsAtMs) && Number.isFinite(periodDurationMs)
-    const hasTimeMarkerContext = hasPaceContext && periodDurationMs! > 0
+    const hasPaceContext = Number.isFinite(resetsAtMs) && Number.isFinite(periodDurationMs) && periodDurationMs! > 0
     const shownAmount =
       displayMode === "used"
         ? line.used
@@ -390,7 +389,7 @@ function MetricLineRenderer({
       ? calculatePaceStatus(line.used, line.limit, resetsAtMs, periodDurationMs!, now)
       : null
     const paceStatus = paceResult?.status ?? null
-    const paceMarkerValue = hasTimeMarkerContext && paceStatus && paceStatus !== "on-track"
+    const paceMarkerValue = hasPaceContext
       ? (() => {
           const periodStartMs = resetsAtMs - periodDurationMs!
           const elapsedFraction = clamp01((now - periodStartMs) / periodDurationMs!)


### PR DESCRIPTION
## Description

For me the Cursor pace estimation was not working. This PR addresses a fix.

## Related Issue

<!-- Link to the issue this PR addresses: Fixes #123 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pace marker visibility in provider usage bars so pace estimation is consistent. The marker now always shows when valid `resetsAt` and `periodDurationMs` (> 0) are present.

- **Bug Fixes**
  - UI: Use a stricter `hasPaceContext` check and always render the marker for on-track, ahead, and behind states.
  - Tests: Update expectations to see three markers and ensure the marker appears even early in the period.

<sup>Written for commit ca0554d69b132ee152a07d7e29d93eec44a000b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

