### PR TITLE
chore(analytics): drop UI-side Aptabase events

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,7 +6,6 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
 const state = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   isTauriMock: vi.fn(() => false),
-  trackMock: vi.fn(),
   setSizeMock: vi.fn(),
   currentMonitorMock: vi.fn(),
   startBatchMock: vi.fn(),
@@ -110,10 +109,6 @@ vi.mock("@dnd-kit/utilities", () => ({
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: state.invokeMock,
   isTauri: state.isTauriMock,
-}))
-
-vi.mock("@/lib/analytics", () => ({
-  track: state.trackMock,
 }))
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -257,7 +252,6 @@ describe("App", () => {
     state.invokeMock.mockReset()
     state.isTauriMock.mockReset()
     state.isTauriMock.mockReturnValue(false)
-    state.trackMock.mockReset()
     state.setSizeMock.mockReset()
     state.currentMonitorMock.mockReset()
     state.startBatchMock.mockReset()
@@ -415,17 +409,6 @@ describe("App", () => {
     const migrateOrder = state.migrateLegacyTraySettingsMock.mock.invocationCallOrder[0]
     const loadOrder = state.loadMenubarIconStyleMock.mock.invocationCallOrder[0]
     expect(migrateOrder).toBeLessThan(loadOrder)
-  })
-
-  it("does not track page_viewed on startup or navigation", async () => {
-    render(<App />)
-    await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
-
-    const settingsButtons = await screen.findAllByRole("button", { name: "Settings" })
-    await userEvent.click(settingsButtons[0])
-
-    expect(state.trackMock).not.toHaveBeenCalledWith("page_viewed", expect.anything())
-    expect(state.trackMock).not.toHaveBeenCalledWith("page_viewed", undefined)
   })
 
   it("skips saving settings when already normalized", async () => {
@@ -961,15 +944,12 @@ describe("App", () => {
       lines: [{ type: "text", label: "Now", value: "OK" }],
     })
     state.startBatchMock.mockClear()
-    state.trackMock.mockClear()
-
     const reloadAction = await triggerPluginContextAction("Beta", "b", "reload")
     const reloadConfig = menuState.iconMenuItemConfigs.find((item) => item.id === "ctx-reload-b")
     expect(reloadConfig?.enabled).toBe(true)
     reloadAction()
 
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalledWith(["b"]))
-    expect(state.trackMock).toHaveBeenCalledWith("provider_refreshed", { provider_id: "b" })
   })
 
   it("respects manual refresh cooldown for sidebar context menu reload", async () => {
@@ -990,8 +970,6 @@ describe("App", () => {
     })
     await waitFor(() => expect(screen.getAllByRole("button", { name: "Retry" })).toHaveLength(2))
     state.startBatchMock.mockClear()
-    state.trackMock.mockClear()
-
     const reloadAction = await triggerPluginContextAction("Beta", "b", "reload")
     const firstReloadConfig = menuState.iconMenuItemConfigs.find((item) => item.id === "ctx-reload-b")
     expect(firstReloadConfig?.enabled).toBe(true)
@@ -1007,14 +985,12 @@ describe("App", () => {
     await waitFor(() => expect(screen.getAllByRole("button", { name: "Retry" })).toHaveLength(1))
 
     state.startBatchMock.mockClear()
-    state.trackMock.mockClear()
     const cooldownReloadAction = await triggerPluginContextAction("Beta", "b", "reload")
     const cooldownReloadConfig = menuState.iconMenuItemConfigs.find((item) => item.id === "ctx-reload-b")
     expect(cooldownReloadConfig?.enabled).toBe(false)
     cooldownReloadAction()
 
     expect(state.startBatchMock).not.toHaveBeenCalled()
-    expect(state.trackMock).not.toHaveBeenCalled()
   })
 
   it("closes sidebar context menu resources after popup", async () => {
@@ -1050,7 +1026,6 @@ describe("App", () => {
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
     state.startBatchMock.mockClear()
-    state.trackMock.mockClear()
     state.savePluginSettingsMock.mockClear()
 
     const removeAction = await triggerPluginContextAction("Beta", "b", "remove")
@@ -1059,7 +1034,6 @@ describe("App", () => {
     await waitFor(() =>
       expect(state.savePluginSettingsMock).toHaveBeenCalledWith({ order: ["a", "b"], disabled: ["b"] })
     )
-    expect(state.trackMock).toHaveBeenCalledWith("provider_toggled", { provider_id: "b", enabled: "false" })
     expect(state.startBatchMock).not.toHaveBeenCalled()
   })
 
@@ -1067,7 +1041,6 @@ describe("App", () => {
     state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
-    state.trackMock.mockClear()
     state.savePluginSettingsMock.mockClear()
 
     const removeAction = await triggerPluginContextAction("Beta", "b", "remove")
@@ -1078,12 +1051,10 @@ describe("App", () => {
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Beta" })).not.toBeInTheDocument()
     )
-    state.trackMock.mockClear()
     state.savePluginSettingsMock.mockClear()
 
     removeAction()
     expect(state.savePluginSettingsMock).not.toHaveBeenCalled()
-    expect(state.trackMock).not.toHaveBeenCalled()
   })
 
   it("returns to home when removing the active plugin from context menu", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import { useSettingsPluginList } from "@/hooks/app/use-settings-plugin-list"
 import { useSettingsSystemActions } from "@/hooks/app/use-settings-system-actions"
 import { useSettingsTheme } from "@/hooks/app/use-settings-theme"
 import { useTrayIcon } from "@/hooks/app/use-tray-icon"
-import { track } from "@/lib/analytics"
 import { REFRESH_COOLDOWN_MS, savePluginSettings } from "@/lib/settings"
 import { type PluginContextAction } from "@/components/side-nav"
 import { useAppPluginStore } from "@/stores/app-plugin-store"
@@ -197,7 +196,6 @@ function App() {
       const alreadyDisabled = currentSettings.disabled.includes(pluginId)
       if (alreadyDisabled) return
 
-      track("provider_toggled", { provider_id: pluginId, enabled: "false" })
       const nextSettings = {
         ...currentSettings,
         disabled: [...currentSettings.disabled, pluginId],

--- a/src/hooks/app/use-probe-refresh-actions.test.ts
+++ b/src/hooks/app/use-probe-refresh-actions.test.ts
@@ -1,13 +1,8 @@
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { getEnabledPluginIdsMock, trackMock } = vi.hoisted(() => ({
-  trackMock: vi.fn(),
+const { getEnabledPluginIdsMock } = vi.hoisted(() => ({
   getEnabledPluginIdsMock: vi.fn(),
-}))
-
-vi.mock("@/lib/analytics", () => ({
-  track: trackMock,
 }))
 
 vi.mock("@/lib/settings", () => ({
@@ -19,14 +14,13 @@ import { useProbeRefreshActions } from "@/hooks/app/use-probe-refresh-actions"
 
 describe("useProbeRefreshActions", () => {
   beforeEach(() => {
-    trackMock.mockReset()
     getEnabledPluginIdsMock.mockReset()
     getEnabledPluginIdsMock.mockImplementation((settings: { order: string[]; disabled: string[] }) =>
       settings.order.filter((id) => !settings.disabled.includes(id))
     )
   })
 
-  it("retries one plugin and tracks manual refresh", () => {
+  it("retries one plugin via manual refresh", () => {
     const manualRefreshIdsRef = { current: new Set<string>() }
     const startBatch = vi.fn().mockResolvedValue(undefined)
     const setLoadingForPlugins = vi.fn()
@@ -47,7 +41,6 @@ describe("useProbeRefreshActions", () => {
       result.current.handleRetryPlugin("codex")
     })
 
-    expect(trackMock).toHaveBeenCalledWith("provider_refreshed", { provider_id: "codex" })
     expect(setLoadingForPlugins).toHaveBeenCalledWith(["codex"])
     expect(startBatch).toHaveBeenCalledWith(["codex"])
     expect(manualRefreshIdsRef.current.has("codex")).toBe(true)

--- a/src/hooks/app/use-probe-refresh-actions.ts
+++ b/src/hooks/app/use-probe-refresh-actions.ts
@@ -1,6 +1,5 @@
 import { useCallback } from "react"
 import type { MutableRefObject } from "react"
-import { track } from "@/lib/analytics"
 import { REFRESH_COOLDOWN_MS, getEnabledPluginIds, type PluginSettings } from "@/lib/settings"
 import type { PluginState } from "@/hooks/app/types"
 
@@ -49,7 +48,6 @@ export function useProbeRefreshActions({
       const lastManualRefreshAt = currentState?.lastManualRefreshAt
       if (lastManualRefreshAt && Date.now() - lastManualRefreshAt < REFRESH_COOLDOWN_MS) return
 
-      track("provider_refreshed", { provider_id: id })
       resetAutoUpdateSchedule()
       startManualRefresh([id], "Failed to retry plugin:")
     },

--- a/src/hooks/app/use-settings-display-actions.test.ts
+++ b/src/hooks/app/use-settings-display-actions.test.ts
@@ -2,19 +2,13 @@ import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
-  trackMock,
   saveDisplayModeMock,
   saveResetTimerDisplayModeMock,
   saveThemeModeMock,
 } = vi.hoisted(() => ({
-  trackMock: vi.fn(),
   saveThemeModeMock: vi.fn(),
   saveDisplayModeMock: vi.fn(),
   saveResetTimerDisplayModeMock: vi.fn(),
-}))
-
-vi.mock("@/lib/analytics", () => ({
-  track: trackMock,
 }))
 
 vi.mock("@/lib/settings", () => ({
@@ -27,7 +21,6 @@ import { useSettingsDisplayActions } from "@/hooks/app/use-settings-display-acti
 
 describe("useSettingsDisplayActions", () => {
   beforeEach(() => {
-    trackMock.mockReset()
     saveThemeModeMock.mockReset()
     saveDisplayModeMock.mockReset()
     saveResetTimerDisplayModeMock.mockReset()
@@ -36,7 +29,7 @@ describe("useSettingsDisplayActions", () => {
     saveResetTimerDisplayModeMock.mockResolvedValue(undefined)
   })
 
-  it("tracks and applies display-related setting changes", () => {
+  it("applies display-related setting changes", () => {
     const setThemeMode = vi.fn()
     const setDisplayMode = vi.fn()
     const setResetTimerDisplayMode = vi.fn()
@@ -56,16 +49,6 @@ describe("useSettingsDisplayActions", () => {
       result.current.handleThemeModeChange("dark")
       result.current.handleDisplayModeChange("used")
       result.current.handleResetTimerDisplayModeChange("absolute")
-    })
-
-    expect(trackMock).toHaveBeenCalledWith("setting_changed", { setting: "theme", value: "dark" })
-    expect(trackMock).toHaveBeenCalledWith("setting_changed", {
-      setting: "display_mode",
-      value: "used",
-    })
-    expect(trackMock).toHaveBeenCalledWith("setting_changed", {
-      setting: "reset_timer_display_mode",
-      value: "absolute",
     })
 
     expect(setThemeMode).toHaveBeenCalledWith("dark")

--- a/src/hooks/app/use-settings-display-actions.ts
+++ b/src/hooks/app/use-settings-display-actions.ts
@@ -1,5 +1,4 @@
 import { useCallback } from "react"
-import { track } from "@/lib/analytics"
 import {
   saveDisplayMode,
   saveMenubarIconStyle,
@@ -31,7 +30,6 @@ export function useSettingsDisplayActions({
   scheduleTrayIconUpdate,
 }: UseSettingsDisplayActionsArgs) {
   const handleThemeModeChange = useCallback((mode: ThemeMode) => {
-    track("setting_changed", { setting: "theme", value: mode })
     setThemeMode(mode)
     void saveThemeMode(mode).catch((error) => {
       console.error("Failed to save theme mode:", error)
@@ -39,7 +37,6 @@ export function useSettingsDisplayActions({
   }, [setThemeMode])
 
   const handleDisplayModeChange = useCallback((mode: DisplayMode) => {
-    track("setting_changed", { setting: "display_mode", value: mode })
     setDisplayMode(mode)
     scheduleTrayIconUpdate("settings", 0)
     void saveDisplayMode(mode).catch((error) => {
@@ -48,7 +45,6 @@ export function useSettingsDisplayActions({
   }, [scheduleTrayIconUpdate, setDisplayMode])
 
   const handleResetTimerDisplayModeChange = useCallback((mode: ResetTimerDisplayMode) => {
-    track("setting_changed", { setting: "reset_timer_display_mode", value: mode })
     setResetTimerDisplayMode(mode)
     void saveResetTimerDisplayMode(mode).catch((error) => {
       console.error("Failed to save reset timer display mode:", error)
@@ -61,7 +57,6 @@ export function useSettingsDisplayActions({
   }, [handleResetTimerDisplayModeChange, resetTimerDisplayMode])
 
   const handleMenubarIconStyleChange = useCallback((style: MenubarIconStyle) => {
-    track("setting_changed", { setting: "menubar_icon_style", value: style })
     setMenubarIconStyle(style)
     scheduleTrayIconUpdate("settings", 0)
     void saveMenubarIconStyle(style).catch((error) => {

--- a/src/hooks/app/use-settings-plugin-actions.test.ts
+++ b/src/hooks/app/use-settings-plugin-actions.test.ts
@@ -1,13 +1,8 @@
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { savePluginSettingsMock, trackMock } = vi.hoisted(() => ({
-  trackMock: vi.fn(),
+const { savePluginSettingsMock } = vi.hoisted(() => ({
   savePluginSettingsMock: vi.fn(),
-}))
-
-vi.mock("@/lib/analytics", () => ({
-  track: trackMock,
 }))
 
 vi.mock("@/lib/settings", () => ({
@@ -18,7 +13,6 @@ import { useSettingsPluginActions } from "@/hooks/app/use-settings-plugin-action
 
 describe("useSettingsPluginActions", () => {
   beforeEach(() => {
-    trackMock.mockReset()
     savePluginSettingsMock.mockReset()
     savePluginSettingsMock.mockResolvedValue(undefined)
   })
@@ -42,7 +36,6 @@ describe("useSettingsPluginActions", () => {
       result.current.handleReorder(["b", "a"])
     })
 
-    expect(trackMock).toHaveBeenCalledWith("providers_reordered", { count: 2 })
     expect(setPluginSettings).toHaveBeenCalledWith({ order: ["b", "a"], disabled: [] })
     expect(savePluginSettingsMock).toHaveBeenCalledWith({ order: ["b", "a"], disabled: [] })
     expect(scheduleTrayIconUpdate).toHaveBeenCalledWith("settings", 2000)
@@ -192,7 +185,6 @@ describe("useSettingsPluginActions", () => {
     act(() => {
       result.current.handleToggle("b")
     })
-    expect(trackMock).toHaveBeenCalledWith("provider_toggled", { provider_id: "b", enabled: "true" })
     expect(setLoadingForPlugins).toHaveBeenCalledWith(["b"])
     expect(startBatch).toHaveBeenCalledWith(["b"])
     expect(setPluginSettings).toHaveBeenNthCalledWith(1, { order: ["a", "b"], disabled: [] })
@@ -200,7 +192,6 @@ describe("useSettingsPluginActions", () => {
     act(() => {
       result.current.handleToggle("a")
     })
-    expect(trackMock).toHaveBeenCalledWith("provider_toggled", { provider_id: "a", enabled: "false" })
     expect(setPluginSettings).toHaveBeenNthCalledWith(2, { order: ["a", "b"], disabled: ["b", "a"] })
   })
 
@@ -225,7 +216,6 @@ describe("useSettingsPluginActions", () => {
 
     expect(setPluginSettings).not.toHaveBeenCalled()
     expect(savePluginSettingsMock).not.toHaveBeenCalled()
-    expect(trackMock).not.toHaveBeenCalled()
   })
 
   it("logs errors when enabling probe start fails", async () => {

--- a/src/hooks/app/use-settings-plugin-actions.ts
+++ b/src/hooks/app/use-settings-plugin-actions.ts
@@ -1,5 +1,4 @@
 import { useCallback } from "react"
-import { track } from "@/lib/analytics"
 import { savePluginSettings, type PluginSettings } from "@/lib/settings"
 
 const TRAY_SETTINGS_DEBOUNCE_MS = 2000
@@ -25,7 +24,6 @@ export function useSettingsPluginActions({
 }: UseSettingsPluginActionsArgs) {
   const handleReorder = useCallback((orderedIds: string[]) => {
     if (!pluginSettings) return
-    track("providers_reordered", { count: orderedIds.length })
     // orderedIds may be a subset (e.g. nav-only, excluding disabled plugins).
     // Re-insert any missing IDs from the previous order at their original
     // relative positions so disabled plugins are not dropped.
@@ -59,7 +57,6 @@ export function useSettingsPluginActions({
   const handleToggle = useCallback((id: string) => {
     if (!pluginSettings) return
     const wasDisabled = pluginSettings.disabled.includes(id)
-    track("provider_toggled", { provider_id: id, enabled: wasDisabled ? "true" : "false" })
     const disabled = new Set(pluginSettings.disabled)
 
     if (wasDisabled) {

--- a/src/hooks/app/use-settings-system-actions.test.ts
+++ b/src/hooks/app/use-settings-system-actions.test.ts
@@ -7,9 +7,7 @@ const {
   saveAutoUpdateIntervalMock,
   saveGlobalShortcutMock,
   saveStartOnLoginMock,
-  trackMock,
 } = vi.hoisted(() => ({
-  trackMock: vi.fn(),
   getEnabledPluginIdsMock: vi.fn(),
   saveAutoUpdateIntervalMock: vi.fn(),
   saveGlobalShortcutMock: vi.fn(),
@@ -19,10 +17,6 @@ const {
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: invokeMock,
-}))
-
-vi.mock("@/lib/analytics", () => ({
-  track: trackMock,
 }))
 
 vi.mock("@/lib/settings", () => ({
@@ -36,7 +30,6 @@ import { useSettingsSystemActions } from "@/hooks/app/use-settings-system-action
 
 describe("useSettingsSystemActions", () => {
   beforeEach(() => {
-    trackMock.mockReset()
     getEnabledPluginIdsMock.mockReset()
     saveAutoUpdateIntervalMock.mockReset()
     saveGlobalShortcutMock.mockReset()
@@ -72,7 +65,6 @@ describe("useSettingsSystemActions", () => {
       result.current.handleAutoUpdateIntervalChange(15)
     })
 
-    expect(trackMock).toHaveBeenCalledWith("setting_changed", { setting: "auto_refresh", value: "15" })
     expect(setAutoUpdateInterval).toHaveBeenCalledWith(15)
     expect(setAutoUpdateNextAt).toHaveBeenCalledWith(910_000)
     expect(saveAutoUpdateIntervalMock).toHaveBeenCalledWith(15)
@@ -119,15 +111,6 @@ describe("useSettingsSystemActions", () => {
     act(() => {
       result.current.handleGlobalShortcutChange("CommandOrControl+Shift+O")
       result.current.handleStartOnLoginChange(true)
-    })
-
-    expect(trackMock).toHaveBeenCalledWith("setting_changed", {
-      setting: "global_shortcut",
-      value: "CommandOrControl+Shift+O",
-    })
-    expect(trackMock).toHaveBeenCalledWith("setting_changed", {
-      setting: "start_on_login",
-      value: "true",
     })
 
     expect(setGlobalShortcut).toHaveBeenCalledWith("CommandOrControl+Shift+O")

--- a/src/hooks/app/use-settings-system-actions.ts
+++ b/src/hooks/app/use-settings-system-actions.ts
@@ -1,6 +1,5 @@
 import { useCallback } from "react"
 import { invoke } from "@tauri-apps/api/core"
-import { track } from "@/lib/analytics"
 import {
   getEnabledPluginIds,
   saveAutoUpdateInterval,
@@ -29,7 +28,6 @@ export function useSettingsSystemActions({
   applyStartOnLogin,
 }: UseSettingsSystemActionsArgs) {
   const handleAutoUpdateIntervalChange = useCallback((value: AutoUpdateIntervalMinutes) => {
-    track("setting_changed", { setting: "auto_refresh", value: String(value) })
     setAutoUpdateInterval(value)
 
     if (pluginSettings) {
@@ -47,7 +45,6 @@ export function useSettingsSystemActions({
   }, [pluginSettings, setAutoUpdateInterval, setAutoUpdateNextAt])
 
   const handleGlobalShortcutChange = useCallback((value: GlobalShortcut) => {
-    track("setting_changed", { setting: "global_shortcut", value: value ?? "disabled" })
     setGlobalShortcut(value)
     void saveGlobalShortcut(value).catch((error) => {
       console.error("Failed to save global shortcut:", error)
@@ -58,7 +55,6 @@ export function useSettingsSystemActions({
   }, [setGlobalShortcut])
 
   const handleStartOnLoginChange = useCallback((value: boolean) => {
-    track("setting_changed", { setting: "start_on_login", value: value ? "true" : "false" })
     setStartOnLogin(value)
     void saveStartOnLogin(value).catch((error) => {
       console.error("Failed to save start on login:", error)

--- a/src/hooks/use-app-update.ts
+++ b/src/hooks/use-app-update.ts
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback, useRef } from "react"
 import { isTauri } from "@tauri-apps/api/core"
 import { check, type Update } from "@tauri-apps/plugin-updater"
 import { relaunch } from "@tauri-apps/plugin-process"
-import { track } from "@/lib/analytics"
 
 export type UpdateStatus =
   | { status: "idle" }
@@ -124,8 +123,6 @@ export function useAppUpdate(): UseAppUpdateReturn {
     if (!update) return
     if (statusRef.current.status !== "ready") return
     if (inFlightRef.current.installing || inFlightRef.current.downloading) return
-
-    track("update_accepted", { version: update.version })
 
     try {
       inFlightRef.current.installing = true

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -22,7 +22,7 @@ describe("analytics track", () => {
     state.isTauriMock.mockReturnValue(false)
     const { track } = await import("./analytics")
 
-    track("setting_changed", { setting: "theme", value: "dark" })
+    track("test_event", { foo: "bar" })
 
     expect(state.invokeMock).not.toHaveBeenCalled()
   })
@@ -30,8 +30,8 @@ describe("analytics track", () => {
   it("tracks all events when running in tauri", async () => {
     const { track } = await import("./analytics")
 
-    track("setting_changed", { setting: "theme", value: "dark" })
-    track("setting_changed", { setting: "theme", value: "dark" })
+    track("test_event", { foo: "bar" })
+    track("test_event", { foo: "bar" })
 
     expect(state.invokeMock).toHaveBeenCalledTimes(2)
   })


### PR DESCRIPTION
## Summary

- Remove 5 custom Aptabase events fired from the React app: `provider_refreshed`, `providers_reordered`, `setting_changed`, `update_accepted`, and `provider_toggled`
- Drop the related `track()` import + tests; the analytics wrapper module stays in place but has no callers in the JS layer
- The Rust-side daily-active `app_started` event remains untouched (sent at most once per UTC day from `src-tauri/src/lib.rs`)

## Test plan

- [x] `bun run test` — 1076 passing (one obsolete `page_viewed` non-tracking test removed)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes client-side analytics calls and related test assertions without changing core app behavior; low risk aside from losing telemetry signals.
> 
> **Overview**
> Drops React/UI-layer Aptabase tracking by removing `track()` calls for plugin refresh/reorder/toggle, settings changes, and update acceptance (e.g. in `App`, `useProbeRefreshActions`, and settings action hooks).
> 
> Cleans up tests by removing analytics mocks/assertions and deleting an obsolete startup/navigation tracking test; `src/lib/analytics` remains covered by a simplified generic event test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 235fedf2438d2db3cd0d942c5a6b04952e118fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed all UI-side Aptabase analytics to simplify the React app and reduce noise. The only remaining analytics is the Rust-side daily `app_started`; the JS `track()` helper remains but has no React callers.

- **Refactors**
  - Removed event calls: `provider_refreshed`, `providers_reordered`, `setting_changed`, `update_accepted`, `provider_toggled`.
  - Cleaned up related imports, mocks, and assertions in tests; removed the obsolete `page_viewed` test.
  - Kept `src/lib/analytics` and `track()`; still a no-op on web and forwards events when running in Tauri (tests updated).

<sup>Written for commit 235fedf2438d2db3cd0d942c5a6b04952e118fe3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

