### PR TITLE
feat: add Grok usage plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ OpenUsage lives in your menu bar and shows you how much of your AI coding subscr
 - [**Cursor**](docs/providers/cursor.md) / credits, total usage, auto usage, API usage, on-demand, CLI auth
 - [**Factory / Droid**](docs/providers/factory.md) / standard, premium tokens
 - [**Gemini**](docs/providers/gemini.md) / pro, flash, workspace/free/paid tier
+- [**Grok**](docs/providers/grok.md) / credits used, plan, pay-as-you-go cap
 - [**JetBrains AI Assistant**](docs/providers/jetbrains-ai-assistant.md) / quota, remaining
 - [**Kiro**](docs/providers/kiro.md) / credits, bonus credits, overages
 - [**Kimi Code**](docs/providers/kimi.md) / session, weekly

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -1,0 +1,91 @@
+# Grok
+
+Tracks Grok Build credit usage from the local Grok CLI login.
+
+> Reverse-engineered, undocumented API. May change without notice.
+
+## Overview
+
+- **Protocol:** REST (plain JSON)
+- **Base URL:** `https://cli-chat-proxy.grok.com/v1`
+- **Auth:** cached Grok CLI token from `~/.grok/auth.json`
+- **Usage unit:** raw billing units from Grok
+- **Plan source:** `GET /settings` (`subscription_tier_display`)
+- **Reset period:** billing period from the CLI billing response
+
+## Setup
+
+1. Install and sign in to the Grok CLI:
+
+```bash
+grok login
+```
+
+2. Enable the Grok plugin in OpenUsage settings.
+
+OpenUsage reads the same local auth file that the Grok CLI uses. If the token expires, run `grok login` again.
+
+## Endpoint
+
+### GET /billing
+
+Returns the current Grok Build billing period, credit usage, and pay-as-you-go cap.
+
+#### Headers
+
+| Header | Required | Value |
+|--------|----------|-------|
+| Authorization | yes | `Bearer <token from ~/.grok/auth.json>` |
+| X-XAI-Token-Auth | yes | `xai-grok-cli` |
+| Accept | yes | `application/json` |
+
+#### Response
+
+```json
+{
+  "config": {
+    "monthlyLimit": { "val": 60000 },
+    "used": { "val": 4277 },
+    "onDemandCap": { "val": 0 },
+    "billingPeriodStart": "2026-05-01T00:00:00+00:00",
+    "billingPeriodEnd": "2026-06-01T00:00:00+00:00",
+    "history": [
+      {
+        "billingCycle": { "year": 2026, "month": 4 },
+        "includedUsed": { "val": 0 },
+        "onDemandUsed": { "val": 0 },
+        "totalUsed": { "val": 0 }
+      }
+    ]
+  }
+}
+```
+
+### GET /settings
+
+Returns remote CLI settings. OpenUsage reads `subscription_tier_display` from this response and shows it as the provider plan label, for example `SuperGrok Heavy`.
+
+Used fields:
+
+- `used.val` — current billing period usage
+- `monthlyLimit.val` — included credit limit
+- `onDemandCap.val` — pay-as-you-go cap; `0` means disabled
+- `billingPeriodEnd` — current billing period reset time
+
+## Displayed Lines
+
+| Line | Description |
+|------|-------------|
+| Credits used | Percent of included monthly credits used |
+| Pay as you go | Disabled, or the configured pay-as-you-go cap |
+
+## Errors
+
+| Condition | Message |
+|-----------|---------|
+| Missing auth file | "Grok not logged in. Run `grok login`." |
+| Expired token | "Grok auth expired. Run `grok login` again." |
+| 401/403 | "Grok auth expired. Run `grok login` again." |
+| HTTP error | "Grok billing request failed (HTTP {status}). Try again later." |
+| Network error | "Grok billing request failed. Check your connection." |
+| Invalid response | "Grok billing response changed." |

--- a/plugins/grok/icon.svg
+++ b/plugins/grok/icon.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="727.27" height="778.68" version="1.1" viewBox="0 0 727.27 778.68" xmlns="http://www.w3.org/2000/svg">
+  <polygon transform="translate(-134,-113.32)" points="508.67 574.07 761.27 213.32 639.19 213.32 447.64 486.9" fill="currentColor"/>
+  <polygon transform="translate(-134,-113.32)" points="356.08 792 417.12 704.83 356.08 617.66 234 792" fill="currentColor"/>
+  <polygon transform="translate(-134,-113.32)" points="508.67 792 630.75 792 356.08 399.72 234 399.72" fill="currentColor"/>
+  <polygon transform="translate(-134,-113.32)" points="761.27 256.91 661.27 399.72 671.27 792 751.27 792" fill="currentColor"/>
+</svg>

--- a/plugins/grok/plugin.js
+++ b/plugins/grok/plugin.js
@@ -1,0 +1,164 @@
+(function () {
+  const AUTH_PATH = "~/.grok/auth.json"
+  const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing"
+  const SETTINGS_URL = "https://cli-chat-proxy.grok.com/v1/settings"
+  const TOKEN_AUTH_HEADER = "xai-grok-cli"
+  const AUTH_REFRESH_BUFFER_MS = 5 * 60 * 1000
+
+  function readJson(ctx, path) {
+    if (!ctx.host.fs.exists(path)) return null
+    try {
+      return ctx.util.tryParseJson(ctx.host.fs.readText(path))
+    } catch {
+      return null
+    }
+  }
+
+  function entryExpiresAtMs(ctx, entry) {
+    if (!entry || typeof entry !== "object") return null
+    if (!entry.expires_at) return null
+    return ctx.util.parseDateMs(entry.expires_at)
+  }
+
+  function isExpired(ctx, entry, nowMs) {
+    const expiresAtMs = entryExpiresAtMs(ctx, entry)
+    if (expiresAtMs === null) return false
+    return nowMs + AUTH_REFRESH_BUFFER_MS >= expiresAtMs
+  }
+
+  function loadAuth(ctx) {
+    const auth = readJson(ctx, AUTH_PATH)
+    if (!auth || typeof auth !== "object") {
+      throw "Grok not logged in. Run `grok login`."
+    }
+
+    const nowMs = ctx.util.parseDateMs(ctx.nowIso) || Date.now()
+    let expiredCandidate = false
+    const keys = Object.keys(auth)
+    for (let i = 0; i < keys.length; i++) {
+      const entry = auth[keys[i]]
+      if (!entry || typeof entry !== "object") continue
+      const token = typeof entry.key === "string" ? entry.key.trim() : ""
+      if (!token) continue
+      if (isExpired(ctx, entry, nowMs)) {
+        expiredCandidate = true
+        continue
+      }
+      return { token }
+    }
+
+    if (expiredCandidate) {
+      throw "Grok auth expired. Run `grok login` again."
+    }
+    throw "Grok auth invalid. Run `grok login` again."
+  }
+
+  function unitsValue(obj) {
+    if (!obj || typeof obj !== "object") return null
+    const n = Number(obj.val)
+    return Number.isFinite(n) ? n : null
+  }
+
+  function clampPercent(value) {
+    const n = Number(value)
+    if (!Number.isFinite(n)) return 0
+    if (n < 0) return 0
+    if (n > 100) return 100
+    return n
+  }
+
+  function fetchBilling(ctx, token) {
+    let resp
+    try {
+      resp = ctx.util.request({
+        method: "GET",
+        url: BILLING_URL,
+        headers: {
+          Authorization: "Bearer " + token,
+          "X-XAI-Token-Auth": TOKEN_AUTH_HEADER,
+          Accept: "application/json",
+          "User-Agent": "OpenUsage",
+        },
+        timeoutMs: 10000,
+      })
+    } catch {
+      throw "Grok billing request failed. Check your connection."
+    }
+
+    if (ctx.util.isAuthStatus(resp.status)) {
+      throw "Grok auth expired. Run `grok login` again."
+    }
+    if (resp.status < 200 || resp.status >= 300) {
+      throw "Grok billing request failed (HTTP " + String(resp.status) + "). Try again later."
+    }
+
+    const data = ctx.util.tryParseJson(resp.bodyText)
+    if (!data) {
+      throw "Grok billing response changed."
+    }
+    return data
+  }
+
+  function fetchPlanName(ctx, token) {
+    try {
+      const resp = ctx.util.request({
+        method: "GET",
+        url: SETTINGS_URL,
+        headers: {
+          Authorization: "Bearer " + token,
+          "X-XAI-Token-Auth": TOKEN_AUTH_HEADER,
+          Accept: "application/json",
+          "User-Agent": "OpenUsage",
+        },
+        timeoutMs: 10000,
+      })
+      if (resp.status < 200 || resp.status >= 300) return null
+      const data = ctx.util.tryParseJson(resp.bodyText)
+      const plan = data && data.subscription_tier_display
+      return typeof plan === "string" && plan.trim() ? plan.trim() : null
+    } catch {
+      return null
+    }
+  }
+
+  function probe(ctx) {
+    const auth = loadAuth(ctx)
+    const data = fetchBilling(ctx, auth.token)
+    const config = data && data.config
+    if (!config || typeof config !== "object") {
+      throw "Grok billing response changed."
+    }
+
+    const usedUnits = unitsValue(config.used)
+    const limitUnits = unitsValue(config.monthlyLimit)
+    const onDemandCapUnits = unitsValue(config.onDemandCap)
+    if (usedUnits === null || limitUnits === null || limitUnits <= 0 || onDemandCapUnits === null) {
+      throw "Grok billing response changed."
+    }
+
+    const resetsAt = ctx.util.toIso(config.billingPeriodEnd)
+    if (!resetsAt) {
+      throw "Grok billing response changed."
+    }
+
+    const usedPercent = clampPercent((usedUnits / limitUnits) * 100)
+    const lines = [
+      ctx.line.progress({
+        label: "Credits used",
+        used: usedPercent,
+        limit: 100,
+        format: { kind: "percent" },
+        resetsAt,
+      }),
+      ctx.line.badge({
+        label: "Pay as you go",
+        text: onDemandCapUnits > 0 ? String(onDemandCapUnits) + " cap" : "Disabled",
+        color: onDemandCapUnits > 0 ? "#22c55e" : "#a3a3a3",
+      }),
+    ]
+
+    return { plan: fetchPlanName(ctx, auth.token), lines }
+  }
+
+  globalThis.__openusage_plugin = { id: "grok", probe }
+})()

--- a/plugins/grok/plugin.json
+++ b/plugins/grok/plugin.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "id": "grok",
+  "name": "Grok",
+  "version": "0.0.1",
+  "entry": "plugin.js",
+  "icon": "icon.svg",
+  "brandColor": "#000000",
+  "links": [
+    { "label": "Usage", "url": "https://grok.com/?_s=usage" }
+  ],
+  "lines": [
+    { "type": "progress", "label": "Credits used", "scope": "overview", "primaryOrder": 1 },
+    { "type": "badge", "label": "Pay as you go", "scope": "overview" }
+  ]
+}

--- a/plugins/grok/plugin.test.js
+++ b/plugins/grok/plugin.test.js
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { makeCtx } from "../test-helpers.js"
+
+const AUTH_PATH = "~/.grok/auth.json"
+const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing"
+const SETTINGS_URL = "https://cli-chat-proxy.grok.com/v1/settings"
+
+const loadPlugin = async () => {
+  await import("./plugin.js?test=" + Math.random())
+  return globalThis.__openusage_plugin
+}
+
+function writeAuth(ctx, entry) {
+  const auth = {}
+  auth["https://auth.x.ai::client"] = entry || {
+    key: "test-token",
+    email: "user@example.com",
+    expires_at: "2026-06-01T00:00:00Z",
+  }
+  ctx.host.fs.writeText(AUTH_PATH, JSON.stringify(auth))
+}
+
+function billingData(overrides) {
+  const config = Object.assign({
+    monthlyLimit: { val: 60000 },
+    used: { val: 4277 },
+    onDemandCap: { val: 0 },
+    billingPeriodStart: "2026-05-01T00:00:00+00:00",
+    billingPeriodEnd: "2026-06-01T00:00:00+00:00",
+    history: [
+      {
+        billingCycle: { year: 2026, month: 4 },
+        includedUsed: { val: 1234 },
+        onDemandUsed: { val: 200 },
+        totalUsed: { val: 1434 },
+      },
+      {
+        billingCycle: { year: 2026, month: 3 },
+        includedUsed: { val: 0 },
+        onDemandUsed: { val: 0 },
+        totalUsed: { val: 0 },
+      },
+    ],
+  }, overrides || {})
+  return { config }
+}
+
+function mockGrokApi(ctx, data, settings) {
+  ctx.host.http.request.mockImplementation((req) => {
+    if (req.url === BILLING_URL) {
+      return {
+        status: 200,
+        bodyText: JSON.stringify(data || billingData()),
+      }
+    }
+    if (req.url === SETTINGS_URL) {
+      return settings || {
+        status: 200,
+        bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+      }
+    }
+    return { status: 404, bodyText: "" }
+  })
+}
+
+describe("grok plugin", () => {
+  beforeEach(() => {
+    delete globalThis.__openusage_plugin
+  })
+
+  it("throws when auth file is missing", async () => {
+    const ctx = makeCtx()
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Grok not logged in. Run `grok login`.")
+  })
+
+  it("throws when auth file has no usable token", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText(AUTH_PATH, JSON.stringify({ account: { email: "user@example.com" } }))
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Grok auth invalid. Run `grok login` again.")
+  })
+
+  it("throws when the only token is expired", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx, {
+      key: "expired-token",
+      email: "user@example.com",
+      expires_at: "2026-01-01T00:00:00Z",
+    })
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Grok auth expired. Run `grok login` again.")
+  })
+
+  it("uses the first non-expired token", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText(AUTH_PATH, JSON.stringify({
+      expired: {
+        key: "expired-token",
+        expires_at: "2026-01-01T00:00:00Z",
+      },
+      active: {
+        key: "active-token",
+        email: "active@example.com",
+        expires_at: "2026-06-01T00:00:00Z",
+      },
+    }))
+    mockGrokApi(ctx)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok Heavy")
+    expect(ctx.host.http.request.mock.calls[0][0].headers.Authorization).toBe("Bearer active-token")
+  })
+
+  it("requests the CLI billing endpoint with Grok CLI headers", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx)
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    const call = ctx.host.http.request.mock.calls[0][0]
+    expect(call.method).toBe("GET")
+    expect(call.url).toBe(BILLING_URL)
+    expect(call.headers.Authorization).toBe("Bearer test-token")
+    expect(call.headers["X-XAI-Token-Auth"]).toBe("xai-grok-cli")
+    expect(call.headers.Accept).toBe("application/json")
+  })
+
+  it("renders credits used as percent progress", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const line = result.lines.find((l) => l.label === "Credits used")
+
+    expect(line.type).toBe("progress")
+    expect(line.used).toBeCloseTo(7.128, 3)
+    expect(line.limit).toBe(100)
+    expect(line.format).toEqual({ kind: "percent" })
+    expect(line.resetsAt).toBe("2026-06-01T00:00:00.000Z")
+  })
+
+  it("does not render duplicate reset or billing detail rows", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx)
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((l) => l.label === "Resets")).toBeUndefined()
+    expect(result.lines.find((l) => l.label === "Current period")).toBeUndefined()
+    expect(result.lines.find((l) => l.label === "Billing cycle")).toBeUndefined()
+  })
+
+  it("renders pay as you go disabled when cap is zero", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData({ onDemandCap: { val: 0 } }))
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const line = result.lines.find((l) => l.label === "Pay as you go")
+
+    expect(line.type).toBe("badge")
+    expect(line.text).toBe("Disabled")
+    expect(line.color).toBe("#a3a3a3")
+  })
+
+  it("renders pay as you go cap when enabled", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData({ onDemandCap: { val: "2500" } }))
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const line = result.lines.find((l) => l.label === "Pay as you go")
+
+    expect(line.text).toBe("2500 cap")
+    expect(line.color).toBe("#22c55e")
+  })
+
+  it("parses billing values provided as strings", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData({
+      monthlyLimit: { val: "10000" },
+      used: { val: "2500" },
+      onDemandCap: { val: "0" },
+    }))
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((l) => l.label === "Credits used").used).toBe(25)
+    expect(result.lines.find((l) => l.label === "Current period")).toBeUndefined()
+  })
+
+  it("reads the plan name from settings instead of auth email", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData(), {
+      status: 200,
+      bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    const settingsCall = ctx.host.http.request.mock.calls.find((call) => call[0].url === SETTINGS_URL)[0]
+    expect(settingsCall.headers.Authorization).toBe("Bearer test-token")
+    expect(settingsCall.headers["X-XAI-Token-Auth"]).toBe("xai-grok-cli")
+    expect(result.plan).toBe("SuperGrok Heavy")
+  })
+
+  it("omits the plan label when settings does not include a plan", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, billingData(), {
+      status: 200,
+      bodyText: JSON.stringify({ release_channel: "stable" }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe(null)
+  })
+
+  it("throws when billing request returns auth error", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    ctx.host.http.request.mockReturnValue({ status: 401, bodyText: "" })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Grok auth expired. Run `grok login` again.")
+  })
+
+  it("throws on billing HTTP error", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    ctx.host.http.request.mockReturnValue({ status: 500, bodyText: "" })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Grok billing request failed (HTTP 500). Try again later.")
+  })
+
+  it("throws on billing network error", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    ctx.host.http.request.mockImplementation(() => {
+      throw new Error("offline")
+    })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Grok billing request failed. Check your connection.")
+  })
+
+  it("throws on invalid billing JSON", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    ctx.host.http.request.mockReturnValue({ status: 200, bodyText: "not-json" })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Grok billing response changed.")
+  })
+
+  it("throws on unexpected billing response shape", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx)
+    mockGrokApi(ctx, { config: { used: { val: 1 } } })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Grok billing response changed.")
+  })
+})

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -252,7 +252,7 @@ export function ProviderCard({
           {plan && (
             <Badge
               variant="outline"
-              className="truncate min-w-0 max-w-[40%]"
+              className="truncate min-w-0 max-w-[50%]"
               title={plan}
             >
               {plan}


### PR DESCRIPTION
## Summary
- Add a Grok usage plugin that reads local Grok CLI auth and calls the CLI billing endpoint.
- Show usage percent, pay-as-you-go state, and plan label from Grok settings.
- Add provider docs, README entry, xAI icon, and focused plugin test coverage.

## Test plan
- `bun test plugin.test.js` from `plugins/grok` passes.
- `bun test src/components/provider-card.test.tsx` was attempted but the existing suite fails before rendering because Bun does not provide `vi.mocked` in this test environment.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new provider plugin that reads local Grok CLI auth and makes external billing/settings requests; correctness depends on an undocumented API and token handling, but changes are isolated to the new plugin plus a small UI tweak.
> 
> **Overview**
> Adds first-class **Grok** support via a new plugin that reads the Grok CLI token from `~/.grok/auth.json`, calls the Grok CLI `billing` endpoint to compute **credits-used percent** and pay-as-you-go cap status, and optionally fetches a **plan label** from `settings`.
> 
> Includes Grok provider documentation, an icon + manifest metadata, and focused Vitest coverage for auth parsing/expiry, request headers, response-shape validation, and error messaging. Separately increases the provider card plan badge max width from `40%` to `50%` to better fit longer plan names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5db81ee3e502ae6ba213dc1aa78ac9912d6c0dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Grok usage plugin that reads local Grok CLI auth to show Build credit usage, plan label, and pay‑as‑you‑go cap in the app.

- **New Features**
  - New `grok` provider plugin using `~/.grok/auth.json` and `https://cli-chat-proxy.grok.com/v1` (`GET /billing`, `GET /settings`) with `X-XAI-Token-Auth: xai-grok-cli`.
  - Displays "Credits used" as a percent with billing period reset, and a "Pay as you go" badge; plan comes from `subscription_tier_display`.
  - Added docs (`docs/providers/grok.md`), README entry, xAI icon, and focused tests (`plugins/grok/plugin.test.js`).

- **Refactors**
  - Widened plan badge max width to 50% in provider cards to reduce truncation.

<sup>Written for commit 5db81ee3e502ae6ba213dc1aa78ac9912d6c0dbb. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/484?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

