### PR TITLE
fix: mitigate macOS 26 Tahoe menu bar state corruption hiding the tray icon

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,8 +46,8 @@ sha2 = "0.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSProcessInfo", "NSString"] }
-objc2-app-kit = { version = "0.3", features = ["NSEvent", "NSScreen", "NSGraphics"] }
+objc2-foundation = { version = "0.3", features = ["NSProcessInfo", "NSString", "NSUserDefaults", "NSValue"] }
+objc2-app-kit = { version = "0.3", features = ["NSAlert", "NSApplication", "NSEvent", "NSGraphics", "NSResponder", "NSScreen", "NSStatusBarButton", "NSStatusItem", "NSView", "NSWindow"] }
 objc2-web-kit = { version = "0.3", features = ["WKPreferences", "WKWebView", "WKWebViewConfiguration"] }
 
 [dev-dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ mod panel;
 mod plugin_engine;
 mod tray;
 #[cfg(target_os = "macos")]
+mod tray_tahoe;
+#[cfg(target_os = "macos")]
 mod webkit_config;
 
 use std::collections::{HashMap, HashSet, VecDeque};

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -47,6 +47,9 @@ fn set_stored_log_level(app_handle: &AppHandle, level: log::LevelFilter) {
 }
 
 pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
+    #[cfg(target_os = "macos")]
+    crate::tray_tahoe::prepare_status_item_defaults();
+
     let tray_icon_path = app_handle
         .path()
         .resolve("icons/tray-icon.png", BaseDirectory::Resource)?;
@@ -154,7 +157,7 @@ pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
         ],
     )?;
 
-    TrayIconBuilder::with_id("tray")
+    let tray = TrayIconBuilder::with_id("tray")
         .icon(icon)
         .icon_as_template(true)
         .tooltip("OpenUsage")
@@ -238,6 +241,12 @@ pub fn create(app_handle: &AppHandle) -> tauri::Result<()> {
             }
         })
         .build(app_handle)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        crate::tray_tahoe::adopt_stable_identity(&tray);
+        crate::tray_tahoe::schedule_health_check(app_handle);
+    }
 
     Ok(())
 }

--- a/src-tauri/src/tray_tahoe.rs
+++ b/src-tauri/src/tray_tahoe.rs
@@ -1,0 +1,250 @@
+//! Mitigations for macOS 26 (Tahoe) menu bar state corruption.
+//!
+//! macOS 26 hosts third-party status items through ControlCenter, and its
+//! per-app bookkeeping can corrupt (notably on 26.5), leaving the tray icon
+//! hidden or parked off-screen while the app believes everything is fine.
+//! See <https://github.com/robinebers/openusage/issues/517>.
+//!
+//! Mirrors the fixes shipped by other affected menu bar apps:
+//! 1. Drop `NSStatusItem Visible* = false` defaults before the tray is
+//!    created, so a stale "hidden" record cannot suppress the icon (CodexBar).
+//! 2. Give the status item an explicit autosave name, which re-registers
+//!    affected installs under a fresh ControlCenter identity (oMLX).
+//! 3. Probe the status item after startup and, if macOS is not actually
+//!    hosting it in the menu bar, tell the user how to recover (oMLX) —
+//!    the tray is the app's only entry point.
+
+use objc2_app_kit::NSAlert;
+use objc2_foundation::{MainThreadMarker, NSNumber, NSProcessInfo, NSString, NSUserDefaults};
+use tauri::AppHandle;
+
+/// Stable ControlCenter identity for the status item. Bumping this value
+/// re-registers every install under a fresh identity, which is the escape
+/// hatch when macOS corrupts the saved state for the current one.
+const STATUS_ITEM_AUTOSAVE_NAME: &str = "OpenUsage";
+
+/// Identity macOS auto-generates when no autosave name is set (all builds
+/// before the explicit name above was introduced).
+const LEGACY_ITEM_NAME: &str = "Item-0";
+
+const PREFERRED_POSITION_KEY_PREFIX: &str = "NSStatusItem Preferred Position";
+const VISIBLE_KEY_PREFIXES: [&str; 2] = ["NSStatusItem Visible", "NSStatusItem VisibleCC"];
+
+const INITIAL_PROBE_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+const CONFIRM_PROBE_DELAY: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Call before the tray icon is created.
+pub fn prepare_status_item_defaults() {
+    let defaults = NSUserDefaults::standardUserDefaults();
+
+    // A `Visible* = false` record left behind by Tahoe's menu bar migration
+    // keeps the icon hidden on every launch. Only `false` entries are stale;
+    // `true` and unrelated entries are left alone.
+    for item_name in [LEGACY_ITEM_NAME, STATUS_ITEM_AUTOSAVE_NAME] {
+        for key_prefix in VISIBLE_KEY_PREFIXES {
+            let key = NSString::from_str(&format!("{key_prefix} {item_name}"));
+            let Some(value) = defaults.objectForKey(&key) else {
+                continue;
+            };
+            let is_stale_false = value
+                .downcast::<NSNumber>()
+                .map(|number| !number.boolValue())
+                .unwrap_or(false);
+            if is_stale_false {
+                log::warn!("clearing stale '{key_prefix} {item_name}' menu bar default");
+                defaults.removeObjectForKey(&key);
+            }
+        }
+    }
+
+    // Carry the saved menu bar position over to the new identity so existing
+    // installs keep their slot when the autosave name is adopted.
+    let legacy_position_key =
+        NSString::from_str(&format!("{PREFERRED_POSITION_KEY_PREFIX} {LEGACY_ITEM_NAME}"));
+    let position_key = NSString::from_str(&format!(
+        "{PREFERRED_POSITION_KEY_PREFIX} {STATUS_ITEM_AUTOSAVE_NAME}"
+    ));
+    if defaults.objectForKey(&position_key).is_none()
+        && let Some(position) = defaults.objectForKey(&legacy_position_key)
+    {
+        unsafe { defaults.setObject_forKey(Some(&position), &position_key) };
+    }
+}
+
+/// Call after the tray icon is created. tray-icon leaves the status item on
+/// the auto-generated "Item-N" identity — exactly the record Tahoe corrupts.
+pub fn adopt_stable_identity(tray: &tauri::tray::TrayIcon) {
+    let result = tray.with_inner_tray_icon(|inner| {
+        let Some(status_item) = inner.ns_status_item() else {
+            return false;
+        };
+        status_item.setAutosaveName(Some(&NSString::from_str(STATUS_ITEM_AUTOSAVE_NAME)));
+        true
+    });
+    match result {
+        Ok(true) => {}
+        Ok(false) => log::error!("status item unavailable while adopting autosave name"),
+        Err(error) => log::error!("failed to adopt status item autosave name: {error}"),
+    }
+}
+
+/// Run once after startup, macOS 26+ only: probe twice (ControlCenter needs
+/// time to settle after launch) and surface recovery guidance if the icon
+/// never lands in the menu bar.
+pub fn schedule_health_check(app_handle: &AppHandle) {
+    if NSProcessInfo::processInfo()
+        .operatingSystemVersion()
+        .majorVersion
+        < 26
+    {
+        return;
+    }
+    let app_handle = app_handle.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(INITIAL_PROBE_DELAY);
+        let Some(first) = probe_status_item(&app_handle) else {
+            return;
+        };
+        if !first.is_broken() {
+            log::debug!("status item health check passed: {first:?}");
+            return;
+        }
+        log::warn!("status item looks broken ({first:?}); re-checking before alerting");
+        std::thread::sleep(CONFIRM_PROBE_DELAY);
+        let Some(second) = probe_status_item(&app_handle) else {
+            return;
+        };
+        if !second.is_broken() {
+            log::info!("status item recovered on second probe: {second:?}");
+            return;
+        }
+        log::error!(
+            "status item is not hosted in the menu bar ({second:?}); macOS 26 menu bar state for this app is likely corrupted (issue #517)"
+        );
+        show_recovery_alert(&app_handle);
+    });
+}
+
+#[derive(Clone, Copy, Debug)]
+struct StatusItemHealth {
+    visible: bool,
+    has_button: bool,
+    has_window: bool,
+    has_screen: bool,
+    /// AppKit y-origin of the button window; the corrupted state parks it at
+    /// a negative value (below the screen). Only read through the `Debug`
+    /// output in logs.
+    #[allow(dead_code)]
+    window_y: f64,
+}
+
+impl StatusItemHealth {
+    /// Broken when the app-side handle looks alive but macOS is not actually
+    /// hosting the item on any screen (or reports it hidden).
+    fn is_broken(&self) -> bool {
+        !(self.visible && self.has_button && self.has_window && self.has_screen)
+    }
+}
+
+fn probe_status_item(app_handle: &AppHandle) -> Option<StatusItemHealth> {
+    let Some(tray) = app_handle.tray_by_id("tray") else {
+        log::error!("tray handle missing during status item health check");
+        return None;
+    };
+    let health = tray.with_inner_tray_icon(|inner| {
+        // The closure is dispatched to the main thread by tauri.
+        let mtm = MainThreadMarker::new()?;
+        let status_item = inner.ns_status_item()?;
+        let button = status_item.button(mtm);
+        let window = button.as_ref().and_then(|button| button.window());
+        let screen = window.as_ref().and_then(|window| window.screen());
+        Some(StatusItemHealth {
+            visible: status_item.isVisible(),
+            has_button: button.is_some(),
+            has_window: window.is_some(),
+            has_screen: screen.is_some(),
+            window_y: window
+                .map(|window| window.frame().origin.y)
+                .unwrap_or(f64::NAN),
+        })
+    });
+    match health {
+        Ok(Some(health)) => Some(health),
+        Ok(None) => {
+            log::error!("status item probe could not run (no status item handle)");
+            None
+        }
+        Err(error) => {
+            log::error!("status item probe failed: {error}");
+            None
+        }
+    }
+}
+
+fn show_recovery_alert(app_handle: &AppHandle) {
+    let result = app_handle.run_on_main_thread(|| {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return;
+        };
+        let alert = NSAlert::new(mtm);
+        alert.setMessageText(&NSString::from_str("Menu Bar Icon Hidden by macOS"));
+        alert.setInformativeText(&NSString::from_str(
+            "macOS is not displaying the OpenUsage menu bar icon. This is caused by a menu bar bug in macOS 26 (Tahoe).\n\nTo fix it:\n\n1. Open System Settings → Menu Bar\n2. Find OpenUsage under \"Allow in the Menu Bar\" and toggle it off and back on\n3. Restart OpenUsage\n\nIf the icon is still missing, please report it at github.com/robinebers/openusage/issues/517",
+        ));
+        alert.runModal();
+    });
+    if let Err(error) = result {
+        log::error!("failed to show menu bar recovery alert: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StatusItemHealth;
+
+    fn healthy() -> StatusItemHealth {
+        StatusItemHealth {
+            visible: true,
+            has_button: true,
+            has_window: true,
+            has_screen: true,
+            window_y: 1093.0,
+        }
+    }
+
+    #[test]
+    fn healthy_item_is_not_broken() {
+        assert!(!healthy().is_broken());
+    }
+
+    #[test]
+    fn off_screen_item_is_broken() {
+        // The #517 signature: window exists but is not attached to any screen.
+        let health = StatusItemHealth {
+            has_screen: false,
+            window_y: -22.0,
+            ..healthy()
+        };
+        assert!(health.is_broken());
+    }
+
+    #[test]
+    fn hidden_item_is_broken() {
+        let health = StatusItemHealth {
+            visible: false,
+            ..healthy()
+        };
+        assert!(health.is_broken());
+    }
+
+    #[test]
+    fn blocked_item_without_window_is_broken() {
+        // Tahoe allow-list blocking: the button never gets a window.
+        let health = StatusItemHealth {
+            has_window: false,
+            has_screen: false,
+            ..healthy()
+        };
+        assert!(health.is_broken());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #517 — on macOS 26.5 (Tahoe), ControlCenter's menu bar bookkeeping can corrupt per-app, parking the status item off-screen at `(-1, screenHeight-1)` and leaving the app completely unreachable. This is an OS bug (same signature hit CodexBar, Stats, oMLX, NetBird, BetterDisplay), so this PR ships the same mitigations those projects merged:

1. **Clear stale visibility defaults before tray creation** (CodexBar [`6665d028`](https://github.com/steipete/CodexBar/issues/1169)): drops `NSStatusItem Visible* = false` records left behind by Tahoe's menu bar migration; `true`/unrelated entries are untouched. Also migrates the saved `Preferred Position` from the auto-generated `Item-0` identity to the new one, so existing installs keep their menu bar slot.
2. **Explicit `autosaveName` on the status item** (oMLX [`7f38bf6`](https://github.com/jundot/omlx/commit/7f38bf66c9d5a250c1a1847daaa2f35815e074dd)): tray-icon leaves the auto-generated `Item-0` identity — exactly the record Tahoe corrupts. A custom name re-registers affected installs under a fresh ControlCenter identity on update.
3. **Startup health check with recovery guidance** (oMLX): macOS 26+ only, probes the item at +5s and confirms at +15s before acting (avoids fighting ControlCenter, per BetterDisplay's recreation-loop failure). If the item is reported visible but isn't actually hosted on any screen, logs the full state and shows a one-shot alert pointing to System Settings → Menu Bar — since the tray is the app's only entry point.

Implementation: reaches the raw `NSStatusItem` via `TrayIcon::with_inner_tray_icon` → `ns_status_item()`; the needed `objc2-app-kit`/`objc2-foundation` features unify with the versions tray-icon already pulls.

## Testing

- `cargo test` — 131 passing (4 new unit tests covering the broken-state detection: off-screen, hidden, allow-list-blocked signatures)
- `cargo clippy` — clean on changed files
- Live smoke test on macOS 26.5 (the affected OS version): tray renders normally, health check probe reports `visible: true, has_button: true, has_window: true, has_screen: true, window_y: 1084.0` (the bug signature is `has_screen: false, window_y: -22`), no alert fires, and the position migration verifiably copied `Preferred Position Item-0` → `Preferred Position OpenUsage` in the live defaults domain
- The corrupted state itself can't be reproduced on a healthy machine — verification on an affected machine is requested from the reporter in #517

## Notes

- No docs in `docs/` describe tray placement behavior, so none needed updating.
- Known consideration: if "Automatically hide and show the menu bar" turns out to detach the status item window from its screen, the double-probe could false-positive for those users; the two-probe delay plus the alert's once-per-launch cap bounds the impact, and the logged `StatusItemHealth` makes any report easy to triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> macOS-only startup logic touches NSUserDefaults and raw NSStatusItem via tray internals; incorrect probes could false-positive alerts, but scope is gated to macOS 26+ with double-delay confirmation.
> 
> **Overview**
> Adds **macOS 26 (Tahoe)–specific tray mitigations** for ControlCenter menu bar state corruption (#517), where the status item can stay hidden or off-screen while the app still thinks it is fine.
> 
> A new **`tray_tahoe`** module runs **before** tray creation to clear stale `NSStatusItem Visible* = false` defaults and migrate **Preferred Position** from legacy `Item-0` to a stable **`OpenUsage`** autosave identity. **After** the tray is built, it sets that autosave name on the raw `NSStatusItem` and, on macOS 26+, runs a **double health probe** (5s + 10s) that shows an **`NSAlert`** with System Settings recovery steps if the icon is not actually hosted in the menu bar.
> 
> **`tray::create`** wires these hooks and keeps the built tray handle for post-build setup. **`Cargo.toml`** expands `objc2-foundation` / `objc2-app-kit` features for `NSUserDefaults`, status item APIs, and alerts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4005e1c2f676a66c78d1becb45e5b918808b5c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mitigates a macOS 26 (Tahoe) menu bar bug that can hide the tray icon by corrupting ControlCenter state, restoring visibility and adding recovery guidance. Addresses #517.

- **Bug Fixes**
  - Clear stale `NSStatusItem Visible* = false` defaults and migrate `Preferred Position` from `Item-0` to `OpenUsage` before tray creation.
  - Set a stable `autosaveName` for the status item to replace the corrupted `Item-0` identity.
  - Add a macOS 26+ startup health check (two probes) that logs state and shows a one-time alert with recovery steps if the icon isn’t hosted.

- **Dependencies**
  - Enable extra `objc2-foundation` features (`NSUserDefaults`, `NSValue`) and `objc2-app-kit` features (`NSStatusItem`, `NSStatusBarButton`, `NSWindow`, `NSAlert`, others) needed for defaults cleanup, identity adoption, and the alert.

<sup>Written for commit 4005e1c2f676a66c78d1becb45e5b918808b5c6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS tray icon stability, particularly on macOS 26 (Tahoe).
  * Added automatic health checks that detect when the menu bar tray icon fails to display.
  * Introduced recovery alerts with step-by-step guidance if tray icon issues are detected.

* **Improvements**
  * Enhanced macOS system integration for more reliable menu bar functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
