### PR TITLE
fix(codex): lazy-load keychain auth fallback

### DIFF
--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -80,7 +80,7 @@ OpenUsage Codex plugin auth lookup order:
 3. `~/.codex/auth.json`
 4. macOS keychain service `Codex Auth` (fallback)
 
-If file OAuth auth is missing, invalid, or fails with an auth/session error during refresh or usage lookup, OpenUsage tries the macOS keychain fallback. Non-auth usage failures, such as server errors or invalid responses, are shown directly.
+If file-based OAuth credentials are missing, invalid, or fail with an auth/session error during refresh or usage lookup, OpenUsage tries the macOS keychain fallback. Non-auth usage failures, such as server errors or invalid responses, are shown directly.
 
 Keychain fallback is available on macOS only.
 

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -80,7 +80,7 @@ OpenUsage Codex plugin auth lookup order:
 3. `~/.codex/auth.json`
 4. macOS keychain service `Codex Auth` (fallback)
 
-If a file credential exists but fails during refresh or usage lookup, OpenUsage tries the next auth source. This handles stale `auth.json` files left behind after Codex starts using keychain storage.
+If file OAuth auth is missing, invalid, or fails with an auth/session error during refresh or usage lookup, OpenUsage tries the macOS keychain fallback. Non-auth usage failures, such as server errors or invalid responses, are shown directly.
 
 Keychain fallback is available on macOS only.
 

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -6,6 +6,14 @@
   const REFRESH_URL = "https://auth.openai.com/oauth/token"
   const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
   const REFRESH_AGE_MS = 8 * 24 * 60 * 60 * 1000
+  const ERR_NOT_LOGGED_IN = "Not logged in. Run `codex` to authenticate."
+  const ERR_SESSION_EXPIRED = "Session expired. Run `codex` to log in again."
+  const ERR_TOKEN_CONFLICT = "Token conflict. Run `codex` to log in again."
+  const ERR_TOKEN_REVOKED = "Token revoked. Run `codex` to log in again."
+  const ERR_TOKEN_EXPIRED = "Token expired. Run `codex` to log in again."
+  const ERR_USAGE_API_KEY = "Usage not available for API key."
+  const ERR_USAGE_CONNECTION = "Usage request failed. Check your connection."
+  const ERR_USAGE_AFTER_REFRESH = "Usage request failed after refresh. Try again."
 
   function joinPath(base, leaf) {
     return base.replace(/[\\/]+$/, "") + "/" + leaf
@@ -85,6 +93,16 @@
     return false
   }
 
+  function isAuthFallbackError(e) {
+    if (typeof e !== "string") return false
+    return (
+      e === ERR_SESSION_EXPIRED ||
+      e === ERR_TOKEN_CONFLICT ||
+      e === ERR_TOKEN_REVOKED ||
+      e === ERR_TOKEN_EXPIRED
+    )
+  }
+
   function loadAuthFromKeychain(ctx) {
     if (!ctx.host.keychain || typeof ctx.host.keychain.readGenericPassword !== "function") {
       return null
@@ -128,11 +146,15 @@
     return false
   }
 
-  function loadAuthCandidates(ctx) {
+  function loadFileAuthCandidates(ctx) {
     const authPaths = resolveAuthPaths(ctx)
     const candidates = []
+    const missingPaths = []
     for (const authPath of authPaths) {
-      if (!ctx.host.fs.exists(authPath)) continue
+      if (!ctx.host.fs.exists(authPath)) {
+        missingPaths.push(authPath)
+        continue
+      }
       try {
         const text = ctx.host.fs.readText(authPath)
         const auth = tryParseAuthJson(ctx, text)
@@ -143,22 +165,11 @@
         ctx.host.log.info("auth loaded from file: " + authPath)
         candidates.push({ auth, authPath, source: "file" })
       } catch (e) {
-        ctx.host.log.warn("auth file read failed: " + String(e))
+        ctx.host.log.warn("auth file read failed: " + authPath + ": " + String(e))
       }
     }
 
-    const keychainAuth = loadAuthFromKeychain(ctx)
-    if (keychainAuth) candidates.push(keychainAuth)
-
-    if (candidates.length === 0 && authPaths.length > 0) {
-      for (const authPath of authPaths) {
-        if (!ctx.host.fs.exists(authPath)) {
-          ctx.host.log.warn("auth file not found: " + authPath)
-        }
-      }
-    }
-
-    return candidates
+    return { candidates, missingPaths }
   }
 
   function needsRefresh(ctx, auth, nowMs) {
@@ -196,15 +207,15 @@
         }
         ctx.host.log.error("refresh failed: status=" + resp.status + " code=" + String(code))
         if (code === "refresh_token_expired") {
-          throw "Session expired. Run `codex` to log in again."
+          throw ERR_SESSION_EXPIRED
         }
         if (code === "refresh_token_reused") {
-          throw "Token conflict. Run `codex` to log in again."
+          throw ERR_TOKEN_CONFLICT
         }
         if (code === "refresh_token_invalidated") {
-          throw "Token revoked. Run `codex` to log in again."
+          throw ERR_TOKEN_REVOKED
         }
-        throw "Token expired. Run `codex` to log in again."
+        throw ERR_TOKEN_EXPIRED
       }
       if (resp.status < 200 || resp.status >= 300) {
         ctx.host.log.warn("refresh returned unexpected status: " + resp.status)
@@ -451,9 +462,9 @@
             } catch (e) {
               ctx.host.log.error("usage request exception: " + String(e))
               if (didRefresh) {
-                throw "Usage request failed after refresh. Try again."
+                throw ERR_USAGE_AFTER_REFRESH
               }
-              throw "Usage request failed. Check your connection."
+              throw ERR_USAGE_CONNECTION
             }
           },
           refresh: () => {
@@ -465,12 +476,12 @@
       } catch (e) {
         if (typeof e === "string") throw e
         ctx.host.log.error("usage request failed: " + String(e))
-        throw "Usage request failed. Check your connection."
+        throw ERR_USAGE_CONNECTION
       }
 
       if (ctx.util.isAuthStatus(resp.status)) {
         ctx.host.log.error("usage returned auth error after all retries: status=" + resp.status)
-        throw "Token expired. Run `codex` to log in again."
+        throw ERR_TOKEN_EXPIRED
       }
 
       if (resp.status < 200 || resp.status >= 300) {
@@ -672,35 +683,39 @@
     }
 
     if (auth.OPENAI_API_KEY) {
-      throw "Usage not available for API key."
+      throw ERR_USAGE_API_KEY
     }
 
-    throw "Not logged in. Run `codex` to authenticate."
+    throw ERR_NOT_LOGGED_IN
   }
 
   function probe(ctx) {
-    const authCandidates = loadAuthCandidates(ctx)
-    if (!authCandidates || authCandidates.length === 0) {
-      ctx.host.log.error("probe failed: not logged in")
-      throw "Not logged in. Run `codex` to authenticate."
-    }
-
-    let lastAuthError = null
-    for (let i = 0; i < authCandidates.length; i++) {
-      const authState = authCandidates[i]
+    const fileAuth = loadFileAuthCandidates(ctx)
+    let lastAuthFallbackError = null
+    for (let i = 0; i < fileAuth.candidates.length; i++) {
+      const authState = fileAuth.candidates[i]
       try {
         return probeWithAuthState(ctx, authState)
       } catch (e) {
-        lastAuthError = e
-        if (i + 1 < authCandidates.length) {
-          ctx.host.log.warn("auth failed for " + authState.source + ", trying next auth source")
-          continue
+        if (!isAuthFallbackError(e)) {
+          throw e
         }
-        throw e
+        lastAuthFallbackError = e
+        ctx.host.log.warn("auth failed for file " + authState.authPath + ", trying next auth source: " + String(e))
       }
     }
 
-    throw lastAuthError || "Not logged in. Run `codex` to authenticate."
+    const keychainAuth = loadAuthFromKeychain(ctx)
+    if (keychainAuth) return probeWithAuthState(ctx, keychainAuth)
+
+    if (lastAuthFallbackError) throw lastAuthFallbackError
+
+    for (const authPath of fileAuth.missingPaths) {
+      ctx.host.log.warn("auth file not found: " + authPath)
+    }
+
+    ctx.host.log.error("probe failed: not logged in")
+    throw ERR_NOT_LOGGED_IN
   }
 
   globalThis.__openusage_plugin = { id: "codex", probe }

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -58,6 +58,30 @@ describe("codex plugin", () => {
     plugin.probe(ctx)
   })
 
+  it("does not read keychain when file auth succeeds", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "file-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.keychain.readGenericPassword.mockImplementation(() => {
+      throw new Error("keychain should not be read")
+    })
+    ctx.host.http.request.mockImplementation((opts) => {
+      expect(opts.headers.Authorization).toBe("Bearer file-token")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "10" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+  })
+
   it("uses CODEX_HOME auth path when env var is set", async () => {
     const ctx = makeCtx()
     ctx.host.env.get.mockImplementation((name) => (name === "CODEX_HOME" ? "/tmp/codex-home" : null))
@@ -76,6 +100,7 @@ describe("codex plugin", () => {
 
     const plugin = await loadPlugin()
     plugin.probe(ctx)
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
 
   it("uses ~/.config/codex/auth.json before ~/.codex/auth.json when env is not set", async () => {
@@ -95,6 +120,7 @@ describe("codex plugin", () => {
 
     const plugin = await loadPlugin()
     plugin.probe(ctx)
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
 
   it("does not fall back when CODEX_HOME is set but missing auth file", async () => {
@@ -671,38 +697,158 @@ describe("codex plugin", () => {
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
   })
 
-  it("falls back to keychain when file usage request fails", async () => {
-    const runCase = async (fileResp) => {
-      const ctx = makeCtx()
-      ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
-        tokens: { access_token: "file-token" },
-        last_refresh: new Date().toISOString(),
-      }))
-      ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
-        tokens: { access_token: "keychain-token" },
-        last_refresh: new Date().toISOString(),
-      }))
-      ctx.host.http.request.mockImplementation((opts) => {
-        if (opts.headers.Authorization === "Bearer file-token") {
-          return fileResp
-        }
-        expect(opts.headers.Authorization).toBe("Bearer keychain-token")
+  it("falls back to keychain when file usage auth still fails after refresh", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "file-token", refresh_token: "file-refresh" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
         return {
           status: 200,
-          headers: { "x-codex-primary-used-percent": "8" },
-          bodyText: JSON.stringify({}),
+          headers: {},
+          bodyText: JSON.stringify({ access_token: "refreshed-file-token" }),
         }
-      })
+      }
+      if (opts.headers.Authorization === "Bearer file-token") {
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      if (opts.headers.Authorization === "Bearer refreshed-file-token") {
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer keychain-token")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "6" },
+        bodyText: JSON.stringify({}),
+      }
+    })
 
-      delete globalThis.__openusage_plugin
-      vi.resetModules()
-      const plugin = await loadPlugin()
-      const result = plugin.probe(ctx)
-      expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
-    }
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Codex Auth")
+  })
 
-    await runCase({ status: 500, headers: {}, bodyText: "" })
-    await runCase({ status: 200, headers: {}, bodyText: "bad" })
+  it("surfaces keychain auth error when file and keychain auth both fail", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "file-token", refresh_token: "file-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token", refresh_token: "keychain-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.bodyText).includes("file-refresh")) {
+        return {
+          status: 400,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+        }
+      }
+      expect(String(opts.bodyText)).toContain("keychain-refresh")
+      return {
+        status: 400,
+        headers: {},
+        bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Session expired")
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Codex Auth")
+  })
+
+  it("tries next file auth before keychain when earlier file auth is stale", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.config/codex/auth.json", JSON.stringify({
+      tokens: { access_token: "old-config-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "legacy-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (opts.headers.Authorization === "Bearer old-config-token") {
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer legacy-token")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "7" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+  })
+
+  it("does not fall back to keychain when file usage request returns server error", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "file-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({ status: 500, headers: {}, bodyText: "" })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Usage request failed (HTTP 500)")
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+  })
+
+  it("does not fall back to keychain when file usage response is invalid", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "file-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({ status: 200, headers: {}, bodyText: "bad" })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Usage response invalid")
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+  })
+
+  it("does not fall back to keychain when file usage request throws", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "file-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockImplementation(() => {
+      throw new Error("offline")
+    })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Usage request failed. Check your connection.")
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
 
   it("throws for api key auth", async () => {
@@ -710,8 +856,13 @@ describe("codex plugin", () => {
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
       OPENAI_API_KEY: "key",
     }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token" },
+      last_refresh: new Date().toISOString(),
+    }))
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Usage not available for API key")
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
 
   it("falls back to rate_limit data and review window", async () => {


### PR DESCRIPTION
## Description

Only read Codex Keychain auth when file auth is missing, invalid, or fails with an auth/session error. Preserve stale `auth.json` recovery while surfacing non-auth usage failures directly.

Fixes a Codex-only macOS Keychain prompt introduced after #413.

The Codex plugin now tries file auth first and only reads the `Codex Auth` Keychain fallback when file auth is missing, invalid, or fails with an auth/session error. This preserves stale `auth.json` recovery while avoiding Keychain prompts on every auto-refresh when file auth already works.

The auth fallback is intentionally driven by a small set of exact, user-facing auth error messages. The plugin treats those messages as its auth-failure contract: when file auth throws one of them, it may try the next auth source. Other errors remain loud and do not fall back.

Non-auth usage failures now surface directly instead of silently falling through to Keychain, including HTTP 500, invalid usage JSON, request exceptions, and API-key-only auth.

## Type of Change

- [x] Bug fix
- [x] Documentation

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification
