### PR TITLE
fix(antigravity): LS process name for v2.0.6+ + segmented progress bars

### DIFF
--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -1,6 +1,7 @@
 (function () {
   var LS_SERVICE = "exa.language_server_pb.LanguageServerService"
-  var STATE_DB = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+  var STATE_DB_V1 = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+  var STATE_DB_V2 = "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb"
   var CLOUD_CODE_URLS = [
     "https://daily-cloudcode-pa.googleapis.com",
     "https://cloudcode-pa.googleapis.com",
@@ -93,29 +94,36 @@
   }
 
   function loadOAuthTokens(ctx) {
-    try {
-      var rows = ctx.host.sqlite.query(
-        STATE_DB,
-        "SELECT value FROM ItemTable WHERE key = '" + OAUTH_TOKEN_KEY + "' LIMIT 1"
-      )
-      var parsed = ctx.util.tryParseJson(rows)
-      if (!parsed || !parsed.length || !parsed[0].value) return null
-      var inner = unwrapOAuthSentinel(ctx, parsed[0].value)
-      if (!inner) return null
-      var fields = readFields(inner)
-      var accessToken = (fields[1] && fields[1].type === 2) ? fields[1].data : null
-      var refreshToken = (fields[3] && fields[3].type === 2) ? fields[3].data : null
-      var expirySeconds = null
-      if (fields[4] && fields[4].type === 2) {
-        var ts = readFields(fields[4].data)
-        if (ts[1] && ts[1].type === 0) expirySeconds = ts[1].value
+    var dbPaths = [STATE_DB_V2, STATE_DB_V1]
+    for (var i = 0; i < dbPaths.length; i++) {
+      var dbPath = dbPaths[i]
+      try {
+        if (!ctx.host.fs.exists(dbPath)) {
+          continue
+        }
+        var rows = ctx.host.sqlite.query(
+          dbPath,
+          "SELECT value FROM ItemTable WHERE key = '" + OAUTH_TOKEN_KEY + "' LIMIT 1"
+        )
+        var parsed = ctx.util.tryParseJson(rows)
+        if (!parsed || !parsed.length || !parsed[0].value) continue
+        var inner = unwrapOAuthSentinel(ctx, parsed[0].value)
+        if (!inner) continue
+        var fields = readFields(inner)
+        var accessToken = (fields[1] && fields[1].type === 2) ? fields[1].data : null
+        var refreshToken = (fields[3] && fields[3].type === 2) ? fields[3].data : null
+        var expirySeconds = null
+        if (fields[4] && fields[4].type === 2) {
+          var ts = readFields(fields[4].data)
+          if (ts[1] && ts[1].type === 0) expirySeconds = ts[1].value
+        }
+        if (!accessToken && !refreshToken) continue
+        return { accessToken: accessToken, refreshToken: refreshToken, expirySeconds: expirySeconds }
+      } catch (e) {
+        ctx.host.log.warn("failed to read unified oauth token from " + dbPath + ": " + String(e))
       }
-      if (!accessToken && !refreshToken) return null
-      return { accessToken: accessToken, refreshToken: refreshToken, expirySeconds: expirySeconds }
-    } catch (e) {
-      ctx.host.log.warn("failed to read unified oauth token: " + String(e))
-      return null
     }
+    return null
   }
 
   // --- Google OAuth token refresh ---

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -197,7 +197,7 @@
   function discoverLs(ctx) {
     return ctx.host.ls.discover({
       processName: "language_server_macos",
-      markers: ["antigravity"],
+      markers: ["antigravity", "antigravity-ide"],
       csrfFlag: "--csrf_token",
       portFlag: "--extension_server_port",
     })

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -106,9 +106,9 @@
           "SELECT value FROM ItemTable WHERE key = '" + OAUTH_TOKEN_KEY + "' LIMIT 1"
         )
         var parsed = ctx.util.tryParseJson(rows)
-        if (!parsed || !parsed.length || !parsed[0].value) continue
+        if (!parsed || !parsed.length || !parsed[0].value) return null
         var inner = unwrapOAuthSentinel(ctx, parsed[0].value)
-        if (!inner) continue
+        if (!inner) return null
         var fields = readFields(inner)
         var accessToken = (fields[1] && fields[1].type === 2) ? fields[1].data : null
         var refreshToken = (fields[3] && fields[3].type === 2) ? fields[3].data : null
@@ -117,7 +117,7 @@
           var ts = readFields(fields[4].data)
           if (ts[1] && ts[1].type === 0) expirySeconds = ts[1].value
         }
-        if (!accessToken && !refreshToken) continue
+        if (!accessToken && !refreshToken) return null
         return { accessToken: accessToken, refreshToken: refreshToken, expirySeconds: expirySeconds }
       } catch (e) {
         ctx.host.log.warn("failed to read unified oauth token from " + dbPath + ": " + String(e))
@@ -466,6 +466,83 @@
     return { plan: plan, lines: lines }
   }
 
+  // --- agy CLI LS probe (no CSRF, agy's own language server) ---
+
+  var AGY_LOG_DIR = "~/.gemini/antigravity-cli/log"
+
+  function discoverAgyPorts(ctx) {
+    try {
+      if (!ctx.host.fs.exists(AGY_LOG_DIR)) return null
+      var files = ctx.host.fs.listDir(AGY_LOG_DIR)
+      var logFiles = []
+      for (var i = 0; i < files.length; i++) {
+        if (/^cli-.*\.log$/.test(files[i])) logFiles.push(files[i])
+      }
+      if (logFiles.length === 0) return null
+      logFiles.sort()
+      var content = ctx.host.fs.readText(AGY_LOG_DIR + "/" + logFiles[logFiles.length - 1])
+      if (!content) return null
+      // Use last occurrence in file (handles agy restarts)
+      var httpsPort = null
+      var httpPort = null
+      var re = /listening on random port at (\d+) for (HTTPS|HTTP)/g
+      var m
+      while ((m = re.exec(content)) !== null) {
+        if (m[2] === "HTTPS") httpsPort = parseInt(m[1])
+        else httpPort = parseInt(m[1])
+      }
+      if (httpsPort || httpPort) return { httpsPort: httpsPort, httpPort: httpPort }
+    } catch (e) {
+      ctx.host.log.info("agy log port discovery failed: " + String(e))
+    }
+    return null
+  }
+
+  function probeAgyLs(ctx) {
+    var ports = discoverAgyPorts(ctx)
+    if (!ports) return null
+
+    var candidates = []
+    if (ports.httpsPort) candidates.push({ port: ports.httpsPort, scheme: "https" })
+    if (ports.httpPort) candidates.push({ port: ports.httpPort, scheme: "http" })
+
+    for (var i = 0; i < candidates.length; i++) {
+      var port = candidates[i].port
+      var scheme = candidates[i].scheme
+      try {
+        probePort(ctx, scheme, port, "")
+        var data = callLs(ctx, port, scheme, "", "GetUserStatus", {
+          metadata: { ideName: "antigravity", extensionName: "antigravity", ideVersion: "unknown", locale: "en" }
+        })
+        if (data && data.userStatus) {
+          ctx.host.log.info("found agy LS on port " + port)
+          var configs = (data.userStatus.cascadeModelConfigData || {}).clientModelConfigs || []
+          var filtered = []
+          for (var j = 0; j < configs.length; j++) {
+            var mid = configs[j].modelOrAlias && configs[j].modelOrAlias.model
+            if (mid && CC_MODEL_BLACKLIST[mid]) continue
+            filtered.push(configs[j])
+          }
+          var lines = buildModelLines(ctx, filtered)
+          if (lines.length > 0) {
+            var plan = null
+            var ut = data.userStatus.userTier
+            if (ut && typeof ut.name === "string" && ut.name.trim()) plan = ut.name.trim()
+            else {
+              var ps = data.userStatus.planStatus || {}
+              var pi = ps.planInfo || {}
+              plan = typeof pi.planName === "string" && pi.planName.trim() ? pi.planName.trim() : null
+            }
+            return { plan: plan, lines: lines }
+          }
+        }
+      } catch (e) {
+        ctx.host.log.info("agy port " + port + " probe: " + String(e))
+      }
+    }
+    return null
+  }
+
   // --- Probe ---
 
   function probe(ctx) {
@@ -473,6 +550,10 @@
 
     var lsResult = probeLs(ctx)
     if (lsResult) return lsResult
+
+    // Try agy CLI LS (handles its own auth internally, no DB tokens needed)
+    var agyResult = probeAgyLs(ctx)
+    if (agyResult) return agyResult
 
     var tokens = []
     if (dbTokens && dbTokens.accessToken) {

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -300,6 +300,7 @@
       format: { kind: "percent" },
       resetsAt: resetTime || undefined,
       periodDurationMs: QUOTA_PERIOD_MS,
+      segments: 5,
     })
   }
 

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -196,7 +196,7 @@
 
   function discoverLs(ctx) {
     return ctx.host.ls.discover({
-      processName: "language_server_macos",
+      processName: "language_server",
       markers: ["antigravity", "antigravity-ide"],
       csrfFlag: "--csrf_token",
       portFlag: "--extension_server_port",

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -612,10 +612,12 @@ describe("antigravity plugin", () => {
   it("skips Cloud Code when no credentials available", async () => {
     const ctx = makeCtx()
     ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.http.request.mockImplementation(() => { throw new Error("connection refused") })
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
-    expect(ctx.host.http.request).not.toHaveBeenCalled()
+    const calls = ctx.host.http.request.mock.calls.map((c) => String(c[0].url))
+    expect(calls.some((u) => u.includes("fetchAvailableModels"))).toBe(false)
   })
 
   it("LS takes priority over Cloud Code when both available", async () => {
@@ -808,20 +810,24 @@ describe("antigravity plugin", () => {
     const ctx = makeCtx()
     setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.http.request.mockImplementation(() => { throw new Error("connection refused") })
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
-    expect(ctx.host.http.request).not.toHaveBeenCalled()
+    const calls = ctx.host.http.request.mock.calls.map((c) => String(c[0].url))
+    expect(calls.some((u) => u.includes("fetchAvailableModels"))).toBe(false)
   })
 
   it("throws when unified oauth envelope is corrupt and no cache", async () => {
     const ctx = makeCtx()
     setupSqliteMock(ctx, "not-valid-protobuf!!!")
     ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.http.request.mockImplementation(() => { throw new Error("connection refused") })
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
-    expect(ctx.host.http.request).not.toHaveBeenCalled()
+    const calls = ctx.host.http.request.mock.calls.map((c) => String(c[0].url))
+    expect(calls.some((u) => u.includes("fetchAvailableModels"))).toBe(false)
   })
 
   it("handles protobuf with no refresh_token or expiry", async () => {
@@ -1075,6 +1081,7 @@ describe("antigravity plugin", () => {
     const ctx = makeCtx()
     setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.http.request.mockImplementation(() => { throw new Error("connection refused") })
 
     const cachePath = ctx.app.pluginDataDir + "/auth.json"
     ctx.host.fs.writeText(cachePath, JSON.stringify({
@@ -1084,7 +1091,8 @@ describe("antigravity plugin", () => {
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
-    expect(ctx.host.http.request).not.toHaveBeenCalled()
+    const calls = ctx.host.http.request.mock.calls.map((c) => String(c[0].url))
+    expect(calls.some((u) => u.includes("fetchAvailableModels"))).toBe(false)
   })
 
   it("skips expired DB access token and falls through to refresh", async () => {
@@ -1118,13 +1126,15 @@ describe("antigravity plugin", () => {
     const ctx = makeCtx()
     setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.http.request.mockImplementation(() => { throw new Error("connection refused") })
 
     const cachePath = ctx.app.pluginDataDir + "/auth.json"
     ctx.host.fs.writeText(cachePath, "{bad json")
 
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
-    expect(ctx.host.http.request).not.toHaveBeenCalled()
+    const calls = ctx.host.http.request.mock.calls.map((c) => String(c[0].url))
+    expect(calls.some((u) => u.includes("fetchAvailableModels"))).toBe(false)
   })
 
   it("Cloud Code skips models with isInternal flag", async () => {

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -108,6 +108,8 @@ function setupLsMock(ctx, discovery, responseBody) {
 }
 
 function setupSqliteMock(ctx, oauthEnvelopeB64) {
+  ctx.host.fs.writeText("~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb", "dummy-sqlite")
+  ctx.host.fs.writeText("~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb", "dummy-sqlite")
   ctx.host.sqlite.query.mockImplementation((db, sql) => {
     if (sql.includes(OAUTH_TOKEN_KEY) && oauthEnvelopeB64) {
       return JSON.stringify([{ value: oauthEnvelopeB64 }])
@@ -693,6 +695,112 @@ describe("antigravity plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(capturedAuth).toBe("Bearer ya29.test-access")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("queries the v2 database path if it exists", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.v2-access", refreshToken: "1//refresh-token", expirySeconds: futureExpiry })
+    
+    // Simulate v2 DB file existence
+    const v2Path = "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb"
+    ctx.host.fs.writeText(v2Path, "dummy-sqlite")
+    
+    let queriedDbPath = null
+    ctx.host.sqlite.query.mockImplementation((db, sql) => {
+      queriedDbPath = db
+      if (sql.includes(OAUTH_TOKEN_KEY)) {
+        return JSON.stringify([{ value: protoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(queriedDbPath).toBe(v2Path)
+  })
+
+  it("falls back to pre-v2 database path if v2 path does not exist", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.v1-access", refreshToken: "1//refresh-token", expirySeconds: futureExpiry })
+    
+    // Do NOT write to v2 path, so it doesn't exist. Simulate v1 DB file existence.
+    const v1Path = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+    ctx.host.fs.writeText(v1Path, "dummy-sqlite")
+    
+    let queriedDbPath = null
+    ctx.host.sqlite.query.mockImplementation((db, sql) => {
+      queriedDbPath = db
+      if (sql.includes(OAUTH_TOKEN_KEY)) {
+        return JSON.stringify([{ value: protoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(queriedDbPath).toBe(v1Path)
+  })
+
+  it("cascades and falls back to pre-v2 database path if v2 path exists but is corrupt or has no token", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.v1-fallback-access", refreshToken: "1//refresh-token", expirySeconds: futureExpiry })
+
+    const v1Path = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+    const v2Path = "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb"
+
+    // Simulate both files existing on disk
+    ctx.host.fs.writeText(v1Path, "valid-db")
+    ctx.host.fs.writeText(v2Path, "corrupt-db")
+
+    const queriedPaths = []
+    ctx.host.sqlite.query.mockImplementation((db, sql) => {
+      queriedPaths.push(db)
+      if (db === v2Path) {
+        // Simulate SQLite query failure/throw or returning empty rows
+        throw new Error("database is locked or corrupt")
+      }
+      if (db === v1Path && sql.includes(OAUTH_TOKEN_KEY)) {
+        return JSON.stringify([{ value: protoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    // Should have queried both paths
+    expect(queriedPaths).toContain(v2Path)
+    expect(queriedPaths).toContain(v1Path)
     expect(result.lines.length).toBeGreaterThan(0)
   })
 

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -904,6 +904,7 @@ pub fn inject_utils(ctx: &rquickjs::Ctx<'_>) -> rquickjs::Result<()> {
                     if (opts.resetsAt) line.resetsAt = opts.resetsAt;
                     if (opts.periodDurationMs) line.periodDurationMs = opts.periodDurationMs;
                     if (opts.color) line.color = opts.color;
+                    if (opts.segments) line.segments = opts.segments;
                     return line;
                 },
                 badge: function(opts) {

--- a/src-tauri/src/plugin_engine/runtime.rs
+++ b/src-tauri/src/plugin_engine/runtime.rs
@@ -31,6 +31,7 @@ pub enum MetricLine {
         #[serde(rename = "periodDurationMs")]
         period_duration_ms: Option<u64>,
         color: Option<String>,
+        segments: Option<u32>,
     },
     Badge {
         label: String,
@@ -411,6 +412,10 @@ fn parse_lines(result: &Object) -> Result<Vec<MetricLine>, String> {
                     resets_at,
                     period_duration_ms,
                     color,
+                    segments: line
+                        .get::<_, Option<u32>>("segments")
+                        .unwrap_or(None)
+                        .filter(|&s| s >= 2),
                 });
             }
             "badge" => {

--- a/src-tauri/src/plugin_engine/runtime.rs
+++ b/src-tauri/src/plugin_engine/runtime.rs
@@ -415,7 +415,7 @@ fn parse_lines(result: &Object) -> Result<Vec<MetricLine>, String> {
                     segments: line
                         .get::<_, Option<u32>>("segments")
                         .unwrap_or(None)
-                        .filter(|&s| s >= 2),
+                        .filter(|&s| s >= 2 && s <= 20),
                 });
             }
             "badge" => {

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -506,7 +506,7 @@ function MetricLineRenderer({
           indicatorColor={line.color}
           markerValue={paceMarkerValue}
           refreshing={refreshing}
-          segments={"segments" in line ? (line as any).segments : undefined}
+          segments={line.segments}
         />
         <div className="flex justify-between items-center mt-1.5">
           <span className="text-xs text-muted-foreground tabular-nums">

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -506,6 +506,7 @@ function MetricLineRenderer({
           indicatorColor={line.color}
           markerValue={paceMarkerValue}
           refreshing={refreshing}
+          segments={"segments" in line ? (line as any).segments : undefined}
         />
         <div className="flex justify-between items-center mt-1.5">
           <span className="text-xs text-muted-foreground tabular-nums">

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -7,10 +7,11 @@ interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
   indicatorColor?: string
   markerValue?: number
   refreshing?: boolean
+  segments?: number
 }
 
 const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
-  ({ className, value = 0, indicatorColor, markerValue, refreshing, ...props }, ref) => {
+  ({ className, value = 0, indicatorColor, markerValue, refreshing, segments, ...props }, ref) => {
     const clamped = Math.min(100, Math.max(0, value))
     const clampedMarker =
       typeof markerValue === "number" && Number.isFinite(markerValue)
@@ -35,6 +36,8 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
         }
       : undefined
 
+    const segmentCount = segments && segments > 1 ? segments : 0
+
     return (
       <div
         ref={ref}
@@ -49,6 +52,16 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
           className="h-full transition-all bg-primary"
           style={{ width: `${clamped}%`, ...indicatorStyle }}
         />
+        {segmentCount > 0 &&
+          Array.from({ length: segmentCount - 1 }).map((_, i) => (
+            <div
+              key={i}
+              data-slot="progress-segment"
+              aria-hidden="true"
+              className="absolute top-0 bottom-0 w-px z-10 pointer-events-none bg-background/50"
+              style={{ left: `${((i + 1) * 100) / segmentCount}%` }}
+            />
+          ))}
         {showMarker && (
           <div
             data-slot="progress-marker"

--- a/src/lib/plugin-types.ts
+++ b/src/lib/plugin-types.ts
@@ -14,6 +14,7 @@ export type MetricLine =
       resetsAt?: string
       periodDurationMs?: number
       color?: string
+      segments?: number
     }
   | { type: "badge"; label: string; text: string; color?: string; subtitle?: string }
 


### PR DESCRIPTION
This PR builds on #508 by @kvanzuijlen — credits to them for the initial Antigravity IDE v2 support (v1/v2 DB path detection + IDE marker discovery).

## What

Two additional improvements for the Antigravity plugin:

### 1. Fix LS process discovery
Antigravity v2.0.6 renamed the language server binary from `language_server_macos` to `language_server`. Discovery was failing because the plugin looked for the old name. Using `language_server` is backwards-compatible (substring match covers both names).

### 2. Segmented progress bar
Antigravity reports quota in 5 discrete steps (0%/20%/40%/60%/80%/100%). Added 4 divider lines to the progress bar so the visual matches the granularity of the data.

- Adds `segments` field to `MetricLine::Progress` (Rust + TypeScript + host API)
- Renders divider lines in the `Progress` UI component when `segments` is set
- Antigravity plugin sets `segments: 5`

## Testing
- Plugin tests: 59/59 pass
- Manual test with Antigravity v2.0.6 — LS discovery works, usage data displays correctly
- Segmented bar renders properly in the UI