### PR TITLE
[codex] Add per-probe runtime deadline

### DIFF
--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -31,6 +31,7 @@ const WHITELISTED_ENV_VARS: [&str; 16] = [
     "SYNTHETIC_API_KEY",
     "PI_CODING_AGENT_DIR",
 ];
+const MIN_BLOCKING_TIMEOUT: Duration = Duration::from_millis(1);
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ProbeDeadline {
@@ -55,20 +56,27 @@ impl ProbeDeadline {
             .unwrap_or(false)
     }
 
-    fn clamp_duration(self, requested: Duration) -> Duration {
+    fn clamp_duration(self, requested: Duration) -> Option<Duration> {
         let Some(expires_at) = self.expires_at else {
-            return requested;
+            return Some(requested);
         };
         let remaining = expires_at
             .checked_duration_since(Instant::now())
-            .unwrap_or_default();
-        let clamped = requested.min(remaining);
-        if clamped.is_zero() {
-            Duration::from_millis(1)
-        } else {
-            clamped
-        }
+            .filter(|remaining| *remaining >= MIN_BLOCKING_TIMEOUT)?;
+        Some(requested.min(remaining))
     }
+}
+
+fn log_probe_deadline_skip(plugin_id: &str, operation: &str) {
+    log::warn!(
+        "[plugin:{}] {} skipped: probe timed out",
+        plugin_id,
+        operation
+    );
+}
+
+fn probe_timeout_error<'js>(ctx: &Ctx<'js>) -> rquickjs::Error {
+    Exception::throw_message(ctx, "probe timed out")
 }
 
 fn last_non_empty_trimmed_line(text: &str) -> Option<String> {
@@ -824,7 +832,10 @@ fn inject_http<'js>(
                 }
 
                 let timeout_ms = req.timeout_ms.unwrap_or(10_000);
-                let timeout = deadline.clamp_duration(Duration::from_millis(timeout_ms));
+                let Some(timeout) = deadline.clamp_duration(Duration::from_millis(timeout_ms))
+                else {
+                    return Err(probe_timeout_error(&ctx_inner));
+                };
                 let mut builder = reqwest::blocking::Client::builder()
                     .timeout(timeout)
                     .connect_timeout(timeout)
@@ -2070,6 +2081,12 @@ fn run_ccusage_with_runner_deadline(
         return CcusageRunnerResult::TimedOut;
     }
 
+    let Some(current_timeout) = deadline.clamp_duration(Duration::from_secs(CCUSAGE_TIMEOUT_SECS))
+    else {
+        log_probe_deadline_skip(plugin_id, "ccusage");
+        return CcusageRunnerResult::TimedOut;
+    };
+
     let current = run_ccusage_with_runner_timeout(
         kind,
         program,
@@ -2077,19 +2094,27 @@ fn run_ccusage_with_runner_deadline(
         provider,
         plugin_id,
         CcusageCommandFlavor::Current,
-        deadline.clamp_duration(Duration::from_secs(CCUSAGE_TIMEOUT_SECS)),
+        current_timeout,
     );
     match current {
         CcusageRunnerResult::Failed if deadline.has_elapsed() => CcusageRunnerResult::TimedOut,
-        CcusageRunnerResult::Failed => run_ccusage_with_runner_timeout(
-            kind,
-            program,
-            opts,
-            provider,
-            plugin_id,
-            CcusageCommandFlavor::Legacy,
-            deadline.clamp_duration(Duration::from_secs(CCUSAGE_TIMEOUT_SECS)),
-        ),
+        CcusageRunnerResult::Failed => {
+            let Some(legacy_timeout) =
+                deadline.clamp_duration(Duration::from_secs(CCUSAGE_TIMEOUT_SECS))
+            else {
+                log_probe_deadline_skip(plugin_id, "ccusage legacy fallback");
+                return CcusageRunnerResult::TimedOut;
+            };
+            run_ccusage_with_runner_timeout(
+                kind,
+                program,
+                opts,
+                provider,
+                plugin_id,
+                CcusageCommandFlavor::Legacy,
+                legacy_timeout,
+            )
+        }
         other => other,
     }
 }
@@ -4187,7 +4212,9 @@ esac
     #[test]
     fn probe_deadline_clamps_host_timeout_to_remaining_budget() {
         let deadline = ProbeDeadline::at(Instant::now() + Duration::from_millis(25));
-        let clamped = deadline.clamp_duration(Duration::from_secs(10));
+        let clamped = deadline
+            .clamp_duration(Duration::from_secs(10))
+            .expect("remaining budget should produce a host timeout");
 
         assert!(
             clamped <= Duration::from_millis(25),
@@ -4197,6 +4224,13 @@ esac
             clamped >= Duration::from_millis(1),
             "host timeout should stay non-zero for blocking clients"
         );
+    }
+
+    #[test]
+    fn probe_deadline_does_not_extend_elapsed_budget() {
+        let deadline = ProbeDeadline::at(Instant::now());
+
+        assert_eq!(deadline.clamp_duration(Duration::from_secs(10)), None);
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -1,9 +1,9 @@
 use aes_gcm::{
-    AesGcm, Nonce,
-    aead::{Aead, KeyInit, OsRng, generic_array::typenum::U16, rand_core::RngCore},
+    aead::{generic_array::typenum::U16, rand_core::RngCore, Aead, KeyInit, OsRng},
     aes::Aes256,
+    AesGcm, Nonce,
 };
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use rquickjs::{Ctx, Exception, Function, Object};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -11,6 +11,7 @@ use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 const WHITELISTED_ENV_VARS: [&str; 16] = [
     "CODEX_HOME",
@@ -30,6 +31,45 @@ const WHITELISTED_ENV_VARS: [&str; 16] = [
     "SYNTHETIC_API_KEY",
     "PI_CODING_AGENT_DIR",
 ];
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ProbeDeadline {
+    expires_at: Option<Instant>,
+}
+
+impl ProbeDeadline {
+    #[cfg(test)]
+    pub(crate) fn none() -> Self {
+        Self { expires_at: None }
+    }
+
+    pub(crate) fn at(expires_at: Instant) -> Self {
+        Self {
+            expires_at: Some(expires_at),
+        }
+    }
+
+    pub(crate) fn has_elapsed(self) -> bool {
+        self.expires_at
+            .map(|expires_at| Instant::now() >= expires_at)
+            .unwrap_or(false)
+    }
+
+    fn clamp_duration(self, requested: Duration) -> Duration {
+        let Some(expires_at) = self.expires_at else {
+            return requested;
+        };
+        let remaining = expires_at
+            .checked_duration_since(Instant::now())
+            .unwrap_or_default();
+        let clamped = requested.min(remaining);
+        if clamped.is_zero() {
+            Duration::from_millis(1)
+        } else {
+            clamped
+        }
+    }
+}
 
 fn last_non_empty_trimmed_line(text: &str) -> Option<String> {
     text.lines()
@@ -511,11 +551,28 @@ fn encrypt_aes_256_gcm_envelope(plaintext: &str, key_b64: &str) -> Result<String
     ))
 }
 
-pub fn inject_host_api<'js>(
+#[cfg(test)]
+pub(crate) fn inject_host_api<'js>(
     ctx: &Ctx<'js>,
     plugin_id: &str,
     app_data_dir: &PathBuf,
     app_version: &str,
+) -> rquickjs::Result<()> {
+    inject_host_api_with_deadline(
+        ctx,
+        plugin_id,
+        app_data_dir,
+        app_version,
+        ProbeDeadline::none(),
+    )
+}
+
+pub(crate) fn inject_host_api_with_deadline<'js>(
+    ctx: &Ctx<'js>,
+    plugin_id: &str,
+    app_data_dir: &PathBuf,
+    app_version: &str,
+    deadline: ProbeDeadline,
 ) -> rquickjs::Result<()> {
     let globals = ctx.globals();
     let probe_ctx = Object::new(ctx.clone())?;
@@ -545,11 +602,11 @@ pub fn inject_host_api<'js>(
     inject_fs(ctx, &host)?;
     inject_crypto(ctx, &host)?;
     inject_env(ctx, &host, plugin_id)?;
-    inject_http(ctx, &host, plugin_id)?;
+    inject_http(ctx, &host, plugin_id, deadline)?;
     inject_keychain(ctx, &host, plugin_id)?;
     inject_sqlite(ctx, &host)?;
     inject_ls(ctx, &host, plugin_id)?;
-    inject_ccusage(ctx, &host, plugin_id)?;
+    inject_ccusage(ctx, &host, plugin_id, deadline)?;
 
     probe_ctx.set("host", host)?;
     globals.set("__openusage_ctx", probe_ctx)?;
@@ -720,7 +777,12 @@ fn inject_env<'js>(ctx: &Ctx<'js>, host: &Object<'js>, _plugin_id: &str) -> rqui
     Ok(())
 }
 
-fn inject_http<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rquickjs::Result<()> {
+fn inject_http<'js>(
+    ctx: &Ctx<'js>,
+    host: &Object<'js>,
+    plugin_id: &str,
+    deadline: ProbeDeadline,
+) -> rquickjs::Result<()> {
     let http_obj = Object::new(ctx.clone())?;
     let pid = plugin_id.to_string();
 
@@ -732,6 +794,10 @@ fn inject_http<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rqui
                 let req: HttpReqParams = serde_json::from_str(&req_json).map_err(|e| {
                     Exception::throw_message(&ctx_inner, &format!("invalid request: {}", e))
                 })?;
+
+                if deadline.has_elapsed() {
+                    return Err(Exception::throw_message(&ctx_inner, "probe timed out"));
+                }
 
                 let method_str = req.method.as_deref().unwrap_or("GET");
                 let redacted_url = redact_url(&req.url);
@@ -758,9 +824,10 @@ fn inject_http<'js>(ctx: &Ctx<'js>, host: &Object<'js>, plugin_id: &str) -> rqui
                 }
 
                 let timeout_ms = req.timeout_ms.unwrap_or(10_000);
+                let timeout = deadline.clamp_duration(Duration::from_millis(timeout_ms));
                 let mut builder = reqwest::blocking::Client::builder()
-                    .timeout(std::time::Duration::from_millis(timeout_ms))
-                    .connect_timeout(std::time::Duration::from_millis(timeout_ms))
+                    .timeout(timeout)
+                    .connect_timeout(timeout)
                     .redirect(reqwest::redirect::Policy::none());
 
                 // Apply pre-resolved proxy (localhost bypass already configured)
@@ -1972,6 +2039,7 @@ fn format_ccusage_timeout(timeout: std::time::Duration) -> String {
     format!("{:.3}s", timeout.as_secs_f64())
 }
 
+#[cfg(test)]
 fn run_ccusage_with_runner(
     kind: CcusageRunnerKind,
     program: &str,
@@ -1979,6 +2047,29 @@ fn run_ccusage_with_runner(
     provider: CcusageProvider,
     plugin_id: &str,
 ) -> CcusageRunnerResult {
+    run_ccusage_with_runner_deadline(
+        kind,
+        program,
+        opts,
+        provider,
+        plugin_id,
+        ProbeDeadline::none(),
+    )
+}
+
+fn run_ccusage_with_runner_deadline(
+    kind: CcusageRunnerKind,
+    program: &str,
+    opts: &CcusageQueryOpts,
+    provider: CcusageProvider,
+    plugin_id: &str,
+    deadline: ProbeDeadline,
+) -> CcusageRunnerResult {
+    if deadline.has_elapsed() {
+        log::warn!("[plugin:{}] ccusage skipped: probe timed out", plugin_id);
+        return CcusageRunnerResult::TimedOut;
+    }
+
     let current = run_ccusage_with_runner_timeout(
         kind,
         program,
@@ -1986,9 +2077,10 @@ fn run_ccusage_with_runner(
         provider,
         plugin_id,
         CcusageCommandFlavor::Current,
-        std::time::Duration::from_secs(CCUSAGE_TIMEOUT_SECS),
+        deadline.clamp_duration(Duration::from_secs(CCUSAGE_TIMEOUT_SECS)),
     );
     match current {
+        CcusageRunnerResult::Failed if deadline.has_elapsed() => CcusageRunnerResult::TimedOut,
         CcusageRunnerResult::Failed => run_ccusage_with_runner_timeout(
             kind,
             program,
@@ -1996,7 +2088,7 @@ fn run_ccusage_with_runner(
             provider,
             plugin_id,
             CcusageCommandFlavor::Legacy,
-            std::time::Duration::from_secs(CCUSAGE_TIMEOUT_SECS),
+            deadline.clamp_duration(Duration::from_secs(CCUSAGE_TIMEOUT_SECS)),
         ),
         other => other,
     }
@@ -2195,6 +2287,7 @@ fn inject_ccusage<'js>(
     ctx: &Ctx<'js>,
     host: &Object<'js>,
     plugin_id: &str,
+    deadline: ProbeDeadline,
 ) -> rquickjs::Result<()> {
     let ccusage_obj = Object::new(ctx.clone())?;
     let pid = plugin_id.to_string();
@@ -2222,7 +2315,11 @@ fn inject_ccusage<'js>(
                     &opts,
                     provider,
                     &pid,
-                    run_ccusage_with_runner,
+                    |kind, program, opts, provider, plugin_id| {
+                        run_ccusage_with_runner_deadline(
+                            kind, program, opts, provider, plugin_id, deadline,
+                        )
+                    },
                 ))
             },
         )?,
@@ -4084,6 +4181,21 @@ esac
         assert_eq!(
             format_ccusage_timeout(std::time::Duration::from_secs(CCUSAGE_TIMEOUT_SECS)),
             "15s"
+        );
+    }
+
+    #[test]
+    fn probe_deadline_clamps_host_timeout_to_remaining_budget() {
+        let deadline = ProbeDeadline::at(Instant::now() + Duration::from_millis(25));
+        let clamped = deadline.clamp_duration(Duration::from_secs(10));
+
+        assert!(
+            clamped <= Duration::from_millis(25),
+            "host timeout should not exceed remaining probe budget"
+        );
+        assert!(
+            clamped >= Duration::from_millis(1),
+            "host timeout should stay non-zero for blocking clients"
         );
     }
 

--- a/src-tauri/src/plugin_engine/runtime.rs
+++ b/src-tauri/src/plugin_engine/runtime.rs
@@ -3,6 +3,9 @@ use crate::plugin_engine::manifest::LoadedPlugin;
 use rquickjs::{Array, Context, Ctx, Error, Object, Promise, Runtime, Value};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+const PROBE_TIMEOUT_SECS: u64 = 30;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
@@ -51,12 +54,32 @@ pub struct PluginOutput {
 }
 
 pub fn run_probe(plugin: &LoadedPlugin, app_data_dir: &PathBuf, app_version: &str) -> PluginOutput {
+    run_probe_with_timeout(
+        plugin,
+        app_data_dir,
+        app_version,
+        Duration::from_secs(PROBE_TIMEOUT_SECS),
+    )
+}
+
+fn run_probe_with_timeout(
+    plugin: &LoadedPlugin,
+    app_data_dir: &PathBuf,
+    app_version: &str,
+    timeout: Duration,
+) -> PluginOutput {
     let fallback = error_output(plugin, "runtime error".to_string());
+    let timeout_message = probe_timeout_message(timeout);
+    let deadline_at = Instant::now()
+        .checked_add(timeout)
+        .unwrap_or_else(Instant::now);
+    let deadline = host_api::ProbeDeadline::at(deadline_at);
 
     let rt = match Runtime::new() {
         Ok(rt) => rt,
         Err(_) => return fallback,
     };
+    rt.set_interrupt_handler(Some(Box::new(move || Instant::now() >= deadline_at)));
 
     let ctx = match Context::full(&rt) {
         Ok(ctx) => ctx,
@@ -70,23 +93,49 @@ pub fn run_probe(plugin: &LoadedPlugin, app_data_dir: &PathBuf, app_version: &st
     let app_data = app_data_dir.clone();
 
     ctx.with(|ctx| {
-        if host_api::inject_host_api(&ctx, &plugin_id, &app_data, app_version).is_err() {
+        if host_api::inject_host_api_with_deadline(
+            &ctx,
+            &plugin_id,
+            &app_data,
+            app_version,
+            deadline,
+        )
+        .is_err()
+        {
+            if deadline.has_elapsed() {
+                return error_output(plugin, timeout_message.clone());
+            }
             return error_output(plugin, "host api injection failed".to_string());
         }
         if host_api::patch_http_wrapper(&ctx).is_err() {
+            if deadline.has_elapsed() {
+                return error_output(plugin, timeout_message.clone());
+            }
             return error_output(plugin, "http wrapper patch failed".to_string());
         }
         if host_api::patch_ls_wrapper(&ctx).is_err() {
+            if deadline.has_elapsed() {
+                return error_output(plugin, timeout_message.clone());
+            }
             return error_output(plugin, "ls wrapper patch failed".to_string());
         }
         if host_api::patch_ccusage_wrapper(&ctx).is_err() {
+            if deadline.has_elapsed() {
+                return error_output(plugin, timeout_message.clone());
+            }
             return error_output(plugin, "ccusage wrapper patch failed".to_string());
         }
         if host_api::inject_utils(&ctx).is_err() {
+            if deadline.has_elapsed() {
+                return error_output(plugin, timeout_message.clone());
+            }
             return error_output(plugin, "utils injection failed".to_string());
         }
 
         if ctx.eval::<(), _>(entry_script.as_bytes()).is_err() {
+            if deadline.has_elapsed() {
+                return error_output(plugin, timeout_message.clone());
+            }
             return error_output(plugin, "script eval failed".to_string());
         }
 
@@ -107,8 +156,16 @@ pub fn run_probe(plugin: &LoadedPlugin, app_data_dir: &PathBuf, app_version: &st
 
         let result_value: Value = match probe_fn.call((probe_ctx,)) {
             Ok(r) => r,
-            Err(_) => return error_output(plugin, extract_error_string(&ctx)),
+            Err(_) => {
+                if deadline.has_elapsed() {
+                    return error_output(plugin, timeout_message.clone());
+                }
+                return error_output(plugin, extract_error_string(&ctx));
+            }
         };
+        if deadline.has_elapsed() {
+            return error_output(plugin, timeout_message.clone());
+        }
         let result: Object = if result_value.is_promise() {
             let promise: Promise = match result_value.into_promise() {
                 Some(promise) => promise,
@@ -121,7 +178,12 @@ pub fn run_probe(plugin: &LoadedPlugin, app_data_dir: &PathBuf, app_version: &st
                 Err(Error::WouldBlock) => {
                     return error_output(plugin, "probe() returned unresolved promise".to_string());
                 }
-                Err(_) => return error_output(plugin, extract_error_string(&ctx)),
+                Err(_) => {
+                    if deadline.has_elapsed() {
+                        return error_output(plugin, timeout_message.clone());
+                    }
+                    return error_output(plugin, extract_error_string(&ctx));
+                }
             }
         } else {
             match result_value.into_object() {
@@ -129,6 +191,9 @@ pub fn run_probe(plugin: &LoadedPlugin, app_data_dir: &PathBuf, app_version: &st
                 None => return error_output(plugin, "probe() returned non-object".to_string()),
             }
         };
+        if deadline.has_elapsed() {
+            return error_output(plugin, timeout_message.clone());
+        }
 
         let plan: Option<String> = result
             .get::<_, String>("plan")
@@ -459,6 +524,16 @@ fn extract_error_string(ctx: &Ctx<'_>) -> String {
     "The plugin failed, try again or contact plugin author.".to_string()
 }
 
+fn probe_timeout_message(timeout: Duration) -> String {
+    if timeout.subsec_millis() == 0 {
+        return format!("probe timed out after {}s", timeout.as_secs());
+    }
+    if timeout.as_secs() == 0 {
+        return format!("probe timed out after {}ms", timeout.as_millis());
+    }
+    format!("probe timed out after {:.3}s", timeout.as_secs_f64())
+}
+
 fn error_line(message: String) -> MetricLine {
     MetricLine::Badge {
         label: "Error".to_string(),
@@ -538,6 +613,28 @@ mod tests {
         );
         let output = run_probe(&plugin, &temp_app_dir("async"), "0.0.0");
         assert_eq!(error_text(output), "boom");
+    }
+
+    #[test]
+    fn run_probe_times_out_cpu_bound_script() {
+        let plugin = test_plugin(
+            r#"
+            globalThis.__openusage_plugin = {
+                probe() {
+                    while (true) {}
+                }
+            };
+            "#,
+        );
+
+        let output = run_probe_with_timeout(
+            &plugin,
+            &temp_app_dir("timeout"),
+            "0.0.0",
+            Duration::from_millis(5),
+        );
+
+        assert_eq!(error_text(output), "probe timed out after 5ms");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a 30s wall-clock budget for each plugin probe execution
- use the QuickJS interrupt handler to stop CPU-bound plugin scripts after the probe budget expires
- pass the same deadline into the host API for the currently deadline-aware blocking calls: `host.http` and `host.ccusage`
- keep the existing plugin output contract by returning an Error badge when a probe times out

## Why

This is another small slice of #487. Previous follow-ups limit duplicate auto-update probes and batch fan-out; this one bounds the duration of an individual provider probe for the highest-risk paths: CPU-bound JavaScript loops and the existing long-running HTTP/ccusage calls.

The timeout is intentionally conservative at 30 seconds per provider. Existing provider-level HTTP defaults and ccusage timeouts continue to work, but they cannot exceed the remaining per-probe budget.

## Scope and limitations

This is not a complete hard deadline for every possible host API path yet. It does not rewrite every synchronous local operation into a killable subprocess helper. In particular, local filesystem operations and the remaining system-command based helpers (`security`, `sqlite3`, `ps`, `lsof`, plus env shell reads) are left for a later, more invasive slice.

That follow-up is called out separately so this PR stays small and reviewable: first stop CPU-bound plugin scripts and clamp the known long-running HTTP/ccusage calls, then add a shared timeout wrapper for the remaining host subprocess helpers.

This does not change frontend scheduling, event names, provider enablement, or manual refresh behavior.

## Validation

- `bun run bundle:plugins`
- `cargo test plugin_engine::runtime::tests`
- `cargo test plugin_engine::host_api::tests::probe_deadline_clamps_host_timeout_to_remaining_budget`
- `cargo test plugin_engine::host_api::tests::ccusage_timeout_stops_runner_fallback`
- `cargo test plugin_engine::host_api::tests::ccusage_runner_retries_legacy_package_when_current_package_fails`
- `cargo test --lib -- --skip ccusage_timeout_kills_descendant_and_closes_pipes`
- `bun run build`
- `node ./node_modules/vitest/vitest.mjs run`

I also ran full `cargo test`; Rust compilation and 97 tests passed, but the existing `ccusage_timeout_kills_descendant_and_closes_pipes` test still fails locally while trying to read `descendant.pid` before it exists. I did not change that unrelated test in this PR. That test is handled separately in #501.

Part of #487.

