### PR TITLE
fix(ccusage): add release-age fallback for costs

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -505,10 +505,10 @@ host.ccusage.query(opts: {
   | { status: "runner_failed" }
 ```
 
-Queries local token usage via provider-specific ccusage CLIs:
+Queries local token usage via provider-focused ccusage commands:
 
-- Claude: [`ccusage`](https://github.com/ryoppippi/ccusage)
-- Codex: [`@ccusage/codex`](https://www.npmjs.com/package/@ccusage/codex)
+- Claude: [`ccusage claude daily`](https://github.com/ryoppippi/ccusage)
+- Codex: [`ccusage codex daily`](https://github.com/ryoppippi/ccusage)
 
 Returns a status envelope:
 
@@ -518,8 +518,10 @@ Returns a status envelope:
 
 ### Behavior
 
-- **Runtime runners**: Executes pinned `ccusage@18.0.10` (Claude) or `@ccusage/codex@18.0.10` (Codex) via fallback chain `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx`
+- **Runtime runners**: Executes pinned `ccusage@20.0.2` via fallback chain `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx`
 - **Provider-aware**: Resolves provider from `opts.provider` or plugin id (`claude`/`codex`)
+- **Focused commands**: Uses `ccusage claude daily` or `ccusage codex daily`; it intentionally does not use `ccusage daily` because that aggregates all detected agents
+- **Legacy fallback**: If `ccusage@20.0.2` cannot run through the package manager release-age policy, retries with release-age-safe `ccusage@18.0.11` for Claude or `@ccusage/codex@18.0.11` for Codex
 - **No provider API calls**: Usage is computed from local JSONL session files; the host does not call Claude/Codex (or other provider) APIs, but package runners may contact a package registry to download the `ccusage` CLI if it is not already available locally
 - **Graceful degradation**: returns `no_runner` when no runner exists, `runner_failed` when execution fails
 - **Pricing**: Uses ccusage's built-in LiteLLM pricing data

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "build:release": "./scripts/build-release.sh",
-    "ccusage:bump": "node ./scripts/bump-ccusage-version.mjs",
+    "ccusage:bump": "bun ./scripts/bump-ccusage-version.mjs",
     "bundle:plugins": "bun copy-bundled.cjs",
     "preview": "vite preview",
     "test": "vitest",

--- a/scripts/bump-ccusage-version.mjs
+++ b/scripts/bump-ccusage-version.mjs
@@ -32,6 +32,13 @@ function replaceOnce(content, regex, replacement, missingMessage) {
 }
 
 const hostApiSource = readFileSync(hostApiPath, "utf8");
+const currentVersionMatch = hostApiSource.match(
+  /const CCUSAGE_VERSION: &str = "(\d+\.\d+\.\d+)";/,
+);
+if (!currentVersionMatch) {
+  fail("could not find CCUSAGE_VERSION constant in host_api.rs");
+}
+const currentVersion = currentVersionMatch[1];
 const updatedHostApiSource = replaceOnce(
   hostApiSource,
   /const CCUSAGE_VERSION: &str = "\d+\.\d+\.\d+";/,
@@ -41,11 +48,17 @@ const updatedHostApiSource = replaceOnce(
 writeFileSync(hostApiPath, updatedHostApiSource);
 
 const docsSource = readFileSync(docsPath, "utf8");
-const docsAfterCcusage = replaceOnce(
-  docsSource,
-  /ccusage@\d+\.\d+\.\d+/,
+const docsCcusageVersionRegex = new RegExp(
+  `\\bccusage@${currentVersion.replaceAll(".", "\\.")}`,
+  "g",
+);
+if (!docsCcusageVersionRegex.test(docsSource)) {
+  fail("could not find ccusage pin in docs/plugins/api.md");
+}
+docsCcusageVersionRegex.lastIndex = 0;
+const docsAfterCcusage = docsSource.replace(
+  docsCcusageVersionRegex,
   `ccusage@${version}`,
-  "could not find ccusage pin in docs/plugins/api.md",
 );
 writeFileSync(docsPath, docsAfterCcusage);
 

--- a/scripts/bump-ccusage-version.mjs
+++ b/scripts/bump-ccusage-version.mjs
@@ -41,19 +41,13 @@ const updatedHostApiSource = replaceOnce(
 writeFileSync(hostApiPath, updatedHostApiSource);
 
 const docsSource = readFileSync(docsPath, "utf8");
-const docsAfterClaude = replaceOnce(
+const docsAfterCcusage = replaceOnce(
   docsSource,
   /ccusage@\d+\.\d+\.\d+/,
   `ccusage@${version}`,
-  "could not find Claude ccusage pin in docs/plugins/api.md",
+  "could not find ccusage pin in docs/plugins/api.md",
 );
-const docsAfterCodex = replaceOnce(
-  docsAfterClaude,
-  /@ccusage\/codex@\d+\.\d+\.\d+/,
-  `@ccusage/codex@${version}`,
-  "could not find Codex ccusage pin in docs/plugins/api.md",
-);
-writeFileSync(docsPath, docsAfterCodex);
+writeFileSync(docsPath, docsAfterCcusage);
 
 console.log(`Updated ccusage version to ${version}`);
 console.log(`- ${path.relative(repoRoot, hostApiPath)}`);

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -1467,9 +1467,13 @@ fn ls_parse_listening_ports(output: &str) -> Vec<i32> {
     ports.into_iter().collect()
 }
 
-const CCUSAGE_VERSION: &str = "18.0.10";
-const CCUSAGE_CLAUDE_PACKAGE_NAME: &str = "ccusage";
-const CCUSAGE_CODEX_PACKAGE_NAME: &str = "@ccusage/codex";
+const CCUSAGE_VERSION: &str = "20.0.2";
+const CCUSAGE_PACKAGE_NAME: &str = "ccusage";
+const CCUSAGE_BIN_NAME: &str = "ccusage";
+const CCUSAGE_LEGACY_VERSION: &str = "18.0.11";
+const CCUSAGE_LEGACY_CLAUDE_PACKAGE_NAME: &str = "ccusage";
+const CCUSAGE_LEGACY_CODEX_PACKAGE_NAME: &str = "@ccusage/codex";
+const CCUSAGE_LEGACY_CODEX_BIN_NAME: &str = "ccusage-codex";
 const CCUSAGE_TIMEOUT_SECS: u64 = 15;
 const CCUSAGE_POLL_INTERVAL_MS: u64 = 100;
 
@@ -1523,6 +1527,12 @@ enum CcusageRunnerKind {
     Npx,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum CcusageCommandFlavor {
+    Current,
+    Legacy,
+}
+
 fn ccusage_runner_order() -> [CcusageRunnerKind; 5] {
     [
         CcusageRunnerKind::Bunx,
@@ -1545,8 +1555,7 @@ fn ccusage_runner_label(kind: CcusageRunnerKind) -> &'static str {
 
 #[derive(Copy, Clone)]
 struct CcusageProviderConfig {
-    package_name: &'static str,
-    npm_exec_bin: &'static str,
+    command_namespace: &'static str,
     home_env_var: &'static str,
 }
 
@@ -1573,21 +1582,26 @@ fn resolve_ccusage_provider(opts: &CcusageQueryOpts, plugin_id: &str) -> Ccusage
 fn ccusage_provider_config(provider: CcusageProvider) -> CcusageProviderConfig {
     match provider {
         CcusageProvider::Claude => CcusageProviderConfig {
-            package_name: CCUSAGE_CLAUDE_PACKAGE_NAME,
-            npm_exec_bin: "ccusage",
+            command_namespace: "claude",
             home_env_var: "CLAUDE_CONFIG_DIR",
         },
         CcusageProvider::Codex => CcusageProviderConfig {
-            package_name: CCUSAGE_CODEX_PACKAGE_NAME,
-            npm_exec_bin: "ccusage-codex",
+            command_namespace: "codex",
             home_env_var: "CODEX_HOME",
         },
     }
 }
 
-fn ccusage_package_spec(provider: CcusageProvider) -> String {
-    let config = ccusage_provider_config(provider);
-    format!("{}@{}", config.package_name, CCUSAGE_VERSION)
+fn ccusage_package_spec() -> String {
+    format!("{}@{}", CCUSAGE_PACKAGE_NAME, CCUSAGE_VERSION)
+}
+
+fn ccusage_legacy_package_spec(provider: CcusageProvider) -> String {
+    let package_name = match provider {
+        CcusageProvider::Claude => CCUSAGE_LEGACY_CLAUDE_PACKAGE_NAME,
+        CcusageProvider::Codex => CCUSAGE_LEGACY_CODEX_PACKAGE_NAME,
+    };
+    format!("{}@{}", package_name, CCUSAGE_LEGACY_VERSION)
 }
 
 fn ccusage_home_override<'a>(
@@ -1792,7 +1806,16 @@ fn collect_ccusage_runners() -> Vec<(CcusageRunnerKind, String)> {
     collect_ccusage_runners_with(resolve_ccusage_runner_binary)
 }
 
-fn append_ccusage_common_args(args: &mut Vec<String>, opts: &CcusageQueryOpts) {
+fn append_ccusage_common_args(
+    args: &mut Vec<String>,
+    opts: &CcusageQueryOpts,
+    provider: CcusageProvider,
+    flavor: CcusageCommandFlavor,
+) {
+    let config = ccusage_provider_config(provider);
+    if flavor == CcusageCommandFlavor::Current {
+        args.push(config.command_namespace.to_string());
+    }
     args.extend([
         "daily".to_string(),
         "--json".to_string(),
@@ -1825,9 +1848,17 @@ fn ccusage_runner_args(
     kind: CcusageRunnerKind,
     opts: &CcusageQueryOpts,
     provider: CcusageProvider,
+    flavor: CcusageCommandFlavor,
 ) -> Vec<String> {
-    let config = ccusage_provider_config(provider);
-    let package_spec = ccusage_package_spec(provider);
+    let package_spec = match flavor {
+        CcusageCommandFlavor::Current => ccusage_package_spec(),
+        CcusageCommandFlavor::Legacy => ccusage_legacy_package_spec(provider),
+    };
+    let npm_exec_bin = match (flavor, provider) {
+        (CcusageCommandFlavor::Current, _) => CCUSAGE_BIN_NAME,
+        (CcusageCommandFlavor::Legacy, CcusageProvider::Claude) => CCUSAGE_BIN_NAME,
+        (CcusageCommandFlavor::Legacy, CcusageProvider::Codex) => CCUSAGE_LEGACY_CODEX_BIN_NAME,
+    };
     let mut args: Vec<String> = match kind {
         CcusageRunnerKind::Bunx => vec!["--silent".to_string(), package_spec.clone()],
         CcusageRunnerKind::PnpmDlx => {
@@ -1841,12 +1872,12 @@ fn ccusage_runner_args(
             "--yes".to_string(),
             format!("--package={package_spec}"),
             "--".to_string(),
-            config.npm_exec_bin.to_string(),
+            npm_exec_bin.to_string(),
         ],
         CcusageRunnerKind::Npx => vec!["--yes".to_string(), package_spec],
     };
 
-    append_ccusage_common_args(&mut args, opts);
+    append_ccusage_common_args(&mut args, opts, provider, flavor);
     args
 }
 
@@ -1948,14 +1979,27 @@ fn run_ccusage_with_runner(
     provider: CcusageProvider,
     plugin_id: &str,
 ) -> CcusageRunnerResult {
-    run_ccusage_with_runner_timeout(
+    let current = run_ccusage_with_runner_timeout(
         kind,
         program,
         opts,
         provider,
         plugin_id,
+        CcusageCommandFlavor::Current,
         std::time::Duration::from_secs(CCUSAGE_TIMEOUT_SECS),
-    )
+    );
+    match current {
+        CcusageRunnerResult::Failed => run_ccusage_with_runner_timeout(
+            kind,
+            program,
+            opts,
+            provider,
+            plugin_id,
+            CcusageCommandFlavor::Legacy,
+            std::time::Duration::from_secs(CCUSAGE_TIMEOUT_SECS),
+        ),
+        other => other,
+    }
 }
 
 fn run_ccusage_with_runner_timeout(
@@ -1964,9 +2008,10 @@ fn run_ccusage_with_runner_timeout(
     opts: &CcusageQueryOpts,
     provider: CcusageProvider,
     plugin_id: &str,
+    flavor: CcusageCommandFlavor,
     timeout: std::time::Duration,
 ) -> CcusageRunnerResult {
-    let args = ccusage_runner_args(kind, opts, provider);
+    let args = ccusage_runner_args(kind, opts, provider, flavor);
     let enriched_path = ccusage_enriched_path();
     let mut command = std::process::Command::new(program);
     configure_ccusage_command(&mut command, &args, enriched_path.as_deref());
@@ -1979,9 +2024,10 @@ fn run_ccusage_with_runner_timeout(
     let redacted_program = redact_log_message(program);
 
     log::info!(
-        "[plugin:{}] ccusage query via {} ({})",
+        "[plugin:{}] ccusage query via {} {:?} ({})",
         plugin_id,
         ccusage_runner_label(kind),
+        flavor,
         redacted_program
     );
 
@@ -3357,15 +3403,22 @@ mod tests {
             home_path: None,
             claude_path: None,
         };
-        let expected_claude_package = ccusage_package_spec(CcusageProvider::Claude);
-        let expected_npm_exec_package = format!("--package={expected_claude_package}");
+        let expected_ccusage_package = ccusage_package_spec();
+        assert_eq!(expected_ccusage_package, "ccusage@20.0.2");
+        let expected_npm_exec_package = format!("--package={expected_ccusage_package}");
 
-        let bunx = ccusage_runner_args(CcusageRunnerKind::Bunx, &opts, CcusageProvider::Claude);
+        let bunx = ccusage_runner_args(
+            CcusageRunnerKind::Bunx,
+            &opts,
+            CcusageProvider::Claude,
+            CcusageCommandFlavor::Current,
+        );
         assert_eq!(
             bunx,
             vec![
                 "--silent",
-                expected_claude_package.as_str(),
+                expected_ccusage_package.as_str(),
+                "claude",
                 "daily",
                 "--json",
                 "--order",
@@ -3377,13 +3430,19 @@ mod tests {
             ]
         );
 
-        let pnpm = ccusage_runner_args(CcusageRunnerKind::PnpmDlx, &opts, CcusageProvider::Claude);
+        let pnpm = ccusage_runner_args(
+            CcusageRunnerKind::PnpmDlx,
+            &opts,
+            CcusageProvider::Claude,
+            CcusageCommandFlavor::Current,
+        );
         assert_eq!(
             pnpm,
             vec![
                 "-s",
                 "dlx",
-                expected_claude_package.as_str(),
+                expected_ccusage_package.as_str(),
+                "claude",
                 "daily",
                 "--json",
                 "--order",
@@ -3395,13 +3454,19 @@ mod tests {
             ]
         );
 
-        let yarn = ccusage_runner_args(CcusageRunnerKind::YarnDlx, &opts, CcusageProvider::Claude);
+        let yarn = ccusage_runner_args(
+            CcusageRunnerKind::YarnDlx,
+            &opts,
+            CcusageProvider::Claude,
+            CcusageCommandFlavor::Current,
+        );
         assert_eq!(
             yarn,
             vec![
                 "dlx",
                 "-q",
-                expected_claude_package.as_str(),
+                expected_ccusage_package.as_str(),
+                "claude",
                 "daily",
                 "--json",
                 "--order",
@@ -3413,8 +3478,12 @@ mod tests {
             ]
         );
 
-        let npm_exec =
-            ccusage_runner_args(CcusageRunnerKind::NpmExec, &opts, CcusageProvider::Claude);
+        let npm_exec = ccusage_runner_args(
+            CcusageRunnerKind::NpmExec,
+            &opts,
+            CcusageProvider::Claude,
+            CcusageCommandFlavor::Current,
+        );
         assert_eq!(
             npm_exec,
             vec![
@@ -3423,6 +3492,7 @@ mod tests {
                 expected_npm_exec_package.as_str(),
                 "--",
                 "ccusage",
+                "claude",
                 "daily",
                 "--json",
                 "--order",
@@ -3434,12 +3504,18 @@ mod tests {
             ]
         );
 
-        let npx = ccusage_runner_args(CcusageRunnerKind::Npx, &opts, CcusageProvider::Claude);
+        let npx = ccusage_runner_args(
+            CcusageRunnerKind::Npx,
+            &opts,
+            CcusageProvider::Claude,
+            CcusageCommandFlavor::Current,
+        );
         assert_eq!(
             npx,
             vec![
                 "--yes",
-                expected_claude_package.as_str(),
+                expected_ccusage_package.as_str(),
+                "claude",
                 "daily",
                 "--json",
                 "--order",
@@ -3453,7 +3529,7 @@ mod tests {
     }
 
     #[test]
-    fn ccusage_runner_args_codex_use_scoped_package_and_bin() {
+    fn ccusage_runner_args_codex_use_unified_package_and_bin() {
         let opts = CcusageQueryOpts {
             provider: Some("codex".to_string()),
             since: Some("20260101".to_string()),
@@ -3461,19 +3537,21 @@ mod tests {
             home_path: None,
             claude_path: None,
         };
-        let expected_codex_package = ccusage_package_spec(CcusageProvider::Codex);
-        let expected_npm_exec_package = format!("--package={expected_codex_package}");
+        let expected_ccusage_package = ccusage_package_spec();
+        let expected_npm_exec_package = format!("--package={expected_ccusage_package}");
 
-        let npm_exec =
-            ccusage_runner_args(CcusageRunnerKind::NpmExec, &opts, CcusageProvider::Codex);
+        let bunx = ccusage_runner_args(
+            CcusageRunnerKind::Bunx,
+            &opts,
+            CcusageProvider::Codex,
+            CcusageCommandFlavor::Current,
+        );
         assert_eq!(
-            npm_exec,
+            bunx,
             vec![
-                "exec",
-                "--yes",
-                expected_npm_exec_package.as_str(),
-                "--",
-                "ccusage-codex",
+                "--silent",
+                expected_ccusage_package.as_str(),
+                "codex",
                 "daily",
                 "--json",
                 "--order",
@@ -3485,12 +3563,102 @@ mod tests {
             ]
         );
 
-        let npx = ccusage_runner_args(CcusageRunnerKind::Npx, &opts, CcusageProvider::Codex);
+        let npm_exec = ccusage_runner_args(
+            CcusageRunnerKind::NpmExec,
+            &opts,
+            CcusageProvider::Codex,
+            CcusageCommandFlavor::Current,
+        );
+        assert_eq!(
+            npm_exec,
+            vec![
+                "exec",
+                "--yes",
+                expected_npm_exec_package.as_str(),
+                "--",
+                "ccusage",
+                "codex",
+                "daily",
+                "--json",
+                "--order",
+                "desc",
+                "--since",
+                "20260101",
+                "--until",
+                "20260131"
+            ]
+        );
+
+        let npx = ccusage_runner_args(
+            CcusageRunnerKind::Npx,
+            &opts,
+            CcusageProvider::Codex,
+            CcusageCommandFlavor::Current,
+        );
         assert_eq!(
             npx,
             vec![
                 "--yes",
-                expected_codex_package.as_str(),
+                expected_ccusage_package.as_str(),
+                "codex",
+                "daily",
+                "--json",
+                "--order",
+                "desc",
+                "--since",
+                "20260101",
+                "--until",
+                "20260131"
+            ]
+        );
+    }
+
+    #[test]
+    fn ccusage_runner_args_legacy_fallback_uses_release_age_safe_packages() {
+        let opts = CcusageQueryOpts {
+            provider: None,
+            since: Some("20260101".to_string()),
+            until: Some("20260131".to_string()),
+            home_path: None,
+            claude_path: None,
+        };
+
+        let claude = ccusage_runner_args(
+            CcusageRunnerKind::Bunx,
+            &opts,
+            CcusageProvider::Claude,
+            CcusageCommandFlavor::Legacy,
+        );
+        assert_eq!(
+            claude,
+            vec![
+                "--silent",
+                "ccusage@18.0.11",
+                "daily",
+                "--json",
+                "--order",
+                "desc",
+                "--since",
+                "20260101",
+                "--until",
+                "20260131"
+            ]
+        );
+
+        let codex_npm = ccusage_runner_args(
+            CcusageRunnerKind::NpmExec,
+            &opts,
+            CcusageProvider::Codex,
+            CcusageCommandFlavor::Legacy,
+        );
+        assert_eq!(
+            codex_npm,
+            vec![
+                "exec",
+                "--yes",
+                "--package=@ccusage/codex@18.0.11",
+                "--",
+                "ccusage-codex",
                 "daily",
                 "--json",
                 "--order",
@@ -3598,10 +3766,7 @@ mod tests {
         std::fs::write(alias_dir.join("default"), "v22.16.0").expect("write alias");
         let result = nvm_default_bin_path(&home);
         let _ = std::fs::remove_dir_all(&home);
-        assert_eq!(
-            result,
-            Some(home.join(".nvm/versions/node/v22.16.0/bin"))
-        );
+        assert_eq!(result, Some(home.join(".nvm/versions/node/v22.16.0/bin")));
     }
 
     #[test]
@@ -3612,10 +3777,7 @@ mod tests {
         std::fs::write(alias_dir.join("default"), "22.16.0").expect("write alias");
         let result = nvm_default_bin_path(&home);
         let _ = std::fs::remove_dir_all(&home);
-        assert_eq!(
-            result,
-            Some(home.join(".nvm/versions/node/v22.16.0/bin"))
-        );
+        assert_eq!(result, Some(home.join(".nvm/versions/node/v22.16.0/bin")));
     }
 
     #[test]
@@ -3845,6 +4007,74 @@ Saved lockfile
         assert_eq!(calls, vec![CcusageRunnerKind::Bunx]);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn ccusage_runner_retries_legacy_package_when_current_package_fails() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let test_id = format!(
+            "openusage-ccusage-legacy-fallback-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        );
+        let dir = std::env::temp_dir().join(test_id);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let script_path = dir.join("fake-bunx.sh");
+        let args_path = dir.join("args.log");
+
+        let mut script = std::fs::File::create(&script_path).expect("create script");
+        let script_body = format!(
+            r#"#!/bin/sh
+echo "$*" >> "{}"
+case "$*" in
+  *"@ccusage/codex@18.0.11"*)
+    printf '{{"daily":[]}}\n'
+    exit 0
+    ;;
+  *)
+    echo "blocked current package" >&2
+    exit 1
+    ;;
+esac
+"#,
+            args_path.display()
+        );
+        script
+            .write_all(script_body.as_bytes())
+            .expect("write script");
+        let mut permissions = script.metadata().expect("script metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script_path, permissions).expect("make script executable");
+
+        let opts = CcusageQueryOpts {
+            provider: Some("codex".to_string()),
+            since: Some("20260101".to_string()),
+            until: None,
+            home_path: None,
+            claude_path: None,
+        };
+        let result = run_ccusage_with_runner(
+            CcusageRunnerKind::Bunx,
+            script_path.to_string_lossy().as_ref(),
+            &opts,
+            CcusageProvider::Codex,
+            "codex",
+        );
+        assert_eq!(
+            result,
+            CcusageRunnerResult::Success(r#"{"daily":[]}"#.to_string())
+        );
+
+        let calls = std::fs::read_to_string(&args_path).expect("read args log");
+        assert!(calls.contains("ccusage@20.0.2 codex daily"));
+        assert!(calls.contains("@ccusage/codex@18.0.11 daily"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn ccusage_timeout_log_uses_actual_timeout() {
         assert_eq!(
@@ -3905,6 +4135,7 @@ wait
             &opts,
             CcusageProvider::Codex,
             "codex",
+            CcusageCommandFlavor::Current,
             Duration::from_millis(100),
         );
 


### PR DESCRIPTION
## Summary
- Migrates the primary ccusage runner path to the unified `ccusage@20.0.2` focused commands for Claude and Codex.
- Adds a release-age-safe legacy fallback to `ccusage@18.0.11` / `@ccusage/codex@18.0.11` so local token costs still render while v20 is blocked by package manager minimum release age.
- Updates plugin API docs and the ccusage bump script for the single-package primary model.

## Test plan
- `bunx --silent ccusage@18.0.11 --version && bunx --silent ccusage@18.0.11 daily --json --order desc --since 20990101 && bunx --silent @ccusage/codex@18.0.11 --version && bunx --silent @ccusage/codex@18.0.11 daily --json --order desc --since 20990101`
- `cargo test ccusage --manifest-path src-tauri/Cargo.toml`
- `bunx vitest run plugins/claude/plugin.test.js plugins/codex/plugin.test.js`
- `bun run ccusage:bump -- 20.0.2`
- `bun run build`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the host’s `ccusage` command invocation and fallback behavior (including spawning external CLIs), which can affect whether usage/cost data renders across environments.
> 
> **Overview**
> Switches the ccusage integration to a unified `ccusage@20.0.2` CLI and runs provider-scoped commands (`ccusage claude daily` / `ccusage codex daily`) instead of provider-specific packages/binaries.
> 
> Adds an automatic legacy fallback when the current CLI run fails (retrying `ccusage@18.0.11` for Claude or `@ccusage/codex@18.0.11` for Codex), updates logs/tests to cover the retry path, and updates the docs plus the `ccusage:bump` tooling to the single-package pin model (including running the bump script via `bun`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af07307a9d3d9fa4029811bf13fe71802e9e2f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches ccusage to the unified `ccusage@20.0.2` focused commands and adds a release‑age fallback to legacy `18.0.11` packages when v20 is blocked. Keeps local token cost rendering working across package managers and aligns docs/pins with the single primary package.

- **Bug Fixes**
  - Runtime: run `ccusage@20.0.2` via `bunx -> pnpm dlx -> yarn dlx -> npm exec -> npx` using `ccusage <provider> daily`; on failure, retry with `ccusage@18.0.11` or `@ccusage/codex@18.0.11` (`ccusage-codex` bin for Codex).
  - Docs: update plugin API for focused commands and fallback; replace all primary `ccusage@<ver>` pins across docs with the current host version.
  - Tooling: run `ccusage:bump` with `bun`; script reads `CCUSAGE_VERSION` from `host_api.rs` and updates every primary docs reference.

<sup>Written for commit af07307a9d3d9fa4029811bf13fe71802e9e2f44. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/482?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

