### PR TITLE
[codex] Bound local HTTP API concurrency

### DIFF
--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -92,4 +92,6 @@ Error responses use this shape:
 }
 ```
 
-Possible error codes: `provider_not_found`, `not_found`, `method_not_allowed`.
+Possible error codes: `provider_not_found`, `not_found`, `method_not_allowed`, `server_busy`.
+
+`server_busy` returns **503 Service Unavailable** when the local API is already handling the maximum number of concurrent connections. Clients should back off and retry later.

--- a/src-tauri/src/local_http_api/server.rs
+++ b/src-tauri/src/local_http_api/server.rs
@@ -9,7 +9,6 @@ const BIND_ADDR: &str = "127.0.0.1:6736";
 const MAX_CONCURRENT_CONNECTIONS: usize = 16;
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 
-#[derive(Clone)]
 struct ConnectionLimiter {
     active: Arc<AtomicUsize>,
     max: usize,

--- a/src-tauri/src/local_http_api/server.rs
+++ b/src-tauri/src/local_http_api/server.rs
@@ -1,8 +1,61 @@
 use super::cache::{cache_state, enabled_snapshots_ordered};
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 const BIND_ADDR: &str = "127.0.0.1:6736";
+const MAX_CONCURRENT_CONNECTIONS: usize = 16;
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+struct ConnectionLimiter {
+    active: Arc<AtomicUsize>,
+    max: usize,
+}
+
+struct ConnectionPermit {
+    active: Arc<AtomicUsize>,
+}
+
+impl ConnectionLimiter {
+    fn new(max: usize) -> Self {
+        Self {
+            active: Arc::new(AtomicUsize::new(0)),
+            max,
+        }
+    }
+
+    fn acquire(&self) -> Option<ConnectionPermit> {
+        loop {
+            let active = self.active.load(Ordering::Acquire);
+            if active >= self.max {
+                return None;
+            }
+            if self
+                .active
+                .compare_exchange(active, active + 1, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return Some(ConnectionPermit {
+                    active: Arc::clone(&self.active),
+                });
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn active_count(&self) -> usize {
+        self.active.load(Ordering::Acquire)
+    }
+}
+
+impl Drop for ConnectionPermit {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
 
 // ---------------------------------------------------------------------------
 // HTTP server
@@ -25,10 +78,21 @@ pub fn start_server() {
             }
         };
 
+        let limiter = ConnectionLimiter::new(MAX_CONCURRENT_CONNECTIONS);
         for stream in listener.incoming() {
             match stream {
-                Ok(stream) => {
-                    std::thread::spawn(move || handle_connection(stream));
+                Ok(mut stream) => {
+                    let Some(permit) = limiter.acquire() else {
+                        log::warn!(
+                            "local HTTP API connection limit reached (max={})",
+                            MAX_CONCURRENT_CONNECTIONS
+                        );
+                        let _ = stream.set_write_timeout(Some(CONNECTION_TIMEOUT));
+                        let _ = stream.write_all(response_service_unavailable().as_bytes());
+                        let _ = stream.flush();
+                        continue;
+                    };
+                    std::thread::spawn(move || handle_connection(stream, permit));
                 }
                 Err(e) => log::debug!("local HTTP API accept error: {}", e),
             }
@@ -36,8 +100,9 @@ pub fn start_server() {
     });
 }
 
-fn handle_connection(mut stream: TcpStream) {
-    let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+fn handle_connection(mut stream: TcpStream, _permit: ConnectionPermit) {
+    let _ = stream.set_read_timeout(Some(CONNECTION_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(CONNECTION_TIMEOUT));
 
     // Read request (up to 4 KB is plenty for a request line + headers)
     let mut buf = [0u8; 4096];
@@ -153,6 +218,11 @@ fn response_method_not_allowed() -> String {
     response_json(405, "Method Not Allowed", body)
 }
 
+fn response_service_unavailable() -> String {
+    let body = r#"{"error":"server_busy"}"#;
+    response_json(503, "Service Unavailable", body)
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::cache::{cache_state, CachedPluginSnapshot};
@@ -249,5 +319,33 @@ mod tests {
         let resp = response_json(200, "OK", "[]");
         assert!(resp.contains("Access-Control-Allow-Origin: *"));
         assert!(resp.contains("Content-Type: application/json; charset=utf-8"));
+    }
+
+    #[test]
+    fn connection_limiter_rejects_above_capacity_and_releases_on_drop() {
+        let limiter = ConnectionLimiter::new(2);
+        let first = limiter.acquire().expect("first permit");
+        let second = limiter.acquire().expect("second permit");
+
+        assert!(limiter.acquire().is_none());
+        assert_eq!(limiter.active_count(), 2);
+
+        drop(first);
+
+        let third = limiter.acquire().expect("permit after release");
+        assert_eq!(limiter.active_count(), 2);
+
+        drop(second);
+        drop(third);
+        assert_eq!(limiter.active_count(), 0);
+    }
+
+    #[test]
+    fn response_service_unavailable_returns_503_json() {
+        let resp = response_service_unavailable();
+
+        assert!(resp.starts_with("HTTP/1.1 503"));
+        assert!(resp.contains(r#""error":"server_busy""#));
+        assert!(resp.contains("Access-Control-Allow-Origin: *"));
     }
 }


### PR DESCRIPTION
## Summary

- cap the local HTTP API to 16 active connection workers
- return `503 {"error":"server_busy"}` without spawning another worker when the cap is reached
- add write timeouts alongside the existing read timeout
- add focused tests for permit release and the busy response

## Why

This is a small follow-up slice of #487. The local API currently accepts each TCP connection and immediately spawns an OS thread for it. Under accidental or intentional local stress traffic, that can grow worker threads without a local app-side bound.

The new connection limiter keeps normal local API behavior unchanged for regular clients, while making overload explicit and bounded. This is intentionally independent from the probe-resource PR stack (#498/#499/#500) and avoids touching `host_api.rs`, which already has active PRs.

## Notes

The local API is read-only and localhost-bound, so returning `503 server_busy` during overload is preferable to creating unbounded OS threads. The cap is deliberately conservative; normal use should be one or a few concurrent requests.

## Validation

- `cargo test local_http_api::server::tests`
- `cargo test --lib -- --skip ccusage_timeout_kills_descendant_and_closes_pipes`
- `bun run build`
- `node ./node_modules/vitest/vitest.mjs run`

I skipped `ccusage_timeout_kills_descendant_and_closes_pipes` in the broad Rust run because that unrelated flaky test is fixed separately in #501 but is not in `main` yet.

Part of #487.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the local HTTP API to 16 concurrent connections and return 503 {"error":"server_busy"} without spawning a worker when at capacity. Added 5s read/write timeouts, tests for permit release and 503 JSON/headers, and updated docs to include `server_busy` with backoff guidance.

<sup>Written for commit 0708889e4b2065254a65be70c380ca1250f5809f. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/502?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

