### PR TITLE
Update MiniMax API endpoint from coding_plan to token_plan

### DIFF
--- a/plugins/minimax/plugin.js
+++ b/plugins/minimax/plugin.js
@@ -1,11 +1,10 @@
 (function () {
-  const GLOBAL_PRIMARY_USAGE_URL = "https://api.minimax.io/v1/api/openplatform/coding_plan/remains"
+  const GLOBAL_PRIMARY_USAGE_URL = "https://www.minimax.io/v1/token_plan/remains"
   const GLOBAL_FALLBACK_USAGE_URLS = [
-    "https://api.minimax.io/v1/coding_plan/remains",
-    "https://www.minimax.io/v1/api/openplatform/coding_plan/remains",
+    "https://www.minimax.io/v1/token_plan/remains",
   ]
-  const CN_PRIMARY_USAGE_URL = "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains"
-  const CN_FALLBACK_USAGE_URLS = ["https://api.minimaxi.com/v1/coding_plan/remains"]
+  const CN_PRIMARY_USAGE_URL = "https://api.minimaxi.com/v1/token_plan/remains"
+  const CN_FALLBACK_USAGE_URLS = ["https://api.minimaxi.com/v1/token_plan/remains"]
   const GLOBAL_API_KEY_ENV_VARS = ["MINIMAX_API_KEY", "MINIMAX_API_TOKEN"]
   const CN_API_KEY_ENV_VARS = ["MINIMAX_CN_API_KEY", "MINIMAX_API_KEY", "MINIMAX_API_TOKEN"]
   const CODING_PLAN_WINDOW_MS = 5 * 60 * 60 * 1000

--- a/plugins/minimax/plugin.js
+++ b/plugins/minimax/plugin.js
@@ -412,11 +412,12 @@
     // GLOBAL API returns prompt counts directly
     const isCnEndpoint = successfulEndpoint === "CN"
     const displayMultiplier = isCnEndpoint ? 1 / MODEL_CALLS_PER_PROMPT : 1
+    const valueMultiplier = parsed.isPercent ? 1 : displayMultiplier
 
     const line = {
       label: "Session",
-      used: Math.round(parsed.used * displayMultiplier),
-      limit: Math.round(parsed.total * displayMultiplier),
+      used: Math.round(parsed.used * valueMultiplier),
+      limit: Math.round(parsed.total * valueMultiplier),
       format: parsed.isPercent
         ? { kind: "percent" }
         : { kind: "count", suffix: "prompts" },

--- a/plugins/minimax/plugin.js
+++ b/plugins/minimax/plugin.js
@@ -257,6 +257,53 @@
     if (!chosen || typeof chosen !== "object") return null
 
     const total = readNumber(chosen.current_interval_total_count ?? chosen.currentIntervalTotalCount)
+    const remainingPercent = readNumber(
+      chosen.current_interval_remaining_percent ??
+        chosen.currentIntervalRemainingPercent
+    )
+
+    // Handle percentage-based response (new Token Plan API)
+    // When total_count is 0 but remaining_percent exists, use percentage mode
+    if ((total === null || total === 0) && remainingPercent !== null) {
+      const percentRemaining = remainingPercent
+      const percentUsed = 100 - percentRemaining
+      const startMs = epochToMs(chosen.start_time ?? chosen.startTime)
+      const endMs = epochToMs(chosen.end_time ?? chosen.endTime)
+      const remainsRaw = readNumber(chosen.remains_time ?? chosen.remainsTime)
+      const nowMs = Date.now()
+      const remainsMs = inferRemainsMs(remainsRaw, endMs, nowMs)
+
+      let resetsAt = endMs !== null ? ctx.util.toIso(endMs) : null
+      if (!resetsAt && remainsMs !== null) {
+        resetsAt = ctx.util.toIso(nowMs + remainsMs)
+      }
+
+      let periodDurationMs = null
+      if (startMs !== null && endMs !== null && endMs > startMs) {
+        periodDurationMs = endMs - startMs
+      }
+
+      const explicitPlanName = normalizePlanName(pickFirstString([
+        data.current_subscribe_title,
+        data.plan_name,
+        data.plan,
+        data.current_plan_title,
+        data.combo_title,
+        payload.current_subscribe_title,
+        payload.plan_name,
+        payload.plan,
+      ]))
+
+      return {
+        planName: explicitPlanName || null,
+        used: percentUsed,
+        total: 100,
+        resetsAt,
+        periodDurationMs,
+        isPercent: true,
+      }
+    }
+
     if (total === null || total <= 0) return null
 
     const usageFieldCount = readNumber(chosen.current_interval_usage_count ?? chosen.currentIntervalUsageCount)
@@ -370,7 +417,9 @@
       label: "Session",
       used: Math.round(parsed.used * displayMultiplier),
       limit: Math.round(parsed.total * displayMultiplier),
-      format: { kind: "count", suffix: "prompts" },
+      format: parsed.isPercent
+        ? { kind: "percent" }
+        : { kind: "count", suffix: "prompts" },
     }
     if (parsed.resetsAt) line.resetsAt = parsed.resetsAt
     if (parsed.periodDurationMs !== null) line.periodDurationMs = parsed.periodDurationMs

--- a/plugins/minimax/plugin.test.js
+++ b/plugins/minimax/plugin.test.js
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { makeCtx } from "../test-helpers.js"
 
-const PRIMARY_USAGE_URL = "https://api.minimax.io/v1/api/openplatform/coding_plan/remains"
-const FALLBACK_USAGE_URL = "https://api.minimax.io/v1/coding_plan/remains"
-const LEGACY_WWW_USAGE_URL = "https://www.minimax.io/v1/api/openplatform/coding_plan/remains"
-const CN_PRIMARY_USAGE_URL = "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains"
-const CN_FALLBACK_USAGE_URL = "https://api.minimaxi.com/v1/coding_plan/remains"
+const PRIMARY_USAGE_URL = "https://www.minimax.io/v1/token_plan/remains"
+const FALLBACK_USAGE_URL = "https://www.minimax.io/v1/token_plan/remains"
+const LEGACY_WWW_USAGE_URL = "https://www.minimax.io/v1/token_plan/remains"
+const CN_PRIMARY_USAGE_URL = "https://api.minimaxi.com/v1/token_plan/remains"
+const CN_FALLBACK_USAGE_URL = "https://api.minimaxi.com/v1/token_plan/remains"
 
 const loadPlugin = async () => {
   await import("./plugin.js")
@@ -441,63 +441,23 @@ describe("minimax plugin", () => {
       message = String(e)
     }
     expect(message).toContain("Session expired")
-    expect(ctx.host.http.request.mock.calls.length).toBe(5)
+    expect(ctx.host.http.request.mock.calls.length).toBe(4)
   })
 
-  it("falls back to secondary endpoint when primary fails", async () => {
+  it("throws when primary endpoint fails", async () => {
     const ctx = makeCtx()
     setEnv(ctx, { MINIMAX_API_KEY: "mini-key" })
-    ctx.host.http.request.mockImplementation((req) => {
-      if (req.url === PRIMARY_USAGE_URL) return { status: 503, headers: {}, bodyText: "{}" }
-      if (req.url === FALLBACK_USAGE_URL) {
-        return {
-          status: 200,
-          headers: {},
-          bodyText: JSON.stringify(successPayload()),
-        }
-      }
-      return { status: 404, headers: {}, bodyText: "{}" }
-    })
-
+    ctx.host.http.request.mockReturnValue({ status: 503, headers: {}, bodyText: "{}" })
     const plugin = await loadPlugin()
-    const result = plugin.probe(ctx)
-
-    expect(result.lines[0].used).toBe(120)
-    expect(ctx.host.http.request.mock.calls.length).toBe(2)
+    expect(() => plugin.probe(ctx)).toThrow("Request failed (HTTP 503)")
   })
 
-  it("uses CN fallback endpoint when CN primary fails", async () => {
+  it("throws when CN primary endpoint fails", async () => {
     const ctx = makeCtx()
     setEnv(ctx, { MINIMAX_CN_API_KEY: "cn-key" })
-    ctx.host.http.request.mockImplementation((req) => {
-      if (req.url === CN_PRIMARY_USAGE_URL) return { status: 503, headers: {}, bodyText: "{}" }
-      if (req.url === CN_FALLBACK_USAGE_URL) {
-        return {
-          status: 200,
-          headers: {},
-          bodyText: JSON.stringify(successPayload({
-            model_remains: [
-              {
-                model_name: "MiniMax-M2",
-                current_interval_total_count: 1500, // CN Plus: 100 prompts × 15
-                current_interval_usage_count: 1200, // Remaining
-                start_time: 1700000000000,
-                end_time: 1700018000000,
-              },
-            ],
-          })),
-        }
-      }
-      return { status: 404, headers: {}, bodyText: "{}" }
-    })
-
+    ctx.host.http.request.mockReturnValue({ status: 503, headers: {}, bodyText: "{}" })
     const plugin = await loadPlugin()
-    const result = plugin.probe(ctx)
-
-    expect(result.lines[0].used).toBe(20) // (1500-1200) / 15 = 20
-    expect(ctx.host.http.request.mock.calls.length).toBe(2)
-    expect(ctx.host.http.request.mock.calls[0][0].url).toBe(CN_PRIMARY_USAGE_URL)
-    expect(ctx.host.http.request.mock.calls[1][0].url).toBe(CN_FALLBACK_USAGE_URL)
+    expect(() => plugin.probe(ctx)).toThrow("Request failed (HTTP 503)")
   })
 
   it("infers CN Starter plan from 600 model-call limit", async () => {
@@ -620,27 +580,12 @@ describe("minimax plugin", () => {
     expect(result.lines[0].used).toBe(200) // (9000-6000) / 15 = 200 prompts
   })
 
-  it("falls back when primary returns auth-like status", async () => {
+  it("throws when primary returns auth-like status", async () => {
     const ctx = makeCtx()
     setEnv(ctx, { MINIMAX_API_KEY: "mini-key" })
-    ctx.host.http.request.mockImplementation((req) => {
-      if (req.url === PRIMARY_USAGE_URL) return { status: 403, headers: {}, bodyText: "<html>cf</html>" }
-      if (req.url === FALLBACK_USAGE_URL) {
-        return {
-          status: 200,
-          headers: {},
-          bodyText: JSON.stringify(successPayload()),
-        }
-      }
-      if (req.url === LEGACY_WWW_USAGE_URL) return { status: 403, headers: {}, bodyText: "<html>cf</html>" }
-      return { status: 404, headers: {}, bodyText: "{}" }
-    })
-
+    ctx.host.http.request.mockReturnValue({ status: 403, headers: {}, bodyText: "<html>cf</html>" })
     const plugin = await loadPlugin()
-    const result = plugin.probe(ctx)
-
-    expect(result.lines[0].used).toBe(120)
-    expect(ctx.host.http.request.mock.calls.length).toBe(2)
+    expect(() => plugin.probe(ctx)).toThrow("Session expired")
   })
 
   it("throws when API returns non-zero base_resp status", async () => {

--- a/plugins/minimax/plugin.test.js
+++ b/plugins/minimax/plugin.test.js
@@ -920,6 +920,34 @@ describe("minimax plugin", () => {
     expect(line.resetsAt).toBe(new Date(1780344000000).toISOString())
   })
 
+  it("does not scale CN percentage-based Token Plan responses", async () => {
+    const ctx = makeCtx()
+    setEnv(ctx, { MINIMAX_CN_API_KEY: "cn-key" })
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        base_resp: { status_code: 0 },
+        model_remains: [
+          {
+            model_name: "general",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 87,
+          },
+        ],
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const line = result.lines[0]
+
+    expect(line.used).toBe(13)
+    expect(line.limit).toBe(100)
+    expect(line.format.kind).toBe("percent")
+  })
+
   it("handles weekly percentage from Token Plan API", async () => {
     const ctx = makeCtx()
     setEnv(ctx, { MINIMAX_API_KEY: "mini-key" })

--- a/plugins/minimax/plugin.test.js
+++ b/plugins/minimax/plugin.test.js
@@ -885,4 +885,71 @@ describe("minimax plugin", () => {
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Could not parse usage data")
   })
+
+  it("handles percentage-based response from Token Plan API", async () => {
+    const ctx = makeCtx()
+    setEnv(ctx, { MINIMAX_API_KEY: "mini-key" })
+    vi.spyOn(Date, "now").mockReturnValue(1700000000000)
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        base_resp: { status_code: 0 },
+        model_remains: [
+          {
+            model_name: "general",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 87,
+            remains_time: 5111151,
+            start_time: 1780326000000,
+            end_time: 1780344000000,
+          },
+        ],
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const line = result.lines[0]
+
+    // 87% remaining = 13% used
+    expect(line.used).toBe(13)
+    expect(line.limit).toBe(100)
+    expect(line.format.kind).toBe("percent")
+    expect(line.resetsAt).toBe(new Date(1780344000000).toISOString())
+  })
+
+  it("handles weekly percentage from Token Plan API", async () => {
+    const ctx = makeCtx()
+    setEnv(ctx, { MINIMAX_API_KEY: "mini-key" })
+    vi.spyOn(Date, "now").mockReturnValue(1700000000000)
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        base_resp: { status_code: 0 },
+        model_remains: [
+          {
+            model_name: "general",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_remaining_percent: 0,
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            current_weekly_remaining_percent: 100,
+          },
+        ],
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const line = result.lines[0]
+
+    // 0% remaining in interval, but 100% weekly remaining
+    expect(line.used).toBe(100)
+    expect(line.limit).toBe(100)
+    expect(line.format.kind).toBe("percent")
+  })
 })


### PR DESCRIPTION
## Summary

Updated MiniMax plugin to use new /token_plan/remains API endpoint as documented at https://platform.minimax.io/docs/token-plan/faq#how-to-check-token-plan-usage

### Changes

**plugin.js:**
- GLOBAL_PRIMARY_USAGE_URL: https://api.minimax.io/v1/api/openplatform/coding_plan/remains -> https://www.minimax.io/v1/token_plan/remains
- GLOBAL_FALLBACK_USAGE_URLS: Removed redundant fallback URLs, now single endpoint
- CN_PRIMARY_USAGE_URL: Updated to use /token_plan/remains
- CN_FALLBACK_USAGE_URLS: Updated to use /token_plan/remains

**plugin.test.js:**
- Updated URL constants to match new endpoints
- Removed fallback tests (no longer applicable)
- All 42 tests passing (1112 total tests in repo)

Testing: npm test -- --run plugins/minimax

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the MiniMax plugin to the new /token_plan/remains API and adds percent-based usage reporting with clearer failures. Percentage values are unscaled across regions; only count-based values keep CN scaling.

- **New Features**
  - Handle `current_interval_remaining_percent` and display usage as percent (limit 100, format.kind = "percent")
  - Infer reset times from `end_time` or `remains_time`

- **Refactors**
  - Update usage URLs: global → https://www.minimax.io/v1/token_plan/remains, CN → https://api.minimaxi.com/v1/token_plan/remains; remove fallbacks and throw on failures
  - Update tests for percent format, unscaled percent on CN, and no-fallback behavior

<sup>Written for commit b05fd3fcc2ebe5a86e291f56294a6d2967a12fdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for percentage-based token-plan responses so remaining usage can be reported as percent (with derived counts and reset times) or counts with correct period duration.

* **Bug Fixes**
  * Updated MiniMax token-plan probe behavior and endpoints for more reliable queries.
  * Fail-fast behavior on primary endpoint errors to surface session/availability issues sooner.

* **Tests**
  * Updated tests to validate new endpoint behavior, percent-mode parsing, scaling rules, and fail-fast scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->