### PR TITLE
fix(claude): prefer keychain credentials

### DIFF
--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -63,7 +63,19 @@ All windows are enforced simultaneously — hitting any limit throttles the user
 
 ### Token Location
 
-**Primary:** `~/.claude/.credentials.json`
+On macOS, OpenUsage reads Claude Code credentials from Keychain first. The default service name is:
+
+```text
+Claude Code-credentials
+```
+
+When `CLAUDE_CONFIG_DIR` is set, Claude Code may use a config-specific service name instead. OpenUsage checks this hashed name before the default service:
+
+```text
+Claude Code-credentials-<sha256(CLAUDE_CONFIG_DIR).slice(0, 8)>
+```
+
+Keychain values use the same JSON structure as the legacy credentials file:
 
 ```jsonc
 {
@@ -78,7 +90,7 @@ All windows are enforced simultaneously — hitting any limit throttles the user
 }
 ```
 
-**Fallback:** macOS Keychain, service name `Claude Code-credentials` (same JSON structure).
+**Fallback:** `~/.claude/.credentials.json`. This file can be left behind by older Claude Code versions, so it is treated as a fallback when Keychain does not contain usable credentials.
 
 ### Token Refresh
 
@@ -94,7 +106,7 @@ Content-Type: application/json
   "grant_type": "refresh_token",
   "refresh_token": "<refresh_token>",
   "client_id": "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
-  "scope": "user:profile user:inference user:sessions:claude_code user:mcp_servers"
+  "scope": "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
 }
 ```
 

--- a/plugins/claude/plugin.js
+++ b/plugins/claude/plugin.js
@@ -266,9 +266,8 @@
     return null
   }
 
-  function loadStoredCredentials(ctx, suppressMissingWarn) {
+  function loadFileCredentials(ctx) {
     const credFile = getClaudeCredentialsPath(ctx)
-    // Try file first
     if (ctx.host.fs.exists(credFile)) {
       try {
         const text = ctx.host.fs.readText(credFile)
@@ -286,7 +285,11 @@
       }
     }
 
-    // Try keychain fallback — iterate hashed-then-legacy service names.
+    return null
+  }
+
+  function loadKeychainCredentials(ctx) {
+    // Iterate hashed-then-legacy service names.
     for (const service of getClaudeKeychainServiceCandidates(ctx)) {
       const keychainResult = readKeychainCredentialText(ctx, service)
       if (keychainResult && keychainResult.value) {
@@ -302,6 +305,18 @@
         // Continue: a stale legacy entry shouldn't shadow a valid hashed one.
       }
     }
+
+    return null
+  }
+
+  function loadStoredCredentials(ctx, suppressMissingWarn) {
+    // Recent Claude Code versions keep the current macOS session in Keychain and
+    // can leave a stale credentials file behind, so Keychain must win when valid.
+    const keychainCredentials = loadKeychainCredentials(ctx)
+    if (keychainCredentials) return keychainCredentials
+
+    const fileCredentials = loadFileCredentials(ctx)
+    if (fileCredentials) return fileCredentials
 
     if (!suppressMissingWarn) {
       ctx.host.log.warn("no credentials found")

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -115,6 +115,53 @@ describe("claude plugin", () => {
     expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Claude Code-credentials")
   })
 
+  it("prefers keychain over a stale credentials file (regression for #444)", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.exists = () => true
+    ctx.host.fs.readText = vi.fn(() =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "stale-file-token",
+          refreshToken: "stale-file-refresh",
+          expiresAt: Date.now() - 1000,
+          subscriptionType: "pro",
+        },
+      })
+    )
+    ctx.host.keychain.readGenericPasswordForCurrentUser.mockReturnValue(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "keychain-token",
+          refreshToken: "keychain-refresh",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+          subscriptionType: "pro",
+        },
+      })
+    )
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("/v1/oauth/token")) {
+        throw new Error("stale file refresh should not be attempted")
+      }
+      return {
+        status: 200,
+        bodyText: JSON.stringify({
+          five_hour: { utilization: 10, resets_at: "2099-01-01T00:00:00.000Z" },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.fs.readText).not.toHaveBeenCalled()
+    expect(ctx.host.http.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer keychain-token" }),
+      })
+    )
+  })
+
   it("falls back to keychain when credentials file is corrupt", async () => {
     const ctx = makeCtx()
     ctx.host.fs.exists = () => true


### PR DESCRIPTION
## Summary
- Prefer valid Claude Code Keychain credentials before falling back to the legacy `.credentials.json` file.
- Add regression coverage for stale file credentials shadowing a valid Keychain session.
- Update Claude provider docs for Keychain precedence and hashed service names.

## Test plan
- [x] `bun run test -- plugins/claude/plugin.test.js`

Closes #444

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential-source precedence for OAuth tokens; mis-ordering could break authentication on macOS, but the change is small and covered by regression tests.
> 
> **Overview**
> Fixes Claude credential resolution to **prefer Keychain sessions first** (including hashed service names when `CLAUDE_CONFIG_DIR` is set) and only fall back to `~/.claude/.credentials.json` when Keychain credentials are missing/invalid, preventing stale file tokens from triggering unnecessary refresh attempts.
> 
> Adds a regression test for the stale-file-shadowing-Keychain scenario and updates Claude provider docs to reflect Keychain precedence, hashed service naming, and the expanded refresh `scope` including `user:file_upload`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55c5877aa7c21ddf5c662a0719ca073603092a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer macOS Keychain Claude Code credentials over the legacy file to avoid stale tokens and failed probes. Updates provider docs and adds a regression test to lock the behavior.

- Bug Fixes
  - Check Keychain first (hashed `Claude Code-credentials-<sha256(CLAUDE_CONFIG_DIR).slice(0, 8)>`, then `Claude Code-credentials`) before `~/.claude/.credentials.json`.
  - Prevent using or refreshing stale file tokens when a valid Keychain session exists; add regression test.
  - Docs clarify Keychain precedence and hashed service names; OAuth scope example now includes `user:file_upload`.

<sup>Written for commit 55c5877aa7c21ddf5c662a0719ca073603092a10. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/483?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

