### PR TITLE
fix(claude): resolve plan tier via /api/oauth/profile

### DIFF
--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -60,6 +60,32 @@ Returns rate limit windows and optional extra credits.
 
 All windows are enforced simultaneously — hitting any limit throttles the user.
 
+### GET /api/oauth/profile
+
+Returns the authenticated account + organization, including the live subscription
+tier. Used to resolve the plan badge when the locally stored `rateLimitTier` /
+`subscriptionType` have gone stale — those are snapshots written at login time
+and are not refreshed when the user changes plan.
+
+Same headers as `/api/oauth/usage`. Fields consumed:
+
+```jsonc
+{
+  "account": {
+    "has_claude_max": true,
+    "has_claude_pro": false
+  },
+  "organization": {
+    "organization_type": "claude_max",            // or "claude_pro"
+    "rate_limit_tier": "default_claude_max_20x"   // "...Nx" → "Nx" badge suffix
+  }
+}
+```
+
+`organization.rate_limit_tier` is preferred over the local
+`claudeAiOauth.rateLimitTier`. The local value is used only as a fallback when
+the profile call fails (network error, non-2xx, non-JSON).
+
 ## Supplemental Peak Hours Status
 
 OpenUsage also augments the Claude card with PromoClock peak/off-peak status:

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -67,7 +67,16 @@ tier. Used to resolve the plan badge when the locally stored `rateLimitTier` /
 `subscriptionType` have gone stale — those are snapshots written at login time
 and are not refreshed when the user changes plan.
 
-Same headers as `/api/oauth/usage`. Fields consumed:
+#### Headers
+
+| Header | Required | Value |
+|---|---|---|
+| Authorization | yes | `Bearer <access_token>` |
+| Accept | yes | `application/json` |
+| Content-Type | yes | `application/json` |
+| anthropic-beta | yes | `oauth-2025-04-20` |
+
+#### Response (fields consumed)
 
 ```jsonc
 {

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -454,23 +454,36 @@
     return mins + "m"
   }
 
+  function profileRequest(ctx, accessToken) {
+    const oauthConfig = getOauthConfig(ctx)
+    return ctx.util.request({
+      method: "GET",
+      url: oauthConfig.profileUrl,
+      headers: {
+        Authorization: "Bearer " + accessToken.trim(),
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "anthropic-beta": "oauth-2025-04-20",
+        "User-Agent": "claude-code/2.1.69",
+      },
+      timeoutMs: 10000,
+    })
+  }
+
   // Best-effort: returns the parsed profile object, or null on any failure.
   // The stored rateLimitTier/subscriptionType in credentials is a snapshot from
   // login time and does not track plan changes; /api/oauth/profile is live truth.
-  function fetchProfile(ctx, accessToken) {
-    const oauthConfig = getOauthConfig(ctx)
+  // Mirrors fetchUsage's retry-once-on-auth pattern so a refreshable 401/403 is
+  // recovered instead of falling back to the stale local tier.
+  function fetchProfile(ctx, creds, accessToken) {
     let resp
     try {
-      resp = ctx.util.request({
-        method: "GET",
-        url: oauthConfig.profileUrl,
-        headers: {
-          Authorization: "Bearer " + accessToken.trim(),
-          Accept: "application/json",
-          "anthropic-beta": "oauth-2025-04-20",
-          "User-Agent": "claude-code/2.1.69",
+      resp = ctx.util.retryOnceOnAuth({
+        request: (token) => profileRequest(ctx, token || accessToken),
+        refresh: () => {
+          ctx.host.log.info("profile returned auth error, attempting refresh")
+          return refreshToken(ctx, creds)
         },
-        timeoutMs: 10000,
       })
     } catch (e) {
       ctx.host.log.warn("profile fetch exception: " + String(e))
@@ -782,7 +795,7 @@
       ctx.host.log.info("skipping live usage fetch for inference-only token")
     }
 
-    const profile = canFetchLiveUsage ? fetchProfile(ctx, creds.oauth.accessToken) : null
+    const profile = canFetchLiveUsage ? fetchProfile(ctx, creds, creds.oauth.accessToken) : null
     const freshOrg = profile && profile.organization
     const freshTier = freshOrg && typeof freshOrg.rate_limit_tier === "string" ? freshOrg.rate_limit_tier : null
     const freshOrgType = freshOrg && typeof freshOrg.organization_type === "string" ? freshOrg.organization_type : null

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -200,6 +200,7 @@
     return {
       baseApiUrl: baseApiUrl,
       usageUrl: baseApiUrl + "/api/oauth/usage",
+      profileUrl: baseApiUrl + "/api/oauth/profile",
       refreshUrl: refreshUrl,
       clientId: clientId,
       oauthFileSuffix: oauthFileSuffix,
@@ -451,6 +452,37 @@
     if (seconds <= 0) return "now"
     const mins = Math.ceil(seconds / 60)
     return mins + "m"
+  }
+
+  // Best-effort: returns the parsed profile object, or null on any failure.
+  // The stored rateLimitTier/subscriptionType in credentials is a snapshot from
+  // login time and does not track plan changes; /api/oauth/profile is live truth.
+  function fetchProfile(ctx, accessToken) {
+    const oauthConfig = getOauthConfig(ctx)
+    let resp
+    try {
+      resp = ctx.util.request({
+        method: "GET",
+        url: oauthConfig.profileUrl,
+        headers: {
+          Authorization: "Bearer " + accessToken.trim(),
+          Accept: "application/json",
+          "anthropic-beta": "oauth-2025-04-20",
+          "User-Agent": "claude-code/2.1.69",
+        },
+        timeoutMs: 10000,
+      })
+    } catch (e) {
+      ctx.host.log.warn("profile fetch exception: " + String(e))
+      return null
+    }
+    if (!resp || resp.status < 200 || resp.status >= 300) {
+      ctx.host.log.warn("profile fetch returned status: " + String(resp && resp.status))
+      return null
+    }
+    const parsed = ctx.util.tryParseJson(resp.bodyText)
+    if (!parsed || typeof parsed !== "object") return null
+    return parsed
   }
 
   function queryTokenUsage(ctx, homePath) {
@@ -750,12 +782,21 @@
       ctx.host.log.info("skipping live usage fetch for inference-only token")
     }
 
+    const profile = canFetchLiveUsage ? fetchProfile(ctx, creds.oauth.accessToken) : null
+    const freshOrg = profile && profile.organization
+    const freshTier = freshOrg && typeof freshOrg.rate_limit_tier === "string" ? freshOrg.rate_limit_tier : null
+    const freshOrgType = freshOrg && typeof freshOrg.organization_type === "string" ? freshOrg.organization_type : null
+
+    let subscriptionType = creds.oauth.subscriptionType
+    if (freshOrgType === "claude_max") subscriptionType = "max"
+    else if (freshOrgType === "claude_pro") subscriptionType = "pro"
+
     let plan = null
-    if (creds.oauth.subscriptionType) {
-      const basePlan = ctx.fmt.planLabel(creds.oauth.subscriptionType)
+    if (subscriptionType) {
+      const basePlan = ctx.fmt.planLabel(subscriptionType)
       if (basePlan) {
         let tierSuffix = ""
-        const rlt = String(creds.oauth.rateLimitTier || "")
+        const rlt = String(freshTier || creds.oauth.rateLimitTier || "")
         const tierMatch = rlt.match(/(\d+)x/)
         if (tierMatch) {
           tierSuffix = " " + tierMatch[1] + "x"

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -19,6 +19,7 @@
   let rateLimitedUntilMs = 0  // epoch ms; 0 = not rate-limited
   let lastUsageFetchMs = 0    // epoch ms of the most-recent API attempt
   let cachedUsageData = null  // last successful API response body (parsed JSON)
+  let cachedProfileData = null  // last successful /api/oauth/profile body
 
   function utf8DecodeBytes(bytes) {
     // Prefer native TextDecoder when available (QuickJS may not expose it).
@@ -454,6 +455,10 @@
     return mins + "m"
   }
 
+  // 5s rather than fetchUsage's 10s: profile is a best-effort augmentation,
+  // so keep the worst-case added latency bounded when the endpoint is slow.
+  const PROFILE_TIMEOUT_MS = 5000
+
   function profileRequest(ctx, accessToken) {
     const oauthConfig = getOauthConfig(ctx)
     return ctx.util.request({
@@ -466,7 +471,7 @@
         "anthropic-beta": "oauth-2025-04-20",
         "User-Agent": "claude-code/2.1.69",
       },
-      timeoutMs: 10000,
+      timeoutMs: PROFILE_TIMEOUT_MS,
     })
   }
 
@@ -697,6 +702,7 @@
     let lines = []
     let rateLimited = false
     let retryAfterSeconds = null
+    let shouldFetchProfile = false
     if (canFetchLiveUsage) {
       if (nowMs < rateLimitedUntilMs) {
         // Still within a rate-limit window from a previous probe call — skip the
@@ -788,6 +794,9 @@
           }
           cachedUsageData = data
           rateLimitedUntilMs = 0
+          // Piggyback profile only when usage returned 2xx — keeps per-probe
+          // HTTP load at one call when usage is rate-limited or throttled.
+          shouldFetchProfile = true
         }
         } // end fetch else-branch
       }
@@ -795,7 +804,13 @@
       ctx.host.log.info("skipping live usage fetch for inference-only token")
     }
 
-    const profile = canFetchLiveUsage ? fetchProfile(ctx, creds, creds.oauth.accessToken) : null
+    // Piggyback profile on live usage fetches; reuse cached profile when usage
+    // was rate-limited / throttled. Don't replace cache with null on failure.
+    if (shouldFetchProfile) {
+      const fresh = fetchProfile(ctx, creds, creds.oauth.accessToken)
+      if (fresh) cachedProfileData = fresh
+    }
+    const profile = canFetchLiveUsage ? cachedProfileData : null
     const freshOrg = profile && profile.organization
     const freshTier = freshOrg && typeof freshOrg.rate_limit_tier === "string" ? freshOrg.rate_limit_tier : null
     const freshOrgType = freshOrg && typeof freshOrg.organization_type === "string" ? freshOrg.organization_type : null
@@ -809,7 +824,12 @@
       const basePlan = ctx.fmt.planLabel(subscriptionType)
       if (basePlan) {
         let tierSuffix = ""
-        const rlt = String(freshTier || creds.oauth.rateLimitTier || "")
+        // Only fall back to the stored tier when the whole profile fetch
+        // failed; if profile succeeded with a missing tier, trust the empty
+        // value rather than mixing a fresh org type with a stale suffix.
+        const rlt = profile
+          ? String(freshTier || "")
+          : String(creds.oauth.rateLimitTier || "")
         const tierMatch = rlt.match(/(\d+)x/)
         if (tierMatch) {
           tierSuffix = " " + tierMatch[1] + "x"
@@ -953,6 +973,7 @@
     rateLimitedUntilMs = 0
     lastUsageFetchMs = 0
     cachedUsageData = null
+    cachedProfileData = null
   }
 
   globalThis.__openusage_plugin = { id: "claude", probe, _resetState }

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -20,6 +20,9 @@
   let lastUsageFetchMs = 0    // epoch ms of the most-recent API attempt
   let cachedUsageData = null  // last successful API response body (parsed JSON)
   let cachedProfileData = null  // last successful /api/oauth/profile body
+  let cachedProfileToken = null  // access token cachedProfileData was fetched with; used to drop
+                                 // the cache on account switch so another account's plan badge
+                                 // never leaks into this probe's output
 
   function utf8DecodeBytes(bytes) {
     // Prefer native TextDecoder when available (QuickJS may not expose it).
@@ -808,7 +811,16 @@
     // was rate-limited / throttled. Don't replace cache with null on failure.
     if (shouldFetchProfile) {
       const fresh = fetchProfile(ctx, creds, creds.oauth.accessToken)
-      if (fresh) cachedProfileData = fresh
+      if (fresh) {
+        cachedProfileData = fresh
+        cachedProfileToken = creds.oauth.accessToken
+      }
+    }
+    // Drop the cached profile if the current access token doesn't match the one
+    // it was fetched with: another account's tier must not leak into this probe.
+    if (cachedProfileToken !== creds.oauth.accessToken) {
+      cachedProfileData = null
+      cachedProfileToken = null
     }
     const profile = canFetchLiveUsage ? cachedProfileData : null
     const freshOrg = profile && profile.organization
@@ -974,6 +986,7 @@
     lastUsageFetchMs = 0
     cachedUsageData = null
     cachedProfileData = null
+    cachedProfileToken = null
   }
 
   globalThis.__openusage_plugin = { id: "claude", probe, _resetState }

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -487,6 +487,62 @@ describe("claude plugin", () => {
     expect(result.plan).toBe("Max 20x")
   })
 
+  it("refreshes token and retries when /api/oauth/profile returns 401", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => true
+    ctx.host.fs.readText = () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "old",
+          refreshToken: "refresh",
+          subscriptionType: "max",
+          rateLimitTier: "default_claude_max_5x",
+        },
+      })
+
+    let refreshCalls = 0
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts && opts.url ? opts.url : "")
+      const auth = opts && opts.headers ? opts.headers.Authorization : ""
+      if (url.endsWith("/v1/oauth/token")) {
+        refreshCalls += 1
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ access_token: "new", expires_in: 3600 }),
+        }
+      }
+      if (url.endsWith("/api/oauth/profile")) {
+        if (auth === "Bearer new") {
+          return {
+            status: 200,
+            headers: {},
+            bodyText: JSON.stringify({
+              account: { has_claude_max: true, has_claude_pro: false },
+              organization: {
+                organization_type: "claude_max",
+                rate_limit_tier: "default_claude_max_20x",
+              },
+            }),
+          }
+        }
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      return {
+        status: 200,
+        headers: {},
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(refreshCalls).toBeGreaterThanOrEqual(1)
+    expect(result.plan).toBe("Max 20x")
+  })
+
   it("falls back to stored rateLimitTier when profile fetch fails", async () => {
     const ctx = makeCtx()
     ctx.host.fs.exists = () => true

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -620,6 +620,65 @@ describe("claude plugin", () => {
     expect(result.plan).toBe("Max 5x")
   })
 
+  // If the user switches Claude accounts, the new access token won't match the
+  // one cachedProfileData was fetched with. Without invalidation, the old
+  // account's tier would still drive the plan badge while usage is throttled
+  // by MIN_USAGE_FETCH_INTERVAL_MS and the profile fetch is skipped.
+  it("drops cached profile on access-token change to prevent cross-account plan leakage", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-14T10:00:00.000Z"))
+    try {
+      const ctx = makeCtx()
+      let currentToken = "token_account_a"
+      ctx.host.fs.exists = () => true
+      ctx.host.fs.readText = () =>
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: currentToken,
+            subscriptionType: "pro",
+          },
+        })
+      ctx.util.requestJson = vi.fn(() => ({
+        resp: { status: 200, bodyText: "{}", headers: {} },
+        json: {},
+      }))
+      ctx.host.http.request.mockImplementation((opts) => {
+        const url = String(opts && opts.url ? opts.url : "")
+        if (url.endsWith("/api/oauth/profile")) {
+          return {
+            status: 200,
+            headers: {},
+            bodyText: JSON.stringify({
+              organization: {
+                organization_type: "claude_max",
+                rate_limit_tier: "default_claude_max_20x",
+              },
+            }),
+          }
+        }
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ five_hour: { utilization: 0 } }),
+        }
+      })
+
+      const plugin = await loadPlugin()
+      const r1 = plugin.probe(ctx)
+      expect(r1.plan).toBe("Max 20x")
+
+      // Simulate account switch: different token loaded from disk. Within the
+      // min-fetch interval, usage (and the piggyback profile call) is skipped,
+      // so only the in-memory cache drives the plan badge.
+      currentToken = "token_account_b"
+      vi.setSystemTime(new Date("2026-04-14T10:02:00.000Z"))
+      const r2 = plugin.probe(ctx)
+      expect(r2.plan).toBe("Pro")
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("omits resetsAt when resets_at is missing", async () => {
     const ctx = makeCtx()
     ctx.host.fs.readText = () =>

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -417,7 +417,7 @@ describe("claude plugin", () => {
     })
   })
 
-  it("appends max rate limit tier to the plan label when present", async () => {
+  it("appends max rate limit tier to the plan label when profile is unavailable", async () => {
     const runCase = async (rateLimitTier, expectedPlan) => {
       const ctx = makeCtx()
       ctx.host.fs.exists = () => true
@@ -429,11 +429,18 @@ describe("claude plugin", () => {
             rateLimitTier,
           },
         })
-      ctx.host.http.request.mockReturnValue({
-        status: 200,
-        bodyText: JSON.stringify({
-          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
-        }),
+      ctx.host.http.request.mockImplementation((opts) => {
+        const url = String(opts && opts.url ? opts.url : "")
+        if (url.endsWith("/api/oauth/profile")) {
+          return { status: 503, headers: {}, bodyText: "" }
+        }
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+          }),
+        }
       })
 
       const plugin = await loadPlugin()
@@ -541,6 +548,46 @@ describe("claude plugin", () => {
     const result = plugin.probe(ctx)
     expect(refreshCalls).toBeGreaterThanOrEqual(1)
     expect(result.plan).toBe("Max 20x")
+  })
+
+  // Regression: don't mix a fresh organization_type with the stored (stale)
+  // rate_limit_tier when the profile payload is partial. Stored tier is only
+  // a fallback for a failed fetch, not for a missing field in a good response.
+  it("does not pair fresh org type with stored tier when profile omits rate_limit_tier", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => true
+    ctx.host.fs.readText = () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "token",
+          subscriptionType: "max",
+          rateLimitTier: "default_claude_max_5x", // stale
+        },
+      })
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts && opts.url ? opts.url : "")
+      if (url.endsWith("/api/oauth/profile")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            account: { has_claude_max: true, has_claude_pro: false },
+            organization: { organization_type: "claude_max" }, // no rate_limit_tier
+          }),
+        }
+      }
+      return {
+        status: 200,
+        headers: {},
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("Max")
   })
 
   it("falls back to stored rateLimitTier when profile fetch fails", async () => {
@@ -2062,10 +2109,11 @@ describe("claude plugin", () => {
         plugin.probe(ctx)
         expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
 
-        // 90 s later — window expired, should attempt API again
+        // 90 s later — window expired, should attempt API again.
+        // Successful usage also triggers the piggybacked profile fetch (+1 call).
         vi.setSystemTime(new Date("2026-04-14T10:01:30.000Z"))
         const result2 = plugin.probe(ctx)
-        expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
+        expect(ctx.host.http.request).toHaveBeenCalledTimes(3)
         // No rate-limited badge after success (amber color = rate-limited)
         expect(result2.lines.find((l) => l.label === "Status" && l.color === "#f59e0b")).toBeUndefined()
       } finally {
@@ -2085,19 +2133,19 @@ describe("claude plugin", () => {
         ctx.host.http.request.mockReturnValue({ status: 200, bodyText: "{}", headers: {} })
         const plugin = await loadPlugin()
 
-        // First probe — succeeds
-        plugin.probe(ctx)
-        expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
-
-        // 30 s later — within MIN_USAGE_FETCH_INTERVAL_MS (5 min), no new request
-        vi.setSystemTime(new Date("2026-04-14T10:00:30.000Z"))
-        plugin.probe(ctx)
-        expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
-
-        // 5+ minutes later — interval elapsed, should fetch again
-        vi.setSystemTime(new Date("2026-04-14T10:05:01.000Z"))
+        // First probe — succeeds (usage + piggyback profile = 2 http calls).
         plugin.probe(ctx)
         expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
+
+        // 30 s later — within MIN_USAGE_FETCH_INTERVAL_MS (5 min), no new requests
+        vi.setSystemTime(new Date("2026-04-14T10:00:30.000Z"))
+        plugin.probe(ctx)
+        expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
+
+        // 5+ minutes later — interval elapsed, usage + profile fetched again.
+        vi.setSystemTime(new Date("2026-04-14T10:05:01.000Z"))
+        plugin.probe(ctx)
+        expect(ctx.host.http.request).toHaveBeenCalledTimes(4)
       } finally {
         vi.useRealTimers()
       }
@@ -2154,10 +2202,11 @@ describe("claude plugin", () => {
         plugin.probe(ctx)
         expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
 
-        // 5 min 1 s later — backoff expired
+        // 5 min 1 s later — backoff expired; usage succeeds and triggers the
+        // piggybacked profile fetch, so +2 HTTP calls.
         vi.setSystemTime(new Date("2026-04-14T10:05:01.000Z"))
         plugin.probe(ctx)
-        expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
+        expect(ctx.host.http.request).toHaveBeenCalledTimes(3)
       } finally {
         vi.useRealTimers()
       }

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -445,6 +445,78 @@ describe("claude plugin", () => {
     await runCase("claude_max_subscription_5x", "Max 5x")
   })
 
+  // Regression for #394: stored rateLimitTier is a login-time snapshot and
+  // goes stale after a plan change; /api/oauth/profile is live truth.
+  it("prefers /api/oauth/profile rate_limit_tier over stale stored tier", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => true
+    ctx.host.fs.readText = () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "token",
+          subscriptionType: "max",
+          rateLimitTier: "default_claude_max_5x", // stale
+        },
+      })
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts && opts.url ? opts.url : "")
+      if (url.endsWith("/api/oauth/profile")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            account: { has_claude_max: true, has_claude_pro: false },
+            organization: {
+              organization_type: "claude_max",
+              rate_limit_tier: "default_claude_max_20x", // fresh
+            },
+          }),
+        }
+      }
+      return {
+        status: 200,
+        headers: {},
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("Max 20x")
+  })
+
+  it("falls back to stored rateLimitTier when profile fetch fails", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => true
+    ctx.host.fs.readText = () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "token",
+          subscriptionType: "max",
+          rateLimitTier: "default_claude_max_5x",
+        },
+      })
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts && opts.url ? opts.url : "")
+      if (url.endsWith("/api/oauth/profile")) {
+        return { status: 503, headers: {}, bodyText: "" }
+      }
+      return {
+        status: 200,
+        headers: {},
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("Max 5x")
+  })
+
   it("omits resetsAt when resets_at is missing", async () => {
     const ctx = makeCtx()
     ctx.host.fs.readText = () =>


### PR DESCRIPTION
## Summary

- Closes #394 (supersedes closed #315 with new evidence).
- Locally stored `rateLimitTier` / `subscriptionType` in `~/.claude/.credentials.json` (and the macOS keychain) is a **snapshot written at login time**. Claude Code CLI does not refresh it on a plan change, and the token-refresh response does not include it either — so after upgrading Max 5x → Max 20x the plan badge stays on the old tier until the user re-logs in.
- **`GET /api/oauth/profile` is the live source of truth** for the current OAuth session. It's guarded by the `user:profile` scope that the plugin already checks. Example response:
  ```jsonc
  {
    "account": { "has_claude_max": true, "has_claude_pro": false },
    "organization": {
      "organization_type": "claude_max",
      "rate_limit_tier": "default_claude_max_20x"
    }
  }
  ```

## Change

- Added `fetchProfile()` helper (same headers as `fetchUsage`, best-effort — swallows all non-2xx/JSON errors).
- Call it after a successful usage fetch when live usage is allowed. Prefer `organization.rate_limit_tier` for the `Nx` suffix and `organization.organization_type` for the base plan label (`claude_max` / `claude_pro`). On failure, fall back to the stored fields — same behaviour as before the change.
- Scoped to `canFetchLiveUsage` so inference-only tokens still skip the extra call.
- Documented the endpoint in `docs/providers/claude.md`.

## Test plan

- [x] `bun run test -- --run plugins/claude/plugin.test.js` — 81 pass, incl. two new regressions:
  - prefers fresh `/api/oauth/profile` `rate_limit_tier` over stale stored tier
  - falls back to stored `rateLimitTier` when profile fetch returns non-2xx
- [x] Verified on my own account against the live endpoint: stored tier = `default_claude_max_5x`, live `organization.rate_limit_tier` = `default_claude_max_20x` — with this change the badge will flip to **Max 20x** on the next probe cycle without requiring a re-login.
- [x] No new plugin-exposed sensitive fields beyond what the existing host-side redactor already covers (email/name/tokens).

## Notes

- No new dependencies, no changes to host APIs, no changes to other plugins.
- No UI changes — this only affects what `probe()` returns as `plan`. Screenshots not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale Claude plan badges by resolving the plan tier from `/api/oauth/profile` (piggybacked after usage) instead of the stored login snapshot. Also invalidates cached profile on access-token change to prevent cross-account plan leakage. Closes #394.

- **Bug Fixes**
  - Calls profile after a successful usage request with JSON headers and a 5s timeout; retries after token refresh on 401/403 and caches the result keyed by the access token (invalidates on token change to prevent cross-account leakage).
  - Prefers `organization.rate_limit_tier` + `organization.organization_type`; if the payload omits `rate_limit_tier`, shows the base plan without a stale suffix; falls back to stored `rateLimitTier`/`subscriptionType` only when the profile request fails.
  - Scoped behind `canFetchLiveUsage`; skips the extra call when rate-limited and reuses cached profile. Docs add an explicit headers table; tests cover stale→fresh tier, 401→refresh→retry, partial payload, token-change invalidation, and call-count updates.

<sup>Written for commit 04de09856e6f49fb48397687ccfdfc08e1766315. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

