### PR TITLE
fix(claude): support hashed macOS keychain service name (closes #423)

### DIFF
--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -211,22 +211,22 @@
   }
 
   function computeKeychainHashSuffix(ctx) {
-    // Mirrors Claude Code's macOsKeychainHelpers.ts:
-    //   expandedConfigDir = process.env.CLAUDE_CONFIG_DIR (raw, NO tilde expansion)
-    //                       || ${HOME}/.claude
-    //   suffix            = sha256(expandedConfigDir).slice(0, 8)
+    // Mirrors upstream Claude Code (decompiled from the binary):
+    //   const suffix = !process.env.CLAUDE_CONFIG_DIR
+    //     ? ""
+    //     : "-" + sha256(CLAUDE_CONFIG_DIR.normalize("NFC")).slice(0, 8)
+    // The hash is ONLY appended when CLAUDE_CONFIG_DIR is explicitly set;
+    // when unset, upstream uses the legacy unhashed service name.
     const explicitConfigDir = readEnvText(ctx, "CLAUDE_CONFIG_DIR")
-    let expandedDir
-    if (explicitConfigDir) {
-      expandedDir = explicitConfigDir
-    } else {
-      const home = readEnvText(ctx, "HOME")
-      if (!home) return null  // can't compute hash; caller will fall back to legacy candidate only
-      expandedDir = home + "/.claude"
-    }
+    if (!explicitConfigDir) return null
     const sha256Hex = ctx.host && ctx.host.crypto && ctx.host.crypto.sha256Hex
     if (typeof sha256Hex !== "function") return null
-    const digest = sha256Hex(expandedDir)
+    // Match upstream's `.normalize("NFC")` exactly.
+    const normalized =
+      typeof explicitConfigDir.normalize === "function"
+        ? explicitConfigDir.normalize("NFC")
+        : explicitConfigDir
+    const digest = sha256Hex(normalized)
     if (typeof digest !== "string" || digest.length < 8) return null
     return digest.slice(0, 8)
   }
@@ -235,8 +235,8 @@
     const base = buildClaudeBaseKeychainService(ctx)
     const candidates = []
     const hash = computeKeychainHashSuffix(ctx)
-    if (hash) candidates.push(base + "-" + hash)  // newer Claude Code (hashed)
-    candidates.push(base)                          // legacy / compatibility
+    if (hash) candidates.push(base + "-" + hash)  // hashed (CLAUDE_CONFIG_DIR set)
+    candidates.push(base)                          // legacy / default
     return candidates
   }
 

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -206,8 +206,38 @@
     }
   }
 
-  function getClaudeKeychainService(ctx) {
+  function buildClaudeBaseKeychainService(ctx) {
     return KEYCHAIN_SERVICE_PREFIX + getOauthConfig(ctx).oauthFileSuffix + "-credentials"
+  }
+
+  function computeKeychainHashSuffix(ctx) {
+    // Mirrors Claude Code's macOsKeychainHelpers.ts:
+    //   expandedConfigDir = process.env.CLAUDE_CONFIG_DIR (raw, NO tilde expansion)
+    //                       || ${HOME}/.claude
+    //   suffix            = sha256(expandedConfigDir).slice(0, 8)
+    const explicitConfigDir = readEnvText(ctx, "CLAUDE_CONFIG_DIR")
+    let expandedDir
+    if (explicitConfigDir) {
+      expandedDir = explicitConfigDir
+    } else {
+      const home = readEnvText(ctx, "HOME")
+      if (!home) return null  // can't compute hash; caller will fall back to legacy candidate only
+      expandedDir = home + "/.claude"
+    }
+    const sha256Hex = ctx.host && ctx.host.crypto && ctx.host.crypto.sha256Hex
+    if (typeof sha256Hex !== "function") return null
+    const digest = sha256Hex(expandedDir)
+    if (typeof digest !== "string" || digest.length < 8) return null
+    return digest.slice(0, 8)
+  }
+
+  function getClaudeKeychainServiceCandidates(ctx) {
+    const base = buildClaudeBaseKeychainService(ctx)
+    const candidates = []
+    const hash = computeKeychainHashSuffix(ctx)
+    if (hash) candidates.push(base + "-" + hash)  // newer Claude Code (hashed)
+    candidates.push(base)                          // legacy / compatibility
+    return candidates
   }
 
   function readKeychainCredentialText(ctx, service) {
@@ -259,18 +289,21 @@
       }
     }
 
-    // Try keychain fallback
-    const keychainResult = readKeychainCredentialText(ctx, getClaudeKeychainService(ctx))
-    if (keychainResult && keychainResult.value) {
-      const parsed = tryParseCredentialJSON(ctx, keychainResult.value)
-      if (parsed) {
-        const oauth = parsed.claudeAiOauth
-        if (oauth && oauth.accessToken) {
-          ctx.host.log.info("credentials loaded from keychain")
-          return { oauth, source: keychainResult.source, fullData: parsed }
+    // Try keychain fallback — iterate hashed-then-legacy service names.
+    for (const service of getClaudeKeychainServiceCandidates(ctx)) {
+      const keychainResult = readKeychainCredentialText(ctx, service)
+      if (keychainResult && keychainResult.value) {
+        const parsed = tryParseCredentialJSON(ctx, keychainResult.value)
+        if (parsed) {
+          const oauth = parsed.claudeAiOauth
+          if (oauth && oauth.accessToken) {
+            ctx.host.log.info("credentials loaded from keychain (service=" + service + ")")
+            return { oauth, source: keychainResult.source, serviceName: service, fullData: parsed }
+          }
         }
+        ctx.host.log.warn("keychain has data for " + service + " but no valid oauth")
+        // Continue: a stale legacy entry shouldn't shadow a valid hashed one.
       }
-      ctx.host.log.warn("keychain has data but no valid oauth")
     }
 
     if (!suppressMissingWarn) {
@@ -291,6 +324,7 @@
     return {
       oauth: oauth,
       source: stored ? stored.source : null,
+      serviceName: stored ? stored.serviceName : null,
       fullData: stored ? stored.fullData : null,
       inferenceOnly: true,
     }
@@ -307,7 +341,7 @@
     return true
   }
 
-  function saveCredentials(ctx, source, fullData) {
+  function saveCredentials(ctx, source, serviceName, fullData) {
     // MUST use minified JSON - macOS `security -w` hex-encodes values with newlines,
     // which Claude Code can't read back, causing it to invalidate the session.
     const text = JSON.stringify(fullData)
@@ -317,19 +351,25 @@
       } catch (e) {
         ctx.host.log.error("Failed to write Claude credentials file: " + String(e))
       }
-    } else if (source === "keychain-current-user") {
+      return
+    }
+    if (!serviceName) {
+      ctx.host.log.error("Refusing keychain write: missing service name (source=" + source + ")")
+      return
+    }
+    if (source === "keychain-current-user") {
       try {
         if (typeof ctx.host.keychain.writeGenericPasswordForCurrentUser === "function") {
-          ctx.host.keychain.writeGenericPasswordForCurrentUser(getClaudeKeychainService(ctx), text)
+          ctx.host.keychain.writeGenericPasswordForCurrentUser(serviceName, text)
         } else {
-          ctx.host.keychain.writeGenericPassword(getClaudeKeychainService(ctx), text)
+          ctx.host.keychain.writeGenericPassword(serviceName, text)
         }
       } catch (e) {
         ctx.host.log.error("Failed to write Claude credentials keychain: " + String(e))
       }
     } else if (source === "keychain-legacy" || source === "keychain") {
       try {
-        ctx.host.keychain.writeGenericPassword(getClaudeKeychainService(ctx), text)
+        ctx.host.keychain.writeGenericPassword(serviceName, text)
       } catch (e) {
         ctx.host.log.error("Failed to write Claude credentials keychain: " + String(e))
       }
@@ -400,9 +440,9 @@
         oauth.expiresAt = Date.now() + body.expires_in * 1000
       }
 
-      // Persist updated credentials
+      // Persist updated credentials back to the same source we read from.
       fullData.claudeAiOauth = oauth
-      saveCredentials(ctx, source, fullData)
+      saveCredentials(ctx, source, creds.serviceName, fullData)
 
       ctx.host.log.info("refresh succeeded, new token expires in " + (body.expires_in || "unknown") + "s")
       return newAccessToken

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -1,5 +1,13 @@
+import crypto from "node:crypto"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { makeCtx } from "../test-helpers.js"
+
+// Default test HOME (set by makeCtx in test-helpers.js).
+const TEST_HOME = "/Users/test"
+const TEST_CLAUDE_DIR = TEST_HOME + "/.claude"
+const expectedHash = (path) =>
+  crypto.createHash("sha256").update(path).digest("hex").slice(0, 8)
+const HASHED_DEFAULT_SERVICE = "Claude Code-credentials-" + expectedHash(TEST_CLAUDE_DIR)
 
 let plugin = null
 
@@ -132,8 +140,9 @@ describe("claude plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    // Hashed candidate is tried first; the mock returns valid creds so we never reach legacy.
     expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
-      "Claude Code-credentials"
+      HASHED_DEFAULT_SERVICE
     )
     expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
@@ -157,7 +166,8 @@ describe("claude plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
-    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Claude Code-credentials")
+    // Hashed candidate is tried first; the legacy `readGenericPassword` returns valid creds for it.
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith(HASHED_DEFAULT_SERVICE)
   })
 
   it("falls back to keychain when credentials file is corrupt", async () => {
@@ -238,6 +248,121 @@ describe("claude plugin", () => {
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith(
       "Claude Code-staging-oauth-credentials"
+    )
+  })
+
+  it("finds the hashed keychain entry when only the hashed name exists (regression for #423)", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation((service) => {
+      if (service === HASHED_DEFAULT_SERVICE) {
+        return JSON.stringify({ claudeAiOauth: { accessToken: "tok", subscriptionType: "pro" } })
+      }
+      return null
+    })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
+      HASHED_DEFAULT_SERVICE
+    )
+  })
+
+  it("falls back to the legacy keychain entry when no hashed entry exists", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation((service) => {
+      if (service === "Claude Code-credentials") {
+        return JSON.stringify({ claudeAiOauth: { accessToken: "tok", subscriptionType: "pro" } })
+      }
+      return null  // hashed lookup misses → legacy candidate is tried next
+    })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
+      HASHED_DEFAULT_SERVICE
+    )
+    expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
+      "Claude Code-credentials"
+    )
+  })
+
+  it("composes the staging-oauth keychain hash correctly", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.env.get.mockImplementation((name) => {
+      if (name === "HOME") return TEST_HOME
+      if (name === "USER_TYPE") return "ant"
+      if (name === "USE_STAGING_OAUTH") return "1"
+      return null
+    })
+    const hashedStagingService =
+      "Claude Code-staging-oauth-credentials-" + expectedHash(TEST_CLAUDE_DIR)
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation((service) => {
+      if (service === hashedStagingService) {
+        return JSON.stringify({ claudeAiOauth: { accessToken: "tok", subscriptionType: "pro" } })
+      }
+      return null
+    })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
+      hashedStagingService
+    )
+  })
+
+  it("hashes CLAUDE_CONFIG_DIR raw without tilde expansion", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    // Raw, tilde-prefixed value: must be hashed verbatim (matches upstream Claude Code).
+    const rawConfigDir = "~/some-custom-claude-home"
+    ctx.host.env.get.mockImplementation((name) => {
+      if (name === "CLAUDE_CONFIG_DIR") return rawConfigDir
+      if (name === "HOME") return TEST_HOME
+      return null
+    })
+    const hashedService = "Claude Code-credentials-" + expectedHash(rawConfigDir)
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation((service) => {
+      if (service === hashedService) {
+        return JSON.stringify({ claudeAiOauth: { accessToken: "tok", subscriptionType: "pro" } })
+      }
+      return null
+    })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
+      hashedService
     )
   })
 

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -2,12 +2,11 @@ import crypto from "node:crypto"
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { makeCtx } from "../test-helpers.js"
 
-// Default test HOME (set by makeCtx in test-helpers.js).
-const TEST_HOME = "/Users/test"
-const TEST_CLAUDE_DIR = TEST_HOME + "/.claude"
+// Helpers for keychain hash regression tests.
 const expectedHash = (path) =>
   crypto.createHash("sha256").update(path).digest("hex").slice(0, 8)
-const HASHED_DEFAULT_SERVICE = "Claude Code-credentials-" + expectedHash(TEST_CLAUDE_DIR)
+const TEST_CONFIG_DIR = "/Users/test/.claude"
+const HASHED_CONFIG_SERVICE = "Claude Code-credentials-" + expectedHash(TEST_CONFIG_DIR)
 
 let plugin = null
 
@@ -140,9 +139,9 @@ describe("claude plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
-    // Hashed candidate is tried first; the mock returns valid creds so we never reach legacy.
+    // No CLAUDE_CONFIG_DIR → upstream uses the legacy unhashed service name only.
     expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
-      HASHED_DEFAULT_SERVICE
+      "Claude Code-credentials"
     )
     expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
@@ -166,8 +165,8 @@ describe("claude plugin", () => {
     const plugin = await loadPlugin()
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
-    // Hashed candidate is tried first; the legacy `readGenericPassword` returns valid creds for it.
-    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith(HASHED_DEFAULT_SERVICE)
+    // No CLAUDE_CONFIG_DIR → upstream uses the legacy unhashed service name only.
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Claude Code-credentials")
   })
 
   it("falls back to keychain when credentials file is corrupt", async () => {
@@ -251,11 +250,14 @@ describe("claude plugin", () => {
     )
   })
 
-  it("finds the hashed keychain entry when only the hashed name exists (regression for #423)", async () => {
+  it("finds the hashed keychain entry when CLAUDE_CONFIG_DIR is set (regression for #423)", async () => {
     const ctx = makeCtx()
     ctx.host.fs.exists = () => false
+    ctx.host.env.get.mockImplementation((name) =>
+      name === "CLAUDE_CONFIG_DIR" ? TEST_CONFIG_DIR : null
+    )
     ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation((service) => {
-      if (service === HASHED_DEFAULT_SERVICE) {
+      if (service === HASHED_CONFIG_SERVICE) {
         return JSON.stringify({ claudeAiOauth: { accessToken: "tok", subscriptionType: "pro" } })
       }
       return null
@@ -271,13 +273,16 @@ describe("claude plugin", () => {
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
-      HASHED_DEFAULT_SERVICE
+      HASHED_CONFIG_SERVICE
     )
   })
 
-  it("falls back to the legacy keychain entry when no hashed entry exists", async () => {
+  it("falls back to legacy unhashed entry when CLAUDE_CONFIG_DIR is set but no hashed entry exists", async () => {
     const ctx = makeCtx()
     ctx.host.fs.exists = () => false
+    ctx.host.env.get.mockImplementation((name) =>
+      name === "CLAUDE_CONFIG_DIR" ? TEST_CONFIG_DIR : null
+    )
     ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation((service) => {
       if (service === "Claude Code-credentials") {
         return JSON.stringify({ claudeAiOauth: { accessToken: "tok", subscriptionType: "pro" } })
@@ -295,24 +300,44 @@ describe("claude plugin", () => {
     const result = plugin.probe(ctx)
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
-      HASHED_DEFAULT_SERVICE
+      HASHED_CONFIG_SERVICE
     )
     expect(ctx.host.keychain.readGenericPasswordForCurrentUser).toHaveBeenCalledWith(
       "Claude Code-credentials"
     )
   })
 
+  it("does NOT compute a hash when CLAUDE_CONFIG_DIR is unset (matches upstream)", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => false
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockReturnValue(
+      JSON.stringify({ claudeAiOauth: { accessToken: "tok", subscriptionType: "pro" } })
+    )
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+    // Only the legacy unhashed service is consulted — no hashed candidate.
+    const calls = ctx.host.keychain.readGenericPasswordForCurrentUser.mock.calls.map((c) => c[0])
+    expect(calls).toEqual(["Claude Code-credentials"])
+  })
+
   it("composes the staging-oauth keychain hash correctly", async () => {
     const ctx = makeCtx()
     ctx.host.fs.exists = () => false
     ctx.host.env.get.mockImplementation((name) => {
-      if (name === "HOME") return TEST_HOME
+      if (name === "CLAUDE_CONFIG_DIR") return TEST_CONFIG_DIR
       if (name === "USER_TYPE") return "ant"
       if (name === "USE_STAGING_OAUTH") return "1"
       return null
     })
     const hashedStagingService =
-      "Claude Code-staging-oauth-credentials-" + expectedHash(TEST_CLAUDE_DIR)
+      "Claude Code-staging-oauth-credentials-" + expectedHash(TEST_CONFIG_DIR)
     ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation((service) => {
       if (service === hashedStagingService) {
         return JSON.stringify({ claudeAiOauth: { accessToken: "tok", subscriptionType: "pro" } })
@@ -334,16 +359,15 @@ describe("claude plugin", () => {
     )
   })
 
-  it("hashes CLAUDE_CONFIG_DIR raw without tilde expansion", async () => {
+  it("hashes CLAUDE_CONFIG_DIR verbatim (no tilde expansion, NFC-normalized)", async () => {
     const ctx = makeCtx()
     ctx.host.fs.exists = () => false
-    // Raw, tilde-prefixed value: must be hashed verbatim (matches upstream Claude Code).
+    // Raw, tilde-prefixed value: hashed verbatim. Upstream applies .normalize("NFC"),
+    // which is a no-op for ASCII so the hash matches a plain sha256 of the string.
     const rawConfigDir = "~/some-custom-claude-home"
-    ctx.host.env.get.mockImplementation((name) => {
-      if (name === "CLAUDE_CONFIG_DIR") return rawConfigDir
-      if (name === "HOME") return TEST_HOME
-      return null
-    })
+    ctx.host.env.get.mockImplementation((name) =>
+      name === "CLAUDE_CONFIG_DIR" ? rawConfigDir : null
+    )
     const hashedService = "Claude Code-credentials-" + expectedHash(rawConfigDir)
     ctx.host.keychain.readGenericPasswordForCurrentUser.mockImplementation((service) => {
       if (service === hashedService) {

--- a/plugins/test-helpers.js
+++ b/plugins/test-helpers.js
@@ -39,7 +39,7 @@ export const makeCtx = () => {
         },
       },
       env: {
-        get: vi.fn(() => null),
+        get: vi.fn((name) => (name === "HOME" ? "/Users/test" : null)),
       },
       keychain: {
         readGenericPassword: vi.fn(),
@@ -68,6 +68,7 @@ export const makeCtx = () => {
           const tag = cipher.getAuthTag()
           return `${iv.toString("base64")}:${tag.toString("base64")}:${ciphertext.toString("base64")}`
         }),
+        sha256Hex: vi.fn((text) => crypto.createHash("sha256").update(String(text)).digest("hex")),
       },
       sqlite: {
         query: vi.fn(() => "[]"),

--- a/plugins/test-helpers.js
+++ b/plugins/test-helpers.js
@@ -39,7 +39,7 @@ export const makeCtx = () => {
         },
       },
       env: {
-        get: vi.fn((name) => (name === "HOME" ? "/Users/test" : null)),
+        get: vi.fn(() => null),
       },
       keychain: {
         readGenericPassword: vi.fn(),

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3070,6 +3070,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-nspanel",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ tauri-plugin-autostart = "2.5.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 regex-lite = "0.1.9"
 aes-gcm = "0.10.3"
+sha2 = "0.10"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -12,8 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
-const WHITELISTED_ENV_VARS: [&str; 17] = [
-    "HOME",
+const WHITELISTED_ENV_VARS: [&str; 16] = [
     "CODEX_HOME",
     "CLAUDE_CONFIG_DIR",
     "CLAUDE_CODE_OAUTH_TOKEN",
@@ -2680,7 +2679,6 @@ mod tests {
     #[test]
     fn env_api_respects_allowlist_in_host_and_js() {
         let claude_env_vars = [
-            "HOME",
             "CLAUDE_CONFIG_DIR",
             "CLAUDE_CODE_OAUTH_TOKEN",
             "USER_TYPE",

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -5,13 +5,15 @@ use aes_gcm::{
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use rquickjs::{Ctx, Exception, Function, Object};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
-const WHITELISTED_ENV_VARS: [&str; 16] = [
+const WHITELISTED_ENV_VARS: [&str; 17] = [
+    "HOME",
     "CODEX_HOME",
     "CLAUDE_CONFIG_DIR",
     "CLAUDE_CODE_OAUTH_TOKEN",
@@ -680,6 +682,24 @@ fn inject_crypto<'js>(ctx: &Ctx<'js>, host: &Object<'js>) -> rquickjs::Result<()
                   -> rquickjs::Result<String> {
                 encrypt_aes_256_gcm_envelope(&plaintext, &key_b64)
                     .map_err(|e| Exception::throw_message(&ctx_inner, &e))
+            },
+        )?,
+    )?;
+
+    crypto_obj.set(
+        "sha256Hex",
+        Function::new(
+            ctx.clone(),
+            move |text: String| -> String {
+                let digest = Sha256::digest(text.as_bytes());
+                // Lowercase hex, matches Node's `crypto.createHash("sha256").update(x).digest("hex")`
+                // and the upstream Claude Code keychain helper.
+                let mut out = String::with_capacity(digest.len() * 2);
+                for byte in digest.iter() {
+                    use std::fmt::Write as _;
+                    let _ = write!(&mut out, "{:02x}", byte);
+                }
+                out
             },
         )?,
     )?;
@@ -2606,6 +2626,32 @@ mod tests {
     }
 
     #[test]
+    fn crypto_api_exposes_sha256_hex() {
+        let rt = Runtime::new().expect("runtime");
+        let ctx = Context::full(&rt).expect("context");
+        ctx.with(|ctx| {
+            let app_data = std::env::temp_dir();
+            inject_host_api(&ctx, "test", &app_data, "0.0.0").expect("inject host api");
+            // Vector: `printf '%s' 'hello' | shasum -a 256`
+            let result: String = ctx
+                .eval(r#"__openusage_ctx.host.crypto.sha256Hex("hello")"#)
+                .expect("js sha256");
+            assert_eq!(
+                result,
+                "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            );
+
+            let empty: String = ctx
+                .eval(r#"__openusage_ctx.host.crypto.sha256Hex("")"#)
+                .expect("js sha256 empty");
+            assert_eq!(
+                empty,
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            );
+        });
+    }
+
+    #[test]
     fn keychain_api_exposes_write_variants() {
         let rt = Runtime::new().expect("runtime");
         let ctx = Context::full(&rt).expect("context");
@@ -2634,6 +2680,7 @@ mod tests {
     #[test]
     fn env_api_respects_allowlist_in_host_and_js() {
         let claude_env_vars = [
+            "HOME",
             "CLAUDE_CONFIG_DIR",
             "CLAUDE_CODE_OAUTH_TOKEN",
             "USER_TYPE",


### PR DESCRIPTION
## Human Summary 👀

Issue #423 said that whenever `CLAUDE_CONFIG_DIR` is set, the keychain name changes. This PR fixes that by replicating exactly what Claude Code does.

## Summary

Fixes #423 — when `CLAUDE_CONFIG_DIR` is set, recent Claude Code stores macOS Keychain credentials under a hashed service name. The plugin only checked the unhashed name, so it reported `Not logged in` even on a freshly-authenticated machine.

## What changed
- `plugins/claude/plugin.js`: build a list of keychain service candidates and probe them in order — hashed first (when applicable), legacy second. Decompiled from the upstream `claude` binary, the service-name builder is:
  ```js
  function iN(H = "") {
    let _ = B6();  // (CLAUDE_CONFIG_DIR ?? path.join(homedir(), ".claude")).normalize("NFC")
    let K = !process.env.CLAUDE_CONFIG_DIR
      ? ""
      : `-${sha256(_).digest("hex").substring(0, 8)}`;
    return `Claude Code${OAUTH_FILE_SUFFIX}${H}${K}`;
  }
  ```
  Key insight: **the hash suffix is only appended when `CLAUDE_CONFIG_DIR` is explicitly set.** When unset, upstream uses the legacy unhashed `Claude Code-credentials`. The plugin now mirrors that exactly, including `.normalize("NFC")` on the hash input.

  The successful service name is also threaded through `loadCredentials` → `saveCredentials` so token refreshes write back to the same entry they were loaded from (no more accidentally writing to the legacy slot when the hashed one was the source).

- `src-tauri/src/plugin_engine/host_api.rs`: expose `host.crypto.sha256Hex(text)` to plugin JS (lowercase hex, matches Node's `crypto.createHash("sha256").update(x).digest("hex")`). New Rust dep: `sha2 = "0.10"`. **No env-allowlist changes** — `HOME` is not needed because we only hash when `CLAUDE_CONFIG_DIR` is set, and at that point we use its value directly.

## Why
The reporter (#423) traced this precisely: a re-auth created `Claude Code-credentials-<8-char-hash>` and the plugin's unhashed lookup found nothing. The hash matches `sha256(CLAUDE_CONFIG_DIR.normalize("NFC")).slice(0, 8)` — confirmed against the decompiled upstream `iN()` and `B6()` helpers.

## Test plan
- [x] Hashed entry found when `CLAUDE_CONFIG_DIR` is set (the #423 regression).
- [x] Legacy fallback works when `CLAUDE_CONFIG_DIR` is set but only the unhashed entry exists.
- [x] No hash computed when `CLAUDE_CONFIG_DIR` is unset (matches upstream behavior).
- [x] `USE_STAGING_OAUTH=1` produces `Claude Code-staging-oauth-credentials-<hash>` when paired with `CLAUDE_CONFIG_DIR`.
- [x] `CLAUDE_CONFIG_DIR=~/some-custom-claude-home` is hashed verbatim, no tilde expansion.
- [x] Rust unit test covers `sha256Hex` against a known vector.
- [ ] Manual smoke on the reporter's machine (CLAUDE_CONFIG_DIR set, only hashed keychain entry).

## Follow-ups
None planned — fix is contained.