### PR TITLE
Add Antigravity CLI fallback to Antigravity provider

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -230,7 +230,7 @@ const resp = ctx.host.http.request({
 ## Keychain (macOS only)
 
 ```typescript
-host.keychain.readGenericPassword(service: string): string
+host.keychain.readGenericPassword(service: string, account?: string): string
 ```
 
 Reads a generic password from the macOS Keychain.
@@ -239,6 +239,7 @@ Reads a generic password from the macOS Keychain.
 
 - **macOS only**: Throws on other platforms
 - **Throws if not found**: Returns the password string if found, throws otherwise
+- **Optional account**: When provided, lookup is scoped to both service and account
 
 ### Example
 

--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -9,11 +9,11 @@ Antigravity is essentially a Google-branded fork of [Windsurf](windsurf.md) — 
 - **Vendor:** Google (internal codename "Jetski")
 - **Protocol:** Connect RPC v1 (JSON over HTTP) on local language server
 - **Service:** `exa.language_server_pb.LanguageServerService`
-- **Auth:** CSRF token from process args; Google OAuth tokens from SQLite (fallback)
+- **Auth:** CSRF token from process args; Google OAuth tokens from SQLite or `agy` keychain (fallbacks)
 - **Quota:** fraction (0.0–1.0, where 1.0 = 100% remaining)
 - **Quota window:** 5 hours
 - **Timestamps:** ISO 8601
-- **Requires:** Antigravity IDE running (language server process), or signed-in credentials in SQLite (Cloud Code fallback)
+- **Requires:** Antigravity IDE or pre-rename Antigravity running, signed-in app credentials from either SQLite path, or an authenticated Antigravity CLI (`agy`)
 
 ## Discovery
 
@@ -21,8 +21,8 @@ The language server listens on a random localhost port. Three values must be dis
 
 ```bash
 # 1. Find process and extract CSRF token
-ps -ax -o pid=,command= | grep 'language_server_macos.*antigravity'
-# Match: --app_data_dir antigravity  OR  path contains /antigravity/
+pgrep -ilf 'language_server.*antigravity|antigravity.*language_server'
+# Match: --app_data_dir antigravity or antigravity-ide, OR matching app path
 # Extract: --csrf_token <token>
 # Extract: --extension_server_port <port>  (HTTP fallback)
 
@@ -158,7 +158,7 @@ Interestingly, non-Google models (Claude, GPT-OSS) are proxied through Codeium/W
 
 Antigravity stores auth credentials in a VS Code-compatible state database.
 
-- **Path:** `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb`
+- **Paths (tried in order):** `~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb`, then `~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb`
 - **Table:** `ItemTable` (`key` TEXT, `value` TEXT)
 
 ### antigravityUnifiedStateSync.oauthToken (sentinel envelope → protobuf)
@@ -244,17 +244,40 @@ The response includes all models provisioned for the account. The plugin filters
 
 The Cloud Code model set is a superset of the LS model set. The LS returns only cascade-configured chat models, Cloud Code includes all provisioned models. This difference is expected.
 
+## Antigravity CLI (`agy`) fallback
+
+The Antigravity CLI stores its own non-secret state under `~/.gemini/antigravity-cli/` and uses the OS keychain for auth. On macOS, current builds store the token under keychain service `gemini`, account `antigravity`.
+
+OpenUsage treats this as a fallback inside the Antigravity provider, not a separate provider, because the app and CLI share the same account/model quota pools. The keychain value may be a raw bearer token, JSON OAuth-style payload, or `go-keyring-base64:` wrapped JSON payload.
+
+CLI quota uses the same Cloud Code base URL but a different endpoint sequence:
+
+1. `POST /v1internal:loadCodeAssist` with the `agy` OAuth token to read the paid tier and Cloud Code project.
+2. `POST /v1internal:retrieveUserQuota` with `{ "project": "<cloudaicompanionProject>" }` to read quota buckets.
+
+Current CLI quota buckets expose Gemini model pools. If the IDE is running, the language server remains preferred because it returns the full Antigravity model set, including Claude.
+
+## Historical token/cost usage
+
+Antigravity does not currently expose the local token/cost history that Claude and Codex use for `Today`, `Yesterday`, and `Last 30 Days` rows. The quota sources above return remaining fraction and reset time only. Antigravity CLI stores conversation state under `~/.gemini/antigravity-cli/`, but the local transcripts and logs do not include input, output, cache, or reasoning token counts, and the `.pb` conversation files are opaque without Google's private schema. Do not estimate token usage from transcript text or quota deltas; that would make the UI look precise while showing guessed data.
+
+Gemini CLI usage data is separate (`${GEMINI_DATA_DIR:-~/.gemini/tmp}`) and must not be merged into Antigravity just because both tools use Google accounts.
+
 ## Plugin Strategy
 
-1. Read `antigravityUnifiedStateSync.oauthToken` from SQLite, unwrap the sentinel envelope, and decode the inner `OAuthTokenInfo` protobuf (optional, may fail).
-2. **Strategy 1 — LS probe (primary):**
+1. **Strategy 1 — LS probe (primary):**
    a. Discover LS process via `ctx.host.ls.discover()` (ps + lsof)
    b. Probe ports with `GetUnleashData` to find the Connect-RPC endpoint
    c. Call `GetUserStatus` for plan name + per-model quota
    d. Fall back to `GetCommandModelConfigs` if `GetUserStatus` fails
-3. **Strategy 2 — Cloud Code API (fallback, only if LS fails):**
-   a. Build candidate token list: proto access_token (if unexpired), cached refreshed token (if fresh), deduplicated
-   b. Try each token with `fetchAvailableModels`
-   c. If all fail with 401/403 (or the list is empty) and a refresh token is available: refresh via Google OAuth, cache result to pluginDataDir, retry once
-   d. Parse model quota: skip `isInternal` models, empty-displayName models, and blacklisted model IDs
-4. If both strategies fail: error "Start Antigravity and try again."
+2. **Strategy 2 — App Cloud Code API (fallback, only if LS fails):**
+   a. Read `antigravityUnifiedStateSync.oauthToken` from SQLite, unwrap the sentinel envelope, and decode the inner `OAuthTokenInfo` protobuf (optional, may fail)
+   b. Build candidate token list: proto access_token (if unexpired), cached refreshed token (if fresh), deduplicated
+   c. Try each token with `fetchAvailableModels`
+   d. If all fail with 401/403 (or the list is empty) and a refresh token is available: refresh via Google OAuth, cache result to pluginDataDir, retry once
+   e. Parse model quota: skip `isInternal` models, empty-displayName models, and blacklisted model IDs
+3. **Strategy 3 — CLI Cloud Code API (final fallback):**
+   a. Read the `agy` keychain token from service `gemini`, account `antigravity`
+   b. Call `loadCodeAssist` for plan/project context
+   c. Call `retrieveUserQuota` for CLI quota buckets
+4. If all strategies fail: error "Start Antigravity or run `agy` and try again."

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -1,11 +1,19 @@
 (function () {
   var LS_SERVICE = "exa.language_server_pb.LanguageServerService"
-  var STATE_DB = "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb"
+  var STATE_DBS = [
+    "~/Library/Application Support/Antigravity IDE/User/globalStorage/state.vscdb",
+    "~/Library/Application Support/Antigravity/User/globalStorage/state.vscdb",
+  ]
+  var CLI_KEYCHAIN_SERVICE = "gemini"
+  var CLI_KEYCHAIN_ACCOUNT = "antigravity"
   var CLOUD_CODE_URLS = [
     "https://daily-cloudcode-pa.googleapis.com",
     "https://cloudcode-pa.googleapis.com",
   ]
+  var LOAD_CODE_ASSIST_PATH = "/v1internal:loadCodeAssist"
   var FETCH_MODELS_PATH = "/v1internal:fetchAvailableModels"
+  var RETRIEVE_QUOTA_PATH = "/v1internal:retrieveUserQuota"
+  var LOGIN_MESSAGE = "Start Antigravity or run `agy` and try again."
   var GOOGLE_OAUTH_URL = "https://oauth2.googleapis.com/token"
   var GOOGLE_CLIENT_ID = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
   var GOOGLE_CLIENT_SECRET = "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"
@@ -92,10 +100,10 @@
     return ctx.base64.decode(innerText)
   }
 
-  function loadOAuthTokens(ctx) {
+  function loadOAuthTokensFromDb(ctx, dbPath) {
     try {
       var rows = ctx.host.sqlite.query(
-        STATE_DB,
+        dbPath,
         "SELECT value FROM ItemTable WHERE key = '" + OAUTH_TOKEN_KEY + "' LIMIT 1"
       )
       var parsed = ctx.util.tryParseJson(rows)
@@ -116,6 +124,15 @@
       ctx.host.log.warn("failed to read unified oauth token: " + String(e))
       return null
     }
+  }
+
+  function loadOAuthTokenCandidates(ctx) {
+    var candidates = []
+    for (var i = 0; i < STATE_DBS.length; i++) {
+      var tokens = loadOAuthTokensFromDb(ctx, STATE_DBS[i])
+      if (tokens) candidates.push(tokens)
+    }
+    return candidates
   }
 
   // --- Google OAuth token refresh ---
@@ -184,12 +201,89 @@
     }
   }
 
+  // --- Antigravity CLI keychain token ---
+
+  function trimString(value) {
+    return typeof value === "string" ? value.trim() : ""
+  }
+
+  function decodeBase64(ctx, text) {
+    try {
+      return ctx.base64.decode(text)
+    } catch (e) {
+      return null
+    }
+  }
+
+  function unwrapCliKeychainText(ctx, raw) {
+    var text = trimString(raw)
+    if (!text) return null
+    if (text.indexOf("go-keyring-base64:") === 0) {
+      text = trimString(decodeBase64(ctx, text.slice("go-keyring-base64:".length)))
+    }
+    return text || null
+  }
+
+  function extractTokenFromObject(obj) {
+    if (!obj || typeof obj !== "object") return null
+
+    var directKeys = [
+      "access_token",
+      "accessToken",
+      "token",
+      "id_token",
+      "idToken",
+      "bearerToken",
+      "auth_token",
+      "authToken",
+    ]
+    for (var i = 0; i < directKeys.length; i++) {
+      var value = obj[directKeys[i]]
+      if (typeof value === "string" && value.trim()) return value.trim()
+    }
+
+    var nestedKeys = ["token", "tokens", "oauth", "oauth2", "credentials", "auth"]
+    for (var j = 0; j < nestedKeys.length; j++) {
+      var nested = extractTokenFromObject(obj[nestedKeys[j]])
+      if (nested) return nested
+    }
+
+    return null
+  }
+
+  function extractCliAccessToken(ctx, raw) {
+    var text = unwrapCliKeychainText(ctx, raw)
+    if (!text) return null
+
+    var parsed = ctx.util.tryParseJson(text)
+    if (typeof parsed === "string" && parsed.trim()) return parsed.trim()
+    if (parsed) return extractTokenFromObject(parsed)
+
+    if (text.indexOf("Bearer ") === 0) return text.slice("Bearer ".length).trim() || null
+    return text
+  }
+
+  function loadCliKeychainToken(ctx) {
+    if (!ctx.host.keychain || typeof ctx.host.keychain.readGenericPassword !== "function") {
+      return null
+    }
+    try {
+      return extractCliAccessToken(
+        ctx,
+        ctx.host.keychain.readGenericPassword(CLI_KEYCHAIN_SERVICE, CLI_KEYCHAIN_ACCOUNT)
+      )
+    } catch (e) {
+      ctx.host.log.info("Antigravity CLI keychain read failed: " + String(e))
+      return null
+    }
+  }
+
   // --- LS discovery ---
 
   function discoverLs(ctx) {
     return ctx.host.ls.discover({
-      processName: "language_server_macos",
-      markers: ["antigravity"],
+      processName: "language_server",
+      markers: ["antigravity", "antigravity-ide"],
       csrfFlag: "--csrf_token",
       portFlag: "--extension_server_port",
     })
@@ -335,20 +429,25 @@
 
   // --- Cloud Code API ---
 
-  function probeCloudCode(ctx, token) {
+  function requestCloudCodeJson(ctx, path, token, userAgent, body) {
     for (var i = 0; i < CLOUD_CODE_URLS.length; i++) {
       try {
         var resp = ctx.host.http.request({
           method: "POST",
-          url: CLOUD_CODE_URLS[i] + FETCH_MODELS_PATH,
+          url: CLOUD_CODE_URLS[i] + path,
           headers: {
+            Accept: "application/json",
             "Content-Type": "application/json",
             Authorization: "Bearer " + token,
-            "User-Agent": "antigravity",
+            "User-Agent": userAgent || "antigravity",
           },
-          bodyText: "{}",
+          bodyText: JSON.stringify(body || {}),
           timeoutMs: 15000,
         })
+        if (!resp || typeof resp.status !== "number" || !Number.isFinite(resp.status)) {
+          ctx.host.log.warn("Cloud Code returned invalid response shape (" + CLOUD_CODE_URLS[i] + ")")
+          continue
+        }
         if (ctx.util.isAuthStatus(resp.status)) return { _authFailed: true }
         if (resp.status >= 200 && resp.status < 300) {
           return ctx.util.tryParseJson(resp.bodyText)
@@ -358,6 +457,10 @@
       }
     }
     return null
+  }
+
+  function probeCloudCode(ctx, token, userAgent) {
+    return requestCloudCodeJson(ctx, FETCH_MODELS_PATH, token, userAgent, {})
   }
 
   function parseCloudCodeModels(data) {
@@ -371,7 +474,10 @@
       if (m.isInternal) continue
       var modelId = m.model || keys[i]
       if (CC_MODEL_BLACKLIST[modelId]) continue
-      var displayName = (typeof m.displayName === "string") ? m.displayName.trim() : ""
+      var displayName =
+        (typeof m.displayName === "string" && m.displayName.trim()) ||
+        (typeof m.label === "string" && m.label.trim()) ||
+        ""
       if (!displayName) continue
       var qi = m.quotaInfo
       var frac = (qi && typeof qi.remainingFraction === "number") ? qi.remainingFraction : 0
@@ -382,6 +488,58 @@
       })
     }
     return configs
+  }
+
+  function readCliPlan(loadData) {
+    var paidTier = loadData && loadData.paidTier
+    if (paidTier && typeof paidTier.name === "string" && paidTier.name.trim()) {
+      return paidTier.name.trim()
+    }
+    var currentTier = loadData && loadData.currentTier
+    if (currentTier && typeof currentTier.name === "string" && currentTier.name.trim()) {
+      return currentTier.name.trim()
+    }
+    return null
+  }
+
+  function parseCliQuotaBuckets(data) {
+    var buckets = data && data.buckets
+    if (!Array.isArray(buckets)) return []
+    var configs = []
+    for (var i = 0; i < buckets.length; i++) {
+      var bucket = buckets[i]
+      if (!bucket || typeof bucket !== "object") continue
+      var modelId = (typeof bucket.modelId === "string" && bucket.modelId.trim()) || ""
+      if (!modelId) continue
+      var frac = (typeof bucket.remainingFraction === "number") ? bucket.remainingFraction : 0
+      configs.push({
+        label: modelId,
+        quotaInfo: { remainingFraction: frac, resetTime: bucket.resetTime || undefined },
+      })
+    }
+    return configs
+  }
+
+  function probeCliCloudCode(ctx, token) {
+    var loadData = requestCloudCodeJson(ctx, LOAD_CODE_ASSIST_PATH, token, "agy", {})
+    if (!loadData || loadData._authFailed) return loadData
+
+    var project =
+      typeof loadData.cloudaicompanionProject === "string" && loadData.cloudaicompanionProject.trim()
+        ? loadData.cloudaicompanionProject.trim()
+        : null
+    var quotaData = null
+    if (project) {
+      quotaData = requestCloudCodeJson(ctx, RETRIEVE_QUOTA_PATH, token, "agy", { project: project })
+    }
+    if (!quotaData || quotaData._authFailed) {
+      quotaData = requestCloudCodeJson(ctx, RETRIEVE_QUOTA_PATH, token, "agy", {})
+    }
+    if (!quotaData || quotaData._authFailed) return quotaData
+
+    var lines = buildModelLines(ctx, parseCliQuotaBuckets(quotaData))
+    if (lines.length === 0) return null
+    return { plan: readCliPlan(loadData), lines: lines }
   }
 
   // --- LS probe ---
@@ -460,24 +618,22 @@
   // --- Probe ---
 
   function probe(ctx) {
-    var dbTokens = loadOAuthTokens(ctx)
-
     var lsResult = probeLs(ctx)
     if (lsResult) return lsResult
 
+    var dbTokenCandidates = loadOAuthTokenCandidates(ctx)
+
     var tokens = []
-    if (dbTokens && dbTokens.accessToken) {
-      if (!dbTokens.expirySeconds || dbTokens.expirySeconds > Math.floor(Date.now() / 1000)) {
-        tokens.push(dbTokens.accessToken)
+    var nowSec = Math.floor(Date.now() / 1000)
+    for (var i = 0; i < dbTokenCandidates.length; i++) {
+      var dbTokens = dbTokenCandidates[i]
+      if (dbTokens.accessToken && (!dbTokens.expirySeconds || dbTokens.expirySeconds > nowSec)) {
+        if (tokens.indexOf(dbTokens.accessToken) === -1) tokens.push(dbTokens.accessToken)
       }
     }
 
     var cached = loadCachedToken(ctx)
     if (cached && tokens.indexOf(cached) === -1) tokens.push(cached)
-
-    if (tokens.length === 0 && !(dbTokens && dbTokens.refreshToken)) {
-      throw "Start Antigravity and try again."
-    }
 
     var ccData = null
     var sawAuthFailure = false
@@ -494,10 +650,31 @@
     // probeCloudCode returns null for transient failures (5xx/timeouts); without this
     // guard a Cloud Code incident would trigger a Google OAuth refresh every probe cycle
     // instead of ~once per token lifetime — risking refresh-token throttling or rotation.
-    if (!ccData && dbTokens && dbTokens.refreshToken &&
-        (sawAuthFailure || tokens.length === 0)) {
-      var refreshed = refreshAccessToken(ctx, dbTokens.refreshToken)
-      if (refreshed) ccData = probeCloudCode(ctx, refreshed)
+    if (!ccData && (sawAuthFailure || tokens.length === 0)) {
+      var refreshTokens = []
+      for (var j = 0; j < dbTokenCandidates.length; j++) {
+        var refreshToken = dbTokenCandidates[j].refreshToken
+        if (refreshToken && refreshTokens.indexOf(refreshToken) === -1) refreshTokens.push(refreshToken)
+      }
+      for (var k = 0; k < refreshTokens.length; k++) {
+        var refreshed = refreshAccessToken(ctx, refreshTokens[k])
+        if (!refreshed) continue
+        var refreshedData = probeCloudCode(ctx, refreshed)
+        if (refreshedData && !refreshedData._authFailed) {
+          ccData = refreshedData
+          break
+        }
+        if (refreshedData && refreshedData._authFailed) ccData = refreshedData
+      }
+    }
+
+    if (!ccData || ccData._authFailed) {
+      var cliToken = loadCliKeychainToken(ctx)
+      if (cliToken && tokens.indexOf(cliToken) === -1) {
+        var cliResult = probeCliCloudCode(ctx, cliToken)
+        if (cliResult && !cliResult._authFailed) return cliResult
+        if (cliResult && cliResult._authFailed) ccData = cliResult
+      }
     }
 
     if (ccData && !ccData._authFailed) {
@@ -506,7 +683,7 @@
       if (lines.length > 0) return { plan: null, lines: lines }
     }
 
-    throw "Start Antigravity and try again."
+    throw LOGIN_MESSAGE
   }
 
   globalThis.__openusage_plugin = { id: "antigravity", probe: probe }

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -97,6 +97,32 @@ function makeCloudCodeResponse(overrides) {
   )
 }
 
+function makeCliLoadResponse(overrides) {
+  return Object.assign(
+    {
+      cloudaicompanionProject: "gold-signer-test",
+      paidTier: { name: "Gemini Code Assist in Google One AI Pro" },
+    },
+    overrides
+  )
+}
+
+function makeCliQuotaResponse(overrides) {
+  return Object.assign(
+    {
+      buckets: [
+        {
+          modelId: "gemini-3-pro-preview",
+          tokenType: "REQUESTS",
+          remainingFraction: 0.25,
+          resetTime: "2026-02-08T12:00:00Z",
+        },
+      ],
+    },
+    overrides
+  )
+}
+
 function setupLsMock(ctx, discovery, responseBody) {
   ctx.host.ls.discover.mockReturnValue(discovery)
   ctx.host.http.request.mockImplementation((opts) => {
@@ -161,7 +187,11 @@ describe("antigravity plugin", () => {
     const ctx = makeCtx()
     ctx.host.ls.discover.mockReturnValue(null)
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
+    expect(ctx.host.ls.discover).toHaveBeenCalledWith(expect.objectContaining({
+      processName: "language_server",
+      markers: ["antigravity", "antigravity-ide"],
+    }))
   })
 
   it("throws when no working port found and no DB credentials", async () => {
@@ -171,7 +201,7 @@ describe("antigravity plugin", () => {
       throw new Error("connection refused")
     })
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
   })
 
   it("throws when both GetUserStatus and GetCommandModelConfigs fail", async () => {
@@ -184,7 +214,7 @@ describe("antigravity plugin", () => {
       return { status: 500, bodyText: "" }
     })
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
   })
 
   it("returns models + plan from GetUserStatus", async () => {
@@ -507,6 +537,9 @@ describe("antigravity plugin", () => {
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600
     setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.proto-token", refreshToken: "1//refresh", expirySeconds: futureExpiry }))
     ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.keychain.readGenericPassword.mockImplementation(() => {
+      throw new Error("CLI keychain should not be read when app credentials work")
+    })
 
     let capturedHeaders = null
     ctx.host.http.request.mockImplementation((opts) => {
@@ -524,6 +557,103 @@ describe("antigravity plugin", () => {
     expect(capturedHeaders).toBeTruthy()
     expect(capturedHeaders.Authorization).toBe("Bearer ya29.proto-token")
     expect(capturedHeaders["User-Agent"]).toBe("antigravity")
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+  })
+
+  it("falls back to Antigravity CLI keychain when app credentials are unavailable", async () => {
+    const ctx = makeCtx()
+    setupSqliteMock(ctx, null)
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.keychain.readGenericPassword.mockImplementation((service, account) => {
+      if (service === "gemini" && account === "antigravity") return "Bearer agy-token"
+      return null
+    })
+
+    let capturedHeaders = null
+    let capturedQuotaBody = null
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("loadCodeAssist")) {
+        capturedHeaders = opts.headers
+        return { status: 200, bodyText: JSON.stringify(makeCliLoadResponse()) }
+      }
+      if (String(opts.url).includes("retrieveUserQuota")) {
+        capturedQuotaBody = JSON.parse(opts.bodyText)
+        return {
+          status: 200,
+          bodyText: JSON.stringify(makeCliQuotaResponse()),
+        }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("gemini", "antigravity")
+    expect(capturedHeaders.Authorization).toBe("Bearer agy-token")
+    expect(capturedHeaders["User-Agent"]).toBe("agy")
+    expect(capturedQuotaBody).toEqual({ project: "gold-signer-test" })
+    expect(result.plan).toBe("Gemini Code Assist in Google One AI Pro")
+    expect(result.lines.find((l) => l.label === "Gemini Pro").used).toBe(75)
+  })
+
+  it("loads go-keyring-base64 wrapped JSON from Antigravity CLI keychain", async () => {
+    const ctx = makeCtx()
+    setupSqliteMock(ctx, null)
+    ctx.host.ls.discover.mockReturnValue(null)
+    const encoded = ctx.base64.encode(JSON.stringify({ tokens: { access_token: "agy-json-token" } }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue("go-keyring-base64:" + encoded)
+
+    let capturedAuth = null
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("loadCodeAssist")) {
+        return { status: 200, bodyText: JSON.stringify(makeCliLoadResponse()) }
+      }
+      if (String(opts.url).includes("retrieveUserQuota")) {
+        capturedAuth = opts.headers.Authorization
+        return { status: 200, bodyText: JSON.stringify(makeCliQuotaResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuth).toBe("Bearer agy-json-token")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("loads go-keyring-base64 wrapped agy token object from keychain", async () => {
+    const ctx = makeCtx()
+    setupSqliteMock(ctx, null)
+    ctx.host.ls.discover.mockReturnValue(null)
+    const encoded = ctx.base64.encode(JSON.stringify({
+      token: {
+        access_token: "agy-object-token",
+        token_type: "Bearer",
+        refresh_token: "agy-refresh-token",
+      },
+      auth_method: "oauth-personal",
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue("go-keyring-base64:" + encoded)
+
+    let capturedAuth = null
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("loadCodeAssist")) {
+        return { status: 200, bodyText: JSON.stringify(makeCliLoadResponse()) }
+      }
+      if (String(opts.url).includes("retrieveUserQuota")) {
+        capturedAuth = opts.headers.Authorization
+        return { status: 200, bodyText: JSON.stringify(makeCliQuotaResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuth).toBe("Bearer agy-object-token")
+    expect(result.lines.length).toBeGreaterThan(0)
   })
 
   it("Cloud Code returns null on 401/403 (invalid token, no refresh)", async () => {
@@ -541,7 +671,7 @@ describe("antigravity plugin", () => {
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
   })
 
   it("Cloud Code tries multiple base URLs", async () => {
@@ -612,7 +742,7 @@ describe("antigravity plugin", () => {
     ctx.host.ls.discover.mockReturnValue(null)
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
     expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
@@ -696,13 +826,144 @@ describe("antigravity plugin", () => {
     expect(result.lines.length).toBeGreaterThan(0)
   })
 
+  it("tries the official Antigravity IDE SQLite path before the legacy app path", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    const protoB64 = makeOAuthSentinelB64(ctx, { accessToken: "ya29.ide-path", refreshToken: "1//refresh-token", expirySeconds: futureExpiry })
+    ctx.host.sqlite.query.mockImplementation((db) => {
+      if (String(db).includes("Antigravity IDE")) {
+        return JSON.stringify([{ value: protoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    let capturedAuth = null
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url.includes("fetchAvailableModels")) {
+        capturedAuth = opts.headers.Authorization
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    const dbPaths = ctx.host.sqlite.query.mock.calls.map((call) => String(call[0]))
+    expect(dbPaths[0]).toContain("Antigravity IDE/User/globalStorage/state.vscdb")
+    expect(dbPaths[1]).toContain("Antigravity/User/globalStorage/state.vscdb")
+    expect(capturedAuth).toBe("Bearer ya29.ide-path")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("tries later SQLite DB access tokens when an earlier DB token is rejected", async () => {
+    const ctx = makeCtx()
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    const ideProtoB64 = makeOAuthSentinelB64(ctx, {
+      accessToken: "ya29.stale-ide-token",
+      refreshToken: null,
+      expirySeconds: futureExpiry,
+    })
+    const appProtoB64 = makeOAuthSentinelB64(ctx, {
+      accessToken: "ya29.valid-app-token",
+      refreshToken: "1//app-refresh",
+      expirySeconds: futureExpiry,
+    })
+    ctx.host.sqlite.query.mockImplementation((db) => {
+      if (String(db).includes("Antigravity IDE/User/globalStorage")) {
+        return JSON.stringify([{ value: ideProtoB64 }])
+      }
+      if (String(db).includes("Antigravity/User/globalStorage")) {
+        return JSON.stringify([{ value: appProtoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url.includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        if (opts.headers.Authorization === "Bearer ya29.stale-ide-token") {
+          return { status: 401, bodyText: '{"error":"unauthorized"}' }
+        }
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuths).toEqual([
+      "Bearer ya29.stale-ide-token",
+      "Bearer ya29.valid-app-token",
+    ])
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("tries later SQLite DB refresh tokens when an earlier DB refresh fails", async () => {
+    const ctx = makeCtx()
+    const pastExpiry = Math.floor(Date.now() / 1000) - 3600
+    const ideProtoB64 = makeOAuthSentinelB64(ctx, {
+      accessToken: "ya29.expired-ide-token",
+      refreshToken: "1//bad-ide-refresh",
+      expirySeconds: pastExpiry,
+    })
+    const appProtoB64 = makeOAuthSentinelB64(ctx, {
+      accessToken: "ya29.expired-app-token",
+      refreshToken: "1//valid-app-refresh",
+      expirySeconds: pastExpiry,
+    })
+    ctx.host.sqlite.query.mockImplementation((db) => {
+      if (String(db).includes("Antigravity IDE/User/globalStorage")) {
+        return JSON.stringify([{ value: ideProtoB64 }])
+      }
+      if (String(db).includes("Antigravity/User/globalStorage")) {
+        return JSON.stringify([{ value: appProtoB64 }])
+      }
+      return "[]"
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    const refreshBodies = []
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url.includes("oauth2.googleapis.com")) {
+        refreshBodies.push(opts.bodyText)
+        if (String(opts.bodyText).includes(encodeURIComponent("1//bad-ide-refresh"))) {
+          return { status: 400, bodyText: '{"error":"invalid_grant"}' }
+        }
+        return { status: 200, bodyText: JSON.stringify({ access_token: "ya29.refreshed-app" }) }
+      }
+      if (url.includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(refreshBodies.length).toBe(2)
+    expect(refreshBodies[0]).toContain(encodeURIComponent("1//bad-ide-refresh"))
+    expect(refreshBodies[1]).toContain(encodeURIComponent("1//valid-app-refresh"))
+    expect(capturedAuths).toEqual(["Bearer ya29.refreshed-app"])
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
   it("throws when unified oauth envelope is missing and no cache", async () => {
     const ctx = makeCtx()
     setupSqliteMock(ctx, null)
     ctx.host.ls.discover.mockReturnValue(null)
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
     expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
@@ -712,7 +973,7 @@ describe("antigravity plugin", () => {
     ctx.host.ls.discover.mockReturnValue(null)
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
     expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
@@ -791,7 +1052,7 @@ describe("antigravity plugin", () => {
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
   })
 
   it("tries DB token first, then cached on auth failure", async () => {
@@ -975,7 +1236,7 @@ describe("antigravity plugin", () => {
     }))
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
     expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
@@ -1015,7 +1276,7 @@ describe("antigravity plugin", () => {
     ctx.host.fs.writeText(cachePath, "{bad json")
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
     expect(ctx.host.http.request).not.toHaveBeenCalled()
   })
 
@@ -1243,7 +1504,7 @@ describe("antigravity plugin", () => {
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
   })
 
   it("handles refresh response missing access_token", async () => {
@@ -1266,7 +1527,7 @@ describe("antigravity plugin", () => {
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
     expect(oauthCalls).toBe(1)
   })
 
@@ -1451,7 +1712,7 @@ describe("antigravity plugin", () => {
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
     expect(refreshCalls).toBe(0)
   })
 
@@ -1481,7 +1742,7 @@ describe("antigravity plugin", () => {
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity or run `agy` and try again.")
     expect(refreshCalls).toBe(0)
   })
 })

--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -2387,16 +2387,43 @@ fn inject_keychain<'js>(
         "readGenericPassword",
         Function::new(
             ctx.clone(),
-            move |ctx_inner: Ctx<'_>, service: String| -> rquickjs::Result<String> {
+            move |ctx_inner: Ctx<'_>,
+                  service: String,
+                  account: Option<String>|
+                  -> rquickjs::Result<String> {
                 if !cfg!(target_os = "macos") {
                     return Err(Exception::throw_message(
                         &ctx_inner,
                         "keychain API is only supported on macOS",
                     ));
                 }
-                log::info!("[plugin:{}] keychain read: service={}", pid_read, service);
+                let account = account.and_then(|value| {
+                    let trimmed = value.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    }
+                });
+                let redacted_account = account.as_ref().map(|value| redact_value(value));
+
+                if let Some(ref redacted) = redacted_account {
+                    log::info!(
+                        "[plugin:{}] keychain read: service={}, account={}",
+                        pid_read,
+                        service,
+                        redacted
+                    );
+                } else {
+                    log::info!("[plugin:{}] keychain read: service={}", pid_read, service);
+                }
+                let args = if let Some(ref account) = account {
+                    keychain_find_generic_password_args_for_account(&service, account)
+                } else {
+                    keychain_find_generic_password_args(&service)
+                };
                 let output = std::process::Command::new("security")
-                    .args(keychain_find_generic_password_args(&service))
+                    .args(args)
                     .output()
                     .map_err(|e| {
                         Exception::throw_message(
@@ -2408,23 +2435,42 @@ fn inject_keychain<'js>(
                 if !output.status.success() {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     let first_line = stderr.lines().next().unwrap_or("").trim();
-                    log::warn!(
-                        "[plugin:{}] keychain read miss: service={}, error={}",
-                        pid_read,
-                        service,
-                        first_line
-                    );
+                    if let Some(ref redacted) = redacted_account {
+                        log::warn!(
+                            "[plugin:{}] keychain read miss: service={}, account={}, error={}",
+                            pid_read,
+                            service,
+                            redacted,
+                            first_line
+                        );
+                    } else {
+                        log::warn!(
+                            "[plugin:{}] keychain read miss: service={}, error={}",
+                            pid_read,
+                            service,
+                            first_line
+                        );
+                    }
                     return Err(Exception::throw_message(
                         &ctx_inner,
                         &format!("keychain item not found: {}", first_line),
                     ));
                 }
 
-                log::info!(
-                    "[plugin:{}] keychain read hit: service={}",
-                    pid_read,
-                    service
-                );
+                if let Some(ref redacted) = redacted_account {
+                    log::info!(
+                        "[plugin:{}] keychain read hit: service={}, account={}",
+                        pid_read,
+                        service,
+                        redacted
+                    );
+                } else {
+                    log::info!(
+                        "[plugin:{}] keychain read hit: service={}",
+                        pid_read,
+                        service
+                    );
+                }
                 Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
             },
         )?,


### PR DESCRIPTION
## Summary

- add Antigravity CLI (`agy`) as a fallback inside the existing `antigravity` provider instead of introducing a separate provider
- keep the probe order aligned with the review feedback from #477: local language server first, app SQLite/OAuth Cloud Code fallback second, CLI keychain/Cloud Code fallback last
- try Antigravity IDE SQLite credentials before legacy Antigravity credentials, and try all app SQLite token candidates so stale credentials in one DB do not hide valid credentials in another
- support account-scoped keychain reads with `host.keychain.readGenericPassword(service, account?)`
- document the IDE/App/CLI data sources and why Antigravity should not show guessed Claude/Codex-style token/cost history

Closes #475.

## Why

#477 added an `antigravity-cli` provider, but the review feedback was to consolidate this into one Antigravity provider because the IDE, app, and CLI share the same quota pools. Gemini stays unchanged for now.

This keeps the UI simple: one Antigravity entry, same existing quota rows, more fallback paths when the standalone app or CLI is the only authenticated source.

## Notes

I kept `plugins/antigravity/plugin.json` unchanged, so this does not add new links, rows, or visual layout changes. The provider still shows quota only; local Antigravity transcripts/logs do not expose reliable token/cost accounting.

Manual verification with only the standalone `/Applications/Antigravity.app` installed returned:

```text
Plan: Google AI Pro
Gemini Pro: 0% used
Gemini Flash: 0% used
Claude: 0% used
```

## Validation

- `git diff --check`
- `bun run build`
- `CI=1 bun run test` (1118 tests passed)
- `cargo test --manifest-path src-tauri/Cargo.toml keychain`
- `cargo test --manifest-path src-tauri/Cargo.toml redact_log_message_redacts_account_and_paths`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Keychain API docs to show optional account parameter for password lookups
  * Revised Antigravity provider docs with clearer auth requirements, discovery, and CLI fallback details

* **New Features**
  * Antigravity now supports CLI authentication fallback when other credential methods are unavailable
  * Keychain lookups can be scoped by account

* **User Experience**
  * Improved authentication failure messaging to guide next steps (Antigravity or CLI)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robinebers/openusage/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->