### PR TITLE
fix(codex): map pro to Pro 20x

### DIFF
--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -276,7 +276,7 @@
     const rawPlan = typeof planType === "string" ? planType.trim() : ""
     if (!rawPlan) return null
     if (rawPlan.toLowerCase() === "prolite") return "Pro 5x"
-    if (rawPlan.toLowerCase() === "pro") return "Pro 10x"
+    if (rawPlan.toLowerCase() === "pro") return "Pro 20x"
     return ctx.fmt.planLabel(rawPlan) || null
   }
 

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -164,7 +164,7 @@ describe("codex plugin", () => {
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
-    expect(result.plan).toBe("Pro 10x")
+    expect(result.plan).toBe("Pro 20x")
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
     const credits = result.lines.find((line) => line.label === "Credits")


### PR DESCRIPTION
## Description

Per the official OpenAI help article, the Pro $200 plan now permanently provides 20x Plus usage. The previous "Pro 10x" mapping came from a tweet about a future post-promo state that never materialized.

`prolite` stays at Pro 5x.

https://help.openai.com/en/articles/9793128-about-chatgpt-pro-tiers
https://web.archive.org/web/20260426203831/https://help.openai.com/en/articles/9793128-about-chatgpt-pro-tiers

## Related Issue

Fixes https://github.com/robinebers/openusage/issues/408

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
