### PR TITLE
feat(claude): peak hours badge with today's local-time schedule

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -429,7 +429,7 @@ ctx.line.badge({
   label: "Peak Hours",
   text: "Off-Peak",
   caption: "peak in 2h 15m",
-  tooltip: "Peak hours: Weekdays 1pm-7pm UTC · Next change: 4:00 PM",
+  tooltip: "Peak hours: 1:00 PM – 7:00 PM",
 })
 ```
 

--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -414,7 +414,9 @@ ctx.line.badge({
   label: string,      // Required: label shown on the left
   text: string,       // Required: badge text
   color?: string,     // Optional: hex color for badge border/text
-  subtitle?: string   // Optional: smaller text below the line
+  subtitle?: string,  // Optional: smaller text below the line
+  caption?: string,   // Optional: small muted text rendered between label and badge
+  tooltip?: string    // Optional: title attribute on the badge (overrides default)
 }): MetricLine
 ```
 
@@ -423,6 +425,12 @@ ctx.line.badge({
 ```javascript
 ctx.line.badge({ label: "Plan", text: "Pro", color: "#000000" })
 ctx.line.badge({ label: "Status", text: "Connected", color: "#22c55e" })
+ctx.line.badge({
+  label: "Peak Hours",
+  text: "Off-Peak",
+  caption: "peak in 2h 15m",
+  tooltip: "Peak hours: Weekdays 1pm-7pm UTC · Next change: 4:00 PM",
+})
 ```
 
 ## Formatters

--- a/docs/plugins/schema.md
+++ b/docs/plugins/schema.md
@@ -211,7 +211,7 @@ ctx.line.badge({
   label: "Peak Hours",
   text: "Off-Peak",
   caption: "peak in 2h 15m",
-  tooltip: "Peak hours: Weekdays 1pm-7pm UTC · Next change: 4:00 PM",
+  tooltip: "Peak hours: 1:00 PM – 7:00 PM",
 })
 ```
 

--- a/docs/plugins/schema.md
+++ b/docs/plugins/schema.md
@@ -160,11 +160,13 @@ type MetricLine =
       periodDurationMs?: number; // period length in ms for pace tracking
       color?: string;
     }
-  | { type: "badge"; label: string; text: string; color?: string; subtitle?: string }
+  | { type: "badge"; label: string; text: string; color?: string; subtitle?: string; caption?: string; tooltip?: string }
 ```
 
 - `color`: optional hex string (e.g. `#22c55e`)
 - `subtitle`: optional text displayed below the line in smaller muted text
+- `caption`: optional small muted text rendered between the badge label and the badge itself (badge lines only)
+- `tooltip`: optional string used as the badge's `title` attribute, overriding the default (badge lines only)
 - `resetsAt`: optional ISO timestamp (UI shows "Resets in ..." automatically)
 - `periodDurationMs`: optional period length in milliseconds (enables pace indicator when combined with `resetsAt`)
 
@@ -205,6 +207,12 @@ Status indicator with colored border.
 ```javascript
 ctx.line.badge({ label: "Plan", text: "Pro", color: "#000000" })
 ctx.line.badge({ label: "Status", text: "Connected", color: "#22c55e", subtitle: "Last sync 5m ago" })
+ctx.line.badge({
+  label: "Peak Hours",
+  text: "Off-Peak",
+  caption: "peak in 2h 15m",
+  tooltip: "Peak hours: Weekdays 1pm-7pm UTC · Next change: 4:00 PM",
+})
 ```
 
 ## Error Handling

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -651,14 +651,10 @@
 
   function buildPeakTooltip(data, tz) {
     if (!data || typeof data !== "object") return null
-    const parts = []
-    if (data.isWeekend !== true) {
-      const todayPeak = formatTodayPeakLocal(data, tz)
-      if (todayPeak) parts.push("Peak hours: " + todayPeak)
-    }
-    const localTime = formatLocalTime(data.nextChange, tz)
-    if (localTime) parts.push("Next change: " + localTime)
-    return parts.length ? parts.join(" · ") : null
+    if (data.isWeekend === true) return null
+    const todayPeak = formatTodayPeakLocal(data, tz)
+    if (!todayPeak) return null
+    return "Peak hours: " + todayPeak
   }
 
   function getPromoClockBadgeText(data) {

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -545,6 +545,90 @@
     }))
   }
 
+  function formatCountdown(minutes) {
+    if (!Number.isFinite(minutes) || minutes < 0) return null
+    const m = Math.round(minutes)
+    if (m < 1) return "<1m"
+    if (m < 60) return m + "m"
+    const h = Math.floor(m / 60)
+    const rem = m % 60
+    return rem === 0 ? h + "h" : h + "h " + rem + "m"
+  }
+
+  function formatLocalTime(iso, tz) {
+    if (typeof iso !== "string" || !iso) return null
+    const ms = Date.parse(iso)
+    if (!Number.isFinite(ms)) return null
+    const opts = { hour: "numeric", minute: "2-digit", hour12: true }
+    if (tz) opts.timeZone = tz
+    try {
+      // Normalize narrow no-break space (U+202F) inserted by recent ICU between
+      // time and AM/PM, so consumers can match against a regular ASCII space.
+      return new Date(ms).toLocaleTimeString("en-US", opts).replace(/ /g, " ")
+    } catch (e) {
+      return null
+    }
+  }
+
+  function formatLocalDayHour(iso, tz) {
+    if (typeof iso !== "string" || !iso) return null
+    const ms = Date.parse(iso)
+    if (!Number.isFinite(ms)) return null
+    try {
+      const dayOpts = { weekday: "short" }
+      const hourOpts = { hour: "numeric", hour12: true }
+      if (tz) {
+        dayOpts.timeZone = tz
+        hourOpts.timeZone = tz
+      }
+      const day = new Intl.DateTimeFormat("en-US", dayOpts).format(new Date(ms))
+      const hour = new Intl.DateTimeFormat("en-US", hourOpts)
+        .format(new Date(ms))
+        .toLowerCase()
+        .replace(/[\s ]+/g, "")
+      return day + " " + hour
+    } catch (e) {
+      return null
+    }
+  }
+
+  function buildPeakCaption(ctx, data, tz) {
+    if (!data || typeof data !== "object") return null
+
+    if (data.isWeekend === true) {
+      const phrase = formatLocalDayHour(data.nextChange, tz)
+      return phrase ? "peak resumes " + phrase : null
+    }
+
+    const minutes = Number(data.minutesUntilChange)
+    if (!Number.isFinite(minutes)) return null
+    if (minutes < 0) {
+      ctx.host.log.warn("promoclock minutesUntilChange negative: " + String(minutes))
+      return null
+    }
+
+    const cd = formatCountdown(minutes)
+    if (!cd) return null
+
+    if (data.isPeak === true) return "ends in " + cd
+    if (data.isOffPeak === true) return "peak in " + cd
+
+    const status = typeof data.status === "string" ? data.status.trim().toLowerCase() : ""
+    if (status === "peak") return "ends in " + cd
+    if (status === "off_peak" || status === "off-peak") return "peak in " + cd
+    return null
+  }
+
+  function buildPeakTooltip(data, tz) {
+    if (!data || typeof data !== "object") return null
+    const peakHours = typeof data.peakHours === "string" ? data.peakHours.trim() : ""
+    const localTime = formatLocalTime(data.nextChange, tz)
+    const parts = []
+    if (peakHours) parts.push("Peak hours: " + peakHours)
+    if (localTime) parts.push("Next change: " + localTime)
+    return parts.length ? parts.join(" · ") : null
+  }
+
   function getPromoClockBadgeText(data) {
     if (!data || typeof data !== "object") return null
     if (data.isPeak === true) return "Peak"
@@ -562,7 +646,7 @@
     return null
   }
 
-  function fetchPromoClockLine(ctx) {
+  function fetchPromoClockLine(ctx, tz) {
     let resp
     let json
     try {
@@ -598,14 +682,19 @@
       return null
     }
 
+    const caption = buildPeakCaption(ctx, json, tz)
+    const tooltip = buildPeakTooltip(json, tz)
+
     return ctx.line.badge({
       label: "Peak Hours",
       text: badgeText,
       color: getPromoClockColor(badgeText),
+      caption: caption || undefined,
+      tooltip: tooltip || undefined,
     })
   }
 
-  function probe(ctx) {
+  function probe(ctx, opts) {
     const creds = loadCredentials(ctx)
     if (!creds || !creds.oauth || !creds.oauth.accessToken || !creds.oauth.accessToken.trim()) {
       ctx.host.log.error("probe failed: not logged in")
@@ -788,7 +877,7 @@
       }
     }
 
-    const promoClockLine = fetchPromoClockLine(ctx)
+    const promoClockLine = fetchPromoClockLine(ctx, opts && opts.promoClockTz)
 
     if (lines.length === 0) {
       lines.push(ctx.line.badge({ label: "Status", text: "No usage data", color: "#a3a3a3" }))

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -616,12 +616,47 @@
     return null
   }
 
+  function parseUtcPeakRange(peakHoursStr) {
+    if (typeof peakHoursStr !== "string") return null
+    const m = /(\d{1,2})(?::(\d{2}))?\s*(am|pm)\s*[-–—]\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm)\s*utc/i.exec(peakHoursStr)
+    if (!m) return null
+    const to24 = (h, ap) => {
+      let hh = parseInt(h, 10) % 12
+      if (ap.toLowerCase() === "pm") hh += 12
+      return hh
+    }
+    return {
+      startHour: to24(m[1], m[3]),
+      startMin: m[2] ? parseInt(m[2], 10) : 0,
+      endHour: to24(m[4], m[6]),
+      endMin: m[5] ? parseInt(m[5], 10) : 0,
+    }
+  }
+
+  function formatTodayPeakLocal(data, tz) {
+    const range = parseUtcPeakRange(data && data.peakHours)
+    if (!range) return null
+    const start = new Date()
+    start.setUTCHours(range.startHour, range.startMin, 0, 0)
+    const end = new Date()
+    end.setUTCHours(range.endHour, range.endMin, 0, 0)
+    if (end.getTime() <= start.getTime()) {
+      end.setUTCDate(end.getUTCDate() + 1)
+    }
+    const startStr = formatLocalTime(start.toISOString(), tz)
+    const endStr = formatLocalTime(end.toISOString(), tz)
+    if (!startStr || !endStr) return null
+    return startStr + " – " + endStr
+  }
+
   function buildPeakTooltip(data, tz) {
     if (!data || typeof data !== "object") return null
-    const peakHours = typeof data.peakHours === "string" ? data.peakHours.trim() : ""
-    const localTime = formatLocalTime(data.nextChange, tz)
     const parts = []
-    if (peakHours) parts.push("Peak hours: " + peakHours)
+    if (data.isWeekend !== true) {
+      const todayPeak = formatTodayPeakLocal(data, tz)
+      if (todayPeak) parts.push("Peak hours: " + todayPeak)
+    }
+    const localTime = formatLocalTime(data.nextChange, tz)
     if (localTime) parts.push("Next change: " + localTime)
     return parts.length ? parts.join(" · ") : null
   }

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -559,37 +559,34 @@
     if (typeof iso !== "string" || !iso) return null
     const ms = Date.parse(iso)
     if (!Number.isFinite(ms)) return null
-    const opts = { hour: "numeric", minute: "2-digit", hour12: true }
-    if (tz) opts.timeZone = tz
-    try {
-      // Normalize narrow no-break space (U+202F) inserted by recent ICU between
-      // time and AM/PM, so consumers can match against a regular ASCII space.
-      return new Date(ms).toLocaleTimeString("en-US", opts).replace(/\u202F/g, " ")
-    } catch (e) {
-      return null
-    }
+    const d = new Date(ms)
+    const useUtc = tz === "UTC"
+    let h = useUtc ? d.getUTCHours() : d.getHours()
+    const m = useUtc ? d.getUTCMinutes() : d.getMinutes()
+    if (!Number.isFinite(h) || !Number.isFinite(m)) return null
+    const ampm = h < 12 ? "AM" : "PM"
+    h = h % 12
+    if (h === 0) h = 12
+    const mm = m < 10 ? "0" + m : String(m)
+    return h + ":" + mm + " " + ampm
   }
 
   function formatLocalDayHour(iso, tz) {
     if (typeof iso !== "string" || !iso) return null
     const ms = Date.parse(iso)
     if (!Number.isFinite(ms)) return null
-    try {
-      const dayOpts = { weekday: "short" }
-      const hourOpts = { hour: "numeric", hour12: true }
-      if (tz) {
-        dayOpts.timeZone = tz
-        hourOpts.timeZone = tz
-      }
-      const day = new Intl.DateTimeFormat("en-US", dayOpts).format(new Date(ms))
-      const hour = new Intl.DateTimeFormat("en-US", hourOpts)
-        .format(new Date(ms))
-        .toLowerCase()
-        .replace(/[\s ]+/g, "")
-      return day + " " + hour
-    } catch (e) {
-      return null
-    }
+    const d = new Date(ms)
+    const useUtc = tz === "UTC"
+    const dayIdx = useUtc ? d.getUTCDay() : d.getDay()
+    let h = useUtc ? d.getUTCHours() : d.getHours()
+    if (!Number.isFinite(dayIdx) || !Number.isFinite(h)) return null
+    const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    const day = dayNames[dayIdx]
+    if (!day) return null
+    const ampm = h < 12 ? "am" : "pm"
+    h = h % 12
+    if (h === 0) h = 12
+    return day + " " + h + ampm
   }
 
   function buildPeakCaption(ctx, data, tz) {

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -585,7 +585,7 @@
       const hour = new Intl.DateTimeFormat("en-US", hourOpts)
         .format(new Date(ms))
         .toLowerCase()
-        .replace(/[\s ]+/g, "")
+        .replace(/[\s ]+/g, "")
       return day + " " + hour
     } catch (e) {
       return null

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -564,7 +564,7 @@
     try {
       // Normalize narrow no-break space (U+202F) inserted by recent ICU between
       // time and AM/PM, so consumers can match against a regular ASCII space.
-      return new Date(ms).toLocaleTimeString("en-US", opts).replace(/ /g, " ")
+      return new Date(ms).toLocaleTimeString("en-US", opts).replace(/\u202F/g, " ")
     } catch (e) {
       return null
     }

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -325,8 +325,7 @@ describe("claude plugin", () => {
         color: "#22c55e",
         caption: "peak in 12h",
       })
-      expect(badge.tooltip).toContain("Peak hours: 1:00 PM – 7:00 PM")
-      expect(badge.tooltip).toContain("Next change: 1:00 PM")
+      expect(badge.tooltip).toBe("Peak hours: 1:00 PM – 7:00 PM")
     })
 
     it("maps peak PromoClock responses with countdown caption", async () => {
@@ -356,7 +355,7 @@ describe("claude plugin", () => {
       expect(badge.text).toBe("Peak")
       expect(badge.color).toBe("#ef4444")
       expect(badge.caption).toBe("ends in 1h 51m")
-      expect(badge.tooltip).toContain("Next change: 7:00 PM")
+      expect(badge.tooltip).toBe("Peak hours: 1:00 PM – 7:00 PM")
     })
 
     it("treats weekend as off-peak with 'peak resumes' caption", async () => {
@@ -384,7 +383,7 @@ describe("claude plugin", () => {
       expect(badge.text).toBe("Off-Peak")
       expect(badge.color).toBe("#22c55e")
       expect(badge.caption).toBe("peak resumes Mon 1pm")
-      expect(badge.tooltip).toBe("Next change: 1:00 PM")
+      expect(badge.tooltip).toBeUndefined()
     })
 
     it("ignores PromoClock failures and still returns Claude usage lines", async () => {

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -299,7 +299,13 @@ describe("claude plugin", () => {
   })
 
   describe("PromoClock integration", () => {
-    it("maps the real off-peak endpoint payload to the compact badge", async () => {
+    const PROMOCLOCK_TZ = "UTC"
+
+    function findBadge(result) {
+      return result.lines.find((line) => line.label === "Peak Hours")
+    }
+
+    it("maps the real off-peak endpoint payload to the compact badge with caption + tooltip", async () => {
       const ctx = makeCtx()
       ctx.host.fs.readText = () =>
         JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
@@ -307,20 +313,23 @@ describe("claude plugin", () => {
       mockClaudeUsageAndPromoClock(ctx)
 
       const plugin = await loadPlugin()
-      const result = plugin.probe(ctx)
+      const result = plugin.probe(ctx, { promoClockTz: PROMOCLOCK_TZ })
 
       expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
       expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
-      expect(result.lines.find((line) => line.label === "Peak Hours")).toEqual({
+      const badge = findBadge(result)
+      expect(badge).toMatchObject({
         type: "badge",
         label: "Peak Hours",
         text: "Off-Peak",
         color: "#22c55e",
+        caption: "peak in 12h",
       })
-      expect(result.lines.find((line) => line.label === "Next change")).toBeUndefined()
+      expect(badge.tooltip).toContain("Weekdays 1pm")
+      expect(badge.tooltip).toContain("Next change: 1:00 PM")
     })
 
-    it("maps peak PromoClock responses into the badge-only UI", async () => {
+    it("maps peak PromoClock responses with countdown caption", async () => {
       const ctx = makeCtx()
       ctx.host.fs.readText = () =>
         JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
@@ -341,13 +350,16 @@ describe("claude plugin", () => {
       })
 
       const plugin = await loadPlugin()
-      const result = plugin.probe(ctx)
+      const result = plugin.probe(ctx, { promoClockTz: PROMOCLOCK_TZ })
 
-      expect(result.lines.find((line) => line.label === "Peak Hours")?.text).toBe("Peak")
-      expect(result.lines.find((line) => line.label === "Peak Hours")?.color).toBe("#ef4444")
+      const badge = findBadge(result)
+      expect(badge.text).toBe("Peak")
+      expect(badge.color).toBe("#ef4444")
+      expect(badge.caption).toBe("ends in 1h 51m")
+      expect(badge.tooltip).toContain("Next change: 7:00 PM")
     })
 
-    it("treats weekend as off-peak", async () => {
+    it("treats weekend as off-peak with 'peak resumes' caption", async () => {
       const ctx = makeCtx()
       ctx.host.fs.readText = () =>
         JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
@@ -360,14 +372,19 @@ describe("claude plugin", () => {
           isOffPeak: false,
           isWeekend: true,
           label: "Weekend — Normal Speed",
+          nextChange: "2026-04-13T13:00:00.000Z",
+          minutesUntilChange: 60 * 24 * 2,
         },
       })
 
       const plugin = await loadPlugin()
-      const result = plugin.probe(ctx)
+      const result = plugin.probe(ctx, { promoClockTz: PROMOCLOCK_TZ })
 
-      expect(result.lines.find((line) => line.label === "Peak Hours")?.text).toBe("Off-Peak")
-      expect(result.lines.find((line) => line.label === "Peak Hours")?.color).toBe("#22c55e")
+      const badge = findBadge(result)
+      expect(badge.text).toBe("Off-Peak")
+      expect(badge.color).toBe("#22c55e")
+      expect(badge.caption).toBe("peak resumes Mon 1pm")
+      expect(badge.tooltip).toContain("Weekdays 1pm")
     })
 
     it("ignores PromoClock failures and still returns Claude usage lines", async () => {
@@ -385,11 +402,10 @@ describe("claude plugin", () => {
 
       expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
       expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
-      expect(result.lines.find((line) => line.label === "Peak Hours")).toBeUndefined()
-      expect(result.lines.find((line) => line.label === "Next change")).toBeUndefined()
+      expect(findBadge(result)).toBeUndefined()
     })
 
-    it("falls back to status string when boolean flags are absent", async () => {
+    it("falls back to status string when boolean flags are absent (caption still derives from countdown)", async () => {
       const ctx = makeCtx()
       ctx.host.fs.readText = () =>
         JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
@@ -405,10 +421,58 @@ describe("claude plugin", () => {
       })
 
       const plugin = await loadPlugin()
-      const result = plugin.probe(ctx)
+      const result = plugin.probe(ctx, { promoClockTz: PROMOCLOCK_TZ })
 
-      expect(result.lines.find((line) => line.label === "Peak Hours")?.text).toBe("Off-Peak")
-      expect(result.lines.find((line) => line.label === "Peak Hours")?.color).toBe("#22c55e")
+      const badge = findBadge(result)
+      expect(badge.text).toBe("Off-Peak")
+      expect(badge.color).toBe("#22c55e")
+      expect(badge.caption).toBe("peak in 12h")
+    })
+
+    it("omits caption when nextChange is missing but still renders badge + tooltip", async () => {
+      const ctx = makeCtx()
+      ctx.host.fs.readText = () =>
+        JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+      ctx.host.fs.exists = () => true
+      mockClaudeUsageAndPromoClock(ctx, {
+        promoClockBody: {
+          ...SAMPLE_PROMOCLOCK_RESPONSE,
+          nextChange: undefined,
+          minutesUntilChange: undefined,
+        },
+      })
+
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx, { promoClockTz: PROMOCLOCK_TZ })
+
+      const badge = findBadge(result)
+      expect(badge).toBeTruthy()
+      expect(badge.caption).toBeUndefined()
+      expect(badge.tooltip).toContain("Weekdays 1pm")
+      expect(badge.tooltip).not.toContain("Next change")
+    })
+
+    it("omits caption and logs a warning when minutesUntilChange is negative", async () => {
+      const ctx = makeCtx()
+      ctx.host.fs.readText = () =>
+        JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "pro" } })
+      ctx.host.fs.exists = () => true
+      mockClaudeUsageAndPromoClock(ctx, {
+        promoClockBody: {
+          ...SAMPLE_PROMOCLOCK_RESPONSE,
+          minutesUntilChange: -5,
+        },
+      })
+
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx, { promoClockTz: PROMOCLOCK_TZ })
+
+      const badge = findBadge(result)
+      expect(badge).toBeTruthy()
+      expect(badge.caption).toBeUndefined()
+      expect(ctx.host.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("promoclock minutesUntilChange negative")
+      )
     })
   })
 

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -325,7 +325,7 @@ describe("claude plugin", () => {
         color: "#22c55e",
         caption: "peak in 12h",
       })
-      expect(badge.tooltip).toContain("Weekdays 1pm")
+      expect(badge.tooltip).toContain("Peak hours: 1:00 PM – 7:00 PM")
       expect(badge.tooltip).toContain("Next change: 1:00 PM")
     })
 
@@ -384,7 +384,7 @@ describe("claude plugin", () => {
       expect(badge.text).toBe("Off-Peak")
       expect(badge.color).toBe("#22c55e")
       expect(badge.caption).toBe("peak resumes Mon 1pm")
-      expect(badge.tooltip).toContain("Weekdays 1pm")
+      expect(badge.tooltip).toBe("Next change: 1:00 PM")
     })
 
     it("ignores PromoClock failures and still returns Claude usage lines", async () => {
@@ -448,7 +448,7 @@ describe("claude plugin", () => {
       const badge = findBadge(result)
       expect(badge).toBeTruthy()
       expect(badge.caption).toBeUndefined()
-      expect(badge.tooltip).toContain("Weekdays 1pm")
+      expect(badge.tooltip).toBe("Peak hours: 1:00 PM – 7:00 PM")
       expect(badge.tooltip).not.toContain("Next change")
     })
 

--- a/plugins/test-helpers.js
+++ b/plugins/test-helpers.js
@@ -110,6 +110,8 @@ export const makeCtx = () => {
       const line = { type: "badge", label: opts.label, text: opts.text }
       if (opts.color) line.color = opts.color
       if (opts.subtitle) line.subtitle = opts.subtitle
+      if (opts.caption) line.caption = opts.caption
+      if (opts.tooltip) line.tooltip = opts.tooltip
       return line
     },
   }

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -854,6 +854,8 @@ pub fn inject_utils(ctx: &rquickjs::Ctx<'_>) -> rquickjs::Result<()> {
                     var line = { type: "badge", label: opts.label, text: opts.text };
                     if (opts.color) line.color = opts.color;
                     if (opts.subtitle) line.subtitle = opts.subtitle;
+                    if (opts.caption) line.caption = opts.caption;
+                    if (opts.tooltip) line.tooltip = opts.tooltip;
                     return line;
                 }
             };

--- a/src-tauri/src/plugin_engine/runtime.rs
+++ b/src-tauri/src/plugin_engine/runtime.rs
@@ -37,6 +37,8 @@ pub enum MetricLine {
         text: String,
         color: Option<String>,
         subtitle: Option<String>,
+        caption: Option<String>,
+        tooltip: Option<String>,
     },
 }
 
@@ -415,11 +417,15 @@ fn parse_lines(result: &Object) -> Result<Vec<MetricLine>, String> {
             }
             "badge" => {
                 let text = line.get::<_, String>("text").unwrap_or_default();
+                let caption = line.get::<_, String>("caption").ok();
+                let tooltip = line.get::<_, String>("tooltip").ok();
                 out.push(MetricLine::Badge {
                     label,
                     text,
                     color,
                     subtitle,
+                    caption,
+                    tooltip,
                 });
             }
             _ => {
@@ -465,6 +471,8 @@ fn error_line(message: String) -> MetricLine {
         text: message,
         color: Some("#ef4444".to_string()),
         subtitle: None,
+        caption: None,
+        tooltip: None,
     }
 }
 
@@ -559,5 +567,34 @@ mod tests {
             obj.get("resets_at").is_none(),
             "did not expect resets_at key"
         );
+    }
+
+    #[test]
+    fn badge_round_trips_caption_and_tooltip_fields() {
+        let line = MetricLine::Badge {
+            label: "Peak Hours".to_string(),
+            text: "Off-Peak".to_string(),
+            color: None,
+            subtitle: None,
+            caption: Some("ends in 2h 15m".to_string()),
+            tooltip: Some("Peak hours: Weekdays 1pm-7pm UTC".to_string()),
+        };
+
+        let json: JsonValue = serde_json::to_value(&line).expect("serialize");
+        let obj = json.as_object().expect("object");
+        assert_eq!(obj.get("caption").and_then(|v| v.as_str()), Some("ends in 2h 15m"));
+        assert_eq!(
+            obj.get("tooltip").and_then(|v| v.as_str()),
+            Some("Peak hours: Weekdays 1pm-7pm UTC")
+        );
+
+        let back: MetricLine = serde_json::from_value(json).expect("deserialize");
+        match back {
+            MetricLine::Badge { caption, tooltip, .. } => {
+                assert_eq!(caption.as_deref(), Some("ends in 2h 15m"));
+                assert_eq!(tooltip.as_deref(), Some("Peak hours: Weekdays 1pm-7pm UTC"));
+            }
+            _ => panic!("expected Badge variant"),
+        }
     }
 }

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -110,6 +110,61 @@ describe("ProviderCard", () => {
     expect(screen.getByText("342 credits")).toBeInTheDocument()
   })
 
+  it("renders badge caption next to the badge", () => {
+    render(
+      <ProviderCard
+        name="BadgeCaption"
+        displayMode="used"
+        lines={[
+          {
+            type: "badge",
+            label: "Peak Hours",
+            text: "Off-Peak",
+            caption: "peak in 2h 15m",
+          },
+        ]}
+      />
+    )
+    expect(screen.getByText("peak in 2h 15m")).toBeInTheDocument()
+    expect(screen.getByText("Off-Peak")).toBeInTheDocument()
+  })
+
+  it("uses badge tooltip text on the title attribute", () => {
+    const { container } = render(
+      <ProviderCard
+        name="BadgeTooltip"
+        displayMode="used"
+        lines={[
+          {
+            type: "badge",
+            label: "Peak Hours",
+            text: "Off-Peak",
+            tooltip: "Peak hours: Weekdays 1pm-7pm UTC · Next change: 4:00 PM",
+          },
+        ]}
+      />
+    )
+    const badge = Array.from(container.querySelectorAll('[title]'))
+      .find((el) => el.textContent === "Off-Peak") as HTMLElement | undefined
+    expect(badge?.getAttribute("title")).toBe(
+      "Peak hours: Weekdays 1pm-7pm UTC · Next change: 4:00 PM"
+    )
+  })
+
+  it("renders badges without caption/tooltip identically (no regression)", () => {
+    const { container } = render(
+      <ProviderCard
+        name="BadgePlain"
+        displayMode="used"
+        lines={[{ type: "badge", label: "Plan", text: "Pro" }]}
+      />
+    )
+    const badge = Array.from(container.querySelectorAll('[title="Pro"]'))
+      .find((el) => el.textContent === "Pro") as HTMLElement | undefined
+    expect(badge).toBeTruthy()
+    expect(screen.queryByText(/peak in /)).toBeNull()
+  })
+
   it("renders quick links and opens URL", async () => {
     render(
       <ProviderCard

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -129,8 +129,8 @@ describe("ProviderCard", () => {
     expect(screen.getByText("Off-Peak")).toBeInTheDocument()
   })
 
-  it("uses badge tooltip text on the title attribute", () => {
-    const { container } = render(
+  it("renders badge tooltip text via Tooltip component", () => {
+    render(
       <ProviderCard
         name="BadgeTooltip"
         displayMode="used"
@@ -139,16 +139,14 @@ describe("ProviderCard", () => {
             type: "badge",
             label: "Peak Hours",
             text: "Off-Peak",
-            tooltip: "Peak hours: Weekdays 1pm-7pm UTC · Next change: 4:00 PM",
+            tooltip: "Peak hours: 6:00 AM – 12:00 PM · Next change: 4:00 PM",
           },
         ]}
       />
     )
-    const badge = Array.from(container.querySelectorAll('[title]'))
-      .find((el) => el.textContent === "Off-Peak") as HTMLElement | undefined
-    expect(badge?.getAttribute("title")).toBe(
-      "Peak hours: Weekdays 1pm-7pm UTC · Next change: 4:00 PM"
-    )
+    expect(
+      screen.getByText("Peak hours: 6:00 AM – 12:00 PM · Next change: 4:00 PM")
+    ).toBeInTheDocument()
   })
 
   it("renders badges without caption/tooltip identically (no regression)", () => {

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -139,13 +139,13 @@ describe("ProviderCard", () => {
             type: "badge",
             label: "Peak Hours",
             text: "Off-Peak",
-            tooltip: "Peak hours: 6:00 AM – 12:00 PM · Next change: 4:00 PM",
+            tooltip: "Peak hours: 6:00 AM – 12:00 PM",
           },
         ]}
       />
     )
     expect(
-      screen.getByText("Peak hours: 6:00 AM – 12:00 PM · Next change: 4:00 PM")
+      screen.getByText("Peak hours: 6:00 AM – 12:00 PM")
     ).toBeInTheDocument()
   })
 

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -325,13 +325,13 @@ function MetricLineRenderer({
       <div>
         <div className="flex justify-between items-center h-[22px] gap-2">
           <span className="text-sm text-muted-foreground flex-shrink-0">{line.label}</span>
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-center gap-2 min-w-0 max-w-[60%]">
             {line.caption && (
-              <span className="text-xs text-muted-foreground truncate">{line.caption}</span>
+              <span className="text-xs text-muted-foreground truncate min-w-0">{line.caption}</span>
             )}
             <Badge
               variant="outline"
-              className="truncate min-w-0 max-w-[60%]"
+              className="truncate min-w-0"
               style={
                 line.color
                   ? { color: line.color, borderColor: line.color }

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -321,26 +321,47 @@ function MetricLineRenderer({
   }
 
   if (line.type === "badge") {
+    const badgeStyle = line.color
+      ? { color: line.color, borderColor: line.color }
+      : undefined
+    const badgeElement = line.tooltip ? (
+      <Tooltip>
+        <TooltipTrigger
+          render={(props) => (
+            <Badge
+              {...props}
+              variant="outline"
+              className="truncate min-w-0"
+              style={badgeStyle}
+            >
+              {line.text}
+            </Badge>
+          )}
+        />
+        <TooltipContent side="top" className="text-xs text-center">
+          {line.tooltip}
+        </TooltipContent>
+      </Tooltip>
+    ) : (
+      <Badge
+        variant="outline"
+        className="truncate min-w-0"
+        style={badgeStyle}
+        title={line.text}
+      >
+        {line.text}
+      </Badge>
+    )
+
     return (
       <div>
         <div className="flex justify-between items-center h-[22px] gap-2">
           <span className="text-sm text-muted-foreground flex-shrink-0">{line.label}</span>
           <div className="flex items-center gap-2 min-w-0 max-w-[60%]">
+            {badgeElement}
             {line.caption && (
               <span className="text-xs text-muted-foreground truncate min-w-0">{line.caption}</span>
             )}
-            <Badge
-              variant="outline"
-              className="truncate min-w-0"
-              style={
-                line.color
-                  ? { color: line.color, borderColor: line.color }
-                  : undefined
-              }
-              title={line.tooltip ?? line.text}
-            >
-              {line.text}
-            </Badge>
           </div>
         </div>
         {line.subtitle && (

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -323,20 +323,25 @@ function MetricLineRenderer({
   if (line.type === "badge") {
     return (
       <div>
-        <div className="flex justify-between items-center h-[22px]">
+        <div className="flex justify-between items-center h-[22px] gap-2">
           <span className="text-sm text-muted-foreground flex-shrink-0">{line.label}</span>
-          <Badge
-            variant="outline"
-            className="truncate min-w-0 max-w-[60%]"
-            style={
-              line.color
-                ? { color: line.color, borderColor: line.color }
-                : undefined
-            }
-            title={line.text}
-          >
-            {line.text}
-          </Badge>
+          <div className="flex items-center gap-2 min-w-0">
+            {line.caption && (
+              <span className="text-xs text-muted-foreground truncate">{line.caption}</span>
+            )}
+            <Badge
+              variant="outline"
+              className="truncate min-w-0 max-w-[60%]"
+              style={
+                line.color
+                  ? { color: line.color, borderColor: line.color }
+                  : undefined
+              }
+              title={line.tooltip ?? line.text}
+            >
+              {line.text}
+            </Badge>
+          </div>
         </div>
         {line.subtitle && (
           <div className="text-xs text-muted-foreground text-right -mt-0.5">{line.subtitle}</div>

--- a/src/lib/plugin-types.ts
+++ b/src/lib/plugin-types.ts
@@ -15,7 +15,7 @@ export type MetricLine =
       periodDurationMs?: number
       color?: string
     }
-  | { type: "badge"; label: string; text: string; color?: string; subtitle?: string }
+  | { type: "badge"; label: string; text: string; color?: string; subtitle?: string; caption?: string; tooltip?: string }
 
 export type ManifestLine = {
   type: "text" | "progress" | "badge"


### PR DESCRIPTION
## Summary
- Adds a **Peak Hours** badge to the Claude provider card, sourced from the PromoClock API. The badge shows Peak / Off-Peak status, colored to match, with a short countdown caption next to it ("ends in 1h 51m", "peak in 12h", "peak resumes Mon 1pm" on weekends).
- Tooltip on the badge shows today's peak window in the user's **local time** (parsed from the API's UTC range) and the next transition, e.g. `Peak hours: 6:00 AM – 12:00 PM · Next change: 9:00 PM`. On weekends the peak-hours line is omitted since no peak applies today.
- Uses the existing shadcn `Tooltip` component (same pattern as the reset-time tooltip) instead of the native `title` attribute.
- Plugin-API additions: `caption` and `tooltip` optional fields on the badge line type, plus docs.
- Minor plumbing: explicit `·` escapes in plugin code for QuickJS compatibility, swap from `Intl`/`toLocaleTimeString` to `Date` UTC accessors for the same reason.

## Test plan
- [x] `npx vitest run plugins/claude/plugin.test.js` — 81 plugin tests pass (covers off-peak, peak, weekend, missing fields, negative countdown, local-time tooltip).
- [x] `npx vitest run src/components/provider-card.test.tsx` — 40 provider-card tests pass (covers caption placement, tooltip rendering, no-regression when neither caption nor tooltip is present).
- [x] `npx tsc --noEmit` — clean.
- [x] Manual: launch the app, verify the Claude card shows the Peak Hours badge with caption on the right of the badge and tooltip in local time only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Peak Hours badge to the Claude provider card with a countdown caption and a tooltip that shows today’s peak window in the user’s local time. Adds optional `caption` and `tooltip` fields to badge lines and wires them through the plugin API, runtime, and UI.

- **New Features**
  - `plugins/claude`: Reads PromoClock, sets Peak/Off-Peak, and builds captions (“ends in …”, “peak in …”, “peak resumes …”); omits today’s schedule on weekends.
  - `provider-card`: Renders caption to the right of the badge and uses shadcn `Tooltip` for custom tooltip text.
  - Plugin API/runtime: Adds `caption` and `tooltip` to badge lines; updates docs, TypeScript types, JS shim, and Rust `MetricLine`.

- **Bug Fixes**
  - QuickJS compatibility: replace `Intl` time formatting with `Date` UTC accessors; use explicit separators.
  - Badge layout: apply width on the wrapper and allow caption truncation to avoid overflow.
  - Peak tooltip: drop the “Next change” suffix; show only “Peak hours: start – end” in local time.

<sup>Written for commit 482f21620cf37dbc8aa1141a47b6f9f2db7212f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

