### PR TITLE
fix: make provider rail scrollable

### DIFF
--- a/src/components/side-nav.tsx
+++ b/src/components/side-nav.tsx
@@ -226,30 +226,29 @@ export function SideNav({
       </NavButton>
 
       {/* Plugin icons */}
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={plugins.map((p) => p.id)}
-          strategy={verticalListSortingStrategy}
+      <div className="flex flex-1 min-h-0 flex-col overflow-y-auto scrollbar-none">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
         >
-          {plugins.map((plugin) => (
-            <SortableNavPlugin
-              key={plugin.id}
-              plugin={plugin}
-              isActive={activeView === plugin.id}
-              isDark={isDark}
-              onClick={() => onViewChange(plugin.id)}
-              onContextMenu={(e) => handlePluginContextMenu(e, plugin.id)}
-            />
-          ))}
-        </SortableContext>
-      </DndContext>
-
-      {/* Spacer */}
-      <div className="flex-1" />
+          <SortableContext
+            items={plugins.map((p) => p.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {plugins.map((plugin) => (
+              <SortableNavPlugin
+                key={plugin.id}
+                plugin={plugin}
+                isActive={activeView === plugin.id}
+                isDark={isDark}
+                onClick={() => onViewChange(plugin.id)}
+                onContextMenu={(e) => handlePluginContextMenu(e, plugin.id)}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
+      </div>
 
       {/* Help */}
       <NavButton


### PR DESCRIPTION
## Description

Makes the provider icon rail scroll independently when the list is taller than the OpenUsage panel.

The fix is scoped to the left rail: Home stays fixed at the top, Help/Settings stay fixed at the bottom, and the provider icons in the middle can scroll.

## Related Issue

<!-- No dedicated issue found. This fixes provider rail overflow with long provider lists. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/9f0a8e67-e969-40dc-8fb0-d02e501aee5e" controls></video> | <video src="https://github.com/user-attachments/assets/0977110e-211d-47e1-8636-449a4edf2f72" controls></video> |

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the plugin icons list layout in the sidebar to be vertically scrollable within a constrained height, preventing unintended sidebar expansion when displaying multiple plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->