### PR TITLE
feat(codex): show rate limit resets

### DIFF
--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -16,7 +16,7 @@
 
 ### GET /backend-api/wham/usage
 
-Returns rate limit windows and optional credits.
+Returns rate limit windows, optional credits, and available on-demand rate limit resets.
 
 #### Headers
 
@@ -54,6 +54,9 @@ Returns rate limit windows and optional credits.
     "has_credits": true,
     "unlimited": false,
     "balance": 820.6969075                 // remaining credits
+  },
+  "rate_limit_reset_credits": {            // on-demand resets (optional)
+    "available_count": 1
   }
 }
 ```
@@ -63,6 +66,9 @@ Both rate_limit windows are enforced simultaneously — hitting either limit thr
 OpenUsage floors the remaining credit balance to a whole number and displays its fixed USD
 equivalent at `$0.04` per credit. For example, `820.6969075` renders as
 `$32.80 · 820 credits`. The credit balance is unbounded; the API does not provide a maximum.
+
+When available, OpenUsage displays the on-demand reset count as the first detail text metric,
+for example `1 available`.
 
 ## Authentication
 

--- a/plugins/codex/plugin.js
+++ b/plugins/codex/plugin.js
@@ -827,6 +827,19 @@
         }
       }
 
+      const resetCredits =
+        data.rate_limit_reset_credits &&
+        typeof data.rate_limit_reset_credits === "object" &&
+        data.rate_limit_reset_credits.available_count != null
+          ? readNumber(data.rate_limit_reset_credits.available_count)
+          : null
+      if (resetCredits !== null && resetCredits >= 0) {
+        lines.push(ctx.line.text({
+          label: "Rate Limit Resets",
+          value: Math.floor(resetCredits) + " available",
+        }))
+      }
+
       const creditsRemaining = readCreditsRemaining(resp, data)
       if (creditsRemaining !== null) {
         const remaining = Math.max(0, Math.floor(creditsRemaining))

--- a/plugins/codex/plugin.json
+++ b/plugins/codex/plugin.json
@@ -16,6 +16,7 @@
     { "type": "progress", "label": "Spark", "scope": "detail" },
     { "type": "progress", "label": "Spark Weekly", "scope": "detail" },
     { "type": "progress", "label": "Reviews", "scope": "detail" },
+    { "type": "text", "label": "Rate Limit Resets", "scope": "detail" },
     { "type": "text", "label": "Credits", "scope": "detail" },
     { "type": "text", "label": "Today", "scope": "detail" },
     { "type": "text", "label": "Yesterday", "scope": "detail" },

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -1397,6 +1397,72 @@ describe("codex plugin", () => {
     expect(credits.value).toBe("$32.80 · 820 credits")
   })
 
+  it("shows available rate limit resets as the first text line", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    ctx.host.http.request.mockReturnValue({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        rate_limit_reset_credits: { available_count: 1 },
+        credits: { balance: 100 },
+      }),
+    })
+    ctx.host.ccusage.query.mockReturnValue({
+      status: "ok",
+      data: { daily: [] },
+    })
+
+    const plugin = await loadPlugin()
+    const result = plugin.probe(ctx)
+    const resetIndex = result.lines.findIndex((line) => line.label === "Rate Limit Resets")
+    const creditsIndex = result.lines.findIndex((line) => line.label === "Credits")
+    const firstTextIndex = result.lines.findIndex((line) => line.type === "text")
+
+    expect(result.lines[resetIndex]).toEqual({
+      type: "text",
+      label: "Rate Limit Resets",
+      value: "1 available",
+    })
+    expect(resetIndex).toBeGreaterThanOrEqual(0)
+    expect(resetIndex).toBe(firstTextIndex)
+    expect(creditsIndex).toBe(resetIndex + 1)
+  })
+
+  it("shows zero available rate limit resets and omits malformed counts", async () => {
+    const ctx = makeCtx()
+    ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({
+      tokens: { access_token: "token" },
+      last_refresh: new Date().toISOString(),
+    }))
+    const plugin = await loadPlugin()
+
+    ctx.host.http.request.mockReturnValueOnce({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        rate_limit_reset_credits: { available_count: 0 },
+      }),
+    })
+    const zeroResult = plugin.probe(ctx)
+    expect(zeroResult.lines.find((line) => line.label === "Rate Limit Resets")?.value)
+      .toBe("0 available")
+
+    ctx.host.http.request.mockReturnValueOnce({
+      status: 200,
+      headers: {},
+      bodyText: JSON.stringify({
+        rate_limit_reset_credits: { available_count: null },
+      }),
+    })
+    const malformedResult = plugin.probe(ctx)
+    expect(malformedResult.lines.find((line) => line.label === "Rate Limit Resets"))
+      .toBeUndefined()
+  })
+
   it("omits resetsAt when window lacks reset info", async () => {
     const ctx = makeCtx()
     ctx.host.fs.writeText("~/.codex/auth.json", JSON.stringify({


### PR DESCRIPTION
## What Changed

- Add a `Rate Limit Resets` detail metric for Codex on-demand reset credits.
- Display the metric as the first text line, before Credits, using values such as `1 available`.
- Document the newly observed `rate_limit_reset_credits.available_count` response field.

## Why

Codex now grants on-demand rate limit resets, but OpenUsage ignored the new usage API field.

## Verification

- `bunx vitest run plugins/codex/plugin.test.js` (78 tests passed)
- `bun run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only parsing and display of an optional API field in the Codex plugin; no auth or billing logic changes.
> 
> **Overview**
> The Codex plugin now reads **`rate_limit_reset_credits.available_count`** from the wham usage API and shows a detail text line **Rate Limit Resets** (e.g. `1 available`). That line is emitted **before Credits** when the count is a valid number ≥ 0; missing or invalid values are skipped.
> 
> **`plugin.json`** registers the new detail metric, **`docs/providers/codex.md`** documents the optional response field and display behavior, and tests cover ordering, zero counts, and malformed data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb1feb405783bc8872226758b1ad6eb25f8c4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show available on-demand rate limit resets in Codex usage. Displays as the first text detail before Credits, e.g. "1 available".

- **New Features**
  - Read `rate_limit_reset_credits.available_count` and render a "Rate Limit Resets" line (shows 0; ignores null/malformed).
  - Ensure it appears before "Credits"; updated docs and tests to cover the new API field and UI behavior.

<sup>Written for commit afb1feb405783bc8872226758b1ad6eb25f8c4f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex plugin now displays the count of available on-demand rate limit resets as a new usage metric.

* **Tests**
  * Added test cases for the new rate limit resets display functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->