### PR TITLE
fix: allow keychain reads without account

### DIFF
--- a/src-tauri/src/plugin_engine/host_api.rs
+++ b/src-tauri/src/plugin_engine/host_api.rs
@@ -4,7 +4,7 @@ use aes_gcm::{
     aes::Aes256,
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
-use rquickjs::{Ctx, Exception, Function, Object};
+use rquickjs::{function::Rest, Ctx, Exception, Function, Object};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
@@ -2469,7 +2469,7 @@ fn inject_keychain<'js>(
             ctx.clone(),
             move |ctx_inner: Ctx<'_>,
                   service: String,
-                  account: Option<String>|
+                  account_args: Rest<Option<String>>|
                   -> rquickjs::Result<String> {
                 if !cfg!(target_os = "macos") {
                     return Err(Exception::throw_message(
@@ -2477,14 +2477,19 @@ fn inject_keychain<'js>(
                         "keychain API is only supported on macOS",
                     ));
                 }
-                let account = account.and_then(|value| {
-                    let trimmed = value.trim();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed.to_string())
-                    }
-                });
+                let account = account_args
+                    .0
+                    .into_iter()
+                    .next()
+                    .flatten()
+                    .and_then(|value| {
+                        let trimmed = value.trim();
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_string())
+                        }
+                    });
                 let redacted_account = account.as_ref().map(|value| redact_value(value));
                 if let Some(ref redacted) = redacted_account {
                     log::info!(
@@ -3122,6 +3127,35 @@ mod tests {
             let _write_current_user: Function = keychain
                 .get("writeGenericPasswordForCurrentUser")
                 .expect("writeGenericPasswordForCurrentUser");
+        });
+    }
+
+    #[test]
+    fn keychain_read_generic_password_accepts_optional_account_arg_from_js() {
+        let rt = Runtime::new().expect("runtime");
+        let ctx = Context::full(&rt).expect("context");
+        ctx.with(|ctx| {
+            let app_data = std::env::temp_dir();
+            inject_host_api(&ctx, "test", &app_data, "0.0.0").expect("inject host api");
+
+            let message: String = ctx
+                .eval(
+                    r#"
+                    try {
+                        __openusage_ctx.host.keychain.readGenericPassword("__openusage_missing_service__");
+                        "ok";
+                    } catch (e) {
+                        String(e);
+                    }
+                    "#,
+                )
+                .expect("js eval");
+
+            assert!(
+                !message.contains("2 where expected"),
+                "single-arg call should reach the keychain implementation, got: {}",
+                message
+            );
         });
     }
 


### PR DESCRIPTION
## Description

Fixes the host keychain binding so `host.keychain.readGenericPassword(service)` works when plugins omit the optional account argument.

The plugin API documents `account` as optional, and several providers call the method with only `service`. The Rust binding now collects the account with `Rest<Option<String>>`, so one-argument calls reach the keychain implementation while existing two-argument calls keep the same account trimming behavior.

A regression test covers the one-argument JavaScript call so this does not come back.

## Related Issue

Fixes #549.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `cargo test keychain_read_generic_password_accepts_optional_account_arg_from_js --lib`
- [x] I ran `cargo test --lib`
- [x] I ran `git diff --check`

## Screenshots

No UI/layout changes, behavior fix only.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow keychain reads without an account by fixing the host keychain binding to accept single-argument calls to readGenericPassword(service). This restores plugin compatibility while keeping the existing account trimming behavior.

- Bug Fixes
  - Updated `rquickjs` binding to accept `Rest<Option<String>>`, so one-arg calls reach the keychain implementation; empty or whitespace-only accounts still resolve to None.
  - Added a regression test for the single-argument JavaScript call.

<sup>Written for commit c337ea75dbe966cff17c53ebdbf56fd47f08a785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `keychain.readGenericPassword` to properly handle single-argument function calls and accept an optional second parameter for enhanced flexibility.

* **Tests**
  * Added test coverage for keychain password retrieval with single arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->