### PR TITLE
fix(codex): trust zero-credit usage response

### DIFF
--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -284,6 +284,17 @@
     return Number.isFinite(n) ? n : null
   }
 
+  function readCreditsRemaining(resp, data) {
+    const credits = data && data.credits && typeof data.credits === "object" ? data.credits : null
+    if (credits) {
+      const bodyBalance = readNumber(credits.balance)
+      if (bodyBalance !== null) return bodyBalance
+      if (credits.has_credits === false) return 0
+    }
+
+    return readNumber(resp.headers["x-codex-credits-balance"])
+  }
+
   function formatCodexPlan(ctx, planType) {
     const rawPlan = typeof planType === "string" ? planType.trim() : ""
     if (!rawPlan) return null
@@ -601,10 +612,7 @@
         }
       }
 
-      const creditsBalance = resp.headers["x-codex-credits-balance"]
-      const creditsHeader = readNumber(creditsBalance)
-      const creditsData = data.credits ? readNumber(data.credits.balance) : null
-      const creditsRemaining = creditsHeader ?? creditsData
+      const creditsRemaining = readCreditsRemaining(resp, data)
       if (creditsRemaining !== null) {
         const remaining = creditsRemaining
         const limit = 1000

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -255,6 +255,51 @@ describe("codex plugin", () => {
     expect(credits.used).toBe(900)
   })
 
+  it("uses zero credits from the response body when the account has no credits", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {
+        "x-codex-credits-balance": "1000",
+      },
+      bodyText: JSON.stringify({
+        plan_type: "plus",
+        rate_limit: {
+          primary_window: { used_percent: 46, limit_window_seconds: 18000, reset_after_seconds: 6699 },
+          secondary_window: { used_percent: 15, limit_window_seconds: 604800, reset_after_seconds: 505326 },
+        },
+        code_review_rate_limit: null,
+        additional_rate_limits: null,
+        credits: {
+          has_credits: false,
+          unlimited: false,
+          overage_limit_reached: false,
+          balance: "0",
+          approx_local_messages: [0, 0],
+          approx_cloud_messages: [0, 0],
+        },
+        spend_control: {
+          reached: false,
+          individual_limit: null,
+        },
+        rate_limit_reached_type: null,
+        promo: null,
+        referral_beacon: null,
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const credits = result.lines.find((line) => line.label === "Credits")
+    expect(credits).toBeTruthy()
+    expect(credits.used).toBe(1000)
+    expect(credits.limit).toBe(1000)
+  })
+
   it("refreshes keychain auth and writes back to keychain", async () => {
     const ctx = makeCtx()
     ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({


### PR DESCRIPTION
## Summary
- Trust Codex `credits.balance` from the usage response body when credits data is present.
- Preserve the credits header as a fallback for responses without body credits.
- Add a regression test for accounts with `has_credits: false` and `balance: "0"`.

Fixes #465

## Test plan
- `bunx vitest run plugins/codex/plugin.test.js`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to how the Codex plugin derives remaining credits, plus a regression test to lock in behavior for zero-credit accounts.
> 
> **Overview**
> Fixes Codex credit reporting to **trust `credits` in the usage response body** when present (including correctly treating `has_credits: false` / `balance: "0"` as zero), while keeping the `x-codex-credits-balance` header as a fallback when body credits are missing.
> 
> Adds a regression test covering the no-credits account case where the header reports a non-zero balance but the response body indicates zero credits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa6f36a8e323dd7c5bd4dd9f83267e07206cedd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex credit parsing to trust the usage response body when present, so zero-credit accounts show correct usage. Keeps the header as a fallback to avoid regressions.

- **Bug Fixes**
  - Read `credits.balance` from the body when available; if `has_credits: false`, treat as 0.
  - Fallback to `x-codex-credits-balance` header when body credits are missing.
  - Add a regression test for `has_credits: false` with `balance: "0"`.

<sup>Written for commit efa6f36a8e323dd7c5bd4dd9f83267e07206cedd. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/481?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

