### PR TITLE
fix(perplexity): handle missing group in API response

### DIFF
--- a/plugins/perplexity/plugin.js
+++ b/plugins/perplexity/plugin.js
@@ -292,10 +292,16 @@
     return (hasCost || hasValidMeter) ? costSum : null
   }
 
-  function detectPlanLabel(customerInfo) {
-    if (!customerInfo || typeof customerInfo !== "object") return null
-    if (customerInfo.is_max === true || customerInfo.subscription_tier === "max") return "Max"
-    if (customerInfo.is_pro === true) return "Pro"
+  function detectPlanLabel(customerInfo, user) {
+    if (customerInfo && typeof customerInfo === "object") {
+      if (customerInfo.is_max === true || customerInfo.subscription_tier === "max") return "Max"
+      if (customerInfo.is_pro === true) return "Pro"
+    }
+    if (user && typeof user === "object") {
+      const tier = user.subscription_tier
+      if (tier === "max") return "Max"
+      if (tier === "pro") return "Pro"
+    }
     return null
   }
 
@@ -360,21 +366,25 @@
     const authToken = session && session.authToken
     if (!authToken) return null
     const restHeaders = makeRestHeaderOverrides(session)
+    const user = fetchJsonOptional(ctx, LOCAL_USER_ENDPOINT, authToken, restHeaders)
     const groups =
       fetchJsonOptional(ctx, REST_GROUPS_ENDPOINT, authToken, restHeaders) ||
       fetchJsonOptional(ctx, REST_GROUPS_ENDPOINT + "/", authToken, restHeaders)
     const groupId = pickGroupId(groups)
-    if (!groupId) return null
-    const base = REST_API_BASE + "/groups/" + encodeURIComponent(groupId)
-    const group =
-      fetchJsonOptional(ctx, base, authToken, restHeaders) ||
-      fetchJsonOptional(ctx, base + "/", authToken, restHeaders)
-    const usageUrl = base + "/usage-analytics"
-    const usageAnalytics =
-      fetchJsonOptional(ctx, usageUrl, authToken, restHeaders) ||
-      fetchJsonOptional(ctx, usageUrl + "/", authToken, restHeaders)
+    let group = null
+    let usageAnalytics = null
+    if (groupId) {
+      const base = REST_API_BASE + "/groups/" + encodeURIComponent(groupId)
+      group =
+        fetchJsonOptional(ctx, base, authToken, restHeaders) ||
+        fetchJsonOptional(ctx, base + "/", authToken, restHeaders)
+      const usageUrl = base + "/usage-analytics"
+      usageAnalytics =
+        fetchJsonOptional(ctx, usageUrl, authToken, restHeaders) ||
+        fetchJsonOptional(ctx, usageUrl + "/", authToken, restHeaders)
+    }
     const rateLimits = fetchJsonOptional(ctx, RATE_LIMIT_ENDPOINT, authToken, restHeaders)
-    return { groupId: groupId, group: group, usageAnalytics: usageAnalytics, rateLimits: rateLimits }
+    return { user: user, groupId: groupId, group: group, usageAnalytics: usageAnalytics, rateLimits: rateLimits }
   }
 
   function probe(ctx) {
@@ -383,13 +393,13 @@
     if (session.sourcePath) ctx.host.log.info("using cache db: " + session.sourcePath)
 
     const restState = fetchRestState(ctx, session)
-    if (!restState || !restState.group) throw "Unable to connect. Try again later."
+    if (!restState || (!restState.group && !restState.user && !restState.rateLimits)) throw "Unable to connect. Try again later."
 
     const customerInfo = restState.group && restState.group.customerInfo
-    const plan = detectPlanLabel(customerInfo)
+    const plan = detectPlanLabel(customerInfo, restState.user)
 
     const dollarLines = []
-    const balanceUsd = readBalanceUsd(restState.group)
+    const balanceUsd = restState.group ? readBalanceUsd(restState.group) : null
     if (balanceUsd !== null && balanceUsd > 0) {
       const usedUsd = sumUsageCostUsd(restState.usageAnalytics)
       if (usedUsd !== null) {

--- a/plugins/perplexity/plugin.js
+++ b/plugins/perplexity/plugin.js
@@ -366,7 +366,9 @@
     const authToken = session && session.authToken
     if (!authToken) return null
     const restHeaders = makeRestHeaderOverrides(session)
-    const user = fetchJsonOptional(ctx, LOCAL_USER_ENDPOINT, authToken, restHeaders)
+    const user =
+      fetchJsonOptional(ctx, LOCAL_USER_ENDPOINT, authToken, restHeaders) ||
+      fetchJsonOptional(ctx, LOCAL_USER_ENDPOINT + "/", authToken, restHeaders)
     const groups =
       fetchJsonOptional(ctx, REST_GROUPS_ENDPOINT, authToken, restHeaders) ||
       fetchJsonOptional(ctx, REST_GROUPS_ENDPOINT + "/", authToken, restHeaders)

--- a/plugins/perplexity/plugin.test.js
+++ b/plugins/perplexity/plugin.test.js
@@ -648,6 +648,54 @@ describe("perplexity plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Rate limits unavailable")
   })
 
+  it("uses user slash fallback and shows rate limits when groups are empty", async () => {
+    const ctx = makeCtx()
+    const token = makeJwtLikeToken()
+    mockCacheSession(ctx, { requestHex: makeRequestHexWithBearer(token) })
+
+    ctx.host.http.request.mockImplementation((req) => {
+      if (req.url === "https://www.perplexity.ai/api/user") {
+        return { status: 404, headers: {}, bodyText: "{}" }
+      }
+      if (req.url === "https://www.perplexity.ai/api/user/") {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ subscription_tier: "pro" }),
+        }
+      }
+      if (req.url === "https://www.perplexity.ai/rest/pplx-api/v2/groups") {
+        return { status: 200, headers: {}, bodyText: JSON.stringify([]) }
+      }
+      if (req.url === "https://www.perplexity.ai/rest/rate-limit/all") {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ remaining_pro: 198, remaining_research: 20 }),
+        }
+      }
+      return { status: 404, headers: {}, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Pro")
+    expect(result.lines.length).toBe(2)
+    expect(result.lines[0].label).toBe("Queries")
+    expect(result.lines[0].value).toBe("198 remaining")
+    expect(result.lines[1].label).toBe("Deep Research")
+    expect(result.lines[1].value).toBe("20 remaining")
+
+    const urls = ctx.host.http.request.mock.calls.map((call) => String(call[0]?.url))
+    expect(urls).toContain("https://www.perplexity.ai/api/user")
+    expect(urls).toContain("https://www.perplexity.ai/api/user/")
+    expect(urls).toContain("https://www.perplexity.ai/rest/pplx-api/v2/groups")
+    expect(urls).toContain("https://www.perplexity.ai/rest/rate-limit/all")
+    expect(urls.some((url) => url.startsWith("https://www.perplexity.ai/rest/pplx-api/v2/groups/"))).toBe(false)
+    expect(urls.some((url) => url.includes("/usage-analytics"))).toBe(false)
+  })
+
   it("shows rate-limit text lines for Pro subscriber with zero balance", async () => {
     const ctx = makeCtx()
     const token = makeJwtLikeToken()


### PR DESCRIPTION
Fixes #278.

Perplexity changed their API to return an empty list from the `/groups` endpoint for regular PRO users. This fix modifies the plugin to fetch the user plan from the `/api/user` endpoint instead, preventing a total connection failure, and allows the flow to proceed without a group object if rate limit data is available.

**Visual Verification:**
A screenshot demonstrating the successful fix (showing the rate limit details without the 'Unable to connect' error) has been provided and verified locally.

🤖 Generated with Gemini CLI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle empty `/groups` responses for Perplexity PRO users by reading the plan from `/api/user` (with a trailing-slash fallback) and proceeding when rate-limit data exists without a group. Adds tests to cover this flow.

- **Bug Fixes**
  - Fetch `user` from `/api/user` or `/api/user/` and use `subscription_tier` in `detectPlanLabel` as a fallback.
  - Only fetch group details and usage analytics when a `groupId` exists.
  - Relax connection check to proceed if `user` or `rateLimits` are present when `group` is missing.
  - Guard balance and usage reads when `group` is null.

<sup>Written for commit e0426ca95a23bd7d9059a77d823dbcc4c6a37da7. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/462?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

