### PR TITLE
feat(codex): support multiple account slots

### DIFF
--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -3,8 +3,6 @@
   const CONFIG_AUTH_PATHS = ["~/.config/codex", "~/.codex"]
   const OPENUSAGE_CODEX_ACCOUNTS_PATH = "~/.openusage/codex-accounts"
   const OPENUSAGE_SLOT_PLUGIN_PREFIX = "codex-slot-"
-  const HERMES_AUTH_PATH = "~/.hermes/auth.json"
-  const HERMES_PROVIDER_ID = "openai-codex"
   const KEYCHAIN_SERVICE = "Codex Auth"
   const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
   const REFRESH_URL = "https://auth.openai.com/oauth/token"
@@ -44,10 +42,6 @@
     return typeof value === "string" ? value.trim() : ""
   }
 
-  function isHermesCodexPlugin(ctx) {
-    return readPluginId(ctx) === "codex-hermes"
-  }
-
   function readOpenUsageSlotName(ctx) {
     const pluginId = readPluginId(ctx)
     if (!pluginId.startsWith(OPENUSAGE_SLOT_PLUGIN_PREFIX)) return null
@@ -57,7 +51,7 @@
   }
 
   function isSecondaryCodexPlugin(ctx) {
-    return isHermesCodexPlugin(ctx) || Boolean(readOpenUsageSlotName(ctx))
+    return Boolean(readOpenUsageSlotName(ctx))
   }
 
   function decodeHexUtf8(hex) {
@@ -101,7 +95,6 @@
   }
 
   function resolveAuthPaths(ctx) {
-    if (isHermesCodexPlugin(ctx)) return []
     const slotName = readOpenUsageSlotName(ctx)
     if (slotName) {
       return [joinPath(joinPath(OPENUSAGE_CODEX_ACCOUNTS_PATH, slotName), AUTH_FILE)]
@@ -157,67 +150,6 @@
     }
   }
 
-  function readHermesAuthRoot(ctx) {
-    if (!ctx.host.fs.exists(HERMES_AUTH_PATH)) return null
-    const text = ctx.host.fs.readText(HERMES_AUTH_PATH)
-    return ctx.util.tryParseJson(text)
-  }
-
-  function loadAuthFromHermes(ctx) {
-    if (!isHermesCodexPlugin(ctx)) return null
-
-    try {
-      const root = readHermesAuthRoot(ctx)
-      const provider = root && root.providers ? root.providers[HERMES_PROVIDER_ID] : null
-      const tokens = provider && provider.tokens ? provider.tokens : null
-      const auth = {
-        OPENAI_API_KEY: null,
-        auth_mode: provider && provider.auth_mode ? provider.auth_mode : "chatgpt",
-        tokens,
-        last_refresh: provider ? provider.last_refresh : null,
-      }
-      if (!hasTokenLikeAuth(auth)) {
-        ctx.host.log.warn("hermes auth exists but no valid openai-codex payload")
-        return null
-      }
-      ctx.host.log.info("auth loaded from hermes file")
-      return { auth, authPath: HERMES_AUTH_PATH, source: "hermes-file" }
-    } catch (e) {
-      ctx.host.log.warn("hermes auth read failed: " + String(e))
-      return null
-    }
-  }
-
-  function saveHermesAuth(ctx, authState) {
-    const auth = authState && authState.auth ? authState.auth : null
-    if (!auth || !auth.tokens) return false
-
-    const root = readHermesAuthRoot(ctx)
-    if (!root || typeof root !== "object") return false
-    if (!root.providers || typeof root.providers !== "object") root.providers = {}
-    if (!root.providers[HERMES_PROVIDER_ID] || typeof root.providers[HERMES_PROVIDER_ID] !== "object") {
-      root.providers[HERMES_PROVIDER_ID] = {}
-    }
-
-    const provider = root.providers[HERMES_PROVIDER_ID]
-    provider.tokens = auth.tokens
-    provider.last_refresh = auth.last_refresh
-    provider.auth_mode = auth.auth_mode || provider.auth_mode || "chatgpt"
-
-    const pool = root.credential_pool && Array.isArray(root.credential_pool[HERMES_PROVIDER_ID])
-      ? root.credential_pool[HERMES_PROVIDER_ID]
-      : []
-    for (const entry of pool) {
-      if (!entry || typeof entry !== "object") continue
-      entry.access_token = auth.tokens.access_token
-      if (auth.tokens.refresh_token) entry.refresh_token = auth.tokens.refresh_token
-      entry.last_refresh = auth.last_refresh
-    }
-
-    ctx.host.fs.writeText(HERMES_AUTH_PATH, JSON.stringify(root, null, 2))
-    return true
-  }
-
   function saveAuth(ctx, authState) {
     const auth = authState && authState.auth ? authState.auth : null
     if (!auth) return false
@@ -225,10 +157,6 @@
     if (authState.source === "file" && authState.authPath) {
       ctx.host.fs.writeText(authState.authPath, JSON.stringify(auth, null, 2))
       return true
-    }
-
-    if (authState.source === "hermes-file" && authState.authPath) {
-      return saveHermesAuth(ctx, authState)
     }
 
     if (authState.source === "keychain") {
@@ -245,9 +173,6 @@
   }
 
   function loadFileAuthCandidates(ctx) {
-    const hermesAuth = loadAuthFromHermes(ctx)
-    if (hermesAuth) return { candidates: [hermesAuth], missingPaths: [] }
-
     const authPaths = resolveAuthPaths(ctx)
     const candidates = []
     const missingPaths = []

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -1,16 +1,20 @@
 (function () {
   const AUTH_FILE = "auth.json"
   const CONFIG_AUTH_PATHS = ["~/.config/codex", "~/.codex"]
+  const OPENUSAGE_CODEX_ACCOUNTS_PATH = "~/.openusage/codex-accounts"
+  const OPENUSAGE_SLOT_PLUGIN_PREFIX = "codex-slot-"
+  const HERMES_AUTH_PATH = "~/.hermes/auth.json"
+  const HERMES_PROVIDER_ID = "openai-codex"
   const KEYCHAIN_SERVICE = "Codex Auth"
   const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
   const REFRESH_URL = "https://auth.openai.com/oauth/token"
   const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
   const REFRESH_AGE_MS = 8 * 24 * 60 * 60 * 1000
-  const ERR_NOT_LOGGED_IN = "Not logged in. Run `codex` to authenticate."
-  const ERR_SESSION_EXPIRED = "Session expired. Run `codex` to log in again."
-  const ERR_TOKEN_CONFLICT = "Token conflict. Run `codex` to log in again."
-  const ERR_TOKEN_REVOKED = "Token revoked. Run `codex` to log in again."
-  const ERR_TOKEN_EXPIRED = "Token expired. Run `codex` to log in again."
+  const ERR_NOT_LOGGED_IN = "Not logged in. Log in to this Codex account."
+  const ERR_SESSION_EXPIRED = "Session expired. Log in to this Codex account again."
+  const ERR_TOKEN_CONFLICT = "Token conflict. Log in to this Codex account again."
+  const ERR_TOKEN_REVOKED = "Token revoked. Log in to this Codex account again."
+  const ERR_TOKEN_EXPIRED = "Token expired. Log in to this Codex account again."
   const ERR_USAGE_API_KEY = "Usage not available for API key."
   const ERR_USAGE_CONNECTION = "Usage request failed. Check your connection."
   const ERR_USAGE_AFTER_REFRESH = "Usage request failed after refresh. Try again."
@@ -33,6 +37,27 @@
       ctx.host.log.warn("CODEX_HOME read failed: " + String(e))
       return null
     }
+  }
+
+  function readPluginId(ctx) {
+    const value = ctx && ctx.app ? ctx.app.pluginId : null
+    return typeof value === "string" ? value.trim() : ""
+  }
+
+  function isHermesCodexPlugin(ctx) {
+    return readPluginId(ctx) === "codex-hermes"
+  }
+
+  function readOpenUsageSlotName(ctx) {
+    const pluginId = readPluginId(ctx)
+    if (!pluginId.startsWith(OPENUSAGE_SLOT_PLUGIN_PREFIX)) return null
+    const slot = pluginId.slice(OPENUSAGE_SLOT_PLUGIN_PREFIX.length)
+    if (!/^[a-zA-Z0-9_-]+$/.test(slot)) return null
+    return slot
+  }
+
+  function isSecondaryCodexPlugin(ctx) {
+    return isHermesCodexPlugin(ctx) || Boolean(readOpenUsageSlotName(ctx))
   }
 
   function decodeHexUtf8(hex) {
@@ -76,6 +101,12 @@
   }
 
   function resolveAuthPaths(ctx) {
+    if (isHermesCodexPlugin(ctx)) return []
+    const slotName = readOpenUsageSlotName(ctx)
+    if (slotName) {
+      return [joinPath(joinPath(OPENUSAGE_CODEX_ACCOUNTS_PATH, slotName), AUTH_FILE)]
+    }
+
     const codexHome = readCodexHome(ctx)
 
     // If CODEX_HOME is set, use it
@@ -104,6 +135,8 @@
   }
 
   function loadAuthFromKeychain(ctx) {
+    if (isSecondaryCodexPlugin(ctx)) return null
+
     if (!ctx.host.keychain || typeof ctx.host.keychain.readGenericPassword !== "function") {
       return null
     }
@@ -124,6 +157,67 @@
     }
   }
 
+  function readHermesAuthRoot(ctx) {
+    if (!ctx.host.fs.exists(HERMES_AUTH_PATH)) return null
+    const text = ctx.host.fs.readText(HERMES_AUTH_PATH)
+    return ctx.util.tryParseJson(text)
+  }
+
+  function loadAuthFromHermes(ctx) {
+    if (!isHermesCodexPlugin(ctx)) return null
+
+    try {
+      const root = readHermesAuthRoot(ctx)
+      const provider = root && root.providers ? root.providers[HERMES_PROVIDER_ID] : null
+      const tokens = provider && provider.tokens ? provider.tokens : null
+      const auth = {
+        OPENAI_API_KEY: null,
+        auth_mode: provider && provider.auth_mode ? provider.auth_mode : "chatgpt",
+        tokens,
+        last_refresh: provider ? provider.last_refresh : null,
+      }
+      if (!hasTokenLikeAuth(auth)) {
+        ctx.host.log.warn("hermes auth exists but no valid openai-codex payload")
+        return null
+      }
+      ctx.host.log.info("auth loaded from hermes file")
+      return { auth, authPath: HERMES_AUTH_PATH, source: "hermes-file" }
+    } catch (e) {
+      ctx.host.log.warn("hermes auth read failed: " + String(e))
+      return null
+    }
+  }
+
+  function saveHermesAuth(ctx, authState) {
+    const auth = authState && authState.auth ? authState.auth : null
+    if (!auth || !auth.tokens) return false
+
+    const root = readHermesAuthRoot(ctx)
+    if (!root || typeof root !== "object") return false
+    if (!root.providers || typeof root.providers !== "object") root.providers = {}
+    if (!root.providers[HERMES_PROVIDER_ID] || typeof root.providers[HERMES_PROVIDER_ID] !== "object") {
+      root.providers[HERMES_PROVIDER_ID] = {}
+    }
+
+    const provider = root.providers[HERMES_PROVIDER_ID]
+    provider.tokens = auth.tokens
+    provider.last_refresh = auth.last_refresh
+    provider.auth_mode = auth.auth_mode || provider.auth_mode || "chatgpt"
+
+    const pool = root.credential_pool && Array.isArray(root.credential_pool[HERMES_PROVIDER_ID])
+      ? root.credential_pool[HERMES_PROVIDER_ID]
+      : []
+    for (const entry of pool) {
+      if (!entry || typeof entry !== "object") continue
+      entry.access_token = auth.tokens.access_token
+      if (auth.tokens.refresh_token) entry.refresh_token = auth.tokens.refresh_token
+      entry.last_refresh = auth.last_refresh
+    }
+
+    ctx.host.fs.writeText(HERMES_AUTH_PATH, JSON.stringify(root, null, 2))
+    return true
+  }
+
   function saveAuth(ctx, authState) {
     const auth = authState && authState.auth ? authState.auth : null
     if (!auth) return false
@@ -131,6 +225,10 @@
     if (authState.source === "file" && authState.authPath) {
       ctx.host.fs.writeText(authState.authPath, JSON.stringify(auth, null, 2))
       return true
+    }
+
+    if (authState.source === "hermes-file" && authState.authPath) {
+      return saveHermesAuth(ctx, authState)
     }
 
     if (authState.source === "keychain") {
@@ -147,6 +245,9 @@
   }
 
   function loadFileAuthCandidates(ctx) {
+    const hermesAuth = loadAuthFromHermes(ctx)
+    if (hermesAuth) return { candidates: [hermesAuth], missingPaths: [] }
+
     const authPaths = resolveAuthPaths(ctx)
     const candidates = []
     const missingPaths = []
@@ -292,6 +393,25 @@
     return ctx.fmt.planLabel(rawPlan) || null
   }
 
+  function readAccountLabel(ctx, auth) {
+    const token = auth && auth.tokens ? auth.tokens.id_token : null
+    const payload = token && ctx.jwt && typeof ctx.jwt.decodePayload === "function"
+      ? ctx.jwt.decodePayload(token)
+      : null
+    const email = payload && typeof payload.email === "string" ? payload.email.trim() : ""
+    if (email) return email
+
+    const name = payload && typeof payload.name === "string" ? payload.name.trim() : ""
+    if (name) return name
+
+    return null
+  }
+
+  function formatPlanWithAccount(accountLabel, planLabel) {
+    if (accountLabel && planLabel) return accountLabel + " - " + planLabel
+    return accountLabel || planLabel || null
+  }
+
   function getResetsAtIso(ctx, nowSec, window) {
     if (!window) return null
     if (typeof window.reset_at === "number") {
@@ -309,6 +429,9 @@
 
   function queryTokenUsage(ctx) {
     if (!ctx.host.ccusage || typeof ctx.host.ccusage.query !== "function") {
+      return { status: "no_runner", data: null }
+    }
+    if (isSecondaryCodexPlugin(ctx)) {
       return { status: "no_runner", data: null }
     }
 
@@ -621,7 +744,7 @@
       if (data.plan_type) {
         const planLabel = formatCodexPlan(ctx, data.plan_type)
         if (planLabel) {
-          plan = planLabel
+          plan = formatPlanWithAccount(readAccountLabel(ctx, auth), planLabel)
         }
       }
 

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -50,6 +50,11 @@
     return slot
   }
 
+  function readOpenUsageSlotHomePath(ctx) {
+    const slotName = readOpenUsageSlotName(ctx)
+    return slotName ? joinPath(OPENUSAGE_CODEX_ACCOUNTS_PATH, slotName) : null
+  }
+
   function isSecondaryCodexPlugin(ctx) {
     return Boolean(readOpenUsageSlotName(ctx))
   }
@@ -95,9 +100,9 @@
   }
 
   function resolveAuthPaths(ctx) {
-    const slotName = readOpenUsageSlotName(ctx)
-    if (slotName) {
-      return [joinPath(joinPath(OPENUSAGE_CODEX_ACCOUNTS_PATH, slotName), AUTH_FILE)]
+    const slotHomePath = readOpenUsageSlotHomePath(ctx)
+    if (slotHomePath) {
+      return [joinPath(slotHomePath, AUTH_FILE)]
     }
 
     const codexHome = readCodexHome(ctx)
@@ -356,9 +361,6 @@
     if (!ctx.host.ccusage || typeof ctx.host.ccusage.query !== "function") {
       return { status: "no_runner", data: null }
     }
-    if (isSecondaryCodexPlugin(ctx)) {
-      return { status: "no_runner", data: null }
-    }
 
     const since = new Date()
     // Inclusive range: today + previous 30 days = 31 calendar days.
@@ -368,7 +370,7 @@
     const d = since.getDate()
     const sinceStr = "" + y + (m < 10 ? "0" : "") + m + (d < 10 ? "0" : "") + d
     const queryOpts = { provider: "codex", since: sinceStr }
-    const codexHome = readCodexHome(ctx)
+    const codexHome = readOpenUsageSlotHomePath(ctx) || readCodexHome(ctx)
     if (codexHome) {
       queryOpts.homePath = codexHome
     }

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -370,7 +370,10 @@
     const d = since.getDate()
     const sinceStr = "" + y + (m < 10 ? "0" : "") + m + (d < 10 ? "0" : "") + d
     const queryOpts = { provider: "codex", since: sinceStr }
-    const codexHome = readOpenUsageSlotHomePath(ctx) || readCodexHome(ctx)
+    // Codex session logs are local CODEX_HOME state and are not reliably tied to
+    // an authenticated account email, so account slots intentionally share the
+    // same token usage source while quotas stay account-specific.
+    const codexHome = readCodexHome(ctx)
     if (codexHome) {
       queryOpts.homePath = codexHome
     }

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -717,12 +717,13 @@
           }
         }
 
-        if (totalTokens > 0) {
-          lines.push(ctx.line.text({
-            label: "Last 30 Days",
-            value: costAndTokensLabel({ tokens: totalTokens, costUSD: hasCost ? totalCostNanos / 1e9 : null })
-          }))
-        }
+        lines.push(ctx.line.text({
+          label: "Last 30 Days",
+          value: costAndTokensLabel(
+            { tokens: totalTokens, costUSD: hasCost ? totalCostNanos / 1e9 : 0 },
+            { includeZeroTokens: true }
+          )
+        }))
       }
 
       if (lines.length === 0) {

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -574,7 +574,10 @@ describe("codex plugin", () => {
     expect(yesterdayLine).toBeTruthy()
     expect(yesterdayLine.value).toContain("$0.00")
     expect(yesterdayLine.value).toContain("0 tokens")
-    expect(result.lines.find((l) => l.label === "Last 30 Days")).toBeUndefined()
+    const last30 = result.lines.find((l) => l.label === "Last 30 Days")
+    expect(last30).toBeTruthy()
+    expect(last30.value).toContain("$0.00")
+    expect(last30.value).toContain("0 tokens")
   })
 
   it("shows empty Yesterday state when yesterday's totals are zero (regression)", async () => {

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -6,6 +6,9 @@ const loadPlugin = async () => {
   return globalThis.__openusage_plugin
 }
 
+const makeIdToken = (payload) =>
+  `header.${Buffer.from(JSON.stringify(payload), "utf8").toString("base64url")}.signature`
+
 describe("codex plugin", () => {
   beforeEach(() => {
     delete globalThis.__openusage_plugin
@@ -253,6 +256,150 @@ describe("codex plugin", () => {
     const credits = result.lines.find((line) => line.label === "Credits")
     expect(credits).toBeTruthy()
     expect(credits.used).toBe(900)
+  })
+
+  it("prefixes plan with account email from id token", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: {
+        access_token: "token",
+        id_token: makeIdToken({ email: "oscar@example.com", name: "Oscar" }),
+      },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: { "x-codex-primary-used-percent": "10" },
+      bodyText: JSON.stringify({ plan_type: "pro" }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("oscar@example.com - Pro 20x")
+  })
+
+  it("loads Hermes OpenAI Codex auth for codex-hermes provider", async () => {
+    const ctx = makeCtx()
+    ctx.app.pluginId = "codex-hermes"
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "default-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.fs.writeText("~/.hermes/auth.json", JSON.stringify({
+      providers: {
+        "openai-codex": {
+          auth_mode: "chatgpt",
+          tokens: {
+            access_token: "hermes-token",
+            id_token: makeIdToken({ email: "hermes@example.com" }),
+            account_id: "hermes-account",
+          },
+          last_refresh: new Date().toISOString(),
+        },
+      },
+      credential_pool: {
+        "openai-codex": [
+          { access_token: "old", refresh_token: "old-refresh" },
+        ],
+      },
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      expect(opts.headers.Authorization).toBe("Bearer hermes-token")
+      expect(opts.headers["ChatGPT-Account-Id"]).toBe("hermes-account")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "7" },
+        bodyText: JSON.stringify({ plan_type: "pro" }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("hermes@example.com - Pro 20x")
+    expect(ctx.host.ccusage.query).not.toHaveBeenCalled()
+  })
+
+  it("loads OpenUsage Codex account slot auth without using default auth", async () => {
+    const ctx = makeCtx()
+    ctx.app.pluginId = "codex-slot-account-2"
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "default-token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.fs.writeText("~/.openusage/codex-accounts/account-2/auth.json", JSON.stringify({
+      tokens: {
+        access_token: "slot-token",
+        id_token: makeIdToken({ email: "slot@example.com" }),
+        account_id: "slot-account",
+      },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      expect(opts.headers.Authorization).toBe("Bearer slot-token")
+      expect(opts.headers["ChatGPT-Account-Id"]).toBe("slot-account")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "11" },
+        bodyText: JSON.stringify({ plan_type: "pro" }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("slot@example.com - Pro 20x")
+    expect(ctx.host.ccusage.query).not.toHaveBeenCalled()
+  })
+
+  it("persists refreshed Hermes OpenAI Codex tokens", async () => {
+    const ctx = makeCtx()
+    ctx.app.pluginId = "codex-hermes"
+    const nextIdToken = makeIdToken({ email: "hermes@example.com" })
+    ctx.host.fs.writeText("~/.hermes/auth.json", JSON.stringify({
+      providers: {
+        "openai-codex": {
+          auth_mode: "chatgpt",
+          tokens: {
+            access_token: "old",
+            refresh_token: "refresh",
+            id_token: makeIdToken({ email: "old@example.com" }),
+            account_id: "acc",
+          },
+          last_refresh: "2000-01-01T00:00:00.000Z",
+        },
+      },
+      credential_pool: {
+        "openai-codex": [
+          { access_token: "old", refresh_token: "refresh" },
+        ],
+      },
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            access_token: "new",
+            refresh_token: "new-refresh",
+            id_token: nextIdToken,
+          }),
+        }
+      }
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "1" },
+        bodyText: JSON.stringify({ plan_type: "pro" }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    const saved = JSON.parse(ctx.host.fs.readText("~/.hermes/auth.json"))
+    expect(saved.providers["openai-codex"].tokens.access_token).toBe("new")
+    expect(saved.providers["openai-codex"].tokens.refresh_token).toBe("new-refresh")
+    expect(saved.providers["openai-codex"].tokens.id_token).toBe(nextIdToken)
+    expect(saved.credential_pool["openai-codex"][0].access_token).toBe("new")
+    expect(saved.credential_pool["openai-codex"][0].refresh_token).toBe("new-refresh")
   })
 
   it("refreshes keychain auth and writes back to keychain", async () => {
@@ -644,6 +791,27 @@ describe("codex plugin", () => {
     })
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Token conflict")
+  })
+
+  it("uses account-neutral copy for codex-hermes token conflicts", async () => {
+    const ctx = makeCtx()
+    ctx.app.pluginId = "codex-hermes"
+    ctx.host.fs.writeText("~/.hermes/auth.json", JSON.stringify({
+      providers: {
+        "openai-codex": {
+          auth_mode: "chatgpt",
+          tokens: { access_token: "old", refresh_token: "refresh" },
+          last_refresh: "2000-01-01T00:00:00.000Z",
+        },
+      },
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 400,
+      headers: {},
+      bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+    })
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Log in to this Codex account again")
   })
 
   it("falls back to keychain when file refresh token was reused", async () => {

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -308,10 +308,10 @@ describe("codex plugin", () => {
     const result = plugin.probe(ctx)
     expect(result.plan).toBe("slot@example.com - Pro 20x")
     expect(ctx.host.ccusage.query).toHaveBeenCalled()
-    expect(ctx.host.ccusage.query.mock.calls[0][0].homePath).toBe("~/.openusage/codex-accounts/account-2")
+    expect(ctx.host.ccusage.query.mock.calls[0][0]).not.toHaveProperty("homePath")
   })
 
-  it("adds token lines from OpenUsage Codex account slot history", async () => {
+  it("adds shared token lines to OpenUsage Codex account slots", async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-02-20T16:00:00.000Z"))
 
@@ -358,7 +358,7 @@ describe("codex plugin", () => {
       expect(ctx.host.ccusage.query).toHaveBeenCalled()
       const firstCall = ctx.host.ccusage.query.mock.calls[0][0]
       expect(firstCall.provider).toBe("codex")
-      expect(firstCall.homePath).toBe("~/.openusage/codex-accounts/account-2")
+      expect(firstCall).not.toHaveProperty("homePath")
     } finally {
       vi.useRealTimers()
     }

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -302,11 +302,66 @@ describe("codex plugin", () => {
         bodyText: JSON.stringify({ plan_type: "pro" }),
       }
     })
+    ctx.host.ccusage.query.mockReturnValue({ status: "ok", data: { daily: [] } })
 
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.plan).toBe("slot@example.com - Pro 20x")
-    expect(ctx.host.ccusage.query).not.toHaveBeenCalled()
+    expect(ctx.host.ccusage.query).toHaveBeenCalled()
+    expect(ctx.host.ccusage.query.mock.calls[0][0].homePath).toBe("~/.openusage/codex-accounts/account-2")
+  })
+
+  it("adds token lines from OpenUsage Codex account slot history", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-02-20T16:00:00.000Z"))
+
+    const ctx = makeCtx()
+    ctx.app.pluginId = "codex-slot-account-2"
+    ctx.host.fs.writeText("~/.openusage/codex-accounts/account-2/auth.json", JSON.stringify({
+      tokens: {
+        access_token: "slot-token",
+        id_token: makeIdToken({ email: "slot@example.com" }),
+      },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: { "x-codex-primary-used-percent": "5" },
+      bodyText: JSON.stringify({ plan_type: "pro" }),
+    })
+    const now = new Date()
+    const month = now.toLocaleString("en-US", { month: "short" })
+    const day = String(now.getDate()).padStart(2, "0")
+    const year = now.getFullYear()
+    const todayKey = month + " " + day + ", " + year
+    ctx.host.ccusage.query.mockReturnValue({
+      status: "ok",
+      data: {
+        daily: [
+          { date: todayKey, totalTokens: 250, costUSD: 1.25 },
+        ],
+      },
+    })
+
+    try {
+      const plugin = await loadPlugin()
+      const result = plugin.probe(ctx)
+      const today = result.lines.find((line) => line.label === "Today")
+      expect(today).toBeTruthy()
+      expect(today.value).toContain("250 tokens")
+      expect(today.value).toContain("$1.25")
+
+      const last30 = result.lines.find((line) => line.label === "Last 30 Days")
+      expect(last30).toBeTruthy()
+      expect(last30.value).toContain("250 tokens")
+
+      expect(ctx.host.ccusage.query).toHaveBeenCalled()
+      const firstCall = ctx.host.ccusage.query.mock.calls[0][0]
+      expect(firstCall.provider).toBe("codex")
+      expect(firstCall.homePath).toBe("~/.openusage/codex-accounts/account-2")
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("persists refreshed OpenUsage Codex account slot tokens", async () => {

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -278,47 +278,6 @@ describe("codex plugin", () => {
     expect(result.plan).toBe("oscar@example.com - Pro 20x")
   })
 
-  it("loads Hermes OpenAI Codex auth for codex-hermes provider", async () => {
-    const ctx = makeCtx()
-    ctx.app.pluginId = "codex-hermes"
-    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
-      tokens: { access_token: "default-token" },
-      last_refresh: new Date().toISOString(),
-    }))
-    ctx.host.fs.writeText("~/.hermes/auth.json", JSON.stringify({
-      providers: {
-        "openai-codex": {
-          auth_mode: "chatgpt",
-          tokens: {
-            access_token: "hermes-token",
-            id_token: makeIdToken({ email: "hermes@example.com" }),
-            account_id: "hermes-account",
-          },
-          last_refresh: new Date().toISOString(),
-        },
-      },
-      credential_pool: {
-        "openai-codex": [
-          { access_token: "old", refresh_token: "old-refresh" },
-        ],
-      },
-    }))
-    ctx.host.http.request.mockImplementation((opts) => {
-      expect(opts.headers.Authorization).toBe("Bearer hermes-token")
-      expect(opts.headers["ChatGPT-Account-Id"]).toBe("hermes-account")
-      return {
-        status: 200,
-        headers: { "x-codex-primary-used-percent": "7" },
-        bodyText: JSON.stringify({ plan_type: "pro" }),
-      }
-    })
-
-    const plugin = await loadPlugin()
-    const result = plugin.probe(ctx)
-    expect(result.plan).toBe("hermes@example.com - Pro 20x")
-    expect(ctx.host.ccusage.query).not.toHaveBeenCalled()
-  })
-
   it("loads OpenUsage Codex account slot auth without using default auth", async () => {
     const ctx = makeCtx()
     ctx.app.pluginId = "codex-slot-account-2"
@@ -350,28 +309,19 @@ describe("codex plugin", () => {
     expect(ctx.host.ccusage.query).not.toHaveBeenCalled()
   })
 
-  it("persists refreshed Hermes OpenAI Codex tokens", async () => {
+  it("persists refreshed OpenUsage Codex account slot tokens", async () => {
     const ctx = makeCtx()
-    ctx.app.pluginId = "codex-hermes"
-    const nextIdToken = makeIdToken({ email: "hermes@example.com" })
-    ctx.host.fs.writeText("~/.hermes/auth.json", JSON.stringify({
-      providers: {
-        "openai-codex": {
-          auth_mode: "chatgpt",
-          tokens: {
-            access_token: "old",
-            refresh_token: "refresh",
-            id_token: makeIdToken({ email: "old@example.com" }),
-            account_id: "acc",
-          },
-          last_refresh: "2000-01-01T00:00:00.000Z",
-        },
+    ctx.app.pluginId = "codex-slot-account-2"
+    const authPath = "~/.openusage/codex-accounts/account-2/auth.json"
+    const nextIdToken = makeIdToken({ email: "slot@example.com" })
+    ctx.host.fs.writeText(authPath, JSON.stringify({
+      tokens: {
+        access_token: "old",
+        refresh_token: "refresh",
+        id_token: makeIdToken({ email: "old@example.com" }),
+        account_id: "acc",
       },
-      credential_pool: {
-        "openai-codex": [
-          { access_token: "old", refresh_token: "refresh" },
-        ],
-      },
+      last_refresh: "2000-01-01T00:00:00.000Z",
     }))
     ctx.host.http.request.mockImplementation((opts) => {
       if (String(opts.url).includes("oauth/token")) {
@@ -394,12 +344,10 @@ describe("codex plugin", () => {
     const plugin = await loadPlugin()
     plugin.probe(ctx)
 
-    const saved = JSON.parse(ctx.host.fs.readText("~/.hermes/auth.json"))
-    expect(saved.providers["openai-codex"].tokens.access_token).toBe("new")
-    expect(saved.providers["openai-codex"].tokens.refresh_token).toBe("new-refresh")
-    expect(saved.providers["openai-codex"].tokens.id_token).toBe(nextIdToken)
-    expect(saved.credential_pool["openai-codex"][0].access_token).toBe("new")
-    expect(saved.credential_pool["openai-codex"][0].refresh_token).toBe("new-refresh")
+    const saved = JSON.parse(ctx.host.fs.readText(authPath))
+    expect(saved.tokens.access_token).toBe("new")
+    expect(saved.tokens.refresh_token).toBe("new-refresh")
+    expect(saved.tokens.id_token).toBe(nextIdToken)
   })
 
   it("refreshes keychain auth and writes back to keychain", async () => {
@@ -793,17 +741,12 @@ describe("codex plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Token conflict")
   })
 
-  it("uses account-neutral copy for codex-hermes token conflicts", async () => {
+  it("uses account-neutral copy for account-slot token conflicts", async () => {
     const ctx = makeCtx()
-    ctx.app.pluginId = "codex-hermes"
-    ctx.host.fs.writeText("~/.hermes/auth.json", JSON.stringify({
-      providers: {
-        "openai-codex": {
-          auth_mode: "chatgpt",
-          tokens: { access_token: "old", refresh_token: "refresh" },
-          last_refresh: "2000-01-01T00:00:00.000Z",
-        },
-      },
+    ctx.app.pluginId = "codex-slot-account-2"
+    ctx.host.fs.writeText("~/.openusage/codex-accounts/account-2/auth.json", JSON.stringify({
+      tokens: { access_token: "old", refresh_token: "refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
     }))
     ctx.host.http.request.mockReturnValue({
       status: 400,

--- a/plugins/test-helpers.js
+++ b/plugins/test-helpers.js
@@ -7,6 +7,7 @@ export const makeCtx = () => {
   const ctx = {
     nowIso: "2026-02-02T00:00:00.000Z",
     app: {
+      pluginId: "codex",
       version: "0.0.0",
       platform: "darwin",
       appDataDir: "/tmp/openusage-test",

--- a/src-tauri/src/local_http_api/cache.rs
+++ b/src-tauri/src/local_http_api/cache.rs
@@ -6,7 +6,7 @@ use std::sync::{Mutex, OnceLock};
 
 const CACHE_FILE_NAME: &str = "usage-api-cache.json";
 const SETTINGS_FILE_NAME: &str = "settings.json";
-const DEFAULT_ENABLED_PLUGINS: &[&str] = &["claude", "codex", "cursor"];
+const DEFAULT_ENABLED_PLUGINS: &[&str] = &["claude", "cursor"];
 
 // ---------------------------------------------------------------------------
 // Types
@@ -166,13 +166,15 @@ fn read_plugin_settings(app_data_dir: &Path) -> (Vec<String>, HashSet<String>, b
 pub(super) fn enabled_snapshots_ordered(state: &CacheState) -> Vec<CachedPluginSnapshot> {
     let (settings_order, disabled, has_settings) = read_plugin_settings(&state.app_data_dir);
 
-    let default_enabled: HashSet<&str> = DEFAULT_ENABLED_PLUGINS.iter().copied().collect();
+    let is_default_enabled = |id: &str| -> bool {
+        DEFAULT_ENABLED_PLUGINS.contains(&id) || id == "codex" || id.starts_with("codex-")
+    };
 
     let is_enabled = |id: &str| -> bool {
         if has_settings {
             !disabled.contains(id)
         } else {
-            default_enabled.contains(id)
+            is_default_enabled(id)
         }
     };
 

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -522,6 +522,7 @@ pub fn inject_host_api<'js>(
     probe_ctx.set("nowIso", iso_now())?;
 
     let app_obj = Object::new(ctx.clone())?;
+    app_obj.set("pluginId", plugin_id)?;
     app_obj.set("version", app_version)?;
     app_obj.set("platform", std::env::consts::OS)?;
     app_obj.set("appDataDir", app_data_dir.to_string_lossy().to_string())?;

--- a/src-tauri/src/plugin_engine/mod.rs
+++ b/src-tauri/src/plugin_engine/mod.rs
@@ -70,18 +70,6 @@ fn add_codex_account_plugins(plugins: &mut Vec<LoadedPlugin>) {
         push_codex_account_plugin(plugins, &codex, plugin_id, account_label);
     }
 
-    let hermes_auth_path = home.join(".hermes").join("auth.json");
-    if let Some(hermes_account) = read_hermes_codex_account_label(&hermes_auth_path) {
-        if !account_exists(&known_accounts, &hermes_account) {
-            push_codex_account_plugin(
-                plugins,
-                &codex,
-                "codex-hermes".to_string(),
-                hermes_account,
-            );
-        }
-    }
-
     plugins.sort_by(|a, b| a.manifest.id.cmp(&b.manifest.id));
 }
 
@@ -163,17 +151,6 @@ fn read_primary_codex_account_label(home: &Path) -> Option<String> {
 fn read_codex_auth_account_label(auth_path: &Path) -> Option<String> {
     let root = read_json_file(auth_path)?;
     let id_token = root
-        .get("tokens")?
-        .get("id_token")?
-        .as_str()?;
-    account_label_from_id_token(id_token)
-}
-
-fn read_hermes_codex_account_label(auth_path: &Path) -> Option<String> {
-    let root = read_json_file(auth_path)?;
-    let id_token = root
-        .get("providers")?
-        .get("openai-codex")?
         .get("tokens")?
         .get("id_token")?
         .as_str()?;

--- a/src-tauri/src/plugin_engine/mod.rs
+++ b/src-tauri/src/plugin_engine/mod.rs
@@ -2,8 +2,15 @@ pub mod host_api;
 pub mod manifest;
 pub mod runtime;
 
+use base64::{
+    Engine as _,
+    engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
+};
 use manifest::LoadedPlugin;
 use std::path::{Path, PathBuf};
+
+const OPENUSAGE_CODEX_ACCOUNTS_DIR: &str = ".openusage/codex-accounts";
+const OPENUSAGE_SLOT_PLUGIN_PREFIX: &str = "codex-slot-";
 
 pub fn initialize_plugins(
     app_data_dir: &Path,
@@ -11,7 +18,8 @@ pub fn initialize_plugins(
 ) -> (PathBuf, Vec<LoadedPlugin>) {
     if let Some(dev_dir) = find_dev_plugins_dir() {
         if !is_dir_empty(&dev_dir) {
-            let plugins = manifest::load_plugins_from_dir(&dev_dir);
+            let mut plugins = manifest::load_plugins_from_dir(&dev_dir);
+            add_codex_account_plugins(&mut plugins);
             return (dev_dir, plugins);
         }
     }
@@ -30,8 +38,169 @@ pub fn initialize_plugins(
         copy_dir_recursive(&bundled_dir, &install_dir);
     }
 
-    let plugins = manifest::load_plugins_from_dir(&install_dir);
+    let mut plugins = manifest::load_plugins_from_dir(&install_dir);
+    add_codex_account_plugins(&mut plugins);
     (install_dir, plugins)
+}
+
+fn add_codex_account_plugins(plugins: &mut Vec<LoadedPlugin>) {
+    let Some(codex) = plugins
+        .iter()
+        .find(|plugin| plugin.manifest.id == "codex")
+        .cloned()
+    else {
+        return;
+    };
+
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+
+    let mut known_accounts = Vec::new();
+    if let Some(codex_account) = read_primary_codex_account_label(&home) {
+        known_accounts.push(codex_account);
+    }
+
+    for (slot_name, account_label) in read_openusage_codex_slots(&home) {
+        if account_exists(&known_accounts, &account_label) {
+            continue;
+        }
+        known_accounts.push(account_label.clone());
+        let plugin_id = format!("{}{}", OPENUSAGE_SLOT_PLUGIN_PREFIX, slot_name);
+        push_codex_account_plugin(plugins, &codex, plugin_id, account_label);
+    }
+
+    let hermes_auth_path = home.join(".hermes").join("auth.json");
+    if let Some(hermes_account) = read_hermes_codex_account_label(&hermes_auth_path) {
+        if !account_exists(&known_accounts, &hermes_account) {
+            push_codex_account_plugin(
+                plugins,
+                &codex,
+                "codex-hermes".to_string(),
+                hermes_account,
+            );
+        }
+    }
+
+    plugins.sort_by(|a, b| a.manifest.id.cmp(&b.manifest.id));
+}
+
+fn push_codex_account_plugin(
+    plugins: &mut Vec<LoadedPlugin>,
+    base: &LoadedPlugin,
+    plugin_id: String,
+    account_label: String,
+) {
+    if plugins.iter().any(|plugin| plugin.manifest.id == plugin_id) {
+        return;
+    }
+    let mut account_plugin = base.clone();
+    account_plugin.manifest.id = plugin_id;
+    account_plugin.manifest.name = account_label;
+    plugins.push(account_plugin);
+}
+
+fn account_exists(existing: &[String], candidate: &str) -> bool {
+    existing
+        .iter()
+        .any(|account| account.eq_ignore_ascii_case(candidate))
+}
+
+fn read_openusage_codex_slots(home: &Path) -> Vec<(String, String)> {
+    let accounts_dir = home.join(OPENUSAGE_CODEX_ACCOUNTS_DIR);
+    let Ok(entries) = std::fs::read_dir(accounts_dir) else {
+        return Vec::new();
+    };
+
+    let mut slots = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let slot_name = entry.file_name().to_string_lossy().to_string();
+        if !is_safe_slot_name(&slot_name) {
+            continue;
+        }
+        let auth_path = entry.path().join("auth.json");
+        if let Some(account_label) = read_codex_auth_account_label(&auth_path) {
+            slots.push((slot_name, account_label));
+        }
+    }
+    slots.sort_by(|a, b| a.0.cmp(&b.0));
+    slots
+}
+
+fn is_safe_slot_name(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn read_primary_codex_account_label(home: &Path) -> Option<String> {
+    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
+        let trimmed = codex_home.trim();
+        if !trimmed.is_empty() {
+            return read_codex_auth_account_label(&PathBuf::from(trimmed).join("auth.json"));
+        }
+    }
+
+    for auth_path in [
+        home.join(".config").join("codex").join("auth.json"),
+        home.join(".codex").join("auth.json"),
+    ] {
+        if let Some(label) = read_codex_auth_account_label(&auth_path) {
+            return Some(label);
+        }
+    }
+
+    None
+}
+
+fn read_codex_auth_account_label(auth_path: &Path) -> Option<String> {
+    let root = read_json_file(auth_path)?;
+    let id_token = root
+        .get("tokens")?
+        .get("id_token")?
+        .as_str()?;
+    account_label_from_id_token(id_token)
+}
+
+fn read_hermes_codex_account_label(auth_path: &Path) -> Option<String> {
+    let root = read_json_file(auth_path)?;
+    let id_token = root
+        .get("providers")?
+        .get("openai-codex")?
+        .get("tokens")?
+        .get("id_token")?
+        .as_str()?;
+    account_label_from_id_token(id_token)
+}
+
+fn read_json_file(path: &Path) -> Option<serde_json::Value> {
+    let text = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn account_label_from_id_token(id_token: &str) -> Option<String> {
+    let payload = id_token.split('.').nth(1)?;
+    let bytes = URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| URL_SAFE.decode(payload))
+        .ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    for key in ["email", "name"] {
+        if let Some(label) = value.get(key).and_then(|value| value.as_str()) {
+            let trimmed = label.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
 }
 
 fn find_dev_plugins_dir() -> Option<PathBuf> {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -671,6 +671,62 @@ describe("App", () => {
     await waitFor(() => expect(state.traySetTitleMock).toHaveBeenCalledWith("70%"))
   })
 
+  it("uses the selected Codex account for provider tray percent", async () => {
+    state.invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "list_plugins") {
+        return [
+          {
+            id: "codex",
+            name: "Codex",
+            iconUrl: "codex-icon",
+            primaryCandidates: ["Session"],
+            lines: [{ type: "progress", label: "Session", scope: "overview" }],
+          },
+          {
+            id: "codex-slot-account-2",
+            name: "oscar@example.com",
+            iconUrl: "codex-icon",
+            primaryCandidates: ["Session"],
+            lines: [{ type: "progress", label: "Session", scope: "overview" }],
+          },
+        ]
+      }
+      return null
+    })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({
+      order: ["codex", "codex-slot-account-2"],
+      disabled: [],
+    })
+    state.startBatchMock.mockResolvedValue(["codex", "codex-slot-account-2"])
+
+    render(<App />)
+    await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
+
+    state.probeHandlers?.onResult({
+      providerId: "codex",
+      displayName: "Codex",
+      plan: "lildev@example.com - Pro 20x",
+      iconUrl: "codex-icon",
+      lines: [{ type: "progress", label: "Session", used: 38, limit: 100, format: { kind: "percent" } }],
+    })
+    state.probeHandlers?.onResult({
+      providerId: "codex-slot-account-2",
+      displayName: "Codex",
+      plan: "oscar@example.com - Pro 20x",
+      iconUrl: "codex-icon",
+      lines: [{ type: "progress", label: "Session", used: 5, limit: 100, format: { kind: "percent" } }],
+    })
+
+    const accountSelect = await screen.findByRole("combobox", { name: "Account" })
+    await userEvent.selectOptions(accountSelect, "codex-slot-account-2")
+
+    await waitFor(() => {
+      const latestCall = state.renderTrayBarsIconMock.mock.calls.at(-1)?.[0]
+      expect(latestCall.bars).toEqual([{ id: "codex-slot-account-2", fraction: 0.95 }])
+    })
+    await waitFor(() => expect(state.traySetTitleMock).toHaveBeenCalledWith("95%"))
+  })
+
   it("covers about open/close callbacks", async () => {
     render(<App />)
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -22,6 +22,8 @@ const state = vi.hoisted(() => ({
   saveResetTimerDisplayModeMock: vi.fn(),
   loadMenubarIconStyleMock: vi.fn(),
   saveMenubarIconStyleMock: vi.fn(),
+  loadCodexMenubarShowAllAccountsMock: vi.fn(),
+  saveCodexMenubarShowAllAccountsMock: vi.fn(),
   migrateLegacyTraySettingsMock: vi.fn(),
   loadGlobalShortcutMock: vi.fn(),
   saveGlobalShortcutMock: vi.fn(),
@@ -234,6 +236,8 @@ vi.mock("@/lib/settings", async () => {
     saveResetTimerDisplayMode: state.saveResetTimerDisplayModeMock,
     loadMenubarIconStyle: state.loadMenubarIconStyleMock,
     saveMenubarIconStyle: state.saveMenubarIconStyleMock,
+    loadCodexMenubarShowAllAccounts: state.loadCodexMenubarShowAllAccountsMock,
+    saveCodexMenubarShowAllAccounts: state.saveCodexMenubarShowAllAccountsMock,
     migrateLegacyTraySettings: state.migrateLegacyTraySettingsMock,
     loadGlobalShortcut: state.loadGlobalShortcutMock,
     saveGlobalShortcut: state.saveGlobalShortcutMock,
@@ -273,6 +277,8 @@ describe("App", () => {
     state.saveResetTimerDisplayModeMock.mockReset()
     state.loadMenubarIconStyleMock.mockReset()
     state.saveMenubarIconStyleMock.mockReset()
+    state.loadCodexMenubarShowAllAccountsMock.mockReset()
+    state.saveCodexMenubarShowAllAccountsMock.mockReset()
     state.migrateLegacyTraySettingsMock.mockReset()
     state.loadGlobalShortcutMock.mockReset()
     state.saveGlobalShortcutMock.mockReset()
@@ -311,6 +317,8 @@ describe("App", () => {
     state.saveResetTimerDisplayModeMock.mockResolvedValue(undefined)
     state.loadMenubarIconStyleMock.mockResolvedValue("provider")
     state.saveMenubarIconStyleMock.mockResolvedValue(undefined)
+    state.loadCodexMenubarShowAllAccountsMock.mockResolvedValue(false)
+    state.saveCodexMenubarShowAllAccountsMock.mockResolvedValue(undefined)
     state.migrateLegacyTraySettingsMock.mockResolvedValue(undefined)
     state.loadGlobalShortcutMock.mockResolvedValue(null)
     state.saveGlobalShortcutMock.mockResolvedValue(undefined)
@@ -725,6 +733,65 @@ describe("App", () => {
       expect(latestCall.bars).toEqual([{ id: "codex-slot-account-2", fraction: 0.95 }])
     })
     await waitFor(() => expect(state.traySetTitleMock).toHaveBeenCalledWith("95%"))
+  })
+
+  it("can show all Codex account percents in provider tray mode", async () => {
+    state.invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "list_plugins") {
+        return [
+          {
+            id: "codex",
+            name: "Codex",
+            iconUrl: "codex-icon",
+            primaryCandidates: ["Session"],
+            lines: [{ type: "progress", label: "Session", scope: "overview" }],
+          },
+          {
+            id: "codex-slot-account-2",
+            name: "oscar@example.com",
+            iconUrl: "codex-icon",
+            primaryCandidates: ["Session"],
+            lines: [{ type: "progress", label: "Session", scope: "overview" }],
+          },
+        ]
+      }
+      return null
+    })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({
+      order: ["codex", "codex-slot-account-2"],
+      disabled: [],
+    })
+    state.startBatchMock.mockResolvedValue(["codex", "codex-slot-account-2"])
+
+    render(<App />)
+    await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
+
+    state.probeHandlers?.onResult({
+      providerId: "codex",
+      displayName: "Codex",
+      plan: "lildev@example.com - Pro 20x",
+      iconUrl: "codex-icon",
+      lines: [{ type: "progress", label: "Session", used: 38, limit: 100, format: { kind: "percent" } }],
+    })
+    state.probeHandlers?.onResult({
+      providerId: "codex-slot-account-2",
+      displayName: "Codex",
+      plan: "oscar@example.com - Pro 20x",
+      iconUrl: "codex-icon",
+      lines: [{ type: "progress", label: "Session", used: 5, limit: 100, format: { kind: "percent" } }],
+    })
+
+    await userEvent.click(await screen.findByRole("checkbox", { name: "Menu bar: all accounts" }))
+
+    await waitFor(() => {
+      const latestCall = state.renderTrayBarsIconMock.mock.calls.at(-1)?.[0]
+      expect(latestCall.bars).toEqual([
+        { id: "codex", fraction: 0.62 },
+        { id: "codex-slot-account-2", fraction: 0.95 },
+      ])
+    })
+    await waitFor(() => expect(state.traySetTitleMock).toHaveBeenCalledWith("62% 95%"))
+    expect(state.saveCodexMenubarShowAllAccountsMock).toHaveBeenCalledWith(true)
   })
 
   it("covers about open/close callbacks", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -790,7 +790,7 @@ describe("App", () => {
         { id: "codex-slot-account-2", fraction: 0.95 },
       ])
     })
-    await waitFor(() => expect(state.traySetTitleMock).toHaveBeenCalledWith("62% 95%"))
+    await waitFor(() => expect(state.traySetTitleMock).toHaveBeenCalledWith("62% | 95%"))
     expect(state.saveCodexMenubarShowAllAccountsMock).toHaveBeenCalledWith(true)
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,11 +23,15 @@ const TRAY_SETTINGS_DEBOUNCE_MS = 2000
 function App() {
   const {
     activeView,
+    selectedCodexProviderId,
     setActiveView,
+    setSelectedCodexProviderId,
   } = useAppUiStore(
     useShallow((state) => ({
       activeView: state.activeView,
+      selectedCodexProviderId: state.selectedCodexProviderId,
       setActiveView: state.setActiveView,
+      setSelectedCodexProviderId: state.setSelectedCodexProviderId,
     }))
   )
 
@@ -172,9 +176,10 @@ function App() {
     pluginsMeta,
   })
 
-  const { displayPlugins, navPlugins, selectedPlugin } = useAppPluginViews({
+  const { displayPlugins, navPlugins, selectedPlugin, codexAccountOptions } = useAppPluginViews({
     activeView,
     setActiveView,
+    selectedCodexProviderId,
     pluginSettings,
     pluginsMeta,
     pluginStates,
@@ -250,6 +255,8 @@ function App() {
         traySettingsPreview,
         onGlobalShortcutChange: handleGlobalShortcutChange,
         onStartOnLoginChange: handleStartOnLoginChange,
+        codexAccountOptions,
+        onCodexAccountChange: setSelectedCodexProviderId,
       }}
     />
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,8 @@ function App() {
     setDisplayMode,
     menubarIconStyle,
     setMenubarIconStyle,
+    codexMenubarShowAllAccounts,
+    setCodexMenubarShowAllAccounts,
     resetTimerDisplayMode,
     setResetTimerDisplayMode,
     setGlobalShortcut,
@@ -72,6 +74,8 @@ function App() {
       setDisplayMode: state.setDisplayMode,
       menubarIconStyle: state.menubarIconStyle,
       setMenubarIconStyle: state.setMenubarIconStyle,
+      codexMenubarShowAllAccounts: state.codexMenubarShowAllAccounts,
+      setCodexMenubarShowAllAccounts: state.setCodexMenubarShowAllAccounts,
       resetTimerDisplayMode: state.resetTimerDisplayMode,
       setResetTimerDisplayMode: state.setResetTimerDisplayMode,
       setGlobalShortcut: state.setGlobalShortcut,
@@ -107,6 +111,7 @@ function App() {
     menubarIconStyle,
     activeView,
     selectedCodexProviderId,
+    codexMenubarShowAllAccounts,
   })
 
   useEffect(() => {
@@ -122,6 +127,7 @@ function App() {
     setThemeMode,
     setDisplayMode,
     setMenubarIconStyle,
+    setCodexMenubarShowAllAccounts,
     setResetTimerDisplayMode,
     setGlobalShortcut,
     setStartOnLogin,
@@ -138,12 +144,14 @@ function App() {
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleMenubarIconStyleChange,
+    handleCodexMenubarShowAllAccountsChange,
   } = useSettingsDisplayActions({
     setThemeMode,
     setDisplayMode,
     resetTimerDisplayMode,
     setResetTimerDisplayMode,
     setMenubarIconStyle,
+    setCodexMenubarShowAllAccounts,
     scheduleTrayIconUpdate,
   })
 
@@ -253,6 +261,8 @@ function App() {
         onResetTimerDisplayModeChange: handleResetTimerDisplayModeChange,
         onResetTimerDisplayModeToggle: handleResetTimerDisplayModeToggle,
         onMenubarIconStyleChange: handleMenubarIconStyleChange,
+        codexMenubarShowAllAccounts,
+        onCodexMenubarShowAllAccountsChange: handleCodexMenubarShowAllAccountsChange,
         traySettingsPreview,
         onGlobalShortcutChange: handleGlobalShortcutChange,
         onStartOnLoginChange: handleStartOnLoginChange,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,6 +106,7 @@ function App() {
     displayMode,
     menubarIconStyle,
     activeView,
+    selectedCodexProviderId,
   })
 
   useEffect(() => {

--- a/src/components/app/app-content.test.tsx
+++ b/src/components/app/app-content.test.tsx
@@ -65,6 +65,8 @@ function createProps(): AppContentProps {
     onResetTimerDisplayModeToggle: vi.fn(),
     onGlobalShortcutChange: vi.fn(),
     onStartOnLoginChange: vi.fn(),
+    codexAccountOptions: [],
+    onCodexAccountChange: vi.fn(),
   }
 }
 

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -37,6 +37,8 @@ export type AppContentActionProps = {
   onStartOnLoginChange: (value: boolean) => void
   codexAccountOptions: AccountOption[]
   onCodexAccountChange: (providerId: string) => void
+  codexMenubarShowAllAccounts?: boolean
+  onCodexMenubarShowAllAccountsChange?: (value: boolean) => void
 }
 
 export type AppContentProps = AppContentDerivedProps & AppContentActionProps
@@ -59,6 +61,8 @@ export function AppContent({
   onStartOnLoginChange,
   codexAccountOptions,
   onCodexAccountChange,
+  codexMenubarShowAllAccounts = false,
+  onCodexMenubarShowAllAccountsChange,
 }: AppContentProps) {
   const { activeView } = useAppUiStore(
     useShallow((state) => ({
@@ -96,6 +100,8 @@ export function AppContent({
         onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
         codexAccountOptions={codexAccountOptions}
         onCodexAccountChange={onCodexAccountChange}
+        codexMenubarShowAllAccounts={codexMenubarShowAllAccounts}
+        onCodexMenubarShowAllAccountsChange={onCodexMenubarShowAllAccountsChange}
       />
     )
   }
@@ -134,6 +140,8 @@ export function AppContent({
       plugin={selectedPlugin}
       planOptions={selectedPlugin?.meta.id === "codex" ? codexAccountOptions : []}
       onPlanOptionChange={onCodexAccountChange}
+      codexMenubarShowAllAccounts={codexMenubarShowAllAccounts}
+      onCodexMenubarShowAllAccountsChange={onCodexMenubarShowAllAccountsChange}
       onRetry={handleRetry}
       displayMode={displayMode}
       resetTimerDisplayMode={resetTimerDisplayMode}

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -2,7 +2,7 @@ import { useShallow } from "zustand/react/shallow"
 import { OverviewPage } from "@/pages/overview"
 import { ProviderDetailPage } from "@/pages/provider-detail"
 import { SettingsPage } from "@/pages/settings"
-import type { DisplayPluginState } from "@/hooks/app/use-app-plugin-views"
+import type { AccountOption, DisplayPluginState } from "@/hooks/app/use-app-plugin-views"
 import type { SettingsPluginState } from "@/hooks/app/use-settings-plugin-list"
 import type { TraySettingsPreview } from "@/hooks/app/use-tray-icon"
 import { useAppPreferencesStore } from "@/stores/app-preferences-store"
@@ -35,6 +35,8 @@ export type AppContentActionProps = {
   traySettingsPreview: TraySettingsPreview
   onGlobalShortcutChange: (value: GlobalShortcut) => void
   onStartOnLoginChange: (value: boolean) => void
+  codexAccountOptions: AccountOption[]
+  onCodexAccountChange: (providerId: string) => void
 }
 
 export type AppContentProps = AppContentDerivedProps & AppContentActionProps
@@ -55,6 +57,8 @@ export function AppContent({
   traySettingsPreview,
   onGlobalShortcutChange,
   onStartOnLoginChange,
+  codexAccountOptions,
+  onCodexAccountChange,
 }: AppContentProps) {
   const { activeView } = useAppUiStore(
     useShallow((state) => ({
@@ -90,6 +94,8 @@ export function AppContent({
         displayMode={displayMode}
         resetTimerDisplayMode={resetTimerDisplayMode}
         onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+        codexAccountOptions={codexAccountOptions}
+        onCodexAccountChange={onCodexAccountChange}
       />
     )
   }
@@ -120,12 +126,14 @@ export function AppContent({
   }
 
   const handleRetry = selectedPlugin
-    ? () => onRetryPlugin(selectedPlugin.meta.id)
+    ? () => onRetryPlugin(selectedPlugin.sourceProviderId ?? selectedPlugin.meta.id)
     : /* v8 ignore next */ undefined
 
   return (
     <ProviderDetailPage
       plugin={selectedPlugin}
+      planOptions={selectedPlugin?.meta.id === "codex" ? codexAccountOptions : []}
+      onPlanOptionChange={onCodexAccountChange}
       onRetry={handleRetry}
       displayMode={displayMode}
       resetTimerDisplayMode={resetTimerDisplayMode}

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -60,6 +60,30 @@ describe("ProviderCard", () => {
     expect(onRetry).toHaveBeenCalledTimes(1)
   })
 
+  it("keeps account selector visible when selected account has no usage data", async () => {
+    const onPlanOptionChange = vi.fn()
+    render(
+      <ProviderCard
+        name="Codex"
+        providerId="codex-account-2"
+        displayMode="used"
+        error="Token conflict"
+        planOptions={[
+          { providerId: "codex", label: "lildev@example.com - Pro 20x" },
+          { providerId: "codex-account-2", label: "oscar@example.com" },
+        ]}
+        onPlanOptionChange={onPlanOptionChange}
+      />
+    )
+
+    const accountSelect = screen.getByRole("combobox", { name: "Account" })
+    expect(accountSelect).toHaveValue("codex-account-2")
+    expect(screen.getByText("Token conflict")).toBeInTheDocument()
+
+    await userEvent.selectOptions(accountSelect, "codex")
+    expect(onPlanOptionChange).toHaveBeenCalledWith("codex")
+  })
+
   it("renders loading skeleton", () => {
     render(
       <ProviderCard

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -84,6 +84,28 @@ describe("ProviderCard", () => {
     expect(onPlanOptionChange).toHaveBeenCalledWith("codex")
   })
 
+  it("lets long account labels use the full card width", () => {
+    const label = "lildev.lehuu@gmail.com - Pro 20x"
+    render(
+      <ProviderCard
+        name="Codex"
+        providerId="codex"
+        displayMode="used"
+        planOptions={[
+          { providerId: "codex", label },
+          { providerId: "codex-slot-account-2", label: "oscar.lehuu@gmail.com - Pro 20x" },
+        ]}
+        onPlanOptionChange={vi.fn()}
+      />
+    )
+
+    const accountSelect = screen.getByRole("combobox", { name: "Account" })
+    expect(accountSelect).toHaveAttribute("title", label)
+    expect(accountSelect).toHaveClass("w-full")
+    expect(accountSelect).toHaveClass("max-w-full")
+    expect(accountSelect).not.toHaveClass("max-w-[52%]")
+  })
+
   it("renders loading skeleton", () => {
     render(
       <ProviderCard

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -106,6 +106,27 @@ describe("ProviderCard", () => {
     expect(accountSelect).not.toHaveClass("max-w-[52%]")
   })
 
+  it("renders Codex menu bar account toggle for account selector", async () => {
+    const onCodexMenubarShowAllAccountsChange = vi.fn()
+    render(
+      <ProviderCard
+        name="Codex"
+        providerId="codex"
+        displayMode="used"
+        planOptions={[
+          { providerId: "codex", label: "lildev@example.com - Pro 20x" },
+          { providerId: "codex-slot-account-2", label: "oscar@example.com - Pro 20x" },
+        ]}
+        onPlanOptionChange={vi.fn()}
+        codexMenubarShowAllAccounts={false}
+        onCodexMenubarShowAllAccountsChange={onCodexMenubarShowAllAccountsChange}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "Menu bar: all accounts" }))
+    expect(onCodexMenubarShowAllAccountsChange).toHaveBeenCalledWith(true)
+  })
+
   it("renders loading skeleton", () => {
     render(
       <ProviderCard

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -19,7 +19,10 @@ import { formatResetAbsoluteLabel, formatResetRelativeLabel, formatResetTooltipT
 
 interface ProviderCardProps {
   name: string
+  providerId?: string
   plan?: string
+  planOptions?: { providerId: string; label: string }[]
+  onPlanOptionChange?: (providerId: string) => void
   links?: PluginLink[]
   showSeparator?: boolean
   loading?: boolean
@@ -93,7 +96,10 @@ function formatRelativeTime(diffMs: number): string {
 
 export function ProviderCard({
   name,
+  providerId,
   plan,
+  planOptions = [],
+  onPlanOptionChange,
   links = [],
   showSeparator = true,
   loading = false,
@@ -163,6 +169,14 @@ export function ProviderCard({
         ),
     [links]
   )
+
+  const selectedPlanLabel = plan
+    ?? planOptions.find((option) => option.providerId === providerId)?.label
+    ?? null
+  const showPlanSelector = planOptions.length > 1 && Boolean(providerId) && Boolean(onPlanOptionChange)
+  const handlePlanOptionChange = (value: string) => {
+    if (onPlanOptionChange) onPlanOptionChange(value)
+  }
 
   // Format remaining cooldown time as "Xm Ys"
   const formatRemainingTime = () => {
@@ -247,15 +261,29 @@ export function ProviderCard({
               )
             )}
           </div>
-          {plan && (
+          {showPlanSelector ? (
+            <select
+              aria-label="Account"
+              className="h-6 max-w-[52%] min-w-0 rounded-md border bg-transparent px-2 py-0.5 text-xs font-medium text-foreground outline-none"
+              title={selectedPlanLabel ?? undefined}
+              value={providerId}
+              onChange={(event) => handlePlanOptionChange(event.target.value)}
+            >
+              {planOptions.map((option) => (
+                <option key={option.providerId} value={option.providerId}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          ) : selectedPlanLabel ? (
             <Badge
               variant="outline"
               className="truncate min-w-0 max-w-[40%]"
-              title={plan}
+              title={selectedPlanLabel}
             >
-              {plan}
+              {selectedPlanLabel}
             </Badge>
-          )}
+          ) : null}
         </div>
         {visibleLinks.length > 0 && (
           <div className="mb-2 -mt-0.5 flex flex-wrap gap-1.5">

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, ExternalLink, Hourglass, RefreshCw } from "lucide-react"
 import { openUrl } from "@tauri-apps/plugin-opener"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Progress } from "@/components/ui/progress"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -36,6 +37,8 @@ interface ProviderCardProps {
   displayMode: DisplayMode
   resetTimerDisplayMode?: ResetTimerDisplayMode
   onResetTimerDisplayModeToggle?: () => void
+  codexMenubarShowAllAccounts?: boolean
+  onCodexMenubarShowAllAccountsChange?: (value: boolean) => void
 }
 
 const PACE_VISUALS: Record<PaceStatus, { dotClass: string }> = {
@@ -113,6 +116,8 @@ export function ProviderCard({
   displayMode,
   resetTimerDisplayMode = "relative",
   onResetTimerDisplayModeToggle,
+  codexMenubarShowAllAccounts = false,
+  onCodexMenubarShowAllAccountsChange,
 }: ProviderCardProps) {
   const cooldownRemainingMs = useMemo(() => {
     if (!lastManualRefreshAt) return 0
@@ -174,6 +179,7 @@ export function ProviderCard({
     ?? planOptions.find((option) => option.providerId === providerId)?.label
     ?? null
   const showPlanSelector = planOptions.length > 1 && Boolean(providerId) && Boolean(onPlanOptionChange)
+  const showCodexMenubarToggle = showPlanSelector && Boolean(onCodexMenubarShowAllAccountsChange)
   const handlePlanOptionChange = (value: string) => {
     if (onPlanOptionChange) onPlanOptionChange(value)
   }
@@ -285,6 +291,20 @@ export function ProviderCard({
             </Badge>
           ) : null}
         </div>
+        {showCodexMenubarToggle && (
+          <label className="mb-2 -mt-0.5 flex min-h-6 items-center gap-2 text-xs text-muted-foreground">
+            <Checkbox
+              aria-label="Menu bar: all accounts"
+              checked={codexMenubarShowAllAccounts}
+              onCheckedChange={(checked) => {
+                if (onCodexMenubarShowAllAccountsChange) {
+                  onCodexMenubarShowAllAccountsChange(Boolean(checked))
+                }
+              }}
+            />
+            <span>Menu bar: all accounts</span>
+          </label>
+        )}
         {visibleLinks.length > 0 && (
           <div className="mb-2 -mt-0.5 flex flex-wrap gap-1.5">
             {visibleLinks.map((link) => (

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -195,8 +195,8 @@ export function ProviderCard({
   return (
     <div>
       <div className="py-3">
-        <div className="flex items-center justify-between mb-2">
-          <div className="relative flex items-center">
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-x-2 gap-y-1">
+          <div className="relative flex min-w-0 items-center">
             <h2 className="text-lg font-semibold" style={{ transform: "translateZ(0)" }}>{name}</h2>
             {onRetry && (
               loading ? (
@@ -264,7 +264,7 @@ export function ProviderCard({
           {showPlanSelector ? (
             <select
               aria-label="Account"
-              className="h-6 max-w-[52%] min-w-0 rounded-md border bg-transparent px-2 py-0.5 text-xs font-medium text-foreground outline-none"
+              className="ml-auto h-6 w-full min-w-0 max-w-full rounded-md border bg-transparent px-2 py-0.5 text-xs font-medium text-foreground outline-none"
               title={selectedPlanLabel ?? undefined}
               value={providerId}
               onChange={(event) => handlePlanOptionChange(event.target.value)}
@@ -278,7 +278,7 @@ export function ProviderCard({
           ) : selectedPlanLabel ? (
             <Badge
               variant="outline"
-              className="truncate min-w-0 max-w-[40%]"
+              className="ml-auto min-w-0 max-w-full truncate"
               title={selectedPlanLabel}
             >
               {selectedPlanLabel}

--- a/src/hooks/app/use-app-plugin-views.test.ts
+++ b/src/hooks/app/use-app-plugin-views.test.ts
@@ -31,6 +31,7 @@ describe("useAppPluginViews", () => {
       useAppPluginViews({
         activeView: "home",
         setActiveView: vi.fn(),
+        selectedCodexProviderId: null,
         pluginSettings,
         pluginsMeta,
         pluginStates: {
@@ -69,6 +70,7 @@ describe("useAppPluginViews", () => {
       useAppPluginViews({
         activeView: "codex",
         setActiveView,
+        selectedCodexProviderId: null,
         pluginSettings,
         pluginsMeta: [createPluginMeta("codex", "Codex")],
         pluginStates: {},
@@ -88,6 +90,7 @@ describe("useAppPluginViews", () => {
         useAppPluginViews({
           activeView: "codex",
           setActiveView,
+          selectedCodexProviderId: null,
           pluginSettings,
           pluginsMeta,
           pluginStates: {},
@@ -119,6 +122,7 @@ describe("useAppPluginViews", () => {
       useAppPluginViews({
         activeView: "codex",
         setActiveView: vi.fn(),
+        selectedCodexProviderId: null,
         pluginSettings,
         pluginsMeta: [createPluginMeta("codex", "Codex")],
         pluginStates: {},
@@ -126,5 +130,43 @@ describe("useAppPluginViews", () => {
     )
 
     expect(result.current.selectedPlugin?.meta.id).toBe("codex")
+  })
+
+  it("groups multiple Codex account providers into one nav and display item", () => {
+    const pluginSettings: PluginSettings = {
+      order: ["codex", "codex-hermes", "cursor"],
+      disabled: [],
+    }
+
+    const pluginsMeta = [
+      createPluginMeta("codex", "Codex"),
+      createPluginMeta("codex-hermes", "Codex"),
+      createPluginMeta("cursor", "Cursor"),
+    ]
+
+    const { result } = renderHook(() =>
+      useAppPluginViews({
+        activeView: "home",
+        setActiveView: vi.fn(),
+        selectedCodexProviderId: "codex-hermes",
+        pluginSettings,
+        pluginsMeta,
+        pluginStates: {
+          "codex-hermes": {
+            data: { providerId: "codex-hermes", displayName: "Codex", plan: "other@example.com - Pro 20x", lines: [], iconUrl: "" },
+            loading: false,
+            error: null,
+            lastManualRefreshAt: null,
+            lastUpdatedAt: 1,
+          },
+        },
+      })
+    )
+
+    expect(result.current.navPlugins.map((plugin) => plugin.id)).toEqual(["codex", "cursor"])
+    expect(result.current.displayPlugins.map((plugin) => plugin.meta.id)).toEqual(["codex", "cursor"])
+    expect(result.current.displayPlugins[0]?.sourceProviderId).toBe("codex-hermes")
+    expect(result.current.displayPlugins[0]?.data?.plan).toBe("other@example.com - Pro 20x")
+    expect(result.current.codexAccountOptions.map((option) => option.providerId)).toEqual(["codex", "codex-hermes"])
   })
 })

--- a/src/hooks/app/use-app-plugin-views.test.ts
+++ b/src/hooks/app/use-app-plugin-views.test.ts
@@ -134,13 +134,13 @@ describe("useAppPluginViews", () => {
 
   it("groups multiple Codex account providers into one nav and display item", () => {
     const pluginSettings: PluginSettings = {
-      order: ["codex", "codex-hermes", "cursor"],
+      order: ["codex", "codex-slot-account-2", "cursor"],
       disabled: [],
     }
 
     const pluginsMeta = [
       createPluginMeta("codex", "Codex"),
-      createPluginMeta("codex-hermes", "Codex"),
+      createPluginMeta("codex-slot-account-2", "Codex"),
       createPluginMeta("cursor", "Cursor"),
     ]
 
@@ -148,12 +148,12 @@ describe("useAppPluginViews", () => {
       useAppPluginViews({
         activeView: "home",
         setActiveView: vi.fn(),
-        selectedCodexProviderId: "codex-hermes",
+        selectedCodexProviderId: "codex-slot-account-2",
         pluginSettings,
         pluginsMeta,
         pluginStates: {
-          "codex-hermes": {
-            data: { providerId: "codex-hermes", displayName: "Codex", plan: "other@example.com - Pro 20x", lines: [], iconUrl: "" },
+          "codex-slot-account-2": {
+            data: { providerId: "codex-slot-account-2", displayName: "Codex", plan: "other@example.com - Pro 20x", lines: [], iconUrl: "" },
             loading: false,
             error: null,
             lastManualRefreshAt: null,
@@ -165,8 +165,8 @@ describe("useAppPluginViews", () => {
 
     expect(result.current.navPlugins.map((plugin) => plugin.id)).toEqual(["codex", "cursor"])
     expect(result.current.displayPlugins.map((plugin) => plugin.meta.id)).toEqual(["codex", "cursor"])
-    expect(result.current.displayPlugins[0]?.sourceProviderId).toBe("codex-hermes")
+    expect(result.current.displayPlugins[0]?.sourceProviderId).toBe("codex-slot-account-2")
     expect(result.current.displayPlugins[0]?.data?.plan).toBe("other@example.com - Pro 20x")
-    expect(result.current.codexAccountOptions.map((option) => option.providerId)).toEqual(["codex", "codex-hermes"])
+    expect(result.current.codexAccountOptions.map((option) => option.providerId)).toEqual(["codex", "codex-slot-account-2"])
   })
 })

--- a/src/hooks/app/use-app-plugin-views.ts
+++ b/src/hooks/app/use-app-plugin-views.ts
@@ -1,59 +1,131 @@
 import { useEffect, useMemo } from "react"
 import type { ActiveView, NavPlugin } from "@/components/side-nav"
-import type { PluginMeta } from "@/lib/plugin-types"
+import { CODEX_GROUP_ID, isCodexAccountProviderId, type PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 import type { PluginState } from "@/hooks/app/types"
 
-export type DisplayPluginState = { meta: PluginMeta } & PluginState
+export type AccountOption = { providerId: string; label: string }
+export type DisplayPluginState = { meta: PluginMeta; sourceProviderId?: string } & PluginState
 
 type UseAppPluginViewsArgs = {
   activeView: ActiveView
   setActiveView: (view: ActiveView) => void
+  selectedCodexProviderId: string | null
   pluginSettings: PluginSettings | null
   pluginsMeta: PluginMeta[]
   pluginStates: Record<string, PluginState>
 }
 
+function emptyState(): PluginState {
+  return { data: null, loading: false, error: null, lastManualRefreshAt: null, lastUpdatedAt: null }
+}
+
 export function useAppPluginViews({
   activeView,
   setActiveView,
+  selectedCodexProviderId,
   pluginSettings,
   pluginsMeta,
   pluginStates,
 }: UseAppPluginViewsArgs) {
-  const displayPlugins = useMemo<DisplayPluginState[]>(() => {
+  const enabledIds = useMemo(() => {
     if (!pluginSettings) return []
     const disabledSet = new Set(pluginSettings.disabled)
-    const metaById = new Map(pluginsMeta.map((plugin) => [plugin.id, plugin]))
+    return pluginSettings.order.filter((id) => !disabledSet.has(id))
+  }, [pluginSettings])
 
-    return pluginSettings.order
-      .filter((id) => !disabledSet.has(id))
-      .map((id) => {
-        const meta = metaById.get(id)
-        if (!meta) return null
-        const state =
-          pluginStates[id] ?? { data: null, loading: false, error: null, lastManualRefreshAt: null, lastUpdatedAt: null }
-        return { meta, ...state }
-      })
-      .filter((plugin): plugin is DisplayPluginState => Boolean(plugin))
-  }, [pluginSettings, pluginStates, pluginsMeta])
+  const metaById = useMemo(
+    () => new Map(pluginsMeta.map((plugin) => [plugin.id, plugin])),
+    [pluginsMeta]
+  )
+
+  const enabledCodexIds = useMemo(
+    () => enabledIds.filter((id) => isCodexAccountProviderId(id) && metaById.has(id)),
+    [enabledIds, metaById]
+  )
+
+  const activeCodexProviderId = useMemo(() => {
+    if (selectedCodexProviderId && enabledCodexIds.includes(selectedCodexProviderId)) {
+      return selectedCodexProviderId
+    }
+    return enabledCodexIds[0] ?? CODEX_GROUP_ID
+  }, [enabledCodexIds, selectedCodexProviderId])
+
+  const displayPlugins = useMemo<DisplayPluginState[]>(() => {
+    if (!pluginSettings) return []
+    const out: DisplayPluginState[] = []
+    let addedCodex = false
+
+    for (const id of enabledIds) {
+      if (isCodexAccountProviderId(id)) {
+        if (addedCodex) continue
+        addedCodex = true
+        const selectedMeta = metaById.get(activeCodexProviderId) ?? metaById.get(CODEX_GROUP_ID)
+        if (!selectedMeta) continue
+        const baseMeta = metaById.get(CODEX_GROUP_ID) ?? selectedMeta
+        const state = pluginStates[activeCodexProviderId] ?? emptyState()
+        out.push({
+          ...state,
+          sourceProviderId: activeCodexProviderId,
+          meta: {
+            ...baseMeta,
+            id: CODEX_GROUP_ID,
+            name: "Codex",
+          },
+        })
+        continue
+      }
+
+      const meta = metaById.get(id)
+      if (!meta) continue
+      const state = pluginStates[id] ?? emptyState()
+      out.push({ meta, ...state })
+    }
+
+    return out
+  }, [activeCodexProviderId, enabledIds, metaById, pluginSettings, pluginStates])
 
   const navPlugins = useMemo<NavPlugin[]>(() => {
     if (!pluginSettings) return []
-    const disabledSet = new Set(pluginSettings.disabled)
-    const metaById = new Map(pluginsMeta.map((plugin) => [plugin.id, plugin]))
+    const out: NavPlugin[] = []
+    let addedCodex = false
 
-    return pluginSettings.order
-      .filter((id) => !disabledSet.has(id))
-      .map((id) => metaById.get(id))
-      .filter((plugin): plugin is PluginMeta => Boolean(plugin))
-      .map((plugin) => ({
+    for (const id of enabledIds) {
+      const plugin = metaById.get(id)
+      if (!plugin) continue
+      if (isCodexAccountProviderId(id)) {
+        if (addedCodex) continue
+        addedCodex = true
+        const baseMeta = metaById.get(CODEX_GROUP_ID) ?? plugin
+        out.push({
+          id: CODEX_GROUP_ID,
+          name: "Codex",
+          iconUrl: baseMeta.iconUrl,
+          brandColor: baseMeta.brandColor,
+        })
+        continue
+      }
+      out.push({
         id: plugin.id,
         name: plugin.name,
         iconUrl: plugin.iconUrl,
         brandColor: plugin.brandColor,
-      }))
-  }, [pluginSettings, pluginsMeta])
+      })
+    }
+
+    return out
+  }, [enabledIds, metaById, pluginSettings])
+
+  const codexAccountOptions = useMemo<AccountOption[]>(() => {
+    return enabledCodexIds.map((id) => {
+      const meta = metaById.get(id)
+      const state = pluginStates[id]
+      return {
+        providerId: id,
+        label: state?.data?.plan ?? meta?.name ?? "Codex",
+      }
+    })
+  }, [enabledCodexIds, metaById, pluginStates])
 
   useEffect(() => {
     if (activeView === "home" || activeView === "settings") return
@@ -75,5 +147,6 @@ export function useAppPluginViews({
     displayPlugins,
     navPlugins,
     selectedPlugin,
+    codexAccountOptions,
   }
 }

--- a/src/hooks/app/use-settings-bootstrap.test.ts
+++ b/src/hooks/app/use-settings-bootstrap.test.ts
@@ -10,6 +10,7 @@ const {
   isAutostartEnabledMock,
   isTauriMock,
   loadAutoUpdateIntervalMock,
+  loadCodexMenubarShowAllAccountsMock,
   loadDisplayModeMock,
   loadGlobalShortcutMock,
   loadMenubarIconStyleMock,
@@ -29,6 +30,7 @@ const {
   arePluginSettingsEqualMock: vi.fn(),
   getEnabledPluginIdsMock: vi.fn(),
   loadAutoUpdateIntervalMock: vi.fn(),
+  loadCodexMenubarShowAllAccountsMock: vi.fn(),
   loadDisplayModeMock: vi.fn(),
   loadGlobalShortcutMock: vi.fn(),
   loadMenubarIconStyleMock: vi.fn(),
@@ -55,6 +57,7 @@ vi.mock("@tauri-apps/plugin-autostart", () => ({
 vi.mock("@/lib/settings", () => ({
   arePluginSettingsEqual: arePluginSettingsEqualMock,
   DEFAULT_AUTO_UPDATE_INTERVAL: 15,
+  DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS: false,
   DEFAULT_DISPLAY_MODE: "left",
   DEFAULT_GLOBAL_SHORTCUT: null,
   DEFAULT_MENUBAR_ICON_STYLE: "provider",
@@ -63,6 +66,7 @@ vi.mock("@/lib/settings", () => ({
   DEFAULT_THEME_MODE: "system",
   getEnabledPluginIds: getEnabledPluginIdsMock,
   loadAutoUpdateInterval: loadAutoUpdateIntervalMock,
+  loadCodexMenubarShowAllAccounts: loadCodexMenubarShowAllAccountsMock,
   loadDisplayMode: loadDisplayModeMock,
   loadGlobalShortcut: loadGlobalShortcutMock,
   loadMenubarIconStyle: loadMenubarIconStyleMock,
@@ -88,6 +92,7 @@ function createArgs() {
     setGlobalShortcut: vi.fn(),
     setStartOnLogin: vi.fn(),
     setMenubarIconStyle: vi.fn(),
+    setCodexMenubarShowAllAccounts: vi.fn(),
     setLoadingForPlugins: vi.fn(),
     setErrorForPlugins: vi.fn(),
     startBatch: vi.fn().mockResolvedValue(undefined),
@@ -104,6 +109,7 @@ describe("useSettingsBootstrap", () => {
     arePluginSettingsEqualMock.mockReset()
     getEnabledPluginIdsMock.mockReset()
     loadAutoUpdateIntervalMock.mockReset()
+    loadCodexMenubarShowAllAccountsMock.mockReset()
     loadDisplayModeMock.mockReset()
     loadGlobalShortcutMock.mockReset()
     loadMenubarIconStyleMock.mockReset()
@@ -131,6 +137,7 @@ describe("useSettingsBootstrap", () => {
     normalizePluginSettingsMock.mockImplementation((stored) => stored)
     arePluginSettingsEqualMock.mockReturnValue(true)
     loadAutoUpdateIntervalMock.mockResolvedValue(15)
+    loadCodexMenubarShowAllAccountsMock.mockResolvedValue(false)
     loadThemeModeMock.mockResolvedValue("dark")
     loadDisplayModeMock.mockResolvedValue("used")
     loadResetTimerDisplayModeMock.mockResolvedValue("relative")

--- a/src/hooks/app/use-settings-bootstrap.ts
+++ b/src/hooks/app/use-settings-bootstrap.ts
@@ -9,6 +9,7 @@ import type { PluginMeta } from "@/lib/plugin-types"
 import {
   arePluginSettingsEqual,
   DEFAULT_AUTO_UPDATE_INTERVAL,
+  DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS,
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
@@ -16,6 +17,7 @@ import {
   DEFAULT_START_ON_LOGIN,
   DEFAULT_THEME_MODE,
   getEnabledPluginIds,
+  loadCodexMenubarShowAllAccounts,
   loadAutoUpdateInterval,
   loadDisplayMode,
   loadGlobalShortcut,
@@ -46,6 +48,7 @@ type UseSettingsBootstrapArgs = {
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setCodexMenubarShowAllAccounts: (value: boolean) => void
   setLoadingForPlugins: (ids: string[]) => void
   setErrorForPlugins: (ids: string[], error: string) => void
   startBatch: (pluginIds?: string[]) => Promise<string[] | undefined>
@@ -61,6 +64,7 @@ export function useSettingsBootstrap({
   setGlobalShortcut,
   setStartOnLogin,
   setMenubarIconStyle,
+  setCodexMenubarShowAllAccounts,
   setLoadingForPlugins,
   setErrorForPlugins,
   startBatch,
@@ -153,6 +157,13 @@ export function useSettingsBootstrap({
           console.error("Failed to load menubar icon style:", error)
         }
 
+        let storedCodexMenubarShowAllAccounts = DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS
+        try {
+          storedCodexMenubarShowAllAccounts = await loadCodexMenubarShowAllAccounts()
+        } catch (error) {
+          console.error("Failed to load Codex menu bar account setting:", error)
+        }
+
         if (isMounted) {
           setPluginSettings(normalized)
           setAutoUpdateInterval(storedInterval)
@@ -162,6 +173,7 @@ export function useSettingsBootstrap({
           setGlobalShortcut(storedGlobalShortcut)
           setStartOnLogin(storedStartOnLogin)
           setMenubarIconStyle(storedMenubarIconStyle)
+          setCodexMenubarShowAllAccounts(storedCodexMenubarShowAllAccounts)
 
           const enabledIds = getEnabledPluginIds(normalized)
           setLoadingForPlugins(enabledIds)
@@ -192,6 +204,7 @@ export function useSettingsBootstrap({
     setGlobalShortcut,
     setLoadingForPlugins,
     setMenubarIconStyle,
+    setCodexMenubarShowAllAccounts,
     migrateLegacyTraySettings,
     setPluginSettings,
     setPluginsMeta,

--- a/src/hooks/app/use-settings-display-actions.test.ts
+++ b/src/hooks/app/use-settings-display-actions.test.ts
@@ -3,13 +3,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
   trackMock,
+  saveCodexMenubarShowAllAccountsMock,
   saveDisplayModeMock,
+  saveMenubarIconStyleMock,
   saveResetTimerDisplayModeMock,
   saveThemeModeMock,
 } = vi.hoisted(() => ({
   trackMock: vi.fn(),
   saveThemeModeMock: vi.fn(),
+  saveCodexMenubarShowAllAccountsMock: vi.fn(),
   saveDisplayModeMock: vi.fn(),
+  saveMenubarIconStyleMock: vi.fn(),
   saveResetTimerDisplayModeMock: vi.fn(),
 }))
 
@@ -19,7 +23,9 @@ vi.mock("@/lib/analytics", () => ({
 
 vi.mock("@/lib/settings", () => ({
   saveThemeMode: saveThemeModeMock,
+  saveCodexMenubarShowAllAccounts: saveCodexMenubarShowAllAccountsMock,
   saveDisplayMode: saveDisplayModeMock,
+  saveMenubarIconStyle: saveMenubarIconStyleMock,
   saveResetTimerDisplayMode: saveResetTimerDisplayModeMock,
 }))
 
@@ -29,10 +35,14 @@ describe("useSettingsDisplayActions", () => {
   beforeEach(() => {
     trackMock.mockReset()
     saveThemeModeMock.mockReset()
+    saveCodexMenubarShowAllAccountsMock.mockReset()
     saveDisplayModeMock.mockReset()
+    saveMenubarIconStyleMock.mockReset()
     saveResetTimerDisplayModeMock.mockReset()
     saveThemeModeMock.mockResolvedValue(undefined)
+    saveCodexMenubarShowAllAccountsMock.mockResolvedValue(undefined)
     saveDisplayModeMock.mockResolvedValue(undefined)
+    saveMenubarIconStyleMock.mockResolvedValue(undefined)
     saveResetTimerDisplayModeMock.mockResolvedValue(undefined)
   })
 
@@ -40,6 +50,8 @@ describe("useSettingsDisplayActions", () => {
     const setThemeMode = vi.fn()
     const setDisplayMode = vi.fn()
     const setResetTimerDisplayMode = vi.fn()
+    const setMenubarIconStyle = vi.fn()
+    const setCodexMenubarShowAllAccounts = vi.fn()
     const scheduleTrayIconUpdate = vi.fn()
 
     const { result } = renderHook(() =>
@@ -48,6 +60,8 @@ describe("useSettingsDisplayActions", () => {
         setDisplayMode,
         resetTimerDisplayMode: "relative",
         setResetTimerDisplayMode,
+        setMenubarIconStyle,
+        setCodexMenubarShowAllAccounts,
         scheduleTrayIconUpdate,
       })
     )
@@ -56,6 +70,8 @@ describe("useSettingsDisplayActions", () => {
       result.current.handleThemeModeChange("dark")
       result.current.handleDisplayModeChange("used")
       result.current.handleResetTimerDisplayModeChange("absolute")
+      result.current.handleMenubarIconStyleChange("bars")
+      result.current.handleCodexMenubarShowAllAccountsChange(true)
     })
 
     expect(trackMock).toHaveBeenCalledWith("setting_changed", { setting: "theme", value: "dark" })
@@ -67,15 +83,27 @@ describe("useSettingsDisplayActions", () => {
       setting: "reset_timer_display_mode",
       value: "absolute",
     })
+    expect(trackMock).toHaveBeenCalledWith("setting_changed", {
+      setting: "menubar_icon_style",
+      value: "bars",
+    })
+    expect(trackMock).toHaveBeenCalledWith("setting_changed", {
+      setting: "codex_menubar_show_all_accounts",
+      value: "true",
+    })
 
     expect(setThemeMode).toHaveBeenCalledWith("dark")
     expect(setDisplayMode).toHaveBeenCalledWith("used")
     expect(setResetTimerDisplayMode).toHaveBeenCalledWith("absolute")
+    expect(setMenubarIconStyle).toHaveBeenCalledWith("bars")
+    expect(setCodexMenubarShowAllAccounts).toHaveBeenCalledWith(true)
     expect(scheduleTrayIconUpdate).toHaveBeenCalledWith("settings", 0)
 
     expect(saveThemeModeMock).toHaveBeenCalledWith("dark")
     expect(saveDisplayModeMock).toHaveBeenCalledWith("used")
     expect(saveResetTimerDisplayModeMock).toHaveBeenCalledWith("absolute")
+    expect(saveMenubarIconStyleMock).toHaveBeenCalledWith("bars")
+    expect(saveCodexMenubarShowAllAccountsMock).toHaveBeenCalledWith(true)
   })
 
   it("toggles reset timer mode in both directions", () => {
@@ -88,6 +116,8 @@ describe("useSettingsDisplayActions", () => {
           setDisplayMode: vi.fn(),
           resetTimerDisplayMode: mode,
           setResetTimerDisplayMode,
+          setMenubarIconStyle: vi.fn(),
+          setCodexMenubarShowAllAccounts: vi.fn(),
           scheduleTrayIconUpdate: vi.fn(),
         }),
       { initialProps: { mode: "relative" as const } }
@@ -109,10 +139,14 @@ describe("useSettingsDisplayActions", () => {
     const themeError = new Error("theme failed")
     const displayError = new Error("display failed")
     const resetError = new Error("reset failed")
+    const menubarError = new Error("menubar failed")
+    const codexMenubarError = new Error("codex menubar failed")
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     saveThemeModeMock.mockRejectedValueOnce(themeError)
     saveDisplayModeMock.mockRejectedValueOnce(displayError)
     saveResetTimerDisplayModeMock.mockRejectedValueOnce(resetError)
+    saveMenubarIconStyleMock.mockRejectedValueOnce(menubarError)
+    saveCodexMenubarShowAllAccountsMock.mockRejectedValueOnce(codexMenubarError)
 
     const { result } = renderHook(() =>
       useSettingsDisplayActions({
@@ -120,6 +154,8 @@ describe("useSettingsDisplayActions", () => {
         setDisplayMode: vi.fn(),
         resetTimerDisplayMode: "relative",
         setResetTimerDisplayMode: vi.fn(),
+        setMenubarIconStyle: vi.fn(),
+        setCodexMenubarShowAllAccounts: vi.fn(),
         scheduleTrayIconUpdate: vi.fn(),
       })
     )
@@ -128,12 +164,19 @@ describe("useSettingsDisplayActions", () => {
       result.current.handleThemeModeChange("light")
       result.current.handleDisplayModeChange("left")
       result.current.handleResetTimerDisplayModeChange("relative")
+      result.current.handleMenubarIconStyleChange("provider")
+      result.current.handleCodexMenubarShowAllAccountsChange(false)
     })
 
     await waitFor(() => {
       expect(errorSpy).toHaveBeenCalledWith("Failed to save theme mode:", themeError)
       expect(errorSpy).toHaveBeenCalledWith("Failed to save display mode:", displayError)
       expect(errorSpy).toHaveBeenCalledWith("Failed to save reset timer display mode:", resetError)
+      expect(errorSpy).toHaveBeenCalledWith("Failed to save menubar icon style:", menubarError)
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to save Codex menu bar account setting:",
+        codexMenubarError
+      )
     })
 
     errorSpy.mockRestore()

--- a/src/hooks/app/use-settings-display-actions.ts
+++ b/src/hooks/app/use-settings-display-actions.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react"
 import { track } from "@/lib/analytics"
 import {
   saveDisplayMode,
+  saveCodexMenubarShowAllAccounts,
   saveMenubarIconStyle,
   saveResetTimerDisplayMode,
   saveThemeMode,
@@ -19,6 +20,7 @@ type UseSettingsDisplayActionsArgs = {
   resetTimerDisplayMode: ResetTimerDisplayMode
   setResetTimerDisplayMode: (value: ResetTimerDisplayMode) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setCodexMenubarShowAllAccounts: (value: boolean) => void
   scheduleTrayIconUpdate: ScheduleTrayIconUpdate
 }
 
@@ -28,6 +30,7 @@ export function useSettingsDisplayActions({
   resetTimerDisplayMode,
   setResetTimerDisplayMode,
   setMenubarIconStyle,
+  setCodexMenubarShowAllAccounts,
   scheduleTrayIconUpdate,
 }: UseSettingsDisplayActionsArgs) {
   const handleThemeModeChange = useCallback((mode: ThemeMode) => {
@@ -69,11 +72,24 @@ export function useSettingsDisplayActions({
     })
   }, [scheduleTrayIconUpdate, setMenubarIconStyle])
 
+  const handleCodexMenubarShowAllAccountsChange = useCallback((value: boolean) => {
+    track("setting_changed", {
+      setting: "codex_menubar_show_all_accounts",
+      value: value ? "true" : "false",
+    })
+    setCodexMenubarShowAllAccounts(value)
+    scheduleTrayIconUpdate("settings", 0)
+    void saveCodexMenubarShowAllAccounts(value).catch((error) => {
+      console.error("Failed to save Codex menu bar account setting:", error)
+    })
+  }, [scheduleTrayIconUpdate, setCodexMenubarShowAllAccounts])
+
   return {
     handleThemeModeChange,
     handleDisplayModeChange,
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleMenubarIconStyleChange,
+    handleCodexMenubarShowAllAccountsChange,
   }
 }

--- a/src/hooks/app/use-settings-plugin-actions.test.ts
+++ b/src/hooks/app/use-settings-plugin-actions.test.ts
@@ -204,6 +204,64 @@ describe("useSettingsPluginActions", () => {
     expect(setPluginSettings).toHaveBeenNthCalledWith(2, { order: ["a", "b"], disabled: ["b", "a"] })
   })
 
+  it("toggles all Codex account providers from the grouped settings row", () => {
+    const setPluginSettings = vi.fn()
+    const setLoadingForPlugins = vi.fn()
+    const startBatch = vi.fn().mockResolvedValue(undefined)
+
+    const { result } = renderHook(() =>
+      useSettingsPluginActions({
+        pluginSettings: {
+          order: ["codex", "codex-hermes", "cursor"],
+          disabled: ["codex", "codex-hermes"],
+        },
+        setPluginSettings,
+        setLoadingForPlugins,
+        setErrorForPlugins: vi.fn(),
+        startBatch,
+        scheduleTrayIconUpdate: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.handleToggle("codex")
+    })
+
+    expect(setLoadingForPlugins).toHaveBeenCalledWith(["codex", "codex-hermes"])
+    expect(startBatch).toHaveBeenCalledWith(["codex", "codex-hermes"])
+    expect(setPluginSettings).toHaveBeenCalledWith({
+      order: ["codex", "codex-hermes", "cursor"],
+      disabled: [],
+    })
+  })
+
+  it("disables all Codex account providers when any grouped account is enabled", () => {
+    const setPluginSettings = vi.fn()
+
+    const { result } = renderHook(() =>
+      useSettingsPluginActions({
+        pluginSettings: {
+          order: ["codex", "codex-hermes", "cursor"],
+          disabled: ["codex-hermes"],
+        },
+        setPluginSettings,
+        setLoadingForPlugins: vi.fn(),
+        setErrorForPlugins: vi.fn(),
+        startBatch: vi.fn(),
+        scheduleTrayIconUpdate: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.handleToggle("codex")
+    })
+
+    expect(setPluginSettings).toHaveBeenCalledWith({
+      order: ["codex", "codex-hermes", "cursor"],
+      disabled: ["codex-hermes", "codex"],
+    })
+  })
+
   it("returns early when plugin settings are missing", () => {
     const setPluginSettings = vi.fn()
 

--- a/src/hooks/app/use-settings-plugin-actions.test.ts
+++ b/src/hooks/app/use-settings-plugin-actions.test.ts
@@ -212,8 +212,8 @@ describe("useSettingsPluginActions", () => {
     const { result } = renderHook(() =>
       useSettingsPluginActions({
         pluginSettings: {
-          order: ["codex", "codex-hermes", "cursor"],
-          disabled: ["codex", "codex-hermes"],
+          order: ["codex", "codex-slot-account-2", "cursor"],
+          disabled: ["codex", "codex-slot-account-2"],
         },
         setPluginSettings,
         setLoadingForPlugins,
@@ -227,10 +227,10 @@ describe("useSettingsPluginActions", () => {
       result.current.handleToggle("codex")
     })
 
-    expect(setLoadingForPlugins).toHaveBeenCalledWith(["codex", "codex-hermes"])
-    expect(startBatch).toHaveBeenCalledWith(["codex", "codex-hermes"])
+    expect(setLoadingForPlugins).toHaveBeenCalledWith(["codex", "codex-slot-account-2"])
+    expect(startBatch).toHaveBeenCalledWith(["codex", "codex-slot-account-2"])
     expect(setPluginSettings).toHaveBeenCalledWith({
-      order: ["codex", "codex-hermes", "cursor"],
+      order: ["codex", "codex-slot-account-2", "cursor"],
       disabled: [],
     })
   })
@@ -241,8 +241,8 @@ describe("useSettingsPluginActions", () => {
     const { result } = renderHook(() =>
       useSettingsPluginActions({
         pluginSettings: {
-          order: ["codex", "codex-hermes", "cursor"],
-          disabled: ["codex-hermes"],
+          order: ["codex", "codex-slot-account-2", "cursor"],
+          disabled: ["codex-slot-account-2"],
         },
         setPluginSettings,
         setLoadingForPlugins: vi.fn(),
@@ -257,8 +257,8 @@ describe("useSettingsPluginActions", () => {
     })
 
     expect(setPluginSettings).toHaveBeenCalledWith({
-      order: ["codex", "codex-hermes", "cursor"],
-      disabled: ["codex-hermes", "codex"],
+      order: ["codex", "codex-slot-account-2", "cursor"],
+      disabled: ["codex-slot-account-2", "codex"],
     })
   })
 

--- a/src/hooks/app/use-settings-plugin-actions.ts
+++ b/src/hooks/app/use-settings-plugin-actions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react"
 import { track } from "@/lib/analytics"
+import { isCodexAccountProviderId } from "@/lib/plugin-types"
 import { savePluginSettings, type PluginSettings } from "@/lib/settings"
 
 const TRAY_SETTINGS_DEBOUNCE_MS = 2000
@@ -23,6 +24,12 @@ export function useSettingsPluginActions({
   startBatch,
   scheduleTrayIconUpdate,
 }: UseSettingsPluginActionsArgs) {
+  const resolveToggleIds = useCallback((id: string) => {
+    if (!pluginSettings || !isCodexAccountProviderId(id)) return [id]
+    const codexIds = (pluginSettings.order ?? []).filter(isCodexAccountProviderId)
+    return codexIds.length > 0 ? codexIds : [id]
+  }, [pluginSettings])
+
   const handleReorder = useCallback((orderedIds: string[]) => {
     if (!pluginSettings) return
     track("providers_reordered", { count: orderedIds.length })
@@ -58,19 +65,24 @@ export function useSettingsPluginActions({
 
   const handleToggle = useCallback((id: string) => {
     if (!pluginSettings) return
-    const wasDisabled = pluginSettings.disabled.includes(id)
+    const toggleIds = resolveToggleIds(id)
+    const wasDisabled = toggleIds.every((toggleId) => pluginSettings.disabled.includes(toggleId))
     track("provider_toggled", { provider_id: id, enabled: wasDisabled ? "true" : "false" })
     const disabled = new Set(pluginSettings.disabled)
 
     if (wasDisabled) {
-      disabled.delete(id)
-      setLoadingForPlugins([id])
-      startBatch([id]).catch((error) => {
+      for (const toggleId of toggleIds) {
+        disabled.delete(toggleId)
+      }
+      setLoadingForPlugins(toggleIds)
+      startBatch(toggleIds).catch((error) => {
         console.error("Failed to start probe for enabled plugin:", error)
-        setErrorForPlugins([id], "Failed to start probe")
+        setErrorForPlugins(toggleIds, "Failed to start probe")
       })
     } else {
-      disabled.add(id)
+      for (const toggleId of toggleIds) {
+        disabled.add(toggleId)
+      }
     }
 
     const nextSettings: PluginSettings = {
@@ -84,6 +96,7 @@ export function useSettingsPluginActions({
     })
   }, [
     pluginSettings,
+    resolveToggleIds,
     scheduleTrayIconUpdate,
     setErrorForPlugins,
     setLoadingForPlugins,

--- a/src/hooks/app/use-settings-plugin-list.test.ts
+++ b/src/hooks/app/use-settings-plugin-list.test.ts
@@ -40,8 +40,8 @@ describe("useSettingsPluginList", () => {
 
   it("groups Codex account providers into one settings row", () => {
     const pluginSettings: PluginSettings = {
-      order: ["codex", "codex-hermes", "cursor"],
-      disabled: ["codex-hermes"],
+      order: ["codex", "codex-slot-account-2", "cursor"],
+      disabled: ["codex-slot-account-2"],
     }
 
     const { result } = renderHook(() =>
@@ -49,7 +49,7 @@ describe("useSettingsPluginList", () => {
         pluginSettings,
         pluginsMeta: [
           createPluginMeta("codex", "Codex"),
-          createPluginMeta("codex-hermes", "oscar@example.com"),
+          createPluginMeta("codex-slot-account-2", "oscar@example.com"),
           createPluginMeta("cursor", "Cursor"),
         ],
       })
@@ -63,8 +63,8 @@ describe("useSettingsPluginList", () => {
 
   it("marks grouped Codex disabled when all account providers are disabled", () => {
     const pluginSettings: PluginSettings = {
-      order: ["codex", "codex-hermes"],
-      disabled: ["codex", "codex-hermes"],
+      order: ["codex", "codex-slot-account-2"],
+      disabled: ["codex", "codex-slot-account-2"],
     }
 
     const { result } = renderHook(() =>
@@ -72,7 +72,7 @@ describe("useSettingsPluginList", () => {
         pluginSettings,
         pluginsMeta: [
           createPluginMeta("codex", "Codex"),
-          createPluginMeta("codex-hermes", "oscar@example.com"),
+          createPluginMeta("codex-slot-account-2", "oscar@example.com"),
         ],
       })
     )

--- a/src/hooks/app/use-settings-plugin-list.test.ts
+++ b/src/hooks/app/use-settings-plugin-list.test.ts
@@ -38,6 +38,50 @@ describe("useSettingsPluginList", () => {
     ])
   })
 
+  it("groups Codex account providers into one settings row", () => {
+    const pluginSettings: PluginSettings = {
+      order: ["codex", "codex-hermes", "cursor"],
+      disabled: ["codex-hermes"],
+    }
+
+    const { result } = renderHook(() =>
+      useSettingsPluginList({
+        pluginSettings,
+        pluginsMeta: [
+          createPluginMeta("codex", "Codex"),
+          createPluginMeta("codex-hermes", "oscar@example.com"),
+          createPluginMeta("cursor", "Cursor"),
+        ],
+      })
+    )
+
+    expect(result.current).toEqual([
+      { id: "codex", name: "Codex", enabled: true },
+      { id: "cursor", name: "Cursor", enabled: true },
+    ])
+  })
+
+  it("marks grouped Codex disabled when all account providers are disabled", () => {
+    const pluginSettings: PluginSettings = {
+      order: ["codex", "codex-hermes"],
+      disabled: ["codex", "codex-hermes"],
+    }
+
+    const { result } = renderHook(() =>
+      useSettingsPluginList({
+        pluginSettings,
+        pluginsMeta: [
+          createPluginMeta("codex", "Codex"),
+          createPluginMeta("codex-hermes", "oscar@example.com"),
+        ],
+      })
+    )
+
+    expect(result.current).toEqual([
+      { id: "codex", name: "Codex", enabled: false },
+    ])
+  })
+
   it("returns empty list when settings are not loaded", () => {
     const { result } = renderHook(() =>
       useSettingsPluginList({

--- a/src/hooks/app/use-settings-plugin-list.ts
+++ b/src/hooks/app/use-settings-plugin-list.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react"
-import type { PluginMeta } from "@/lib/plugin-types"
+import { CODEX_GROUP_ID, isCodexAccountProviderId, type PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 
 export type SettingsPluginState = {
@@ -17,17 +17,35 @@ export function useSettingsPluginList({ pluginSettings, pluginsMeta }: UseSettin
   return useMemo<SettingsPluginState[]>(() => {
     if (!pluginSettings) return []
     const pluginMap = new Map(pluginsMeta.map((plugin) => [plugin.id, plugin]))
+    const disabledSet = new Set(pluginSettings.disabled)
+    let addedCodex = false
+    const codexIds = pluginSettings.order.filter((id) => isCodexAccountProviderId(id) && pluginMap.has(id))
+    const codexEnabled = codexIds.some((id) => !disabledSet.has(id))
 
-    return pluginSettings.order
-      .map((id) => {
-        const meta = pluginMap.get(id)
-        if (!meta) return null
-        return {
-          id,
-          name: meta.name,
-          enabled: !pluginSettings.disabled.includes(id),
-        }
+    const plugins: SettingsPluginState[] = []
+    for (const id of pluginSettings.order) {
+      const meta = pluginMap.get(id)
+      if (!meta) continue
+
+      if (isCodexAccountProviderId(id)) {
+        if (addedCodex) continue
+        addedCodex = true
+        const baseMeta = pluginMap.get(CODEX_GROUP_ID) ?? meta
+        plugins.push({
+          id: CODEX_GROUP_ID,
+          name: baseMeta.name,
+          enabled: codexEnabled,
+        })
+        continue
+      }
+
+      plugins.push({
+        id,
+        name: meta.name,
+        enabled: !disabledSet.has(id),
       })
-      .filter((plugin): plugin is SettingsPluginState => Boolean(plugin))
+    }
+
+    return plugins
   }, [pluginSettings, pluginsMeta])
 }

--- a/src/hooks/app/use-tray-icon.ts
+++ b/src/hooks/app/use-tray-icon.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { resolveResource } from "@tauri-apps/api/path"
 import { TrayIcon } from "@tauri-apps/api/tray"
-import type { PluginMeta } from "@/lib/plugin-types"
+import { isCodexAccountProviderId, type PluginMeta } from "@/lib/plugin-types"
 import type { DisplayMode, MenubarIconStyle, PluginSettings } from "@/lib/settings"
 import { getEnabledPluginIds } from "@/lib/settings"
 import { getTrayIconSizePx, renderTrayBarsIcon } from "@/lib/tray-bars-icon"
@@ -18,6 +18,7 @@ type UseTrayIconArgs = {
   displayMode: DisplayMode
   menubarIconStyle: MenubarIconStyle
   activeView: string
+  selectedCodexProviderId?: string | null
 }
 
 export type TraySettingsPreview = {
@@ -56,6 +57,7 @@ export function useTrayIcon({
   displayMode,
   menubarIconStyle,
   activeView,
+  selectedCodexProviderId = null,
 }: UseTrayIconArgs) {
   const trayRef = useRef<TrayIcon | null>(null)
   const trayGaugeIconPathRef = useRef<string | null>(null)
@@ -73,6 +75,7 @@ export function useTrayIcon({
   const displayModeRef = useRef(displayMode)
   const menubarIconStyleRef = useRef(menubarIconStyle)
   const activeViewRef = useRef(activeView)
+  const selectedCodexProviderIdRef = useRef(selectedCodexProviderId)
   const lastTrayProviderIdRef = useRef<string | null>(null)
 
   useEffect(() => {
@@ -98,6 +101,10 @@ export function useTrayIcon({
   useEffect(() => {
     activeViewRef.current = activeView
   }, [activeView])
+
+  useEffect(() => {
+    selectedCodexProviderIdRef.current = selectedCodexProviderId
+  }, [selectedCodexProviderId])
 
   const scheduleTrayIconUpdate = useCallback((
     _reason: TrayUpdateReason,
@@ -189,10 +196,22 @@ export function useTrayIcon({
       const nextActiveView = activeViewRef.current
       const activeProviderId =
         nextActiveView !== "home" && nextActiveView !== "settings" ? nextActiveView : null
+      const selectedCodexProviderId = selectedCodexProviderIdRef.current
+      const activeCodexProviderId =
+        selectedCodexProviderId &&
+        isCodexAccountProviderId(selectedCodexProviderId) &&
+        enabledPluginIds.includes(selectedCodexProviderId)
+          ? selectedCodexProviderId
+          : null
 
       let trayProviderId: string | null = null
-      if (activeProviderId && enabledPluginIds.includes(activeProviderId)) {
+      if (activeProviderId && isCodexAccountProviderId(activeProviderId)) {
+        trayProviderId = activeCodexProviderId
+          ?? (enabledPluginIds.includes(activeProviderId) ? activeProviderId : null)
+      } else if (activeProviderId && enabledPluginIds.includes(activeProviderId)) {
         trayProviderId = activeProviderId
+      } else if (activeCodexProviderId) {
+        trayProviderId = activeCodexProviderId
       } else if (
         lastTrayProviderIdRef.current &&
         enabledPluginIds.includes(lastTrayProviderIdRef.current)
@@ -357,7 +376,7 @@ export function useTrayIcon({
   useEffect(() => {
     if (!trayReady) return
     scheduleTrayIconUpdate("settings", 0)
-  }, [activeView, menubarIconStyle, scheduleTrayIconUpdate, trayReady])
+  }, [activeView, menubarIconStyle, scheduleTrayIconUpdate, selectedCodexProviderId, trayReady])
 
   useEffect(() => {
     return () => {

--- a/src/hooks/app/use-tray-icon.ts
+++ b/src/hooks/app/use-tray-icon.ts
@@ -19,6 +19,7 @@ type UseTrayIconArgs = {
   menubarIconStyle: MenubarIconStyle
   activeView: string
   selectedCodexProviderId?: string | null
+  codexMenubarShowAllAccounts?: boolean
 }
 
 export type TraySettingsPreview = {
@@ -58,6 +59,7 @@ export function useTrayIcon({
   menubarIconStyle,
   activeView,
   selectedCodexProviderId = null,
+  codexMenubarShowAllAccounts = false,
 }: UseTrayIconArgs) {
   const trayRef = useRef<TrayIcon | null>(null)
   const trayGaugeIconPathRef = useRef<string | null>(null)
@@ -76,6 +78,7 @@ export function useTrayIcon({
   const menubarIconStyleRef = useRef(menubarIconStyle)
   const activeViewRef = useRef(activeView)
   const selectedCodexProviderIdRef = useRef(selectedCodexProviderId)
+  const codexMenubarShowAllAccountsRef = useRef(codexMenubarShowAllAccounts)
   const lastTrayProviderIdRef = useRef<string | null>(null)
 
   useEffect(() => {
@@ -105,6 +108,10 @@ export function useTrayIcon({
   useEffect(() => {
     selectedCodexProviderIdRef.current = selectedCodexProviderId
   }, [selectedCodexProviderId])
+
+  useEffect(() => {
+    codexMenubarShowAllAccountsRef.current = codexMenubarShowAllAccounts
+  }, [codexMenubarShowAllAccounts])
 
   const scheduleTrayIconUpdate = useCallback((
     _reason: TrayUpdateReason,
@@ -203,6 +210,10 @@ export function useTrayIcon({
         enabledPluginIds.includes(selectedCodexProviderId)
           ? selectedCodexProviderId
           : null
+      const enabledCodexProviderIds = enabledPluginIds.filter((id) =>
+        isCodexAccountProviderId(id) &&
+        pluginsMetaRef.current.some((plugin) => plugin.id === id)
+      )
 
       let trayProviderId: string | null = null
       if (activeProviderId && isCodexAccountProviderId(activeProviderId)) {
@@ -229,21 +240,36 @@ export function useTrayIcon({
         displayMode: displayModeRef.current,
       })
 
-      const providerBars = trayProviderId
+      const providerBarIds =
+        trayProviderId &&
+        codexMenubarShowAllAccountsRef.current &&
+        isCodexAccountProviderId(trayProviderId) &&
+        enabledCodexProviderIds.length > 1
+          ? enabledCodexProviderIds
+          : trayProviderId
+            ? [trayProviderId]
+            : []
+
+      const providerBars = providerBarIds.length > 0
         ? getTrayPrimaryBars({
             pluginsMeta: pluginsMetaRef.current,
-            pluginSettings: currentSettings,
+            pluginSettings: {
+              order: providerBarIds,
+              disabled: [],
+            },
             pluginStates: pluginStatesRef.current,
-            maxBars: 1,
+            maxBars: 4,
             displayMode: displayModeRef.current,
-            pluginId: trayProviderId,
           })
         : []
 
       const providerIconUrl = trayProviderId
         ? pluginsMetaRef.current.find((plugin) => plugin.id === trayProviderId)?.iconUrl
         : undefined
-      const providerPercentText = formatTrayPercentText(providerBars[0]?.fraction)
+      const providerPercentText =
+        providerBars.length > 1
+          ? providerBars.map((bar) => formatTrayPercentText(bar.fraction)).join(" ")
+          : formatTrayPercentText(providerBars[0]?.fraction)
 
       const nextPreview: TraySettingsPreview = {
         bars: barsForPreview,
@@ -376,7 +402,14 @@ export function useTrayIcon({
   useEffect(() => {
     if (!trayReady) return
     scheduleTrayIconUpdate("settings", 0)
-  }, [activeView, menubarIconStyle, scheduleTrayIconUpdate, selectedCodexProviderId, trayReady])
+  }, [
+    activeView,
+    codexMenubarShowAllAccounts,
+    menubarIconStyle,
+    scheduleTrayIconUpdate,
+    selectedCodexProviderId,
+    trayReady,
+  ])
 
   useEffect(() => {
     return () => {

--- a/src/hooks/app/use-tray-icon.ts
+++ b/src/hooks/app/use-tray-icon.ts
@@ -268,7 +268,7 @@ export function useTrayIcon({
         : undefined
       const providerPercentText =
         providerBars.length > 1
-          ? providerBars.map((bar) => formatTrayPercentText(bar.fraction)).join(" ")
+          ? providerBars.map((bar) => formatTrayPercentText(bar.fraction)).join(" | ")
           : formatTrayPercentText(providerBars[0]?.fraction)
 
       const nextPreview: TraySettingsPreview = {

--- a/src/lib/plugin-types.ts
+++ b/src/lib/plugin-types.ts
@@ -47,8 +47,15 @@ export type PluginMeta = {
   primaryCandidates: string[]
 }
 
+export const CODEX_GROUP_ID = "codex"
+
+export function isCodexAccountProviderId(id: string): boolean {
+  return id === CODEX_GROUP_ID || id.startsWith(`${CODEX_GROUP_ID}-`)
+}
+
 export type PluginDisplayState = {
   meta: PluginMeta
+  sourceProviderId?: string
   data: PluginOutput | null
   loading: boolean
   error: string | null

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   DEFAULT_AUTO_UPDATE_INTERVAL,
+  DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS,
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
@@ -10,6 +11,7 @@ import {
   DEFAULT_THEME_MODE,
   arePluginSettingsEqual,
   getEnabledPluginIds,
+  loadCodexMenubarShowAllAccounts,
   loadAutoUpdateInterval,
   loadDisplayMode,
   loadGlobalShortcut,
@@ -21,6 +23,7 @@ import {
   loadThemeMode,
   normalizePluginSettings,
   saveAutoUpdateInterval,
+  saveCodexMenubarShowAllAccounts,
   saveDisplayMode,
   saveGlobalShortcut,
   saveMenubarIconStyle,
@@ -259,6 +262,29 @@ describe("settings", () => {
   it("falls back to default for invalid menubar icon style", async () => {
     storeState.set("menubarIconStyle", "invalid")
     await expect(loadMenubarIconStyle()).resolves.toBe(DEFAULT_MENUBAR_ICON_STYLE)
+  })
+
+  it("loads default Codex menubar account setting when missing", async () => {
+    await expect(loadCodexMenubarShowAllAccounts()).resolves.toBe(
+      DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS
+    )
+  })
+
+  it("loads stored Codex menubar account setting", async () => {
+    storeState.set("codexMenubarShowAllAccounts", true)
+    await expect(loadCodexMenubarShowAllAccounts()).resolves.toBe(true)
+  })
+
+  it("saves Codex menubar account setting", async () => {
+    await saveCodexMenubarShowAllAccounts(true)
+    await expect(loadCodexMenubarShowAllAccounts()).resolves.toBe(true)
+  })
+
+  it("falls back to default for invalid Codex menubar account setting", async () => {
+    storeState.set("codexMenubarShowAllAccounts", "yes")
+    await expect(loadCodexMenubarShowAllAccounts()).resolves.toBe(
+      DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS
+    )
   })
 
   it("skips legacy tray migration when keys are absent", async () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,5 +1,5 @@
 import { LazyStore } from "@tauri-apps/plugin-store";
-import type { PluginMeta } from "@/lib/plugin-types";
+import { isCodexAccountProviderId, type PluginMeta } from "@/lib/plugin-types";
 
 // Refresh cooldown duration in milliseconds (5 minutes)
 export const REFRESH_COOLDOWN_MS = 300_000;
@@ -78,7 +78,11 @@ export const RESET_TIMER_DISPLAY_OPTIONS: { value: ResetTimerDisplayMode; label:
 
 const store = new LazyStore(SETTINGS_STORE_PATH);
 
-const DEFAULT_ENABLED_PLUGINS = new Set(["claude", "codex", "cursor"]);
+const DEFAULT_ENABLED_PLUGINS = new Set(["claude", "cursor"]);
+
+function isDefaultEnabledPlugin(id: string): boolean {
+  return DEFAULT_ENABLED_PLUGINS.has(id) || isCodexAccountProviderId(id);
+}
 
 export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   order: [],
@@ -144,7 +148,7 @@ export function normalizePluginSettings(
 
   const disabled = settings.disabled.filter((id) => knownSet.has(id));
   for (const id of newlyAdded) {
-    if (!DEFAULT_ENABLED_PLUGINS.has(id) && !disabled.includes(id)) {
+    if (!isDefaultEnabledPlugin(id) && !disabled.includes(id)) {
       disabled.push(id);
     }
   }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -20,6 +20,8 @@ export type ResetTimerDisplayMode = "relative" | "absolute";
 
 export type MenubarIconStyle = "provider" | "bars" | "donut";
 
+export type CodexMenubarShowAllAccounts = boolean;
+
 export type GlobalShortcut = string | null;
 
 const SETTINGS_STORE_PATH = "settings.json";
@@ -29,6 +31,7 @@ const THEME_MODE_KEY = "themeMode";
 const DISPLAY_MODE_KEY = "displayMode";
 const RESET_TIMER_DISPLAY_MODE_KEY = "resetTimerDisplayMode";
 const MENUBAR_ICON_STYLE_KEY = "menubarIconStyle";
+const CODEX_MENUBAR_SHOW_ALL_ACCOUNTS_KEY = "codexMenubarShowAllAccounts";
 const LEGACY_TRAY_ICON_STYLE_KEY = "trayIconStyle";
 const LEGACY_TRAY_SHOW_PERCENTAGE_KEY = "trayShowPercentage";
 const GLOBAL_SHORTCUT_KEY = "globalShortcut";
@@ -39,6 +42,7 @@ export const DEFAULT_THEME_MODE: ThemeMode = "system";
 export const DEFAULT_DISPLAY_MODE: DisplayMode = "left";
 export const DEFAULT_RESET_TIMER_DISPLAY_MODE: ResetTimerDisplayMode = "relative";
 export const DEFAULT_MENUBAR_ICON_STYLE: MenubarIconStyle = "provider";
+export const DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS = false;
 export const DEFAULT_GLOBAL_SHORTCUT: GlobalShortcut = null;
 export const DEFAULT_START_ON_LOGIN = false;
 
@@ -233,6 +237,17 @@ export async function loadMenubarIconStyle(): Promise<MenubarIconStyle> {
 
 export async function saveMenubarIconStyle(style: MenubarIconStyle): Promise<void> {
   await store.set(MENUBAR_ICON_STYLE_KEY, style);
+  await store.save();
+}
+
+export async function loadCodexMenubarShowAllAccounts(): Promise<boolean> {
+  const stored = await store.get<unknown>(CODEX_MENUBAR_SHOW_ALL_ACCOUNTS_KEY);
+  if (typeof stored === "boolean") return stored;
+  return DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS;
+}
+
+export async function saveCodexMenubarShowAllAccounts(value: boolean): Promise<void> {
+  await store.set(CODEX_MENUBAR_SHOW_ALL_ACCOUNTS_KEY, value);
   await store.save();
 }
 

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -11,6 +11,8 @@ interface OverviewPageProps {
   onResetTimerDisplayModeToggle?: () => void
   codexAccountOptions?: AccountOption[]
   onCodexAccountChange?: (providerId: string) => void
+  codexMenubarShowAllAccounts?: boolean
+  onCodexMenubarShowAllAccountsChange?: (value: boolean) => void
 }
 
 export function OverviewPage({
@@ -21,6 +23,8 @@ export function OverviewPage({
   onResetTimerDisplayModeToggle,
   codexAccountOptions = [],
   onCodexAccountChange,
+  codexMenubarShowAllAccounts = false,
+  onCodexMenubarShowAllAccountsChange,
 }: OverviewPageProps) {
   if (plugins.length === 0) {
     return (
@@ -40,6 +44,10 @@ export function OverviewPage({
           plan={plugin.data?.plan}
           planOptions={plugin.meta.id === "codex" ? codexAccountOptions : []}
           onPlanOptionChange={onCodexAccountChange}
+          codexMenubarShowAllAccounts={codexMenubarShowAllAccounts}
+          onCodexMenubarShowAllAccountsChange={
+            plugin.meta.id === "codex" ? onCodexMenubarShowAllAccountsChange : undefined
+          }
           showSeparator={index < plugins.length - 1}
           loading={plugin.loading}
           error={plugin.error}

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -1,4 +1,5 @@
 import { ProviderCard } from "@/components/provider-card"
+import type { AccountOption } from "@/hooks/app/use-app-plugin-views"
 import type { PluginDisplayState } from "@/lib/plugin-types"
 import type { DisplayMode, ResetTimerDisplayMode } from "@/lib/settings"
 
@@ -8,6 +9,8 @@ interface OverviewPageProps {
   displayMode: DisplayMode
   resetTimerDisplayMode: ResetTimerDisplayMode
   onResetTimerDisplayModeToggle?: () => void
+  codexAccountOptions?: AccountOption[]
+  onCodexAccountChange?: (providerId: string) => void
 }
 
 export function OverviewPage({
@@ -16,6 +19,8 @@ export function OverviewPage({
   displayMode,
   resetTimerDisplayMode,
   onResetTimerDisplayModeToggle,
+  codexAccountOptions = [],
+  onCodexAccountChange,
 }: OverviewPageProps) {
   if (plugins.length === 0) {
     return (
@@ -31,7 +36,10 @@ export function OverviewPage({
         <ProviderCard
           key={plugin.meta.id}
           name={plugin.meta.name}
+          providerId={plugin.sourceProviderId ?? plugin.meta.id}
           plan={plugin.data?.plan}
+          planOptions={plugin.meta.id === "codex" ? codexAccountOptions : []}
+          onPlanOptionChange={onCodexAccountChange}
           showSeparator={index < plugins.length - 1}
           loading={plugin.loading}
           error={plugin.error}
@@ -39,7 +47,7 @@ export function OverviewPage({
           skeletonLines={plugin.meta.lines}
           lastManualRefreshAt={plugin.lastManualRefreshAt}
           lastUpdatedAt={plugin.lastUpdatedAt}
-          onRetry={onRetryPlugin ? () => onRetryPlugin(plugin.meta.id) : undefined}
+          onRetry={onRetryPlugin ? () => onRetryPlugin(plugin.sourceProviderId ?? plugin.meta.id) : undefined}
           scopeFilter="overview"
           displayMode={displayMode}
           resetTimerDisplayMode={resetTimerDisplayMode}

--- a/src/pages/provider-detail.tsx
+++ b/src/pages/provider-detail.tsx
@@ -10,6 +10,8 @@ interface ProviderDetailPageProps {
   displayMode: DisplayMode
   resetTimerDisplayMode: ResetTimerDisplayMode
   onResetTimerDisplayModeToggle?: () => void
+  codexMenubarShowAllAccounts?: boolean
+  onCodexMenubarShowAllAccountsChange?: (value: boolean) => void
 }
 
 export function ProviderDetailPage({
@@ -20,6 +22,8 @@ export function ProviderDetailPage({
   displayMode,
   resetTimerDisplayMode,
   onResetTimerDisplayModeToggle,
+  codexMenubarShowAllAccounts = false,
+  onCodexMenubarShowAllAccountsChange,
 }: ProviderDetailPageProps) {
   if (!plugin) {
     return (
@@ -49,6 +53,10 @@ export function ProviderDetailPage({
       displayMode={displayMode}
       resetTimerDisplayMode={resetTimerDisplayMode}
       onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+      codexMenubarShowAllAccounts={codexMenubarShowAllAccounts}
+      onCodexMenubarShowAllAccountsChange={
+        plugin.meta.id === "codex" ? onCodexMenubarShowAllAccountsChange : undefined
+      }
     />
   )
 }

--- a/src/pages/provider-detail.tsx
+++ b/src/pages/provider-detail.tsx
@@ -4,6 +4,8 @@ import type { DisplayMode, ResetTimerDisplayMode } from "@/lib/settings"
 
 interface ProviderDetailPageProps {
   plugin: PluginDisplayState | null
+  planOptions?: { providerId: string; label: string }[]
+  onPlanOptionChange?: (providerId: string) => void
   onRetry?: () => void
   displayMode: DisplayMode
   resetTimerDisplayMode: ResetTimerDisplayMode
@@ -12,6 +14,8 @@ interface ProviderDetailPageProps {
 
 export function ProviderDetailPage({
   plugin,
+  planOptions,
+  onPlanOptionChange,
   onRetry,
   displayMode,
   resetTimerDisplayMode,
@@ -28,7 +32,10 @@ export function ProviderDetailPage({
   return (
     <ProviderCard
       name={plugin.meta.name}
+      providerId={plugin.sourceProviderId ?? plugin.meta.id}
       plan={plugin.data?.plan}
+      planOptions={planOptions}
+      onPlanOptionChange={onPlanOptionChange}
       links={plugin.meta.links}
       showSeparator={false}
       loading={plugin.loading}

--- a/src/stores/app-preferences-store.ts
+++ b/src/stores/app-preferences-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand"
 import {
   DEFAULT_AUTO_UPDATE_INTERVAL,
+  DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS,
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
@@ -23,6 +24,7 @@ type AppPreferencesStore = {
   globalShortcut: GlobalShortcut
   startOnLogin: boolean
   menubarIconStyle: MenubarIconStyle
+  codexMenubarShowAllAccounts: boolean
   setAutoUpdateInterval: (value: AutoUpdateIntervalMinutes) => void
   setThemeMode: (value: ThemeMode) => void
   setDisplayMode: (value: DisplayMode) => void
@@ -30,6 +32,7 @@ type AppPreferencesStore = {
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setCodexMenubarShowAllAccounts: (value: boolean) => void
   resetState: () => void
 }
 
@@ -41,6 +44,7 @@ const initialState = {
   globalShortcut: DEFAULT_GLOBAL_SHORTCUT,
   startOnLogin: DEFAULT_START_ON_LOGIN,
   menubarIconStyle: DEFAULT_MENUBAR_ICON_STYLE,
+  codexMenubarShowAllAccounts: DEFAULT_CODEX_MENUBAR_SHOW_ALL_ACCOUNTS,
 }
 
 export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
@@ -52,5 +56,6 @@ export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
   setGlobalShortcut: (value) => set({ globalShortcut: value }),
   setStartOnLogin: (value) => set({ startOnLogin: value }),
   setMenubarIconStyle: (value) => set({ menubarIconStyle: value }),
+  setCodexMenubarShowAllAccounts: (value) => set({ codexMenubarShowAllAccounts: value }),
   resetState: () => set(initialState),
 }))

--- a/src/stores/app-ui-store.ts
+++ b/src/stores/app-ui-store.ts
@@ -7,7 +7,7 @@ type AppUiStore = {
   selectedCodexProviderId: string | null
   setActiveView: (view: ActiveView) => void
   setShowAbout: (value: boolean) => void
-  setSelectedCodexProviderId: (value: string) => void
+  setSelectedCodexProviderId: (value: string | null) => void
   resetState: () => void
 }
 

--- a/src/stores/app-ui-store.ts
+++ b/src/stores/app-ui-store.ts
@@ -4,19 +4,23 @@ import type { ActiveView } from "@/components/side-nav"
 type AppUiStore = {
   activeView: ActiveView
   showAbout: boolean
+  selectedCodexProviderId: string | null
   setActiveView: (view: ActiveView) => void
   setShowAbout: (value: boolean) => void
+  setSelectedCodexProviderId: (value: string) => void
   resetState: () => void
 }
 
 const initialState = {
   activeView: "home" as ActiveView,
   showAbout: false,
+  selectedCodexProviderId: null as string | null,
 }
 
 export const useAppUiStore = create<AppUiStore>((set) => ({
   ...initialState,
   setActiveView: (view) => set({ activeView: view }),
   setShowAbout: (value) => set({ showAbout: value }),
+  setSelectedCodexProviderId: (value) => set({ selectedCodexProviderId: value }),
   resetState: () => set(initialState),
 }))


### PR DESCRIPTION
## Summary

- Add support for additional Codex auth slots under `~/.openusage/codex-accounts/<slot>/auth.json`.
- Detect Codex account identity from `id_token` and show account labels as `{account} - {plan}`.
- Group multiple Codex account providers into one Codex nav/settings entry.
- Add an account dropdown on the Codex card/detail view when multiple distinct Codex accounts are available.
- Add a Codex sheet toggle to show all Codex account percentages in the menu bar provider title.
- Keep retry/refresh scoped to the selected account source, so extra accounts do not overwrite the default Codex login.
- Use the selected Codex account for the menu bar provider percentage by default.
- Show local Codex token usage on every Codex account option, using the shared Codex session-log source instead of pretending it is account-specific.
- Keep long account labels readable by giving the account selector the full card width.
- Keep the implementation account-based only; no third-party app credential source is read.

## Usage

Default account keeps working as before:

```sh
codex login
```

To add another Codex account without overwriting the default account:

```sh
mkdir -p "$HOME/.openusage/codex-accounts/account-2"
CODEX_HOME="$HOME/.openusage/codex-accounts/account-2" codex login
```

Restart OpenUsage after adding a new slot so it can discover the account. If the slot contains a different Codex account, OpenUsage shows one Codex entry with an account dropdown.

By default, the menu bar provider percentage follows the selected Codex account. In the Codex sheet, enable `Menu bar: all accounts` to show every enabled Codex account percentage together in the menu bar, for example `62% | 95%`.

## Token usage note

Codex quota/usage bars are fetched per selected account, but the `$ / tokens` rows come from local Codex session JSONL logs via `ccusage-codex`. Those local logs are rooted at `CODEX_HOME` and are not reliably tied to an authenticated account email. To avoid showing misleading zeroes for secondary accounts, this PR displays the same shared local token totals for each Codex account option.

I am aware this is a tradeoff: the token totals are a shared local-history view, not a guaranteed per-account billing/account split. If maintainers prefer a different behavior, such as hiding token rows for account slots or reading slot-specific `CODEX_HOME` histories, I am happy to adjust.

## Validation

- `bunx vitest run src/lib/settings.test.ts src/hooks/app/use-settings-bootstrap.test.ts src/hooks/app/use-settings-display-actions.test.ts src/components/provider-card.test.tsx src/App.test.tsx src/lib/tray-primary-progress.test.ts src/hooks/app/use-app-plugin-views.test.ts src/hooks/app/use-settings-plugin-list.test.ts src/hooks/app/use-settings-plugin-actions.test.ts`
- `bun run build`
- `cargo test --manifest-path src-tauri/Cargo.toml`

