### PR TITLE
fix(gemini): refresh OAuth tokens on Homebrew-installed gemini-cli

### DIFF
--- a/plugins/gemini/plugin.js
+++ b/plugins/gemini/plugin.js
@@ -148,7 +148,7 @@
         const parsed = parseOauthClientCreds(ctx.host.fs.readText(path))
         if (parsed) return parsed
       } catch (e) {
-        ctx.host.log.warn("failed reading oauth2.js at " + path + ": " + String(e))
+        ctx.host.log.warn("failed reading oauth candidate at " + path + ": " + String(e))
       }
     }
     ctx.host.log.warn("Gemini OAuth client credentials not found in any known install path")

--- a/plugins/gemini/plugin.js
+++ b/plugins/gemini/plugin.js
@@ -3,6 +3,7 @@
   const CREDS_PATH = "~/.gemini/oauth_creds.json"
   const OAUTH2_SUFFIX_FLAT = "/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
   const OAUTH2_SUFFIX_NESTED = "/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
+  const BUNDLE_SUFFIX = "/@google/gemini-cli/bundle"
 
   const STATIC_MODULE_ROOTS = [
     "~/.bun/install/global/node_modules",
@@ -39,6 +40,18 @@
 
     for (var i = 0; i < STATIC_NESTED_ONLY.length; i += 1) {
       paths.push(STATIC_NESTED_ONLY[i] + OAUTH2_SUFFIX_NESTED)
+    }
+
+    // Homebrew builds bundle everything into bundle/chunk-*.js — hash names vary per version
+    for (var i = 0; i < STATIC_NESTED_ONLY.length; i += 1) {
+      var bundleDir = STATIC_NESTED_ONLY[i] + BUNDLE_SUFFIX
+      var entries = listDirSafe(ctx, bundleDir)
+      for (var j = 0; j < entries.length; j += 1) {
+        var name = entries[j]
+        if (name.indexOf("chunk-") === 0 && name.slice(-3) === ".js") {
+          paths.push(bundleDir + "/" + name)
+        }
+      }
     }
 
     for (var i = 0; i < VERSION_MANAGER_ROOTS.length; i += 1) {
@@ -192,7 +205,7 @@
     }
 
     if (ctx.util.isAuthStatus(resp.status)) {
-      throw "Gemini session expired. Run `gemini auth login` to authenticate."
+      throw "Gemini session expired. Run `gemini` and re-authenticate when prompted."
     }
     if (resp.status < 200 || resp.status >= 300) return null
 
@@ -368,7 +381,7 @@
     })
 
     if (ctx.util.isAuthStatus(resp.status)) {
-      throw "Gemini session expired. Run `gemini auth login` to authenticate."
+      throw "Gemini session expired. Run `gemini` and re-authenticate when prompted."
     }
     if (resp.status < 200 || resp.status >= 300) return { data: null, accessToken: currentToken }
     return { data: ctx.util.tryParseJson(resp.bodyText), accessToken: currentToken }
@@ -389,7 +402,7 @@
     })
 
     if (ctx.util.isAuthStatus(resp.status)) {
-      throw "Gemini session expired. Run `gemini auth login` to authenticate."
+      throw "Gemini session expired. Run `gemini` and re-authenticate when prompted."
     }
     if (resp.status < 200 || resp.status >= 300) {
       throw "Gemini quota request failed (HTTP " + String(resp.status) + "). Try again later."
@@ -401,13 +414,13 @@
     assertSupportedAuthType(ctx)
 
     const creds = loadOauthCreds(ctx)
-    if (!creds) throw "Not logged in. Run `gemini auth login` to authenticate."
+    if (!creds) throw "Not logged in. Run `gemini` and complete the OAuth prompt."
 
     let accessToken = creds.access_token
     if (needsRefresh(creds)) {
       const refreshed = refreshToken(ctx, creds)
       if (refreshed) accessToken = refreshed
-      else if (!accessToken) throw "Not logged in. Run `gemini auth login` to authenticate."
+      else if (!accessToken) throw "Not logged in. Run `gemini` and complete the OAuth prompt."
     }
 
     const idTokenPayload = decodeIdToken(ctx, creds.id_token)

--- a/plugins/gemini/plugin.test.js
+++ b/plugins/gemini/plugin.test.js
@@ -843,6 +843,54 @@ describe("gemini plugin", () => {
     expect(result.lines.find((line) => line.label === "Pro")).toBeTruthy()
   })
 
+  it("discovers oauth creds via Homebrew bundle chunks", async () => {
+    const ctx = makeCtx()
+    const nowMs = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockReturnValue(nowMs)
+
+    const bundleDir =
+      "/opt/homebrew/opt/gemini-cli/libexec/lib/node_modules/@google/gemini-cli/bundle"
+
+    ctx.host.fs.writeText(
+      CREDS_PATH,
+      JSON.stringify({
+        access_token: "old-token",
+        refresh_token: "refresh-token",
+        expiry_date: nowMs - 1000,
+      })
+    )
+    ctx.host.fs.writeText(bundleDir + "/chunk-AAAAAAAA.js", "unrelated bundle code")
+    ctx.host.fs.writeText(
+      bundleDir + "/chunk-BBBBBBBB.js",
+      "const OAUTH_CLIENT_ID='brew-id'; const OAUTH_CLIENT_SECRET='brew-secret';"
+    )
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url === TOKEN_URL) {
+        expect(opts.bodyText).toContain("brew-id")
+        expect(opts.bodyText).toContain("brew-secret")
+        return { status: 200, bodyText: JSON.stringify({ access_token: "brewed-token", expires_in: 3600 }) }
+      }
+      if (url === LOAD_CODE_ASSIST_URL) return { status: 200, bodyText: JSON.stringify({ tier: "standard-tier" }) }
+      if (url === PROJECTS_URL) return { status: 200, bodyText: JSON.stringify({ projects: [{ projectId: "gen-lang-client-brew" }] }) }
+      if (url === QUOTA_URL) {
+        expect(opts.headers.Authorization).toBe("Bearer brewed-token")
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            quotaBuckets: [{ modelId: "gemini-2.5-pro", remainingFraction: 0.5, resetTime: "2099-01-01T00:00:00Z" }],
+          }),
+        }
+      }
+      throw new Error("unexpected url: " + url)
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Pro")).toBeTruthy()
+  })
+
   it("logs warning when no oauth2.js is found at any path", async () => {
     const ctx = makeCtx()
     const nowMs = 1_700_000_000_000


### PR DESCRIPTION
## Summary

Fixes #384 — Gemini plugin fails to refresh OAuth tokens when `gemini-cli` is installed via Homebrew, producing misleading "Gemini session expired. Run \`gemini auth login\`..." errors (a command that doesn't exist).

**Root cause:** `loadOauthClientCreds()` only searched for `oauth2.js` at known install paths. Homebrew-installed `gemini-cli` (verified on v0.38.2) bundles everything into `@google/gemini-cli/bundle/chunk-*.js` — no `oauth2.js` exists. `refreshToken()` returned `null` silently, the access token expired, and API calls threw "session expired".

## Changes

- **`plugins/gemini/plugin.js`**
  - Scan `STATIC_NESTED_ONLY` + `/@google/gemini-cli/bundle/chunk-*.js` as OAuth cred candidates (chunk hashes change per version, so we can't hardcode filenames)
  - Replace 5 misleading `"Run \`gemini auth login\`..."` messages with `"Run \`gemini\` and re-authenticate when prompted."` (per [docs](https://geminicli.com/docs/get-started/authentication/), Gemini CLI has no `auth login` subcommand — users just re-run `gemini`)
- **`plugins/gemini/plugin.test.js`**
  - Regression test covering Homebrew bundle layout + mixed chunk content (one unrelated + one with creds) to verify scan + parse behavior

## Test plan

- [x] All 31 existing unit tests still pass (`bun run test plugins/gemini/plugin.test.js`)
- [x] New regression test passes
- [x] End-to-end verification on real Homebrew-installed `gemini-cli` v0.38.2:
  - Forced `expiry_date = 1` in `~/.gemini/oauth_creds.json`
  - Loaded plugin.js in Node.js with real filesystem
  - `probe()` scanned bundle → found creds in `chunk-EA775AOR.js` → `POST oauth2.googleapis.com/token` returned 200 → `loadCodeAssist` and `retrieveUserQuota` returned 200 with new token → `expiry_date` updated, `access_token` rotated, Pro/Flash usage rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth token refresh when `gemini-cli` is installed via Homebrew by scanning bundled chunk files and updating error messages to direct users to re-run `gemini`. Prevents false “session expired” errors and restores API calls.

- **Bug Fixes**
  - Scan `.../@google/gemini-cli/bundle/chunk-*.js` for OAuth client creds when `oauth2.js` isn’t present (Homebrew layout).
  - Update messages: replace “Run `gemini auth login`” with “Run `gemini` and re-authenticate when prompted,” and clarify warn logs to refer to an OAuth “candidate” path (covers bundle chunks).
  - Add regression test for Homebrew bundle discovery and mixed chunk content.

<sup>Written for commit 1a911019a190bc90180c800a35f94d9caeab34a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

