### PR TITLE
feat(claude): add Claude Design weekly detail metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tmpcov-gem
 # Editor directories and files
 .vscode/
 .conductor/
+.claude/settings.local.json
 .idea
 .DS_Store
 *.suo

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -45,6 +45,10 @@ Returns rate limit windows and optional extra credits.
     "utilization": 0,
     "resets_at": "2026-02-01T00:00:00Z"
   },
+  "seven_day_omelette": {           // separate weekly Claude Design limit (optional, plan-dependent)
+    "utilization": 0,
+    "resets_at": "2026-02-01T00:00:00Z"
+  },
   "extra_usage": {                  // on-demand overage credits (optional)
     "is_enabled": true,
     "used_credits": 500,            // cents spent

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -723,6 +723,16 @@
           periodDurationMs: 7 * 24 * 60 * 60 * 1000 // 7 days
         }))
       }
+      if (data.seven_day_omelette && typeof data.seven_day_omelette.utilization === "number") {
+        lines.push(ctx.line.progress({
+          label: "Claude Design",
+          used: data.seven_day_omelette.utilization,
+          limit: 100,
+          format: { kind: "percent" },
+          resetsAt: ctx.util.toIso(data.seven_day_omelette.resets_at),
+          periodDurationMs: 7 * 24 * 60 * 60 * 1000 // 7 days
+        }))
+      }
 
       if (data.extra_usage && data.extra_usage.is_enabled) {
         const used = data.extra_usage.used_credits

--- a/plugins/claude/plugin.json
+++ b/plugins/claude/plugin.json
@@ -15,6 +15,7 @@
     { "type": "progress", "label": "Weekly", "scope": "overview" },
     { "type": "badge", "label": "Peak Hours", "scope": "overview" },
     { "type": "progress", "label": "Sonnet", "scope": "detail" },
+    { "type": "progress", "label": "Claude Design", "scope": "detail" },
     { "type": "progress", "label": "Extra usage spent", "scope": "detail" },
     { "type": "text", "label": "Today", "scope": "detail" },
     { "type": "text", "label": "Yesterday", "scope": "detail" },

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -496,6 +496,59 @@ describe("claude plugin", () => {
     expect(result.lines.find((line) => line.label === "Extra usage spent")).toBeTruthy()
   })
 
+  it("renders Claude Design line from seven_day_omelette with normalized resetsAt", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.readText = () =>
+      JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+    ctx.host.fs.exists = () => true
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        seven_day_omelette: { utilization: 7, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const line = result.lines.find((l) => l.label === "Claude Design")
+    expect(line).toBeTruthy()
+    expect(line.used).toBe(7)
+    expect(line.limit).toBe(100)
+    expect(line.format).toEqual({ kind: "percent" })
+    expect(line.resetsAt).toBe("2099-01-01T00:00:00.000Z")
+  })
+
+  it("omits Claude Design line when seven_day_omelette has no utilization", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.readText = () =>
+      JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+    ctx.host.fs.exists = () => true
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        seven_day_omelette: {},
+      }),
+    })
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((l) => l.label === "Claude Design")).toBeUndefined()
+  })
+
+  it("omits Claude Design line when seven_day_omelette utilization is non-numeric", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.readText = () =>
+      JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+    ctx.host.fs.exists = () => true
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        seven_day_omelette: { utilization: "5", resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((l) => l.label === "Claude Design")).toBeUndefined()
+  })
+
   it("omits extra usage line when used credits are zero and no limit exists", async () => {
     const ctx = makeCtx()
     ctx.host.fs.readText = () =>

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -504,7 +504,7 @@ describe("claude plugin", () => {
     ctx.host.http.request.mockReturnValue({
       status: 200,
       bodyText: JSON.stringify({
-        seven_day_omelette: { utilization: 7, resets_at: "2099-01-01T00:00:00.000Z" },
+        seven_day_omelette: { utilization: 7, resets_at: "2099-01-01 00:00:00 UTC" },
       }),
     })
     const plugin = await loadPlugin()


### PR DESCRIPTION
## Summary

- Render the Claude API `seven_day_omelette` bucket as a new detail-only `Claude Design` weekly percent line in the Claude plugin, mirroring the existing `seven_day_sonnet` shape.
- Document `seven_day_omelette` in the Claude provider reference.
- Ignore local `.claude/settings.local.json` so it stops appearing as untracked.

Scope is intentionally narrow: no change to overview cards, primary progress selection, `primaryCandidates`, tray wiring, or the local HTTP API shape.

## Changes

- `plugins/claude/plugin.json` — add detail-scoped `Claude Design` line between `Sonnet` and `Extra usage spent`.
- `plugins/claude/plugin.js` — push a weekly percent progress line when `data.seven_day_omelette.utilization` is numeric; uses `ctx.util.toIso` for `resetsAt`.
- `plugins/claude/plugin.test.js` — three new cases: numeric utilization renders the line with normalized ISO, missing field omits, non-numeric omits.
- `docs/providers/claude.md` — add `seven_day_omelette` to the `/api/oauth/usage` example.
- `.gitignore` — ignore `.claude/settings.local.json`.

## Test plan

- [x] `bunx vitest run plugins/claude/plugin.test.js` (82/82 passing, incl. 3 new cases)
- [ ] Visual: Claude card detail view shows `Claude Design` line when API returns `seven_day_omelette` with a numeric utilization
- [ ] Visual: overview/tray/primary progress unchanged

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional detail-only usage line driven by an additional API field, plus docs/tests and a `.gitignore` entry; no auth, request flow, or overview behavior changes.
> 
> **Overview**
> Adds a new **detail-only** weekly usage progress line, `Claude Design`, sourced from the Claude API `seven_day_omelette` bucket (rendered only when `utilization` is numeric and `resets_at` is normalized via `toIso`).
> 
> Updates the Claude plugin manifest to include the new line, extends provider docs to document the new response field, adds targeted tests for render/omit behavior, and ignores local `.claude/settings.local.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b2e87ba260830ac7bd9272915ae2ea8b04ce6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new detail-only "Claude Design" weekly percent metric to the Claude plugin using the `seven_day_omelette` API bucket. No changes to overview, tray, primary progress, or local API shape.

- **New Features**
  - Render "Claude Design" weekly percent line in detail when `seven_day_omelette.utilization` is numeric (limit 100, 7-day window), normalizing `resets_at` to ISO.
  - Add the line to the Claude plugin detail config and document `seven_day_omelette` in the provider reference.
  - Tests cover numeric/missing/non-numeric cases and assert ISO normalization using a non-normalized `resets_at`; ignore `.claude/settings.local.json`.

<sup>Written for commit 4b2e87ba260830ac7bd9272915ae2ea8b04ce6c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

