### PR TITLE
Fix Codex auth fallback

### DIFF
--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -80,6 +80,8 @@ OpenUsage Codex plugin auth lookup order:
 3. `~/.codex/auth.json`
 4. macOS keychain service `Codex Auth` (fallback)
 
+If a file credential exists but fails during refresh or usage lookup, OpenUsage tries the next auth source. This handles stale `auth.json` files left behind after Codex starts using keychain storage.
+
 Keychain fallback is available on macOS only.
 
 Expected auth payload shape (file or keychain JSON value):

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -128,8 +128,9 @@
     return false
   }
 
-  function loadAuth(ctx) {
+  function loadAuthCandidates(ctx) {
     const authPaths = resolveAuthPaths(ctx)
+    const candidates = []
     for (const authPath of authPaths) {
       if (!ctx.host.fs.exists(authPath)) continue
       try {
@@ -140,16 +141,16 @@
           continue
         }
         ctx.host.log.info("auth loaded from file: " + authPath)
-        return { auth, authPath, source: "file" }
+        candidates.push({ auth, authPath, source: "file" })
       } catch (e) {
         ctx.host.log.warn("auth file read failed: " + String(e))
       }
     }
 
     const keychainAuth = loadAuthFromKeychain(ctx)
-    if (keychainAuth) return keychainAuth
+    if (keychainAuth) candidates.push(keychainAuth)
 
-    if (authPaths.length > 0) {
+    if (candidates.length === 0 && authPaths.length > 0) {
       for (const authPath of authPaths) {
         if (!ctx.host.fs.exists(authPath)) {
           ctx.host.log.warn("auth file not found: " + authPath)
@@ -157,7 +158,7 @@
       }
     }
 
-    return null
+    return candidates
   }
 
   function needsRefresh(ctx, auth, nowMs) {
@@ -422,12 +423,7 @@
     }))
   }
 
-  function probe(ctx) {
-    const authState = loadAuth(ctx)
-    if (!authState || !authState.auth) {
-      ctx.host.log.error("probe failed: not logged in")
-      throw "Not logged in. Run `codex` to authenticate."
-    }
+  function probeWithAuthState(ctx, authState) {
     const auth = authState.auth
 
     if (auth.tokens && auth.tokens.access_token) {
@@ -680,6 +676,31 @@
     }
 
     throw "Not logged in. Run `codex` to authenticate."
+  }
+
+  function probe(ctx) {
+    const authCandidates = loadAuthCandidates(ctx)
+    if (!authCandidates || authCandidates.length === 0) {
+      ctx.host.log.error("probe failed: not logged in")
+      throw "Not logged in. Run `codex` to authenticate."
+    }
+
+    let lastAuthError = null
+    for (let i = 0; i < authCandidates.length; i++) {
+      const authState = authCandidates[i]
+      try {
+        return probeWithAuthState(ctx, authState)
+      } catch (e) {
+        lastAuthError = e
+        if (i + 1 < authCandidates.length) {
+          ctx.host.log.warn("auth failed for " + authState.source + ", trying next auth source")
+          continue
+        }
+        throw e
+      }
+    }
+
+    throw lastAuthError || "Not logged in. Run `codex` to authenticate."
   }
 
   globalThis.__openusage_plugin = { id: "codex", probe }

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -12,6 +12,31 @@ describe("codex plugin", () => {
     vi.resetModules()
   })
 
+  const expectStaleFileAuthFallsBackToKeychain = async (refreshResponse) => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "old-file-token", refresh_token: "old-file-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) return refreshResponse
+      expect(opts.headers.Authorization).toBe("Bearer keychain-token")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "12" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+  }
+
   it("throws when auth missing", async () => {
     const ctx = makeCtx()
     const plugin = await loadPlugin()
@@ -593,6 +618,91 @@ describe("codex plugin", () => {
     })
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Token conflict")
+  })
+
+  it("falls back to keychain when file refresh token was reused", async () => {
+    await expectStaleFileAuthFallsBackToKeychain({
+      status: 400,
+      headers: {},
+      bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+    })
+  })
+
+  it("falls back to keychain when file refresh token expired", async () => {
+    await expectStaleFileAuthFallsBackToKeychain({
+      status: 400,
+      headers: {},
+      bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
+    })
+  })
+
+  it("falls back to keychain when file refresh token was revoked", async () => {
+    await expectStaleFileAuthFallsBackToKeychain({
+      status: 400,
+      headers: {},
+      bodyText: JSON.stringify({ error: { code: "refresh_token_invalidated" } }),
+    })
+  })
+
+  it("falls back to keychain when file usage auth fails after refresh attempt", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "old-file-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (opts.headers.Authorization === "Bearer old-file-token") {
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer keychain-token")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "9" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+  })
+
+  it("falls back to keychain when file usage request fails", async () => {
+    const runCase = async (fileResp) => {
+      const ctx = makeCtx()
+      ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+        tokens: { access_token: "file-token" },
+        last_refresh: new Date().toISOString(),
+      }))
+      ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+        tokens: { access_token: "keychain-token" },
+        last_refresh: new Date().toISOString(),
+      }))
+      ctx.host.http.request.mockImplementation((opts) => {
+        if (opts.headers.Authorization === "Bearer file-token") {
+          return fileResp
+        }
+        expect(opts.headers.Authorization).toBe("Bearer keychain-token")
+        return {
+          status: 200,
+          headers: { "x-codex-primary-used-percent": "8" },
+          bodyText: JSON.stringify({}),
+        }
+      })
+
+      delete globalThis.__openusage_plugin
+      vi.resetModules()
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx)
+      expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    }
+
+    await runCase({ status: 500, headers: {}, bodyText: "" })
+    await runCase({ status: 200, headers: {}, bodyText: "bad" })
   })
 
   it("throws for api key auth", async () => {


### PR DESCRIPTION
## Description

Fixes Codex auth lookup so a stale file credential does not block a working keychain credential. The plugin now tries valid auth sources in order and falls through to the next source when one fails during refresh or usage lookup.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [x] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [ ] I ran `bun run build` and it succeeded
- [ ] I ran `bun run test` and all tests pass
- [ ] I tested the change locally with `bun tauri dev`

Focused test run:

- `bunx vitest run plugins/codex/plugin.test.js` passed

## Screenshots

N/A - no UI changes.

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex auth lookup so a stale `~/.codex/auth.json` no longer blocks a valid macOS keychain credential. This prevents false “Not logged in” errors and uses the first working auth source.

- **Bug Fixes**
  - Tries auth candidates in order (files, then keychain) and falls through on refresh or usage failures.
  - Introduces `loadAuthCandidates` and `probeWithAuthState` to iterate and validate per-source auth with clear logging.
  - Adds tests for stale file scenarios (token reused/expired/revoked, 401, bad/500 usage responses) to confirm keychain fallback.
  - Updates `docs/providers/codex.md` to document the fallback behavior and macOS keychain note.

<sup>Written for commit f894473c0c80f1ca58223cd3142d63df7e5d4f56. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/413?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex authentication selection and error handling so failures during token refresh/usage can switch credentials; issues could cause unexpected auth source selection or new “not logged in”/refresh error behavior.
> 
> **Overview**
> Fixes Codex auth resolution so **stale file-based credentials no longer block a working macOS keychain credential**.
> 
> The plugin now loads *all* valid auth candidates (files first, then keychain) and `probe` iterates through them, retrying the next source when refresh or usage lookup fails.
> 
> Adds test coverage for fallback on refresh-token errors and usage failures, and updates `docs/providers/codex.md` to document the new failover behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f894473c0c80f1ca58223cd3142d63df7e5d4f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->