### PR TITLE
Add weekly menubar limit preference

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -21,6 +21,8 @@ const state = vi.hoisted(() => ({
   saveResetTimerDisplayModeMock: vi.fn(),
   loadMenubarIconStyleMock: vi.fn(),
   saveMenubarIconStyleMock: vi.fn(),
+  loadPreferMenubarWeeklyLimitMock: vi.fn(),
+  savePreferMenubarWeeklyLimitMock: vi.fn(),
   migrateLegacyTraySettingsMock: vi.fn(),
   loadGlobalShortcutMock: vi.fn(),
   saveGlobalShortcutMock: vi.fn(),
@@ -229,6 +231,8 @@ vi.mock("@/lib/settings", async () => {
     saveResetTimerDisplayMode: state.saveResetTimerDisplayModeMock,
     loadMenubarIconStyle: state.loadMenubarIconStyleMock,
     saveMenubarIconStyle: state.saveMenubarIconStyleMock,
+    loadPreferMenubarWeeklyLimit: state.loadPreferMenubarWeeklyLimitMock,
+    savePreferMenubarWeeklyLimit: state.savePreferMenubarWeeklyLimitMock,
     migrateLegacyTraySettings: state.migrateLegacyTraySettingsMock,
     loadGlobalShortcut: state.loadGlobalShortcutMock,
     saveGlobalShortcut: state.saveGlobalShortcutMock,
@@ -267,6 +271,8 @@ describe("App", () => {
     state.saveResetTimerDisplayModeMock.mockReset()
     state.loadMenubarIconStyleMock.mockReset()
     state.saveMenubarIconStyleMock.mockReset()
+    state.loadPreferMenubarWeeklyLimitMock.mockReset()
+    state.savePreferMenubarWeeklyLimitMock.mockReset()
     state.migrateLegacyTraySettingsMock.mockReset()
     state.loadGlobalShortcutMock.mockReset()
     state.saveGlobalShortcutMock.mockReset()
@@ -305,6 +311,8 @@ describe("App", () => {
     state.saveResetTimerDisplayModeMock.mockResolvedValue(undefined)
     state.loadMenubarIconStyleMock.mockResolvedValue("provider")
     state.saveMenubarIconStyleMock.mockResolvedValue(undefined)
+    state.loadPreferMenubarWeeklyLimitMock.mockResolvedValue(false)
+    state.savePreferMenubarWeeklyLimitMock.mockResolvedValue(undefined)
     state.migrateLegacyTraySettingsMock.mockResolvedValue(undefined)
     state.loadGlobalShortcutMock.mockResolvedValue(null)
     state.saveGlobalShortcutMock.mockResolvedValue(undefined)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,8 @@ function App() {
     setDisplayMode,
     menubarIconStyle,
     setMenubarIconStyle,
+    preferMenubarWeeklyLimit,
+    setPreferMenubarWeeklyLimit,
     resetTimerDisplayMode,
     setResetTimerDisplayMode,
     setGlobalShortcut,
@@ -67,6 +69,8 @@ function App() {
       setDisplayMode: state.setDisplayMode,
       menubarIconStyle: state.menubarIconStyle,
       setMenubarIconStyle: state.setMenubarIconStyle,
+      preferMenubarWeeklyLimit: state.preferMenubarWeeklyLimit,
+      setPreferMenubarWeeklyLimit: state.setPreferMenubarWeeklyLimit,
       resetTimerDisplayMode: state.resetTimerDisplayMode,
       setResetTimerDisplayMode: state.setResetTimerDisplayMode,
       setGlobalShortcut: state.setGlobalShortcut,
@@ -100,6 +104,7 @@ function App() {
     pluginStates,
     displayMode,
     menubarIconStyle,
+    preferMenubarWeeklyLimit,
     activeView,
   })
 
@@ -116,6 +121,7 @@ function App() {
     setThemeMode,
     setDisplayMode,
     setMenubarIconStyle,
+    setPreferMenubarWeeklyLimit,
     setResetTimerDisplayMode,
     setGlobalShortcut,
     setStartOnLogin,
@@ -132,12 +138,14 @@ function App() {
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleMenubarIconStyleChange,
+    handlePreferMenubarWeeklyLimitChange,
   } = useSettingsDisplayActions({
     setThemeMode,
     setDisplayMode,
     resetTimerDisplayMode,
     setResetTimerDisplayMode,
     setMenubarIconStyle,
+    setPreferMenubarWeeklyLimit,
     scheduleTrayIconUpdate,
   })
 
@@ -245,6 +253,7 @@ function App() {
         onResetTimerDisplayModeChange: handleResetTimerDisplayModeChange,
         onResetTimerDisplayModeToggle: handleResetTimerDisplayModeToggle,
         onMenubarIconStyleChange: handleMenubarIconStyleChange,
+        onPreferMenubarWeeklyLimitChange: handlePreferMenubarWeeklyLimitChange,
         traySettingsPreview,
         onGlobalShortcutChange: handleGlobalShortcutChange,
         onStartOnLoginChange: handleStartOnLoginChange,

--- a/src/components/app/app-content.test.tsx
+++ b/src/components/app/app-content.test.tsx
@@ -63,6 +63,13 @@ function createProps(): AppContentProps {
     onDisplayModeChange: vi.fn(),
     onResetTimerDisplayModeChange: vi.fn(),
     onResetTimerDisplayModeToggle: vi.fn(),
+    onMenubarIconStyleChange: vi.fn(),
+    onPreferMenubarWeeklyLimitChange: vi.fn(),
+    traySettingsPreview: {
+      bars: [],
+      providerBars: [],
+      providerPercentText: "--%",
+    },
     onGlobalShortcutChange: vi.fn(),
     onStartOnLoginChange: vi.fn(),
   }

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -32,6 +32,7 @@ export type AppContentActionProps = {
   onResetTimerDisplayModeChange: (mode: ResetTimerDisplayMode) => void
   onResetTimerDisplayModeToggle: () => void
   onMenubarIconStyleChange: (value: MenubarIconStyle) => void
+  onPreferMenubarWeeklyLimitChange: (value: boolean) => void
   traySettingsPreview: TraySettingsPreview
   onGlobalShortcutChange: (value: GlobalShortcut) => void
   onStartOnLoginChange: (value: boolean) => void
@@ -52,6 +53,7 @@ export function AppContent({
   onResetTimerDisplayModeChange,
   onResetTimerDisplayModeToggle,
   onMenubarIconStyleChange,
+  onPreferMenubarWeeklyLimitChange,
   traySettingsPreview,
   onGlobalShortcutChange,
   onStartOnLoginChange,
@@ -66,6 +68,7 @@ export function AppContent({
     displayMode,
     resetTimerDisplayMode,
     menubarIconStyle,
+    preferMenubarWeeklyLimit,
     autoUpdateInterval,
     globalShortcut,
     themeMode,
@@ -75,6 +78,7 @@ export function AppContent({
       displayMode: state.displayMode,
       resetTimerDisplayMode: state.resetTimerDisplayMode,
       menubarIconStyle: state.menubarIconStyle,
+      preferMenubarWeeklyLimit: state.preferMenubarWeeklyLimit,
       autoUpdateInterval: state.autoUpdateInterval,
       globalShortcut: state.globalShortcut,
       themeMode: state.themeMode,
@@ -110,6 +114,8 @@ export function AppContent({
         onResetTimerDisplayModeChange={onResetTimerDisplayModeChange}
         menubarIconStyle={menubarIconStyle}
         onMenubarIconStyleChange={onMenubarIconStyleChange}
+        preferMenubarWeeklyLimit={preferMenubarWeeklyLimit}
+        onPreferMenubarWeeklyLimitChange={onPreferMenubarWeeklyLimitChange}
         traySettingsPreview={traySettingsPreview}
         globalShortcut={globalShortcut}
         onGlobalShortcutChange={onGlobalShortcutChange}

--- a/src/hooks/app/use-settings-bootstrap.test.ts
+++ b/src/hooks/app/use-settings-bootstrap.test.ts
@@ -13,6 +13,7 @@ const {
   loadDisplayModeMock,
   loadGlobalShortcutMock,
   loadMenubarIconStyleMock,
+  loadPreferMenubarWeeklyLimitMock,
   loadPluginSettingsMock,
   loadResetTimerDisplayModeMock,
   loadStartOnLoginMock,
@@ -32,6 +33,7 @@ const {
   loadDisplayModeMock: vi.fn(),
   loadGlobalShortcutMock: vi.fn(),
   loadMenubarIconStyleMock: vi.fn(),
+  loadPreferMenubarWeeklyLimitMock: vi.fn(),
   loadPluginSettingsMock: vi.fn(),
   loadResetTimerDisplayModeMock: vi.fn(),
   loadStartOnLoginMock: vi.fn(),
@@ -58,6 +60,7 @@ vi.mock("@/lib/settings", () => ({
   DEFAULT_DISPLAY_MODE: "left",
   DEFAULT_GLOBAL_SHORTCUT: null,
   DEFAULT_MENUBAR_ICON_STYLE: "provider",
+  DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT: false,
   DEFAULT_RESET_TIMER_DISPLAY_MODE: "relative",
   DEFAULT_START_ON_LOGIN: false,
   DEFAULT_THEME_MODE: "system",
@@ -66,6 +69,7 @@ vi.mock("@/lib/settings", () => ({
   loadDisplayMode: loadDisplayModeMock,
   loadGlobalShortcut: loadGlobalShortcutMock,
   loadMenubarIconStyle: loadMenubarIconStyleMock,
+  loadPreferMenubarWeeklyLimit: loadPreferMenubarWeeklyLimitMock,
   loadPluginSettings: loadPluginSettingsMock,
   loadResetTimerDisplayMode: loadResetTimerDisplayModeMock,
   loadStartOnLogin: loadStartOnLoginMock,
@@ -88,6 +92,7 @@ function createArgs() {
     setGlobalShortcut: vi.fn(),
     setStartOnLogin: vi.fn(),
     setMenubarIconStyle: vi.fn(),
+    setPreferMenubarWeeklyLimit: vi.fn(),
     setLoadingForPlugins: vi.fn(),
     setErrorForPlugins: vi.fn(),
     startBatch: vi.fn().mockResolvedValue(undefined),
@@ -107,6 +112,7 @@ describe("useSettingsBootstrap", () => {
     loadDisplayModeMock.mockReset()
     loadGlobalShortcutMock.mockReset()
     loadMenubarIconStyleMock.mockReset()
+    loadPreferMenubarWeeklyLimitMock.mockReset()
     loadPluginSettingsMock.mockReset()
     loadResetTimerDisplayModeMock.mockReset()
     loadStartOnLoginMock.mockReset()
@@ -136,6 +142,7 @@ describe("useSettingsBootstrap", () => {
     loadResetTimerDisplayModeMock.mockResolvedValue("relative")
     loadGlobalShortcutMock.mockResolvedValue("CommandOrControl+Shift+O")
     loadMenubarIconStyleMock.mockResolvedValue("provider")
+    loadPreferMenubarWeeklyLimitMock.mockResolvedValue(true)
     loadStartOnLoginMock.mockResolvedValue(true)
     migrateLegacyTraySettingsMock.mockResolvedValue(undefined)
     savePluginSettingsMock.mockResolvedValue(undefined)
@@ -166,6 +173,25 @@ describe("useSettingsBootstrap", () => {
         resetModeError
       )
       expect(args.setResetTimerDisplayMode).toHaveBeenCalledWith("relative")
+    })
+
+    errorSpy.mockRestore()
+  })
+
+  it("falls back to default menubar weekly limit preference when loading fails", async () => {
+    const weeklyPreferenceError = new Error("weekly preference unavailable")
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    loadPreferMenubarWeeklyLimitMock.mockRejectedValueOnce(weeklyPreferenceError)
+    const args = createArgs()
+
+    renderHook(() => useSettingsBootstrap(args))
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to load menubar weekly limit preference:",
+        weeklyPreferenceError
+      )
+      expect(args.setPreferMenubarWeeklyLimit).toHaveBeenCalledWith(false)
     })
 
     errorSpy.mockRestore()

--- a/src/hooks/app/use-settings-bootstrap.ts
+++ b/src/hooks/app/use-settings-bootstrap.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
+  DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT,
   DEFAULT_RESET_TIMER_DISPLAY_MODE,
   DEFAULT_START_ON_LOGIN,
   DEFAULT_THEME_MODE,
@@ -21,6 +22,7 @@ import {
   loadGlobalShortcut,
   loadMenubarIconStyle,
   migrateLegacyTraySettings,
+  loadPreferMenubarWeeklyLimit,
   loadPluginSettings,
   loadResetTimerDisplayMode,
   loadStartOnLogin,
@@ -46,6 +48,7 @@ type UseSettingsBootstrapArgs = {
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setPreferMenubarWeeklyLimit: (value: boolean) => void
   setLoadingForPlugins: (ids: string[]) => void
   setErrorForPlugins: (ids: string[], error: string) => void
   startBatch: (pluginIds?: string[]) => Promise<string[] | undefined>
@@ -61,6 +64,7 @@ export function useSettingsBootstrap({
   setGlobalShortcut,
   setStartOnLogin,
   setMenubarIconStyle,
+  setPreferMenubarWeeklyLimit,
   setLoadingForPlugins,
   setErrorForPlugins,
   startBatch,
@@ -153,6 +157,13 @@ export function useSettingsBootstrap({
           console.error("Failed to load menubar icon style:", error)
         }
 
+        let storedPreferMenubarWeeklyLimit = DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT
+        try {
+          storedPreferMenubarWeeklyLimit = await loadPreferMenubarWeeklyLimit()
+        } catch (error) {
+          console.error("Failed to load menubar weekly limit preference:", error)
+        }
+
         if (isMounted) {
           setPluginSettings(normalized)
           setAutoUpdateInterval(storedInterval)
@@ -162,6 +173,7 @@ export function useSettingsBootstrap({
           setGlobalShortcut(storedGlobalShortcut)
           setStartOnLogin(storedStartOnLogin)
           setMenubarIconStyle(storedMenubarIconStyle)
+          setPreferMenubarWeeklyLimit(storedPreferMenubarWeeklyLimit)
 
           const enabledIds = getEnabledPluginIds(normalized)
           setLoadingForPlugins(enabledIds)
@@ -192,6 +204,7 @@ export function useSettingsBootstrap({
     setGlobalShortcut,
     setLoadingForPlugins,
     setMenubarIconStyle,
+    setPreferMenubarWeeklyLimit,
     migrateLegacyTraySettings,
     setPluginSettings,
     setPluginsMeta,

--- a/src/hooks/app/use-settings-display-actions.test.ts
+++ b/src/hooks/app/use-settings-display-actions.test.ts
@@ -3,17 +3,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
   saveDisplayModeMock,
+  savePreferMenubarWeeklyLimitMock,
   saveResetTimerDisplayModeMock,
   saveThemeModeMock,
 } = vi.hoisted(() => ({
   saveThemeModeMock: vi.fn(),
   saveDisplayModeMock: vi.fn(),
+  savePreferMenubarWeeklyLimitMock: vi.fn(),
   saveResetTimerDisplayModeMock: vi.fn(),
 }))
 
 vi.mock("@/lib/settings", () => ({
   saveThemeMode: saveThemeModeMock,
   saveDisplayMode: saveDisplayModeMock,
+  savePreferMenubarWeeklyLimit: savePreferMenubarWeeklyLimitMock,
   saveResetTimerDisplayMode: saveResetTimerDisplayModeMock,
 }))
 
@@ -23,9 +26,11 @@ describe("useSettingsDisplayActions", () => {
   beforeEach(() => {
     saveThemeModeMock.mockReset()
     saveDisplayModeMock.mockReset()
+    savePreferMenubarWeeklyLimitMock.mockReset()
     saveResetTimerDisplayModeMock.mockReset()
     saveThemeModeMock.mockResolvedValue(undefined)
     saveDisplayModeMock.mockResolvedValue(undefined)
+    savePreferMenubarWeeklyLimitMock.mockResolvedValue(undefined)
     saveResetTimerDisplayModeMock.mockResolvedValue(undefined)
   })
 
@@ -33,6 +38,7 @@ describe("useSettingsDisplayActions", () => {
     const setThemeMode = vi.fn()
     const setDisplayMode = vi.fn()
     const setResetTimerDisplayMode = vi.fn()
+    const setPreferMenubarWeeklyLimit = vi.fn()
     const scheduleTrayIconUpdate = vi.fn()
 
     const { result } = renderHook(() =>
@@ -41,6 +47,7 @@ describe("useSettingsDisplayActions", () => {
         setDisplayMode,
         resetTimerDisplayMode: "relative",
         setResetTimerDisplayMode,
+        setPreferMenubarWeeklyLimit,
         scheduleTrayIconUpdate,
       })
     )
@@ -49,16 +56,19 @@ describe("useSettingsDisplayActions", () => {
       result.current.handleThemeModeChange("dark")
       result.current.handleDisplayModeChange("used")
       result.current.handleResetTimerDisplayModeChange("absolute")
+      result.current.handlePreferMenubarWeeklyLimitChange(true)
     })
 
     expect(setThemeMode).toHaveBeenCalledWith("dark")
     expect(setDisplayMode).toHaveBeenCalledWith("used")
     expect(setResetTimerDisplayMode).toHaveBeenCalledWith("absolute")
+    expect(setPreferMenubarWeeklyLimit).toHaveBeenCalledWith(true)
     expect(scheduleTrayIconUpdate).toHaveBeenCalledWith("settings", 0)
 
     expect(saveThemeModeMock).toHaveBeenCalledWith("dark")
     expect(saveDisplayModeMock).toHaveBeenCalledWith("used")
     expect(saveResetTimerDisplayModeMock).toHaveBeenCalledWith("absolute")
+    expect(savePreferMenubarWeeklyLimitMock).toHaveBeenCalledWith(true)
   })
 
   it("toggles reset timer mode in both directions", () => {
@@ -71,6 +81,7 @@ describe("useSettingsDisplayActions", () => {
           setDisplayMode: vi.fn(),
           resetTimerDisplayMode: mode,
           setResetTimerDisplayMode,
+          setPreferMenubarWeeklyLimit: vi.fn(),
           scheduleTrayIconUpdate: vi.fn(),
         }),
       { initialProps: { mode: "relative" as const } }
@@ -92,10 +103,12 @@ describe("useSettingsDisplayActions", () => {
     const themeError = new Error("theme failed")
     const displayError = new Error("display failed")
     const resetError = new Error("reset failed")
+    const menubarWeeklyError = new Error("menubar weekly failed")
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     saveThemeModeMock.mockRejectedValueOnce(themeError)
     saveDisplayModeMock.mockRejectedValueOnce(displayError)
     saveResetTimerDisplayModeMock.mockRejectedValueOnce(resetError)
+    savePreferMenubarWeeklyLimitMock.mockRejectedValueOnce(menubarWeeklyError)
 
     const { result } = renderHook(() =>
       useSettingsDisplayActions({
@@ -103,6 +116,7 @@ describe("useSettingsDisplayActions", () => {
         setDisplayMode: vi.fn(),
         resetTimerDisplayMode: "relative",
         setResetTimerDisplayMode: vi.fn(),
+        setPreferMenubarWeeklyLimit: vi.fn(),
         scheduleTrayIconUpdate: vi.fn(),
       })
     )
@@ -111,12 +125,17 @@ describe("useSettingsDisplayActions", () => {
       result.current.handleThemeModeChange("light")
       result.current.handleDisplayModeChange("left")
       result.current.handleResetTimerDisplayModeChange("relative")
+      result.current.handlePreferMenubarWeeklyLimitChange(true)
     })
 
     await waitFor(() => {
       expect(errorSpy).toHaveBeenCalledWith("Failed to save theme mode:", themeError)
       expect(errorSpy).toHaveBeenCalledWith("Failed to save display mode:", displayError)
       expect(errorSpy).toHaveBeenCalledWith("Failed to save reset timer display mode:", resetError)
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to save menubar weekly limit preference:",
+        menubarWeeklyError
+      )
     })
 
     errorSpy.mockRestore()

--- a/src/hooks/app/use-settings-display-actions.ts
+++ b/src/hooks/app/use-settings-display-actions.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react"
 import {
   saveDisplayMode,
   saveMenubarIconStyle,
+  savePreferMenubarWeeklyLimit,
   saveResetTimerDisplayMode,
   saveThemeMode,
   type DisplayMode,
@@ -18,6 +19,7 @@ type UseSettingsDisplayActionsArgs = {
   resetTimerDisplayMode: ResetTimerDisplayMode
   setResetTimerDisplayMode: (value: ResetTimerDisplayMode) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setPreferMenubarWeeklyLimit: (value: boolean) => void
   scheduleTrayIconUpdate: ScheduleTrayIconUpdate
 }
 
@@ -27,6 +29,7 @@ export function useSettingsDisplayActions({
   resetTimerDisplayMode,
   setResetTimerDisplayMode,
   setMenubarIconStyle,
+  setPreferMenubarWeeklyLimit,
   scheduleTrayIconUpdate,
 }: UseSettingsDisplayActionsArgs) {
   const handleThemeModeChange = useCallback((mode: ThemeMode) => {
@@ -64,11 +67,20 @@ export function useSettingsDisplayActions({
     })
   }, [scheduleTrayIconUpdate, setMenubarIconStyle])
 
+  const handlePreferMenubarWeeklyLimitChange = useCallback((value: boolean) => {
+    setPreferMenubarWeeklyLimit(value)
+    scheduleTrayIconUpdate("settings", 0)
+    void savePreferMenubarWeeklyLimit(value).catch((error) => {
+      console.error("Failed to save menubar weekly limit preference:", error)
+    })
+  }, [scheduleTrayIconUpdate, setPreferMenubarWeeklyLimit])
+
   return {
     handleThemeModeChange,
     handleDisplayModeChange,
     handleResetTimerDisplayModeChange,
     handleResetTimerDisplayModeToggle,
     handleMenubarIconStyleChange,
+    handlePreferMenubarWeeklyLimitChange,
   }
 }

--- a/src/hooks/app/use-tray-icon.ts
+++ b/src/hooks/app/use-tray-icon.ts
@@ -17,6 +17,7 @@ type UseTrayIconArgs = {
   pluginStates: Record<string, PluginState>
   displayMode: DisplayMode
   menubarIconStyle: MenubarIconStyle
+  preferMenubarWeeklyLimit: boolean
   activeView: string
 }
 
@@ -55,6 +56,7 @@ export function useTrayIcon({
   pluginStates,
   displayMode,
   menubarIconStyle,
+  preferMenubarWeeklyLimit,
   activeView,
 }: UseTrayIconArgs) {
   const trayRef = useRef<TrayIcon | null>(null)
@@ -72,6 +74,7 @@ export function useTrayIcon({
   const pluginStatesRef = useRef(pluginStates)
   const displayModeRef = useRef(displayMode)
   const menubarIconStyleRef = useRef(menubarIconStyle)
+  const preferMenubarWeeklyLimitRef = useRef(preferMenubarWeeklyLimit)
   const activeViewRef = useRef(activeView)
   const lastTrayProviderIdRef = useRef<string | null>(null)
 
@@ -94,6 +97,10 @@ export function useTrayIcon({
   useEffect(() => {
     menubarIconStyleRef.current = menubarIconStyle
   }, [menubarIconStyle])
+
+  useEffect(() => {
+    preferMenubarWeeklyLimitRef.current = preferMenubarWeeklyLimit
+  }, [preferMenubarWeeklyLimit])
 
   useEffect(() => {
     activeViewRef.current = activeView
@@ -208,6 +215,7 @@ export function useTrayIcon({
         pluginStates: pluginStatesRef.current,
         maxBars: 4,
         displayMode: displayModeRef.current,
+        preferWeeklyLimit: preferMenubarWeeklyLimitRef.current,
       })
 
       const providerBars = trayProviderId
@@ -218,6 +226,7 @@ export function useTrayIcon({
             maxBars: 1,
             displayMode: displayModeRef.current,
             pluginId: trayProviderId,
+            preferWeeklyLimit: preferMenubarWeeklyLimitRef.current,
           })
         : []
 
@@ -242,6 +251,7 @@ export function useTrayIcon({
         pluginStates: pluginStatesRef.current,
         maxBars: 20, // Show more in tooltip
         displayMode: displayModeRef.current,
+        preferWeeklyLimit: preferMenubarWeeklyLimitRef.current,
       })
       const tooltip = formatTrayTooltip(tooltipBars, pluginsMetaRef.current)
       const updateTooltip = () => setTrayTooltip(tooltip)

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
+  DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT,
   DEFAULT_PLUGIN_SETTINGS,
   DEFAULT_RESET_TIMER_DISPLAY_MODE,
   DEFAULT_START_ON_LOGIN,
@@ -14,6 +15,7 @@ import {
   loadDisplayMode,
   loadGlobalShortcut,
   loadMenubarIconStyle,
+  loadPreferMenubarWeeklyLimit,
   loadPluginSettings,
   loadResetTimerDisplayMode,
   loadStartOnLogin,
@@ -24,6 +26,7 @@ import {
   saveDisplayMode,
   saveGlobalShortcut,
   saveMenubarIconStyle,
+  savePreferMenubarWeeklyLimit,
   savePluginSettings,
   saveResetTimerDisplayMode,
   saveStartOnLogin,
@@ -259,6 +262,22 @@ describe("settings", () => {
   it("falls back to default for invalid menubar icon style", async () => {
     storeState.set("menubarIconStyle", "invalid")
     await expect(loadMenubarIconStyle()).resolves.toBe(DEFAULT_MENUBAR_ICON_STYLE)
+  })
+
+  it("loads default menubar weekly limit preference when missing", async () => {
+    await expect(loadPreferMenubarWeeklyLimit()).resolves.toBe(
+      DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT
+    )
+  })
+
+  it("loads stored menubar weekly limit preference", async () => {
+    storeState.set("preferMenubarWeeklyLimit", true)
+    await expect(loadPreferMenubarWeeklyLimit()).resolves.toBe(true)
+  })
+
+  it("saves menubar weekly limit preference", async () => {
+    await savePreferMenubarWeeklyLimit(true)
+    await expect(loadPreferMenubarWeeklyLimit()).resolves.toBe(true)
   })
 
   it("skips legacy tray migration when keys are absent", async () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -29,6 +29,7 @@ const THEME_MODE_KEY = "themeMode";
 const DISPLAY_MODE_KEY = "displayMode";
 const RESET_TIMER_DISPLAY_MODE_KEY = "resetTimerDisplayMode";
 const MENUBAR_ICON_STYLE_KEY = "menubarIconStyle";
+const PREFER_MENUBAR_WEEKLY_LIMIT_KEY = "preferMenubarWeeklyLimit";
 const LEGACY_TRAY_ICON_STYLE_KEY = "trayIconStyle";
 const LEGACY_TRAY_SHOW_PERCENTAGE_KEY = "trayShowPercentage";
 const GLOBAL_SHORTCUT_KEY = "globalShortcut";
@@ -39,6 +40,7 @@ export const DEFAULT_THEME_MODE: ThemeMode = "system";
 export const DEFAULT_DISPLAY_MODE: DisplayMode = "left";
 export const DEFAULT_RESET_TIMER_DISPLAY_MODE: ResetTimerDisplayMode = "relative";
 export const DEFAULT_MENUBAR_ICON_STYLE: MenubarIconStyle = "provider";
+export const DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT = false;
 export const DEFAULT_GLOBAL_SHORTCUT: GlobalShortcut = null;
 export const DEFAULT_START_ON_LOGIN = false;
 
@@ -229,6 +231,17 @@ export async function loadMenubarIconStyle(): Promise<MenubarIconStyle> {
 
 export async function saveMenubarIconStyle(style: MenubarIconStyle): Promise<void> {
   await store.set(MENUBAR_ICON_STYLE_KEY, style);
+  await store.save();
+}
+
+export async function loadPreferMenubarWeeklyLimit(): Promise<boolean> {
+  const stored = await store.get<unknown>(PREFER_MENUBAR_WEEKLY_LIMIT_KEY);
+  if (typeof stored === "boolean") return stored;
+  return DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT;
+}
+
+export async function savePreferMenubarWeeklyLimit(value: boolean): Promise<void> {
+  await store.set(PREFER_MENUBAR_WEEKLY_LIMIT_KEY, value);
   await store.save();
 }
 

--- a/src/lib/tray-primary-progress.test.ts
+++ b/src/lib/tray-primary-progress.test.ts
@@ -286,6 +286,104 @@ describe("getTrayPrimaryBars", () => {
     expect(bars).toEqual([{ id: "a", fraction: 0.2 }])
   })
 
+  it("prefers weekly overview line when enabled", () => {
+    const bars = getTrayPrimaryBars({
+      displayMode: "used",
+      preferWeeklyLimit: true,
+      pluginsMeta: [
+        {
+          id: "a",
+          name: "A",
+          iconUrl: "",
+          primaryCandidates: ["Session"],
+          lines: [
+            { type: "progress", label: "Session", scope: "overview" },
+            { type: "progress", label: "Weekly", scope: "overview" },
+          ],
+        },
+      ],
+      pluginSettings: { order: ["a"], disabled: [] },
+      pluginStates: {
+        a: {
+          data: {
+            providerId: "a",
+            displayName: "A",
+            iconUrl: "",
+            lines: [
+              {
+                type: "progress",
+                label: "Session",
+                used: 20,
+                limit: 100,
+                format: { kind: "percent" },
+              },
+              {
+                type: "progress",
+                label: "Weekly",
+                used: 60,
+                limit: 100,
+                format: { kind: "percent" },
+              },
+            ],
+          },
+          loading: false,
+          error: null,
+        },
+      },
+    })
+
+    expect(bars).toEqual([{ id: "a", fraction: 0.6 }])
+  })
+
+  it("falls back to primary candidates when no weekly overview line is available", () => {
+    const bars = getTrayPrimaryBars({
+      displayMode: "used",
+      preferWeeklyLimit: true,
+      pluginsMeta: [
+        {
+          id: "a",
+          name: "A",
+          iconUrl: "",
+          primaryCandidates: ["Session"],
+          lines: [
+            { type: "progress", label: "Session", scope: "overview" },
+            { type: "progress", label: "Monthly", scope: "overview" },
+          ],
+        },
+      ],
+      pluginSettings: { order: ["a"], disabled: [] },
+      pluginStates: {
+        a: {
+          data: {
+            providerId: "a",
+            displayName: "A",
+            iconUrl: "",
+            lines: [
+              {
+                type: "progress",
+                label: "Session",
+                used: 20,
+                limit: 100,
+                format: { kind: "percent" },
+              },
+              {
+                type: "progress",
+                label: "Monthly",
+                used: 60,
+                limit: 100,
+                format: { kind: "percent" },
+              },
+            ],
+          },
+          loading: false,
+          error: null,
+        },
+      },
+    })
+
+    expect(bars).toEqual([{ id: "a", fraction: 0.2 }])
+  })
+
   it("skips plugins with empty primaryCandidates", () => {
     const bars = getTrayPrimaryBars({
       pluginsMeta: [
@@ -303,4 +401,3 @@ describe("getTrayPrimaryBars", () => {
     expect(bars).toEqual([])
   })
 })
-

--- a/src/lib/tray-primary-progress.ts
+++ b/src/lib/tray-primary-progress.ts
@@ -23,6 +23,15 @@ function isProgressLine(line: PluginOutput["lines"][number]): line is ProgressLi
   return line.type === "progress"
 }
 
+function isWeeklyOverviewLine(meta: PluginMeta, label: string): boolean {
+  return meta.lines.some((line) =>
+    line.type === "progress" &&
+    line.scope === "overview" &&
+    line.label === label &&
+    /weekly/i.test(label)
+  )
+}
+
 export function getTrayPrimaryBars(args: {
   pluginsMeta: PluginMeta[]
   pluginSettings: PluginSettings | null
@@ -30,6 +39,7 @@ export function getTrayPrimaryBars(args: {
   maxBars?: number
   displayMode?: DisplayMode
   pluginId?: string
+  preferWeeklyLimit?: boolean
 }): TrayPrimaryBar[] {
   const {
     pluginsMeta,
@@ -38,6 +48,7 @@ export function getTrayPrimaryBars(args: {
     maxBars = 4,
     displayMode = DEFAULT_DISPLAY_MODE,
     pluginId,
+    preferWeeklyLimit = false,
   } = args
   if (!pluginSettings) return []
 
@@ -61,8 +72,15 @@ export function getTrayPrimaryBars(args: {
 
     let fraction: number | undefined
     if (data) {
+      const weeklyLabel = preferWeeklyLimit
+        ? data.lines
+            .filter(isProgressLine)
+            .find((line) => isWeeklyOverviewLine(meta, line.label))
+            ?.label
+        : undefined
+
       // Find first candidate that exists in runtime data
-      const primaryLabel = meta.primaryCandidates.find((label) =>
+      const primaryLabel = weeklyLabel ?? meta.primaryCandidates.find((label) =>
         data.lines.some((line) => isProgressLine(line) && line.label === label)
       )
       if (primaryLabel) {
@@ -86,4 +104,3 @@ export function getTrayPrimaryBars(args: {
 
   return out
 }
-

--- a/src/pages/settings.test.tsx
+++ b/src/pages/settings.test.tsx
@@ -57,6 +57,8 @@ const defaultProps = {
   onResetTimerDisplayModeChange: vi.fn(),
   menubarIconStyle: "provider" as const,
   onMenubarIconStyleChange: vi.fn(),
+  preferMenubarWeeklyLimit: false,
+  onPreferMenubarWeeklyLimitChange: vi.fn(),
   traySettingsPreview: {
     bars: [{ id: "a", fraction: 0.7 }],
     providerBars: [{ id: "a", fraction: 0.7 }],
@@ -225,6 +227,19 @@ describe("SettingsPage", () => {
     render(<SettingsPage {...defaultProps} />)
     expect(screen.queryByText("Bar Icon")).not.toBeInTheDocument()
     expect(screen.queryByText("Show percentage")).not.toBeInTheDocument()
+  })
+
+  it("toggles menubar weekly limit preference", async () => {
+    const onPreferMenubarWeeklyLimitChange = vi.fn()
+    render(
+      <SettingsPage
+        {...defaultProps}
+        onPreferMenubarWeeklyLimitChange={onPreferMenubarWeeklyLimitChange}
+      />
+    )
+
+    await userEvent.click(screen.getByText("Prefer weekly limits when available"))
+    expect(onPreferMenubarWeeklyLimitChange).toHaveBeenCalledWith(true)
   })
 
   it("toggles start on login checkbox", async () => {

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -270,6 +270,8 @@ interface SettingsPageProps {
   onResetTimerDisplayModeChange: (value: ResetTimerDisplayMode) => void;
   menubarIconStyle: MenubarIconStyle;
   onMenubarIconStyleChange: (value: MenubarIconStyle) => void;
+  preferMenubarWeeklyLimit: boolean;
+  onPreferMenubarWeeklyLimitChange: (value: boolean) => void;
   traySettingsPreview: TraySettingsPreview;
   globalShortcut: GlobalShortcut;
   onGlobalShortcutChange: (value: GlobalShortcut) => void;
@@ -291,6 +293,8 @@ export function SettingsPage({
   onResetTimerDisplayModeChange,
   menubarIconStyle,
   onMenubarIconStyleChange,
+  preferMenubarWeeklyLimit,
+  onPreferMenubarWeeklyLimitChange,
   traySettingsPreview,
   globalShortcut,
   onGlobalShortcutChange,
@@ -443,6 +447,14 @@ export function SettingsPage({
             })}
           </div>
         </div>
+        <label className="mt-3 flex items-center gap-2 text-sm select-none text-foreground">
+          <Checkbox
+            key={`prefer-menubar-weekly-limit-${preferMenubarWeeklyLimit}`}
+            checked={preferMenubarWeeklyLimit}
+            onCheckedChange={(checked) => onPreferMenubarWeeklyLimitChange(checked === true)}
+          />
+          Prefer weekly limits when available
+        </label>
       </section>
       <section>
         <h3 className="text-lg font-semibold mb-0">App Theme</h3>

--- a/src/stores/app-preferences-store.ts
+++ b/src/stores/app-preferences-store.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_MENUBAR_ICON_STYLE,
+  DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT,
   DEFAULT_RESET_TIMER_DISPLAY_MODE,
   DEFAULT_START_ON_LOGIN,
   DEFAULT_THEME_MODE,
@@ -23,6 +24,7 @@ type AppPreferencesStore = {
   globalShortcut: GlobalShortcut
   startOnLogin: boolean
   menubarIconStyle: MenubarIconStyle
+  preferMenubarWeeklyLimit: boolean
   setAutoUpdateInterval: (value: AutoUpdateIntervalMinutes) => void
   setThemeMode: (value: ThemeMode) => void
   setDisplayMode: (value: DisplayMode) => void
@@ -30,6 +32,7 @@ type AppPreferencesStore = {
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
+  setPreferMenubarWeeklyLimit: (value: boolean) => void
   resetState: () => void
 }
 
@@ -41,6 +44,7 @@ const initialState = {
   globalShortcut: DEFAULT_GLOBAL_SHORTCUT,
   startOnLogin: DEFAULT_START_ON_LOGIN,
   menubarIconStyle: DEFAULT_MENUBAR_ICON_STYLE,
+  preferMenubarWeeklyLimit: DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT,
 }
 
 export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
@@ -52,5 +56,6 @@ export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
   setGlobalShortcut: (value) => set({ globalShortcut: value }),
   setStartOnLogin: (value) => set({ startOnLogin: value }),
   setMenubarIconStyle: (value) => set({ menubarIconStyle: value }),
+  setPreferMenubarWeeklyLimit: (value) => set({ preferMenubarWeeklyLimit: value }),
   resetState: () => set(initialState),
 }))


### PR DESCRIPTION
## Description

Adds a global setting to prefer weekly limits in the menubar when a provider exposes a weekly overview progress line.

This keeps the current primary metric behavior by default. When enabled, providers like Claude and Codex can show their weekly usage in the menubar instead of the shorter session/window metric.

## Related Issue

Fixes #393

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

Test results:

- `bun run test`: 60 files passed, 1083 tests passed
- `bun run build`: passed
- `bun tauri dev`: launched locally and setting worked in manual testing

## Screenshots

<details>
<summary>View screenshots</summary>

Before:

![Before: Menubar Icon settings without weekly preference](https://gist.githubusercontent.com/Whiteknight07/550c07164caddd64d3efa17ca2a942f0/raw/27a2ac37712c9bba954bf69f20c53e46c462c893/before-menubar-icon.svg)

After, unchecked:

![After: weekly preference visible, unchecked](https://gist.githubusercontent.com/Whiteknight07/550c07164caddd64d3efa17ca2a942f0/raw/48be3e0748a9aaa5fabcbd5910b6c9861afd03b2/after-weekly-preference-unchecked.svg)

After, checked:

![After: weekly preference visible, checked](https://gist.githubusercontent.com/Whiteknight07/550c07164caddd64d3efa17ca2a942f0/raw/e10e2c84ac963bca7b1cbc0a6be57c0b687b9aa7/after-weekly-preference-checked.svg)

</details>

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Prefer weekly limits” menubar setting that, when enabled, shows weekly usage for providers that expose a weekly overview line (e.g., Claude, Codex). Default is off; existing primary metric behavior remains unchanged. Fixes #393.

- **New Features**
  - Settings: Added checkbox “Prefer weekly limits when available” under Menubar Icon; persisted as `preferMenubarWeeklyLimit` (default `false`).
  - Tray: Updated `getTrayPrimaryBars` to prefer weekly overview lines when enabled and fall back to primary candidates otherwise; menubar icon, provider view, and tooltip respect the setting.
  - App wiring: Preference loads at boot, saves on change, and updates the tray preview immediately.

<sup>Written for commit 8b0b27ac0866bf8c4405bf7f01c50a0116f6ceb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


