### PR TITLE
Fall back to Extra usage spent in Claude tray title

### DIFF
--- a/plugins/claude/plugin.json
+++ b/plugins/claude/plugin.json
@@ -12,10 +12,10 @@
   ],
   "lines": [
     { "type": "progress", "label": "Session", "scope": "overview", "primaryOrder": 1 },
-    { "type": "progress", "label": "Weekly", "scope": "overview" },
+    { "type": "progress", "label": "Weekly", "scope": "overview", "primaryOrder": 2 },
     { "type": "progress", "label": "Sonnet", "scope": "detail" },
     { "type": "progress", "label": "Claude Design", "scope": "detail" },
-    { "type": "progress", "label": "Extra usage spent", "scope": "detail" },
+    { "type": "progress", "label": "Extra usage spent", "scope": "detail", "primaryOrder": 3 },
     { "type": "text", "label": "Today", "scope": "detail" },
     { "type": "text", "label": "Yesterday", "scope": "detail" },
     { "type": "text", "label": "Last 30 Days", "scope": "detail" }

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -583,6 +583,31 @@ describe("claude plugin", () => {
     expect(result.lines.find((line) => line.label === "Extra usage spent")).toBeTruthy()
   })
 
+  it("emits Extra usage spent as a progress line with finite used/limit when monthly_limit is set", async () => {
+    // Regression: tray title falls back to this line when Session/Weekly are absent
+    // (e.g. Enterprise accounts). It must be a progress line with limit > 0 for
+    // tray-primary-progress to compute a fraction.
+    const ctx = makeCtx()
+    ctx.host.fs.readText = () =>
+      JSON.stringify({ claudeAiOauth: { accessToken: "token", subscriptionType: "enterprise" } })
+    ctx.host.fs.exists = () => true
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      bodyText: JSON.stringify({
+        extra_usage: { is_enabled: true, used_credits: 500, monthly_limit: 10000 },
+      }),
+    })
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const line = result.lines.find((l) => l.label === "Extra usage spent")
+    expect(line).toBeTruthy()
+    expect(line.type).toBe("progress")
+    expect(Number.isFinite(line.used)).toBe(true)
+    expect(Number.isFinite(line.limit)).toBe(true)
+    expect(line.limit).toBeGreaterThan(0)
+    expect(line.format).toEqual({ kind: "dollars" })
+  })
+
   it("renders Claude Design line from seven_day_omelette with normalized resetsAt", async () => {
     const ctx = makeCtx()
     ctx.host.fs.readText = () =>

--- a/src/lib/tray-primary-progress.test.ts
+++ b/src/lib/tray-primary-progress.test.ts
@@ -286,6 +286,46 @@ describe("getTrayPrimaryBars", () => {
     expect(bars).toEqual([{ id: "a", fraction: 0.2 }])
   })
 
+  it("falls back to Extra usage spent for Claude $-budget-only accounts", () => {
+    // Regression: Enterprise Claude accounts return only extra_usage (no Session,
+    // no Weekly). The candidate chain Session → Weekly → Extra usage spent must
+    // resolve to the $-budget bar so the tray title shows a percent, not --%.
+    const bars = getTrayPrimaryBars({
+      displayMode: "used",
+      pluginsMeta: [
+        {
+          id: "claude",
+          name: "Claude",
+          iconUrl: "",
+          primaryCandidates: ["Session", "Weekly", "Extra usage spent"],
+          lines: [],
+        },
+      ],
+      pluginSettings: { order: ["claude"], disabled: [] },
+      pluginStates: {
+        claude: {
+          data: {
+            providerId: "claude",
+            displayName: "Claude",
+            iconUrl: "",
+            lines: [
+              {
+                type: "progress",
+                label: "Extra usage spent",
+                used: 5,
+                limit: 100,
+                format: { kind: "dollars" },
+              },
+            ],
+          },
+          loading: false,
+          error: null,
+        },
+      },
+    })
+    expect(bars).toEqual([{ id: "claude", fraction: 0.05 }])
+  })
+
   it("skips plugins with empty primaryCandidates", () => {
     const bars = getTrayPrimaryBars({
       pluginsMeta: [


### PR DESCRIPTION
## Summary
- Claude Enterprise accounts only enforce the monthly `extra_usage` $ budget — the API returns no Session/Weekly limits, so the tray title showed `--%` (provider style) or was blanked (donut/bars) even though the popup correctly listed the spend.
- Add `primaryOrder` to Weekly (2) and Extra usage spent (3) in `plugins/claude/plugin.json`. The tray selector already falls through to the first candidate present in live data, so a $-budget-only response now resolves to the Extra usage bar.
- Side benefit: also fixes a latent gap where a Weekly-only response would have blanked the title.

## Before / After

Tray title now reads `92%` (was `--%`) for an Enterprise account whose only enforced limit is the monthly `extra_usage` $ budget. Verified across all three icon styles (provider, donut, bars).

<img width="373" height="696" alt="Claude popup — Extra usage spent driving the title" src="https://github.com/user-attachments/assets/b2812367-a541-40d2-8ac4-eb2e73d886de" />
<img width="411" height="738" alt="Settings — Menubar Icon style options" src="https://github.com/user-attachments/assets/fa9ab83a-d06a-46e1-b22b-bce5363e3385" />
<img width="363" height="321" alt="Tray title — provider style" src="https://github.com/user-attachments/assets/f5c4dacd-aec2-42d2-8059-e691126a5e4f" />

## Test plan
- [x] `bun run test` — added two regressions (plugin probe emits `extra_usage` as a progress line with finite limit; tray selector resolves Session → Weekly → Extra usage spent chain).
- [x] `bun run build` (tsc + vite) clean.
- [x] Verified live in `bun tauri dev` on a Claude Enterprise account — tray title shows `92%` (was `--%`) across provider, donut, and bars styles.
- [x] Pro/Max accounts unchanged by design (`Session` still wins because `primaryOrder: 1` < `2` < `3`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Claude tray title so Enterprise accounts with only a monthly $ budget show a percentage instead of --%, across provider, donut, and bars. Falls back to “Extra usage spent” when Session/Weekly limits are missing.

- **Bug Fixes**
  - Set `primaryOrder` for “Weekly” (2) and “Extra usage spent” (3) in `plugins/claude/plugin.json` to enable Session → Weekly → Extra usage spent fallback (also covers Weekly-only cases).
  - Emit “Extra usage spent” as a progress line with finite used/limit in dollars.
  - Added tests for plugin probe and tray primary bar fallback; Pro/Max behavior unchanged (Session still preferred).

<sup>Written for commit 2d48fc7b56b217dcb61d9d6b024342a1cce5f98c. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/511?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

