### PR TITLE
fix(ui): improve pace marker visibility on usage bars

### DIFF
--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -53,7 +53,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
           <div
             data-slot="progress-marker"
             aria-hidden="true"
-            className="absolute top-0 bottom-0 w-[2px] z-10 pointer-events-none bg-muted-foreground opacity-50"
+            className="absolute top-0 bottom-0 w-1 z-10 pointer-events-none rounded-sm bg-muted-foreground ring-1 ring-background/50"
             style={markerStyle}
           />
         )}

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -62,7 +62,7 @@ describe("ui components", () => {
     expect(marker).toBeTruthy()
     expect(marker?.style.left).toBe("100%")
     expect(marker?.style.transform).toBe("translateX(-100%)")
-    expect(marker).toHaveClass("bg-muted-foreground", "opacity-50")
+    expect(marker).toHaveClass("bg-muted-foreground", "w-1", "ring-background/50")
 
     rerender(<Progress value={25} markerValue={-10} />)
     marker = container.querySelector<HTMLElement>('[data-slot="progress-marker"]')


### PR DESCRIPTION
## Summary
- Makes the pace/elapsed-time marker on progress bars easier to see (4px width, full opacity, subtle 50% background ring).
- Addresses contrast issues reported in dark mode when the bar fill is bright.

<img width="293" height="179" alt="image" src="https://github.com/user-attachments/assets/df614ae2-f7e5-44e6-950e-ed3bdec1014f" />

Fixes #417

## Test plan
- [x] `vitest run src/components/ui/ui.test.tsx src/components/provider-card.test.tsx`
- [x] Manually verify pace markers on ahead/behind usage lines in light and dark mode


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change to the `Progress` marker styling with a small test assertion update; no logic or data flow changes.
> 
> **Overview**
> Improves the `Progress` pace/marker indicator styling to be more visible by increasing its width, adding rounded corners, and applying a subtle background ring (replacing the prior thin/opacity-based marker).
> 
> Updates the UI test to assert the new marker classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d37a5c2041fd207de775894b3e1e9a43f457861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves visibility of the pace/elapsed-time marker on usage progress bars by widening it and adding a subtle ring. Fixes #417 by resolving contrast issues in dark mode when the bar fill is bright.

<sup>Written for commit 5d37a5c2041fd207de775894b3e1e9a43f457861. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/485?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

