### PR TITLE
fix(ccusage): resolve nvm node bin path from alias/default

### DIFF
--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -1666,12 +1666,30 @@ fn ccusage_runner_candidates(kind: CcusageRunnerKind) -> Vec<String> {
     unique
 }
 
+fn nvm_default_bin_path(home: &Path) -> Option<PathBuf> {
+    let alias_path = home.join(".nvm/alias/default");
+    let version = std::fs::read_to_string(&alias_path).ok()?;
+    let version = version.trim();
+    if version.is_empty() {
+        return None;
+    }
+    let version = if version.starts_with('v') {
+        version.to_string()
+    } else {
+        format!("v{version}")
+    };
+    Some(home.join(".nvm/versions/node").join(version).join("bin"))
+}
+
 fn ccusage_path_entries_with(home: Option<&Path>, existing_path: Option<&OsStr>) -> Vec<PathBuf> {
     let mut entries: Vec<PathBuf> = Vec::new();
 
     if let Some(home) = home {
         entries.push(home.join(".bun/bin"));
         entries.push(home.join(".nvm/current/bin"));
+        if let Some(nvm_bin) = nvm_default_bin_path(home) {
+            entries.push(nvm_bin);
+        }
         entries.push(home.join(".local/bin"));
     }
 
@@ -3569,6 +3587,56 @@ mod tests {
                 std::path::PathBuf::from("/usr/bin"),
                 std::path::PathBuf::from("/bin"),
             ]
+        );
+    }
+
+    #[test]
+    fn nvm_default_bin_path_resolves_version_with_v_prefix() {
+        let home = std::env::temp_dir().join("openusage-test-nvm-v-prefix");
+        let alias_dir = home.join(".nvm/alias");
+        std::fs::create_dir_all(&alias_dir).expect("create alias dir");
+        std::fs::write(alias_dir.join("default"), "v22.16.0").expect("write alias");
+        let result = nvm_default_bin_path(&home);
+        let _ = std::fs::remove_dir_all(&home);
+        assert_eq!(
+            result,
+            Some(home.join(".nvm/versions/node/v22.16.0/bin"))
+        );
+    }
+
+    #[test]
+    fn nvm_default_bin_path_resolves_version_without_v_prefix() {
+        let home = std::env::temp_dir().join("openusage-test-nvm-no-v-prefix");
+        let alias_dir = home.join(".nvm/alias");
+        std::fs::create_dir_all(&alias_dir).expect("create alias dir");
+        std::fs::write(alias_dir.join("default"), "22.16.0").expect("write alias");
+        let result = nvm_default_bin_path(&home);
+        let _ = std::fs::remove_dir_all(&home);
+        assert_eq!(
+            result,
+            Some(home.join(".nvm/versions/node/v22.16.0/bin"))
+        );
+    }
+
+    #[test]
+    fn nvm_default_bin_path_returns_none_when_alias_missing() {
+        let home = std::env::temp_dir().join("openusage-test-nvm-no-alias");
+        let _ = std::fs::remove_dir_all(&home);
+        let result = nvm_default_bin_path(&home);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn ccusage_path_entries_with_includes_nvm_default_version() {
+        let home = std::env::temp_dir().join("openusage-test-nvm-entries");
+        let alias_dir = home.join(".nvm/alias");
+        std::fs::create_dir_all(&alias_dir).expect("create alias dir");
+        std::fs::write(alias_dir.join("default"), "22.16.0").expect("write alias");
+        let entries = ccusage_path_entries_with(Some(&home), None);
+        let _ = std::fs::remove_dir_all(&home);
+        assert!(
+            entries.contains(&home.join(".nvm/versions/node/v22.16.0/bin")),
+            "expected nvm default version bin in entries"
         );
     }
 


### PR DESCRIPTION
## Description

While using openusage after an update, I noticed that the `Today / Yesterday / Last 30 Days`
lines had disappeared from the Codex card. I checked my version and also confirmed the version
of a teammate who could still see them — both were on v0.6.23.
After some investigation, I believe I've found the cause —
though I'm not deeply familiar with the codebase, so please let me know if my
analysis is off.

**What I think is happening:**

On my machine, the Codex CLI is installed via nvm, which places a `codex` binary
at `~/.nvm/versions/node/<version>/bin/codex`. When openusage runs
`bunx @ccusage/codex`, bunx appears to strip the package scope and search for a
binary named `codex` in PATH — finding the Codex CLI instead of the
`@ccusage/codex` npm package. This causes an immediate failure since the Codex
CLI doesn't recognize the `--json` flag.

In principle, the fallback runners (`npm exec`, `npx`) should recover from this.
However, the enriched PATH used to locate them includes `~/.nvm/current/bin`,
which nvm does not appear to create by default — at least not on my setup. As a
result, the fallback runners can't be found either, and all runners are exhausted
silently.

I verified this by creating a `~/.nvm/current` symlink manually, which restored
the missing lines immediately. Removing the symlink caused them to disappear again.

Note: the bunx binary conflict itself is not addressed here — but if the fallback
runners are reachable, the failed bunx attempt is already recovered correctly by
the existing logic.

**Fix:** Read `~/.nvm/alias/default` to resolve the active nvm version and add
`~/.nvm/versions/node/<version>/bin` to the enriched PATH alongside the existing
`~/.nvm/current/bin` entry.

~~This affects both the Codex and Claude plugins, as they are the only two plugins
that call `ctx.host.ccusage.query()` to fetch local token usage — all other
plugins retrieve data directly from their respective provider APIs and are
unaffected.~~

This issue appears to be specific to the Codex plugin. The Claude plugin uses
`bunx ccusage` (an unscoped package name), so bunx resolves it without conflict.
The Codex plugin uses `bunx @ccusage/codex` (a scoped package), where bunx strips
the scope and searches for a `codex` binary — which, if the Codex CLI is installed
via nvm, ends up running the Codex CLI binary rather than downloading the
`@ccusage/codex` npm package as intended.

I'm not sure how common this setup is, but I hope this helps others in a similar
situation. Happy to adjust anything if I've misunderstood the codebase.

## Related Issue

N/A

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [ ] I tested the change locally with `bun tauri dev`

## Screenshots


**Before** (without `~/.nvm/current` symlink — `Today / Yesterday / Last 30 Days` missing)
<img width="778" height="1048" alt="image" src="https://github.com/user-attachments/assets/a9b52c9b-e39f-4dad-92e6-823fd592ba00" />

**After** (with `~/.nvm/current` symlink — lines restored)
<img width="732" height="1262" alt="image" src="https://github.com/user-attachments/assets/6a64142a-841a-49dc-93af-8a78460fe0e5" />

## Checklist

- [x] I read CONTRIBUTING.md
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix NVM path resolution so `ccusage` can find Node runners when `~/.nvm/current` is missing. Restores the Codex/Claude local usage lines when `bunx` resolves the wrong `codex` binary.

- **Bug Fixes**
  - Resolve the active nvm Node bin from `~/.nvm/alias/default` (handles versions with/without `v`) and add `~/.nvm/versions/node/<version>/bin` to PATH.
  - Ensure fallback `npm exec`/`npx` are reachable even if `bunx` picks the `codex` CLI instead of `@ccusage/codex`.
  - Add tests for alias resolution and PATH entries.

<sup>Written for commit fa1438ef264cb1f99a4b821483ab49a9e1e5b993. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

