### PR TITLE
Fix Factory usage metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OpenUsage lives in your menu bar and shows you how much of your AI coding subscr
 - [**Codex**](docs/providers/codex.md) / session, weekly, reviews, credits
 - [**Copilot**](docs/providers/copilot.md) / premium, chat, completions
 - [**Cursor**](docs/providers/cursor.md) / credits, total usage, auto usage, API usage, on-demand, CLI auth
-- [**Factory / Droid**](docs/providers/factory.md) / standard, premium tokens
+- [**Factory / Droid**](docs/providers/factory.md) / 5h, weekly, monthly, extra usage, Droid Core, managed computers
 - [**Grok**](docs/providers/grok.md) / credits used, plan, pay-as-you-go cap
 - [**JetBrains AI Assistant**](docs/providers/jetbrains-ai-assistant.md) / quota, remaining
 - [**Kiro**](docs/providers/kiro.md) / credits, bonus credits, overages

--- a/docs/providers/factory.md
+++ b/docs/providers/factory.md
@@ -65,9 +65,61 @@ Returns token usage for the current billing period.
 }
 ```
 
+### GET /api/billing/limits
+
+Returns current Factory/Droid quota windows shown in the web app.
+
+#### Headers
+
+| Header | Required | Value |
+|---|---|---|
+| Authorization | yes | `Bearer <access_token>` |
+| Accept | no | `application/json` |
+
+#### Response
+
+```jsonc
+{
+  "limits": {
+    "standard": {
+      "fiveHour": { "usedPercent": 0.12, "windowEnd": 1770626926000, "secondsRemaining": 1200 },
+      "weekly": { "usedPercent": 0.34, "windowEnd": 1771228126000, "secondsRemaining": 604800 },
+      "monthly": { "usedPercent": 0.56, "windowEnd": 1772956800000, "secondsRemaining": 2333474 }
+    },
+    "core": {
+      "enabled": true
+    }
+  },
+  "extraUsageBalanceCents": 1200,
+  "usesTokenRateLimitsBilling": true
+}
+```
+
+### GET /api/organization/compute-usage
+
+Returns Droid Core / managed computer usage for the current period.
+
+#### Headers
+
+| Header | Required | Value |
+|---|---|---|
+| Authorization | yes | `Bearer <access_token>` |
+| Accept | no | `application/json` |
+
+#### Response
+
+```jsonc
+{
+  "orgUsageMs": 3600000,
+  "limitMs": 7200000,
+  "periodStart": 1770623326000,
+  "periodEnd": 1772956800000
+}
+```
+
 ### Plan Detection
 
-Plan is inferred from `standard.totalAllowance`:
+Plan is inferred from `standard.totalAllowance` and Droid Core fields:
 
 | Allowance | Plan |
 |---|---|
@@ -76,6 +128,7 @@ Plan is inferred from `standard.totalAllowance`:
 | >0 | Basic |
 
 Premium tokens (`premium.totalAllowance > 0`) are only available on Max/Enterprise plans.
+Droid Core/managed computer usage adds `+ Droid Core` when enabled.
 
 ## Authentication
 

--- a/plugins/factory/plugin.js
+++ b/plugins/factory/plugin.js
@@ -5,7 +5,10 @@
   const KEYCHAIN_SERVICES = ["Factory Token", "Factory token", "Factory Auth", "Droid Auth"]
   const WORKOS_CLIENT_ID = "client_01HNM792M5G5G1A2THWPXKFMXB"
   const WORKOS_AUTH_URL = "https://api.workos.com/user_management/authenticate"
+  const APP_URL = "https://app.factory.ai"
   const USAGE_URL = "https://api.factory.ai/api/organization/subscription/usage"
+  const BILLING_LIMITS_URL = "https://api.factory.ai/api/billing/limits"
+  const COMPUTE_USAGE_URL = "https://api.factory.ai/api/organization/compute-usage"
   const TOKEN_REFRESH_THRESHOLD_MS = 24 * 60 * 60 * 1000 // 24 hours before expiry
 
   function decodeHexUtf8(hex) {
@@ -255,6 +258,42 @@
     return typeof expiresAtMs === "number" && nowMs < expiresAtMs
   }
 
+  function getUserIdFromAccessToken(ctx, accessToken) {
+    const payload = ctx.jwt.decodePayload(accessToken)
+    if (!payload || typeof payload !== "object") return null
+    const rawUserId = payload.sub || payload.user_id || payload.userId
+    if (typeof rawUserId !== "string") return null
+    const userId = rawUserId.trim()
+    return userId || null
+  }
+
+  function buildUsageHeaders(accessToken) {
+    return {
+      Authorization: "Bearer " + accessToken,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "User-Agent": "OpenUsage",
+      Origin: APP_URL,
+      Referer: APP_URL + "/",
+      "x-factory-client": "web-app",
+    }
+  }
+
+  function buildUsagePayload(ctx, accessToken) {
+    const userId = getUserIdFromAccessToken(ctx, accessToken)
+    const body = { useCache: true }
+    if (userId) body.userId = userId
+    return body
+  }
+
+  function buildUsageGetUrl(body) {
+    const params = ["useCache=" + encodeURIComponent(String(body.useCache))]
+    if (typeof body.userId === "string" && body.userId) {
+      params.push("userId=" + encodeURIComponent(body.userId))
+    }
+    return USAGE_URL + "?" + params.join("&")
+  }
+
   function refreshToken(ctx, authState) {
     const auth = authState.auth
     if (!auth.refresh_token) {
@@ -314,32 +353,361 @@
   }
 
   function fetchUsage(ctx, accessToken) {
+    const body = buildUsagePayload(ctx, accessToken)
     var resp = ctx.util.request({
       method: "POST",
       url: USAGE_URL,
-      headers: {
-        Authorization: "Bearer " + accessToken,
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "User-Agent": "OpenUsage",
-      },
-      bodyText: JSON.stringify({ useCache: true }),
+      headers: buildUsageHeaders(accessToken),
+      bodyText: JSON.stringify(body),
       timeoutMs: 10000,
     })
     if (resp.status === 405) {
       ctx.host.log.info("POST returned 405, retrying with GET")
       resp = ctx.util.request({
         method: "GET",
-        url: USAGE_URL,
-        headers: {
-          Authorization: "Bearer " + accessToken,
-          Accept: "application/json",
-          "User-Agent": "OpenUsage",
-        },
+        url: buildUsageGetUrl(body),
+        headers: buildUsageHeaders(accessToken),
         timeoutMs: 10000,
       })
     }
     return resp
+  }
+
+  function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+  }
+
+  function asNumber(value) {
+    if (typeof value === "number" && Number.isFinite(value)) return value
+    if (typeof value === "string") {
+      const trimmed = value.trim().replace(/%$/, "")
+      if (!trimmed) return null
+      const parsed = Number(trimmed)
+      return Number.isFinite(parsed) ? parsed : null
+    }
+    return null
+  }
+
+  function firstValue(source, keys) {
+    if (!isObject(source)) return undefined
+    for (const key of keys) {
+      if (source[key] !== undefined && source[key] !== null) return source[key]
+    }
+    return undefined
+  }
+
+  function firstNumber(source, keys) {
+    return asNumber(firstValue(source, keys))
+  }
+
+  function firstObject() {
+    for (let i = 0; i < arguments.length; i += 1) {
+      if (isObject(arguments[i])) return arguments[i]
+    }
+    return null
+  }
+
+  function requestGetJson(ctx, accessToken, url, label) {
+    try {
+      const resp = ctx.util.request({
+        method: "GET",
+        url,
+        headers: buildUsageHeaders(accessToken),
+        timeoutMs: 10000,
+      })
+      if (resp.status < 200 || resp.status >= 300) {
+        ctx.host.log.warn(label + " request failed: status=" + resp.status)
+        return null
+      }
+      const parsed = ctx.util.tryParseJson(resp.bodyText)
+      if (!isObject(parsed)) {
+        ctx.host.log.warn(label + " response invalid JSON")
+        return null
+      }
+      return parsed
+    } catch (e) {
+      ctx.host.log.warn(label + " request exception: " + String(e))
+      return null
+    }
+  }
+
+  function droidCoreConfig(usage) {
+    return firstObject(
+      usage.droidCore,
+      usage.droid_core,
+      usage.models && usage.models.droidCore,
+      usage.modelConfiguration && usage.modelConfiguration.droidCore,
+    )
+  }
+
+  function hasExtendedUsageFields(usage) {
+    if (!isObject(usage)) return false
+    return Boolean(firstObject(
+      usage.standardUsage,
+      usage.standardLimits,
+      usage.usageLimits,
+      usage.limits,
+      usage.extraUsage,
+      usage.extra_usage,
+      usage.extraUsageBalance,
+      usage.extra,
+      usage.overage,
+      usage.managedComputers,
+      usage.managedComputerUsage,
+      usage.managedCompute,
+      usage.compute,
+      usage.computers,
+      droidCoreConfig(usage),
+    ))
+  }
+
+  function windowMetricWithDuration(metric, periodDurationMs) {
+    if (!isObject(metric)) return null
+    const out = {}
+    const usedPercent = firstNumber(metric, [
+      "usedPercent",
+      "percentUsed",
+      "usagePercent",
+      "percentage",
+      "percent",
+    ])
+    if (usedPercent !== null) out.usedPercent = usedPercent
+
+    const windowEnd = firstValue(metric, ["windowEnd", "endDate", "endAt", "resetsAt", "resetAt"])
+    if (windowEnd !== undefined && windowEnd !== null) out.endDate = windowEnd
+
+    const secondsRemaining = firstNumber(metric, ["secondsRemaining", "remainingSeconds", "secondsLeft"])
+    if (!("endDate" in out) && secondsRemaining !== null) {
+      out.endDate = Date.now() + (secondsRemaining * 1000)
+    }
+
+    if (periodDurationMs > 0) out.periodDurationMs = periodDurationMs
+    return Object.keys(out).length ? out : null
+  }
+
+  function mergeSupplementalUsage(ctx, accessToken, data, usage) {
+    const merged = isObject(usage) ? Object.assign({}, usage) : {}
+    const shouldFetchSupplemental = !hasExtendedUsageFields(merged) && (
+      data.globalLimit !== undefined || data.userLimits !== undefined
+    )
+    if (!shouldFetchSupplemental) return merged
+
+    const billing = requestGetJson(ctx, accessToken, BILLING_LIMITS_URL, "billing limits")
+    if (isObject(billing)) {
+      const limits = firstObject(billing.limits, billing.usageLimits)
+      const standardLimits = limits && firstObject(limits.standard, limits.standardUsage)
+      if (standardLimits && !firstObject(merged.standardUsage, merged.standardLimits, merged.usageLimits, merged.limits)) {
+        const fiveHour = windowMetricWithDuration(firstObject(
+          standardLimits.fiveHour,
+          standardLimits.fiveHourUsage,
+          standardLimits.five_hour,
+          standardLimits["5Hour"],
+          standardLimits["5-hour"],
+        ), 5 * 60 * 60 * 1000)
+        const weekly = windowMetricWithDuration(firstObject(
+          standardLimits.weekly,
+          standardLimits.weeklyUsage,
+          standardLimits.week,
+        ), 7 * 24 * 60 * 60 * 1000)
+        const monthly = windowMetricWithDuration(firstObject(
+          standardLimits.monthly,
+          standardLimits.monthlyUsage,
+          standardLimits.month,
+        ), 30 * 24 * 60 * 60 * 1000)
+        merged.standardUsage = {}
+        if (fiveHour) merged.standardUsage.fiveHour = fiveHour
+        if (weekly) merged.standardUsage.weekly = weekly
+        if (monthly) merged.standardUsage.monthly = monthly
+      }
+
+      const extraUsageBalanceCents = firstNumber(billing, ["extraUsageBalanceCents", "extra_usage_balance_cents"])
+      if (
+        extraUsageBalanceCents !== null &&
+        !firstObject(merged.extraUsage, merged.extra_usage, merged.extraUsageBalance, merged.extra, merged.overage)
+      ) {
+        merged.extraUsage = { remainingCents: extraUsageBalanceCents }
+      }
+
+      const coreLimits = limits && firstObject(limits.core, limits.droidCore, limits.droid_core)
+      if (coreLimits && !droidCoreConfig(merged)) {
+        merged.droidCore = { enabled: true }
+      }
+    }
+
+    const compute = requestGetJson(ctx, accessToken, COMPUTE_USAGE_URL, "compute usage")
+    if (isObject(compute) && !firstObject(
+      merged.managedComputers,
+      merged.managedComputerUsage,
+      merged.computers,
+      merged.compute,
+      merged.managedCompute,
+    )) {
+      const limitMs = firstNumber(compute, ["limitMs", "includedMs", "allowanceMs", "totalMs", "limit"])
+      if (limitMs !== null && limitMs > 0) {
+        const usedMs = firstNumber(compute, ["orgUsageMs", "usageMs", "usedMs", "used"]) || 0
+        merged.managedComputers = {
+          usedHours: usedMs / (60 * 60 * 1000),
+          includedHours: limitMs / (60 * 60 * 1000),
+          startDate: firstValue(compute, ["periodStart", "startDate", "startAt"]),
+          endDate: firstValue(compute, ["periodEnd", "endDate", "endAt"]),
+        }
+      }
+    }
+
+    return merged
+  }
+
+  function normalizePercent(value, ratioHint) {
+    const n = asNumber(value)
+    if (n === null) return null
+    if (ratioHint || (n > 0 && n < 1)) return n * 100
+    return n
+  }
+
+  function percentFromMetric(metric) {
+    if (!isObject(metric)) return null
+    const ratioValue = firstValue(metric, ["usedRatio", "usageRatio", "ratio"])
+    if (ratioValue !== undefined) return normalizePercent(ratioValue, true)
+    const percentValue = firstValue(metric, [
+      "usedPercent",
+      "percentUsed",
+      "usagePercent",
+      "percentage",
+      "percent",
+    ])
+    if (percentValue !== undefined) return normalizePercent(percentValue, false)
+    const used = firstNumber(metric, ["used", "value", "current", "usedAmount"])
+    const limit = firstNumber(metric, ["limit", "allowance", "total", "totalAllowance"])
+    if (used !== null && limit !== null && limit > 0) return (used / limit) * 100
+    return null
+  }
+
+  function metricEndValue(metric, fallbackEnd) {
+    const value = firstValue(metric, ["resetsAt", "resetAt", "endDate", "endAt", "periodEnd", "periodEndDate"])
+    return value === undefined ? fallbackEnd : value
+  }
+
+  function metricStartValue(metric, fallbackStart) {
+    const value = firstValue(metric, ["startDate", "startAt", "periodStart", "periodStartDate"])
+    return value === undefined ? fallbackStart : value
+  }
+
+  function metricResetsAt(ctx, metric, fallbackEnd) {
+    const value = metricEndValue(metric, fallbackEnd)
+    return value === undefined || value === null ? null : ctx.util.toIso(value)
+  }
+
+  function metricPeriodDurationMs(metric, fallbackStart, fallbackEnd) {
+    const explicit = firstNumber(metric, ["periodDurationMs", "durationMs", "periodMs"])
+    if (explicit !== null && explicit > 0) return explicit
+    const start = asNumber(metricStartValue(metric, fallbackStart))
+    const end = asNumber(metricEndValue(metric, fallbackEnd))
+    if (start !== null && end !== null && end > start) return end - start
+    return null
+  }
+
+  function addPercentUsageLine(ctx, lines, label, metric, fallbackStart, fallbackEnd) {
+    const used = percentFromMetric(metric)
+    if (used === null) return false
+    lines.push(ctx.line.progress({
+      label,
+      used: Math.round(used * 100) / 100,
+      limit: 100,
+      format: { kind: "percent" },
+      resetsAt: metricResetsAt(ctx, metric, fallbackEnd),
+      periodDurationMs: metricPeriodDurationMs(metric, fallbackStart, fallbackEnd),
+    }))
+    return true
+  }
+
+  function addExtraUsageLine(ctx, lines, usage) {
+    const extraUsage = firstObject(
+      usage.extraUsage,
+      usage.extra_usage,
+      usage.extraUsageBalance,
+      usage.extra,
+      usage.overage,
+    )
+    if (!extraUsage) return false
+    let remaining = firstNumber(extraUsage, [
+      "remainingUsd",
+      "remainingUSD",
+      "remainingDollars",
+      "balanceUsd",
+      "balanceUSD",
+      "balance",
+      "amountRemainingUsd",
+    ])
+    const remainingCents = firstNumber(extraUsage, ["remainingCents", "balanceCents", "amountRemainingCents"])
+    if (remaining === null && remainingCents !== null) remaining = remainingCents / 100
+    if (remaining === null) return false
+    lines.push(ctx.line.text({
+      label: "Extra Usage",
+      value: "$" + remaining.toFixed(2) + " remaining",
+    }))
+    return true
+  }
+
+  function isDroidCoreEnabled(usage) {
+    const droidCore = droidCoreConfig(usage)
+    return Boolean(droidCore && (
+      droidCore.enabled === true ||
+      droidCore.available === true ||
+      droidCore.included === true
+    ))
+  }
+
+  function addDroidCoreLine(ctx, lines, usage) {
+    if (!isDroidCoreEnabled(usage)) return false
+    lines.push(ctx.line.badge({
+      label: "Droid Core",
+      text: "Enabled",
+      color: "#f97316",
+    }))
+    return true
+  }
+
+  function addManagedComputersLine(ctx, lines, usage, fallbackStart, fallbackEnd) {
+    const managed = firstObject(
+      usage.managedComputers,
+      usage.managedComputerUsage,
+      usage.computers,
+      usage.compute,
+      usage.managedCompute,
+    )
+    if (!managed) return false
+    const managedUsed = firstNumber(managed, ["usedHours", "usageHours", "hoursUsed", "used", "current"])
+    const used = managedUsed === null ? 0 : managedUsed
+    const limit = firstNumber(managed, ["includedHours", "limitHours", "allowanceHours", "totalHours", "limit"])
+    if (limit === null || limit <= 0) return false
+    lines.push(ctx.line.progress({
+      label: "Managed Computers",
+      used,
+      limit,
+      format: { kind: "count", suffix: "h" },
+      resetsAt: metricResetsAt(ctx, managed, fallbackEnd),
+      periodDurationMs: metricPeriodDurationMs(managed, fallbackStart, fallbackEnd),
+    }))
+    return true
+  }
+
+  function inferPlan(ctx, usage, standard) {
+    const rawPlan = firstValue(usage, ["plan", "planName", "tier", "usageMode", "currentUsageMode"])
+    let plan = typeof rawPlan === "string" && rawPlan.trim()
+      ? ctx.fmt.planLabel(rawPlan.trim())
+      : null
+    if (!plan && standard && typeof standard.totalAllowance === "number") {
+      const allowance = standard.totalAllowance
+      if (allowance >= 200000000) {
+        plan = "Max"
+      } else if (allowance >= 20000000) {
+        plan = "Pro"
+      } else if (allowance > 0) {
+        plan = "Basic"
+      }
+    }
+    if (isDroidCoreEnabled(usage)) return plan ? plan + " + Droid Core" : "Droid Core"
+    return plan
   }
 
   function probe(ctx) {
@@ -380,7 +748,9 @@
       resp = ctx.util.retryOnceOnAuth({
         request: (token) => {
           try {
-            return fetchUsage(ctx, token || accessToken)
+            const effectiveToken = token || accessToken
+            accessToken = effectiveToken
+            return fetchUsage(ctx, effectiveToken)
           } catch (e) {
             ctx.host.log.error("usage request exception: " + String(e))
             if (didRefresh) {
@@ -418,10 +788,11 @@
       throw "Usage response invalid. Try again later."
     }
 
-    const usage = data.usage
+    let usage = data.usage
     if (!usage) {
       throw "Usage response missing data. Try again later."
     }
+    usage = mergeSupplementalUsage(ctx, accessToken, data, usage)
 
     const lines = []
 
@@ -432,6 +803,37 @@
     const periodDurationMs = (typeof endDate === "number" && typeof startDate === "number")
       ? (endDate - startDate)
       : null
+
+    addExtraUsageLine(ctx, lines, usage)
+
+    const standardUsage = firstObject(
+      usage.standardUsage,
+      usage.standardLimits,
+      usage.usageLimits,
+      usage.limits,
+    )
+    if (standardUsage) {
+      addPercentUsageLine(ctx, lines, "5-hour usage", firstObject(
+        standardUsage.fiveHour,
+        standardUsage.fiveHourUsage,
+        standardUsage.five_hour,
+        standardUsage["5Hour"],
+        standardUsage["5-hour"],
+      ), startDate, endDate)
+      addPercentUsageLine(ctx, lines, "Weekly usage", firstObject(
+        standardUsage.weekly,
+        standardUsage.weeklyUsage,
+        standardUsage.week,
+      ), startDate, endDate)
+      addPercentUsageLine(ctx, lines, "Monthly usage", firstObject(
+        standardUsage.monthly,
+        standardUsage.monthlyUsage,
+        standardUsage.month,
+      ), startDate, endDate)
+    }
+
+    addDroidCoreLine(ctx, lines, usage)
+    addManagedComputersLine(ctx, lines, usage, startDate, endDate)
 
     // Standard tokens (primary line)
     const standard = usage.standard
@@ -463,18 +865,7 @@
       }))
     }
 
-    // Infer plan from allowance
-    let plan = null
-    if (standard && typeof standard.totalAllowance === "number") {
-      const allowance = standard.totalAllowance
-      if (allowance >= 200000000) {
-        plan = "Max"
-      } else if (allowance >= 20000000) {
-        plan = "Pro"
-      } else if (allowance > 0) {
-        plan = "Basic"
-      }
-    }
+    const plan = inferPlan(ctx, usage, standard)
 
     if (lines.length === 0) {
       lines.push(ctx.line.badge({ label: "Status", text: "No usage data", color: "#a3a3a3" }))

--- a/plugins/factory/plugin.json
+++ b/plugins/factory/plugin.json
@@ -7,7 +7,13 @@
   "icon": "icon.svg",
   "brandColor": "#020202",
   "lines": [
-    { "type": "progress", "label": "Standard", "scope": "overview", "primaryOrder": 1 },
+    { "type": "text", "label": "Extra Usage", "scope": "overview" },
+    { "type": "progress", "label": "5-hour usage", "scope": "overview", "primaryOrder": 1 },
+    { "type": "progress", "label": "Weekly usage", "scope": "detail" },
+    { "type": "progress", "label": "Monthly usage", "scope": "detail" },
+    { "type": "badge", "label": "Droid Core", "scope": "detail" },
+    { "type": "progress", "label": "Managed Computers", "scope": "detail" },
+    { "type": "progress", "label": "Standard", "scope": "overview", "primaryOrder": 2 },
     { "type": "progress", "label": "Premium", "scope": "detail" }
   ]
 }

--- a/plugins/factory/plugin.test.js
+++ b/plugins/factory/plugin.test.js
@@ -8,9 +8,12 @@ const loadPlugin = async () => {
 }
 
 // Helper to create a valid JWT with configurable expiry
-function makeJwt(expSeconds) {
+function makeJwt(expSecondsOrClaims) {
   const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
-  const payload = btoa(JSON.stringify({ exp: expSeconds, org_id: "org_123", email: "test@example.com" }))
+  const claims = typeof expSecondsOrClaims === "object"
+    ? { org_id: "org_123", email: "test@example.com", ...expSecondsOrClaims }
+    : { exp: expSecondsOrClaims, org_id: "org_123", email: "test@example.com" }
+  const payload = btoa(JSON.stringify(claims))
   const sig = "signature"
   return `${header}.${payload}.${sig}`
 }
@@ -500,6 +503,253 @@ describe("factory plugin", () => {
     expect(standardLine).toBeTruthy()
     expect(standardLine.used).toBe(5000000)
     expect(standardLine.limit).toBe(20000000)
+  })
+
+  it("formats Factory usage-limit, extra usage, Droid Core, and managed compute metrics", async () => {
+    const ctx = makeCtx()
+    const futureExp = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
+    ctx.host.fs.writeText("~/.factory/auth.json", JSON.stringify({
+      access_token: makeJwt(futureExp),
+      refresh_token: "refresh",
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        usage: {
+          plan: "Standard",
+          extraUsage: {
+            remainingUsd: 0,
+          },
+          standardUsage: {
+            fiveHour: {
+              usedPercent: 2,
+              startDate: 1770623326000,
+              endDate: 1770641326000,
+            },
+            weekly: {
+              usedRatio: 0.01,
+              startDate: 1770623326000,
+              endDate: 1771228126000,
+            },
+            monthly: {
+              usedPercent: 1,
+              startDate: 1770623326000,
+              endDate: 1773128926000,
+            },
+          },
+          droidCore: {
+            enabled: true,
+          },
+          managedComputers: {
+            usedHours: 0,
+            includedHours: 10,
+            startDate: 1770623326000,
+            endDate: 1772178526000,
+          },
+        },
+      }),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Standard + Droid Core")
+    expect(result.lines.find((line) => line.label === "Extra Usage")).toMatchObject({
+      type: "text",
+      value: "$0.00 remaining",
+    })
+    expect(result.lines.find((line) => line.label === "5-hour usage")).toMatchObject({
+      type: "progress",
+      used: 2,
+      limit: 100,
+      format: { kind: "percent" },
+    })
+    expect(result.lines.find((line) => line.label === "Weekly usage")).toMatchObject({
+      type: "progress",
+      used: 1,
+      limit: 100,
+      format: { kind: "percent" },
+    })
+    expect(result.lines.find((line) => line.label === "Monthly usage")).toMatchObject({
+      type: "progress",
+      used: 1,
+      limit: 100,
+      format: { kind: "percent" },
+    })
+    expect(result.lines.find((line) => line.label === "Droid Core")).toMatchObject({
+      type: "badge",
+      text: "Enabled",
+    })
+    expect(result.lines.find((line) => line.label === "Managed Computers")).toMatchObject({
+      type: "progress",
+      used: 0,
+      limit: 10,
+      format: { kind: "count", suffix: "h" },
+    })
+  })
+
+  it("fetches billing limits and compute usage when subscription usage is legacy-only", async () => {
+    const ctx = makeCtx()
+    const futureExp = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
+    const accessToken = makeJwt({ exp: futureExp, sub: "user_abc123" })
+    ctx.host.fs.writeText("~/.factory/auth.json", JSON.stringify({
+      access_token: accessToken,
+      refresh_token: "refresh",
+    }))
+
+    ctx.host.http.request.mockImplementation((opts) => {
+      const url = String(opts.url)
+      if (url === "https://api.factory.ai/api/organization/subscription/usage") {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            usage: {
+              startDate: 1770623326000,
+              endDate: 1772956800000,
+              standard: {
+                orgTotalTokensUsed: 5000000,
+                totalAllowance: 230000000,
+              },
+              premium: {
+                orgTotalTokensUsed: 0,
+                totalAllowance: 0,
+              },
+            },
+            globalLimit: null,
+            userLimits: [],
+          }),
+        }
+      }
+
+      if (url === "https://api.factory.ai/api/billing/limits") {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            usesTokenRateLimitsBilling: true,
+            limits: {
+              standard: {
+                fiveHour: { usedPercent: 44, windowEnd: "2026-05-26T13:25:52.000Z", secondsRemaining: 14200 },
+                weekly: { usedPercent: 12, windowEnd: "2026-06-01T13:25:52.000Z", secondsRemaining: 470000 },
+                monthly: { usedPercent: 9, windowEnd: "2026-06-25T13:25:52.000Z", secondsRemaining: 2580000 },
+              },
+              core: {
+                fiveHour: { usedPercent: 0, windowEnd: null, secondsRemaining: null },
+              },
+            },
+            extraUsageBalanceCents: 0,
+          }),
+        }
+      }
+
+      if (url === "https://api.factory.ai/api/organization/compute-usage") {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({
+            orgUsageMs: 0,
+            limitMs: 36000000,
+            periodStart: "2026-05-25T13:25:19.000Z",
+            periodEnd: "2026-06-13T13:25:19.000Z",
+          }),
+        }
+      }
+
+      throw new Error(`unexpected URL: ${url}`)
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.plan).toBe("Max + Droid Core")
+    expect(result.lines.find((line) => line.label === "Extra Usage")).toMatchObject({
+      type: "text",
+      value: "$0.00 remaining",
+    })
+    expect(result.lines.find((line) => line.label === "5-hour usage")).toMatchObject({
+      type: "progress",
+      used: 44,
+      limit: 100,
+      format: { kind: "percent" },
+    })
+    expect(result.lines.find((line) => line.label === "Weekly usage")).toMatchObject({
+      type: "progress",
+      used: 12,
+      limit: 100,
+      format: { kind: "percent" },
+    })
+    expect(result.lines.find((line) => line.label === "Monthly usage")).toMatchObject({
+      type: "progress",
+      used: 9,
+      limit: 100,
+      format: { kind: "percent" },
+    })
+    expect(result.lines.find((line) => line.label === "Droid Core")).toMatchObject({
+      type: "badge",
+      text: "Enabled",
+    })
+    expect(result.lines.find((line) => line.label === "Managed Computers")).toMatchObject({
+      type: "progress",
+      used: 0,
+      limit: 10,
+      format: { kind: "count", suffix: "h" },
+    })
+    expect(result.lines.find((line) => line.label === "Standard")).toMatchObject({
+      type: "progress",
+      used: 5000000,
+      limit: 230000000,
+    })
+  })
+
+  it("sends browser-like headers and userId when available", async () => {
+    const ctx = makeCtx()
+    const futureExp = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
+    const accessToken = makeJwt({ exp: futureExp, sub: "user_abc123" })
+    ctx.host.fs.writeText("~/.factory/auth.json", JSON.stringify({
+      access_token: accessToken,
+      refresh_token: "refresh",
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("billing/limits") || String(opts.url).includes("compute-usage")) {
+        return { status: 404, headers: {}, bodyText: "{}" }
+      }
+
+      expect(opts.method).toBe("POST")
+      expect(opts.url).toBe("https://api.factory.ai/api/organization/subscription/usage")
+      expect(opts.headers.Authorization).toBe("Bearer " + accessToken)
+      expect(opts.headers.Accept).toBe("application/json")
+      expect(opts.headers.Origin).toBe("https://app.factory.ai")
+      expect(opts.headers.Referer).toBe("https://app.factory.ai/")
+      expect(opts.headers["x-factory-client"]).toBe("web-app")
+      expect(JSON.parse(opts.bodyText)).toEqual({
+        useCache: true,
+        userId: "user_abc123",
+      })
+      return {
+        status: 200,
+        headers: {},
+        bodyText: JSON.stringify({
+          usage: {
+            startDate: 1770623326000,
+            endDate: 1772956800000,
+            standard: {
+              orgTotalTokensUsed: 5000000,
+              totalAllowance: 20000000,
+            },
+            premium: {
+              orgTotalTokensUsed: 0,
+              totalAllowance: 0,
+            },
+          },
+        }),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    expect(result.lines.find((line) => line.label === "Standard")).toBeTruthy()
   })
 
   it("shows premium line when premium allowance > 0", async () => {


### PR DESCRIPTION
## Summary
- Add Factory supplemental usage calls for billing limits and compute usage.
- Show current Factory/Droid metrics: extra usage, 5-hour, weekly, monthly, Droid Core, managed computers, and legacy token usage.
- Update Factory manifest, docs, README provider summary, and regression tests.

## Scope
Surgical Factory-only change based on latest upstream/main. No version bump, build workflow changes, or unrelated provider/app changes.

## Validation
- `bun run test --run plugins/factory/plugin.test.js` — 44 tests passed
- `bun run test --run` — 64 files / 1093 tests passed
- `bun run build` — passed

## Screenshots
Draft PR: screenshots are pending because they require authenticated Factory account data. No UI layout/components changed; this updates provider data lines displayed by the existing UI.

Conversation: https://app.warp.dev/conversation/0133ae31-1784-4e10-87f5-baf8d6c69bca

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show full Factory/Droid usage: 5-hour, weekly, monthly, extra usage balance, Droid Core, and managed computer hours. Adds supplemental API calls and smarter parsing so data matches the Factory app.

- **New Features**
  - Fetches `GET /api/billing/limits` and `GET /api/organization/compute-usage` when subscription usage lacks these fields; sends browser-like headers and `userId`; falls back to GET if POST returns 405.
  - Adds lines: Extra Usage, 5-hour usage, Weekly usage, Monthly usage, Droid Core (badge), and Managed Computers; preserves Standard and Premium tokens.
  - Normalizes legacy/new response shapes (percent vs ratio, start/end, durations) and shows reset timing.
  - Infers plan from allowance and appends "+ Droid Core" when enabled.
  - Updates provider docs with new endpoints and plan detection; refreshes README summary and regression tests.

<sup>Written for commit cfc20411450397e8e506b439273fc86058c55abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Factory/Droid provider documentation with new plan types and API reference.

* **New Features**
  * Added support for tracking Extra usage, Droid Core status, and Managed Computers usage.
  * Introduced new billing limits and compute usage tracking endpoints with improved plan detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->