### PR TITLE
[codex] Remove retired Windsurf plugin on startup

### DIFF
--- a/src-tauri/src/plugin_engine/mod.rs
+++ b/src-tauri/src/plugin_engine/mod.rs
@@ -5,13 +5,15 @@ pub mod runtime;
 use manifest::LoadedPlugin;
 use std::path::{Path, PathBuf};
 
+const RETIRED_BUNDLED_PLUGIN_IDS: &[&str] = &["windsurf"];
+
 pub fn initialize_plugins(
     app_data_dir: &Path,
     resource_dir: &Path,
 ) -> (PathBuf, Vec<LoadedPlugin>) {
     if let Some(dev_dir) = find_dev_plugins_dir() {
         if !is_dir_empty(&dev_dir) {
-            let plugins = manifest::load_plugins_from_dir(&dev_dir);
+            let plugins = load_active_plugins_from_dir(&dev_dir);
             return (dev_dir, plugins);
         }
     }
@@ -28,10 +30,22 @@ pub fn initialize_plugins(
     let bundled_dir = resolve_bundled_dir(resource_dir);
     if bundled_dir.exists() {
         copy_dir_recursive(&bundled_dir, &install_dir);
+        remove_retired_bundled_plugins(&install_dir);
     }
 
-    let plugins = manifest::load_plugins_from_dir(&install_dir);
+    let plugins = load_active_plugins_from_dir(&install_dir);
     (install_dir, plugins)
+}
+
+fn load_active_plugins_from_dir(plugins_dir: &Path) -> Vec<LoadedPlugin> {
+    manifest::load_plugins_from_dir(plugins_dir)
+        .into_iter()
+        .filter(|plugin| !is_retired_bundled_plugin_id(&plugin.manifest.id))
+        .collect()
+}
+
+fn is_retired_bundled_plugin_id(id: &str) -> bool {
+    RETIRED_BUNDLED_PLUGIN_IDS.contains(&id)
 }
 
 fn find_dev_plugins_dir() -> Option<PathBuf> {
@@ -64,6 +78,37 @@ fn is_dir_empty(path: &Path) -> bool {
             true
         }
     }
+}
+
+fn remove_retired_bundled_plugins(install_dir: &Path) {
+    for id in RETIRED_BUNDLED_PLUGIN_IDS {
+        let plugin_dir = install_dir.join(id);
+        if !plugin_dir.is_dir() || !plugin_dir_has_id(&plugin_dir, id) {
+            continue;
+        }
+
+        if let Err(err) = std::fs::remove_dir_all(&plugin_dir) {
+            log::warn!(
+                "failed to remove retired bundled plugin {}: {}",
+                plugin_dir.display(),
+                err
+            );
+        }
+    }
+}
+
+fn plugin_dir_has_id(plugin_dir: &Path, expected_id: &str) -> bool {
+    let manifest_path = plugin_dir.join("plugin.json");
+    let Ok(text) = std::fs::read_to_string(&manifest_path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return false;
+    };
+    value
+        .get("id")
+        .and_then(|id| id.as_str())
+        .is_some_and(|id| id == expected_id)
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) {
@@ -114,5 +159,147 @@ fn copy_dir_recursive(src: &Path, dst: &Path) {
         Err(err) => {
             log::warn!("failed to read dir {}: {}", src.display(), err);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let suffix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "openusage-plugin-engine-{}-{}-{}",
+                name,
+                std::process::id(),
+                suffix
+            ));
+            fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    struct CurrentDirGuard {
+        original: PathBuf,
+    }
+
+    impl CurrentDirGuard {
+        fn enter(path: &Path) -> Self {
+            let original = std::env::current_dir().expect("read current dir");
+            std::env::set_current_dir(path).expect("set current dir");
+            Self { original }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
+    fn write_plugin(parent: &Path, id: &str, name: &str) {
+        let plugin_dir = parent.join(id);
+        write_plugin_at(&plugin_dir, id, name);
+    }
+
+    fn write_plugin_at(plugin_dir: &Path, id: &str, name: &str) {
+        fs::create_dir_all(&plugin_dir).expect("create plugin dir");
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            format!(
+                r##"{{
+  "schemaVersion": 1,
+  "id": "{}",
+  "name": "{}",
+  "version": "0.0.1",
+  "entry": "plugin.js",
+  "icon": "icon.svg",
+  "brandColor": "#000000",
+  "lines": []
+}}"##,
+                id, name
+            ),
+        )
+        .expect("write plugin manifest");
+        fs::write(
+            plugin_dir.join("plugin.js"),
+            format!(
+                r#"globalThis.__openusage_plugin = {{ id: "{}", probe: () => ({{ lines: [] }}) }}"#,
+                id
+            ),
+        )
+        .expect("write plugin script");
+        fs::write(
+            plugin_dir.join("icon.svg"),
+            r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>"#,
+        )
+        .expect("write plugin icon");
+    }
+
+    #[test]
+    #[serial]
+    fn initialize_plugins_removes_retired_windsurf_without_removing_custom_plugins() {
+        let root = TempDir::new("retired");
+        let _cwd = CurrentDirGuard::enter(root.path());
+        let app_data_dir = root.path().join("app-data");
+        let install_dir = app_data_dir.join("plugins");
+        let resource_dir = root.path().join("resources");
+        let bundled_dir = resource_dir.join("bundled_plugins");
+
+        write_plugin(&install_dir, "windsurf", "Windsurf");
+        write_plugin(&install_dir, "custom", "Custom");
+        write_plugin(&bundled_dir, "devin", "Devin");
+
+        let (loaded_dir, plugins) = initialize_plugins(&app_data_dir, &resource_dir);
+        let ids: Vec<_> = plugins
+            .iter()
+            .map(|plugin| plugin.manifest.id.as_str())
+            .collect();
+
+        assert_eq!(loaded_dir, install_dir);
+        assert!(!loaded_dir.join("windsurf").exists());
+        assert!(loaded_dir.join("custom").exists());
+        assert!(loaded_dir.join("devin").exists());
+        assert_eq!(ids, vec!["custom", "devin"]);
+    }
+
+    #[test]
+    #[serial]
+    fn initialize_plugins_skips_retired_plugin_even_when_cleanup_does_not_remove_it() {
+        let root = TempDir::new("retired-skip");
+        let _cwd = CurrentDirGuard::enter(root.path());
+        let app_data_dir = root.path().join("app-data");
+        let install_dir = app_data_dir.join("plugins");
+        let resource_dir = root.path().join("resources");
+        fs::create_dir_all(&resource_dir).expect("create resource dir");
+
+        let mismatched_dir = install_dir.join("legacy-name");
+        write_plugin_at(&mismatched_dir, "windsurf", "Windsurf");
+
+        let (_loaded_dir, plugins) = initialize_plugins(&app_data_dir, &resource_dir);
+
+        assert!(mismatched_dir.exists());
+        assert!(plugins.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Remove the retired bundled `windsurf` plugin folder from the app-data plugin install directory during startup.
- Filter retired bundled plugin IDs out of plugin loading as a defensive backstop.
- Add regression coverage for upgraded installs that still have a stale `app_data/plugins/windsurf` directory.

## Root Cause

Auto-updated installs keep the persisted app-data plugin directory. The new release stopped bundling Windsurf, but startup only copied bundled plugins into app data and never pruned plugin folders removed from later bundles, so stale Windsurf code could still be discovered and loaded.

## Impact

After the next release, upgraded users should no longer see the old Windsurf plugin. The cleanup only removes the retired bundled-code folder when its manifest ID is `windsurf`; plugin data and unrelated/custom plugin folders are left alone.

## Validation

- `cargo test --lib`
- `bun run test -- src/lib/settings.test.ts src/hooks/app/use-settings-bootstrap.test.ts --run`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the retired bundled Windsurf plugin on startup and block it from loading. Prevents stale `windsurf` code from old installs from being discovered and run; custom plugins are untouched.

- Bug Fixes
  - On startup, delete `app_data/plugins/windsurf` only if its manifest id is `windsurf`.
  - Filter retired bundled plugin IDs from loading as a safety net.
  - Added regression tests for upgraded installs and legacy/mismatched directories.

<sup>Written for commit ad4e69a6558863e6002b22c9696d134996eecfde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped filesystem cleanup and load-time filtering for one retired bundled ID with manifest checks; custom plugins are preserved by design.
> 
> **Overview**
> Fixes upgraded installs still loading a **retired bundled Windsurf plugin** from persisted `app_data/plugins`, even after Windsurf was removed from new bundles.
> 
> Startup now **prunes** `install_dir/windsurf` after bundled copy, but only when `plugin.json`’s `id` is `windsurf`, so unrelated or custom plugin folders are not deleted by folder name alone. Plugin discovery goes through **`load_active_plugins_from_dir`**, which drops IDs in `RETIRED_BUNDLED_PLUGIN_IDS` (`windsurf`) as a backstop if cleanup misses a legacy layout (e.g. manifest under a non-`windsurf` directory name).
> 
> Regression tests cover removal alongside other plugins and the filter-only path when the directory is not removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad4e69a6558863e6002b22c9696d134996eecfde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin loading to exclude and clean up retired bundled plugins
  * Preserved custom plugins while removing obsolete system plugins from the installation directory

* **Tests**
  * Added test coverage for plugin management and cleanup operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->