### PR TITLE
fix(panel): clamp panel to visible screen when menu bar auto-hides

### DIFF
--- a/src-tauri/src/panel.rs
+++ b/src-tauri/src/panel.rs
@@ -272,7 +272,10 @@ pub fn position_panel_at_tray_icon(
     let icon_center_x = icon_logical_x + (icon_logical_w / 2.0);
     let panel_x = icon_center_x - (panel_width / 2.0);
     let nudge_up: f64 = 6.0;
-    let panel_y = icon_logical_y + icon_logical_h - nudge_up;
+    // Clamp to the monitor's top edge: when the menu bar is set to auto-hide,
+    // the tray rect sits above the visible screen, which would otherwise push
+    // the panel's top edge off-screen and clip it.
+    let panel_y = (icon_logical_y + icon_logical_h - nudge_up).max(mon_logical_y);
 
     set_panel_top_left_immediately(&window, app_handle, panel_x, panel_y, primary_logical_h);
 }


### PR DESCRIPTION
Fixes #556

## Root cause

`position_panel_at_tray_icon` anchors the panel's top edge to the bottom of the tray icon rect. When the macOS menu bar is set to auto-hide and is currently hidden, the bar — and the status item in it — sits *above* the visible screen, so `tray.rect()` reports a rect above the monitor's top edge. The computed `panel_y` lands off-screen and nothing clamps it, so the panel header renders clipped above the screen top.

## Fix

Clamp the panel's top edge to the monitor's top edge (one line, plus comment). Behavior with a visible menu bar is unchanged: the anchor already lands below the bar in that case, so the clamp never engages.

## Testing

- Built and ran the patched bundle on macOS 26.5 (Tahoe), Mac Studio (Apple Silicon), OpenUsage 0.6.26 base
- Menu bar auto-hide ON, bar hidden, panel opened via global shortcut: panel now pins fully visible at the top edge (previously clipped — before screenshot in #556)
- Menu bar visible: panel position identical to current behavior
- `bun run build` and `bun run test` pass (64 files, 1090 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp the panel’s top edge to the monitor top when the macOS menu bar auto-hides, so the panel stays fully visible instead of clipping off-screen. Behavior is unchanged when the menu bar is visible.

<sup>Written for commit d4c4f451faa3f432781bf21535d9d4b52d21c088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a macOS-specific issue where the panel could be positioned off-screen when the system menu bar auto-hides, causing the tray icon location to shift. The panel position is now automatically adjusted to remain within the monitor's visible boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->