### PR TITLE
fix(cursor): handle free account pooled limit

### DIFF
--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -25,7 +25,7 @@
 
 **Enterprise flow** remains request-based via the REST `/api/usage` endpoint -- unchanged.
 
-**Team detection**: an account is treated as "team" when `planName` is `"Team"`, or `spendLimitUsage.limitType` is `"team"`, or `spendLimitUsage.pooledLimit` is present. Team accounts display Total usage in dollars; individual accounts display it as a percentage.
+**Team detection**: an account is treated as "team" when `planName` is `"Team"`, or `spendLimitUsage.limitType` is `"team"`, or `spendLimitUsage.pooledLimit` is greater than `0`. Team accounts display Total usage in dollars; individual accounts display it as a percentage.
 
 ## Endpoints
 

--- a/plugins/cursor/plugin.js
+++ b/plugins/cursor/plugin.js
@@ -595,7 +595,7 @@
     const isTeamAccount = (
       normalizedPlanName === "team" ||
       (su && su.limitType === "team") ||
-      (su && typeof su.pooledLimit === "number")
+      (su && typeof su.pooledLimit === "number" && su.pooledLimit > 0)
     )
 
     if (isTeamAccount) {

--- a/plugins/cursor/plugin.test.js
+++ b/plugins/cursor/plugin.test.js
@@ -319,6 +319,50 @@ describe("cursor plugin", () => {
     expect(totalLine.limit).toBe(100)
   })
 
+  it("uses percent-only free usage when pooledLimit is zero", async () => {
+    const ctx = makeCtx()
+    ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("GetCurrentPeriodUsage")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            enabled: true,
+            billingCycleStart: "1772556293029",
+            billingCycleEnd: "1775234693029",
+            planUsage: {
+              autoPercentUsed: 0,
+              apiPercentUsed: 0,
+              totalPercentUsed: 0,
+            },
+            spendLimitUsage: { pooledLimit: 0, pooledRemaining: 0 },
+          }),
+        }
+      }
+      if (String(opts.url).includes("GetPlanInfo")) {
+        return {
+          status: 200,
+          bodyText: JSON.stringify({
+            planInfo: { planName: "Free" },
+          }),
+        }
+      }
+      if (String(opts.url).includes("cursor.com/api/usage")) {
+        throw new Error("unexpected REST usage fallback")
+      }
+      return { status: 200, bodyText: "{}" }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.plan).toBe("Free")
+    const totalLine = result.lines.find((line) => line.label === "Total usage")
+    expect(totalLine).toBeTruthy()
+    expect(totalLine.format).toEqual({ kind: "percent" })
+    expect(totalLine.used).toBe(0)
+    expect(totalLine.limit).toBe(100)
+  })
+
   it("renders percent-only usage when plan info is unavailable", async () => {
     const ctx = makeCtx()
     ctx.host.sqlite.query.mockReturnValue(JSON.stringify([{ value: "token" }]))


### PR DESCRIPTION
## Description

Fixes Cursor free accounts that return `spendLimitUsage.pooledLimit: 0`.

OpenUsage was treating any numeric `pooledLimit` as a team account signal. For free accounts, Cursor can include `pooledLimit: 0`, which made the plugin incorrectly switch to the request-based fallback API and fail with unavailable usage data.

This keeps the existing team detection for `planName: Team` and `limitType: team`, but only treats `pooledLimit` as a team signal when it is greater than `0`.

## Related Issue

Fixes #529

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [x] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I ran `bun run test -- plugins/cursor/plugin.test.js` and all tests pass

## Screenshots

<img width="400" height="384" alt="SCREENSHOT_3" src="https://github.com/user-attachments/assets/0dd9d5a7-58f7-4ca6-aad1-10bc98ffe95c" />


## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix team detection in the Cursor provider so free accounts with `spendLimitUsage.pooledLimit: 0` are treated as individual accounts, avoiding the REST fallback and missing usage data. Restores correct percent-only usage for free plans.

- **Bug Fixes**
  - Treat `pooledLimit` as a team signal only when greater than `0`; keep `planName: Team` and `limitType: team` checks.
  - Add a test verifying percent-only free usage when `pooledLimit` is `0`, and update docs to reflect the rule.

<sup>Written for commit 219c4b8f4314445b9ee2db0d556ed031d25a5405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team account detection now requires a positive pooled spending limit to be classified as a team account.

* **Documentation**
  * Updated account classification documentation to reflect the new team detection rule.

* **Tests**
  * Adjusted test coverage to validate free-tier usage formatting when pooled limit is zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->