### PR TITLE
feat: Tray/Dock app position with draggable, centered Dock window

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-outer-size",
     "core:window:allow-inner-size",
     "core:window:allow-scale-factor",
+    "core:window:allow-start-dragging",
     "opener:default",
     "store:default",
     "aptabase:allow-track-event",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,22 @@ const DAILY_ACTIVE_TRACKED_DAY_KEY: &str = "analytics.daily_active_day";
 const DAILY_ACTIVE_EVENT_NAME: &str = "app_started";
 const MAX_CONCURRENT_PROBES: usize = 4;
 
+// Mirrors the frontend `hideDockIcon` setting and its default. OpenUsage has
+// always run as a menu bar-only app, so the Dock icon stays hidden unless the
+// user opts in. Read natively at startup so the policy is applied before the
+// Dock would otherwise show an icon.
+#[cfg(target_os = "macos")]
+const HIDE_DOCK_ICON_STORE_KEY: &str = "hideDockIcon";
+#[cfg(target_os = "macos")]
+const DEFAULT_HIDE_DOCK_ICON: bool = true;
+
+// Mirrors the frontend `alwaysOnTop` setting. Only meaningful in Dock mode,
+// where it keeps the window floating above other windows. Defaults to off.
+#[cfg(target_os = "macos")]
+const ALWAYS_ON_TOP_STORE_KEY: &str = "alwaysOnTop";
+#[cfg(target_os = "macos")]
+const DEFAULT_ALWAYS_ON_TOP: bool = false;
+
 fn probe_worker_count(plugin_count: usize) -> usize {
     plugin_count.min(MAX_CONCURRENT_PROBES)
 }
@@ -384,6 +400,125 @@ fn get_log_path(app_handle: tauri::AppHandle) -> Result<String, String> {
     log_path::for_app(&app_handle).map(|path| path.to_string_lossy().to_string())
 }
 
+/// Reads the persisted `hideDockIcon` preference from the settings store.
+/// Falls back to the default when the store or key is unavailable so a missing
+/// or unreadable setting never changes the long-standing menu bar-only behavior.
+#[cfg(target_os = "macos")]
+fn get_stored_hide_dock_icon(app_handle: &tauri::AppHandle) -> bool {
+    use tauri_plugin_store::StoreExt;
+
+    let store = match app_handle.store("settings.json") {
+        Ok(store) => store,
+        Err(error) => {
+            log::warn!(
+                "Failed to access settings store for dock icon visibility: {}",
+                error
+            );
+            return DEFAULT_HIDE_DOCK_ICON;
+        }
+    };
+
+    store
+        .get(HIDE_DOCK_ICON_STORE_KEY)
+        .and_then(|value| value.as_bool())
+        .unwrap_or(DEFAULT_HIDE_DOCK_ICON)
+}
+
+/// Reads the persisted `alwaysOnTop` preference from the settings store.
+/// Falls back to the default when the store or key is unavailable.
+#[cfg(target_os = "macos")]
+fn get_stored_always_on_top(app_handle: &tauri::AppHandle) -> bool {
+    use tauri_plugin_store::StoreExt;
+
+    let store = match app_handle.store("settings.json") {
+        Ok(store) => store,
+        Err(error) => {
+            log::warn!("Failed to access settings store for always on top: {}", error);
+            return DEFAULT_ALWAYS_ON_TOP;
+        }
+    };
+
+    store
+        .get(ALWAYS_ON_TOP_STORE_KEY)
+        .and_then(|value| value.as_bool())
+        .unwrap_or(DEFAULT_ALWAYS_ON_TOP)
+}
+
+/// Applies Dock icon visibility by switching the macOS activation policy.
+/// `Accessory` hides the Dock icon (menu bar-only); `Regular` shows it.
+#[cfg(target_os = "macos")]
+fn apply_dock_icon_visibility(app_handle: &tauri::AppHandle, hidden: bool) -> Result<(), String> {
+    let policy = if hidden {
+        tauri::ActivationPolicy::Accessory
+    } else {
+        tauri::ActivationPolicy::Regular
+    };
+    app_handle
+        .set_activation_policy(policy)
+        .map_err(|e| format!("Failed to set activation policy: {}", e))
+}
+
+/// Shows or hides the menu bar (tray) icon. The tray icon and the Dock icon are
+/// mutually exclusive (see `update_dock_icon_visibility`), so the tray is shown
+/// only when the Dock icon is hidden.
+#[cfg(target_os = "macos")]
+fn apply_tray_visibility(app_handle: &tauri::AppHandle, visible: bool) -> Result<(), String> {
+    match app_handle.tray_by_id("tray") {
+        Some(tray) => tray
+            .set_visible(visible)
+            .map_err(|e| format!("Failed to set tray visibility: {}", e)),
+        None => {
+            log::warn!("Tray icon 'tray' not found while updating visibility");
+            Ok(())
+        }
+    }
+}
+
+/// Switches OpenUsage between menu bar-only and Dock-only presentation.
+/// `hidden = true` hides the Dock icon and shows the menu bar (tray) icon;
+/// `hidden = false` shows the Dock icon and hides the menu bar icon. The two are
+/// mutually exclusive so the menu bar never shows a redundant icon. No-op on
+/// other platforms, where there is no Dock concept.
+#[tauri::command]
+fn update_dock_icon_visibility(
+    #[allow(unused)] app_handle: tauri::AppHandle,
+    #[allow(unused)] hidden: bool,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        log::info!("Updating dock icon visibility: hidden={}", hidden);
+        apply_dock_icon_visibility(&app_handle, hidden)?;
+        // Tray is the inverse of the Dock icon: visible only when Dock is hidden.
+        apply_tray_visibility(&app_handle, hidden)?;
+
+        // In Dock-only mode the panel becomes a normal, draggable window centered
+        // on screen; in menu-bar mode it returns to the anchored dropdown.
+        let dock_mode = !hidden;
+        panel::set_dock_mode(dock_mode);
+        panel::apply_panel_presentation(&app_handle);
+        if dock_mode {
+            panel::position_panel_centered(&app_handle);
+        }
+    }
+    Ok(())
+}
+
+/// Toggles whether the Dock-mode window floats above other windows. Only has a
+/// visible effect in Dock mode; the panel level is updated immediately.
+#[tauri::command]
+fn update_always_on_top(
+    #[allow(unused)] app_handle: tauri::AppHandle,
+    #[allow(unused)] enabled: bool,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        log::info!("Updating always on top: enabled={}", enabled);
+        panel::set_always_on_top(enabled);
+        panel::apply_panel_presentation(&app_handle);
+    }
+    Ok(())
+}
+
 /// Update the global shortcut registration.
 /// Pass `null` to disable the shortcut, or a shortcut string like "CommandOrControl+Shift+U".
 #[cfg(desktop)]
@@ -530,11 +665,31 @@ pub fn run() {
             start_probe_batch,
             list_plugins,
             get_log_path,
-            update_global_shortcut
+            update_global_shortcut,
+            update_dock_icon_visibility,
+            update_always_on_top
         ])
         .setup(|app| {
+            // Apply the persisted Dock icon preference before anything else so the
+            // Dock never briefly shows an icon on launch. The app shows EITHER the
+            // menu bar (tray) icon OR the Dock icon, never both, to save menu bar
+            // space. Defaults to hidden Dock (menu bar-only). Tray visibility is
+            // applied below, right after the tray is created.
             #[cfg(target_os = "macos")]
-            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+            let hide_dock_icon = get_stored_hide_dock_icon(app.handle());
+            #[cfg(target_os = "macos")]
+            {
+                let policy = if hide_dock_icon {
+                    tauri::ActivationPolicy::Accessory
+                } else {
+                    tauri::ActivationPolicy::Regular
+                };
+                app.set_activation_policy(policy);
+                // Dock-only mode (Dock icon shown) makes the panel a normal,
+                // persistent window; record it so the panel behaves accordingly.
+                panel::set_dock_mode(!hide_dock_icon);
+                panel::set_always_on_top(get_stored_always_on_top(app.handle()));
+            }
 
             #[cfg(target_os = "macos")]
             {
@@ -582,6 +737,13 @@ pub fn run() {
 
             tray::create(app.handle())?;
 
+            // Show the tray icon only when the Dock icon is hidden, so the user
+            // gets the menu bar icon OR the Dock icon, never both.
+            #[cfg(target_os = "macos")]
+            if let Err(error) = apply_tray_visibility(app.handle(), hide_dock_icon) {
+                log::warn!("Failed to set initial tray visibility: {}", error);
+            }
+
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
 
@@ -621,9 +783,15 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|_, event| match event {
+        .run(|_app_handle, event| match event {
             tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
                 local_http_api::flush_cache();
+            }
+            // In Dock-only mode there is no tray icon to click, so clicking the
+            // Dock icon (which triggers Reopen) is how the user opens the panel.
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen { .. } => {
+                panel::show_panel_dock(_app_handle);
             }
             _ => {}
         });

--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -1,7 +1,41 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use tauri::{AppHandle, Manager, Position, Size};
 use tauri_nspanel::{
     CollectionBehavior, ManagerExt, PanelLevel, StyleMask, WebviewWindowExt, tauri_panel,
 };
+
+/// True while the app runs as a Dock-only window (no tray icon). In this mode
+/// the panel behaves like a normal window: it does not auto-hide on blur and is
+/// centered instead of anchored under the (absent) tray icon.
+static DOCK_MODE: AtomicBool = AtomicBool::new(false);
+
+/// When in Dock mode, keep the window floating above other windows.
+static ALWAYS_ON_TOP: AtomicBool = AtomicBool::new(false);
+
+/// Tracks whether the Dock-only window has been positioned at least once this
+/// session. We center it once per launch (the first time it shows), then leave
+/// it wherever the user dragged it. Leaving Dock mode resets this.
+static DOCK_POSITIONED: AtomicBool = AtomicBool::new(false);
+
+pub fn set_dock_mode(enabled: bool) {
+    DOCK_MODE.store(enabled, Ordering::SeqCst);
+    if !enabled {
+        DOCK_POSITIONED.store(false, Ordering::SeqCst);
+    }
+}
+
+pub fn set_always_on_top(enabled: bool) {
+    ALWAYS_ON_TOP.store(enabled, Ordering::SeqCst);
+}
+
+fn is_dock_mode() -> bool {
+    DOCK_MODE.load(Ordering::SeqCst)
+}
+
+fn is_dock_positioned() -> bool {
+    DOCK_POSITIONED.load(Ordering::SeqCst)
+}
 
 fn monitor_contains_physical_point(
     origin_x: f64,
@@ -116,6 +150,72 @@ pub fn show_panel(app_handle: &AppHandle) {
     }
 }
 
+/// Show the panel in Dock-only mode, where there is no tray icon to anchor to.
+/// It is centered the first time it shows each launch, then left wherever the
+/// user dragged it for the rest of the session.
+pub fn show_panel_dock(app_handle: &AppHandle) {
+    if let Some(panel) = get_or_init_panel!(app_handle) {
+        panel.show_and_make_key();
+        apply_panel_presentation(app_handle);
+        if !is_dock_positioned() {
+            position_panel_centered(app_handle);
+        }
+    }
+}
+
+/// Set the panel window level for the current mode. Menu-bar mode floats above
+/// everything as a dropdown. Dock mode uses a normal window level, unless
+/// "always on top" is enabled, in which case it floats above other windows.
+pub fn apply_panel_presentation(app_handle: &AppHandle) {
+    let Ok(panel) = app_handle.get_webview_panel("main") else {
+        return;
+    };
+    let level = if is_dock_mode() {
+        if ALWAYS_ON_TOP.load(Ordering::SeqCst) {
+            PanelLevel::Floating.value()
+        } else {
+            PanelLevel::Normal.value()
+        }
+    } else {
+        PanelLevel::MainMenu.value() + 1
+    };
+    panel.set_level(level);
+}
+
+/// Center the window on the primary monitor. Dock mode places the window here
+/// on launch (and when first switching to Dock mode); the user can drag it
+/// afterwards. Marks the window as positioned for the session.
+pub fn position_panel_centered(app_handle: &AppHandle) {
+    let Some(window) = app_handle.get_webview_window("main") else {
+        return;
+    };
+
+    let monitor = match window.primary_monitor() {
+        Ok(Some(monitor)) => monitor,
+        _ => return,
+    };
+
+    let scale = monitor.scale_factor();
+    let mon_logical_x = monitor.position().x as f64 / scale;
+    let mon_logical_y = monitor.position().y as f64 / scale;
+    let mon_logical_w = monitor.size().width as f64 / scale;
+    let mon_logical_h = monitor.size().height as f64 / scale;
+
+    let (panel_w, panel_h) = match (window.outer_size(), window.scale_factor()) {
+        (Ok(size), Ok(win_scale)) => (
+            size.width as f64 / win_scale,
+            size.height as f64 / win_scale,
+        ),
+        _ => (400.0, 500.0),
+    };
+
+    let panel_x = mon_logical_x + (mon_logical_w - panel_w) / 2.0;
+    let panel_y = mon_logical_y + (mon_logical_h - panel_h) / 2.0;
+
+    set_panel_top_left_immediately(&window, app_handle, panel_x, panel_y, mon_logical_h);
+    DOCK_POSITIONED.store(true, Ordering::SeqCst);
+}
+
 /// Toggle panel visibility. If visible, hide it. If hidden, show it.
 /// Used by global shortcut handler.
 pub fn toggle_panel(app_handle: &AppHandle) {
@@ -178,6 +278,11 @@ pub fn init(app_handle: &tauri::AppHandle) -> tauri::Result<()> {
 
     let handle = app_handle.clone();
     event_handler.window_did_resign_key(move |_notification| {
+        // In Dock-only mode the panel is a normal, persistent window, so it
+        // must stay open when it loses focus instead of auto-hiding.
+        if is_dock_mode() {
+            return;
+        }
         if let Ok(panel) = handle.get_webview_panel("main") {
             panel.hide();
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,8 @@ function App() {
     setTimeFormatMode,
     setGlobalShortcut,
     setStartOnLogin,
+    setHideDockIcon,
+    setAlwaysOnTop,
   } = useAppPreferencesStore(
     useShallow((state) => ({
       autoUpdateInterval: state.autoUpdateInterval,
@@ -73,6 +75,8 @@ function App() {
       setTimeFormatMode: state.setTimeFormatMode,
       setGlobalShortcut: state.setGlobalShortcut,
       setStartOnLogin: state.setStartOnLogin,
+      setHideDockIcon: state.setHideDockIcon,
+      setAlwaysOnTop: state.setAlwaysOnTop,
     }))
   )
 
@@ -122,6 +126,8 @@ function App() {
     setTimeFormatMode,
     setGlobalShortcut,
     setStartOnLogin,
+    setHideDockIcon,
+    setAlwaysOnTop,
     setLoadingForPlugins,
     setErrorForPlugins,
     startBatch,
@@ -150,12 +156,16 @@ function App() {
     handleAutoUpdateIntervalChange,
     handleGlobalShortcutChange,
     handleStartOnLoginChange,
+    handleHideDockIconChange,
+    handleAlwaysOnTopChange,
   } = useSettingsSystemActions({
     pluginSettings,
     setAutoUpdateInterval,
     setAutoUpdateNextAt,
     setGlobalShortcut,
     setStartOnLogin,
+    setHideDockIcon,
+    setAlwaysOnTop,
     applyStartOnLogin,
   })
 
@@ -254,6 +264,8 @@ function App() {
         traySettingsPreview,
         onGlobalShortcutChange: handleGlobalShortcutChange,
         onStartOnLoginChange: handleStartOnLoginChange,
+        onHideDockIconChange: handleHideDockIconChange,
+        onAlwaysOnTopChange: handleAlwaysOnTopChange,
       }}
     />
   )

--- a/src/components/app/app-content.test.tsx
+++ b/src/components/app/app-content.test.tsx
@@ -65,6 +65,8 @@ function createProps(): AppContentProps {
     onResetTimerDisplayModeToggle: vi.fn(),
     onGlobalShortcutChange: vi.fn(),
     onStartOnLoginChange: vi.fn(),
+    onHideDockIconChange: vi.fn(),
+    onAlwaysOnTopChange: vi.fn(),
   }
 }
 

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -37,6 +37,8 @@ export type AppContentActionProps = {
   traySettingsPreview: TraySettingsPreview
   onGlobalShortcutChange: (value: GlobalShortcut) => void
   onStartOnLoginChange: (value: boolean) => void
+  onHideDockIconChange: (value: boolean) => void
+  onAlwaysOnTopChange: (value: boolean) => void
 }
 
 export type AppContentProps = AppContentDerivedProps & AppContentActionProps
@@ -58,6 +60,8 @@ export function AppContent({
   traySettingsPreview,
   onGlobalShortcutChange,
   onStartOnLoginChange,
+  onHideDockIconChange,
+  onAlwaysOnTopChange,
 }: AppContentProps) {
   const { activeView } = useAppUiStore(
     useShallow((state) => ({
@@ -74,6 +78,8 @@ export function AppContent({
     globalShortcut,
     themeMode,
     startOnLogin,
+    hideDockIcon,
+    alwaysOnTop,
   } = useAppPreferencesStore(
     useShallow((state) => ({
       displayMode: state.displayMode,
@@ -84,6 +90,8 @@ export function AppContent({
       globalShortcut: state.globalShortcut,
       themeMode: state.themeMode,
       startOnLogin: state.startOnLogin,
+      hideDockIcon: state.hideDockIcon,
+      alwaysOnTop: state.alwaysOnTop,
     }))
   )
 
@@ -123,6 +131,10 @@ export function AppContent({
         onGlobalShortcutChange={onGlobalShortcutChange}
         startOnLogin={startOnLogin}
         onStartOnLoginChange={onStartOnLoginChange}
+        hideDockIcon={hideDockIcon}
+        onHideDockIconChange={onHideDockIconChange}
+        alwaysOnTop={alwaysOnTop}
+        onAlwaysOnTopChange={onAlwaysOnTopChange}
       />
     )
   }

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -7,9 +7,12 @@ import type { SettingsPluginState } from "@/hooks/app/use-settings-plugin-list"
 import { useAppVersion } from "@/hooks/app/use-app-version"
 import { usePanel } from "@/hooks/app/use-panel"
 import { useAppUpdate } from "@/hooks/use-app-update"
+import { useAppPreferencesStore } from "@/stores/app-preferences-store"
 import { useAppUiStore } from "@/stores/app-ui-store"
 
 const ARROW_OVERHEAD_PX = 37
+// Dock mode has no tray arrow; only the container's vertical padding eats height.
+const DOCK_OVERHEAD_PX = 30
 
 type AppShellProps = {
   onRefreshAll: () => void
@@ -66,16 +69,19 @@ export function AppShell({
   const appVersion = useAppVersion()
   const { updateStatus, triggerInstall, checkForUpdates } = useAppUpdate()
 
+  const dockMode = useAppPreferencesStore((state) => !state.hideDockIcon)
+  const topOverhead = dockMode ? DOCK_OVERHEAD_PX : ARROW_OVERHEAD_PX
+
   return (
     <div
       ref={containerRef}
       tabIndex={-1}
       className="flex flex-col items-center p-6 pt-1.5 bg-transparent outline-none"
     >
-      <div className="tray-arrow" />
+      {!dockMode && <div className="tray-arrow" />}
       <div
         className="relative bg-card rounded-xl overflow-hidden select-none w-full border shadow-lg flex flex-col"
-        style={maxPanelHeightPx ? { maxHeight: `${maxPanelHeightPx - ARROW_OVERHEAD_PX}px` } : undefined}
+        style={maxPanelHeightPx ? { maxHeight: `${maxPanelHeightPx - topOverhead}px` } : undefined}
       >
         <div className="flex flex-1 min-h-0 flex-row">
           <SideNav
@@ -85,6 +91,7 @@ export function AppShell({
             onPluginContextAction={onPluginContextAction}
             isPluginRefreshAvailable={isPluginRefreshAvailable}
             onReorder={onNavReorder}
+            draggable={dockMode}
           />
           <div className="flex-1 flex flex-col px-3 pt-2 pb-1.5 min-w-0 bg-card dark:bg-muted/50">
             <div className="relative flex-1 min-h-0">

--- a/src/components/side-nav.tsx
+++ b/src/components/side-nav.tsx
@@ -48,6 +48,8 @@ interface SideNavProps {
   onPluginContextAction?: (pluginId: string, action: PluginContextAction) => void
   isPluginRefreshAvailable?: (pluginId: string) => boolean
   onReorder?: (orderedIds: string[]) => void
+  /** In Dock-only mode the sidebar doubles as the window drag handle. */
+  draggable?: boolean
 }
 
 interface NavButtonProps {
@@ -66,7 +68,7 @@ function NavButton({ isActive, onClick, onContextMenu, children, "aria-label": a
       onContextMenu={onContextMenu}
       aria-label={ariaLabel}
       className={cn(
-        "relative flex items-center justify-center w-full p-2.5 transition-colors",
+        "relative flex items-center justify-center w-full p-2.5 transition-colors cursor-pointer",
         "hover:bg-accent",
         isActive
           ? "text-foreground before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-0.5 before:bg-primary dark:before:bg-page-accent before:rounded-full"
@@ -146,6 +148,7 @@ export function SideNav({
   onPluginContextAction,
   isPluginRefreshAvailable,
   onReorder,
+  draggable = false,
 }: SideNavProps) {
   const isDark = useDarkMode()
 
@@ -215,7 +218,13 @@ export function SideNav({
   )
 
   return (
-    <nav className="flex flex-col w-12 border-r bg-muted/50 dark:bg-card py-3">
+    <nav
+      data-tauri-drag-region={draggable ? "deep" : undefined}
+      className={cn(
+        "flex flex-col w-12 border-r bg-muted/50 dark:bg-card py-3",
+        draggable && "cursor-grab active:cursor-grabbing"
+      )}
+    >
       {/* Home */}
       <NavButton
         isActive={activeView === "home"}

--- a/src/hooks/app/use-settings-bootstrap.test.ts
+++ b/src/hooks/app/use-settings-bootstrap.test.ts
@@ -9,9 +9,11 @@ const {
   invokeMock,
   isAutostartEnabledMock,
   isTauriMock,
+  loadAlwaysOnTopMock,
   loadAutoUpdateIntervalMock,
   loadDisplayModeMock,
   loadGlobalShortcutMock,
+  loadHideDockIconMock,
   loadMenubarIconStyleMock,
   loadPluginSettingsMock,
   loadResetTimerDisplayModeMock,
@@ -29,9 +31,11 @@ const {
   disableAutostartMock: vi.fn(),
   arePluginSettingsEqualMock: vi.fn(),
   getEnabledPluginIdsMock: vi.fn(),
+  loadAlwaysOnTopMock: vi.fn(),
   loadAutoUpdateIntervalMock: vi.fn(),
   loadDisplayModeMock: vi.fn(),
   loadGlobalShortcutMock: vi.fn(),
+  loadHideDockIconMock: vi.fn(),
   loadMenubarIconStyleMock: vi.fn(),
   loadPluginSettingsMock: vi.fn(),
   loadResetTimerDisplayModeMock: vi.fn(),
@@ -56,18 +60,22 @@ vi.mock("@tauri-apps/plugin-autostart", () => ({
 
 vi.mock("@/lib/settings", () => ({
   arePluginSettingsEqual: arePluginSettingsEqualMock,
+  DEFAULT_ALWAYS_ON_TOP: false,
   DEFAULT_AUTO_UPDATE_INTERVAL: 15,
   DEFAULT_DISPLAY_MODE: "left",
   DEFAULT_GLOBAL_SHORTCUT: null,
+  DEFAULT_HIDE_DOCK_ICON: true,
   DEFAULT_MENUBAR_ICON_STYLE: "provider",
   DEFAULT_RESET_TIMER_DISPLAY_MODE: "relative",
   DEFAULT_START_ON_LOGIN: false,
   DEFAULT_THEME_MODE: "system",
   DEFAULT_TIME_FORMAT_MODE: "auto",
   getEnabledPluginIds: getEnabledPluginIdsMock,
+  loadAlwaysOnTop: loadAlwaysOnTopMock,
   loadAutoUpdateInterval: loadAutoUpdateIntervalMock,
   loadDisplayMode: loadDisplayModeMock,
   loadGlobalShortcut: loadGlobalShortcutMock,
+  loadHideDockIcon: loadHideDockIconMock,
   loadMenubarIconStyle: loadMenubarIconStyleMock,
   loadPluginSettings: loadPluginSettingsMock,
   loadResetTimerDisplayMode: loadResetTimerDisplayModeMock,
@@ -92,6 +100,8 @@ function createArgs() {
     setTimeFormatMode: vi.fn(),
     setGlobalShortcut: vi.fn(),
     setStartOnLogin: vi.fn(),
+    setHideDockIcon: vi.fn(),
+    setAlwaysOnTop: vi.fn(),
     setMenubarIconStyle: vi.fn(),
     setLoadingForPlugins: vi.fn(),
     setErrorForPlugins: vi.fn(),
@@ -108,9 +118,11 @@ describe("useSettingsBootstrap", () => {
     disableAutostartMock.mockReset()
     arePluginSettingsEqualMock.mockReset()
     getEnabledPluginIdsMock.mockReset()
+    loadAlwaysOnTopMock.mockReset()
     loadAutoUpdateIntervalMock.mockReset()
     loadDisplayModeMock.mockReset()
     loadGlobalShortcutMock.mockReset()
+    loadHideDockIconMock.mockReset()
     loadMenubarIconStyleMock.mockReset()
     loadPluginSettingsMock.mockReset()
     loadResetTimerDisplayModeMock.mockReset()
@@ -142,6 +154,8 @@ describe("useSettingsBootstrap", () => {
     loadResetTimerDisplayModeMock.mockResolvedValue("relative")
     loadTimeFormatModeMock.mockResolvedValue("auto")
     loadGlobalShortcutMock.mockResolvedValue("CommandOrControl+Shift+O")
+    loadHideDockIconMock.mockResolvedValue(true)
+    loadAlwaysOnTopMock.mockResolvedValue(false)
     loadMenubarIconStyleMock.mockResolvedValue("provider")
     loadStartOnLoginMock.mockResolvedValue(true)
     migrateLegacyTraySettingsMock.mockResolvedValue(undefined)

--- a/src/hooks/app/use-settings-bootstrap.ts
+++ b/src/hooks/app/use-settings-bootstrap.ts
@@ -8,18 +8,22 @@ import {
 import type { PluginMeta } from "@/lib/plugin-types"
 import {
   arePluginSettingsEqual,
+  DEFAULT_ALWAYS_ON_TOP,
   DEFAULT_AUTO_UPDATE_INTERVAL,
   DEFAULT_DISPLAY_MODE,
   DEFAULT_GLOBAL_SHORTCUT,
+  DEFAULT_HIDE_DOCK_ICON,
   DEFAULT_MENUBAR_ICON_STYLE,
   DEFAULT_RESET_TIMER_DISPLAY_MODE,
   DEFAULT_START_ON_LOGIN,
   DEFAULT_THEME_MODE,
   DEFAULT_TIME_FORMAT_MODE,
   getEnabledPluginIds,
+  loadAlwaysOnTop,
   loadAutoUpdateInterval,
   loadDisplayMode,
   loadGlobalShortcut,
+  loadHideDockIcon,
   loadMenubarIconStyle,
   migrateLegacyTraySettings,
   loadPluginSettings,
@@ -49,6 +53,8 @@ type UseSettingsBootstrapArgs = {
   setTimeFormatMode: (value: TimeFormatMode) => void
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
+  setHideDockIcon: (value: boolean) => void
+  setAlwaysOnTop: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
   setLoadingForPlugins: (ids: string[]) => void
   setErrorForPlugins: (ids: string[], error: string) => void
@@ -65,6 +71,8 @@ export function useSettingsBootstrap({
   setTimeFormatMode,
   setGlobalShortcut,
   setStartOnLogin,
+  setHideDockIcon,
+  setAlwaysOnTop,
   setMenubarIconStyle,
   setLoadingForPlugins,
   setErrorForPlugins,
@@ -147,6 +155,25 @@ export function useSettingsBootstrap({
           console.error("Failed to load start on login:", error)
         }
 
+        // The native startup path already reads this value and applies the
+        // activation policy, so here we only load it to reflect the current
+        // state in the settings UI.
+        let storedHideDockIcon = DEFAULT_HIDE_DOCK_ICON
+        try {
+          storedHideDockIcon = await loadHideDockIcon()
+        } catch (error) {
+          console.error("Failed to load hide dock icon setting:", error)
+        }
+
+        // Native startup already reads this to set the panel level; loaded here
+        // only to reflect the current state in the settings UI.
+        let storedAlwaysOnTop = DEFAULT_ALWAYS_ON_TOP
+        try {
+          storedAlwaysOnTop = await loadAlwaysOnTop()
+        } catch (error) {
+          console.error("Failed to load always on top setting:", error)
+        }
+
         try {
           await applyStartOnLogin(storedStartOnLogin)
         } catch (error) {
@@ -174,6 +201,8 @@ export function useSettingsBootstrap({
           setTimeFormatMode(storedTimeFormatMode)
           setGlobalShortcut(storedGlobalShortcut)
           setStartOnLogin(storedStartOnLogin)
+          setHideDockIcon(storedHideDockIcon)
+          setAlwaysOnTop(storedAlwaysOnTop)
           setMenubarIconStyle(storedMenubarIconStyle)
 
           const enabledIds = getEnabledPluginIds(normalized)
@@ -204,6 +233,8 @@ export function useSettingsBootstrap({
     setErrorForPlugins,
     setGlobalShortcut,
     setLoadingForPlugins,
+    setHideDockIcon,
+    setAlwaysOnTop,
     setMenubarIconStyle,
     migrateLegacyTraySettings,
     setPluginSettings,

--- a/src/hooks/app/use-settings-system-actions.test.ts
+++ b/src/hooks/app/use-settings-system-actions.test.ts
@@ -4,13 +4,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const {
   getEnabledPluginIdsMock,
   invokeMock,
+  saveAlwaysOnTopMock,
   saveAutoUpdateIntervalMock,
   saveGlobalShortcutMock,
+  saveHideDockIconMock,
   saveStartOnLoginMock,
 } = vi.hoisted(() => ({
   getEnabledPluginIdsMock: vi.fn(),
+  saveAlwaysOnTopMock: vi.fn(),
   saveAutoUpdateIntervalMock: vi.fn(),
   saveGlobalShortcutMock: vi.fn(),
+  saveHideDockIconMock: vi.fn(),
   saveStartOnLoginMock: vi.fn(),
   invokeMock: vi.fn(),
 }))
@@ -21,8 +25,10 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getEnabledPluginIds: getEnabledPluginIdsMock,
+  saveAlwaysOnTop: saveAlwaysOnTopMock,
   saveAutoUpdateInterval: saveAutoUpdateIntervalMock,
   saveGlobalShortcut: saveGlobalShortcutMock,
+  saveHideDockIcon: saveHideDockIconMock,
   saveStartOnLogin: saveStartOnLoginMock,
 }))
 
@@ -31,16 +37,20 @@ import { useSettingsSystemActions } from "@/hooks/app/use-settings-system-action
 describe("useSettingsSystemActions", () => {
   beforeEach(() => {
     getEnabledPluginIdsMock.mockReset()
+    saveAlwaysOnTopMock.mockReset()
     saveAutoUpdateIntervalMock.mockReset()
     saveGlobalShortcutMock.mockReset()
+    saveHideDockIconMock.mockReset()
     saveStartOnLoginMock.mockReset()
     invokeMock.mockReset()
 
     getEnabledPluginIdsMock.mockImplementation((settings: { order: string[]; disabled: string[] }) =>
       settings.order.filter((id) => !settings.disabled.includes(id))
     )
+    saveAlwaysOnTopMock.mockResolvedValue(undefined)
     saveAutoUpdateIntervalMock.mockResolvedValue(undefined)
     saveGlobalShortcutMock.mockResolvedValue(undefined)
+    saveHideDockIconMock.mockResolvedValue(undefined)
     saveStartOnLoginMock.mockResolvedValue(undefined)
     invokeMock.mockResolvedValue(undefined)
   })
@@ -57,6 +67,8 @@ describe("useSettingsSystemActions", () => {
         setAutoUpdateNextAt,
         setGlobalShortcut: vi.fn(),
         setStartOnLogin: vi.fn(),
+        setHideDockIcon: vi.fn(),
+        setAlwaysOnTop: vi.fn(),
         applyStartOnLogin: vi.fn().mockResolvedValue(undefined),
       })
     )
@@ -81,6 +93,8 @@ describe("useSettingsSystemActions", () => {
         setAutoUpdateNextAt,
         setGlobalShortcut: vi.fn(),
         setStartOnLogin: vi.fn(),
+        setHideDockIcon: vi.fn(),
+        setAlwaysOnTop: vi.fn(),
         applyStartOnLogin: vi.fn().mockResolvedValue(undefined),
       })
     )
@@ -95,6 +109,8 @@ describe("useSettingsSystemActions", () => {
   it("updates shortcut and start-on-login settings", () => {
     const setGlobalShortcut = vi.fn()
     const setStartOnLogin = vi.fn()
+    const setHideDockIcon = vi.fn()
+    const setAlwaysOnTop = vi.fn()
     const applyStartOnLogin = vi.fn().mockResolvedValue(undefined)
 
     const { result } = renderHook(() =>
@@ -104,6 +120,8 @@ describe("useSettingsSystemActions", () => {
         setAutoUpdateNextAt: vi.fn(),
         setGlobalShortcut,
         setStartOnLogin,
+        setHideDockIcon,
+        setAlwaysOnTop,
         applyStartOnLogin,
       })
     )
@@ -111,6 +129,8 @@ describe("useSettingsSystemActions", () => {
     act(() => {
       result.current.handleGlobalShortcutChange("CommandOrControl+Shift+O")
       result.current.handleStartOnLoginChange(true)
+      result.current.handleHideDockIconChange(false)
+      result.current.handleAlwaysOnTopChange(true)
     })
 
     expect(setGlobalShortcut).toHaveBeenCalledWith("CommandOrControl+Shift+O")
@@ -122,6 +142,18 @@ describe("useSettingsSystemActions", () => {
     expect(setStartOnLogin).toHaveBeenCalledWith(true)
     expect(saveStartOnLoginMock).toHaveBeenCalledWith(true)
     expect(applyStartOnLogin).toHaveBeenCalledWith(true)
+
+    expect(setHideDockIcon).toHaveBeenCalledWith(false)
+    expect(saveHideDockIconMock).toHaveBeenCalledWith(false)
+    expect(invokeMock).toHaveBeenCalledWith("update_dock_icon_visibility", {
+      hidden: false,
+    })
+
+    expect(setAlwaysOnTop).toHaveBeenCalledWith(true)
+    expect(saveAlwaysOnTopMock).toHaveBeenCalledWith(true)
+    expect(invokeMock).toHaveBeenCalledWith("update_always_on_top", {
+      enabled: true,
+    })
   })
 
   it("logs persistence/update failures", async () => {
@@ -130,12 +162,16 @@ describe("useSettingsSystemActions", () => {
     const shortcutInvokeError = new Error("shortcut invoke failed")
     const startOnLoginSaveError = new Error("start on login save failed")
     const startOnLoginApplyError = new Error("start on login apply failed")
+    const hideDockIconSaveError = new Error("hide dock icon save failed")
+    const hideDockIconInvokeError = new Error("hide dock icon invoke failed")
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
 
     saveAutoUpdateIntervalMock.mockRejectedValueOnce(autoError)
     saveGlobalShortcutMock.mockRejectedValueOnce(shortcutSaveError)
     invokeMock.mockRejectedValueOnce(shortcutInvokeError)
     saveStartOnLoginMock.mockRejectedValueOnce(startOnLoginSaveError)
+    saveHideDockIconMock.mockRejectedValueOnce(hideDockIconSaveError)
+    invokeMock.mockRejectedValueOnce(hideDockIconInvokeError)
     const applyStartOnLogin = vi.fn().mockRejectedValueOnce(startOnLoginApplyError)
 
     const { result } = renderHook(() =>
@@ -145,6 +181,8 @@ describe("useSettingsSystemActions", () => {
         setAutoUpdateNextAt: vi.fn(),
         setGlobalShortcut: vi.fn(),
         setStartOnLogin: vi.fn(),
+        setHideDockIcon: vi.fn(),
+        setAlwaysOnTop: vi.fn(),
         applyStartOnLogin,
       })
     )
@@ -153,6 +191,7 @@ describe("useSettingsSystemActions", () => {
       result.current.handleAutoUpdateIntervalChange(5)
       result.current.handleGlobalShortcutChange(null)
       result.current.handleStartOnLoginChange(false)
+      result.current.handleHideDockIconChange(true)
     })
 
     await waitFor(() => {
@@ -161,6 +200,14 @@ describe("useSettingsSystemActions", () => {
       expect(errorSpy).toHaveBeenCalledWith("Failed to update global shortcut:", shortcutInvokeError)
       expect(errorSpy).toHaveBeenCalledWith("Failed to save start on login:", startOnLoginSaveError)
       expect(errorSpy).toHaveBeenCalledWith("Failed to update start on login:", startOnLoginApplyError)
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to save hide dock icon setting:",
+        hideDockIconSaveError
+      )
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to update dock icon visibility:",
+        hideDockIconInvokeError
+      )
     })
 
     errorSpy.mockRestore()

--- a/src/hooks/app/use-settings-system-actions.ts
+++ b/src/hooks/app/use-settings-system-actions.ts
@@ -2,8 +2,10 @@ import { useCallback } from "react"
 import { invoke } from "@tauri-apps/api/core"
 import {
   getEnabledPluginIds,
+  saveAlwaysOnTop,
   saveAutoUpdateInterval,
   saveGlobalShortcut,
+  saveHideDockIcon,
   saveStartOnLogin,
   type AutoUpdateIntervalMinutes,
   type GlobalShortcut,
@@ -16,6 +18,8 @@ type UseSettingsSystemActionsArgs = {
   setAutoUpdateNextAt: (value: number | null) => void
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
+  setHideDockIcon: (value: boolean) => void
+  setAlwaysOnTop: (value: boolean) => void
   applyStartOnLogin: (value: boolean) => Promise<void>
 }
 
@@ -25,6 +29,8 @@ export function useSettingsSystemActions({
   setAutoUpdateNextAt,
   setGlobalShortcut,
   setStartOnLogin,
+  setHideDockIcon,
+  setAlwaysOnTop,
   applyStartOnLogin,
 }: UseSettingsSystemActionsArgs) {
   const handleAutoUpdateIntervalChange = useCallback((value: AutoUpdateIntervalMinutes) => {
@@ -64,9 +70,31 @@ export function useSettingsSystemActions({
     })
   }, [applyStartOnLogin, setStartOnLogin])
 
+  const handleHideDockIconChange = useCallback((value: boolean) => {
+    setHideDockIcon(value)
+    void saveHideDockIcon(value).catch((error) => {
+      console.error("Failed to save hide dock icon setting:", error)
+    })
+    invoke("update_dock_icon_visibility", { hidden: value }).catch((error) => {
+      console.error("Failed to update dock icon visibility:", error)
+    })
+  }, [setHideDockIcon])
+
+  const handleAlwaysOnTopChange = useCallback((value: boolean) => {
+    setAlwaysOnTop(value)
+    void saveAlwaysOnTop(value).catch((error) => {
+      console.error("Failed to save always on top setting:", error)
+    })
+    invoke("update_always_on_top", { enabled: value }).catch((error) => {
+      console.error("Failed to update always on top:", error)
+    })
+  }, [setAlwaysOnTop])
+
   return {
     handleAutoUpdateIntervalChange,
     handleGlobalShortcutChange,
     handleStartOnLoginChange,
+    handleHideDockIconChange,
+    handleAlwaysOnTopChange,
   }
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -36,6 +36,8 @@ const LEGACY_TRAY_ICON_STYLE_KEY = "trayIconStyle";
 const LEGACY_TRAY_SHOW_PERCENTAGE_KEY = "trayShowPercentage";
 const GLOBAL_SHORTCUT_KEY = "globalShortcut";
 const START_ON_LOGIN_KEY = "startOnLogin";
+const HIDE_DOCK_ICON_KEY = "hideDockIcon";
+const ALWAYS_ON_TOP_KEY = "alwaysOnTop";
 
 export const DEFAULT_AUTO_UPDATE_INTERVAL: AutoUpdateIntervalMinutes = 15;
 export const DEFAULT_THEME_MODE: ThemeMode = "system";
@@ -45,6 +47,11 @@ export const DEFAULT_TIME_FORMAT_MODE: TimeFormatMode = "auto";
 export const DEFAULT_MENUBAR_ICON_STYLE: MenubarIconStyle = "provider";
 export const DEFAULT_GLOBAL_SHORTCUT: GlobalShortcut = null;
 export const DEFAULT_START_ON_LOGIN = false;
+// Defaults to true because OpenUsage has always run as a menu bar-only app
+// (the native startup applied the accessory activation policy unconditionally).
+export const DEFAULT_HIDE_DOCK_ICON = true;
+// Only applies in Dock mode; defaults to off so the window behaves normally.
+export const DEFAULT_ALWAYS_ON_TOP = false;
 
 const AUTO_UPDATE_INTERVALS: AutoUpdateIntervalMinutes[] = [5, 15, 30, 60];
 const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
@@ -330,5 +337,27 @@ export async function loadStartOnLogin(): Promise<boolean> {
 
 export async function saveStartOnLogin(value: boolean): Promise<void> {
   await store.set(START_ON_LOGIN_KEY, value);
+  await store.save();
+}
+
+export async function loadHideDockIcon(): Promise<boolean> {
+  const stored = await store.get<unknown>(HIDE_DOCK_ICON_KEY);
+  if (typeof stored === "boolean") return stored;
+  return DEFAULT_HIDE_DOCK_ICON;
+}
+
+export async function saveHideDockIcon(value: boolean): Promise<void> {
+  await store.set(HIDE_DOCK_ICON_KEY, value);
+  await store.save();
+}
+
+export async function loadAlwaysOnTop(): Promise<boolean> {
+  const stored = await store.get<unknown>(ALWAYS_ON_TOP_KEY);
+  if (typeof stored === "boolean") return stored;
+  return DEFAULT_ALWAYS_ON_TOP;
+}
+
+export async function saveAlwaysOnTop(value: boolean): Promise<void> {
+  await store.set(ALWAYS_ON_TOP_KEY, value);
   await store.save();
 }

--- a/src/pages/settings.test.tsx
+++ b/src/pages/settings.test.tsx
@@ -69,6 +69,10 @@ const defaultProps = {
   onGlobalShortcutChange: vi.fn(),
   startOnLogin: false,
   onStartOnLoginChange: vi.fn(),
+  hideDockIcon: true,
+  onHideDockIconChange: vi.fn(),
+  alwaysOnTop: false,
+  onAlwaysOnTopChange: vi.fn(),
 }
 
 afterEach(() => {
@@ -269,5 +273,50 @@ describe("SettingsPage", () => {
     )
     await userEvent.click(screen.getByText("Start on login"))
     expect(onStartOnLoginChange).toHaveBeenCalledWith(true)
+  })
+
+  it("selects Dock app position", async () => {
+    const onHideDockIconChange = vi.fn()
+    render(
+      <SettingsPage
+        {...defaultProps}
+        hideDockIcon
+        onHideDockIconChange={onHideDockIconChange}
+      />
+    )
+    await userEvent.click(screen.getByRole("radio", { name: "Dock" }))
+    expect(onHideDockIconChange).toHaveBeenCalledWith(false)
+  })
+
+  it("selects Tray app position", async () => {
+    const onHideDockIconChange = vi.fn()
+    render(
+      <SettingsPage
+        {...defaultProps}
+        hideDockIcon={false}
+        onHideDockIconChange={onHideDockIconChange}
+      />
+    )
+    await userEvent.click(screen.getByRole("radio", { name: "Tray" }))
+    expect(onHideDockIconChange).toHaveBeenCalledWith(true)
+  })
+
+  it("hides 'Always keep on top' in Tray mode", () => {
+    render(<SettingsPage {...defaultProps} hideDockIcon />)
+    expect(screen.queryByText("Always keep on top")).not.toBeInTheDocument()
+  })
+
+  it("toggles 'Always keep on top' in Dock mode", async () => {
+    const onAlwaysOnTopChange = vi.fn()
+    render(
+      <SettingsPage
+        {...defaultProps}
+        hideDockIcon={false}
+        alwaysOnTop={false}
+        onAlwaysOnTopChange={onAlwaysOnTopChange}
+      />
+    )
+    await userEvent.click(screen.getByText("Always keep on top"))
+    expect(onAlwaysOnTopChange).toHaveBeenCalledWith(true)
   })
 })

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -47,6 +47,13 @@ interface PluginConfig {
 
 const TRAY_PREVIEW_SIZE_PX = getTrayIconSizePx(1);
 
+// App position is stored as `hideDockIcon`: Tray (menu bar only) hides the Dock
+// icon; Dock shows the Dock icon and hides the tray icon.
+const APP_POSITION_OPTIONS: { label: string; hideDockIcon: boolean }[] = [
+  { label: "Tray", hideDockIcon: true },
+  { label: "Dock", hideDockIcon: false },
+];
+
 const PREVIEW_BAR_TRACK_PX = 20;
 
 function getPreviewBarLayout(fraction: number): { fillPercent: number; remainderPercent: number } {
@@ -280,6 +287,10 @@ interface SettingsPageProps {
   onGlobalShortcutChange: (value: GlobalShortcut) => void;
   startOnLogin: boolean;
   onStartOnLoginChange: (value: boolean) => void;
+  hideDockIcon: boolean;
+  onHideDockIconChange: (value: boolean) => void;
+  alwaysOnTop: boolean;
+  onAlwaysOnTopChange: (value: boolean) => void;
 }
 
 export function SettingsPage({
@@ -303,6 +314,10 @@ export function SettingsPage({
   onGlobalShortcutChange,
   startOnLogin,
   onStartOnLoginChange,
+  hideDockIcon,
+  onHideDockIconChange,
+  alwaysOnTop,
+  onAlwaysOnTopChange,
 }: SettingsPageProps) {
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -529,6 +544,43 @@ export function SettingsPage({
           />
           Start on login
         </label>
+      </section>
+      <section>
+        <h3 className="text-lg font-semibold mb-0">App Position</h3>
+        <p className="text-sm text-muted-foreground mb-2">
+          Where should OpenUsage live?
+        </p>
+        <div className="bg-muted/50 rounded-lg p-1">
+          <div className="flex gap-1" role="radiogroup" aria-label="App position">
+            {APP_POSITION_OPTIONS.map((option) => {
+              const isActive = option.hideDockIcon === hideDockIcon;
+              return (
+                <Button
+                  key={option.label}
+                  type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  variant={isActive ? "default" : "outline"}
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => onHideDockIconChange(option.hideDockIcon)}
+                >
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+        {!hideDockIcon && (
+          <label className="flex items-center gap-2 text-sm select-none text-foreground mt-2">
+            <Checkbox
+              key={`always-on-top-${alwaysOnTop}`}
+              checked={alwaysOnTop}
+              onCheckedChange={(checked) => onAlwaysOnTopChange(checked === true)}
+            />
+            Always keep on top
+          </label>
+        )}
       </section>
       <section>
         <h3 className="text-lg font-semibold mb-0">Plugins</h3>

--- a/src/stores/app-preferences-store.ts
+++ b/src/stores/app-preferences-store.ts
@@ -2,7 +2,9 @@ import { create } from "zustand"
 import {
   DEFAULT_AUTO_UPDATE_INTERVAL,
   DEFAULT_DISPLAY_MODE,
+  DEFAULT_ALWAYS_ON_TOP,
   DEFAULT_GLOBAL_SHORTCUT,
+  DEFAULT_HIDE_DOCK_ICON,
   DEFAULT_MENUBAR_ICON_STYLE,
   DEFAULT_RESET_TIMER_DISPLAY_MODE,
   DEFAULT_START_ON_LOGIN,
@@ -25,6 +27,8 @@ type AppPreferencesStore = {
   timeFormatMode: TimeFormatMode
   globalShortcut: GlobalShortcut
   startOnLogin: boolean
+  hideDockIcon: boolean
+  alwaysOnTop: boolean
   menubarIconStyle: MenubarIconStyle
   setAutoUpdateInterval: (value: AutoUpdateIntervalMinutes) => void
   setThemeMode: (value: ThemeMode) => void
@@ -33,6 +37,8 @@ type AppPreferencesStore = {
   setTimeFormatMode: (value: TimeFormatMode) => void
   setGlobalShortcut: (value: GlobalShortcut) => void
   setStartOnLogin: (value: boolean) => void
+  setHideDockIcon: (value: boolean) => void
+  setAlwaysOnTop: (value: boolean) => void
   setMenubarIconStyle: (value: MenubarIconStyle) => void
   resetState: () => void
 }
@@ -45,6 +51,8 @@ const initialState = {
   timeFormatMode: DEFAULT_TIME_FORMAT_MODE,
   globalShortcut: DEFAULT_GLOBAL_SHORTCUT,
   startOnLogin: DEFAULT_START_ON_LOGIN,
+  hideDockIcon: DEFAULT_HIDE_DOCK_ICON,
+  alwaysOnTop: DEFAULT_ALWAYS_ON_TOP,
   menubarIconStyle: DEFAULT_MENUBAR_ICON_STYLE,
 }
 
@@ -57,6 +65,8 @@ export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
   setTimeFormatMode: (value) => set({ timeFormatMode: value }),
   setGlobalShortcut: (value) => set({ globalShortcut: value }),
   setStartOnLogin: (value) => set({ startOnLogin: value }),
+  setHideDockIcon: (value) => set({ hideDockIcon: value }),
+  setAlwaysOnTop: (value) => set({ alwaysOnTop: value }),
   setMenubarIconStyle: (value) => set({ menubarIconStyle: value }),
   resetState: () => set(initialState),
 }))


### PR DESCRIPTION
## Summary

This PR adds an app position setting to OpenUsage so that you can either show the app in the macOS tray or in the macOS dock. When docked, the sidebar becomes draggable And there is a conditional setting to always show the app on top of all other apps.

**This is NOT finished. But I'm creating the draft now to see if there's any demand for this.**

Floating Window             |  Settings Screen
:-------------------------:|:-------------------------:
<img width="1096" height="1896" alt="CleanShot 2026-06-03 at 09 24 07@2x" src="https://github.com/user-attachments/assets/eae55a90-358b-42d0-80ab-0039f0f9cfdb" />  |  <img width="1097" height="2118" alt="CleanShot 2026-06-03 at 09 27 07@2x" src="https://github.com/user-attachments/assets/8d1b95f6-cc22-46d8-aa7b-753c81846aa5" />


## Todo
- [ ] Fix window positioning in dock mode
- [ ] Add resizability in dock mode (?)
- [ ] Remember window position in dock mode

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `cargo check` + `cargo clippy` (no new warnings)
- [x] `bunx vitest run` (affected suites) — settings, side-nav, app-content, bootstrap, system-actions
- [ ] Manual on macOS: toggle Tray↔Dock; Dock window centers on launch, drag via sidebar, click away (stays open), Escape hides, Dock-icon click reopens; relaunch recenters; "Always keep on top" floats above other apps; tray and Dock are never both visible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an App Position setting to choose Tray or Dock so the app shows either the menu bar icon or the Dock icon, never both. Default is Tray; in Dock mode the window is centered, draggable, persists on blur, and can be kept on top.

- **New Features**
  - App Position segmented control in Settings; choice persists and is applied at startup to avoid Dock flicker.
  - Dock mode: window centers on first show, stays open on blur (Escape still hides), draggable via the sidebar; clicking the Dock icon reopens it.
  - Dock-only “Always keep on top” toggle to float the window.
  - macOS: switches activation policy (Accessory vs Regular) and inverses tray visibility; added `update_dock_icon_visibility`, `update_always_on_top`, and `core:window:allow-start-dragging`.

<sup>Written for commit 5f1cd71e8c9a717b885ca0db18abc373e4787643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

