### PR TITLE
[codex] Debounce usage API cache writes

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -590,7 +590,12 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|_, _| {});
+        .run(|_, event| match event {
+            tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
+                local_http_api::flush_cache();
+            }
+            _ => {}
+        });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/local_http_api/cache.rs
+++ b/src-tauri/src/local_http_api/cache.rs
@@ -13,6 +13,7 @@ const DEFAULT_ENABLED_PLUGINS: &[&str] = &["claude", "codex", "cursor"];
 const CACHE_WRITE_DEBOUNCE: Duration = Duration::from_millis(500);
 #[cfg(test)]
 const CACHE_WRITE_DEBOUNCE: Duration = Duration::from_millis(10);
+const CACHE_WRITE_RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -42,6 +43,13 @@ pub(super) struct CacheState {
     dirty_generation: u64,
     flushed_generation: u64,
     flush_scheduled: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CacheFlushResult {
+    Idle,
+    Flushed,
+    Failed(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -121,13 +129,50 @@ fn schedule_cache_flush_locked(state: &mut CacheState) {
 }
 
 fn debounced_cache_flush_worker() {
-    loop {
-        std::thread::sleep(CACHE_WRITE_DEBOUNCE);
+    let mut consecutive_failures = 0_u32;
+    let mut retry_delay = CACHE_WRITE_DEBOUNCE;
 
-        if !flush_pending_cache_once() {
-            return;
-        };
+    loop {
+        std::thread::sleep(retry_delay);
+
+        match flush_pending_cache_once() {
+            CacheFlushResult::Idle => return,
+            CacheFlushResult::Flushed => {
+                if consecutive_failures > 0 {
+                    log::info!(
+                        "usage-api-cache.json write recovered after {} failed attempts",
+                        consecutive_failures
+                    );
+                }
+                consecutive_failures = 0;
+                retry_delay = CACHE_WRITE_DEBOUNCE;
+            }
+            CacheFlushResult::Failed(e) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                retry_delay = cache_write_retry_delay(consecutive_failures);
+                if should_log_cache_write_failure(consecutive_failures) {
+                    log::warn!(
+                        "{}; retrying in {:?} (consecutive failures: {})",
+                        e,
+                        retry_delay,
+                        consecutive_failures
+                    );
+                }
+            }
+        }
     }
+}
+
+fn cache_write_retry_delay(consecutive_failures: u32) -> Duration {
+    let factor = 1_u32 << consecutive_failures.min(16);
+    std::cmp::min(
+        CACHE_WRITE_DEBOUNCE.saturating_mul(factor),
+        CACHE_WRITE_RETRY_MAX_DELAY,
+    )
+}
+
+fn should_log_cache_write_failure(consecutive_failures: u32) -> bool {
+    consecutive_failures == 1 || consecutive_failures.is_power_of_two()
 }
 
 fn pending_cache_write() -> Option<(u64, PathBuf, HashMap<String, CachedPluginSnapshot>)> {
@@ -149,19 +194,21 @@ fn mark_cache_flushed(generation: u64) {
     state.flushed_generation = generation;
 }
 
-fn flush_pending_cache_once() -> bool {
+fn flush_pending_cache_once() -> CacheFlushResult {
     let _write_guard = cache_write_lock()
         .lock()
         .expect("cache write lock poisoned");
     let Some((generation, app_data_dir, snapshots)) = pending_cache_write() else {
-        return false;
+        return CacheFlushResult::Idle;
     };
 
     match save_cache(&app_data_dir, &snapshots) {
-        Ok(()) => mark_cache_flushed(generation),
-        Err(e) => log::warn!("{}", e),
+        Ok(()) => {
+            mark_cache_flushed(generation);
+            CacheFlushResult::Flushed
+        }
+        Err(e) => CacheFlushResult::Failed(e),
     }
-    true
 }
 
 // ---------------------------------------------------------------------------
@@ -199,7 +246,9 @@ pub fn cache_successful_output(output: &PluginOutput) {
 }
 
 pub fn flush_cache() {
-    let _ = flush_pending_cache_once();
+    if let CacheFlushResult::Failed(e) = flush_pending_cache_once() {
+        log::warn!("{}", e);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +400,29 @@ mod tests {
     }
 
     #[test]
+    fn cache_write_retry_delay_backs_off_and_caps() {
+        assert_eq!(
+            cache_write_retry_delay(1),
+            CACHE_WRITE_DEBOUNCE.saturating_mul(2)
+        );
+        assert_eq!(
+            cache_write_retry_delay(2),
+            CACHE_WRITE_DEBOUNCE.saturating_mul(4)
+        );
+        assert_eq!(cache_write_retry_delay(20), CACHE_WRITE_RETRY_MAX_DELAY);
+    }
+
+    #[test]
+    fn cache_write_failure_logs_are_throttled() {
+        assert!(should_log_cache_write_failure(1));
+        assert!(should_log_cache_write_failure(2));
+        assert!(!should_log_cache_write_failure(3));
+        assert!(should_log_cache_write_failure(4));
+        assert!(!should_log_cache_write_failure(5));
+        assert!(should_log_cache_write_failure(16));
+    }
+
+    #[test]
     fn snapshot_serializes_with_fetched_at() {
         let snap = make_snapshot("claude", "Claude");
         let json: serde_json::Value = serde_json::to_value(&snap).unwrap();
@@ -466,7 +538,10 @@ mod tests {
             state.flush_scheduled = true;
         }
 
-        assert!(flush_pending_cache_once());
+        assert!(matches!(
+            flush_pending_cache_once(),
+            CacheFlushResult::Failed(_)
+        ));
         {
             let state = cache_state().lock().unwrap();
             assert_eq!(state.dirty_generation, 1);
@@ -475,13 +550,13 @@ mod tests {
         }
 
         std::fs::create_dir_all(&dir).unwrap();
-        assert!(flush_pending_cache_once());
+        assert_eq!(flush_pending_cache_once(), CacheFlushResult::Flushed);
 
         let loaded = load_cache(&dir);
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded["claude"].display_name, "Claude");
 
-        assert!(!flush_pending_cache_once());
+        assert_eq!(flush_pending_cache_once(), CacheFlushResult::Idle);
         {
             let state = cache_state().lock().unwrap();
             assert_eq!(state.dirty_generation, 1);

--- a/src-tauri/src/local_http_api/cache.rs
+++ b/src-tauri/src/local_http_api/cache.rs
@@ -3,10 +3,16 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 const CACHE_FILE_NAME: &str = "usage-api-cache.json";
 const SETTINGS_FILE_NAME: &str = "settings.json";
 const DEFAULT_ENABLED_PLUGINS: &[&str] = &["claude", "codex", "cursor"];
+
+#[cfg(not(test))]
+const CACHE_WRITE_DEBOUNCE: Duration = Duration::from_millis(500);
+#[cfg(test)]
+const CACHE_WRITE_DEBOUNCE: Duration = Duration::from_millis(10);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,6 +39,9 @@ pub(super) struct CacheState {
     pub snapshots: HashMap<String, CachedPluginSnapshot>,
     pub app_data_dir: PathBuf,
     pub known_plugin_ids: Vec<String>,
+    dirty_generation: u64,
+    flushed_generation: u64,
+    flush_scheduled: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -46,6 +55,9 @@ pub(super) fn cache_state() -> &'static Mutex<CacheState> {
             snapshots: HashMap::new(),
             app_data_dir: PathBuf::new(),
             known_plugin_ids: Vec::new(),
+            dirty_generation: 0,
+            flushed_generation: 0,
+            flush_scheduled: false,
         })
     })
 }
@@ -67,7 +79,10 @@ pub fn load_cache(app_data_dir: &Path) -> HashMap<String, CachedPluginSnapshot> 
             HashMap::new()
         }
         Err(e) => {
-            log::warn!("failed to parse usage-api-cache.json: {}, starting empty", e);
+            log::warn!(
+                "failed to parse usage-api-cache.json: {}, starting empty",
+                e
+            );
             HashMap::new()
         }
     }
@@ -94,6 +109,38 @@ fn save_cache(app_data_dir: &Path, snapshots: &HashMap<String, CachedPluginSnaps
     }
 }
 
+fn schedule_cache_flush_locked(state: &mut CacheState) {
+    if state.flush_scheduled {
+        return;
+    }
+
+    state.flush_scheduled = true;
+    std::thread::spawn(debounced_cache_flush_worker);
+}
+
+fn debounced_cache_flush_worker() {
+    loop {
+        std::thread::sleep(CACHE_WRITE_DEBOUNCE);
+
+        let Some((app_data_dir, snapshots)) = pending_cache_write() else {
+            return;
+        };
+
+        save_cache(&app_data_dir, &snapshots);
+    }
+}
+
+fn pending_cache_write() -> Option<(PathBuf, HashMap<String, CachedPluginSnapshot>)> {
+    let mut state = cache_state().lock().expect("cache state poisoned");
+    if state.dirty_generation == state.flushed_generation {
+        state.flush_scheduled = false;
+        return None;
+    }
+
+    state.flushed_generation = state.dirty_generation;
+    Some((state.app_data_dir.clone(), state.snapshots.clone()))
+}
+
 // ---------------------------------------------------------------------------
 // Public API: initialise + update cache
 // ---------------------------------------------------------------------------
@@ -104,6 +151,9 @@ pub fn init(app_data_dir: &Path, known_plugin_ids: Vec<String>) {
     state.snapshots = snapshots;
     state.app_data_dir = app_data_dir.to_path_buf();
     state.known_plugin_ids = known_plugin_ids;
+    state.dirty_generation = 0;
+    state.flushed_generation = 0;
+    state.flush_scheduled = false;
 }
 
 pub fn cache_successful_output(output: &PluginOutput) {
@@ -120,10 +170,9 @@ pub fn cache_successful_output(output: &PluginOutput) {
     };
 
     let mut state = cache_state().lock().expect("cache state poisoned");
-    state
-        .snapshots
-        .insert(output.provider_id.clone(), snapshot);
-    save_cache(&state.app_data_dir, &state.snapshots);
+    state.snapshots.insert(output.provider_id.clone(), snapshot);
+    state.dirty_generation = state.dirty_generation.wrapping_add(1);
+    schedule_cache_flush_locked(&mut state);
 }
 
 // ---------------------------------------------------------------------------
@@ -200,7 +249,9 @@ pub(super) fn enabled_snapshots_ordered(state: &CacheState) -> Vec<CachedPluginS
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plugin_engine::runtime::ProgressFormat;
+    use crate::plugin_engine::runtime::{MetricLine, PluginOutput, ProgressFormat};
+    use serial_test::serial;
+    use std::time::Instant;
 
     fn make_snapshot(id: &str, name: &str) -> CachedPluginSnapshot {
         CachedPluginSnapshot {
@@ -209,6 +260,50 @@ mod tests {
             plan: Some("Pro".to_string()),
             lines: vec![],
             fetched_at: "2026-03-26T08:15:30Z".to_string(),
+        }
+    }
+
+    fn make_output(id: &str, name: &str) -> PluginOutput {
+        PluginOutput {
+            provider_id: id.to_string(),
+            display_name: name.to_string(),
+            plan: Some("Pro".to_string()),
+            lines: vec![MetricLine::Text {
+                label: "Usage".to_string(),
+                value: "42%".to_string(),
+                color: None,
+                subtitle: None,
+            }],
+            icon_url: String::new(),
+        }
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "openusage-test-{}-{}",
+            label,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn wait_for_cached_snapshots(
+        dir: &Path,
+        expected_len: usize,
+    ) -> HashMap<String, CachedPluginSnapshot> {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let loaded = load_cache(dir);
+            if loaded.len() == expected_len {
+                return loaded;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "cache file was not flushed within the test deadline"
+            );
+            std::thread::sleep(Duration::from_millis(5));
         }
     }
 
@@ -223,13 +318,7 @@ mod tests {
 
     #[test]
     fn cache_file_round_trip() {
-        let dir = std::env::temp_dir().join(format!(
-            "openusage-test-cache-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let dir = temp_dir("cache");
         std::fs::create_dir_all(&dir).unwrap();
 
         let mut snapshots = HashMap::new();
@@ -247,31 +336,61 @@ mod tests {
 
     #[test]
     fn load_cache_returns_empty_on_missing_file() {
-        let dir = std::env::temp_dir().join(format!(
-            "openusage-test-no-cache-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let dir = temp_dir("no-cache");
         let loaded = load_cache(&dir);
         assert!(loaded.is_empty());
     }
 
     #[test]
     fn load_cache_returns_empty_on_invalid_json() {
-        let dir = std::env::temp_dir().join(format!(
-            "openusage-test-bad-cache-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
+        let dir = temp_dir("bad-cache");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join(CACHE_FILE_NAME), "not json").unwrap();
 
         let loaded = load_cache(&dir);
         assert!(loaded.is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[serial]
+    fn cache_successful_output_debounces_disk_writes() {
+        let dir = temp_dir("debounced-cache");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        init(&dir, vec!["claude".to_string(), "codex".to_string()]);
+        cache_successful_output(&make_output("claude", "Claude"));
+        cache_successful_output(&make_output("codex", "Codex"));
+
+        {
+            let state = cache_state().lock().unwrap();
+            assert!(state.flush_scheduled);
+            assert_eq!(state.dirty_generation, 2);
+            assert_eq!(state.flushed_generation, 0);
+        }
+        assert!(
+            !dir.join(CACHE_FILE_NAME).exists(),
+            "cache should not be written synchronously for every result"
+        );
+
+        let loaded = wait_for_cached_snapshots(&dir, 2);
+        assert_eq!(loaded["claude"].display_name, "Claude");
+        assert_eq!(loaded["codex"].display_name, "Codex");
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let state = cache_state().lock().unwrap();
+            if !state.flush_scheduled && state.dirty_generation == state.flushed_generation {
+                break;
+            }
+            drop(state);
+            assert!(
+                Instant::now() < deadline,
+                "debounced cache writer did not return to idle"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/local_http_api/cache.rs
+++ b/src-tauri/src/local_http_api/cache.rs
@@ -93,25 +93,22 @@ pub fn load_cache(app_data_dir: &Path) -> HashMap<String, CachedPluginSnapshot> 
     }
 }
 
-fn save_cache(app_data_dir: &Path, snapshots: &HashMap<String, CachedPluginSnapshot>) {
+fn save_cache(
+    app_data_dir: &Path,
+    snapshots: &HashMap<String, CachedPluginSnapshot>,
+) -> Result<(), String> {
     let file = UsageApiCacheFile {
         version: 1,
         snapshots: snapshots.clone(),
     };
     let path = app_data_dir.join(CACHE_FILE_NAME);
     let tmp_path = app_data_dir.join(".usage-api-cache.json.tmp");
-    match serde_json::to_string(&file) {
-        Ok(json) => {
-            if let Err(e) = std::fs::write(&tmp_path, &json) {
-                log::warn!("failed to write temp cache file: {}", e);
-                return;
-            }
-            if let Err(e) = std::fs::rename(&tmp_path, &path) {
-                log::warn!("failed to rename cache file: {}", e);
-            }
-        }
-        Err(e) => log::warn!("failed to serialize usage cache: {}", e),
-    }
+    let json = serde_json::to_string(&file)
+        .map_err(|e| format!("failed to serialize usage cache: {}", e))?;
+    std::fs::write(&tmp_path, &json)
+        .map_err(|e| format!("failed to write temp cache file: {}", e))?;
+    std::fs::rename(&tmp_path, &path).map_err(|e| format!("failed to rename cache file: {}", e))?;
+    Ok(())
 }
 
 fn schedule_cache_flush_locked(state: &mut CacheState) {
@@ -133,26 +130,37 @@ fn debounced_cache_flush_worker() {
     }
 }
 
-fn pending_cache_write() -> Option<(PathBuf, HashMap<String, CachedPluginSnapshot>)> {
+fn pending_cache_write() -> Option<(u64, PathBuf, HashMap<String, CachedPluginSnapshot>)> {
     let mut state = cache_state().lock().expect("cache state poisoned");
     if state.dirty_generation == state.flushed_generation {
         state.flush_scheduled = false;
         return None;
     }
 
-    state.flushed_generation = state.dirty_generation;
-    Some((state.app_data_dir.clone(), state.snapshots.clone()))
+    Some((
+        state.dirty_generation,
+        state.app_data_dir.clone(),
+        state.snapshots.clone(),
+    ))
+}
+
+fn mark_cache_flushed(generation: u64) {
+    let mut state = cache_state().lock().expect("cache state poisoned");
+    state.flushed_generation = generation;
 }
 
 fn flush_pending_cache_once() -> bool {
     let _write_guard = cache_write_lock()
         .lock()
         .expect("cache write lock poisoned");
-    let Some((app_data_dir, snapshots)) = pending_cache_write() else {
+    let Some((generation, app_data_dir, snapshots)) = pending_cache_write() else {
         return false;
     };
 
-    save_cache(&app_data_dir, &snapshots);
+    match save_cache(&app_data_dir, &snapshots) {
+        Ok(()) => mark_cache_flushed(generation),
+        Err(e) => log::warn!("{}", e),
+    }
     true
 }
 
@@ -359,7 +367,7 @@ mod tests {
         let mut snapshots = HashMap::new();
         snapshots.insert("claude".to_string(), make_snapshot("claude", "Claude"));
 
-        save_cache(&dir, &snapshots);
+        save_cache(&dir, &snapshots).unwrap();
         let loaded = load_cache(&dir);
 
         assert_eq!(loaded.len(), 1);
@@ -438,6 +446,48 @@ mod tests {
         assert_eq!(loaded["claude"].display_name, "Claude");
 
         wait_for_cache_writer_idle();
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[serial]
+    fn failed_cache_write_stays_pending_for_retry() {
+        let dir = temp_dir("cache-write-retry");
+
+        init(&dir, vec!["claude".to_string()]);
+        {
+            let mut state = cache_state().lock().unwrap();
+            state
+                .snapshots
+                .insert("claude".to_string(), make_snapshot("claude", "Claude"));
+            state.dirty_generation = 1;
+            state.flushed_generation = 0;
+            state.flush_scheduled = true;
+        }
+
+        assert!(flush_pending_cache_once());
+        {
+            let state = cache_state().lock().unwrap();
+            assert_eq!(state.dirty_generation, 1);
+            assert_eq!(state.flushed_generation, 0);
+            assert!(state.flush_scheduled);
+        }
+
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(flush_pending_cache_once());
+
+        let loaded = load_cache(&dir);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded["claude"].display_name, "Claude");
+
+        assert!(!flush_pending_cache_once());
+        {
+            let state = cache_state().lock().unwrap();
+            assert_eq!(state.dirty_generation, 1);
+            assert_eq!(state.flushed_generation, 1);
+            assert!(!state.flush_scheduled);
+        }
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/local_http_api/cache.rs
+++ b/src-tauri/src/local_http_api/cache.rs
@@ -62,6 +62,11 @@ pub(super) fn cache_state() -> &'static Mutex<CacheState> {
     })
 }
 
+fn cache_write_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 // ---------------------------------------------------------------------------
 // Cache persistence
 // ---------------------------------------------------------------------------
@@ -122,11 +127,9 @@ fn debounced_cache_flush_worker() {
     loop {
         std::thread::sleep(CACHE_WRITE_DEBOUNCE);
 
-        let Some((app_data_dir, snapshots)) = pending_cache_write() else {
+        if !flush_pending_cache_once() {
             return;
         };
-
-        save_cache(&app_data_dir, &snapshots);
     }
 }
 
@@ -139,6 +142,18 @@ fn pending_cache_write() -> Option<(PathBuf, HashMap<String, CachedPluginSnapsho
 
     state.flushed_generation = state.dirty_generation;
     Some((state.app_data_dir.clone(), state.snapshots.clone()))
+}
+
+fn flush_pending_cache_once() -> bool {
+    let _write_guard = cache_write_lock()
+        .lock()
+        .expect("cache write lock poisoned");
+    let Some((app_data_dir, snapshots)) = pending_cache_write() else {
+        return false;
+    };
+
+    save_cache(&app_data_dir, &snapshots);
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -173,6 +188,10 @@ pub fn cache_successful_output(output: &PluginOutput) {
     state.snapshots.insert(output.provider_id.clone(), snapshot);
     state.dirty_generation = state.dirty_generation.wrapping_add(1);
     schedule_cache_flush_locked(&mut state);
+}
+
+pub fn flush_cache() {
+    let _ = flush_pending_cache_once();
 }
 
 // ---------------------------------------------------------------------------
@@ -307,6 +326,22 @@ mod tests {
         }
     }
 
+    fn wait_for_cache_writer_idle() {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let state = cache_state().lock().unwrap();
+            if !state.flush_scheduled && state.dirty_generation == state.flushed_generation {
+                return;
+            }
+            drop(state);
+            assert!(
+                Instant::now() < deadline,
+                "debounced cache writer did not return to idle"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
     #[test]
     fn snapshot_serializes_with_fetched_at() {
         let snap = make_snapshot("claude", "Claude");
@@ -378,19 +413,31 @@ mod tests {
         assert_eq!(loaded["claude"].display_name, "Claude");
         assert_eq!(loaded["codex"].display_name, "Codex");
 
-        let deadline = Instant::now() + Duration::from_secs(1);
-        loop {
-            let state = cache_state().lock().unwrap();
-            if !state.flush_scheduled && state.dirty_generation == state.flushed_generation {
-                break;
-            }
-            drop(state);
-            assert!(
-                Instant::now() < deadline,
-                "debounced cache writer did not return to idle"
-            );
-            std::thread::sleep(Duration::from_millis(5));
-        }
+        wait_for_cache_writer_idle();
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[serial]
+    fn flush_cache_persists_pending_write_synchronously() {
+        let dir = temp_dir("flush-cache");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        init(&dir, vec!["claude".to_string()]);
+        cache_successful_output(&make_output("claude", "Claude"));
+        assert!(
+            !dir.join(CACHE_FILE_NAME).exists(),
+            "cache write should be pending before explicit flush"
+        );
+
+        flush_cache();
+
+        let loaded = load_cache(&dir);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded["claude"].display_name, "Claude");
+
+        wait_for_cache_writer_idle();
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/local_http_api/mod.rs
+++ b/src-tauri/src/local_http_api/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod cache;
 mod server;
 
-pub use cache::{cache_successful_output, init};
+pub use cache::{cache_successful_output, flush_cache, init};
 pub use server::start_server;


### PR DESCRIPTION
## Summary

Part of #487.

This PR coalesces `usage-api-cache.json` persistence so a burst of successful probe results does not rewrite the full cache file once per provider result.

Changes:

- keep local HTTP API snapshots updated in memory immediately;
- mark cache state dirty using a generation counter;
- start at most one debounced cache writer thread at a time;
- flush the latest snapshot map after a short debounce window;
- flush any pending cache write during normal Tauri app shutdown (`ExitRequested` / `Exit`);
- keep failed disk writes pending so a temp write/rename failure does not lose the latest successful snapshot;
- serialize cache writes with a small write lock so an exit-time flush cannot be overwritten by an older debounced writer snapshot;
- add test coverage for non-synchronous writes, eventual persistence of close updates, exit-time flush, and failed-write retry.

This is based on current `main`. It is independent from #498/#499/#500/#501/#502 and can merge separately after review.

## Verification

- `cargo test local_http_api::cache::tests`
- `cargo test --lib -- --skip ccusage_timeout_kills_descendant_and_closes_pipes`
- `bun run build`
- `git diff --check`

Note: the skipped Rust test is the existing unrelated flaky `ccusage_timeout_kills_descendant_and_closes_pipes`, handled separately in #501.

Part of #487.

