### PR TITLE
fix(minimax): handle CN percent-only quotas

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -78,9 +78,14 @@ Expected payload fields:
 - **Plan**: best-effort from API payload (normalized to concise label, with ` (CN)` or ` (GLOBAL)` suffix)
 - **Session** (overview progress line):
   - `label`: `Session`
-  - `format`: count (`prompts`)
-  - `used`: computed used prompts
-  - `limit`: total prompt limit for current window
+  - Count format when totals are available:
+    - `format`: count (`prompts`)
+    - `used`: computed used prompts
+    - `limit`: total prompt limit for current window
+  - Percent format when totals are unavailable but remaining percent is present:
+    - `format`: percent
+    - `used`: `100 - current_interval_remaining_percent`
+    - `limit`: `100`
   - `resetsAt`: derived from `end_time` or `remains_time`
 
 ## Errors

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -54,6 +54,7 @@ Expected payload fields:
 - `model_remains[].current_interval_total_count`
 - `model_remains[].current_interval_usage_count`
 - optional remaining aliases (`current_interval_remaining_count`, `current_interval_remains_count`)
+- optional remaining percent fields (`current_interval_remaining_percent`)
 - `model_remains[].start_time`
 - `model_remains[].end_time`
 - `model_remains[].remains_time`
@@ -64,6 +65,7 @@ Expected payload fields:
 - Treat `current_interval_usage_count` as remaining prompts (MiniMax remains API behavior).
 - If only remaining aliases are provided, compute `used = total - remaining`.
 - If explicit used-count fields are provided, prefer them.
+- If count totals are unavailable but a remaining percentage is provided, render a percent progress line.
 - Plan name is taken from explicit plan/title fields when available.
 - If plan fields are missing in GLOBAL mode, infer plan tier from known limits (`100/300/1000/2000` prompts or `1500/4500/15000/30000` model-call equivalents).
 - If plan fields are missing in CN mode, infer only exact known CN limits (`600/1500/4500` model-call counts).

--- a/plugins/minimax/plugin.js
+++ b/plugins/minimax/plugin.js
@@ -245,7 +245,9 @@
     if (!modelRemains || modelRemains.length === 0) return null
 
     const displayMultiplierForSelection = endpointSelection === "CN" ? 1 / MODEL_CALLS_PER_PROMPT : 1
-    let chosen = modelRemains[0]
+    let chosen = null
+    let percentFallbackCandidate = null
+    let generalPercentFallbackCandidate = null
     for (let i = 0; i < modelRemains.length; i += 1) {
       const item = modelRemains[i]
       if (!item || typeof item !== "object") continue
@@ -254,11 +256,24 @@
         chosen = item
         break
       }
+      const remainingPercent = readNumber(
+        item.current_interval_remaining_percent ?? item.currentIntervalRemainingPercent
+      )
+      if (remainingPercent !== null && remainingPercent >= 0 && remainingPercent <= 100) {
+        const modelName = readString(item.model_name ?? item.modelName)
+        if (!percentFallbackCandidate) percentFallbackCandidate = item
+        if (!generalPercentFallbackCandidate && modelName === "general") {
+          generalPercentFallbackCandidate = item
+        }
+      }
     }
+    if (!chosen) chosen = generalPercentFallbackCandidate || percentFallbackCandidate
 
     if (!chosen || typeof chosen !== "object") return null
 
     const total = readNumber(chosen.current_interval_total_count ?? chosen.currentIntervalTotalCount)
+    const hasDisplayableCount =
+      total !== null && total > 0 && Math.round(total * displayMultiplierForSelection) > 0
     const startMs = epochToMs(chosen.start_time ?? chosen.startTime)
     const endMs = epochToMs(chosen.end_time ?? chosen.endTime)
     const remainsRaw = readNumber(chosen.remains_time ?? chosen.remainsTime)
@@ -288,7 +303,7 @@
     const inferredPlanName = inferPlanNameFromLimit(total, endpointSelection)
     const planName = explicitPlanName || inferredPlanName
 
-    if (total === null || total <= 0) {
+    if (!hasDisplayableCount) {
       const remainingPercent = readNumber(
         chosen.current_interval_remaining_percent ?? chosen.currentIntervalRemainingPercent
       )

--- a/plugins/minimax/plugin.js
+++ b/plugins/minimax/plugin.js
@@ -244,12 +244,13 @@
 
     if (!modelRemains || modelRemains.length === 0) return null
 
+    const displayMultiplierForSelection = endpointSelection === "CN" ? 1 / MODEL_CALLS_PER_PROMPT : 1
     let chosen = modelRemains[0]
     for (let i = 0; i < modelRemains.length; i += 1) {
       const item = modelRemains[i]
       if (!item || typeof item !== "object") continue
       const total = readNumber(item.current_interval_total_count ?? item.currentIntervalTotalCount)
-      if (total !== null && total > 0) {
+      if (total !== null && total > 0 && Math.round(total * displayMultiplierForSelection) > 0) {
         chosen = item
         break
       }
@@ -258,7 +259,51 @@
     if (!chosen || typeof chosen !== "object") return null
 
     const total = readNumber(chosen.current_interval_total_count ?? chosen.currentIntervalTotalCount)
-    if (total === null || total <= 0) return null
+    const startMs = epochToMs(chosen.start_time ?? chosen.startTime)
+    const endMs = epochToMs(chosen.end_time ?? chosen.endTime)
+    const remainsRaw = readNumber(chosen.remains_time ?? chosen.remainsTime)
+    const nowMs = Date.now()
+    const remainsMs = inferRemainsMs(remainsRaw, endMs, nowMs)
+
+    let resetsAt = endMs !== null ? ctx.util.toIso(endMs) : null
+    if (!resetsAt && remainsMs !== null) {
+      resetsAt = ctx.util.toIso(nowMs + remainsMs)
+    }
+
+    let periodDurationMs = null
+    if (startMs !== null && endMs !== null && endMs > startMs) {
+      periodDurationMs = endMs - startMs
+    }
+
+    const explicitPlanName = normalizePlanName(pickFirstString([
+      data.current_subscribe_title,
+      data.plan_name,
+      data.plan,
+      data.current_plan_title,
+      data.combo_title,
+      payload.current_subscribe_title,
+      payload.plan_name,
+      payload.plan,
+    ]))
+    const inferredPlanName = inferPlanNameFromLimit(total, endpointSelection)
+    const planName = explicitPlanName || inferredPlanName
+
+    if (total === null || total <= 0) {
+      const remainingPercent = readNumber(
+        chosen.current_interval_remaining_percent ?? chosen.currentIntervalRemainingPercent
+      )
+      if (remainingPercent !== null && remainingPercent >= 0 && remainingPercent <= 100) {
+        return {
+          planName: planName || "Coding Plan",
+          used: 100 - remainingPercent,
+          total: 100,
+          resetsAt,
+          periodDurationMs,
+          formatKind: "percent",
+        }
+      }
+      return null
+    }
 
     const usageFieldCount = readNumber(chosen.current_interval_usage_count ?? chosen.currentIntervalUsageCount)
     const remainingCount = readNumber(
@@ -291,35 +336,6 @@
     if (used === null) return null
     if (used < 0) used = 0
     if (used > total) used = total
-
-    const startMs = epochToMs(chosen.start_time ?? chosen.startTime)
-    const endMs = epochToMs(chosen.end_time ?? chosen.endTime)
-    const remainsRaw = readNumber(chosen.remains_time ?? chosen.remainsTime)
-    const nowMs = Date.now()
-    const remainsMs = inferRemainsMs(remainsRaw, endMs, nowMs)
-
-    let resetsAt = endMs !== null ? ctx.util.toIso(endMs) : null
-    if (!resetsAt && remainsMs !== null) {
-      resetsAt = ctx.util.toIso(nowMs + remainsMs)
-    }
-
-    let periodDurationMs = null
-    if (startMs !== null && endMs !== null && endMs > startMs) {
-      periodDurationMs = endMs - startMs
-    }
-
-    const explicitPlanName = normalizePlanName(pickFirstString([
-      data.current_subscribe_title,
-      data.plan_name,
-      data.plan,
-      data.current_plan_title,
-      data.combo_title,
-      payload.current_subscribe_title,
-      payload.plan_name,
-      payload.plan,
-    ]))
-    const inferredPlanName = inferPlanNameFromLimit(total, endpointSelection)
-    const planName = explicitPlanName || inferredPlanName
 
     return {
       planName,
@@ -367,12 +383,20 @@
     const isCnEndpoint = successfulEndpoint === "CN"
     const displayMultiplier = isCnEndpoint ? 1 / MODEL_CALLS_PER_PROMPT : 1
 
-    const line = {
-      label: "Session",
-      used: Math.round(parsed.used * displayMultiplier),
-      limit: Math.round(parsed.total * displayMultiplier),
-      format: { kind: "count", suffix: "prompts" },
-    }
+    const line =
+      parsed.formatKind === "percent"
+        ? {
+            label: "Session",
+            used: Math.round(parsed.used),
+            limit: 100,
+            format: { kind: "percent" },
+          }
+        : {
+            label: "Session",
+            used: Math.round(parsed.used * displayMultiplier),
+            limit: Math.round(parsed.total * displayMultiplier),
+            format: { kind: "count", suffix: "prompts" },
+          }
     if (parsed.resetsAt) line.resetsAt = parsed.resetsAt
     if (parsed.periodDurationMs !== null) line.periodDurationMs = parsed.periodDurationMs
 

--- a/plugins/minimax/plugin.test.js
+++ b/plugins/minimax/plugin.test.js
@@ -925,6 +925,42 @@ describe("minimax plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Could not parse usage data")
   })
 
+  it("falls back to CN remaining percent when count totals are unavailable", async () => {
+    const ctx = makeCtx()
+    setEnv(ctx, { MINIMAX_CN_API_KEY: "mini-cn-key" })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        base_resp: { status_code: 0 },
+        model_remains: [
+          {
+            model_name: "general",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 94,
+            start_time: 1780279200000,
+            end_time: 1780297200000,
+          },
+          {
+            model_name: "video",
+            current_interval_total_count: 3,
+            current_interval_usage_count: 3,
+            current_interval_remaining_percent: 100,
+          },
+        ],
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Coding Plan (CN)")
+    expect(result.lines[0].used).toBe(6)
+    expect(result.lines[0].limit).toBe(100)
+    expect(result.lines[0].format).toEqual({ kind: "percent" })
+  })
+
   it("throws parse error when both used and remaining counts are missing", async () => {
     const ctx = makeCtx()
     setEnv(ctx, { MINIMAX_API_KEY: "mini-key" })

--- a/plugins/minimax/plugin.test.js
+++ b/plugins/minimax/plugin.test.js
@@ -961,6 +961,42 @@ describe("minimax plugin", () => {
     expect(result.lines[0].format).toEqual({ kind: "percent" })
   })
 
+  it("falls back to CN remaining percent when small count rows come first", async () => {
+    const ctx = makeCtx()
+    setEnv(ctx, { MINIMAX_CN_API_KEY: "mini-cn-key" })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        base_resp: { status_code: 0 },
+        model_remains: [
+          {
+            model_name: "video",
+            current_interval_total_count: 3,
+            current_interval_usage_count: 3,
+            current_interval_remaining_percent: 100,
+          },
+          {
+            model_name: "general",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 94,
+            start_time: 1780279200000,
+            end_time: 1780297200000,
+          },
+        ],
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Coding Plan (CN)")
+    expect(result.lines[0].used).toBe(6)
+    expect(result.lines[0].limit).toBe(100)
+    expect(result.lines[0].format).toEqual({ kind: "percent" })
+  })
+
   it("throws parse error when both used and remaining counts are missing", async () => {
     const ctx = makeCtx()
     setEnv(ctx, { MINIMAX_API_KEY: "mini-key" })


### PR DESCRIPTION
## Summary

- handle MiniMax CN Coding Plan responses where `current_interval_total_count` is `0` but `current_interval_remaining_percent` is present
- avoid selecting CN count totals that round down to `0` prompts after the model-call-to-prompt conversion
- document the percent fallback and add a regression test based on a sanitized MiniMax CN payload

## Problem

Some MiniMax CN Coding Plan accounts return a usable percentage quota but no count total for the `general` model, for example:

```text
model_name = general
current_interval_total_count = 0
current_interval_usage_count = 0
current_interval_remaining_percent = 94
current_weekly_total_count = 0
current_weekly_usage_count = 0
current_weekly_remaining_percent = 99
```

The existing plugin expects a positive `current_interval_total_count`. For CN, small model-call totals can also round down to `0` prompts after dividing by 15. That produces a progress line with `limit: 0`, which the runtime rejects with:

```text
progress line at index 0 invalid limit: 0
```

## Fix

When counts are unavailable but `current_interval_remaining_percent` is valid, the MiniMax plugin now returns a percent progress line with `limit: 100`. For the example above, the line renders as `used: 6`, `limit: 100`, `format: { kind: "percent" }`.

## Testing

- `npm install --no-package-lock`
- `npm exec vitest -- run plugins/minimax/plugin.test.js`
  - 43 tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a percent-based fallback to the MiniMax CN plugin and avoids zero-limit progress lines by skipping CN totals that round to 0 prompts. This fixes rejected progress lines and shows accurate usage when only percentages are provided.

- **Bug Fixes**
  - Return a percent progress line (limit: 100) when `current_interval_total_count` is `0` but `current_interval_remaining_percent` exists.
  - For CN, skip totals that round to `0` prompts after the model-call→prompt conversion and prefer the `general` model when only percent data is available.
  - Update docs and add tests for percent-only CN quotas and for cases where small-count rows come first.

<sup>Written for commit ea42413804eef8d89c3b8571394952736270a67d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MiniMax provider now supports percent-based usage display when explicit usage counts are unavailable and better detects plan titles.

* **Documentation**
  * Updated MiniMax docs to document the new percent-based progress field and show percent-rendering behavior.

* **Tests**
  * Added tests covering percent-based remaining-usage fallback and rendering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->