### PR TITLE
fix(grok): refresh expired auth tokens

### DIFF
--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -9,6 +9,7 @@ Tracks Grok Build credit usage from the local Grok CLI login.
 - **Protocol:** REST (plain JSON)
 - **Base URL:** `https://cli-chat-proxy.grok.com/v1`
 - **Auth:** cached Grok CLI token from `~/.grok/auth.json`
+- **Refresh:** Grok CLI refresh token from the same file
 - **Usage unit:** raw billing units from Grok
 - **Plan source:** `GET /settings` (`subscription_tier_display`)
 - **Reset period:** billing period from the CLI billing response
@@ -23,7 +24,7 @@ grok login
 
 2. Enable the Grok plugin in OpenUsage settings.
 
-OpenUsage reads the same local auth file that the Grok CLI uses. If the token expires, run `grok login` again.
+OpenUsage reads the same local auth file that the Grok CLI uses. Access tokens are refreshed automatically when a `refresh_token` is present. If refresh fails, run `grok login` again.
 
 ## Endpoint
 
@@ -84,8 +85,9 @@ Used fields:
 | Condition | Message |
 |-----------|---------|
 | Missing auth file | "Grok not logged in. Run `grok login`." |
-| Expired token | "Grok auth expired. Run `grok login` again." |
-| 401/403 | "Grok auth expired. Run `grok login` again." |
+| Expired token with no refresh token | "Grok auth expired. Run `grok login` again." |
+| Refresh token rejected | "Grok auth expired. Run `grok login` again." |
+| 401/403 after retry | "Grok auth expired. Run `grok login` again." |
 | HTTP error | "Grok billing request failed (HTTP {status}). Try again later." |
 | Network error | "Grok billing request failed. Check your connection." |
 | Invalid response | "Grok billing response changed." |

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -24,7 +24,7 @@ grok login
 
 2. Enable the Grok plugin in OpenUsage settings.
 
-OpenUsage reads the same local auth file that the Grok CLI uses. Access tokens are refreshed automatically when a `refresh_token` is present. If refresh fails, run `grok login` again.
+OpenUsage reads the same local auth file that the Grok CLI uses. Access tokens are refreshed automatically before expiry when a `refresh_token` is present. If refresh fails, run `grok login` again.
 
 ## Endpoint
 

--- a/plugins/grok/plugin.js
+++ b/plugins/grok/plugin.js
@@ -2,8 +2,11 @@
   const AUTH_PATH = "~/.grok/auth.json"
   const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing"
   const SETTINGS_URL = "https://cli-chat-proxy.grok.com/v1/settings"
+  const REFRESH_URL = "https://auth.x.ai/oauth2/token"
+  const DEFAULT_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
   const TOKEN_AUTH_HEADER = "xai-grok-cli"
   const AUTH_REFRESH_BUFFER_MS = 5 * 60 * 1000
+  const LOGIN_HINT = "Grok auth expired. Run `grok login` again."
 
   function readJson(ctx, path) {
     if (!ctx.host.fs.exists(path)) return null
@@ -16,14 +19,128 @@
 
   function entryExpiresAtMs(ctx, entry) {
     if (!entry || typeof entry !== "object") return null
-    if (!entry.expires_at) return null
-    return ctx.util.parseDateMs(entry.expires_at)
+    if (entry.expires_at) return ctx.util.parseDateMs(entry.expires_at)
+    if (entry.expires) return ctx.util.parseDateMs(entry.expires)
+    return null
   }
 
-  function isExpired(ctx, entry, nowMs) {
-    const expiresAtMs = entryExpiresAtMs(ctx, entry)
+  function tokenExpiresAtMs(ctx, token) {
+    const payload = ctx.jwt.decodePayload(token)
+    if (!payload || typeof payload.exp !== "number") return null
+    return payload.exp * 1000
+  }
+
+  function needsRefresh(ctx, entry, token, nowMs) {
+    const entryMs = entryExpiresAtMs(ctx, entry)
+    const tokenMs = tokenExpiresAtMs(ctx, token)
+    const entryNeedsRefresh = entryMs !== null && ctx.util.needsRefreshByExpiry({
+      nowMs,
+      expiresAtMs: entryMs,
+      bufferMs: AUTH_REFRESH_BUFFER_MS,
+    })
+    const tokenNeedsRefresh = tokenMs !== null && ctx.util.needsRefreshByExpiry({
+      nowMs,
+      expiresAtMs: tokenMs,
+      bufferMs: AUTH_REFRESH_BUFFER_MS,
+    })
+    return entryNeedsRefresh || tokenNeedsRefresh
+  }
+
+  function isExpired(ctx, entry, token, nowMs) {
+    const entryMs = entryExpiresAtMs(ctx, entry)
+    const tokenMs = tokenExpiresAtMs(ctx, token)
+    const expiresAtMs = tokenMs !== null ? tokenMs : entryMs
     if (expiresAtMs === null) return false
-    return nowMs + AUTH_REFRESH_BUFFER_MS >= expiresAtMs
+    return nowMs >= expiresAtMs
+  }
+
+  function readRefreshToken(entry) {
+    if (!entry || typeof entry !== "object") return ""
+    const refreshToken = typeof entry.refresh_token === "string" ? entry.refresh_token.trim() : ""
+    if (refreshToken) return refreshToken
+    return typeof entry.refresh === "string" ? entry.refresh.trim() : ""
+  }
+
+  function readClientId(entryKey, entry) {
+    if (entry && typeof entry.oidc_client_id === "string" && entry.oidc_client_id.trim()) {
+      return entry.oidc_client_id.trim()
+    }
+    const parts = String(entryKey || "").split("::")
+    const fromKey = parts.length > 1 ? parts[parts.length - 1].trim() : ""
+    return fromKey || DEFAULT_CLIENT_ID
+  }
+
+  function nowMs(ctx) {
+    return ctx.util.parseDateMs(ctx.nowIso) || Date.now()
+  }
+
+  function refreshAuth(ctx, auth, entryKey, entry) {
+    const refreshToken = readRefreshToken(entry)
+    if (!refreshToken) {
+      ctx.host.log.warn("refresh skipped: no refresh token")
+      return null
+    }
+
+    ctx.host.log.info("attempting Grok auth refresh")
+    try {
+      const resp = ctx.util.request({
+        method: "POST",
+        url: REFRESH_URL,
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        bodyText:
+          "grant_type=refresh_token" +
+          "&client_id=" + encodeURIComponent(readClientId(entryKey, entry)) +
+          "&refresh_token=" + encodeURIComponent(refreshToken),
+        timeoutMs: 15000,
+      })
+
+      if (resp.status === 400 || resp.status === 401 || resp.status === 403) {
+        const body = ctx.util.tryParseJson(resp.bodyText)
+        const code = body && ((body.error && body.error.code) || body.error || body.code)
+        ctx.host.log.error("Grok auth refresh failed: status=" + resp.status + " code=" + String(code))
+        throw LOGIN_HINT
+      }
+      if (resp.status < 200 || resp.status >= 300) {
+        ctx.host.log.warn("Grok auth refresh returned status: " + resp.status)
+        return null
+      }
+
+      const body = ctx.util.tryParseJson(resp.bodyText)
+      if (!body || typeof body.access_token !== "string" || !body.access_token.trim()) {
+        ctx.host.log.warn("Grok auth refresh response missing access_token")
+        return null
+      }
+
+      const accessToken = body.access_token.trim()
+      entry.key = accessToken
+      if (typeof body.refresh_token === "string" && body.refresh_token.trim()) {
+        entry.refresh_token = body.refresh_token.trim()
+      }
+      if (typeof body.id_token === "string" && body.id_token.trim()) {
+        entry.id_token = body.id_token.trim()
+      }
+
+      const refreshedAtMs = nowMs(ctx)
+      const expiresIn = Number(body.expires_in)
+      const tokenExpiryMs = tokenExpiresAtMs(ctx, accessToken)
+      const expiresAtMs = Number.isFinite(expiresIn) && expiresIn > 0
+        ? refreshedAtMs + expiresIn * 1000
+        : tokenExpiryMs || refreshedAtMs + 3600 * 1000
+      entry.expires_at = new Date(expiresAtMs).toISOString()
+
+      try {
+        ctx.host.fs.writeText(AUTH_PATH, JSON.stringify(auth, null, 2))
+        ctx.host.log.info("Grok auth refresh succeeded, token persisted")
+      } catch (e) {
+        ctx.host.log.warn("Grok auth refresh succeeded but failed to save auth: " + String(e))
+      }
+
+      return accessToken
+    } catch (e) {
+      if (typeof e === "string") throw e
+      ctx.host.log.error("Grok auth refresh exception: " + String(e))
+      return null
+    }
   }
 
   function loadAuth(ctx) {
@@ -32,23 +149,30 @@
       throw "Grok not logged in. Run `grok login`."
     }
 
-    const nowMs = ctx.util.parseDateMs(ctx.nowIso) || Date.now()
+    const currentMs = nowMs(ctx)
     let expiredCandidate = false
     const keys = Object.keys(auth)
     for (let i = 0; i < keys.length; i++) {
-      const entry = auth[keys[i]]
+      const entryKey = keys[i]
+      const entry = auth[entryKey]
       if (!entry || typeof entry !== "object") continue
       const token = typeof entry.key === "string" ? entry.key.trim() : ""
       if (!token) continue
-      if (isExpired(ctx, entry, nowMs)) {
+      if (needsRefresh(ctx, entry, token, currentMs)) {
+        const refreshed = refreshAuth(ctx, auth, entryKey, entry)
+        if (refreshed) return { auth, entryKey, entry, token: refreshed }
+        if (!isExpired(ctx, entry, token, currentMs)) {
+          ctx.host.log.warn("Grok refresh failed, trying existing access token")
+          return { auth, entryKey, entry, token }
+        }
         expiredCandidate = true
         continue
       }
-      return { token }
+      return { auth, entryKey, entry, token }
     }
 
     if (expiredCandidate) {
-      throw "Grok auth expired. Run `grok login` again."
+      throw LOGIN_HINT
     }
     throw "Grok auth invalid. Run `grok login` again."
   }
@@ -67,10 +191,9 @@
     return n
   }
 
-  function fetchBilling(ctx, token) {
-    let resp
+  function fetchBillingResponse(ctx, token) {
     try {
-      resp = ctx.util.request({
+      return ctx.util.request({
         method: "GET",
         url: BILLING_URL,
         headers: {
@@ -84,9 +207,11 @@
     } catch {
       throw "Grok billing request failed. Check your connection."
     }
+  }
 
+  function parseBilling(ctx, resp) {
     if (ctx.util.isAuthStatus(resp.status)) {
-      throw "Grok auth expired. Run `grok login` again."
+      throw LOGIN_HINT
     }
     if (resp.status < 200 || resp.status >= 300) {
       throw "Grok billing request failed (HTTP " + String(resp.status) + "). Try again later."
@@ -123,7 +248,15 @@
 
   function probe(ctx) {
     const auth = loadAuth(ctx)
-    const data = fetchBilling(ctx, auth.token)
+    const billingResp = ctx.util.retryOnceOnAuth({
+      request: (token) => fetchBillingResponse(ctx, token || auth.token),
+      refresh: () => {
+        const refreshed = refreshAuth(ctx, auth.auth, auth.entryKey, auth.entry)
+        if (refreshed) auth.token = refreshed
+        return refreshed
+      },
+    })
+    const data = parseBilling(ctx, billingResp)
     const config = data && data.config
     if (!config || typeof config !== "object") {
       throw "Grok billing response changed."

--- a/plugins/grok/plugin.js
+++ b/plugins/grok/plugin.js
@@ -98,7 +98,7 @@
         const body = ctx.util.tryParseJson(resp.bodyText)
         const code = body && ((body.error && body.error.code) || body.error || body.code)
         ctx.host.log.error("Grok auth refresh failed: status=" + resp.status + " code=" + String(code))
-        throw LOGIN_HINT
+        return null
       }
       if (resp.status < 200 || resp.status >= 300) {
         ctx.host.log.warn("Grok auth refresh returned status: " + resp.status)

--- a/plugins/grok/plugin.test.js
+++ b/plugins/grok/plugin.test.js
@@ -4,6 +4,7 @@ import { makeCtx } from "../test-helpers.js"
 const AUTH_PATH = "~/.grok/auth.json"
 const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing"
 const SETTINGS_URL = "https://cli-chat-proxy.grok.com/v1/settings"
+const REFRESH_URL = "https://auth.x.ai/oauth2/token"
 
 const loadPlugin = async () => {
   await import("./plugin.js?test=" + Math.random())
@@ -81,7 +82,7 @@ describe("grok plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Grok auth invalid. Run `grok login` again.")
   })
 
-  it("throws when the only token is expired", async () => {
+  it("throws when the only token is expired and no refresh token is available", async () => {
     const ctx = makeCtx()
     writeAuth(ctx, {
       key: "expired-token",
@@ -90,6 +91,109 @@ describe("grok plugin", () => {
     })
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Grok auth expired. Run `grok login` again.")
+  })
+
+  it("refreshes an expired Grok CLI token and persists rotated auth", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx, {
+      key: "expired-token",
+      refresh_token: "refresh-token",
+      email: "user@example.com",
+      oidc_client_id: "client-id",
+      expires_at: "2026-01-01T00:00:00Z",
+    })
+    ctx.host.http.request.mockImplementation((req) => {
+      if (req.url === REFRESH_URL) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            access_token: "new-token",
+            refresh_token: "new-refresh",
+            expires_in: 3600,
+          }),
+        }
+      }
+      if (req.url === BILLING_URL) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify(billingData()),
+        }
+      }
+      if (req.url === SETTINGS_URL) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+        }
+      }
+      return { status: 404, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok Heavy")
+    expect(ctx.host.http.request.mock.calls[0][0].url).toBe(REFRESH_URL)
+    expect(ctx.host.http.request.mock.calls[0][0].bodyText).toContain("client_id=client-id")
+    expect(ctx.host.http.request.mock.calls[0][0].bodyText).toContain("refresh_token=refresh-token")
+    const billingCall = ctx.host.http.request.mock.calls.find((call) => call[0].url === BILLING_URL)[0]
+    expect(billingCall.headers.Authorization).toBe("Bearer new-token")
+
+    const authWrites = ctx.host.fs.writeText.mock.calls.filter((call) => call[0] === AUTH_PATH)
+    const saved = JSON.parse(authWrites[authWrites.length - 1][1])
+    const entry = saved["https://auth.x.ai::client"]
+    expect(entry.key).toBe("new-token")
+    expect(entry.refresh_token).toBe("new-refresh")
+    expect(entry.expires_at).toBe("2026-02-02T01:00:00.000Z")
+  })
+
+  it("refreshes and retries once when billing returns an auth error", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx, {
+      key: "old-token",
+      refresh_token: "refresh-token",
+      email: "user@example.com",
+      expires_at: "2026-06-01T00:00:00Z",
+    })
+    let billingCalls = 0
+    ctx.host.http.request.mockImplementation((req) => {
+      if (req.url === BILLING_URL) {
+        billingCalls += 1
+        if (billingCalls === 1) return { status: 401, bodyText: "" }
+        return {
+          status: 200,
+          bodyText: JSON.stringify(billingData()),
+        }
+      }
+      if (req.url === REFRESH_URL) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            access_token: "new-token",
+            refresh_token: "new-refresh",
+            expires_in: 3600,
+          }),
+        }
+      }
+      if (req.url === SETTINGS_URL) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+        }
+      }
+      return { status: 404, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok Heavy")
+    const billingAuths = ctx.host.http.request.mock.calls
+      .filter((call) => call[0].url === BILLING_URL)
+      .map((call) => call[0].headers.Authorization)
+    expect(billingAuths).toEqual(["Bearer old-token", "Bearer new-token"])
+    const refreshCall = ctx.host.http.request.mock.calls.find((call) => call[0].url === REFRESH_URL)[0]
+    expect(refreshCall.bodyText).toContain("client_id=client")
+    expect(refreshCall.bodyText).toContain("refresh_token=refresh-token")
   })
 
   it("uses the first non-expired token", async () => {

--- a/plugins/grok/plugin.test.js
+++ b/plugins/grok/plugin.test.js
@@ -196,6 +196,44 @@ describe("grok plugin", () => {
     expect(refreshCall.bodyText).toContain("refresh_token=refresh-token")
   })
 
+  it("uses a still-valid token when proactive refresh is unauthorized", async () => {
+    const ctx = makeCtx()
+    writeAuth(ctx, {
+      key: "old-token",
+      refresh_token: "refresh-token",
+      email: "user@example.com",
+      expires_at: "2026-02-02T00:04:00Z",
+    })
+    ctx.host.http.request.mockImplementation((req) => {
+      if (req.url === REFRESH_URL) {
+        return {
+          status: 401,
+          bodyText: JSON.stringify({ error: "invalid_grant" }),
+        }
+      }
+      if (req.url === BILLING_URL) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify(billingData()),
+        }
+      }
+      if (req.url === SETTINGS_URL) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+        }
+      }
+      return { status: 404, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("SuperGrok Heavy")
+    const billingCall = ctx.host.http.request.mock.calls.find((call) => call[0].url === BILLING_URL)[0]
+    expect(billingCall.headers.Authorization).toBe("Bearer old-token")
+  })
+
   it("uses the first non-expired token", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText(AUTH_PATH, JSON.stringify({


### PR DESCRIPTION
## Summary
- refresh Grok CLI access tokens using the local refresh_token before expiry
- persist rotated Grok auth back to ~/.grok/auth.json
- retry billing once after 401/403 and document refresh behavior

## Checks
- bun run test --run plugins/grok/plugin.test.js
- bun run test --run plugins
- bun run build
- git diff --check

## Notes
- README already lists Grok as a supported plugin.
- Redaction audit: refresh response fields use access_token/refresh_token/id_token, already covered by host_api redaction; request bodies are not logged.
- No visual changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth refresh and local persistence of Grok credentials; behavior is aligned with other plugins but touches auth tokens and ~/.grok/auth.json writes.
> 
> **Overview**
> Adds **automatic Grok CLI token refresh** so usage probes keep working without re-running `grok login` whenever the access token is near expiry or billing returns **401/403**.
> 
> The Grok plugin now reads `refresh_token` from `~/.grok/auth.json`, calls xAI’s OAuth token endpoint, updates rotated tokens/`expires_at`, and **writes the auth file back**. Proactive refresh runs before expiry (entry metadata or JWT `exp`); if refresh fails but the access token is still valid, it **falls back** to the existing token. Billing is fetched through **`retryOnceOnAuth`** so a single refresh+retry can recover from auth errors.
> 
> Provider docs and tests cover refresh persistence, billing retry after 401, and the no-refresh / rejected-refresh error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c592f071cc0ab32a0303e6a230850ddbabe06929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically refreshes Grok CLI access tokens before expiry and saves the new auth to cut down on login failures. Also preserves a still-valid token when refresh fails and retries billing once after 401/403.

- **Bug Fixes**
  - Auto-refresh using local `refresh_token` via x.ai OAuth; updates `access_token`, `refresh_token`, `id_token`, and `expires_at` in `~/.grok/auth.json`.
  - Expiry detection uses JWT `exp` or `expires_at` with a 5‑minute buffer; if refresh is rejected but the token isn’t expired, keep using it.
  - Retry billing once on 401/403 with a refreshed token; clearer errors when refresh is missing, rejected, or still unauthorized.
  - Docs updated to note auto-refresh and error cases; tests added for proactive refresh, retry, and refresh‑failure fallback.

<sup>Written for commit c592f071cc0ab32a0303e6a230850ddbabe06929. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grok provider now refreshes authentication tokens automatically when possible, reducing interrupted usage.
  * Billing checks now retry once after re-authentication, improving reliability when access is temporarily rejected.

* **Documentation**
  * Updated Grok authentication docs with clearer token expiration guidance.
  * Added more specific error scenarios and next steps when login needs to be repeated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->