### PR TITLE
fix Antigravity local DB import loading error

### DIFF
--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -9,7 +9,7 @@ Antigravity is essentially a Google-branded fork of [Windsurf](windsurf.md) — 
 - **Vendor:** Google (internal codename "Jetski")
 - **Protocol:** Connect RPC v1 (JSON over HTTP) on local language server
 - **Service:** `exa.language_server_pb.LanguageServerService`
-- **Auth:** CSRF token from process args, API key from SQLite (fallback)
+- **Auth:** CSRF token from process args; Google OAuth tokens from SQLite (fallback)
 - **Quota:** fraction (0.0–1.0, where 1.0 = 100% remaining)
 - **Quota window:** 5 hours
 - **Timestamps:** ISO 8601
@@ -65,8 +65,6 @@ POST http://127.0.0.1:{port}/exa.language_server_pb.LanguageServerService/GetUse
   }
 }
 ```
-
-The CSRF token alone authenticates. When an API key is available from the local SQLite database, it is included in the metadata.
 
 #### Response
 
@@ -163,38 +161,31 @@ Antigravity stores auth credentials in a VS Code-compatible state database.
 - **Path:** `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb`
 - **Table:** `ItemTable` (`key` TEXT, `value` TEXT)
 
-### antigravityAuthStatus
+### antigravityUnifiedStateSync.oauthToken (sentinel envelope → protobuf)
 
-```json
-{
-  "apiKey": "ya29.<token>",
-  "email": "user@example.com",
-  "name": "Test User"
-}
-```
+Google OAuth tokens are stored under this key in a double-wrapped base64 envelope.
 
-`apiKey` is a Google OAuth access token (`ya29...`). It's included in LS metadata and used as a last-resort Bearer token for Cloud Code when protobuf OAuth tokens are unavailable. It appears to be a separately-issued copy of the same kind of token stored in the protobuf data below.
+Decoding layers:
 
-### jetskiStateSync.agentManagerInitState (protobuf)
-
-Google OAuth tokens are also stored as a base64-encoded protobuf blob, with the addition of a refresh token and expiry timestamp.
+1. Base64-decode the DB `value` → `outer` bytes.
+2. `outer` field 1 (wire type 2) → `wrapper` bytes.
+3. Inside `wrapper`: field 1 is the sentinel string `"oauthTokenInfoSentinelKey"`; field 2 is `payload` bytes.
+4. Inside `payload`: field 1 (wire type 2) is a **UTF-8 base64 string** (not raw bytes).
+5. Base64-decode that string → final `OAuthTokenInfo` protobuf.
 
 ```protobuf
-message AgentManagerInitState {
-  OAuthTokenInfo oauth_token = 6;       // field 6, wire type 2
-}
 message OAuthTokenInfo {
   string access_token = 1;              // "ya29...." Google OAuth access token
-  string token_type = 2;               // ignored
-  string refresh_token = 3;            // "1//..." Google OAuth refresh token
-  Timestamp expiry = 4;                // field 4, wire type 2
+  string token_type = 2;                // ignored
+  string refresh_token = 3;             // "1//..." Google OAuth refresh token
+  Timestamp expiry = 4;                 // field 4, wire type 2
 }
 message Timestamp {
-  int64 seconds = 1;                   // Unix epoch seconds
+  int64 seconds = 1;                    // Unix epoch seconds
 }
 ```
 
-The plugin decodes this using a minimal protobuf wire-format parser (varint + length-delimited only). The access token is short-lived; the refresh token is used to obtain new access tokens via Google OAuth.
+The plugin decodes this using a minimal protobuf wire-format parser (varint, length-delimited, fixed32, fixed64). The access token is short-lived; the refresh token is used to obtain new access tokens via Google OAuth.
 
 ### Token Refresh
 
@@ -214,7 +205,7 @@ Same client_id/secret is there in the Antigravity app bundle, used for the Googl
 
 ## Cloud Code API (fallback)
 
-When the language server is not running, the plugin falls back to Google's Cloud Code API using a Google OAuth access token (from protobuf data, or apiKey as last resort).
+When the language server is not running, the plugin falls back to Google's Cloud Code API using a Google OAuth access token (from the unified-state protobuf, or a cached refreshed token).
 
 ### fetchAvailableModels
 
@@ -255,17 +246,15 @@ The Cloud Code model set is a superset of the LS model set. The LS returns only 
 
 ## Plugin Strategy
 
-1. Read `antigravityAuthStatus` from SQLite for API key (optional, may fail)
-2. Read `jetskiStateSync.agentManagerInitState` from SQLite, decode protobuf for OAuth tokens (optional, may fail)
-3. **Strategy 1 — LS probe (primary):**
+1. Read `antigravityUnifiedStateSync.oauthToken` from SQLite, unwrap the sentinel envelope, and decode the inner `OAuthTokenInfo` protobuf (optional, may fail).
+2. **Strategy 1 — LS probe (primary):**
    a. Discover LS process via `ctx.host.ls.discover()` (ps + lsof)
    b. Probe ports with `GetUnleashData` to find the Connect-RPC endpoint
-   c. Include `apiKey` in metadata if available
-   d. Call `GetUserStatus` for plan name + per-model quota
-   e. Fall back to `GetCommandModelConfigs` if `GetUserStatus` fails
-4. **Strategy 2 — Cloud Code API (fallback, only if LS fails):**
-   a. Build candidate token list: proto access_token, cached refreshed token (if fresh), apiKey (all deduplicated)
+   c. Call `GetUserStatus` for plan name + per-model quota
+   d. Fall back to `GetCommandModelConfigs` if `GetUserStatus` fails
+3. **Strategy 2 — Cloud Code API (fallback, only if LS fails):**
+   a. Build candidate token list: proto access_token (if unexpired), cached refreshed token (if fresh), deduplicated
    b. Try each token with `fetchAvailableModels`
-   c. If all fail with 401/403 and refresh token available: refresh via Google OAuth, cache result to pluginDataDir, retry once
+   c. If all fail with 401/403 (or the list is empty) and a refresh token is available: refresh via Google OAuth, cache result to pluginDataDir, retry once
    d. Parse model quota: skip `isInternal` models, empty-displayName models, and blacklisted model IDs
-5. If both strategies fail: error "Start Antigravity and try again."
+4. If both strategies fail: error "Start Antigravity and try again."

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -460,22 +460,22 @@
   // --- Probe ---
 
   function probe(ctx) {
-    var proto = loadOAuthTokens(ctx)
+    var dbTokens = loadOAuthTokens(ctx)
 
     var lsResult = probeLs(ctx)
     if (lsResult) return lsResult
 
     var tokens = []
-    if (proto && proto.accessToken) {
-      if (!proto.expirySeconds || proto.expirySeconds > Math.floor(Date.now() / 1000)) {
-        tokens.push(proto.accessToken)
+    if (dbTokens && dbTokens.accessToken) {
+      if (!dbTokens.expirySeconds || dbTokens.expirySeconds > Math.floor(Date.now() / 1000)) {
+        tokens.push(dbTokens.accessToken)
       }
     }
 
     var cached = loadCachedToken(ctx)
     if (cached && tokens.indexOf(cached) === -1) tokens.push(cached)
 
-    if (tokens.length === 0 && !(proto && proto.refreshToken)) {
+    if (tokens.length === 0 && !(dbTokens && dbTokens.refreshToken)) {
       throw "Start Antigravity and try again."
     }
 
@@ -486,8 +486,8 @@
       ccData = null
     }
 
-    if ((!ccData || ccData._authFailed) && proto && proto.refreshToken) {
-      var refreshed = refreshAccessToken(ctx, proto.refreshToken)
+    if ((!ccData || ccData._authFailed) && dbTokens && dbTokens.refreshToken) {
+      var refreshed = refreshAccessToken(ctx, dbTokens.refreshToken)
       if (refreshed) ccData = probeCloudCode(ctx, refreshed)
     }
 

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -480,13 +480,22 @@
     }
 
     var ccData = null
+    var sawAuthFailure = false
     for (var i = 0; i < tokens.length; i++) {
-      ccData = probeCloudCode(ctx, tokens[i])
-      if (ccData && !ccData._authFailed) break
-      ccData = null
+      var nextData = probeCloudCode(ctx, tokens[i])
+      if (nextData && !nextData._authFailed) {
+        ccData = nextData
+        break
+      }
+      if (nextData && nextData._authFailed) sawAuthFailure = true
     }
 
-    if ((!ccData || ccData._authFailed) && dbTokens && dbTokens.refreshToken) {
+    // Only refresh on evidence of an auth failure, or when there were no tokens to try.
+    // probeCloudCode returns null for transient failures (5xx/timeouts); without this
+    // guard a Cloud Code incident would trigger a Google OAuth refresh every probe cycle
+    // instead of ~once per token lifetime — risking refresh-token throttling or rotation.
+    if (!ccData && dbTokens && dbTokens.refreshToken &&
+        (sawAuthFailure || tokens.length === 0)) {
       var refreshed = refreshAccessToken(ctx, dbTokens.refreshToken)
       if (refreshed) ccData = probeCloudCode(ctx, refreshed)
     }

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -9,6 +9,8 @@
   var GOOGLE_OAUTH_URL = "https://oauth2.googleapis.com/token"
   var GOOGLE_CLIENT_ID = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
   var GOOGLE_CLIENT_SECRET = "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"
+  var OAUTH_TOKEN_KEY = "antigravityUnifiedStateSync.oauthToken"
+  var OAUTH_TOKEN_SENTINEL = "oauthTokenInfoSentinelKey"
   var CC_MODEL_BLACKLIST = {
     "MODEL_CHAT_20706": true,
     "MODEL_CHAT_23310": true,
@@ -48,12 +50,19 @@
         if (!val) break
         fields[fieldNum] = { type: 0, value: val.v }
         pos = val.p
+      } else if (wireType === 1) {
+        if (pos + 8 > s.length) break
+        pos += 8
       } else if (wireType === 2) {
         var len = readVarint(s, pos)
         if (!len) break
         pos = len.p
+        if (pos + len.v > s.length) break
         fields[fieldNum] = { type: 2, data: s.substring(pos, pos + len.v) }
         pos += len.v
+      } else if (wireType === 5) {
+        if (pos + 4 > s.length) break
+        pos += 4
       } else {
         break
       }
@@ -63,46 +72,48 @@
 
   // --- SQLite credential reading ---
 
-  function loadApiKey(ctx) {
-    try {
-      var rows = ctx.host.sqlite.query(
-        STATE_DB,
-        "SELECT value FROM ItemTable WHERE key = 'antigravityAuthStatus' LIMIT 1"
-      )
-      var parsed = ctx.util.tryParseJson(rows)
-      if (!parsed || !parsed.length || !parsed[0].value) return null
-      var auth = ctx.util.tryParseJson(parsed[0].value)
-      if (!auth || !auth.apiKey) return null
-      return auth.apiKey
-    } catch (e) {
-      ctx.host.log.warn("failed to read auth from antigravity DB: " + String(e))
-      return null
-    }
+  // Antigravity wraps OAuth state in a double-base64 envelope:
+  //   b64(outer.f1 = wrapper{ f1=sentinel, f2=payload{ f1=b64(inner proto) } }).
+  // The inner base64 layer is the unusual part — it's a UTF-8 string field, not raw bytes.
+  function unwrapOAuthSentinel(ctx, base64Text) {
+    var trimmed = String(base64Text || "").replace(/^\s+|\s+$/g, "")
+    if (!trimmed) return null
+    var outer = ctx.base64.decode(trimmed)
+    var outerFields = readFields(outer)
+    if (!outerFields[1] || outerFields[1].type !== 2) return null
+    var wrapper = readFields(outerFields[1].data)
+    var sentinel = (wrapper[1] && wrapper[1].type === 2) ? wrapper[1].data : null
+    var payload = (wrapper[2] && wrapper[2].type === 2) ? wrapper[2].data : null
+    if (sentinel !== OAUTH_TOKEN_SENTINEL || !payload) return null
+    var payloadFields = readFields(payload)
+    if (!payloadFields[1] || payloadFields[1].type !== 2) return null
+    var innerText = payloadFields[1].data.replace(/^\s+|\s+$/g, "")
+    if (!innerText) return null
+    return ctx.base64.decode(innerText)
   }
 
-  function loadProtoTokens(ctx) {
+  function loadOAuthTokens(ctx) {
     try {
       var rows = ctx.host.sqlite.query(
         STATE_DB,
-        "SELECT value FROM ItemTable WHERE key = 'jetskiStateSync.agentManagerInitState' LIMIT 1"
+        "SELECT value FROM ItemTable WHERE key = '" + OAUTH_TOKEN_KEY + "' LIMIT 1"
       )
       var parsed = ctx.util.tryParseJson(rows)
       if (!parsed || !parsed.length || !parsed[0].value) return null
-      var raw = ctx.base64.decode(parsed[0].value)
-      var outer = readFields(raw)
-      if (!outer[6] || outer[6].type !== 2) return null
-      var inner = readFields(outer[6].data)
-      var accessToken = (inner[1] && inner[1].type === 2) ? inner[1].data : null
-      var refreshToken = (inner[3] && inner[3].type === 2) ? inner[3].data : null
+      var inner = unwrapOAuthSentinel(ctx, parsed[0].value)
+      if (!inner) return null
+      var fields = readFields(inner)
+      var accessToken = (fields[1] && fields[1].type === 2) ? fields[1].data : null
+      var refreshToken = (fields[3] && fields[3].type === 2) ? fields[3].data : null
       var expirySeconds = null
-      if (inner[4] && inner[4].type === 2) {
-        var ts = readFields(inner[4].data)
+      if (fields[4] && fields[4].type === 2) {
+        var ts = readFields(fields[4].data)
         if (ts[1] && ts[1].type === 0) expirySeconds = ts[1].value
       }
-      if (!accessToken) return null
+      if (!accessToken && !refreshToken) return null
       return { accessToken: accessToken, refreshToken: refreshToken, expirySeconds: expirySeconds }
     } catch (e) {
-      ctx.host.log.warn("failed to read proto tokens from antigravity DB: " + String(e))
+      ctx.host.log.warn("failed to read unified oauth token: " + String(e))
       return null
     }
   }
@@ -375,7 +386,7 @@
 
   // --- LS probe ---
 
-  function probeLs(ctx, apiKey) {
+  function probeLs(ctx) {
     var discovery = discoverLs(ctx)
     if (!discovery) return null
 
@@ -390,7 +401,6 @@
       ideVersion: "unknown",
       locale: "en",
     }
-    if (apiKey) metadata.apiKey = apiKey
 
     // Try GetUserStatus first, fall back to GetCommandModelConfigs
     var data = null
@@ -450,10 +460,9 @@
   // --- Probe ---
 
   function probe(ctx) {
-    var apiKey = loadApiKey(ctx)
-    var proto = loadProtoTokens(ctx)
+    var proto = loadOAuthTokens(ctx)
 
-    var lsResult = probeLs(ctx, apiKey)
+    var lsResult = probeLs(ctx)
     if (lsResult) return lsResult
 
     var tokens = []
@@ -464,11 +473,11 @@
     }
 
     var cached = loadCachedToken(ctx)
-    if (cached && cached !== (proto && proto.accessToken)) tokens.push(cached)
+    if (cached && tokens.indexOf(cached) === -1) tokens.push(cached)
 
-    if (apiKey && apiKey !== (proto && proto.accessToken) && apiKey !== cached) tokens.push(apiKey)
-
-    if (tokens.length === 0) throw "Start Antigravity and try again."
+    if (tokens.length === 0 && !(proto && proto.refreshToken)) {
+      throw "Start Antigravity and try again."
+    }
 
     var ccData = null
     for (var i = 0; i < tokens.length; i++) {
@@ -477,7 +486,7 @@
       ccData = null
     }
 
-    if (!ccData && proto && proto.refreshToken) {
+    if ((!ccData || ccData._authFailed) && proto && proto.refreshToken) {
       var refreshed = refreshAccessToken(ctx, proto.refreshToken)
       if (refreshed) ccData = probeCloudCode(ctx, refreshed)
     }

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -502,7 +502,7 @@ describe("antigravity plugin", () => {
     expect(labels).toContain("Claude")
   })
 
-  it("Cloud Code sends correct Authorization header with proto token", async () => {
+  it("Cloud Code sends correct Authorization header with DB token", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
     setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.proto-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
@@ -794,7 +794,7 @@ describe("antigravity plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
   })
 
-  it("tries proto token first, then cached on auth failure", async () => {
+  it("tries DB token first, then cached on auth failure", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
     const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.proto-first", refreshToken: "1//refresh", expirySeconds: futureExpiry })
@@ -869,7 +869,7 @@ describe("antigravity plugin", () => {
     expect(result.lines.length).toBeGreaterThan(0)
   })
 
-  it("deduplicates proto access token and identical cached token", async () => {
+  it("deduplicates DB access token and identical cached token", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
     const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.same-token", refreshToken: "1//refresh", expirySeconds: futureExpiry })
@@ -937,7 +937,7 @@ describe("antigravity plugin", () => {
     expect(cached.expiresAtMs).toBeGreaterThan(Date.now())
   })
 
-  it("uses cached token when no proto access token", async () => {
+  it("uses cached token when no DB access token", async () => {
     const ctx = makeCtx()
     setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
@@ -963,7 +963,7 @@ describe("antigravity plugin", () => {
     expect(capturedTokens[0]).toBe("Bearer ya29.cached-token")
   })
 
-  it("throws when cached token is expired and no proto tokens", async () => {
+  it("throws when cached token is expired and no DB tokens", async () => {
     const ctx = makeCtx()
     setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
@@ -979,7 +979,7 @@ describe("antigravity plugin", () => {
     expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
-  it("skips expired proto access token and falls through to refresh", async () => {
+  it("skips expired DB access token and falls through to refresh", async () => {
     const ctx = makeCtx()
     const pastExpiry = Math.floor(Date.now() / 1000) - 3600
     setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.expired-proto-token", refreshToken: "1//refresh", expirySeconds: pastExpiry }))
@@ -1001,12 +1001,12 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     plugin.probe(ctx)
 
-    // Expired proto token must NOT be sent. The refreshed token is used instead.
+    // Expired DB token must NOT be sent. The refreshed token is used instead.
     expect(capturedAuths).not.toContain("Bearer ya29.expired-proto-token")
     expect(capturedAuths[0]).toBe("Bearer ya29.refreshed")
   })
 
-  it("throws when cache file is corrupt and no proto tokens", async () => {
+  it("throws when cache file is corrupt and no DB tokens", async () => {
     const ctx = makeCtx()
     setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
@@ -1210,7 +1210,7 @@ describe("antigravity plugin", () => {
     expect(labels).toEqual(["Gemini Pro", "Claude"])
   })
 
-  it("LS still takes priority over Cloud Code with proto tokens (no regression)", async () => {
+  it("LS still takes priority over Cloud Code with DB tokens (no regression)", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
     const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.proto-token", refreshToken: "1//refresh", expirySeconds: futureExpiry })
@@ -1404,7 +1404,7 @@ describe("antigravity plugin", () => {
     expect(ccCallTokens).toEqual(["Bearer ya29.new"])
   })
 
-  it("proto access token equals cached token: Cloud Code is called exactly once", async () => {
+  it("DB access token equals cached token: Cloud Code is called exactly once", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
     setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.shared", refreshToken: "1//refresh", expirySeconds: futureExpiry }))

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -1430,4 +1430,58 @@ describe("antigravity plugin", () => {
 
     expect(ccCalls).toBe(1)
   })
+
+  it("does not refresh when Cloud Code returns 5xx (transient, not auth)", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.valid", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    let refreshCalls = 0
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url.includes("oauth2.googleapis.com")) {
+        refreshCalls += 1
+        return { status: 200, bodyText: JSON.stringify({ access_token: "ya29.new" }) }
+      }
+      if (url.includes("fetchAvailableModels")) {
+        return { status: 500, bodyText: "" }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(refreshCalls).toBe(0)
+  })
+
+  it("does not refresh when Cloud Code calls all throw (timeouts)", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.valid", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    const cachePath = ctx.app.pluginDataDir + "/auth.json"
+    ctx.host.fs.writeText(cachePath, JSON.stringify({
+      accessToken: "ya29.cached",
+      expiresAtMs: Date.now() + 3600000,
+    }))
+
+    let refreshCalls = 0
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url.includes("oauth2.googleapis.com")) {
+        refreshCalls += 1
+        return { status: 200, bodyText: JSON.stringify({ access_token: "ya29.new" }) }
+      }
+      if (url.includes("fetchAvailableModels")) {
+        throw new Error("timeout")
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(refreshCalls).toBe(0)
+  })
 })

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -6,6 +6,9 @@ const loadPlugin = async () => {
   return globalThis.__openusage_plugin
 }
 
+const OAUTH_TOKEN_KEY = "antigravityUnifiedStateSync.oauthToken"
+const OAUTH_TOKEN_SENTINEL = "oauthTokenInfoSentinelKey"
+
 // --- Fixtures ---
 
 function makeDiscovery(overrides) {
@@ -94,12 +97,6 @@ function makeCloudCodeResponse(overrides) {
   )
 }
 
-function makeAuthStatusJson(overrides) {
-  return JSON.stringify(
-    Object.assign({ apiKey: "test-api-key-123", email: "user@example.com", name: "Test User" }, overrides)
-  )
-}
-
 function setupLsMock(ctx, discovery, responseBody) {
   ctx.host.ls.discover.mockReturnValue(discovery)
   ctx.host.http.request.mockImplementation((opts) => {
@@ -110,42 +107,45 @@ function setupLsMock(ctx, discovery, responseBody) {
   })
 }
 
-function setupSqliteMock(ctx, authJson, protoBase64) {
+function setupSqliteMock(ctx, oauthEnvelopeB64) {
   ctx.host.sqlite.query.mockImplementation((db, sql) => {
-    if (sql.includes("agentManagerInitState") && protoBase64) {
-      return JSON.stringify([{ value: protoBase64 }])
-    }
-    if (sql.includes("antigravityAuthStatus") && authJson) {
-      return JSON.stringify([{ value: authJson }])
+    if (sql.includes(OAUTH_TOKEN_KEY) && oauthEnvelopeB64) {
+      return JSON.stringify([{ value: oauthEnvelopeB64 }])
     }
     return "[]"
   })
 }
 
-function makeProtobufBase64(ctx, accessToken, refreshToken, expirySeconds) {
-  function encodeVarint(n) {
-    var bytes = ""
-    while (n > 0x7f) {
-      bytes += String.fromCharCode((n & 0x7f) | 0x80)
-      n = Math.floor(n / 128)
-    }
-    bytes += String.fromCharCode(n & 0x7f)
-    return bytes
+function encodeVarint(n) {
+  var bytes = ""
+  while (n > 0x7f) {
+    bytes += String.fromCharCode((n & 0x7f) | 0x80)
+    n = Math.floor(n / 128)
   }
-  function encodeField(fieldNum, wireType, data) {
-    var tag = encodeVarint(fieldNum * 8 + wireType)
-    if (wireType === 2) return tag + encodeVarint(data.length) + data
-    if (wireType === 0) return tag + encodeVarint(data)
-    return ""
-  }
+  bytes += String.fromCharCode(n & 0x7f)
+  return bytes
+}
+
+function encodeField(fieldNum, wireType, data) {
+  var tag = encodeVarint(fieldNum * 8 + wireType)
+  if (wireType === 2) return tag + encodeVarint(data.length) + data
+  if (wireType === 0) return tag + encodeVarint(data)
+  return ""
+}
+
+function makeOAuthSentinelB64(ctx, opts) {
+  opts = opts || {}
   var inner = ""
-  if (accessToken) inner += encodeField(1, 2, accessToken)
-  if (refreshToken) inner += encodeField(3, 2, refreshToken)
-  if (expirySeconds !== null && expirySeconds !== undefined) {
-    var tsMsg = encodeField(1, 0, expirySeconds)
+  if (opts.accessToken) inner += encodeField(1, 2, opts.accessToken)
+  if (opts.refreshToken) inner += encodeField(3, 2, opts.refreshToken)
+  if (opts.expirySeconds !== null && opts.expirySeconds !== undefined) {
+    var tsMsg = encodeField(1, 0, opts.expirySeconds)
     inner += encodeField(4, 2, tsMsg)
   }
-  var outer = encodeField(6, 2, inner)
+  var innerB64 = ctx.base64.encode(inner)
+  var payload = encodeField(1, 2, innerB64)
+  var wrapper = encodeField(1, 2, OAUTH_TOKEN_SENTINEL) + encodeField(2, 2, payload)
+  var outer = encodeField(1, 2, wrapper)
   return ctx.base64.encode(outer)
 }
 
@@ -451,35 +451,7 @@ describe("antigravity plugin", () => {
     ])
   })
 
-  it("includes apiKey in LS metadata when DB has credentials", async () => {
-    const ctx = makeCtx()
-    setupSqliteMock(ctx, makeAuthStatusJson())
-    const discovery = makeDiscovery()
-    ctx.host.ls.discover.mockReturnValue(discovery)
-
-    let capturedMetadata = null
-    ctx.host.http.request.mockImplementation((opts) => {
-      const url = String(opts.url)
-      if (url.includes("GetUnleashData")) {
-        return { status: 200, bodyText: "{}" }
-      }
-      if (url.includes("GetUserStatus")) {
-        const body = JSON.parse(opts.bodyText)
-        capturedMetadata = body.metadata
-        return { status: 200, bodyText: JSON.stringify(makeUserStatusResponse()) }
-      }
-      return { status: 200, bodyText: "{}" }
-    })
-
-    const plugin = await loadPlugin()
-    plugin.probe(ctx)
-
-    expect(capturedMetadata).toBeTruthy()
-    expect(capturedMetadata.apiKey).toBe("test-api-key-123")
-    expect(capturedMetadata.ideName).toBe("antigravity")
-  })
-
-  it("works without apiKey when SQLite returns empty", async () => {
+  it("never sends apiKey in LS metadata (unified schema has no apiKey)", async () => {
     const ctx = makeCtx()
     const discovery = makeDiscovery()
     const response = makeUserStatusResponse()
@@ -510,7 +482,7 @@ describe("antigravity plugin", () => {
   it("falls back to Cloud Code API when LS is not available", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -533,7 +505,7 @@ describe("antigravity plugin", () => {
   it("Cloud Code sends correct Authorization header with proto token", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.proto-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.proto-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     let capturedHeaders = null
@@ -557,7 +529,7 @@ describe("antigravity plugin", () => {
   it("Cloud Code returns null on 401/403 (invalid token, no refresh)", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.bad-token", null, futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.bad-token", refreshToken: null, expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -575,7 +547,7 @@ describe("antigravity plugin", () => {
   it("Cloud Code tries multiple base URLs", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     const calledUrls = []
@@ -603,7 +575,7 @@ describe("antigravity plugin", () => {
   it("Cloud Code correctly parses model quota response", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -647,11 +619,11 @@ describe("antigravity plugin", () => {
   it("LS takes priority over Cloud Code when both available", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     const discovery = makeDiscovery()
     const response = makeUserStatusResponse()
     setupLsMock(ctx, discovery, response)
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
@@ -666,7 +638,7 @@ describe("antigravity plugin", () => {
   it("Cloud Code treats models without quotaInfo as depleted (100% used)", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -703,8 +675,8 @@ describe("antigravity plugin", () => {
   it("decodes protobuf tokens from SQLite", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    const protoB64 = makeProtobufBase64(ctx, "ya29.test-access", "1//refresh-token", futureExpiry)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-access", refreshToken: "1//refresh-token", expirySeconds: futureExpiry })
+    setupSqliteMock(ctx, protoB64)
     ctx.host.ls.discover.mockReturnValue(null)
 
     let capturedAuth = null
@@ -724,52 +696,30 @@ describe("antigravity plugin", () => {
     expect(result.lines.length).toBeGreaterThan(0)
   })
 
-  it("handles missing protobuf data gracefully (falls back to apiKey)", async () => {
+  it("throws when unified oauth envelope is missing and no cache", async () => {
     const ctx = makeCtx()
-    setupSqliteMock(ctx, makeAuthStatusJson())
+    setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
 
-    let capturedAuth = null
-    ctx.host.http.request.mockImplementation((opts) => {
-      if (String(opts.url).includes("fetchAvailableModels")) {
-        capturedAuth = opts.headers.Authorization
-        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
-      }
-      return { status: 500, bodyText: "" }
-    })
-
     const plugin = await loadPlugin()
-    const result = plugin.probe(ctx)
-
-    expect(capturedAuth).toBe("Bearer test-api-key-123")
-    expect(result.lines.length).toBeGreaterThan(0)
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
-  it("handles corrupt protobuf base64 gracefully (falls back to apiKey)", async () => {
+  it("throws when unified oauth envelope is corrupt and no cache", async () => {
     const ctx = makeCtx()
-    setupSqliteMock(ctx, makeAuthStatusJson(), "not-valid-protobuf!!!")
+    setupSqliteMock(ctx, "not-valid-protobuf!!!")
     ctx.host.ls.discover.mockReturnValue(null)
 
-    let capturedAuth = null
-    ctx.host.http.request.mockImplementation((opts) => {
-      if (String(opts.url).includes("fetchAvailableModels")) {
-        capturedAuth = opts.headers.Authorization
-        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
-      }
-      return { status: 500, bodyText: "" }
-    })
-
     const plugin = await loadPlugin()
-    const result = plugin.probe(ctx)
-
-    expect(capturedAuth).toBe("Bearer test-api-key-123")
-    expect(result.lines.length).toBeGreaterThan(0)
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
   it("handles protobuf with no refresh_token or expiry", async () => {
     const ctx = makeCtx()
-    const protoB64 = makeProtobufBase64(ctx, "ya29.access-only", null, null)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.access-only", refreshToken: null, expirySeconds: null })
+    setupSqliteMock(ctx, protoB64)
     ctx.host.ls.discover.mockReturnValue(null)
 
     let capturedAuth = null
@@ -790,8 +740,8 @@ describe("antigravity plugin", () => {
   it("sends correct form-urlencoded POST to Google OAuth", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    const protoB64 = makeProtobufBase64(ctx, "ya29.expired", "1//my-refresh", futureExpiry)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.expired", refreshToken: "1//my-refresh", expirySeconds: futureExpiry })
+    setupSqliteMock(ctx, protoB64)
     ctx.host.ls.discover.mockReturnValue(null)
 
     let oauthBody = null
@@ -825,8 +775,8 @@ describe("antigravity plugin", () => {
   it("throws when all tokens fail and refresh returns invalid_grant", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    const protoB64 = makeProtobufBase64(ctx, "ya29.expired", "1//bad-refresh", futureExpiry)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.expired", refreshToken: "1//bad-refresh", expirySeconds: futureExpiry })
+    setupSqliteMock(ctx, protoB64)
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -844,12 +794,18 @@ describe("antigravity plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
   })
 
-  it("tries proto token first, then apiKey on auth failure", async () => {
+  it("tries proto token first, then cached on auth failure", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    const protoB64 = makeProtobufBase64(ctx, "ya29.proto-first", "1//refresh", futureExpiry)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.proto-first", refreshToken: "1//refresh", expirySeconds: futureExpiry })
+    setupSqliteMock(ctx, protoB64)
     ctx.host.ls.discover.mockReturnValue(null)
+
+    const cachePath = ctx.app.pluginDataDir + "/auth.json"
+    ctx.host.fs.writeText(cachePath, JSON.stringify({
+      accessToken: "ya29.cached",
+      expiresAtMs: Date.now() + 3600000,
+    }))
 
     const capturedTokens = []
     ctx.host.http.request.mockImplementation((opts) => {
@@ -868,16 +824,22 @@ describe("antigravity plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(capturedTokens[0]).toBe("Bearer ya29.proto-first")
-    expect(capturedTokens[capturedTokens.length - 1]).toBe("Bearer test-api-key-123")
+    expect(capturedTokens[capturedTokens.length - 1]).toBe("Bearer ya29.cached")
     expect(result.lines.length).toBeGreaterThan(0)
   })
 
   it("tries both tokens before refreshing", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    const protoB64 = makeProtobufBase64(ctx, "ya29.both-fail", "1//refresh", futureExpiry)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.both-fail", refreshToken: "1//refresh", expirySeconds: futureExpiry })
+    setupSqliteMock(ctx, protoB64)
     ctx.host.ls.discover.mockReturnValue(null)
+
+    const cachePath = ctx.app.pluginDataDir + "/auth.json"
+    ctx.host.fs.writeText(cachePath, JSON.stringify({
+      accessToken: "ya29.cached-also-bad",
+      expiresAtMs: Date.now() + 3600000,
+    }))
 
     const capturedTokens = []
     let refreshCalled = false
@@ -902,17 +864,23 @@ describe("antigravity plugin", () => {
 
     expect(refreshCalled).toBe(true)
     expect(capturedTokens.filter((t) => t === "Bearer ya29.both-fail").length).toBeGreaterThan(0)
-    expect(capturedTokens.filter((t) => t === "Bearer test-api-key-123").length).toBeGreaterThan(0)
+    expect(capturedTokens.filter((t) => t === "Bearer ya29.cached-also-bad").length).toBeGreaterThan(0)
     expect(capturedTokens[capturedTokens.length - 1]).toBe("Bearer ya29.refreshed")
     expect(result.lines.length).toBeGreaterThan(0)
   })
 
-  it("deduplicates identical tokens", async () => {
+  it("deduplicates proto access token and identical cached token", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    const protoB64 = makeProtobufBase64(ctx, "ya29.same-token", "1//refresh", futureExpiry)
-    setupSqliteMock(ctx, makeAuthStatusJson({ apiKey: "ya29.same-token" }), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.same-token", refreshToken: "1//refresh", expirySeconds: futureExpiry })
+    setupSqliteMock(ctx, protoB64)
     ctx.host.ls.discover.mockReturnValue(null)
+
+    const cachePath = ctx.app.pluginDataDir + "/auth.json"
+    ctx.host.fs.writeText(cachePath, JSON.stringify({
+      accessToken: "ya29.same-token",
+      expiresAtMs: Date.now() + 3600000,
+    }))
 
     const capturedTokens = []
     ctx.host.http.request.mockImplementation((opts) => {
@@ -938,31 +906,11 @@ describe("antigravity plugin", () => {
     expect(result.lines.length).toBeGreaterThan(0)
   })
 
-  it("uses apiKey as only token when proto data unavailable", async () => {
-    const ctx = makeCtx()
-    setupSqliteMock(ctx, makeAuthStatusJson())
-    ctx.host.ls.discover.mockReturnValue(null)
-
-    let capturedAuth = null
-    ctx.host.http.request.mockImplementation((opts) => {
-      if (String(opts.url).includes("fetchAvailableModels")) {
-        capturedAuth = opts.headers.Authorization
-        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
-      }
-      return { status: 500, bodyText: "" }
-    })
-
-    const plugin = await loadPlugin()
-    plugin.probe(ctx)
-
-    expect(capturedAuth).toBe("Bearer test-api-key-123")
-  })
-
   it("caches refreshed token to pluginDataDir", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    const protoB64 = makeProtobufBase64(ctx, "ya29.will-fail", "1//refresh", futureExpiry)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.will-fail", refreshToken: "1//refresh", expirySeconds: futureExpiry })
+    setupSqliteMock(ctx, protoB64)
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -989,9 +937,9 @@ describe("antigravity plugin", () => {
     expect(cached.expiresAtMs).toBeGreaterThan(Date.now())
   })
 
-  it("uses cached token before falling back to apiKey", async () => {
+  it("uses cached token when no proto access token", async () => {
     const ctx = makeCtx()
-    setupSqliteMock(ctx, makeAuthStatusJson())
+    setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
 
     const cachePath = ctx.app.pluginDataDir + "/auth.json"
@@ -1015,9 +963,9 @@ describe("antigravity plugin", () => {
     expect(capturedTokens[0]).toBe("Bearer ya29.cached-token")
   })
 
-  it("skips expired cached token", async () => {
+  it("throws when cached token is expired and no proto tokens", async () => {
     const ctx = makeCtx()
-    setupSqliteMock(ctx, makeAuthStatusJson())
+    setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
 
     const cachePath = ctx.app.pluginDataDir + "/auth.json"
@@ -1026,31 +974,25 @@ describe("antigravity plugin", () => {
       expiresAtMs: Date.now() - 1000,
     }))
 
-    let capturedAuth = null
-    ctx.host.http.request.mockImplementation((opts) => {
-      if (String(opts.url).includes("fetchAvailableModels")) {
-        capturedAuth = opts.headers.Authorization
-        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
-      }
-      return { status: 500, bodyText: "" }
-    })
-
     const plugin = await loadPlugin()
-    plugin.probe(ctx)
-
-    expect(capturedAuth).toBe("Bearer test-api-key-123")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
-  it("skips expired proto token and falls back to next token", async () => {
+  it("skips expired proto access token and falls through to refresh", async () => {
     const ctx = makeCtx()
     const pastExpiry = Math.floor(Date.now() / 1000) - 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.expired-proto-token", "1//refresh", pastExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.expired-proto-token", refreshToken: "1//refresh", expirySeconds: pastExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
-    let capturedAuth = null
+    const capturedAuths = []
     ctx.host.http.request.mockImplementation((opts) => {
-      if (String(opts.url).includes("fetchAvailableModels")) {
-        capturedAuth = opts.headers.Authorization
+      const url = String(opts.url)
+      if (url.includes("oauth2.googleapis.com")) {
+        return { status: 200, bodyText: JSON.stringify({ access_token: "ya29.refreshed" }) }
+      }
+      if (url.includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
         return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
       }
       return { status: 500, bodyText: "" }
@@ -1059,36 +1001,28 @@ describe("antigravity plugin", () => {
     const plugin = await loadPlugin()
     plugin.probe(ctx)
 
-    expect(capturedAuth).toBe("Bearer test-api-key-123")
+    // Expired proto token must NOT be sent. The refreshed token is used instead.
+    expect(capturedAuths).not.toContain("Bearer ya29.expired-proto-token")
+    expect(capturedAuths[0]).toBe("Bearer ya29.refreshed")
   })
 
-  it("handles missing/corrupt cache file gracefully", async () => {
+  it("throws when cache file is corrupt and no proto tokens", async () => {
     const ctx = makeCtx()
-    setupSqliteMock(ctx, makeAuthStatusJson())
+    setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
 
     const cachePath = ctx.app.pluginDataDir + "/auth.json"
     ctx.host.fs.writeText(cachePath, "{bad json")
 
-    let capturedAuth = null
-    ctx.host.http.request.mockImplementation((opts) => {
-      if (String(opts.url).includes("fetchAvailableModels")) {
-        capturedAuth = opts.headers.Authorization
-        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
-      }
-      return { status: 500, bodyText: "" }
-    })
-
     const plugin = await loadPlugin()
-    plugin.probe(ctx)
-
-    expect(capturedAuth).toBe("Bearer test-api-key-123")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
   it("Cloud Code skips models with isInternal flag", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test", "1//r", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test", refreshToken: "1//r", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -1126,7 +1060,7 @@ describe("antigravity plugin", () => {
   it("Cloud Code skips models with empty or missing displayName", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test", "1//r", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test", refreshToken: "1//r", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -1166,7 +1100,7 @@ describe("antigravity plugin", () => {
   it("Cloud Code skips blacklisted model IDs", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test", "1//r", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test", refreshToken: "1//r", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -1207,7 +1141,7 @@ describe("antigravity plugin", () => {
   it("Cloud Code keeps non-blacklisted models with valid displayName", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test", "1//r", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test", refreshToken: "1//r", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     ctx.host.http.request.mockImplementation((opts) => {
@@ -1279,12 +1213,12 @@ describe("antigravity plugin", () => {
   it("LS still takes priority over Cloud Code with proto tokens (no regression)", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    const protoB64 = makeProtobufBase64(ctx, "ya29.proto-token", "1//refresh", futureExpiry)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.proto-token", refreshToken: "1//refresh", expirySeconds: futureExpiry })
+    setupSqliteMock(ctx, protoB64)
     const discovery = makeDiscovery()
     const response = makeUserStatusResponse()
     setupLsMock(ctx, discovery, response)
-    setupSqliteMock(ctx, makeAuthStatusJson(), protoB64)
+    setupSqliteMock(ctx, protoB64)
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
@@ -1299,7 +1233,7 @@ describe("antigravity plugin", () => {
   it("throws when Cloud Code returns no models", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
     ctx.host.http.request.mockImplementation((opts) => {
       if (String(opts.url).includes("fetchAvailableModels")) {
@@ -1315,7 +1249,7 @@ describe("antigravity plugin", () => {
   it("handles refresh response missing access_token", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.will-fail", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.will-fail", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     let oauthCalls = 0
@@ -1339,7 +1273,7 @@ describe("antigravity plugin", () => {
   it("continues to next Cloud Code base URL after non-2xx response", async () => {
     const ctx = makeCtx()
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
-    setupSqliteMock(ctx, makeAuthStatusJson(), makeProtobufBase64(ctx, "ya29.test-token", "1//refresh", futureExpiry))
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.test-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
 
     let ccCalls = 0
@@ -1403,5 +1337,97 @@ describe("antigravity plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(result.plan).toBe("Pro")
+  })
+
+  // --- Regression tests for unified-schema bug fixes ---
+
+  it("refresh-token-only state (no access token, no cache) refreshes and succeeds", async () => {
+    const ctx = makeCtx()
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: null, refreshToken: "1//only-refresh", expirySeconds: null }))
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    const capturedAuths = []
+    let refreshCalls = 0
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url.includes("oauth2.googleapis.com")) {
+        refreshCalls += 1
+        return { status: 200, bodyText: JSON.stringify({ access_token: "ya29.from-refresh", expires_in: 3600 }) }
+      }
+      if (url.includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        if (opts.headers.Authorization === "Bearer ya29.from-refresh") {
+          return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+        }
+        return { status: 401, bodyText: '{"error":"unauthorized"}' }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(refreshCalls).toBe(1)
+    expect(capturedAuths[capturedAuths.length - 1]).toBe("Bearer ya29.from-refresh")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("expired access token + valid refresh token: refresh is called exactly once with the refreshed token", async () => {
+    const ctx = makeCtx()
+    const pastExpiry = Math.floor(Date.now() / 1000) - 60
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.expired", refreshToken: "1//refresh", expirySeconds: pastExpiry }))
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    let refreshCalls = 0
+    const ccCallTokens = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url.includes("oauth2.googleapis.com")) {
+        refreshCalls += 1
+        return { status: 200, bodyText: JSON.stringify({ access_token: "ya29.new", expires_in: 3600 }) }
+      }
+      if (url.includes("fetchAvailableModels")) {
+        ccCallTokens.push(opts.headers.Authorization)
+        if (opts.headers.Authorization === "Bearer ya29.new") {
+          return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+        }
+        return { status: 401, bodyText: '{"error":"unauthorized"}' }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(refreshCalls).toBe(1)
+    // The expired token must never be sent, and Cloud Code is called exactly once with the refreshed token.
+    expect(ccCallTokens).toEqual(["Bearer ya29.new"])
+  })
+
+  it("proto access token equals cached token: Cloud Code is called exactly once", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.shared", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    const cachePath = ctx.app.pluginDataDir + "/auth.json"
+    ctx.host.fs.writeText(cachePath, JSON.stringify({
+      accessToken: "ya29.shared",
+      expiresAtMs: Date.now() + 3600000,
+    }))
+
+    let ccCalls = 0
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        ccCalls += 1
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(ccCalls).toBe(1)
   })
 })


### PR DESCRIPTION
## Description
### From Copilot:
This pull request refactors the Antigravity plugin and its documentation to switch from the legacy `antigravityAuthStatus`/`jetskiStateSync.agentManagerInitState` authentication schema to the new unified Google OAuth envelope stored under `antigravityUnifiedStateSync.oauthToken`. The plugin now exclusively uses Google OAuth tokens (with double base64/protobuf wrapping) for authentication, removes all references to the deprecated API key, and updates the probing and fallback strategies accordingly. The test suite and documentation are updated to match the new schema and logic.

**Authentication and Credential Handling**
* Switched all SQLite credential reading to use the new `antigravityUnifiedStateSync.oauthToken` key, decoding the double-wrapped base64/protobuf envelope to extract Google OAuth tokens; removed support for the legacy `antigravityAuthStatus` and `jetskiStateSync.agentManagerInitState` keys and the API key. [[1]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8L66-R116) [[2]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8L453-R465) [[3]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8L467-R480) [[4]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8L480-R489) [[5]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L166-L185)
* Updated the protobuf wire-format parser to support fixed32 and fixed64 field types, matching the new envelope structure. [[1]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8R53-R65) [[2]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L197-R188)

**Plugin Logic and Probing**
* Refactored the LS and Cloud Code probing logic to use only OAuth tokens (no API key); removed all logic for sending the API key in LS metadata. [[1]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8L378-R389) [[2]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8L393) [[3]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L12-R12) [[4]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L69-L70) [[5]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L258-R260)
* Improved Cloud Code fallback: Only attempts refresh if no valid tokens are available or all fail, and handles empty token lists more robustly. [[1]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8L467-R480) [[2]](diffhunk://#diff-d9bdb102480d440f0918356be145b4a7929bdd2ceeea09b5bb014110278443c8L480-R489) [[3]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L217-R208)

**Test Suite Updates**
* Updated all plugin tests and fixtures to generate and use the new OAuth sentinel envelope format, removing all references to the legacy API key and old protobuf schema. [[1]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349R9-R11) [[2]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L97-L102) [[3]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L113-L125) [[4]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349R128-R148) [[5]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L454-R454) [[6]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L513-R485) [[7]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L536-R508) [[8]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L560-R532) [[9]](diffhunk://#diff-3572110fe5bc7018242a91a04438ab6c0aa6934a97839fd88c893e5855eac349L578-R550)

**Documentation**
* Overhauled the Antigravity provider documentation to describe the new OAuth envelope schema, credential storage, and updated plugin strategy; removed all references to the legacy API key and protobuf keys. [[1]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L12-R12) [[2]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L69-L70) [[3]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L166-L185) [[4]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L197-R188) [[5]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L217-R208) [[6]](diffhunk://#diff-0dbb1e91611a6bc1312e293790c61a9531e3c34b26c14faff077d9c0f56e87d8L258-R260)

These changes ensure the plugin and its documentation are aligned with the new unified authentication schema and improve reliability and maintainability.

### From commit:
Antigravity migrated its state store to the unified-state-sync layout. The plugin's Cloud Code fallback was reading the old keys, so whenever the language server wasn't reachable, every probe returned "Start Antigravity and try again."

Read tokens from antigravityUnifiedStateSync.oauthToken and unwrap the double-base64 sentinel envelope (outer.f1 -> wrapper{f1=sentinel, f2=payload{f1=b64(inner OAuthTokenInfo)}}). The new layout carries no apiKey, so drop it from LS metadata and the Cloud Code token list.

Ported from steipete/CodexBar#255 (the work is also done by myself).


## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots
The old behavior is like this:
<img width="1108" height="786" alt="CleanShot 2026-04-18 at 14 42 15@2x" src="https://github.com/user-attachments/assets/958a46d0-a49e-47da-b1d8-1c040e67cb95" />

The fixed behavior is this:
<img width="1124" height="1032" alt="CleanShot 2026-04-18 at 15 27 56@2x" src="https://github.com/user-attachments/assets/e9438028-ce85-433d-9a52-e164fd7701ef" />

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
