### PR TITLE
fix(antigravity): fix support for antigravity ide (v2)

### DIFF
--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -158,7 +158,9 @@ Interestingly, non-Google models (Claude, GPT-OSS) are proxied through Codeium/W
 
 Antigravity stores auth credentials in a VS Code-compatible state database.
 
-- **Path:** `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb`
+- **Paths (tried in order):**
+  - `~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb` (v2 - renamed app)
+  - `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb` (v1 - pre-rename, retained for backwards compatibility)
 - **Table:** `ItemTable` (`key` TEXT, `value` TEXT)
 
 ### antigravityUnifiedStateSync.oauthToken (sentinel envelope → protobuf)

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -1,6 +1,7 @@
 (function () {
   var LS_SERVICE = "exa.language_server_pb.LanguageServerService"
-  var STATE_DB = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+  var STATE_DB_V1 = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+  var STATE_DB_V2 = "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb"
   var CLOUD_CODE_URLS = [
     "https://daily-cloudcode-pa.googleapis.com",
     "https://cloudcode-pa.googleapis.com",
@@ -93,29 +94,36 @@
   }
 
   function loadOAuthTokens(ctx) {
-    try {
-      var rows = ctx.host.sqlite.query(
-        STATE_DB,
-        "SELECT value FROM ItemTable WHERE key = '" + OAUTH_TOKEN_KEY + "' LIMIT 1"
-      )
-      var parsed = ctx.util.tryParseJson(rows)
-      if (!parsed || !parsed.length || !parsed[0].value) return null
-      var inner = unwrapOAuthSentinel(ctx, parsed[0].value)
-      if (!inner) return null
-      var fields = readFields(inner)
-      var accessToken = (fields[1] && fields[1].type === 2) ? fields[1].data : null
-      var refreshToken = (fields[3] && fields[3].type === 2) ? fields[3].data : null
-      var expirySeconds = null
-      if (fields[4] && fields[4].type === 2) {
-        var ts = readFields(fields[4].data)
-        if (ts[1] && ts[1].type === 0) expirySeconds = ts[1].value
+    var dbPaths = [STATE_DB_V2, STATE_DB_V1]
+    for (var i = 0; i < dbPaths.length; i++) {
+      var dbPath = dbPaths[i]
+      try {
+        if (!ctx.host.fs.exists(dbPath)) {
+          continue
+        }
+        var rows = ctx.host.sqlite.query(
+          dbPath,
+          "SELECT value FROM ItemTable WHERE key = '" + OAUTH_TOKEN_KEY + "' LIMIT 1"
+        )
+        var parsed = ctx.util.tryParseJson(rows)
+        if (!parsed || !parsed.length || !parsed[0].value) continue
+        var inner = unwrapOAuthSentinel(ctx, parsed[0].value)
+        if (!inner) continue
+        var fields = readFields(inner)
+        var accessToken = (fields[1] && fields[1].type === 2) ? fields[1].data : null
+        var refreshToken = (fields[3] && fields[3].type === 2) ? fields[3].data : null
+        var expirySeconds = null
+        if (fields[4] && fields[4].type === 2) {
+          var ts = readFields(fields[4].data)
+          if (ts[1] && ts[1].type === 0) expirySeconds = ts[1].value
+        }
+        if (!accessToken && !refreshToken) continue
+        return { accessToken: accessToken, refreshToken: refreshToken, expirySeconds: expirySeconds }
+      } catch (e) {
+        ctx.host.log.warn("failed to read unified oauth token from " + dbPath + ": " + String(e))
       }
-      if (!accessToken && !refreshToken) return null
-      return { accessToken: accessToken, refreshToken: refreshToken, expirySeconds: expirySeconds }
-    } catch (e) {
-      ctx.host.log.warn("failed to read unified oauth token: " + String(e))
-      return null
     }
+    return null
   }
 
   // --- Google OAuth token refresh ---

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -197,7 +197,7 @@
   function discoverLs(ctx) {
     return ctx.host.ls.discover({
       processName: "language_server_macos",
-      markers: ["antigravity"],
+      markers: ["antigravity", "antigravity-ide"],
       csrfFlag: "--csrf_token",
       portFlag: "--extension_server_port",
     })

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -108,6 +108,8 @@ function setupLsMock(ctx, discovery, responseBody) {
 }
 
 function setupSqliteMock(ctx, oauthEnvelopeB64) {
+  ctx.host.fs.writeText("~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb", "dummy-sqlite")
+  ctx.host.fs.writeText("~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb", "dummy-sqlite")
   ctx.host.sqlite.query.mockImplementation((db, sql) => {
     if (sql.includes(OAUTH_TOKEN_KEY) && oauthEnvelopeB64) {
       return JSON.stringify([{ value: oauthEnvelopeB64 }])
@@ -693,6 +695,112 @@ describe("antigravity plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(capturedAuth).toBe("Bearer ya29.test-access")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("queries the v2 database path if it exists", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.v2-access", refreshToken: "1//refresh-token", expirySeconds: futureExpiry })
+    
+    // Simulate v2 DB file existence
+    const v2Path = "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb"
+    ctx.host.fs.writeText(v2Path, "dummy-sqlite")
+    
+    let queriedDbPath = null
+    ctx.host.sqlite.query.mockImplementation((db, sql) => {
+      queriedDbPath = db
+      if (sql.includes(OAUTH_TOKEN_KEY)) {
+        return JSON.stringify([{ value: protoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(queriedDbPath).toBe(v2Path)
+  })
+
+  it("falls back to pre-v2 database path if v2 path does not exist", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.v1-access", refreshToken: "1//refresh-token", expirySeconds: futureExpiry })
+    
+    // Do NOT write to v2 path, so it doesn't exist. Simulate v1 DB file existence.
+    const v1Path = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+    ctx.host.fs.writeText(v1Path, "dummy-sqlite")
+    
+    let queriedDbPath = null
+    ctx.host.sqlite.query.mockImplementation((db, sql) => {
+      queriedDbPath = db
+      if (sql.includes(OAUTH_TOKEN_KEY)) {
+        return JSON.stringify([{ value: protoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(queriedDbPath).toBe(v1Path)
+  })
+
+  it("cascades and falls back to pre-v2 database path if v2 path exists but is corrupt or has no token", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.v1-fallback-access", refreshToken: "1//refresh-token", expirySeconds: futureExpiry })
+
+    const v1Path = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+    const v2Path = "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb"
+
+    // Simulate both files existing on disk
+    ctx.host.fs.writeText(v1Path, "valid-db")
+    ctx.host.fs.writeText(v2Path, "corrupt-db")
+
+    const queriedPaths = []
+    ctx.host.sqlite.query.mockImplementation((db, sql) => {
+      queriedPaths.push(db)
+      if (db === v2Path) {
+        // Simulate SQLite query failure/throw or returning empty rows
+        throw new Error("database is locked or corrupt")
+      }
+      if (db === v1Path && sql.includes(OAUTH_TOKEN_KEY)) {
+        return JSON.stringify([{ value: protoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    // Should have queried both paths
+    expect(queriedPaths).toContain(v2Path)
+    expect(queriedPaths).toContain(v1Path)
     expect(result.lines.length).toBeGreaterThan(0)
   })
 


### PR DESCRIPTION
## Description

This PR adds support for Antigravity IDE (the new name for what was previously known as Antigravity)

For backwards compatibility, it checks both the v2 (Antigravity IDE) and v1 (Antigravity) paths.

### Note on Plugin Renaming & Standalone v2
Google made some changes to Antigravity. Antigravity now refers to a standalone, agent-first app, while Antigravity IDE is now what was previously known as Antigravity IDE. I think it might make sense to rename the plugin to Antigravity IDE. I decided to keep it out of scope for this PR, as I suppose renaming the plugin could break existing users' configuration.

The standalone app is no longer VSC based, and thus doesn't have a state.vscdb.

## Related Issue

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass (verified with `npx vitest run`)
- [x] I tested the change locally with `bun tauri dev`

## Checklist

- [x] I read CONTRIBUTING.md
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore support for the renamed Antigravity IDE (v2) by reading OAuth tokens from the new v2 DB first and detecting the renamed IDE process. Docs now show the v2 path and the fallback order.

- **Bug Fixes**
  - Read tokens from `~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb` (v2), then fall back to the v1 path.
  - Skip missing DBs and fall back when v2 is corrupt or has no token.
  - Update LS discovery to look for both "antigravity" and "antigravity-ide" markers.

<sup>Written for commit e417c511ab12364248018ba4db616a8968d23ec8. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/508?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

