### PR TITLE
[codex] Skip auto-update probes already in flight

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -343,6 +343,7 @@ describe("App", () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     delete (HTMLElement.prototype as unknown as Record<string, unknown>).scrollHeight
   })
 
@@ -1373,6 +1374,13 @@ describe("App", () => {
     await vi.waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
 
     // Clear the initial batch call count
+    state.probeHandlers?.onResult({
+      providerId: "a",
+      displayName: "Alpha",
+      iconUrl: "icon-a",
+      lines: [{ type: "text", label: "Now", value: "OK" }],
+    })
+    state.probeHandlers?.onBatchComplete()
     const initialCalls = state.startBatchMock.mock.calls.length
 
     // Advance time by 5 minutes to trigger the interval
@@ -1401,6 +1409,13 @@ describe("App", () => {
 
     // Wait for initial batch
     await vi.waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
+    state.probeHandlers?.onResult({
+      providerId: "a",
+      displayName: "Alpha",
+      iconUrl: "icon-a",
+      lines: [{ type: "text", label: "Now", value: "OK" }],
+    })
+    state.probeHandlers?.onBatchComplete()
 
     // Advance time to trigger the interval (which will fail)
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000)

--- a/src/hooks/app/use-probe-auto-update.test.ts
+++ b/src/hooks/app/use-probe-auto-update.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const { getEnabledPluginIdsMock } = vi.hoisted(() => ({
   getEnabledPluginIdsMock: vi.fn(),
@@ -19,6 +19,11 @@ describe("useProbeAutoUpdate", () => {
     )
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
   it("keeps auto-update cleared when plugin settings are missing", () => {
     const { result } = renderHook(() =>
       useProbeAutoUpdate({
@@ -26,6 +31,7 @@ describe("useProbeAutoUpdate", () => {
         autoUpdateInterval: 15,
         setLoadingForPlugins: vi.fn(),
         setErrorForPlugins: vi.fn(),
+        isPluginLoading: vi.fn(() => false),
         startBatch: vi.fn(),
       })
     )
@@ -46,6 +52,7 @@ describe("useProbeAutoUpdate", () => {
         autoUpdateInterval: 15,
         setLoadingForPlugins: vi.fn(),
         setErrorForPlugins: vi.fn(),
+        isPluginLoading: vi.fn(() => false),
         startBatch: vi.fn(),
       })
     )
@@ -56,5 +63,67 @@ describe("useProbeAutoUpdate", () => {
 
     expect(result.current.autoUpdateNextAt).toBe(910_000)
     nowSpy.mockRestore()
+  })
+
+  it("skips providers that are still loading when auto-update fires", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(10_000)
+
+    const setLoadingForPlugins = vi.fn()
+    const setErrorForPlugins = vi.fn()
+    const startBatch = vi.fn().mockResolvedValue(["idle"])
+    const isPluginLoading = vi.fn((id: string) => id === "slow")
+
+    renderHook(() =>
+      useProbeAutoUpdate({
+        pluginSettings: { order: ["slow", "idle"], disabled: [] },
+        autoUpdateInterval: 15,
+        setLoadingForPlugins,
+        setErrorForPlugins,
+        isPluginLoading,
+        startBatch,
+      })
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15 * 60_000)
+    })
+
+    expect(isPluginLoading).toHaveBeenCalledWith("slow")
+    expect(isPluginLoading).toHaveBeenCalledWith("idle")
+    expect(setLoadingForPlugins).toHaveBeenCalledWith(["idle"])
+    expect(startBatch).toHaveBeenCalledWith(["idle"])
+    expect(setErrorForPlugins).not.toHaveBeenCalled()
+  })
+
+  it("does not start an auto-update batch when every provider is still loading", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(10_000)
+
+    const setLoadingForPlugins = vi.fn()
+    const setErrorForPlugins = vi.fn()
+    const startBatch = vi.fn()
+
+    const { result } = renderHook(() =>
+      useProbeAutoUpdate({
+        pluginSettings: { order: ["slow"], disabled: [] },
+        autoUpdateInterval: 15,
+        setLoadingForPlugins,
+        setErrorForPlugins,
+        isPluginLoading: vi.fn(() => true),
+        startBatch,
+      })
+    )
+
+    expect(result.current.autoUpdateNextAt).toBe(910_000)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15 * 60_000)
+    })
+
+    expect(result.current.autoUpdateNextAt).toBe(1_810_000)
+    expect(setLoadingForPlugins).not.toHaveBeenCalled()
+    expect(startBatch).not.toHaveBeenCalled()
+    expect(setErrorForPlugins).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/app/use-probe-auto-update.ts
+++ b/src/hooks/app/use-probe-auto-update.ts
@@ -10,6 +10,7 @@ type UseProbeAutoUpdateArgs = {
   autoUpdateInterval: AutoUpdateIntervalMinutes
   setLoadingForPlugins: (ids: string[]) => void
   setErrorForPlugins: (ids: string[], error: string) => void
+  isPluginLoading: (id: string) => boolean
   startBatch: (pluginIds?: string[]) => Promise<string[] | undefined>
 }
 
@@ -18,6 +19,7 @@ export function useProbeAutoUpdate({
   autoUpdateInterval,
   setLoadingForPlugins,
   setErrorForPlugins,
+  isPluginLoading,
   startBatch,
 }: UseProbeAutoUpdateArgs) {
   const [autoUpdateNextAt, setAutoUpdateNextAt] = useState<number | null>(null)
@@ -40,10 +42,16 @@ export function useProbeAutoUpdate({
     scheduleNext()
 
     const interval = setInterval(() => {
-      setLoadingForPlugins(enabledIds)
-      startBatch(enabledIds).catch((error) => {
+      const idleIds = enabledIds.filter((id) => !isPluginLoading(id))
+      if (idleIds.length === 0) {
+        scheduleNext()
+        return
+      }
+
+      setLoadingForPlugins(idleIds)
+      startBatch(idleIds).catch((error) => {
         console.error("Failed to start auto-update batch:", error)
-        setErrorForPlugins(enabledIds, "Failed to start probe")
+        setErrorForPlugins(idleIds, "Failed to start probe")
       })
       scheduleNext()
     }, intervalMs)
@@ -53,6 +61,7 @@ export function useProbeAutoUpdate({
     autoUpdateInterval,
     autoUpdateResetToken,
     pluginSettings,
+    isPluginLoading,
     setLoadingForPlugins,
     setErrorForPlugins,
     startBatch,

--- a/src/hooks/app/use-probe-state.test.ts
+++ b/src/hooks/app/use-probe-state.test.ts
@@ -1,0 +1,19 @@
+import { renderHook, act } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { useProbeState } from "@/hooks/app/use-probe-state"
+
+describe("useProbeState", () => {
+  it("updates pluginStatesRef synchronously when marking plugins loading", () => {
+    const { result } = renderHook(() => useProbeState({}))
+
+    let loadingImmediatelyAfterSet: boolean | undefined
+    act(() => {
+      result.current.setLoadingForPlugins(["codex"])
+      loadingImmediatelyAfterSet =
+        result.current.pluginStatesRef.current.codex?.loading
+    })
+
+    expect(loadingImmediatelyAfterSet).toBe(true)
+    expect(result.current.pluginStates.codex?.loading).toBe(true)
+  })
+})

--- a/src/hooks/app/use-probe-state.ts
+++ b/src/hooks/app/use-probe-state.ts
@@ -16,6 +16,19 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
 
   const manualRefreshIdsRef = useRef<Set<string>>(new Set())
 
+  const updatePluginStates = useCallback(
+    (
+      updater: (
+        previousStates: Record<string, PluginState>
+      ) => Record<string, PluginState>
+    ) => {
+      const nextStates = updater(pluginStatesRef.current)
+      pluginStatesRef.current = nextStates
+      setPluginStates(nextStates)
+    },
+    []
+  )
+
   const getErrorMessage = useCallback((output: PluginOutput) => {
     if (output.lines.length !== 1) return null
     const line = output.lines[0]
@@ -26,7 +39,7 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
   }, [])
 
   const setLoadingForPlugins = useCallback((ids: string[]) => {
-    setPluginStates((prev) => {
+    updatePluginStates((prev) => {
       const next = { ...prev }
       for (const id of ids) {
         const existing = prev[id]
@@ -40,10 +53,10 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
       }
       return next
     })
-  }, [])
+  }, [updatePluginStates])
 
   const setErrorForPlugins = useCallback((ids: string[], error: string) => {
-    setPluginStates((prev) => {
+    updatePluginStates((prev) => {
       const next = { ...prev }
       for (const id of ids) {
         const existing = prev[id]
@@ -57,7 +70,7 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
       }
       return next
     })
-  }, [])
+  }, [updatePluginStates])
 
   const handleProbeResult = useCallback(
     (output: PluginOutput) => {
@@ -68,7 +81,7 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
       }
 
       const now = Date.now()
-      setPluginStates((prev) => {
+      updatePluginStates((prev) => {
         const existing = prev[output.providerId]
         return {
           ...prev,
@@ -86,7 +99,7 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
 
       onProbeResult?.()
     },
-    [getErrorMessage, onProbeResult]
+    [getErrorMessage, onProbeResult, updatePluginStates]
   )
 
   return {

--- a/src/hooks/app/use-probe.ts
+++ b/src/hooks/app/use-probe.ts
@@ -35,6 +35,11 @@ export function useProbe({
     onBatchComplete: handleBatchComplete,
   })
 
+  const isPluginLoading = useCallback(
+    (id: string) => Boolean(pluginStatesRef.current[id]?.loading),
+    [pluginStatesRef]
+  )
+
   const {
     autoUpdateNextAt,
     setAutoUpdateNextAt,
@@ -44,6 +49,7 @@ export function useProbe({
     autoUpdateInterval,
     setLoadingForPlugins,
     setErrorForPlugins,
+    isPluginLoading,
     startBatch,
   })
 


### PR DESCRIPTION
## Summary

- skip auto-update probes for providers that are already marked `loading`
- keep refreshing idle providers when only part of the enabled set is still in flight
- keep the next auto-update schedule moving even when every provider is still busy
- add focused hook coverage and update App integration tests to model initial probe completion before auto-update

## Why

This is a small first slice of #487. If a provider probe is slow or stuck, the fixed auto-update interval should not start another probe for that same provider on top of the existing one. The app already uses `loading` to prevent repeated manual refreshes; this applies the same resource-budget guard to background auto-updates.

The change does not alter the configured refresh interval, provider plugin runtime, or manual refresh behavior. It only avoids redundant auto-update work for providers that are still in flight.

## Validation

- `node ./node_modules/vitest/vitest.mjs run src/hooks/app/use-probe-auto-update.test.ts`
- `node ./node_modules/vitest/vitest.mjs run src/App.test.tsx -t "auto-update"`
- `node ./node_modules/vitest/vitest.mjs run`
- `bun run build`

The full Vitest run passes. Existing App tests still print Tauri store mock stderr, but the suite exits successfully.

Closes part of #487.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip auto-update probes already in flight and keep probe state in sync so loading checks are accurate. Only idle providers run; the schedule still advances when all providers are busy. Part of #487.

- **Bug Fixes**
  - Only start auto-update batches for idle providers; skip those still `loading`.
  - If all enabled providers are busy, do not start a batch and reschedule the next run.
  - Keep `pluginStatesRef` current when setting loading/errors so `isPluginLoading` reflects changes immediately; wire `isPluginLoading` into `use-probe-auto-update` and update tests (App timers, initial batch completion, and new `use-probe-state` coverage).

<sup>Written for commit 6e414966d0aae0c54beada14f2a3d1b76c8ff1c8. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/498?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


