### PR TITLE
fix(codex): correct usage dashboard URL to ChatGPT Codex settings

### DIFF
--- a/plugins/codex/plugin.json
+++ b/plugins/codex/plugin.json
@@ -8,7 +8,7 @@
   "brandColor": "#74AA9C",
   "links": [
     { "label": "Status", "url": "https://status.openai.com/" },
-    { "label": "Usage dashboard", "url": "https://platform.openai.com/usage" }
+    { "label": "Usage dashboard", "url": "https://chatgpt.com/codex/settings/usage" }
   ],
   "lines": [
     { "type": "progress", "label": "Session", "scope": "overview", "primaryOrder": 1 },


### PR DESCRIPTION
## Description

The "Usage dashboard" link in the Codex plugin currently points to
https://platform.openai.com/usage, which is the OpenAI API platform page intended for API key users.

However, Codex authenticates via ChatGPT OAuth rather than the OpenAI platform, so the correct usage page should be
https://chatgpt.com/codex/settings/usage.

This link appears to have been introduced in [#162](https://github.com/robinebers/openusage/pull/162).

I understand that since this project supports multiple AI agents, it may be difficult to keep up with changes across all providers.
That said, from a user's perspective, having these details work correctly can significantly improve the overall experience.

I'm both a user and a developer who finds this project very useful and wanted to contribute.
Since this is my first time contributing to an open source project, I may not have followed the process perfectly.
Please let me know if anything needs to be adjusted.

## Related Issue

N/A

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [ ] I tested the change locally with `bun tauri dev`

## Checklist

- [x] I read CONTRIBUTING.md
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Codex plugin’s “Usage dashboard” link to point to the ChatGPT Codex usage settings. This prevents sending ChatGPT-authenticated users to the OpenAI API usage page.

<sup>Written for commit a8515df06240c0f3795352ce1a45467af60f9c31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

