### PR TITLE
[codex] Stabilize ccusage timeout cleanup test

### DIFF
--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -4092,10 +4092,26 @@ esac
     fn ccusage_timeout_kills_descendant_and_closes_pipes() {
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
+        use std::path::Path;
         use std::time::{Duration, Instant};
 
         fn pid_exists(pid: i32) -> bool {
             unsafe { libc::kill(pid, 0) == 0 }
+        }
+
+        fn read_pid_file(path: &Path, deadline: Instant) -> i32 {
+            loop {
+                if let Ok(pid_text) = std::fs::read_to_string(path) {
+                    let pid_text = pid_text.trim();
+                    if !pid_text.is_empty() {
+                        return pid_text.parse().expect("parse descendant pid");
+                    }
+                }
+                if Instant::now() >= deadline {
+                    panic!("descendant pid file was not created at {}", path.display());
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
         }
 
         let test_id = format!(
@@ -4136,7 +4152,7 @@ wait
             CcusageProvider::Codex,
             "codex",
             CcusageCommandFlavor::Current,
-            Duration::from_millis(100),
+            Duration::from_secs(1),
         );
 
         assert_eq!(result, CcusageRunnerResult::TimedOut);
@@ -4145,11 +4161,7 @@ wait
             "timeout cleanup should not hang on inherited stdout/stderr pipes"
         );
 
-        let descendant_pid: i32 = std::fs::read_to_string(&pid_path)
-            .expect("read descendant pid")
-            .trim()
-            .parse()
-            .expect("parse descendant pid");
+        let descendant_pid = read_pid_file(&pid_path, Instant::now() + Duration::from_secs(1));
 
         let deadline = Instant::now() + Duration::from_secs(2);
         while pid_exists(descendant_pid) && Instant::now() < deadline {


### PR DESCRIPTION
## Summary

- make `ccusage_timeout_kills_descendant_and_closes_pipes` wait for the descendant pid file with a short retry loop
- give the fake runner a 1s timeout budget instead of 100ms so the shell has time to create `descendant.pid` before the timeout kill path runs
- keep the production ccusage timeout/kill behavior unchanged

## Why

The test was racing its own setup. On a slower or busy machine, the 100ms timeout can kill the fake shell runner before it reaches:

```sh
echo $! > descendant.pid
```

When that happens, the assertion fails with:

```text
read descendant pid: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

The test is meant to verify timeout cleanup of descendant processes and pipe draining, not whether a shell script can always initialize in under 100ms. The new version still exercises the timeout path, keeps the cleanup hang guard, and then verifies that the descendant is killed.

## Validation

- `cargo test plugin_engine::host_api::tests::ccusage_timeout_kills_descendant_and_closes_pipes -- --nocapture`
- `cargo test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the `ccusage_timeout_kills_descendant_and_closes_pipes` test to remove timing flakiness on slower machines while keeping production timeout/kill behavior unchanged.

- **Bug Fixes**
  - Poll for `descendant.pid` with a 20ms interval and 1s deadline before asserting.
  - Increase the fake runner timeout from 100ms to 1s to avoid setup races; still exercises the timeout path and verifies descendant kill and pipe cleanup.

<sup>Written for commit bbc999a24cb3039c7b5383ce2a49682496fcc3a4. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/501?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

