### PR TITLE
[codex] Recover from reused Codex refresh tokens

### DIFF
--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -6,6 +6,7 @@
   const REFRESH_URL = "https://auth.openai.com/oauth/token"
   const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
   const REFRESH_AGE_MS = 8 * 24 * 60 * 60 * 1000
+  const ACCESS_TOKEN_REFRESH_WINDOW_MS = 5 * 60 * 1000
   const ERR_NOT_LOGGED_IN = "Not logged in. Run `codex` to authenticate."
   const ERR_SESSION_EXPIRED = "Session expired. Run `codex` to log in again."
   const ERR_TOKEN_CONFLICT = "Token conflict. Run `codex` to log in again."
@@ -173,10 +174,49 @@
   }
 
   function needsRefresh(ctx, auth, nowMs) {
-    if (!auth.last_refresh) return true
+    const accessToken = auth.tokens && auth.tokens.access_token
+    if (accessToken && ctx.jwt && typeof ctx.jwt.decodePayload === "function") {
+      const payload = ctx.jwt.decodePayload(accessToken)
+      const expiresAtSeconds = payload && payload.exp
+      if (typeof expiresAtSeconds === "number" && Number.isFinite(expiresAtSeconds)) {
+        const expiresAtMs = expiresAtSeconds * 1000
+        return expiresAtMs <= nowMs + ACCESS_TOKEN_REFRESH_WINDOW_MS
+      }
+    }
+
+    if (!auth.last_refresh) return false
     const lastMs = ctx.util.parseDateMs(auth.last_refresh)
-    if (lastMs === null) return true
+    if (lastMs === null) return false
     return nowMs - lastMs > REFRESH_AGE_MS
+  }
+
+  function reloadAuthState(ctx, authState) {
+    let reloaded = null
+    if (authState.source === "file" && authState.authPath) {
+      try {
+        const auth = tryParseAuthJson(ctx, ctx.host.fs.readText(authState.authPath))
+        if (hasTokenLikeAuth(auth)) {
+          reloaded = { auth, authPath: authState.authPath, source: "file" }
+        }
+      } catch (e) {
+        ctx.host.log.warn("auth reload failed for file " + authState.authPath + ": " + String(e))
+      }
+    } else if (authState.source === "keychain") {
+      reloaded = loadAuthFromKeychain(ctx)
+    }
+
+    if (!reloaded) return authState
+
+    const expectedAccountId = authState.auth.tokens && authState.auth.tokens.account_id
+    const reloadedAccountId = reloaded.auth.tokens && reloaded.auth.tokens.account_id
+    if (expectedAccountId && reloadedAccountId !== expectedAccountId) {
+      throw ERR_TOKEN_CONFLICT
+    }
+
+    if (JSON.stringify(reloaded.auth) !== JSON.stringify(authState.auth)) {
+      ctx.host.log.info("auth changed during guarded reload, using updated credentials")
+    }
+    return reloaded
   }
 
   function refreshToken(ctx, authState) {
@@ -566,25 +606,29 @@
     }))
   }
 
-  function probeWithAuthState(ctx, authState, opts) {
-    const auth = authState.auth
+  function probeWithAuthState(ctx, initialAuthState) {
+    let authState = initialAuthState
+    let auth = authState.auth
 
     if (auth.tokens && auth.tokens.access_token) {
       const nowMs = Date.now()
       let accessToken = auth.tokens.access_token
-      const accountId = auth.tokens.account_id
       let proactiveRefreshAuthError = null
 
       if (needsRefresh(ctx, auth, nowMs)) {
-        ctx.host.log.info("token needs refresh (age > " + (REFRESH_AGE_MS / 1000 / 60 / 60 / 24) + " days)")
+        ctx.host.log.info("token needs refresh")
+        authState = reloadAuthState(ctx, authState)
+        auth = authState.auth
+        accessToken = auth.tokens.access_token
         let refreshed = null
-        try {
-          refreshed = refreshToken(ctx, authState)
-        } catch (e) {
-          if (!isAuthFallbackError(e)) throw e
-          if (!opts || !opts.tryExistingTokenAfterProactiveAuthError) throw e
-          proactiveRefreshAuthError = e
-          ctx.host.log.warn("proactive refresh failed, trying existing token: " + String(e))
+        if (needsRefresh(ctx, auth, nowMs)) {
+          try {
+            refreshed = refreshToken(ctx, authState)
+          } catch (e) {
+            if (!isAuthFallbackError(e)) throw e
+            proactiveRefreshAuthError = e
+            ctx.host.log.warn("proactive refresh failed, trying existing token: " + String(e))
+          }
         }
         if (refreshed) {
           accessToken = refreshed
@@ -595,6 +639,7 @@
 
       let resp
       let didRefresh = false
+      const accountId = auth.tokens.account_id
       try {
         resp = ctx.util.retryOnceOnAuth({
           request: (token) => {
@@ -834,7 +879,6 @@
   function probe(ctx) {
     const fileAuth = loadFileAuthCandidates(ctx)
     let lastAuthFallbackError = null
-    let tokenConflictAuthState = null
     for (let i = 0; i < fileAuth.candidates.length; i++) {
       const authState = fileAuth.candidates[i]
       try {
@@ -844,9 +888,6 @@
           throw e
         }
         lastAuthFallbackError = e
-        if (e === ERR_TOKEN_CONFLICT && !tokenConflictAuthState) {
-          tokenConflictAuthState = authState
-        }
         ctx.host.log.warn("auth failed for file " + authState.authPath + ", trying next auth source: " + String(e))
       }
     }
@@ -858,14 +899,8 @@
       } catch (e) {
         if (!isAuthFallbackError(e)) throw e
         lastAuthFallbackError = e
-        ctx.host.log.warn("keychain auth failed, trying final auth fallback: " + String(e))
+        ctx.host.log.warn("keychain auth failed: " + String(e))
       }
-    }
-
-    if (tokenConflictAuthState) {
-      return probeWithAuthState(ctx, tokenConflictAuthState, {
-        tryExistingTokenAfterProactiveAuthError: true,
-      })
     }
 
     if (lastAuthFallbackError) throw lastAuthFallbackError

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -566,20 +566,29 @@
     }))
   }
 
-  function probeWithAuthState(ctx, authState) {
+  function probeWithAuthState(ctx, authState, opts) {
     const auth = authState.auth
 
     if (auth.tokens && auth.tokens.access_token) {
       const nowMs = Date.now()
       let accessToken = auth.tokens.access_token
       const accountId = auth.tokens.account_id
+      let proactiveRefreshAuthError = null
 
       if (needsRefresh(ctx, auth, nowMs)) {
         ctx.host.log.info("token needs refresh (age > " + (REFRESH_AGE_MS / 1000 / 60 / 60 / 24) + " days)")
-        const refreshed = refreshToken(ctx, authState)
+        let refreshed = null
+        try {
+          refreshed = refreshToken(ctx, authState)
+        } catch (e) {
+          if (!isAuthFallbackError(e)) throw e
+          if (!opts || !opts.tryExistingTokenAfterProactiveAuthError) throw e
+          proactiveRefreshAuthError = e
+          ctx.host.log.warn("proactive refresh failed, trying existing token: " + String(e))
+        }
         if (refreshed) {
           accessToken = refreshed
-        } else {
+        } else if (!proactiveRefreshAuthError) {
           ctx.host.log.warn("proactive refresh failed, trying with existing token")
         }
       }
@@ -600,6 +609,7 @@
             }
           },
           refresh: () => {
+            if (proactiveRefreshAuthError) throw proactiveRefreshAuthError
             ctx.host.log.info("usage returned 401, attempting refresh")
             didRefresh = true
             return refreshToken(ctx, authState)
@@ -824,6 +834,7 @@
   function probe(ctx) {
     const fileAuth = loadFileAuthCandidates(ctx)
     let lastAuthFallbackError = null
+    let tokenConflictAuthState = null
     for (let i = 0; i < fileAuth.candidates.length; i++) {
       const authState = fileAuth.candidates[i]
       try {
@@ -833,12 +844,29 @@
           throw e
         }
         lastAuthFallbackError = e
+        if (e === ERR_TOKEN_CONFLICT && !tokenConflictAuthState) {
+          tokenConflictAuthState = authState
+        }
         ctx.host.log.warn("auth failed for file " + authState.authPath + ", trying next auth source: " + String(e))
       }
     }
 
     const keychainAuth = loadAuthFromKeychain(ctx)
-    if (keychainAuth) return probeWithAuthState(ctx, keychainAuth)
+    if (keychainAuth) {
+      try {
+        return probeWithAuthState(ctx, keychainAuth)
+      } catch (e) {
+        if (!isAuthFallbackError(e)) throw e
+        lastAuthFallbackError = e
+        ctx.host.log.warn("keychain auth failed, trying final auth fallback: " + String(e))
+      }
+    }
+
+    if (tokenConflictAuthState) {
+      return probeWithAuthState(ctx, tokenConflictAuthState, {
+        tryExistingTokenAfterProactiveAuthError: true,
+      })
+    }
 
     if (lastAuthFallbackError) throw lastAuthFallbackError
 

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -94,6 +94,10 @@
     return false
   }
 
+  function hasAccessTokenAuth(auth) {
+    return !!(auth && auth.tokens && auth.tokens.access_token)
+  }
+
   function isAuthFallbackError(e) {
     if (typeof e !== "string") return false
     return (
@@ -205,18 +209,22 @@
       reloaded = loadAuthFromKeychain(ctx)
     }
 
-    if (!reloaded) return authState
+    if (!reloaded) return { status: "unchanged", authState }
+    if (!hasAccessTokenAuth(reloaded.auth)) {
+      return { status: "error", error: ERR_TOKEN_CONFLICT }
+    }
 
     const expectedAccountId = authState.auth.tokens && authState.auth.tokens.account_id
     const reloadedAccountId = reloaded.auth.tokens && reloaded.auth.tokens.account_id
     if (expectedAccountId && reloadedAccountId !== expectedAccountId) {
-      throw ERR_TOKEN_CONFLICT
+      return { status: "error", error: ERR_TOKEN_CONFLICT }
     }
 
     if (JSON.stringify(reloaded.auth) !== JSON.stringify(authState.auth)) {
       ctx.host.log.info("auth changed during guarded reload, using updated credentials")
+      return { status: "changed", authState: reloaded }
     }
-    return reloaded
+    return { status: "unchanged", authState }
   }
 
   function refreshToken(ctx, authState) {
@@ -613,13 +621,17 @@
     if (auth.tokens && auth.tokens.access_token) {
       const nowMs = Date.now()
       let accessToken = auth.tokens.access_token
+      let accountId = auth.tokens.account_id
       let proactiveRefreshAuthError = null
 
       if (needsRefresh(ctx, auth, nowMs)) {
         ctx.host.log.info("token needs refresh")
-        authState = reloadAuthState(ctx, authState)
+        const reload = reloadAuthState(ctx, authState)
+        if (reload.status === "error") throw reload.error
+        authState = reload.authState
         auth = authState.auth
         accessToken = auth.tokens.access_token
+        accountId = auth.tokens.account_id
         let refreshed = null
         if (needsRefresh(ctx, auth, nowMs)) {
           try {
@@ -639,7 +651,7 @@
 
       let resp
       let didRefresh = false
-      const accountId = auth.tokens.account_id
+      let didReloadAuth = false
       try {
         resp = ctx.util.retryOnceOnAuth({
           request: (token) => {
@@ -654,6 +666,18 @@
             }
           },
           refresh: () => {
+            const reload = reloadAuthState(ctx, authState)
+            if (reload.status === "error") throw reload.error
+            if (reload.status === "changed") {
+              authState = reload.authState
+              auth = authState.auth
+              accessToken = auth.tokens.access_token
+              accountId = auth.tokens.account_id
+              proactiveRefreshAuthError = null
+              didReloadAuth = true
+              ctx.host.log.info("usage returned 401, retrying with reloaded auth")
+              return accessToken
+            }
             if (proactiveRefreshAuthError) throw proactiveRefreshAuthError
             ctx.host.log.info("usage returned 401, attempting refresh")
             didRefresh = true
@@ -664,6 +688,20 @@
         if (typeof e === "string") throw e
         ctx.host.log.error("usage request failed: " + String(e))
         throw ERR_USAGE_CONNECTION
+      }
+
+      if (didReloadAuth && ctx.util.isAuthStatus(resp.status)) {
+        ctx.host.log.info("reloaded auth returned 401, attempting refresh")
+        didRefresh = true
+        const refreshed = refreshToken(ctx, authState)
+        if (refreshed) {
+          try {
+            resp = fetchUsage(ctx, refreshed, accountId)
+          } catch (e) {
+            ctx.host.log.error("usage request exception after reloaded auth refresh: " + String(e))
+            throw ERR_USAGE_AFTER_REFRESH
+          }
+        }
       }
 
       if (ctx.util.isAuthStatus(resp.status)) {

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -6,6 +6,12 @@ const loadPlugin = async () => {
   return globalThis.__openusage_plugin
 }
 
+const makeJwt = (payload) => [
+  Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+  Buffer.from(JSON.stringify(payload)).toString("base64url"),
+  "signature",
+].join(".")
+
 describe("codex plugin", () => {
   beforeEach(() => {
     delete globalThis.__openusage_plugin
@@ -24,6 +30,9 @@ describe("codex plugin", () => {
     }))
     ctx.host.http.request.mockImplementation((opts) => {
       if (String(opts.url).includes("oauth/token")) return refreshResponse
+      if (opts.headers.Authorization === "Bearer old-file-token") {
+        return { status: 401, headers: {}, bodyText: "" }
+      }
       expect(opts.headers.Authorization).toBe("Bearer keychain-token")
       return {
         status: 200,
@@ -676,6 +685,127 @@ describe("codex plugin", () => {
     expect(() => plugin.probe(ctx)).toThrow("Token expired")
   })
 
+  it("does not proactively refresh an unexpired JWT", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-08T00:00:00.000Z"))
+    try {
+      const ctx = makeCtx()
+      const accessToken = makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 6 * 60,
+      })
+      ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+        tokens: { access_token: accessToken, refresh_token: "refresh" },
+        last_refresh: "2000-01-01T00:00:00.000Z",
+      }))
+      ctx.host.http.request.mockImplementation((opts) => {
+        expect(String(opts.url)).not.toContain("oauth/token")
+        expect(opts.headers.Authorization).toBe("Bearer " + accessToken)
+        return { status: 200, headers: {}, bodyText: JSON.stringify({}) }
+      })
+
+      const plugin = await loadPlugin()
+      plugin.probe(ctx)
+
+      expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not proactively refresh without expiry or last_refresh", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "opaque-token", refresh_token: "refresh" },
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      expect(String(opts.url)).not.toContain("oauth/token")
+      expect(opts.headers.Authorization).toBe("Bearer opaque-token")
+      return { status: 200, headers: {}, bodyText: JSON.stringify({}) }
+    })
+
+    const plugin = await loadPlugin()
+    plugin.probe(ctx)
+
+    expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
+  })
+
+  it("proactively refreshes a JWT within five minutes of expiry", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-08T00:00:00.000Z"))
+    try {
+      const ctx = makeCtx()
+      const accessToken = makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 4 * 60,
+      })
+      ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+        tokens: { access_token: accessToken, refresh_token: "refresh" },
+        last_refresh: new Date().toISOString(),
+      }))
+      ctx.host.http.request.mockImplementation((opts) => {
+        if (String(opts.url).includes("oauth/token")) {
+          return {
+            status: 200,
+            headers: {},
+            bodyText: JSON.stringify({ access_token: "refreshed" }),
+          }
+        }
+        expect(opts.headers.Authorization).toBe("Bearer refreshed")
+        return { status: 200, headers: {}, bodyText: JSON.stringify({}) }
+      })
+
+      const plugin = await loadPlugin()
+      plugin.probe(ctx)
+
+      expect(ctx.host.http.request).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("uses auth changed on disk instead of refreshing stale credentials", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-08T00:00:00.000Z"))
+    try {
+      const ctx = makeCtx()
+      const authPath = "~/.codex/auth.json"
+      const staleAuth = JSON.stringify({
+        tokens: {
+          access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 }),
+          refresh_token: "stale-refresh",
+          account_id: "account",
+        },
+        last_refresh: "2000-01-01T00:00:00.000Z",
+      })
+      const freshToken = makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 60 * 60,
+      })
+      const freshAuth = JSON.stringify({
+        tokens: {
+          access_token: freshToken,
+          refresh_token: "fresh-refresh",
+          account_id: "account",
+        },
+        last_refresh: new Date().toISOString(),
+      })
+      ctx.host.fs.writeText(authPath, staleAuth)
+      ctx.host.fs.readText = vi.fn()
+        .mockReturnValueOnce(staleAuth)
+        .mockReturnValue(freshAuth)
+      ctx.host.http.request.mockImplementation((opts) => {
+        expect(String(opts.url)).not.toContain("oauth/token")
+        expect(opts.headers.Authorization).toBe("Bearer " + freshToken)
+        return { status: 200, headers: {}, bodyText: JSON.stringify({}) }
+      })
+
+      const plugin = await loadPlugin()
+      plugin.probe(ctx)
+
+      expect(ctx.host.http.request).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("throws token conflict when refresh token is reused", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
@@ -722,10 +852,10 @@ describe("codex plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
-    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Codex Auth")
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
 
-  it("retries the first reusable file token after later auth candidates fail", async () => {
+  it("uses the first valid file access token before later auth candidates", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.config/codex/auth.json", JSON.stringify({
       tokens: { access_token: "still-valid", refresh_token: "used-refresh" },
@@ -764,7 +894,7 @@ describe("codex plugin", () => {
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
   })
 
-  it("uses existing file token after keychain auth is exhausted", async () => {
+  it("uses existing file token before checking keychain", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
       tokens: { access_token: "still-valid", refresh_token: "used-refresh" },
@@ -801,6 +931,7 @@ describe("codex plugin", () => {
     const result = plugin.probe(ctx)
 
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
   })
 
   it("preserves usage server errors when retrying an existing access token", async () => {
@@ -913,7 +1044,7 @@ describe("codex plugin", () => {
     expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Codex Auth")
   })
 
-  it("surfaces original token conflict when file and keychain auth both fail", async () => {
+  it("surfaces keychain auth error when file and keychain auth both fail", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
       tokens: { access_token: "file-token", refresh_token: "file-refresh" },
@@ -938,12 +1069,15 @@ describe("codex plugin", () => {
           bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
         }
       }
-      expect(opts.headers.Authorization).toBe("Bearer file-token")
+      if (opts.headers.Authorization === "Bearer file-token") {
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer keychain-token")
       return { status: 401, headers: {}, bodyText: "" }
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Token conflict")
+    expect(() => plugin.probe(ctx)).toThrow("Session expired")
     expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Codex Auth")
   })
 
@@ -1413,19 +1547,29 @@ describe("codex plugin", () => {
       tokens: { access_token: "old", refresh_token: "refresh" },
       last_refresh: "2000-01-01T00:00:00.000Z",
     }))
-    ctx.host.http.request.mockReturnValueOnce({
-      status: 400,
-      headers: {},
-      bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        return {
+          status: 400,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
+        }
+      }
+      return { status: 401, headers: {}, bodyText: "" }
     })
     let plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Session expired")
 
     ctx.host.http.request.mockReset()
-    ctx.host.http.request.mockReturnValueOnce({
-      status: 400,
-      headers: {},
-      bodyText: JSON.stringify({ error: { code: "refresh_token_invalidated" } }),
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        return {
+          status: 400,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_invalidated" } }),
+        }
+      }
+      return { status: 401, headers: {}, bodyText: "" }
     })
     delete globalThis.__openusage_plugin
     vi.resetModules()

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -682,13 +682,146 @@ describe("codex plugin", () => {
       tokens: { access_token: "old", refresh_token: "refresh" },
       last_refresh: "2000-01-01T00:00:00.000Z",
     }))
-    ctx.host.http.request.mockReturnValue({
-      status: 400,
-      headers: {},
-      bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        return {
+          status: 400,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+        }
+      }
+      return { status: 401, headers: {}, bodyText: "" }
     })
     const plugin = await loadPlugin()
     expect(() => plugin.probe(ctx)).toThrow("Token conflict")
+  })
+
+  it("uses existing access token when proactive refresh token was reused", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "still-valid", refresh_token: "used-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        return {
+          status: 401,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+        }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer still-valid")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "14" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Codex Auth")
+  })
+
+  it("retries the first reusable file token after later auth candidates fail", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.config/codex/auth.json", JSON.stringify({
+      tokens: { access_token: "still-valid", refresh_token: "used-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "expired", refresh_token: "expired-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.bodyText).includes("used-refresh")) {
+        return {
+          status: 401,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+        }
+      }
+      if (String(opts.bodyText).includes("expired-refresh")) {
+        return {
+          status: 401,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
+        }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer still-valid")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "15" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+  })
+
+  it("uses existing file token after keychain auth is exhausted", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "still-valid", refresh_token: "used-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.keychain.readGenericPassword.mockReturnValue(JSON.stringify({
+      tokens: { access_token: "keychain-token", refresh_token: "expired-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.bodyText).includes("used-refresh")) {
+        return {
+          status: 401,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+        }
+      }
+      if (String(opts.bodyText).includes("expired-refresh")) {
+        return {
+          status: 401,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
+        }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer still-valid")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "16" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+  })
+
+  it("preserves usage server errors when retrying an existing access token", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "still-valid", refresh_token: "used-refresh" },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        return {
+          status: 401,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+        }
+      }
+      return { status: 500, headers: {}, bodyText: "" }
+    })
+
+    const plugin = await loadPlugin()
+    expect(() => plugin.probe(ctx)).toThrow("Usage request failed (HTTP 500)")
   })
 
   it("falls back to keychain when file refresh token was reused", async () => {
@@ -780,7 +913,7 @@ describe("codex plugin", () => {
     expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Codex Auth")
   })
 
-  it("surfaces keychain auth error when file and keychain auth both fail", async () => {
+  it("surfaces original token conflict when file and keychain auth both fail", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
       tokens: { access_token: "file-token", refresh_token: "file-refresh" },
@@ -798,16 +931,19 @@ describe("codex plugin", () => {
           bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
         }
       }
-      expect(String(opts.bodyText)).toContain("keychain-refresh")
-      return {
-        status: 400,
-        headers: {},
-        bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
+      if (String(opts.bodyText).includes("keychain-refresh")) {
+        return {
+          status: 400,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_expired" } }),
+        }
       }
+      expect(opts.headers.Authorization).toBe("Bearer file-token")
+      return { status: 401, headers: {}, bodyText: "" }
     })
 
     const plugin = await loadPlugin()
-    expect(() => plugin.probe(ctx)).toThrow("Session expired")
+    expect(() => plugin.probe(ctx)).toThrow("Token conflict")
     expect(ctx.host.keychain.readGenericPassword).toHaveBeenCalledWith("Codex Auth")
   })
 

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -806,6 +806,162 @@ describe("codex plugin", () => {
     }
   })
 
+  it("reloads newer auth after a proactive refresh error and usage 401", async () => {
+    const ctx = makeCtx()
+    const authPath = "~/.codex/auth.json"
+    const staleAuth = {
+      tokens: {
+        access_token: "stale-access",
+        refresh_token: "used-refresh",
+        account_id: "account",
+      },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }
+    const freshAuth = {
+      tokens: {
+        access_token: "fresh-access",
+        refresh_token: "fresh-refresh",
+        account_id: "account",
+      },
+      last_refresh: new Date().toISOString(),
+    }
+    ctx.host.fs.writeText(authPath, JSON.stringify(staleAuth))
+    let refreshCalls = 0
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.url).includes("oauth/token")) {
+        refreshCalls += 1
+        return {
+          status: 401,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+        }
+      }
+      if (opts.headers.Authorization === "Bearer stale-access") {
+        ctx.host.fs.writeText(authPath, JSON.stringify(freshAuth))
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer fresh-access")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "17" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+    expect(refreshCalls).toBe(1)
+  })
+
+  it("refreshes reloaded auth when its access token is also unauthorized", async () => {
+    const ctx = makeCtx()
+    const authPath = "~/.codex/auth.json"
+    const staleAuth = {
+      tokens: {
+        access_token: "stale-access",
+        refresh_token: "used-refresh",
+        account_id: "account",
+      },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    }
+    const freshAuth = {
+      tokens: {
+        access_token: "fresh-access",
+        refresh_token: "fresh-refresh",
+        account_id: "account",
+      },
+      last_refresh: new Date().toISOString(),
+    }
+    ctx.host.fs.writeText(authPath, JSON.stringify(staleAuth))
+    ctx.host.http.request.mockImplementation((opts) => {
+      if (String(opts.bodyText).includes("used-refresh")) {
+        return {
+          status: 401,
+          headers: {},
+          bodyText: JSON.stringify({ error: { code: "refresh_token_reused" } }),
+        }
+      }
+      if (String(opts.bodyText).includes("fresh-refresh")) {
+        return {
+          status: 200,
+          headers: {},
+          bodyText: JSON.stringify({ access_token: "refreshed-access" }),
+        }
+      }
+      if (opts.headers.Authorization === "Bearer stale-access") {
+        ctx.host.fs.writeText(authPath, JSON.stringify(freshAuth))
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      if (opts.headers.Authorization === "Bearer fresh-access") {
+        return { status: 401, headers: {}, bodyText: "" }
+      }
+      expect(opts.headers.Authorization).toBe("Bearer refreshed-access")
+      return {
+        status: 200,
+        headers: { "x-codex-primary-used-percent": "18" },
+        bodyText: JSON.stringify({}),
+      }
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+
+    expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
+  })
+
+  it("fails cleanly when guarded reload switches to API-key auth", async () => {
+    const ctx = makeCtx()
+    const authPath = "~/.codex/auth.json"
+    const staleAuth = JSON.stringify({
+      tokens: {
+        access_token: "stale-access",
+        refresh_token: "stale-refresh",
+        account_id: "account",
+      },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    })
+    ctx.host.fs.writeText(authPath, staleAuth)
+    ctx.host.fs.readText = vi.fn()
+      .mockReturnValueOnce(staleAuth)
+      .mockReturnValue(JSON.stringify({ OPENAI_API_KEY: "sk-test" }))
+
+    const plugin = await loadPlugin()
+
+    expect(() => plugin.probe(ctx)).toThrow("Token conflict")
+    expect(ctx.host.http.request).not.toHaveBeenCalled()
+  })
+
+  it("fails cleanly when guarded reload switches accounts", async () => {
+    const ctx = makeCtx()
+    const authPath = "~/.codex/auth.json"
+    const staleAuth = JSON.stringify({
+      tokens: {
+        access_token: "stale-access",
+        refresh_token: "stale-refresh",
+        account_id: "account",
+      },
+      last_refresh: "2000-01-01T00:00:00.000Z",
+    })
+    ctx.host.fs.writeText(authPath, staleAuth)
+    ctx.host.fs.readText = vi.fn()
+      .mockReturnValueOnce(staleAuth)
+      .mockReturnValue(JSON.stringify({
+        tokens: {
+          access_token: "other-access",
+          refresh_token: "other-refresh",
+          account_id: "other-account",
+        },
+        last_refresh: new Date().toISOString(),
+      }))
+
+    const plugin = await loadPlugin()
+
+    expect(() => plugin.probe(ctx)).toThrow("Token conflict")
+    expect(ctx.host.http.request).not.toHaveBeenCalled()
+  })
+
   it("throws token conflict when refresh token is reused", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
@@ -832,8 +988,10 @@ describe("codex plugin", () => {
       tokens: { access_token: "still-valid", refresh_token: "used-refresh" },
       last_refresh: "2000-01-01T00:00:00.000Z",
     }))
+    let refreshCalls = 0
     ctx.host.http.request.mockImplementation((opts) => {
       if (String(opts.url).includes("oauth/token")) {
+        refreshCalls += 1
         return {
           status: 401,
           headers: {},
@@ -853,6 +1011,7 @@ describe("codex plugin", () => {
 
     expect(result.lines.find((line) => line.label === "Session")).toBeTruthy()
     expect(ctx.host.keychain.readGenericPassword).not.toHaveBeenCalled()
+    expect(refreshCalls).toBe(1)
   })
 
   it("uses the first valid file access token before later auth candidates", async () => {


### PR DESCRIPTION
## What changed

- Match current Codex proactive refresh timing: use access-token JWT expiry with a five-minute window; use the eight-day `last_refresh` rule only when JWT expiry is unavailable.
- Re-read the selected auth file or Keychain entry immediately before refresh. If Codex wrote newer token credentials for the same account, use them and skip the stale refresh.
- Keep using the existing access token when proactive refresh fails. A consumed refresh token does not mean the access token is invalid.
- On usage 401, reload persisted auth again. Retry changed credentials first; if those are also unauthorized, refresh those credentials once and retry.
- Only swap guarded reloads into token auth. Concurrent API-key or account changes fail cleanly as token conflicts instead of entering the token path with an invalid shape.
- Persist successful access-token and refresh-token rotation back to the original source.

## Latest Codex behavior

This matches `openai/codex` `main` at commit [`5a440c0`](https://github.com/openai/codex/tree/5a440c03f2f3393169c5df517d1fd8eee969e45e):

- [`should_refresh_proactively`](https://github.com/openai/codex/blob/5a440c03f2f3393169c5df517d1fd8eee969e45e/codex-rs/login/src/auth/manager.rs#L1912-L1934): prefer JWT expiry; refresh within five minutes.
- [`refresh_token`](https://github.com/openai/codex/blob/5a440c03f2f3393169c5df517d1fd8eee969e45e/codex-rs/login/src/auth/manager.rs#L1771-L1810): reload persisted auth before OAuth refresh and skip stale refresh when another process updated it.
- [`auth`](https://github.com/openai/codex/blob/5a440c03f2f3393169c5df517d1fd8eee969e45e/codex-rs/login/src/auth/manager.rs#L1516-L1532): retain current auth when proactive refresh fails.
- [Unauthorized recovery](https://github.com/openai/codex/blob/5a440c03f2f3393169c5df517d1fd8eee969e45e/codex-rs/login/src/auth/manager.rs#L1278-L1320): reload persisted auth on 401, retry changed credentials, then refresh and retry once.

## Why

A stale refresh token can return `refresh_token_reused` while its access token remains valid. OpenUsage previously treated the refresh failure as proof that the access token was unusable. It also did not fully recover when another Codex process updated credentials after the first guarded reload.

The diagnosis and initial patch came from @youngchangjo in #566. Their commit remains credited through the `Co-authored-by` trailer. This PR extends that fix to match current Codex handling.

## Validation

- `bunx vitest run plugins/codex/plugin.test.js plugins/codex/plugin.ccusage.test.js` (76 passed)
- `bun run test -- --run` (1,121 passed)
- `bun run build`
- `cargo test --manifest-path src-tauri/Cargo.toml redact_` (21 passed)
- Local CodeRabbit review: 0 findings

README provider support and plugin-host redaction fields were audited. Codex is already listed, and this change exposes no new request or response fields.

Closes #566