### PR TITLE
[codex] Refactor Codex credits display

### DIFF
--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -53,12 +53,16 @@ Returns rate limit windows and optional credits.
   "credits": {                             // purchased credits (optional)
     "has_credits": true,
     "unlimited": false,
-    "balance": 5.39                        // remaining balance
+    "balance": 820.6969075                 // remaining credits
   }
 }
 ```
 
 Both rate_limit windows are enforced simultaneously — hitting either limit throttles the user.
+
+OpenUsage floors the remaining credit balance to a whole number and displays its fixed USD
+equivalent at `$0.04` per credit. For example, `820.6969075` renders as
+`$32.80 · 820 credits`. The credit balance is unbounded; the API does not provide a maximum.
 
 ## Authentication
 

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -5,6 +5,7 @@
   const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
   const REFRESH_URL = "https://auth.openai.com/oauth/token"
   const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+  const CREDIT_USD_RATE = 0.04
   const REFRESH_AGE_MS = 8 * 24 * 60 * 60 * 1000
   const ERR_NOT_LOGGED_IN = "Not logged in. Run `codex` to authenticate."
   const ERR_SESSION_EXPIRED = "Session expired. Run `codex` to log in again."
@@ -735,14 +736,11 @@
 
       const creditsRemaining = readCreditsRemaining(resp, data)
       if (creditsRemaining !== null) {
-        const remaining = creditsRemaining
-        const limit = 1000
-        const used = Math.max(0, Math.min(limit, limit - remaining))
-        lines.push(ctx.line.progress({
+        const remaining = Math.max(0, Math.floor(creditsRemaining))
+        const usdValue = (remaining * CREDIT_USD_RATE).toFixed(2)
+        lines.push(ctx.line.text({
           label: "Credits",
-          used: used,
-          limit: limit,
-          format: { kind: "count", suffix: "credits" },
+          value: "$" + usdValue + " · " + remaining + " credits",
         }))
       }
 

--- a/plugins/codex/plugin.json
+++ b/plugins/codex/plugin.json
@@ -16,7 +16,7 @@
     { "type": "progress", "label": "Spark", "scope": "detail" },
     { "type": "progress", "label": "Spark Weekly", "scope": "detail" },
     { "type": "progress", "label": "Reviews", "scope": "detail" },
-    { "type": "progress", "label": "Credits", "scope": "detail" },
+    { "type": "text", "label": "Credits", "scope": "detail" },
     { "type": "text", "label": "Today", "scope": "detail" },
     { "type": "text", "label": "Yesterday", "scope": "detail" },
     { "type": "text", "label": "Last 30 Days", "scope": "detail" },

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -220,7 +220,13 @@ describe("codex plugin", () => {
     expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
     const credits = result.lines.find((line) => line.label === "Credits")
     expect(credits).toBeTruthy()
-    expect(credits.used).toBe(900)
+    expect(credits).toEqual({
+      type: "text",
+      label: "Credits",
+      value: "$4.00 · 100 credits",
+    })
+    expect(credits).not.toHaveProperty("used")
+    expect(credits).not.toHaveProperty("limit")
   })
 
   it("maps prolite plan to Pro 5x", async () => {
@@ -252,7 +258,7 @@ describe("codex plugin", () => {
     expect(result.lines.find((line) => line.label === "Weekly")).toBeTruthy()
     const credits = result.lines.find((line) => line.label === "Credits")
     expect(credits).toBeTruthy()
-    expect(credits.used).toBe(900)
+    expect(credits.value).toBe("$4.00 · 100 credits")
   })
 
   it("uses zero credits from the response body when the account has no credits", async () => {
@@ -296,8 +302,31 @@ describe("codex plugin", () => {
     const result = plugin.probe(ctx)
     const credits = result.lines.find((line) => line.label === "Credits")
     expect(credits).toBeTruthy()
-    expect(credits.used).toBe(1000)
-    expect(credits.limit).toBe(1000)
+    expect(credits.value).toBe("$0.00 · 0 credits")
+  })
+
+  it("shows credit balances above 1000 without a fake cap", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {
+        "x-codex-credits-balance": "1250",
+      },
+      bodyText: JSON.stringify({}),
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const credits = result.lines.find((line) => line.label === "Credits")
+    expect(credits).toEqual({
+      type: "text",
+      label: "Credits",
+      value: "$50.00 · 1250 credits",
+    })
   })
 
   it("refreshes keychain auth and writes back to keychain", async () => {
@@ -927,7 +956,7 @@ describe("codex plugin", () => {
         code_review_rate_limit: {
           primary_window: { used_percent: 15, reset_after_seconds: 90 },
         },
-        credits: { balance: 500 },
+        credits: { balance: 820.6969075 },
       }),
     })
     const plugin = await loadPlugin()
@@ -936,7 +965,7 @@ describe("codex plugin", () => {
     expect(result.lines.find((line) => line.label === "Reviews")).toBeTruthy()
     const credits = result.lines.find((line) => line.label === "Credits")
     expect(credits).toBeTruthy()
-    expect(credits.used).toBe(500)
+    expect(credits.value).toBe("$32.80 · 820 credits")
   })
 
   it("omits resetsAt when window lacks reset info", async () => {


### PR DESCRIPTION
## Summary

- replace the Codex credits progress bar with a text row
- show the fixed USD value and absolute remaining credits as `$32.80 · 820 credits`
- remove the invented 1000-credit cap and inverted usage calculation
- document the $0.04-per-credit display conversion

| Before | After |
|--------|--------|
| <img width="294" height="397" alt="image" src="https://github.com/user-attachments/assets/fafeef53-ff5f-4f85-a11b-f4c97880552d" /> | <img width="293" height="342" alt="image" src="https://github.com/user-attachments/assets/411fe704-7a0b-4510-8fab-b9a98a078d74" /> | 

## Root cause

The Codex usage API returns an absolute remaining credit balance and does not provide a maximum. The plugin treated that balance as usage against a hardcoded 1000-credit limit, producing an incorrect progress bar.

## Validation

- `bun run test -- run plugins/codex/plugin.test.js` (64 tests)
- `bun run test -- run` (1,110 tests)
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the Codex plugin and docs; no auth or rate-limit logic changes.
> 
> **Overview**
> **Codex credits** no longer use a progress bar. The plugin now emits a **text** row with floored remaining credits and a fixed **$0.04/credit** USD estimate (e.g. `$32.80 · 820 credits`), matching the API’s absolute balance with no invented maximum.
> 
> This removes the previous **1000-credit cap** and inverted “used vs limit” math that misrepresented balances above 1000 or fractional API values. **`plugin.json`** registers Credits as `text` instead of `progress`. **`docs/providers/codex.md`** documents the display rule and unbounded balance.
> 
> Tests were updated for the new line shape and a case for balances **> 1000**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a12796be2019e4fdc31e241f5aa2e6389add6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API response examples to reflect unbounded credit balance with no maximum limit.

* **Refactor**
  * Changed credits display from progress indicator to text format, now showing remaining credit count and equivalent USD value ($0.04 per credit).

* **Tests**
  * Updated test assertions to validate new credits display format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->