### PR TITLE
fix(plugins/claude): add fallback primary candidates for tray percentage

### DIFF
--- a/plugins/claude/plugin.json
+++ b/plugins/claude/plugin.json
@@ -15,7 +15,7 @@
     { "type": "progress", "label": "Weekly", "scope": "overview", "primaryOrder": 2 },
     { "type": "progress", "label": "Sonnet", "scope": "detail" },
     { "type": "progress", "label": "Claude Design", "scope": "detail" },
-    { "type": "progress", "label": "Extra usage spent", "scope": "detail", "primaryOrder": 3 },
+    { "type": "progress", "label": "Extra usage spent", "scope": "overview", "primaryOrder": 3 },
     { "type": "text", "label": "Today", "scope": "detail" },
     { "type": "text", "label": "Yesterday", "scope": "detail" },
     { "type": "text", "label": "Last 30 Days", "scope": "detail" }

--- a/plugins/claude/plugin.json
+++ b/plugins/claude/plugin.json
@@ -12,10 +12,10 @@
   ],
   "lines": [
     { "type": "progress", "label": "Session", "scope": "overview", "primaryOrder": 1 },
-    { "type": "progress", "label": "Weekly", "scope": "overview" },
+    { "type": "progress", "label": "Weekly", "scope": "overview", "primaryOrder": 2 },
     { "type": "progress", "label": "Sonnet", "scope": "detail" },
     { "type": "progress", "label": "Claude Design", "scope": "detail" },
-    { "type": "progress", "label": "Extra usage spent", "scope": "detail" },
+    { "type": "progress", "label": "Extra usage spent", "scope": "detail", "primaryOrder": 3 },
     { "type": "text", "label": "Today", "scope": "detail" },
     { "type": "text", "label": "Yesterday", "scope": "detail" },
     { "type": "text", "label": "Last 30 Days", "scope": "detail" }

--- a/src/lib/tray-primary-progress.test.ts
+++ b/src/lib/tray-primary-progress.test.ts
@@ -314,68 +314,93 @@ describe("getTrayPrimaryBars", () => {
       },
     ]
 
-    // Case 1: Only Extra usage spent is available (e.g. Claude Enterprise/Team account overage)
-    const barsExtraOnly = getTrayPrimaryBars({
-      displayMode: "used",
-      pluginsMeta,
-      pluginSettings: { order: ["claude"], disabled: [] },
-      pluginStates: {
-        claude: {
-          data: {
-            providerId: "claude",
-            displayName: "Claude",
-            iconUrl: "",
-            lines: [
-              {
-                type: "progress",
-                label: "Extra usage spent",
-                used: 30,
-                limit: 100,
-                format: { kind: "dollars" },
-              },
-            ],
+    const runTest = (
+      lines: Array<{
+        type: "progress"
+        label: string
+        used: number
+        limit: number
+        format: { kind: "dollars" | "percent" }
+      }>
+    ) => {
+      return getTrayPrimaryBars({
+        displayMode: "used",
+        pluginsMeta,
+        pluginSettings: { order: ["claude"], disabled: [] },
+        pluginStates: {
+          claude: {
+            data: {
+              providerId: "claude",
+              displayName: "Claude",
+              iconUrl: "",
+              lines,
+            },
+            loading: false,
+            error: null,
           },
-          loading: false,
-          error: null,
         },
-      },
-    })
-    expect(barsExtraOnly).toEqual([{ id: "claude", fraction: 0.3 }])
+      })
+    }
+
+    // Case 1: Only Extra usage spent is available (e.g. Claude Enterprise/Team account overage)
+    expect(
+      runTest([
+        {
+          type: "progress",
+          label: "Extra usage spent",
+          used: 30,
+          limit: 100,
+          format: { kind: "dollars" },
+        },
+      ])
+    ).toEqual([{ id: "claude", fraction: 0.3 }])
 
     // Case 2: Weekly is available (but Session is not)
-    const barsWeeklyOnly = getTrayPrimaryBars({
-      displayMode: "used",
-      pluginsMeta,
-      pluginSettings: { order: ["claude"], disabled: [] },
-      pluginStates: {
-        claude: {
-          data: {
-            providerId: "claude",
-            displayName: "Claude",
-            iconUrl: "",
-            lines: [
-              {
-                type: "progress",
-                label: "Weekly",
-                used: 40,
-                limit: 100,
-                format: { kind: "percent" },
-              },
-              {
-                type: "progress",
-                label: "Extra usage spent",
-                used: 30,
-                limit: 100,
-                format: { kind: "dollars" },
-              },
-            ],
-          },
-          loading: false,
-          error: null,
+    expect(
+      runTest([
+        {
+          type: "progress",
+          label: "Weekly",
+          used: 40,
+          limit: 100,
+          format: { kind: "percent" },
         },
-      },
-    })
-    expect(barsWeeklyOnly).toEqual([{ id: "claude", fraction: 0.4 }])
+        {
+          type: "progress",
+          label: "Extra usage spent",
+          used: 30,
+          limit: 100,
+          format: { kind: "dollars" },
+        },
+      ])
+    ).toEqual([{ id: "claude", fraction: 0.4 }])
+
+    // Case 3: Session is available alongside Weekly and Extra usage spent (Session should win)
+    expect(
+      runTest([
+        {
+          type: "progress",
+          label: "Session",
+          used: 50,
+          limit: 100,
+          format: { kind: "percent" },
+        },
+        {
+          type: "progress",
+          label: "Weekly",
+          used: 40,
+          limit: 100,
+          format: { kind: "percent" },
+        },
+        {
+          type: "progress",
+          label: "Extra usage spent",
+          used: 30,
+          limit: 100,
+          format: { kind: "dollars" },
+        },
+      ])
+    ).toEqual([{ id: "claude", fraction: 0.5 }])
   })
 })
 

--- a/src/lib/tray-primary-progress.test.ts
+++ b/src/lib/tray-primary-progress.test.ts
@@ -302,5 +302,80 @@ describe("getTrayPrimaryBars", () => {
     })
     expect(bars).toEqual([])
   })
+
+  it("handles Claude fallback from Session to Weekly to Extra usage spent", () => {
+    const pluginsMeta = [
+      {
+        id: "claude",
+        name: "Claude",
+        iconUrl: "",
+        primaryCandidates: ["Session", "Weekly", "Extra usage spent"],
+        lines: [],
+      },
+    ]
+
+    // Case 1: Only Extra usage spent is available (e.g. Claude Enterprise/Team account overage)
+    const barsExtraOnly = getTrayPrimaryBars({
+      displayMode: "used",
+      pluginsMeta,
+      pluginSettings: { order: ["claude"], disabled: [] },
+      pluginStates: {
+        claude: {
+          data: {
+            providerId: "claude",
+            displayName: "Claude",
+            iconUrl: "",
+            lines: [
+              {
+                type: "progress",
+                label: "Extra usage spent",
+                used: 30,
+                limit: 100,
+                format: { kind: "dollars" },
+              },
+            ],
+          },
+          loading: false,
+          error: null,
+        },
+      },
+    })
+    expect(barsExtraOnly).toEqual([{ id: "claude", fraction: 0.3 }])
+
+    // Case 2: Weekly is available (but Session is not)
+    const barsWeeklyOnly = getTrayPrimaryBars({
+      displayMode: "used",
+      pluginsMeta,
+      pluginSettings: { order: ["claude"], disabled: [] },
+      pluginStates: {
+        claude: {
+          data: {
+            providerId: "claude",
+            displayName: "Claude",
+            iconUrl: "",
+            lines: [
+              {
+                type: "progress",
+                label: "Weekly",
+                used: 40,
+                limit: 100,
+                format: { kind: "percent" },
+              },
+              {
+                type: "progress",
+                label: "Extra usage spent",
+                used: 30,
+                limit: 100,
+                format: { kind: "dollars" },
+              },
+            ],
+          },
+          loading: false,
+          error: null,
+        },
+      },
+    })
+    expect(barsWeeklyOnly).toEqual([{ id: "claude", fraction: 0.4 }])
+  })
 })
 


### PR DESCRIPTION
## Description

Fixes an issue where the menu bar tray and tooltip display  --%  for Claude accounts that lack rolling session limits (e.g., Claude Enterprise or Team accounts).

The tray progress bar calculator ( getTrayPrimaryBars ) selects a metric by matching runtime data against configured  primaryCandidates  (metrics with a  primaryOrder  defined in the plugin's manifest). Previously, only the  "Session"  limit was configured with a  primaryOrder  for Claude. If the reverse-engineered API response does not include rolling session limits, no candidate matched, resulting in an undefined percentage formatted as  --% .

1. Added fallback  primaryOrder  definitions to Claude's other usage metrics:
    •  "Weekly"  limit:  primaryOrder: 2
    •  "Extra usage spent"  limit:  primaryOrder: 3
2. Updated the bundled assets via  bun run bundle:plugins .
3. Added a regression/unit test verifying the fallback ordering.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `bun run build` and it succeeded
- [x] I ran `bun run test` and all tests pass
- [x] I tested the change locally with `bun tauri dev`

## Screenshots

Before:

<img width="68" height="38" alt="image" src="https://github.com/user-attachments/assets/f262d4b0-1d0f-4aab-8692-81ab5b652cf1" />

After:

<img width="64" height="38" alt="image" src="https://github.com/user-attachments/assets/255140f4-8d4d-4111-a411-f5bfbd0002e8" />

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tray and tooltip percentage for Claude accounts without rolling session limits by falling back to Weekly or Extra usage spent instead of showing --%. Also moves Extra usage spent to the overview scope so it can be used as a primary metric.

- **Bug Fixes**
  - Set `primaryOrder` for "Weekly" (2) and "Extra usage spent" (3) in `plugins/claude/plugin.json`.
  - Changed "Extra usage spent" scope to `overview` to make it eligible for the tray.
  - Refactored and expanded tests to cover fallback ordering (Session → Weekly → Extra usage spent).

<sup>Written for commit 455f72111664d71336f935c46becf2fa96767ba9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reordered progress metrics and adjusted display ordering for overview items.
  * Promoted an "extra usage" metric to the overview and refined how weekly/extra metrics are prioritized.
* **Tests**
  * Added test coverage for progress-bar metric fallback logic to ensure correct metric selection and displayed fractions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->