### PR TITLE
fix(factory): handle HTTP 405 from Factory usage endpoint

### DIFF
--- a/plugins/factory/plugin.js
+++ b/plugins/factory/plugin.js
@@ -314,7 +314,7 @@
   }
 
   function fetchUsage(ctx, accessToken) {
-    return ctx.util.request({
+    var resp = ctx.util.request({
       method: "POST",
       url: USAGE_URL,
       headers: {
@@ -326,6 +326,20 @@
       bodyText: JSON.stringify({ useCache: true }),
       timeoutMs: 10000,
     })
+    if (resp.status === 405) {
+      ctx.host.log.info("POST returned 405, retrying with GET")
+      resp = ctx.util.request({
+        method: "GET",
+        url: USAGE_URL,
+        headers: {
+          Authorization: "Bearer " + accessToken,
+          Accept: "application/json",
+          "User-Agent": "OpenUsage",
+        },
+        timeoutMs: 10000,
+      })
+    }
+    return resp
   }
 
   function probe(ctx) {

--- a/plugins/factory/plugin.test.js
+++ b/plugins/factory/plugin.test.js
@@ -898,6 +898,47 @@ describe("factory plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Token expired")
   })
 
+  it("retries with GET when POST returns 405", async () => {
+    const ctx = makeCtx()
+    const futureExp = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
+    ctx.host.fs.writeText("~/.factory/auth.json", JSON.stringify({
+      access_token: makeJwt(futureExp),
+      refresh_token: "refresh",
+    }))
+
+    let calls = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      calls.push(opts)
+      if (opts.method === "POST" && String(opts.url).includes("usage")) {
+        return { status: 405, headers: {}, bodyText: "" }
+      }
+      if (opts.method === "GET" && String(opts.url).includes("usage")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            usage: {
+              startDate: 1770623326000,
+              endDate: 1772956800000,
+              standard: { orgTotalTokensUsed: 100, totalAllowance: 20000000 },
+              premium: { orgTotalTokensUsed: 0, totalAllowance: 0 },
+            },
+          }),
+        }
+      }
+      return { status: 500, headers: {}, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Standard")).toBeTruthy()
+    const usageCalls = calls.filter((c) => String(c.url).includes("usage"))
+    expect(usageCalls).toHaveLength(2)
+    expect(usageCalls[0].method).toBe("POST")
+    expect(usageCalls[1].method).toBe("GET")
+    expect(usageCalls[1].headers.Authorization).toContain("Bearer ")
+  })
+
   it("infers Basic plan from low allowance", async () => {
     const ctx = makeCtx()
     const futureExp = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60


### PR DESCRIPTION
## Summary

Handle Factory usage endpoint returning HTTP 405 for POST requests by falling back to GET.

Keep POST first for backward compatibility with older Factory API versions. On 405 response, retry once with GET (same `Authorization` header, no body).

## Testing

All 41 factory plugin tests pass, including new regression test.

```
npx vitest run plugins/factory/plugin.test.js
```

Added test: `retries with GET when POST returns 405` — verifies POST→405 triggers a GET retry that succeeds with 200.

> **Low Risk**
>
> Minimal change scoped to `fetchUsage` in `plugins/factory/plugin.js`. No auth, refresh, or persistence paths affected. Single new conditional branch with regression coverage.

Fixes #389

## Proof of Fix
<img width="375" height="351" alt="Screenshot of Droid Working Fine Again" src="https://github.com/user-attachments/assets/2d6be69d-5ff1-482d-85f6-a8d985aa24cf" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle HTTP 405 from the Factory usage endpoint by retrying with GET. Restores usage fetching on newer Factory API versions while keeping POST first for older versions.

- **Bug Fixes**
  - On 405 from POST to usage, retry once with GET using the same Authorization header and no body.
  - Added a regression test; all factory plugin tests pass.

<sup>Written for commit 722e91b5a3a1b2c4db882a5d01e608c8552deea0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

