### PR TITLE
[codex] Pause ticker while panel is hidden

### DIFF
--- a/src/hooks/use-now-ticker.test.ts
+++ b/src/hooks/use-now-ticker.test.ts
@@ -1,13 +1,20 @@
 import { renderHook, act } from "@testing-library/react"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
 import { useNowTicker } from "./use-now-ticker"
 
 describe("useNowTicker", () => {
+  let originalDocumentHiddenDescriptor: PropertyDescriptor | undefined
+
+  beforeAll(() => {
+    originalDocumentHiddenDescriptor = Object.getOwnPropertyDescriptor(document, "hidden")
+  })
+
   afterEach(() => {
-    Object.defineProperty(document, "hidden", {
-      configurable: true,
-      value: false,
-    })
+    if (originalDocumentHiddenDescriptor) {
+      Object.defineProperty(document, "hidden", originalDocumentHiddenDescriptor)
+    } else {
+      Reflect.deleteProperty(document, "hidden")
+    }
     vi.useRealTimers()
   })
 
@@ -64,6 +71,29 @@ describe("useNowTicker", () => {
       document.dispatchEvent(new Event("visibilitychange"))
     })
     expect(result.current).toBe(visibleNow)
+  })
+
+  it("does not refresh when disabled and the document becomes visible", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-02-03T00:00:00.000Z"))
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      value: true,
+    })
+
+    const { result } = renderHook(() => useNowTicker({ enabled: false, intervalMs: 1000 }))
+    expect(result.current).toBe(Date.parse("2026-02-03T00:00:00.000Z"))
+
+    vi.setSystemTime(new Date("2026-02-03T00:00:05.000Z"))
+    act(() => {
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      })
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+
+    expect(result.current).toBe(Date.parse("2026-02-03T00:00:00.000Z"))
   })
 
   it("stops an active ticker when the document becomes hidden", () => {

--- a/src/hooks/use-now-ticker.test.ts
+++ b/src/hooks/use-now-ticker.test.ts
@@ -4,6 +4,10 @@ import { useNowTicker } from "./use-now-ticker"
 
 describe("useNowTicker", () => {
   afterEach(() => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      value: false,
+    })
     vi.useRealTimers()
   })
 
@@ -29,10 +33,90 @@ describe("useNowTicker", () => {
     expect(result.current).toBe(Date.parse("2026-02-03T00:00:00.000Z"))
 
     act(() => {
-      vi.setSystemTime(new Date("2026-02-03T00:00:05.000Z"))
       vi.advanceTimersByTime(5_000)
     })
 
     expect(result.current).toBe(Date.parse("2026-02-03T00:00:00.000Z"))
+  })
+
+  it("pauses ticks while the document is hidden", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-02-03T00:00:00.000Z"))
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      value: true,
+    })
+
+    const { result } = renderHook(() => useNowTicker({ intervalMs: 1000 }))
+    expect(result.current).toBe(Date.parse("2026-02-03T00:00:00.000Z"))
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(result.current).toBe(Date.parse("2026-02-03T00:00:00.000Z"))
+
+    const visibleNow = Date.now()
+    act(() => {
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      })
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+    expect(result.current).toBe(visibleNow)
+  })
+
+  it("stops an active ticker when the document becomes hidden", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-02-03T00:00:00.000Z"))
+
+    const { result } = renderHook(() => useNowTicker({ intervalMs: 1000 }))
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current).toBe(Date.parse("2026-02-03T00:00:01.000Z"))
+
+    act(() => {
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: true,
+      })
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(result.current).toBe(Date.parse("2026-02-03T00:00:01.000Z"))
+
+    const visibleNow = Date.now()
+    act(() => {
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      })
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+    expect(result.current).toBe(visibleNow)
+  })
+
+  it("keeps ticking while hidden when pauseWhenHidden is false", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-02-03T00:00:00.000Z"))
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      value: true,
+    })
+
+    const { result } = renderHook(() =>
+      useNowTicker({ intervalMs: 1000, pauseWhenHidden: false })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(result.current).toBe(Date.parse("2026-02-03T00:00:01.000Z"))
   })
 })

--- a/src/hooks/use-now-ticker.ts
+++ b/src/hooks/use-now-ticker.ts
@@ -34,7 +34,7 @@ export function useNowTicker({
     const handleVisibilityChange = () => {
       const visible = isDocumentVisible()
       setDocumentVisible(visible)
-      if (visible) {
+      if (visible && enabled) {
         setNow(Date.now())
       }
     }
@@ -42,7 +42,7 @@ export function useNowTicker({
     handleVisibilityChange()
     document.addEventListener("visibilitychange", handleVisibilityChange)
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange)
-  }, [pauseWhenHidden])
+  }, [enabled, pauseWhenHidden])
 
   useEffect(() => {
     if (!enabled || !documentVisible) return undefined

--- a/src/hooks/use-now-ticker.ts
+++ b/src/hooks/use-now-ticker.ts
@@ -4,19 +4,48 @@ type UseNowTickerOptions = {
   enabled?: boolean
   intervalMs?: number
   stopAfterMs?: number | null
+  pauseWhenHidden?: boolean
   resetKey?: unknown
+}
+
+function isDocumentVisible() {
+  if (typeof document === "undefined") return true
+  return !document.hidden
 }
 
 export function useNowTicker({
   enabled = true,
   intervalMs = 1000,
   stopAfterMs = null,
+  pauseWhenHidden = true,
   resetKey,
 }: UseNowTickerOptions = {}) {
   const [now, setNow] = useState(() => Date.now())
+  const [documentVisible, setDocumentVisible] = useState(() =>
+    pauseWhenHidden ? isDocumentVisible() : true
+  )
 
   useEffect(() => {
-    if (!enabled) return undefined
+    if (!pauseWhenHidden || typeof document === "undefined") {
+      setDocumentVisible(true)
+      return undefined
+    }
+
+    const handleVisibilityChange = () => {
+      const visible = isDocumentVisible()
+      setDocumentVisible(visible)
+      if (visible) {
+        setNow(Date.now())
+      }
+    }
+
+    handleVisibilityChange()
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange)
+  }, [pauseWhenHidden])
+
+  useEffect(() => {
+    if (!enabled || !documentVisible) return undefined
 
     setNow(Date.now())
     const interval = window.setInterval(() => setNow(Date.now()), intervalMs)
@@ -35,7 +64,7 @@ export function useNowTicker({
       window.clearInterval(interval)
       window.clearTimeout(timeout)
     }
-  }, [enabled, intervalMs, stopAfterMs, resetKey])
+  }, [enabled, intervalMs, stopAfterMs, resetKey, documentVisible])
 
   return now
 }


### PR DESCRIPTION
## Summary

- pause `useNowTicker` intervals while `document.hidden` is true by default
- refresh `now` immediately when the document becomes visible again, before the next interval tick
- add hook coverage for initially hidden documents, active ticker pause/resume, and opt-out behavior

## Why

`useNowTicker` drives display-only UI such as countdowns and relative timestamps. When the menu panel WebView is hidden, those React timer updates do not change visible UI but can still wake the app. Pausing the ticker while hidden reduces idle UI work without changing provider probes or background refresh scheduling.

This addresses #488 and complements the broader resource-budget discussion in #487.

## Notes

The default behavior is visibility-aware, but callers can keep the old hidden ticking behavior with `pauseWhenHidden: false` if a future use case needs it.

## Validation

- `node ./node_modules/vitest/vitest.mjs run src/hooks/use-now-ticker.test.ts`
- `bun run build`
- `node ./node_modules/vitest/vitest.mjs run`

The full Vitest run passes. Existing tests print Tauri store mock stderr in `App.test.tsx`, but the suite exits successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pause `useNowTicker` ticks while the document is hidden to reduce idle updates, and resume with an immediate refresh when it becomes visible. Adds a `pauseWhenHidden` option (default true), respects `enabled` on visibility changes (no refresh when disabled), and tests for initial hidden state, pause/resume, disabled behavior, and opt‑out.

<sup>Written for commit be7d219de3a68e3e1369c4bba2ad4c06552e08ad. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/490?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


