### PR TITLE
fix: sanitize shell-derived env values before building auth headers

### DIFF
--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -38,23 +38,39 @@ fn last_non_empty_trimmed_line(text: &str) -> Option<String> {
         .map(|line| line.to_string())
 }
 
-fn read_env_from_process(name: &str) -> Option<String> {
-    let value = std::env::var(name).ok()?;
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        None
+fn sanitize_env_value(text: &str) -> Option<String> {
+    let mut cleaned = if let Ok(ansi_re) = regex_lite::Regex::new(r"\x1B\[[0-?]*[ -/]*[@-~]") {
+        ansi_re.replace_all(text, "").to_string()
     } else {
-        Some(trimmed.to_string())
-    }
+        text.to_string()
+    };
+    cleaned.retain(|ch| ch == '\n' || ch == '\r' || ch == '\t' || !ch.is_control());
+    last_non_empty_trimmed_line(&cleaned)
 }
 
-fn read_env_value_via_command(program: &str, args: &[&str]) -> Option<String> {
+fn extract_marked_value(text: &str, start_marker: &str, end_marker: &str) -> Option<String> {
+    let start = text.find(start_marker)?;
+    let after_start = &text[start + start_marker.len()..];
+    let end = after_start.find(end_marker)?;
+    sanitize_env_value(&after_start[..end])
+}
+
+fn read_env_from_process(name: &str) -> Option<String> {
+    let value = std::env::var(name).ok()?;
+    sanitize_env_value(&value)
+}
+
+fn read_command_stdout(program: &str, args: &[&str]) -> Option<String> {
     let output = Command::new(program).args(args).output().ok()?;
     if !output.status.success() {
         return None;
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    last_non_empty_trimmed_line(&stdout)
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn read_env_value_via_command(program: &str, args: &[&str]) -> Option<String> {
+    let stdout = read_command_stdout(program, args)?;
+    sanitize_env_value(&stdout)
 }
 
 fn current_macos_keychain_account_from_user_env(user_env: Option<String>) -> String {
@@ -144,8 +160,15 @@ fn shell_from_env() -> Option<String> {
 }
 
 fn read_env_from_interactive_shell(program: &str, name: &str) -> Option<String> {
-    let script = format!("printenv {}", name);
-    read_env_value_via_command(program, &["-ilc", script.as_str()])
+    const START_MARKER: &str = "__OPENUSAGE_ENV_START__";
+    const END_MARKER: &str = "__OPENUSAGE_ENV_END__";
+
+    let script = format!(
+        "printf '{}\\n'; printenv {}; printf '{}\\n'",
+        START_MARKER, name, END_MARKER
+    );
+    let output = read_command_stdout(program, &["-ilc", script.as_str()])?;
+    extract_marked_value(&output, START_MARKER, END_MARKER).or_else(|| sanitize_env_value(&output))
 }
 
 fn read_env_from_interactive_shells(name: &str) -> Option<String> {
@@ -2465,6 +2488,49 @@ mod tests {
         )
         .expect_err("tag length");
         assert!(tag_err.contains("auth tag length"));
+    }
+
+    #[test]
+    fn sanitize_env_value_strips_ansi_and_control_sequences() {
+        let raw = "\u{1b}[?1000l\n  sk-test-key-12345\u{1b}[?2004h\r\n";
+        let value = sanitize_env_value(raw);
+        assert_eq!(value.as_deref(), Some("sk-test-key-12345"));
+    }
+
+    #[test]
+    fn extract_marked_value_ignores_noisy_shell_output() {
+        let stdout = concat!(
+            "startup banner\n",
+            "\u{1b}[31mplugin failed\u{1b}[0m\n",
+            "__OPENUSAGE_ENV_START__\n",
+            "  sk-test-key-12345  \n",
+            "__OPENUSAGE_ENV_END__\n",
+            "\u{1b}[32muser@host\u{1b}[0m\n"
+        );
+        let value =
+            extract_marked_value(stdout, "__OPENUSAGE_ENV_START__", "__OPENUSAGE_ENV_END__");
+        assert_eq!(value.as_deref(), Some("sk-test-key-12345"));
+    }
+
+    #[test]
+    fn extract_marked_value_strips_inline_terminal_sequences_from_marked_value() {
+        let stdout = concat!(
+            "__OPENUSAGE_ENV_START__\n",
+            "\u{1b}[?1000l\n",
+            "  sk-test-key-12345\u{1b}[?2004h\r\n",
+            "__OPENUSAGE_ENV_END__\n"
+        );
+        let value =
+            extract_marked_value(stdout, "__OPENUSAGE_ENV_START__", "__OPENUSAGE_ENV_END__");
+        assert_eq!(value.as_deref(), Some("sk-test-key-12345"));
+    }
+
+    #[test]
+    fn extract_marked_value_returns_none_when_marked_value_is_empty() {
+        let stdout = "__OPENUSAGE_ENV_START__\n  \n__OPENUSAGE_ENV_END__\n";
+        let value =
+            extract_marked_value(stdout, "__OPENUSAGE_ENV_START__", "__OPENUSAGE_ENV_END__");
+        assert!(value.is_none());
     }
 
     #[test]

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -55,6 +55,23 @@ fn extract_marked_value(text: &str, start_marker: &str, end_marker: &str) -> Opt
     sanitize_env_value(&after_start[..end])
 }
 
+fn parse_interactive_shell_env_output(
+    text: &str,
+    start_marker: &str,
+    end_marker: &str,
+) -> Option<String> {
+    if let Some(marked) = extract_marked_value(text, start_marker, end_marker) {
+        return Some(marked);
+    }
+
+    let has_complete_markers = text.contains(start_marker) && text.contains(end_marker);
+    if has_complete_markers {
+        return None;
+    }
+
+    sanitize_env_value(text)
+}
+
 fn read_env_from_process(name: &str) -> Option<String> {
     let value = std::env::var(name).ok()?;
     sanitize_env_value(&value)
@@ -168,7 +185,7 @@ fn read_env_from_interactive_shell(program: &str, name: &str) -> Option<String> 
         START_MARKER, name, END_MARKER
     );
     let output = read_command_stdout(program, &["-ilc", script.as_str()])?;
-    extract_marked_value(&output, START_MARKER, END_MARKER).or_else(|| sanitize_env_value(&output))
+    parse_interactive_shell_env_output(&output, START_MARKER, END_MARKER)
 }
 
 fn read_env_from_interactive_shells(name: &str) -> Option<String> {
@@ -2531,6 +2548,28 @@ mod tests {
         let value =
             extract_marked_value(stdout, "__OPENUSAGE_ENV_START__", "__OPENUSAGE_ENV_END__");
         assert!(value.is_none());
+    }
+
+    #[test]
+    fn parse_interactive_shell_env_output_does_not_fallback_to_end_marker_for_empty_value() {
+        let stdout = "__OPENUSAGE_ENV_START__\n  \n__OPENUSAGE_ENV_END__\n";
+        let value = parse_interactive_shell_env_output(
+            stdout,
+            "__OPENUSAGE_ENV_START__",
+            "__OPENUSAGE_ENV_END__",
+        );
+        assert!(value.is_none());
+    }
+
+    #[test]
+    fn parse_interactive_shell_env_output_falls_back_without_markers() {
+        let stdout = "\u{1b}[?1000l\n  sk-test-key-12345\u{1b}[?2004h\r\n";
+        let value = parse_interactive_shell_env_output(
+            stdout,
+            "__OPENUSAGE_ENV_START__",
+            "__OPENUSAGE_ENV_END__",
+        );
+        assert_eq!(value.as_deref(), Some("sk-test-key-12345"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes the Z.ai failure mode where OpenUsage reads a valid API key from an interactive shell, but hidden ANSI/control bytes in shell startup output contaminate the resolved value and make the `Authorization` header invalid.

The fix hardens the shared host env resolver instead of patching only the Z.ai plugin:
- add explicit start/end markers around interactive-shell env reads
- sanitize ANSI/control sequences from resolved env values
- add regression tests for noisy shell output and inline control bytes

## Related Issue

Fixes #358

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`
- [x] I ran `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] I ran `cargo check --manifest-path src-tauri/Cargo.toml`

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I read [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes env values from interactive shells and direct env reads to prevent ANSI/control noise from corrupting API keys and breaking `Authorization` headers (notably for Z.ai). Hardens the shared host env resolver so all plugins benefit; also fixes empty-marker cases.

- **Bug Fixes**
  - Use start/end markers for interactive shell reads; parse only the marked value. If markers exist but payload is empty, return None (no fallback). Keep sanitized fallback only when markers are missing.
  - Strip ANSI/control bytes and trim across shell and process env reads; added regression tests for noisy startup output, inline control bytes, and empty marked payload.

<sup>Written for commit 7cf7a6f68da833893099851a969a458db11100eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

