### PR TITLE
[antigravity] Add keychain auth for agy CLI; stop bundle overwriting user plugins on restart

### DIFF
--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -548,7 +548,7 @@
       }
     }
 
-    ctx.host.log.info("no antigravity tokens found in keychain")
+    ctx.host.log.debug("no antigravity tokens found in keychain")
     return null
   }
 

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -457,10 +457,106 @@
     return { plan: plan, lines: lines }
   }
 
+  // --- Keychain auth (Antigravity CLI / Gemini CLI) ---
+
+  var KEYCHAIN_SERVICE_NAMES = ["gemini", "gemini-cli-oauth", "antigravity-cli-oauth"]
+
+  var KEYCHAIN_GO_PREFIX = "go-keyring-base64:"
+
+  function decodeGoKeyringValue(raw, ctx) {
+    if (typeof raw !== "string") return null
+    var trimmed = raw.replace(/^\s+|\s+$/g, "")
+    if (trimmed.indexOf(KEYCHAIN_GO_PREFIX) !== 0) return null
+    var b64 = trimmed.substring(KEYCHAIN_GO_PREFIX.length)
+    var decoded = ctx.base64.decode(b64)
+    if (!decoded) return null
+    return ctx.util.tryParseJson(decoded)
+  }
+
+  function extractTokens(parsed) {
+    if (!parsed || typeof parsed !== "object") return null
+
+    var accessToken = null
+    var refreshToken = null
+    var expirySeconds = null
+
+    // Go keyring format: { token: { access_token, refresh_token, expiry }, auth_method }
+    if (parsed.token && typeof parsed.token === "object") {
+      var t = parsed.token
+      accessToken = t.access_token || null
+      refreshToken = t.refresh_token || null
+      if (t.expiry) {
+        var ms = Date.parse(t.expiry)
+        if (!isNaN(ms)) expirySeconds = Math.floor(ms / 1000)
+      }
+    }
+
+    // Direct format: { accessToken, refreshToken } or { access_token, refresh_token }
+    if (!accessToken) accessToken = parsed.accessToken || parsed.access_token || null
+    if (!refreshToken) refreshToken = parsed.refreshToken || parsed.refresh_token || null
+
+    // Nested tokens object (Codex-style format)
+    if (!accessToken && parsed.tokens && typeof parsed.tokens === "object") {
+      var t = parsed.tokens
+      accessToken = t.accessToken || t.access_token || null
+      if (!refreshToken) refreshToken = t.refreshToken || t.refresh_token || null
+    }
+
+    if (!accessToken && !refreshToken) return null
+
+    if (expirySeconds === null) {
+      if (parsed.expiresAt != null) {
+        expirySeconds = Math.floor(Number(parsed.expiresAt) / 1000)
+      } else if (parsed.expiresAtMs != null) {
+        expirySeconds = Math.floor(Number(parsed.expiresAtMs) / 1000)
+      } else if (parsed.expirySeconds != null) {
+        expirySeconds = Number(parsed.expirySeconds)
+      } else if (parsed.expiry_seconds != null) {
+        expirySeconds = Number(parsed.expiry_seconds)
+      }
+    }
+
+    return { accessToken: accessToken, refreshToken: refreshToken, expirySeconds: expirySeconds }
+  }
+
+  function loadKeychainTokens(ctx) {
+    if (!ctx.host.keychain || typeof ctx.host.keychain.readGenericPassword !== "function") {
+      return null
+    }
+
+    for (var i = 0; i < KEYCHAIN_SERVICE_NAMES.length; i++) {
+      try {
+        var value = ctx.host.keychain.readGenericPassword(KEYCHAIN_SERVICE_NAMES[i])
+        if (!value) continue
+
+        var parsed = ctx.util.tryParseJson(value)
+
+        // Try go-keyring base64 envelope (Antigravity CLI / Go keyring format)
+        if (!parsed) {
+          parsed = decodeGoKeyringValue(value, ctx)
+        }
+
+        if (!parsed || typeof parsed !== "object") continue
+
+        var tokens = extractTokens(parsed)
+        if (!tokens) continue
+
+        ctx.host.log.info("tokens loaded from keychain: " + KEYCHAIN_SERVICE_NAMES[i])
+        return tokens
+      } catch (e) {
+        ctx.host.log.warn("keychain read failed (" + KEYCHAIN_SERVICE_NAMES[i] + "): " + String(e))
+      }
+    }
+
+    ctx.host.log.info("no antigravity tokens found in keychain")
+    return null
+  }
+
   // --- Probe ---
 
   function probe(ctx) {
     var dbTokens = loadOAuthTokens(ctx)
+    var keychainTokens = loadKeychainTokens(ctx)
 
     var lsResult = probeLs(ctx)
     if (lsResult) return lsResult
@@ -475,7 +571,17 @@
     var cached = loadCachedToken(ctx)
     if (cached && tokens.indexOf(cached) === -1) tokens.push(cached)
 
-    if (tokens.length === 0 && !(dbTokens && dbTokens.refreshToken)) {
+    if (keychainTokens && keychainTokens.accessToken) {
+      if (!keychainTokens.expirySeconds || keychainTokens.expirySeconds > Math.floor(Date.now() / 1000)) {
+        if (tokens.indexOf(keychainTokens.accessToken) === -1) tokens.push(keychainTokens.accessToken)
+      }
+    }
+
+    var refreshToken = null
+    if (dbTokens && dbTokens.refreshToken) refreshToken = dbTokens.refreshToken
+    else if (keychainTokens && keychainTokens.refreshToken) refreshToken = keychainTokens.refreshToken
+
+    if (tokens.length === 0 && !refreshToken) {
       throw "Start Antigravity and try again."
     }
 
@@ -494,9 +600,8 @@
     // probeCloudCode returns null for transient failures (5xx/timeouts); without this
     // guard a Cloud Code incident would trigger a Google OAuth refresh every probe cycle
     // instead of ~once per token lifetime — risking refresh-token throttling or rotation.
-    if (!ccData && dbTokens && dbTokens.refreshToken &&
-        (sawAuthFailure || tokens.length === 0)) {
-      var refreshed = refreshAccessToken(ctx, dbTokens.refreshToken)
+    if (!ccData && refreshToken && (sawAuthFailure || tokens.length === 0)) {
+      var refreshed = refreshAccessToken(ctx, refreshToken)
       if (refreshed) ccData = probeCloudCode(ctx, refreshed)
     }
 

--- a/plugins/antigravity/plugin.js
+++ b/plugins/antigravity/plugin.js
@@ -506,13 +506,17 @@
 
     if (expirySeconds === null) {
       if (parsed.expiresAt != null) {
-        expirySeconds = Math.floor(Number(parsed.expiresAt) / 1000)
+        var ea = Number(parsed.expiresAt)
+        if (Number.isFinite(ea)) expirySeconds = Math.floor(ea / 1000)
       } else if (parsed.expiresAtMs != null) {
-        expirySeconds = Math.floor(Number(parsed.expiresAtMs) / 1000)
+        var em = Number(parsed.expiresAtMs)
+        if (Number.isFinite(em)) expirySeconds = Math.floor(em / 1000)
       } else if (parsed.expirySeconds != null) {
-        expirySeconds = Number(parsed.expirySeconds)
+        var es = Number(parsed.expirySeconds)
+        if (Number.isFinite(es)) expirySeconds = es
       } else if (parsed.expiry_seconds != null) {
-        expirySeconds = Number(parsed.expiry_seconds)
+        var es2 = Number(parsed.expiry_seconds)
+        if (Number.isFinite(es2)) expirySeconds = es2
       }
     }
 

--- a/plugins/antigravity/plugin.test.js
+++ b/plugins/antigravity/plugin.test.js
@@ -1484,4 +1484,286 @@ describe("antigravity plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
     expect(refreshCalls).toBe(0)
   })
+
+  // --- Keychain auth tests ---
+
+  it("uses keychain token from gemini service name when LS and DB unavailable", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini") {
+        return JSON.stringify({ accessToken: "ya29.keychain-token", refreshToken: "1//refresh", expiresAt: Date.now() + 3600000 })
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuths[0]).toBe("Bearer ya29.keychain-token")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("uses keychain token from gemini-cli-oauth fallback service name", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini-cli-oauth") {
+        return JSON.stringify({ accessToken: "ya29.cli-oauth-token", refreshToken: "1//refresh", expiresAt: Date.now() + 3600000 })
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuths[0]).toBe("Bearer ya29.cli-oauth-token")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("tries antigravity-cli-oauth when gemini-cli-oauth has no entry", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "antigravity-cli-oauth") {
+        return JSON.stringify({ accessToken: "ya29.ag-cli-token", refreshToken: "1//refresh", expiresAt: Date.now() + 3600000 })
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuths[0]).toBe("Bearer ya29.ag-cli-token")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("skips expired keychain token and throws", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini-cli-oauth") {
+        return JSON.stringify({ accessToken: "ya29.expired-keychain", expiresAt: Date.now() - 1000 })
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Start Antigravity and try again.")
+    expect(ctx.host.http.request).not.toHaveBeenCalled()
+  })
+
+  it("uses keychain refresh token to call Cloud Code", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini-cli-oauth") {
+        return JSON.stringify({ refreshToken: "1//keychain-refresh", expiresAt: Date.now() + 3600000 })
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    let oauthCalled = false
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url.includes("oauth2.googleapis.com")) {
+        oauthCalled = true
+        return { status: 200, bodyText: JSON.stringify({ access_token: "ya29.refreshed-from-kc" }) }
+      }
+      if (url.includes("fetchAvailableModels")) {
+        if (opts.headers.Authorization === "Bearer ya29.refreshed-from-kc") {
+          return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+        }
+        return { status: 401, bodyText: "{}" }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(oauthCalled).toBe(true)
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("prefers DB token over keychain token", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini-cli-oauth") {
+        return JSON.stringify({ accessToken: "ya29.keychain", refreshToken: "1//refresh", expiresAt: Date.now() + 3600000 })
+      }
+      return null
+    })
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600
+    setupSqliteMock(ctx, makeOAuthSentinelB64(ctx, { accessToken: "ya29.db-token", refreshToken: "1//db-refresh", expirySeconds: futureExpiry }))
+    ctx.host.ls.discover.mockReturnValue(null)
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    // DB token used first (not keychain)
+    expect(capturedAuths[0]).toBe("Bearer ya29.db-token")
+  })
+
+  it("parses keychain token with snake_case fields", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini-cli-oauth") {
+        return JSON.stringify({ access_token: "ya29.snake-token", refresh_token: "1//refresh", expires_at: Date.now() + 3600000 })
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuths[0]).toBe("Bearer ya29.snake-token")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("parses keychain token with nested tokens.access_token format", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini-cli-oauth") {
+        return JSON.stringify({ tokens: { access_token: "ya29.nested-token", refresh_token: "1//nested" }, last_refresh: new Date().toISOString() })
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuths[0]).toBe("Bearer ya29.nested-token")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("uses keychain token with expiresAtMs field", async () => {
+    const ctx = makeCtx()
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini-cli-oauth") {
+        return JSON.stringify({ accessToken: "ya29.ms-token", refreshToken: "1//refresh", expiresAtMs: Date.now() + 3600000 })
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuths[0]).toBe("Bearer ya29.ms-token")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
+
+  it("decodes go-keyring base64 envelope (Antigravity CLI format)", async () => {
+    const ctx = makeCtx()
+    // Simulate the go-keyring library format used by the Antigravity CLI (agy)
+    const tokenPayload = {
+      token: {
+        access_token: "ya29.go-keyring-token",
+        refresh_token: "1//go-keyring-refresh",
+        token_type: "Bearer",
+        expiry: "2026-12-31T23:59:59Z",
+      },
+      auth_method: "consumer",
+    }
+    const b64 = ctx.base64.encode(JSON.stringify(tokenPayload))
+    const keychainValue = "go-keyring-base64:" + b64
+
+    ctx.host.keychain.readGenericPassword.mockImplementation((service) => {
+      if (service === "gemini") {
+        return keychainValue
+      }
+      return null
+    })
+    ctx.host.ls.discover.mockReturnValue(null)
+    ctx.host.sqlite.query.mockReturnValue("[]")
+
+    const capturedAuths = []
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("fetchAvailableModels")) {
+        capturedAuths.push(opts.headers.Authorization)
+        return { status: 200, bodyText: JSON.stringify(makeCloudCodeResponse()) }
+      }
+      return { status: 500, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(capturedAuths[0]).toBe("Bearer ya29.go-keyring-token")
+    expect(result.lines.length).toBeGreaterThan(0)
+  })
 })

--- a/src-tauri/src/plugin_engine/mod.rs
+++ b/src-tauri/src/plugin_engine/mod.rs
@@ -100,6 +100,9 @@ fn copy_dir_recursive(src: &Path, dst: &Path) {
                     }
                     copy_dir_recursive(&src_path, &dst_path);
                 } else if file_type.is_file() {
+                    if dst_path.exists() {
+                        continue;
+                    }
                     if let Err(err) = std::fs::copy(&src_path, &dst_path) {
                         log::warn!(
                             "failed to copy {} to {}: {}",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds keychain-based auth for the Antigravity/Gemini CLI so the plugin can use tokens from the OS keychain when LS/DB are unavailable. Also prevents app restarts from overwriting user-installed plugins.

- **New Features**
  - Reads tokens from OS keychain using service names: gemini, gemini-cli-oauth, antigravity-cli-oauth.
  - Supports go-keyring base64 envelope and common JSON shapes (access_token/refresh_token, nested tokens, expiry fields).
  - Prefers DB tokens; uses non-expired keychain access tokens or refreshes via keychain refresh token when needed.

- **Bug Fixes**
  - Skip copying plugin files if the destination already exists in `src-tauri` to avoid overwriting user plugins.
  - Guard keychain expiry parsing against NaN to avoid invalid token handling.

<sup>Written for commit 8c5e8394bfd7fd4de3e4274bf77002a34ffb9236. Summary will update on new commits. <a href="https://cubic.dev/pr/robinebers/openusage/pull/514?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

