### PR TITLE
Refactor: remove dead code, DRY duplication, and hot-path allocations

### DIFF
--- a/Sources/OpenUsage/Models/MetricLine.swift
+++ b/Sources/OpenUsage/Models/MetricLine.swift
@@ -90,6 +90,17 @@ enum MetricLine: Hashable, Sendable, Codable {
         return false
     }
 
+    /// The shared "no usage data" placeholder badge, shown when a provider returns no metric lines.
+    static let noUsageData = MetricLine.badge(label: "Status", text: "No usage data", colorHex: "#A3A3A3")
+
+    /// Append `noUsageData` when nothing was produced, so an empty result reads as a clear status
+    /// instead of a blank tile.
+    static func appendNoDataIfNeeded(_ lines: inout [MetricLine]) {
+        if lines.isEmpty {
+            lines.append(.noUsageData)
+        }
+    }
+
     private enum CodingKeys: String, CodingKey {
         case type
         case label

--- a/Sources/OpenUsage/Providers/CcusageSpendMapper.swift
+++ b/Sources/OpenUsage/Providers/CcusageSpendMapper.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Turns ccusage's local daily token/cost data into Today / Yesterday / Last 30 Days `MetricLine`s.
+/// Shared by the Claude and Codex providers (both read the same `ccusage` CLI), so this lives outside
+/// any one provider's mapper rather than being borrowed across provider folders.
+enum CcusageSpendMapper {
+    static func appendTokenUsage(_ usage: CcusageDailyUsage, to lines: inout [MetricLine], now: Date = Date()) {
+        let today = dayKey(from: now)
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now).map(dayKey(from:))
+
+        let todayEntry = usage.daily.first { dayKey(fromUsageDate: $0.date) == today }
+        let yesterdayEntry = usage.daily.first { dayKey(fromUsageDate: $0.date) == yesterday }
+
+        lines.append(dayUsageLine(label: "Today", entry: todayEntry, includeZeroTokens: true))
+        lines.append(dayUsageLine(label: "Yesterday", entry: yesterdayEntry, includeZeroTokens: true))
+
+        let totalTokens = usage.daily.reduce(0) { $0 + $1.totalTokens }
+        let costValues = usage.daily.compactMap(\.costUSD)
+        let totalCost = costValues.isEmpty ? nil : costValues.reduce(0, +)
+        if totalTokens > 0 {
+            lines.append(.text(
+                label: "Last 30 Days",
+                value: costAndTokensLabel(tokens: totalTokens, costUSD: totalCost)
+            ))
+        }
+    }
+
+    static func dayKey(from date: Date) -> String {
+        let components = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
+    }
+
+    static func dayKey(fromUsageDate rawDate: String) -> String? {
+        let value = rawDate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        if let match = value.range(of: #"^\d{4}-\d{2}-\d{2}"#, options: .regularExpression) {
+            return String(value[match])
+        }
+        if value.range(of: #"^\d{8}$"#, options: .regularExpression) != nil {
+            let year = value.prefix(4)
+            let month = value.dropFirst(4).prefix(2)
+            let day = value.suffix(2)
+            return "\(year)-\(month)-\(day)"
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "MMM dd, yyyy"
+        if let date = formatter.date(from: value) {
+            return dayKey(from: date)
+        }
+
+        if let date = OpenUsageISO8601.date(from: value) {
+            return dayKey(from: date)
+        }
+        return nil
+    }
+
+    static func dayUsageLine(label: String, entry: CcusageDay?, includeZeroTokens: Bool) -> MetricLine {
+        let tokens = entry?.totalTokens ?? 0
+        let cost = entry?.costUSD
+        if tokens > 0 || includeZeroTokens {
+            return .text(label: label, value: costAndTokensLabel(tokens: tokens, costUSD: cost))
+        }
+        return .text(label: label, value: "")
+    }
+
+    static func costAndTokensLabel(tokens: Int, costUSD: Double?) -> String {
+        var parts: [String] = []
+        if let costUSD {
+            parts.append(Formatters.currency(costUSD))
+        }
+        parts.append("\(formatTokens(tokens)) tokens")
+        return parts.joined(separator: " · ")
+    }
+
+    static func formatTokens(_ tokens: Int) -> String {
+        let absValue = abs(tokens)
+        let sign = tokens < 0 ? "-" : ""
+        let units: [(threshold: Double, divisor: Double, suffix: String)] = [
+            (1_000_000_000, 1_000_000_000, "B"),
+            (1_000_000, 1_000_000, "M"),
+            (1_000, 1_000, "K")
+        ]
+        for unit in units where Double(absValue) >= unit.threshold {
+            let scaled = Double(absValue) / unit.divisor
+            let formatted = scaled >= 10
+                ? String(Int(scaled.rounded()))
+                : String(format: "%.1f", scaled).replacingOccurrences(of: ".0", with: "")
+            return sign + formatted + unit.suffix
+        }
+        return "\(tokens)"
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -80,7 +80,7 @@ struct ClaudeAuthStore: Sendable {
 
     func loadCredentials() -> ClaudeCredentialState? {
         let envAccessToken = envText("CLAUDE_CODE_OAUTH_TOKEN")
-        let stored = loadStoredCredentials(suppressMissingWarn: envAccessToken != nil)
+        let stored = loadStoredCredentials()
         guard let envAccessToken else {
             return stored
         }
@@ -175,31 +175,10 @@ struct ClaudeAuthStore: Sendable {
     }
 
     static func parseCredentials(_ text: String) -> ClaudeCredentialsFile? {
-        if let parsed = decodeCredentials(text) {
-            return parsed
-        }
-
-        var hex = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if hex.hasPrefix("0x") || hex.hasPrefix("0X") {
-            hex = String(hex.dropFirst(2))
-        }
-        guard !hex.isEmpty, hex.count.isMultiple(of: 2), hex.allSatisfy(\.isHexDigit) else {
-            return nil
-        }
-
-        var bytes: [UInt8] = []
-        var index = hex.startIndex
-        while index < hex.endIndex {
-            let next = hex.index(index, offsetBy: 2)
-            guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
-            bytes.append(byte)
-            index = next
-        }
-        guard let decoded = String(bytes: bytes, encoding: .utf8) else { return nil }
-        return decodeCredentials(decoded)
+        ProviderParse.decodeJSONWithHexFallback(text, as: ClaudeCredentialsFile.self)
     }
 
-    private func loadStoredCredentials(suppressMissingWarn: Bool) -> ClaudeCredentialState? {
+    private func loadStoredCredentials() -> ClaudeCredentialState? {
         if let keychain = loadKeychainCredentials() { return keychain }
         if let file = loadFileCredentials() { return file }
         return nil
@@ -269,11 +248,6 @@ struct ClaudeAuthStore: Sendable {
         let normalized = value.precomposedStringWithCanonicalMapping
         let digest = SHA256.hash(data: Data(normalized.utf8))
         return digest.map { String(format: "%02x", $0) }.joined().prefix(8).description
-    }
-
-    private static func decodeCredentials(_ text: String) -> ClaudeCredentialsFile? {
-        guard let data = text.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(ClaudeCredentialsFile.self, from: data)
     }
 }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -61,13 +61,13 @@ final class ClaudeProvider: ProviderRuntime {
             mapped = try await fetchLiveUsage(state: &state)
         }
 
-        let since = sinceString(daysBack: 30, from: now())
+        let since = CcusageRunner.sinceString(daysBack: 30, from: now())
         let tokenUsage = await ccusageRunner.query(provider: .claude, since: since, homePath: authStore.claudeHomeOverride())
         if case .success(let usage) = tokenUsage {
-            CodexUsageMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
+            CcusageSpendMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
         }
 
-        ClaudeUsageMapper.appendNoDataIfNeeded(&mapped.lines)
+        MetricLine.appendNoDataIfNeeded(&mapped.lines)
         return ProviderSnapshot(
             providerID: provider.id,
             displayName: provider.displayName,
@@ -132,12 +132,6 @@ final class ClaudeProvider: ProviderRuntime {
         }
         try? authStore.save(state)
         return decoded.accessToken
-    }
-
-    private func sinceString(daysBack: Int, from date: Date) -> String {
-        let since = Calendar.current.date(byAdding: .day, value: -daysBack, to: date) ?? date
-        let components = Calendar.current.dateComponents([.year, .month, .day], from: since)
-        return String(format: "%04d%02d%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
     }
 
 }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -6,8 +6,8 @@ struct ClaudeMappedUsage: Equatable, Sendable {
 }
 
 enum ClaudeUsageMapper {
-    static let sessionPeriodMs = 5 * 60 * 60 * 1000
-    static let weeklyPeriodMs = 7 * 24 * 60 * 60 * 1000
+    static let sessionPeriodMs = MetricPeriod.sessionMs
+    static let weeklyPeriodMs = MetricPeriod.weekMs
 
     static func mapUsageResponse(_ response: HTTPResponse, credentials: ClaudeOAuth, now: Date = Date()) throws -> ClaudeMappedUsage {
         guard (200..<300).contains(response.statusCode) else {
@@ -46,12 +46,6 @@ enum ClaudeUsageMapper {
         )
     }
 
-    static func appendNoDataIfNeeded(_ lines: inout [MetricLine]) {
-        if lines.isEmpty {
-            lines.append(.badge(label: "Status", text: "No usage data", colorHex: "#A3A3A3"))
-        }
-    }
-
     static func parseRetryAfterSeconds(_ response: HTTPResponse, now: Date = Date()) -> Int? {
         guard let raw = response.header("retry-after")?.trimmingCharacters(in: .whitespacesAndNewlines),
               !raw.isEmpty
@@ -73,10 +67,7 @@ enum ClaudeUsageMapper {
         else {
             return nil
         }
-        let base = raw
-            .split(separator: " ")
-            .map { $0.prefix(1).uppercased() + $0.dropFirst().lowercased() }
-            .joined(separator: " ")
+        let base = raw.titleCased(separator: { $0 == " " }, lowercasingTail: true)
 
         guard let tier = rateLimitTier,
               let match = tier.range(of: #"\d+x"#, options: .regularExpression)
@@ -119,7 +110,7 @@ enum ClaudeUsageMapper {
                 format: .dollars
             ))
         } else if used > 0 {
-            lines.append(.text(label: "Extra usage spent", value: String(format: "$%.2f", used)))
+            lines.append(.text(label: "Extra usage spent", value: Formatters.currency(used)))
         }
     }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
@@ -169,39 +169,13 @@ struct CodexAuthStore: Sendable {
     }
 
     static func parseAuth(_ text: String) -> CodexAuth? {
-        if let auth = decodeAuth(text) {
-            return auth
-        }
-
-        var hex = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if hex.hasPrefix("0x") || hex.hasPrefix("0X") {
-            hex = String(hex.dropFirst(2))
-        }
-        guard !hex.isEmpty, hex.count.isMultiple(of: 2), hex.allSatisfy(\.isHexDigit) else {
-            return nil
-        }
-
-        var bytes: [UInt8] = []
-        var index = hex.startIndex
-        while index < hex.endIndex {
-            let next = hex.index(index, offsetBy: 2)
-            guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
-            bytes.append(byte)
-            index = next
-        }
-        guard let decoded = String(bytes: bytes, encoding: .utf8) else { return nil }
-        return decodeAuth(decoded)
+        ProviderParse.decodeJSONWithHexFallback(text, as: CodexAuth.self)
     }
 
     static func hasTokenLikeAuth(_ auth: CodexAuth) -> Bool {
         if auth.tokens?.accessToken?.isEmpty == false { return true }
         if auth.apiKey?.isEmpty == false { return true }
         return false
-    }
-
-    private static func decodeAuth(_ text: String) -> CodexAuth? {
-        guard let data = text.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(CodexAuth.self, from: data)
     }
 
     private func joinPath(_ base: String, _ leaf: String) -> String {

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -80,10 +80,10 @@ final class CodexProvider: ProviderRuntime {
         let response = try await fetchUsageWithRetry(accessToken: accessToken, authState: &authState)
         var mapped = try CodexUsageMapper.mapUsageResponse(response, now: now())
 
-        let since = sinceString(daysBack: 30, from: now())
+        let since = CcusageRunner.sinceString(daysBack: 30, from: now())
         let tokenUsage = await ccusageRunner.query(provider: .codex, since: since, homePath: authStore.codexHome())
         if case .success(let usage) = tokenUsage {
-            CodexUsageMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
+            CcusageSpendMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
         }
 
         return ProviderSnapshot(
@@ -130,11 +130,5 @@ final class CodexProvider: ProviderRuntime {
         authState.auth.lastRefresh = OpenUsageISO8601.string(from: now())
         try? authStore.save(authState)
         return response.accessToken
-    }
-
-    private func sinceString(daysBack: Int, from date: Date) -> String {
-        let since = Calendar.current.date(byAdding: .day, value: -daysBack, to: date) ?? date
-        let components = Calendar.current.dateComponents([.year, .month, .day], from: since)
-        return String(format: "%04d%02d%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
     }
 }

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageClient.swift
@@ -32,12 +32,13 @@ struct CodexUsageClient: Sendable {
         ))
 
         if response.statusCode == 400 || response.statusCode == 401 {
-            let code = ProviderParse.jsonObject(response.body)?["error"].flatMap { errorValue -> String? in
+            let errorBody = ProviderParse.jsonObject(response.body)
+            let code = errorBody?["error"].flatMap { errorValue -> String? in
                 if let error = errorValue as? [String: Any] {
                     return error["code"] as? String ?? error["error"] as? String
                 }
                 return errorValue as? String
-            } ?? ProviderParse.jsonObject(response.body)?["code"] as? String
+            } ?? errorBody?["code"] as? String
 
             switch code {
             case "refresh_token_expired":

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -6,8 +6,8 @@ struct CodexMappedUsage: Equatable, Sendable {
 }
 
 enum CodexUsageMapper {
-    static let sessionPeriodMs = 5 * 60 * 60 * 1000
-    static let weeklyPeriodMs = 7 * 24 * 60 * 60 * 1000
+    static let sessionPeriodMs = MetricPeriod.sessionMs
+    static let weeklyPeriodMs = MetricPeriod.weekMs
     /// Codex flex credits are worth 4¢ each; the credits line leads with the dollar value
     /// (mirrors the JS plugin's `CREDIT_USD_RATE`).
     static let creditUSDRate = 0.04
@@ -76,32 +76,9 @@ enum CodexUsageMapper {
             lines.append(.text(label: "Credits", value: creditsLabel(remaining: remaining)))
         }
 
-        if lines.isEmpty {
-            lines.append(.badge(label: "Status", text: "No usage data", colorHex: "#A3A3A3"))
-        }
+        MetricLine.appendNoDataIfNeeded(&lines)
 
         return CodexMappedUsage(plan: formatCodexPlan(body["plan_type"]), lines: lines)
-    }
-
-    static func appendTokenUsage(_ usage: CcusageDailyUsage, to lines: inout [MetricLine], now: Date = Date()) {
-        let today = dayKey(from: now)
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now).map(dayKey(from:))
-
-        let todayEntry = usage.daily.first { dayKey(fromUsageDate: $0.date) == today }
-        let yesterdayEntry = usage.daily.first { dayKey(fromUsageDate: $0.date) == yesterday }
-
-        lines.append(dayUsageLine(label: "Today", entry: todayEntry, includeZeroTokens: true))
-        lines.append(dayUsageLine(label: "Yesterday", entry: yesterdayEntry, includeZeroTokens: true))
-
-        let totalTokens = usage.daily.reduce(0) { $0 + $1.totalTokens }
-        let costValues = usage.daily.compactMap(\.costUSD)
-        let totalCost = costValues.isEmpty ? nil : costValues.reduce(0, +)
-        if totalTokens > 0 {
-            lines.append(.text(
-                label: "Last 30 Days",
-                value: costAndTokensLabel(tokens: totalTokens, costUSD: totalCost)
-            ))
-        }
     }
 
     private static func appendAdditionalRateLimits(from body: [String: Any], to lines: inout [MetricLine], now: Date) {
@@ -193,7 +170,7 @@ enum CodexUsageMapper {
     static func creditsLabel(remaining: Double) -> String {
         let credits = max(0, Int(remaining.rounded(.down)))
         let usd = Double(credits) * creditUSDRate
-        return String(format: "$%.2f", usd) + " · \(credits.formatted(.number.locale(Locale(identifier: "en_US")))) credits"
+        return Formatters.currency(usd) + " · \(credits.formatted(.number.locale(Locale(identifier: "en_US")))) credits"
     }
 
     private static func readCreditsRemaining(response: HTTPResponse, body: [String: Any]) -> Double? {
@@ -220,79 +197,8 @@ enum CodexUsageMapper {
         case "pro":
             return "Pro 20x"
         default:
-            return raw
-                .split(separator: "_")
-                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
-                .joined(separator: " ")
+            return raw.titleCased(separator: { $0 == "_" })
         }
-    }
-
-    static func dayKey(from date: Date) -> String {
-        let components = Calendar.current.dateComponents([.year, .month, .day], from: date)
-        return String(format: "%04d-%02d-%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
-    }
-
-    static func dayKey(fromUsageDate rawDate: String) -> String? {
-        let value = rawDate.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !value.isEmpty else { return nil }
-
-        if let match = value.range(of: #"^\d{4}-\d{2}-\d{2}"#, options: .regularExpression) {
-            return String(value[match])
-        }
-        if value.range(of: #"^\d{8}$"#, options: .regularExpression) != nil {
-            let year = value.prefix(4)
-            let month = value.dropFirst(4).prefix(2)
-            let day = value.suffix(2)
-            return "\(year)-\(month)-\(day)"
-        }
-
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "MMM dd, yyyy"
-        if let date = formatter.date(from: value) {
-            return dayKey(from: date)
-        }
-
-        if let date = OpenUsageISO8601.date(from: value) {
-            return dayKey(from: date)
-        }
-        return nil
-    }
-
-    static func dayUsageLine(label: String, entry: CcusageDay?, includeZeroTokens: Bool) -> MetricLine {
-        let tokens = entry?.totalTokens ?? 0
-        let cost = entry?.costUSD
-        if tokens > 0 || includeZeroTokens {
-            return .text(label: label, value: costAndTokensLabel(tokens: tokens, costUSD: cost))
-        }
-        return .text(label: label, value: "")
-    }
-
-    static func costAndTokensLabel(tokens: Int, costUSD: Double?) -> String {
-        var parts: [String] = []
-        if let costUSD {
-            parts.append(String(format: "$%.2f", costUSD))
-        }
-        parts.append("\(formatTokens(tokens)) tokens")
-        return parts.joined(separator: " · ")
-    }
-
-    static func formatTokens(_ tokens: Int) -> String {
-        let absValue = abs(tokens)
-        let sign = tokens < 0 ? "-" : ""
-        let units: [(threshold: Double, divisor: Double, suffix: String)] = [
-            (1_000_000_000, 1_000_000_000, "B"),
-            (1_000_000, 1_000_000, "M"),
-            (1_000, 1_000, "K")
-        ]
-        for unit in units where Double(absValue) >= unit.threshold {
-            let scaled = Double(absValue) / unit.divisor
-            let formatted = scaled >= 10
-                ? String(Int(scaled.rounded()))
-                : String(format: "%.1f", scaled).replacingOccurrences(of: ".0", with: "")
-            return sign + formatted + unit.suffix
-        }
-        return "\(tokens)"
     }
 
 }

--- a/Sources/OpenUsage/Providers/Cursor/CursorAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorAuthStore.swift
@@ -133,35 +133,18 @@ struct CursorAuthStore: Sendable {
     }
 
     private static func tokenExpiration(_ token: String) -> Date? {
-        guard let exp = jwtPayload(token)?["exp"].flatMap(ProviderParse.number) else { return nil }
+        guard let exp = ProviderParse.jwtPayload(token)?["exp"].flatMap(ProviderParse.number) else { return nil }
         return Date(timeIntervalSince1970: exp)
     }
 
     static func tokenSubject(_ token: String?) -> String? {
         guard let token,
-              let subject = jwtPayload(token)?["sub"] as? String
+              let subject = ProviderParse.jwtPayload(token)?["sub"] as? String
         else {
             return nil
         }
         let trimmed = subject.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
-    }
-
-    static func jwtPayload(_ token: String) -> [String: Any]? {
-        let parts = token.split(separator: ".")
-        guard parts.count >= 2 else { return nil }
-        var payload = String(parts[1])
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        while !payload.count.isMultiple(of: 4) {
-            payload.append("=")
-        }
-        guard let data = Data(base64Encoded: payload),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return nil
-        }
-        return json
     }
 
     private static func sqlEscaped(_ value: String) -> String {

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
@@ -12,25 +12,35 @@ struct CursorUsageCSVRow: Sendable, Equatable {
 }
 
 enum CursorUsageCSV {
+    // Date parsing runs once per row of a potentially large export; the three fixed-format parsers are
+    // stateless after configuration, so they're built once instead of per call. DateFormatter and
+    // ISO8601DateFormatter are thread-safe for parsing; `nonisolated(unsafe)` shares the immutable
+    // instances without per-call allocation.
+    private nonisolated(unsafe) static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private nonisolated(unsafe) static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+    private static let plainDateTime: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f
+    }()
+
     /// Pure parser: maps Cursor's exported CSV text into priced rows. Rows with an unparseable date or
     /// header are skipped.
     static func parse(csv: String) -> [CursorUsageCSVRow] {
-        let isoFractional: ISO8601DateFormatter = {
-            let f = ISO8601DateFormatter()
-            f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            return f
-        }()
-        let iso: ISO8601DateFormatter = {
-            let f = ISO8601DateFormatter()
-            f.formatOptions = [.withInternetDateTime]
-            return f
-        }()
-
         var rows: [CursorUsageCSVRow] = []
         CursorCSVParser.forEachRecord(in: csv) { r in
             guard let dateStr = r["Date"]?.trimmingCharacters(in: .whitespaces),
                   !dateStr.isEmpty,
-                  let date = parseDate(dateStr, iso: iso, isoFractional: isoFractional)
+                  let date = parseDate(dateStr)
             else { return }
 
             let model = (r["Model"] ?? "").trimmingCharacters(in: .whitespaces)
@@ -54,17 +64,10 @@ enum CursorUsageCSV {
         return rows
     }
 
-    private static func parseDate(
-        _ raw: String,
-        iso: ISO8601DateFormatter,
-        isoFractional: ISO8601DateFormatter
-    ) -> Date? {
+    private static func parseDate(_ raw: String) -> Date? {
         if let d = isoFractional.date(from: raw) { return d }
         if let d = iso.date(from: raw) { return d }
-        let df = DateFormatter()
-        df.locale = Locale(identifier: "en_US_POSIX")
-        df.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return df.date(from: raw)
+        return plainDateTime.date(from: raw)
     }
 
     private static func parseIntValue(_ raw: String) -> Int {

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -35,7 +35,7 @@ enum CursorUsageError: Error, LocalizedError, Equatable {
 }
 
 enum CursorUsageMapper {
-    static let billingPeriodMs = 30 * 24 * 60 * 60 * 1000
+    static let billingPeriodMs = MetricPeriod.monthMs
 
     static func mapUsage(
         usage: [String: Any],
@@ -88,7 +88,7 @@ enum CursorUsageMapper {
                 periodDurationMs: cycle.periodDurationMs
             ))
             if let bonusSpendCents = ProviderParse.number(planUsage["bonusSpend"]), bonusSpendCents > 0 {
-                lines.append(.text(label: "Bonus spend", value: String(format: "$%.2f", ProviderParse.centsToDollars(bonusSpendCents))))
+                lines.append(.text(label: "Bonus spend", value: Formatters.currency(ProviderParse.centsToDollars(bonusSpendCents))))
             }
         } else {
             lines.append(.progress(
@@ -237,7 +237,7 @@ enum CursorUsageMapper {
     /// Sum dollars then snap to integer cents once (avoiding per-row rounding loss and final float
     /// drift), and always format with a "$" so `WidgetDataStore.firstCurrencyAmount` parses it.
     private static func spendDollars(_ dollars: Double) -> String {
-        String(format: "$%.2f", Double(CursorPricing.toCents(dollars)) / 100)
+        Formatters.currency(Double(CursorPricing.toCents(dollars)) / 100)
     }
 
     static func stripeBalanceCents(from response: HTTPResponse?) -> Double {
@@ -287,9 +287,6 @@ enum CursorUsageMapper {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return trimmed
-            .split(whereSeparator: \.isWhitespace)
-            .map { word in word.prefix(1).uppercased() + word.dropFirst() }
-            .joined(separator: " ")
+        return trimmed.titleCased(separator: \.isWhitespace)
     }
 }

--- a/Sources/OpenUsage/Providers/Devin/DevinUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinUsageMapper.swift
@@ -6,8 +6,8 @@ struct DevinMappedUsage: Equatable, Sendable {
 }
 
 enum DevinUsageMapper {
-    static let dayPeriodMs = 24 * 60 * 60 * 1000
-    static let weekPeriodMs = 7 * dayPeriodMs
+    static let dayPeriodMs = MetricPeriod.dayMs
+    static let weekPeriodMs = MetricPeriod.weekMs
 
     static func mapUserStatusResponse(_ response: HTTPResponse) throws -> DevinMappedUsage {
         guard let body = ProviderParse.jsonObject(response.body),
@@ -97,7 +97,7 @@ enum DevinUsageMapper {
     private static func formatDollarsFromMicros(_ value: Any?) -> String? {
         guard var micros = ProviderParse.number(value) else { return nil }
         micros = max(0, micros)
-        return String(format: "$%.2f", micros / 1_000_000)
+        return Formatters.currency(micros / 1_000_000)
     }
 
     private static func readTrimmedString(_ value: Any?) -> String? {

--- a/Sources/OpenUsage/Providers/Grok/GrokAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokAuthStore.swift
@@ -8,7 +8,6 @@ struct GrokAuthEntry: Codable, Hashable, Sendable {
     var expiresAt: String?
     var expires: String?
     var oidcClientID: String?
-    var email: String?
 
     enum CodingKeys: String, CodingKey {
         case key
@@ -18,7 +17,6 @@ struct GrokAuthEntry: Codable, Hashable, Sendable {
         case expiresAt = "expires_at"
         case expires
         case oidcClientID = "oidc_client_id"
-        case email
     }
 }
 
@@ -136,12 +134,7 @@ struct GrokAuthStore: Sendable {
     }
 
     func tokenExpiresAt(_ token: String) -> Date? {
-        let parts = token.split(separator: ".")
-        guard parts.count >= 2,
-              let data = Self.base64URLData(String(parts[1])),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let exp = ProviderParse.number(object["exp"])
-        else {
+        guard let exp = ProviderParse.jwtPayload(token)?["exp"].flatMap(ProviderParse.number) else {
             return nil
         }
         return Date(timeIntervalSince1970: exp)
@@ -155,17 +148,6 @@ struct GrokAuthStore: Sendable {
     static func parseJSONObject(_ text: String) -> [String: Any]? {
         guard let data = text.data(using: .utf8) else { return nil }
         return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
-    }
-
-    static func base64URLData(_ value: String) -> Data? {
-        var normalized = value
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        let padding = normalized.count % 4
-        if padding > 0 {
-            normalized += String(repeating: "=", count: 4 - padding)
-        }
-        return Data(base64Encoded: normalized)
     }
 
     private func entryExpiresAt(_ entry: GrokAuthEntry) -> Date? {

--- a/Sources/OpenUsage/Services/CcusageRunner.swift
+++ b/Sources/OpenUsage/Services/CcusageRunner.swift
@@ -50,6 +50,13 @@ struct CcusageRunner {
         self.homeDirectory = homeDirectory
     }
 
+    /// The `--since` argument ccusage expects: `yyyyMMdd`, `daysBack` days before `date`.
+    static func sinceString(daysBack: Int, from date: Date) -> String {
+        let since = Calendar.current.date(byAdding: .day, value: -daysBack, to: date) ?? date
+        let components = Calendar.current.dateComponents([.year, .month, .day], from: since)
+        return String(format: "%04d%02d%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
+    }
+
     func query(provider: CcusageProvider, since: String, homePath: String? = nil) async -> Result<CcusageDailyUsage, CcusageRunnerError> {
         guard let bunx = resolveBunx() else {
             return .failure(.noRunner)
@@ -198,15 +205,11 @@ struct CcusageRunner {
     }
 
     private static func readInt(_ value: Any?) -> Int? {
-        if let number = value as? NSNumber { return number.intValue }
-        if let string = value as? String { return Int(string) }
-        return nil
+        ProviderParse.number(value).map { Int($0) }
     }
 
     private static func readDouble(_ value: Any?) -> Double? {
-        if let number = value as? NSNumber { return number.doubleValue }
-        if let string = value as? String { return Double(string) }
-        return nil
+        ProviderParse.number(value)
     }
 }
 

--- a/Sources/OpenUsage/Services/ProcessRunner.swift
+++ b/Sources/OpenUsage/Services/ProcessRunner.swift
@@ -22,8 +22,8 @@ struct SystemProcessRunner: ProcessRunning {
     func run(
         executable: String,
         arguments: [String],
-        environment: [String: String] = [:],
-        timeout: TimeInterval = 15
+        environment: [String: String],
+        timeout: TimeInterval
     ) throws -> ProcessResult {
         let process = Process()
         if executable.hasPrefix("/") {

--- a/Sources/OpenUsage/Stores/AppearanceSetting.swift
+++ b/Sources/OpenUsage/Stores/AppearanceSetting.swift
@@ -6,12 +6,14 @@ import AppKit
 /// `NSApp.appearance` (an `NSPopover` follows its positioning view, the status-bar button), so
 /// `applyCurrent()` also posts `didChangeNotification` for `StatusItemController` to restyle the
 /// popover directly. The menu-bar label is unaffected (template image).
-enum AppearanceSetting: String, Hashable, Sendable, CaseIterable {
+enum AppearanceSetting: String, Hashable, Sendable, CaseIterable, UserDefaultsBacked {
     case system
     case light
     case dark
 
     static let key = "appearance"
+    static var defaultsKey: String { key }
+    static var fallback: AppearanceSetting { .system }
 
     /// Posted by `applyCurrent()` after the app-level appearance is set, so the popover owner can
     /// mirror the override onto the popover (which does not inherit `NSApp.appearance`).
@@ -35,11 +37,7 @@ enum AppearanceSetting: String, Hashable, Sendable, CaseIterable {
         }
     }
 
-    /// The stored choice (`.system` when unset).
-    static var current: AppearanceSetting {
-        UserDefaults.standard.string(forKey: key)
-            .flatMap(AppearanceSetting.init(rawValue:)) ?? .system
-    }
+    // `current` (the stored choice, `.system` when unset) comes from `UserDefaultsBacked`.
 
     /// Reads the stored choice and applies it app-wide. Call once at launch and again whenever
     /// the setting changes — app windows restyle immediately, and the notification lets the

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -113,8 +113,7 @@ final class LayoutStore {
         } else {
             pinnedMetricIDs = Set(DefaultLayout.pinnedMetricIDs.filter { registry.descriptor(id: $0) != nil })
         }
-        menuBarStyle = defaults.string(forKey: menuBarStyleKey)
-            .flatMap(MenuBarStyle.init(rawValue:)) ?? .text
+        menuBarStyle = defaults.enumValue(forKey: menuBarStyleKey, default: .text)
 
         syncPlacedOrder(persistChanges: false)
     }

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -12,6 +12,8 @@ struct ProviderSnapshotCache {
     /// a relaunch without an immediate refetch and expire precisely when the next refresh is due.
     private let ttlProvider: () -> TimeInterval
     private let now: () -> Date
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
 
     init(
         userDefaults: UserDefaults = .standard,
@@ -23,6 +25,12 @@ struct ProviderSnapshotCache {
         self.storageKey = storageKey
         self.ttlProvider = ttlProvider ?? { RefreshSetting.interval(from: userDefaults) }
         self.now = now
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
     }
 
     /// Fixed-TTL convenience used by tests that want a deterministic freshness window.
@@ -79,18 +87,6 @@ struct ProviderSnapshotCache {
     private func save(_ payload: Payload) {
         guard let data = try? encoder.encode(payload) else { return }
         userDefaults.set(data, forKey: storageKey)
-    }
-
-    private var encoder: JSONEncoder {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        return encoder
-    }
-
-    private var decoder: JSONDecoder {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return decoder
     }
 }
 

--- a/Sources/OpenUsage/Stores/TimeFormatSetting.swift
+++ b/Sources/OpenUsage/Stores/TimeFormatSetting.swift
@@ -2,17 +2,16 @@ import Foundation
 
 /// How wall-clock times read (the absolute reset labels): the system's 12/24-hour convention, or
 /// an explicit override — matching the original app's Auto/12h/24h setting.
-enum TimeFormatSetting: String, Hashable, Sendable, CaseIterable {
+enum TimeFormatSetting: String, Hashable, Sendable, CaseIterable, UserDefaultsBacked {
     case auto
     case twelveHour = "12h"
     case twentyFourHour = "24h"
 
     static let key = "timeFormat"
+    static var defaultsKey: String { key }
+    static var fallback: TimeFormatSetting { .auto }
 
-    /// The user's current choice (read live so a Settings change applies on the next render tick).
-    static var current: TimeFormatSetting {
-        UserDefaults.standard.string(forKey: key).flatMap(TimeFormatSetting.init(rawValue:)) ?? .auto
-    }
+    // `current` (the user's current choice, read live) comes from `UserDefaultsBacked`.
 
     var label: String {
         switch self {

--- a/Sources/OpenUsage/Stores/UserDefaultsBacked.swift
+++ b/Sources/OpenUsage/Stores/UserDefaultsBacked.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension UserDefaults {
+    /// Read a `RawRepresentable` (String-backed) enum from defaults, falling back to `fallback` when
+    /// the key is unset or holds an unrecognized raw value. The single home for the
+    /// `string(forKey:).flatMap(init(rawValue:)) ?? default` idiom that every persisted enum setting
+    /// shares — so a new persisted enum reads its stored choice without restating the parse.
+    func enumValue<T: RawRepresentable>(forKey key: String, default fallback: T) -> T where T.RawValue == String {
+        string(forKey: key).flatMap(T.init(rawValue:)) ?? fallback
+    }
+}
+
+/// A `String`-raw enum persisted under a fixed `UserDefaults.standard` key, with a default for when the
+/// key is unset. Conformers get a free `current` accessor, removing the per-enum copy of the
+/// read-with-default idiom. Stores that read from an injected (non-standard) `UserDefaults` or an
+/// instance-scoped key use `UserDefaults.enumValue(forKey:default:)` directly instead.
+protocol UserDefaultsBacked: RawRepresentable where RawValue == String {
+    /// The `UserDefaults.standard` key this setting persists under.
+    static var defaultsKey: String { get }
+    /// The value used when the key is unset or holds an unrecognized raw value.
+    static var fallback: Self { get }
+}
+
+extension UserDefaultsBacked {
+    /// The stored choice, read live from `UserDefaults.standard` (falls back to `fallback`).
+    static var current: Self {
+        UserDefaults.standard.enumValue(forKey: defaultsKey, default: fallback)
+    }
+}

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -56,10 +56,8 @@ final class WidgetDataStore {
         self.defaults = defaults
         self.isProviderEnabled = isProviderEnabled
         self.orderedDescriptors = orderedDescriptors ?? { registry.descriptors }
-        self.meterStyle = defaults.string(forKey: Self.meterStyleKey)
-            .flatMap(WidgetDisplayMode.init(rawValue:)) ?? .remaining
-        self.resetDisplayMode = defaults.string(forKey: Self.resetDisplayModeKey)
-            .flatMap(ResetDisplayMode.init(rawValue:)) ?? .relative
+        self.meterStyle = defaults.enumValue(forKey: Self.meterStyleKey, default: .remaining)
+        self.resetDisplayMode = defaults.enumValue(forKey: Self.resetDisplayModeKey, default: .relative)
         // Stale-while-revalidate: load whatever was cached (expired included) so the menu bar and
         // dashboard show last-known values immediately at launch instead of "—"; the refresh loop
         // replaces them as soon as fresh data lands.
@@ -211,52 +209,53 @@ final class WidgetDataStore {
     }
 
     private func resolveText(_ value: String, descriptor: WidgetDescriptor) -> WidgetData? {
-        switch descriptor.sample.kind {
+        let sample = descriptor.sample
+        switch sample.kind {
         case .dollars:
-            guard let amount = Self.firstCurrencyAmount(in: value) else { return descriptor.sample }
-            return WidgetData(
-                title: descriptor.sample.title,
-                icon: descriptor.sample.icon,
-                kind: .dollars,
-                used: amount,
-                limit: descriptor.sample.limit,
-                countSuffix: descriptor.sample.countSuffix,
-                valuePrefix: descriptor.sample.valuePrefix,
-                // A raw-text descriptor shows the provider's line verbatim (the parsed amount above
-                // still feeds the menu bar's compact value).
-                valueTextOverride: descriptor.sample.preservesRawText ? value : nil,
-                subtitleOverride: descriptor.sample.subtitleOverride,
-                unboundedValueWord: descriptor.sample.unboundedValueWord,
-                infoNote: descriptor.sample.infoNote
-            )
+            guard let amount = Self.firstCurrencyAmount(in: value) else { return sample }
+            // A raw-text descriptor shows the provider's line verbatim (the parsed amount above still
+            // feeds the menu bar's compact value); otherwise the value is reformatted from `used`.
+            return textData(sample, kind: .dollars, used: amount, limit: sample.limit,
+                            valueTextOverride: sample.preservesRawText ? value : nil,
+                            unboundedValueWord: sample.unboundedValueWord)
         case .count:
-            guard let count = Self.firstNumber(in: value) else { return descriptor.sample }
-            return WidgetData(
-                title: descriptor.sample.title,
-                icon: descriptor.sample.icon,
-                kind: .count,
-                used: count,
-                limit: descriptor.sample.limit,
-                countSuffix: descriptor.sample.countSuffix,
-                valuePrefix: descriptor.sample.valuePrefix,
-                subtitleOverride: descriptor.sample.subtitleOverride,
-                unboundedValueWord: descriptor.sample.unboundedValueWord,
-                infoNote: descriptor.sample.infoNote
-            )
+            guard let count = Self.firstNumber(in: value) else { return sample }
+            return textData(sample, kind: .count, used: count, limit: sample.limit,
+                            unboundedValueWord: sample.unboundedValueWord)
         case .percent:
-            guard let percent = Self.firstNumber(in: value) else { return descriptor.sample }
-            return WidgetData(
-                title: descriptor.sample.title,
-                icon: descriptor.sample.icon,
-                kind: .percent,
-                used: percent,
-                limit: descriptor.sample.limit ?? 100,
-                countSuffix: descriptor.sample.countSuffix,
-                valuePrefix: descriptor.sample.valuePrefix,
-                subtitleOverride: descriptor.sample.subtitleOverride,
-                infoNote: descriptor.sample.infoNote
-            )
+            guard let percent = Self.firstNumber(in: value) else { return sample }
+            // Percent rows are always 0–100, so a missing sample limit defaults to a full 100 scale,
+            // and they carry no `unboundedValueWord` (they're never an unbounded balance).
+            return textData(sample, kind: .percent, used: percent, limit: sample.limit ?? 100)
         }
+    }
+
+    /// Builds the resolved `WidgetData` for a `.text` line: the metric identity and presentation come
+    /// from the descriptor's `sample`, while the parsed `used` (and the per-kind `limit`,
+    /// `valueTextOverride`, `unboundedValueWord`) come from the live value. Fields the sample uses for
+    /// real metrics but a fresh text row must not inherit (display/reset mode, reset timing, period,
+    /// limit noun, raw-text flag, no-data flag) deliberately reset to their `WidgetData` defaults.
+    private func textData(
+        _ sample: WidgetData,
+        kind: MetricKind,
+        used: Double,
+        limit: Double?,
+        valueTextOverride: String? = nil,
+        unboundedValueWord: String? = nil
+    ) -> WidgetData {
+        WidgetData(
+            title: sample.title,
+            icon: sample.icon,
+            kind: kind,
+            used: used,
+            limit: limit,
+            countSuffix: sample.countSuffix,
+            valuePrefix: sample.valuePrefix,
+            valueTextOverride: valueTextOverride,
+            subtitleOverride: sample.subtitleOverride,
+            unboundedValueWord: unboundedValueWord,
+            infoNote: sample.infoNote
+        )
     }
 
     static func firstCurrencyAmount(in value: String) -> Double? {

--- a/Sources/OpenUsage/Stores/WidgetRegistry.swift
+++ b/Sources/OpenUsage/Stores/WidgetRegistry.swift
@@ -2,14 +2,46 @@ import Foundation
 
 /// Read-only catalog of providers and the widgets they register, built from the live
 /// `ProviderRuntime`s at launch.
+///
+/// The registry is immutable once built, and its lookups are read on every render through
+/// `LayoutStore`'s `@Observable` computed properties (display groups, metric order, pin counts).
+/// So the three accessors are backed by lookup maps precomputed once at construction — O(1)/O(k)
+/// instead of linear scans of every descriptor on every call.
 struct WidgetRegistry: Sendable {
     let providers: [Provider]
     let descriptors: [WidgetDescriptor]
 
-    func descriptor(id: String) -> WidgetDescriptor? { descriptors.first { $0.id == id } }
-    func provider(id: String) -> Provider? { providers.first { $0.id == id } }
+    /// Descriptor by id — backs `descriptor(id:)`.
+    private let descriptorsByID: [String: WidgetDescriptor]
+    /// Provider by id — backs `provider(id:)`.
+    private let providersByID: [String: Provider]
+    /// Per-provider descriptor lists, preserving the original `descriptors` order within each provider
+    /// (a stable `filter` walk), so `descriptors(for:)` returns the exact sequence the UI metric order
+    /// depends on.
+    private let descriptorsByProvider: [String: [WidgetDescriptor]]
+
+    init(providers: [Provider], descriptors: [WidgetDescriptor]) {
+        self.providers = providers
+        self.descriptors = descriptors
+        self.descriptorsByID = Dictionary(
+            descriptors.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        self.providersByID = Dictionary(
+            providers.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var byProvider: [String: [WidgetDescriptor]] = [:]
+        for descriptor in descriptors {
+            byProvider[descriptor.providerID, default: []].append(descriptor)
+        }
+        self.descriptorsByProvider = byProvider
+    }
+
+    func descriptor(id: String) -> WidgetDescriptor? { descriptorsByID[id] }
+    func provider(id: String) -> Provider? { providersByID[id] }
     func descriptors(for providerID: String) -> [WidgetDescriptor] {
-        descriptors.filter { $0.providerID == providerID }
+        descriptorsByProvider[providerID] ?? []
     }
 
     @MainActor

--- a/Sources/OpenUsage/Support/MetricPeriod.swift
+++ b/Sources/OpenUsage/Support/MetricPeriod.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Canonical usage-window lengths in milliseconds, defined once and shared by the providers so the
+/// same window (5h session, 1 day, 7 days, 30-day billing cycle) isn't re-spelled as a magic number
+/// in each mapper.
+enum MetricPeriod {
+    static let sessionMs = 5 * 60 * 60 * 1000
+    static let dayMs = 24 * 60 * 60 * 1000
+    static let weekMs = 7 * dayMs
+    static let monthMs = 30 * dayMs
+}

--- a/Sources/OpenUsage/Support/OpenUsageISO8601.swift
+++ b/Sources/OpenUsage/Support/OpenUsageISO8601.swift
@@ -72,7 +72,18 @@ enum OpenUsageISO8601 {
         return head + frac + tz
     }
 
+    // ISO8601DateFormatter is expensive to construct and is hit on every snapshot decode and local-API
+    // encode, so the two fixed configurations are built once. `ISO8601DateFormatter` is thread-safe for
+    // parsing/formatting, and parsing here runs on the main-actor refresh path; `nonisolated(unsafe)`
+    // shares the immutable instances without per-call allocation.
+    private nonisolated(unsafe) static let fractionalFormatter = makeFormatter(fractionalSeconds: true)
+    private nonisolated(unsafe) static let plainFormatter = makeFormatter(fractionalSeconds: false)
+
     private static func formatter(fractionalSeconds: Bool) -> ISO8601DateFormatter {
+        fractionalSeconds ? fractionalFormatter : plainFormatter
+    }
+
+    private static func makeFormatter(fractionalSeconds: Bool) -> ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = fractionalSeconds
             ? [.withInternetDateTime, .withFractionalSeconds]

--- a/Sources/OpenUsage/Support/ProviderIconShape.swift
+++ b/Sources/OpenUsage/Support/ProviderIconShape.swift
@@ -54,13 +54,13 @@ struct ProviderIconShape: Shape {
     }
 }
 
-/// A provider vector mark: the combined path data plus the source `viewBox` it was authored in.
+/// A provider vector mark: the combined SVG path data. `ProviderIconShape` normalizes by the path's
+/// true bounding box, so the source `viewBox` isn't needed.
 struct ProviderMark: Hashable {
     let path: String
-    let viewBox: CGRect
 }
 
-/// Loads copied provider SVGs from the bundle and extracts their path data + viewBox (cached).
+/// Loads copied provider SVGs from the bundle and extracts their path data (cached).
 @MainActor
 enum ProviderMarks {
     private static var cache: [String: ProviderMark] = [:]
@@ -77,10 +77,7 @@ enum ProviderMarks {
             missing.insert(id)
             return nil
         }
-        let mark = ProviderMark(
-            path: d,
-            viewBox: extractViewBox(text) ?? CGRect(x: 0, y: 0, width: 100, height: 100)
-        )
+        let mark = ProviderMark(path: d)
         cache[id] = mark
         return mark
     }
@@ -105,18 +102,6 @@ enum ProviderMarks {
             searchStart = end
         }
         return values.isEmpty ? nil : values.joined(separator: " ")
-    }
-
-    /// Parses `viewBox="minX minY width height"`. Falls back to `nil` when absent or malformed.
-    private static func extractViewBox(_ svg: String) -> CGRect? {
-        guard let start = svg.range(of: "viewBox=\"") else { return nil }
-        let rest = svg[start.upperBound...]
-        guard let end = rest.firstIndex(of: "\"") else { return nil }
-        let numbers = rest[..<end]
-            .split { $0 == " " || $0 == "," }
-            .compactMap { Double($0) }
-        guard numbers.count == 4, numbers[2] > 0, numbers[3] > 0 else { return nil }
-        return CGRect(x: numbers[0], y: numbers[1], width: numbers[2], height: numbers[3])
     }
 }
 

--- a/Sources/OpenUsage/Support/ProviderParse.swift
+++ b/Sources/OpenUsage/Support/ProviderParse.swift
@@ -27,9 +27,59 @@ enum ProviderParse {
         return min(max(value, 0), 100)
     }
 
-    /// Convert integer cents to dollars, preserving the providers' existing rounding behavior.
+    /// Convert integer cents to dollars: snap to whole cents, then scale. Inputs are already integer
+    /// cents from the providers' APIs; rounding guards against float drift before the divide.
     static func centsToDollars(_ cents: Double) -> Double {
-        (cents / 100 * 100).rounded() / 100
+        cents.rounded() / 100
+    }
+
+    /// Decode `T` from JSON text, falling back to a hex-encoded JSON blob — some providers store their
+    /// credentials/auth file as hex (optionally `0x`-prefixed) rather than plain JSON.
+    static func decodeJSONWithHexFallback<T: Decodable>(_ text: String, as type: T.Type) -> T? {
+        if let decoded = decodeJSON(text, as: type) { return decoded }
+
+        var hex = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.hasPrefix("0x") || hex.hasPrefix("0X") {
+            hex = String(hex.dropFirst(2))
+        }
+        guard !hex.isEmpty, hex.count.isMultiple(of: 2), hex.allSatisfy(\.isHexDigit) else {
+            return nil
+        }
+
+        var bytes: [UInt8] = []
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        guard let decoded = String(bytes: bytes, encoding: .utf8) else { return nil }
+        return decodeJSON(decoded, as: type)
+    }
+
+    private static func decodeJSON<T: Decodable>(_ text: String, as type: T.Type) -> T? {
+        guard let data = text.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    /// Decode a JWT's payload (the middle dot-separated segment) as a JSON object. Base64url is
+    /// translated to standard base64 and padded before decoding.
+    static func jwtPayload(_ token: String) -> [String: Any]? {
+        let parts = token.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+        var payload = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while !payload.count.isMultiple(of: 4) {
+            payload.append("=")
+        }
+        guard let data = Data(base64Encoded: payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return json
     }
 }
 
@@ -46,5 +96,18 @@ extension String {
             copy.removeLast()
         }
         return copy
+    }
+
+    /// Title-case a provider plan name: split on `isSeparator`, upper-case each word's first character,
+    /// and re-join with single spaces. When `lowercasingTail` is true the rest of each word is
+    /// lower-cased (e.g. "PRO PLAN" → "Pro Plan"); otherwise it's preserved (e.g. "pro_plus" → "Pro Plus").
+    func titleCased(separator isSeparator: (Character) -> Bool, lowercasingTail: Bool = false) -> String {
+        split(whereSeparator: isSeparator)
+            .map { word in
+                let head = word.prefix(1).uppercased()
+                let tail = lowercasingTail ? word.dropFirst().lowercased() : String(word.dropFirst())
+                return head + tail
+            }
+            .joined(separator: " ")
     }
 }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -46,6 +46,41 @@ enum Theme {
     /// Backing for lifted drag previews: material, so the floating card stays legible over the rows
     /// it passes instead of letting them bleed through a translucent fill.
     static let liftedCardFill = AnyShapeStyle(Material.regular)
+
+    /// The single corner radius for every metric/settings card surface and its lifted twin, so the
+    /// floating drag preview always matches the live card's shape.
+    static let cardCornerRadius: CGFloat = 12
+
+    /// The rounded rectangle shared by every card surface (live and lifted), so the shape is defined once.
+    static var cardShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
+    }
+}
+
+extension View {
+    /// The grouped-card surface used for provider/settings cards: the semantic quaternary fill in
+    /// the shared rounded shape. Pass `lifted: true` for the floating drag preview, which swaps the
+    /// fill for the legible material so the card reads over (not through) the rows it passes.
+    /// Routing every card site through this keeps the live card and its lifted twin one shape.
+    func cardSurface(lifted: Bool = false) -> some View {
+        background(lifted ? Theme.liftedCardFill : Theme.cardFill, in: Theme.cardShape)
+    }
+
+    /// A single-row lifted preview surface: the card fill plus the thin separator hairline that
+    /// fences a free-floating one-row chip off from the rows beneath it (the multi-row provider
+    /// previews don't take the hairline — the card outline alone reads as detached there).
+    func liftedRowSurface() -> some View {
+        cardSurface(lifted: true)
+            .overlay { Theme.cardShape.strokeBorder(.separator, lineWidth: 0.5) }
+    }
+
+    /// The trailing on/off switch styling shared by every settings + Customize row toggle: no inline
+    /// label (the row's leading text is the label), the native switch style, small control size.
+    func settingsSwitchStyle() -> some View {
+        labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.small)
+    }
 }
 
 /// Saturated tint softened for Liquid Glass; Increase Contrast resolves to the full-strength

--- a/Sources/OpenUsage/Views/CustomizeRow.swift
+++ b/Sources/OpenUsage/Views/CustomizeRow.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// The Customize metric row shape, shared by the live row in `CustomizeView` and the lifted drag
+/// preview in `ReorderLiftPreview`. Defining the grip + label + trailing layout (and its
+/// density-derived padding) once is what keeps the floating preview pixel-identical to the row the
+/// user is dragging — the two used to be hand-rebuilt separately and drifted apart.
+///
+/// The leading grip + label form the drag *handle* (the live row attaches its reorder gesture to
+/// just that region, leaving the trailing pin + toggle normally tappable); the trailing slot is
+/// supplied by the caller — the live row passes its real pin button + `Toggle`, the preview a
+/// static switch placeholder.
+struct CustomizeMetricRow<Handle: View, Trailing: View>: View {
+    let title: String
+    /// Wraps the leading grip + label + spacer (the drag-handle region). The live row threads its
+    /// `contentShape` + reorder gesture through here; the preview leaves it untouched.
+    let handle: (AnyView) -> Handle
+    @ViewBuilder var trailing: Trailing
+
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    var body: some View {
+        HStack(spacing: 10) {
+            handle(
+                AnyView(
+                    HStack(spacing: 10) {
+                        ReorderGrip()
+                        Text(title)
+                            .foregroundStyle(.primary)
+                        Spacer(minLength: 8)
+                    }
+                )
+            )
+            trailing
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+}
+
+extension CustomizeMetricRow where Handle == AnyView {
+    /// Static variant for the lifted drag preview: the handle region is rendered inert (no gesture).
+    init(title: String, @ViewBuilder trailing: () -> Trailing) {
+        self.init(title: title, handle: { $0 }, trailing: trailing)
+    }
+}
+
+/// The static switch placeholder the lifted previews render where the live row shows a real
+/// `Toggle` — a quaternary capsule the size of a small switch, so the floating chip reads like the
+/// row without carrying a live control.
+struct CustomizeSwitchPlaceholder: View {
+    var body: some View {
+        Capsule()
+            .fill(.quaternary)
+            .frame(width: 28, height: 16)
+    }
+}

--- a/Sources/OpenUsage/Views/CustomizeView.swift
+++ b/Sources/OpenUsage/Views/CustomizeView.swift
@@ -28,23 +28,17 @@ struct CustomizeView: View {
     }
 
     /// Fills the region the dashboard's pinned footer leaves; reports its content height up so
-    /// `DashboardView` can clamp the popover. The native scroll edge effect handles the bar transition.
-    ///
-    /// The scroll edge effect needs the scroll view to keep a vertical scroller, so we don't hide
-    /// indicators (that would kill the effect). `invisibleOverlayScroller()` instead keeps the overlay
-    /// scroller (which reserves no gutter) and just makes it invisible: effect intact, no visible bar.
+    /// `DashboardView` can clamp the popover. A mid-drag measurement is ignored (`!isReordering`) so
+    /// the lifted row's transient layout never reseeds the popover height.
     private var scrollContent: some View {
-        ScrollView(.vertical) {
+        MeasuredScrollScreen(onMeasure: { newValue in
+            if newValue > 0, !isReordering {
+                contentHeight = newValue
+                hasMeasuredContent = true
+            }
+        }) {
             content
-                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { newValue in
-                    if newValue > 0, !isReordering {
-                        contentHeight = newValue
-                        hasMeasuredContent = true
-                    }
-                }
-                .invisibleOverlayScroller()
         }
-        .scrollBounceBehavior(.basedOnSize)
         .onPreferenceChange(ReorderFramePreferenceKey.self) { rowFrames = $0 }
     }
 
@@ -100,34 +94,36 @@ struct CustomizeView: View {
                 metricRow(metric, in: group.provider.id, metricIDs: group.metrics.map(\.id))
             }
         }
-        .background(Theme.cardFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .cardSurface()
     }
 
     private func metricRow(_ metric: WidgetDescriptor, in providerID: String, metricIDs: [String]) -> some View {
         let isActive = activeMetricID == metric.id
-        return HStack(spacing: 10) {
+        // Same row builder the lifted preview uses, so the floating chip can't drift from the live row.
+        return CustomizeMetricRow(
+            title: metric.title,
             // Grip + label form the drag handle; the trailing pin + toggle stay normal tappable controls.
-            HStack(spacing: 10) {
-                ReorderGrip()
-                Text(metric.title)
-                    .foregroundStyle(.primary)
-                Spacer(minLength: 8)
+            handle: { handle in
+                handle
+                    .contentShape(Rectangle())
+                    .highPriorityGesture(
+                        metricDragGesture(
+                            for: metric.id,
+                            providerID: providerID,
+                            metricIDs: metricIDs,
+                            title: metric.title
+                        )
+                    )
+            },
+            trailing: {
+                pinButton(metric)
+                Toggle("", isOn: Binding(
+                    get: { layout.isMetricEnabled(metric.id) },
+                    set: { layout.setMetricEnabled(metric.id, $0) }
+                ))
+                .settingsSwitchStyle()
             }
-            .contentShape(Rectangle())
-            .highPriorityGesture(metricDragGesture(for: metric.id, providerID: providerID, metricIDs: metricIDs))
-
-            pinButton(metric)
-
-            Toggle("", isOn: Binding(
-                get: { layout.isMetricEnabled(metric.id) },
-                set: { layout.setMetricEnabled(metric.id, $0) }
-            ))
-            .labelsHidden()
-            .toggleStyle(.switch)
-            .controlSize(.small)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, density.controlRowPadding)
+        )
         .contentShape(Rectangle())
         .opacity(isActive ? 0 : 1)
         .onHover { hovering in
@@ -190,55 +186,37 @@ struct CustomizeView: View {
         )
     }
 
-    private func metricDragGesture(for metricID: String, providerID: String, metricIDs: [String]) -> some Gesture {
+    private func metricDragGesture(for metricID: String, providerID: String, metricIDs: [String], title: String) -> some Gesture {
         reorderDragGesture(
             id: metricID,
             coordinateSpaceName: reorderSpaceName,
             rowFrames: rowFrames,
             active: $activeMetricID,
             lift: $reorderLift,
-            makeLift: { makeMetricLift(metricID: metricID, value: $0) },
+            makeLift: { makeMetricLift(metricID: metricID, title: title, value: $0) },
             orderedIDs: { metricIDs },
             reorder: { layout.reorderMetric(dragged: metricID, target: $0, in: providerID) }
         )
     }
 
     private func makeProviderLift(for group: ProviderMetrics, value: DragGesture.Value) -> ReorderLift? {
-        guard let sourceFrame = rowFrames[group.provider.id] else { return nil }
-        return ReorderLift(
+        ReorderLift.make(
             id: group.provider.id,
             payload: .customizeProvider(
                 provider: group.provider,
                 rows: group.metrics.map(\.title)
             ),
-            sourceFrame: sourceFrame,
-            touchOffset: CGPoint(
-                x: value.startLocation.x - sourceFrame.minX,
-                y: value.startLocation.y - sourceFrame.minY
-            ),
-            location: value.location
+            value: value,
+            frames: rowFrames
         )
     }
 
-    private func makeMetricLift(metricID: String, value: DragGesture.Value) -> ReorderLift? {
-        guard let sourceFrame = rowFrames[metricID],
-              let title = layout.orderedSupportedMetrics(for: sourceFrameMetricProviderID(metricID)).first(where: { $0.id == metricID })?.title
-        else { return nil }
-        return ReorderLift(
+    private func makeMetricLift(metricID: String, title: String, value: DragGesture.Value) -> ReorderLift? {
+        ReorderLift.make(
             id: metricID,
             payload: .customizeMetric(title: title),
-            sourceFrame: sourceFrame,
-            touchOffset: CGPoint(
-                x: value.startLocation.x - sourceFrame.minX,
-                y: value.startLocation.y - sourceFrame.minY
-            ),
-            location: value.location
+            value: value,
+            frames: rowFrames
         )
-    }
-
-    private func sourceFrameMetricProviderID(_ metricID: String) -> String {
-        layout.customizeGroups.first { group in
-            group.metrics.contains { $0.id == metricID }
-        }?.provider.id ?? ""
     }
 }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -204,25 +204,20 @@ struct DashboardView: View {
     }
 
     /// The widget list as a scroll view that fills the region the footer leaves. The content scrolls
-    /// under the footer; the native scroll edge effect handles the visual transition.
-    ///
-    /// The scroll edge effect needs the scroll view to keep a vertical scroller, so we don't hide
-    /// indicators (that would kill the effect). `invisibleOverlayScroller()` instead keeps the overlay
-    /// scroller (which reserves no gutter) and just makes it invisible: effect intact, no visible bar.
+    /// under the footer; the native scroll edge effect handles the visual transition. Unlike the
+    /// Customize/Settings screens it tracks the dashboard's own scroll position and adds the top
+    /// soft edge effect, so those modifiers wrap the shared measuring container here.
     private var scrollingDashboard: some View {
-        ScrollView(.vertical) {
+        MeasuredScrollScreen(onMeasure: { newValue in
+            if newValue > 0 { listContentHeight = newValue }
+        }) {
             widgetContent
                 .padding(.horizontal, Self.outerPadding)
                 .padding(.top, density.contentTopPadding)
                 .padding(.bottom, Self.contentBottomGap)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { newValue in
-                    if newValue > 0 { listContentHeight = newValue }
-                }
-                .invisibleOverlayScroller()
         }
         .scrollPosition($dashboardScrollPosition)
-        .scrollBounceBehavior(.basedOnSize)
         .scrollEdgeEffectStyle(.soft, for: .top)
     }
 

--- a/Sources/OpenUsage/Views/MeasuredScrollScreen.swift
+++ b/Sources/OpenUsage/Views/MeasuredScrollScreen.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// The self-measuring scroll container shared by the popover's three full-height screens
+/// (dashboard, Customize, Settings). Each one fills the region the pinned footer leaves, measures
+/// its content height so `DashboardView` can fit the popover to it, and keeps the native scroll edge
+/// effect alive while hiding the scrollbar.
+///
+/// The scroll edge effect (the blur as content passes under the `safeAreaBar`) needs the scroll view
+/// to keep a vertical scroller, so indicators are not hidden the SwiftUI way (that removes the
+/// scroller and kills the effect). `invisibleOverlayScroller()` instead keeps the overlay scroller
+/// (which reserves no gutter) and just makes it invisible: effect intact, no visible bar.
+///
+/// `onMeasure` fires on every content-height change; the caller owns what to write and any guards
+/// (e.g. ignore zero, skip while reordering, or set a "measured once" flag). Screen-specific
+/// modifiers — scroll position, edge-effect style, `onAppear`, reorder-frame preferences — are
+/// applied by the caller on the returned view, since those differ per screen.
+struct MeasuredScrollScreen<Content: View>: View {
+    let onMeasure: (CGFloat) -> Void
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        ScrollView(.vertical) {
+            content
+                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { onMeasure($0) }
+                .invisibleOverlayScroller()
+        }
+        .scrollBounceBehavior(.basedOnSize)
+    }
+}

--- a/Sources/OpenUsage/Views/ProviderCard.swift
+++ b/Sources/OpenUsage/Views/ProviderCard.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// The grouped metric-card body shared by the live dashboard list and its lifted drag preview:
+/// a spacing-0 stack of rows (separated by row padding, never dividers), the density gutter that
+/// keeps the first/last row off the card edge, and the shared card surface. Both surfaces build the
+/// card through this so the floating preview can't drift from the live card (it once hard-coded its
+/// spacing and even drew dividers the live list doesn't).
+///
+/// The live list threads per-row gestures/opacity/frames through `rows`; the preview passes plain
+/// `WidgetRowView`s and flips `lifted` for the legible material backing.
+struct DashboardMetricCard<Rows: View>: View {
+    var lifted: Bool = false
+    @ViewBuilder var rows: Rows
+
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    var body: some View {
+        VStack(spacing: 0) {
+            rows
+        }
+        .padding(.vertical, density.cardGutter)
+        .cardSurface(lifted: lifted)
+    }
+}

--- a/Sources/OpenUsage/Views/ReorderGeometry.swift
+++ b/Sources/OpenUsage/Views/ReorderGeometry.swift
@@ -13,10 +13,37 @@ struct ReorderLift {
     let sourceFrame: CGRect
     let touchOffset: CGPoint
     var location: CGPoint
+
+    /// The one place a lift is built from a drag value. Every reorder site (dashboard/Customize ×
+    /// provider/metric) differs only in the `payload`; the frame lookup and touch-offset math are
+    /// identical, so they live here once. Returns `nil` when the dragged row has no recorded frame.
+    static func make(
+        id: String,
+        payload: Payload,
+        value: DragGesture.Value,
+        frames: [String: CGRect]
+    ) -> ReorderLift? {
+        guard let sourceFrame = frames[id] else { return nil }
+        return ReorderLift(
+            id: id,
+            payload: payload,
+            sourceFrame: sourceFrame,
+            touchOffset: CGPoint(
+                x: value.startLocation.x - sourceFrame.minX,
+                y: value.startLocation.y - sourceFrame.minY
+            ),
+            location: value.location
+        )
+    }
 }
 
 struct ReorderLiftPreview: View {
     let lift: ReorderLift
+
+    // The previews are deliberately the same views the live screens render (shared row/card
+    // builders); reading the density here lets the header→card spacing track the live sections too,
+    // so a lifted provider block matches its source block in every density.
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
     var body: some View {
         preview
@@ -46,72 +73,50 @@ struct ReorderLiftPreview: View {
     }
 
     private func dashboardProviderPreview(provider: Provider, plan: String?, rows: [WidgetData]) -> some View {
-        VStack(alignment: .leading, spacing: 9) {
+        // Same anatomy as the live dashboard section (`WidgetGroupedListView.section` + `container`):
+        // header over the shared metric card, at the density's header→card spacing.
+        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
             ProviderSectionHeader(provider: provider, plan: plan)
+                .padding(.horizontal, 8)
 
-            VStack(spacing: 0) {
-                ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+            DashboardMetricCard(lifted: true) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                     WidgetRowView(data: row)
-                    if index < rows.count - 1 {
-                        Divider().padding(.leading, 14)
-                    }
                 }
             }
-            .background(Theme.liftedCardFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
     }
 
     private func dashboardMetricPreview(_ data: WidgetData) -> some View {
         WidgetRowView(data: data)
-            .background(Theme.liftedCardFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .strokeBorder(.separator, lineWidth: 0.5)
-            }
+            .liftedRowSurface()
     }
 
     private func customizeProviderPreview(provider: Provider, rows: [String]) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+        // Same anatomy as the live Customize block (`CustomizeView.providerBlock`): header over the
+        // card of metric rows, at the density's header→card spacing.
+        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
             ProviderSectionHeader(provider: provider) {
                 ReorderGrip()
             }
+            .padding(.horizontal, 8)
 
             VStack(spacing: 0) {
                 ForEach(Array(rows.enumerated()), id: \.offset) { _, title in
-                    HStack(spacing: 10) {
-                        ReorderGrip()
-                        Text(title)
-                            .foregroundStyle(.primary)
-                        Spacer(minLength: 8)
-                        Capsule()
-                            .fill(.quaternary)
-                            .frame(width: 28, height: 16)
+                    CustomizeMetricRow(title: title) {
+                        CustomizeSwitchPlaceholder()
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 9)
                 }
             }
-            .background(Theme.liftedCardFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .cardSurface(lifted: true)
         }
     }
 
     private func customizeMetricPreview(_ title: String) -> some View {
-        HStack(spacing: 10) {
-            ReorderGrip()
-            Text(title)
-                .foregroundStyle(.primary)
-            Spacer(minLength: 8)
-            Capsule()
-                .fill(.quaternary)
-                .frame(width: 28, height: 16)
+        CustomizeMetricRow(title: title) {
+            CustomizeSwitchPlaceholder()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(Theme.liftedCardFill, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .strokeBorder(.separator, lineWidth: 0.5)
-        }
+        .liftedRowSurface()
     }
 
 }

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -34,17 +34,14 @@ struct SettingsScreen: View {
     /// `DashboardView` can fit the popover to it (`settingsScrollHeight`). Same scroller treatment
     /// as Customize: the overlay scroller stays (the scroll edge effect needs it) but is invisible.
     var body: some View {
-        ScrollView(.vertical) {
+        MeasuredScrollScreen(onMeasure: { newValue in
+            if newValue > 0 {
+                contentHeight = newValue
+                hasMeasuredContent = true
+            }
+        }) {
             content
-                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { newValue in
-                    if newValue > 0 {
-                        contentHeight = newValue
-                        hasMeasuredContent = true
-                    }
-                }
-                .invisibleOverlayScroller()
         }
-        .scrollBounceBehavior(.basedOnSize)
         .onAppear {
             // The menu-bar panel never activates the app on its own, and an inactive accessory
             // app receives no text input — the shortcut recorder field would silently ignore
@@ -63,9 +60,7 @@ struct SettingsScreen: View {
             section("Startup") {
                 row("Launch at Login") {
                     Toggle("", isOn: $launchAtLogin)
-                        .labelsHidden()
-                        .toggleStyle(.switch)
-                        .controlSize(.small)
+                        .settingsSwitchStyle()
                         .onChange(of: launchAtLogin) { _, enabled in
                             do {
                                 if enabled {
@@ -140,15 +135,11 @@ struct SettingsScreen: View {
                 section("Updates") {
                     row("Update Automatically") {
                         Toggle("", isOn: $updater.automaticallyChecksForUpdates)
-                            .labelsHidden()
-                            .toggleStyle(.switch)
-                            .controlSize(.small)
+                            .settingsSwitchStyle()
                     }
                     row("Beta Updates") {
                         Toggle("", isOn: $updater.betaChannelEnabled)
-                            .labelsHidden()
-                            .toggleStyle(.switch)
-                            .controlSize(.small)
+                            .settingsSwitchStyle()
                             .help("Receive pre-release builds before they ship to everyone")
                     }
                     // No version label here — the footer already shows it. The frame goes on the label so
@@ -185,7 +176,7 @@ struct SettingsScreen: View {
             VStack(spacing: 0) {
                 rows()
             }
-            .background(Theme.cardFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .cardSurface()
         }
     }
 
@@ -228,9 +219,7 @@ struct SettingsScreen: View {
                 get: { container.enablement.isEnabled(provider.id) },
                 set: { container.enablement.setEnabled($0, for: provider.id) }
             ))
-            .labelsHidden()
-            .toggleStyle(.switch)
-            .controlSize(.small)
+            .settingsSwitchStyle()
         }
         .padding(.horizontal, 12)
         .padding(.vertical, density.controlRowPadding)

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -63,38 +63,50 @@ struct WidgetGroupedListView: View {
         }
     }
 
+    /// A row's placed widget paired with its resolved descriptor + data, so each `dataStore.data(for:)`
+    /// is computed once per render and reused by both the condensing rule and the row. Keyed off the
+    /// `PlacedWidget` so `ForEach` identity stays exactly what it was before this was precomputed.
+    private struct ResolvedRow: Identifiable {
+        let widget: PlacedWidget
+        let descriptor: WidgetDescriptor
+        let data: WidgetData
+        var id: PlacedWidget.ID { widget.id }
+    }
+
     private func container(_ group: ProviderGroup) -> some View {
-        let condensedIDs = condensedTextRowIDs(group)
-        return VStack(spacing: 0) {
-            ForEach(group.widgets) { widget in
-                if let descriptor = layout.descriptor(for: widget) {
-                    row(descriptor, in: group.provider.id, condensedTop: condensedIDs.contains(descriptor.id))
-                }
+        // Resolve each row's descriptor + data exactly once per render, then reuse it for both the
+        // neighbor-aware condensing rule and the row itself — `dataStore.data(for:)` used to be
+        // recomputed several times per row (twice per adjacent pair plus once in `row`).
+        let rows = group.widgets.compactMap { widget -> ResolvedRow? in
+            guard let descriptor = layout.descriptor(for: widget) else { return nil }
+            return ResolvedRow(widget: widget, descriptor: descriptor, data: dataStore.data(for: descriptor))
+        }
+        let condensedIDs = condensedTextRowIDs(rows)
+        // Same card builder the lifted preview uses, so the floating chip can't drift from the live card.
+        return DashboardMetricCard {
+            ForEach(rows) { entry in
+                row(entry.descriptor, data: entry.data, in: group.provider.id,
+                    condensedTop: condensedIDs.contains(entry.descriptor.id))
             }
         }
-        // The card groups a provider's metrics; rows are separated by spacing, not dividers (mirrors the
-        // original). The small gutter keeps the first/last row off the card edge regardless of row type.
-        .padding(.vertical, density.cardGutter)
-        .background(Theme.cardFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
     /// Neighbor-aware rule: IDs of text-only rows sitting directly under another text-only row.
     /// Rows can't see their neighbors, so the list computes the pairs; Compact density pulls these
     /// rows up so a run of one-liners reads as one cluster.
-    private func condensedTextRowIDs(_ group: ProviderGroup) -> Set<String> {
-        let descriptors = group.widgets.compactMap { layout.descriptor(for: $0) }
+    private func condensedTextRowIDs(_ rows: [ResolvedRow]) -> Set<String> {
         var ids = Set<String>()
-        for (previous, current) in zip(descriptors, descriptors.dropFirst())
-        where !dataStore.data(for: previous).isBounded && !dataStore.data(for: current).isBounded {
-            ids.insert(current.id)
+        for (previous, current) in zip(rows, rows.dropFirst())
+        where !previous.data.isBounded && !current.data.isBounded {
+            ids.insert(current.descriptor.id)
         }
         return ids
     }
 
-    private func row(_ descriptor: WidgetDescriptor, in providerID: String, condensedTop: Bool) -> some View {
+    private func row(_ descriptor: WidgetDescriptor, data: WidgetData, in providerID: String, condensedTop: Bool) -> some View {
         let isActive = activeMetricID == descriptor.id
         return WidgetRowView(
-            data: dataStore.data(for: descriptor),
+            data: data,
             onToggleResetDisplay: { dataStore.resetDisplayMode.toggle() },
             onToggleMeterStyle: { dataStore.meterStyle.toggle() },
             condensedTop: condensedTop
@@ -176,38 +188,28 @@ struct WidgetGroupedListView: View {
     }
 
     private func makeProviderLift(for group: ProviderGroup, value: DragGesture.Value) -> ReorderLift? {
-        guard let sourceFrame = rowFrames[group.provider.id] else { return nil }
         let rows = group.widgets.compactMap { widget -> WidgetData? in
             guard let descriptor = layout.descriptor(for: widget) else { return nil }
             return dataStore.data(for: descriptor)
         }
-        return ReorderLift(
+        return ReorderLift.make(
             id: group.provider.id,
             payload: .dashboardProvider(
                 provider: group.provider,
                 plan: dataStore.plan(for: group.provider.id),
                 rows: rows
             ),
-            sourceFrame: sourceFrame,
-            touchOffset: CGPoint(
-                x: value.startLocation.x - sourceFrame.minX,
-                y: value.startLocation.y - sourceFrame.minY
-            ),
-            location: value.location
+            value: value,
+            frames: rowFrames
         )
     }
 
     private func makeMetricLift(for descriptor: WidgetDescriptor, value: DragGesture.Value) -> ReorderLift? {
-        guard let sourceFrame = rowFrames[descriptor.id] else { return nil }
-        return ReorderLift(
+        ReorderLift.make(
             id: descriptor.id,
             payload: .dashboardMetric(data: dataStore.data(for: descriptor)),
-            sourceFrame: sourceFrame,
-            touchOffset: CGPoint(
-                x: value.startLocation.x - sourceFrame.minX,
-                y: value.startLocation.y - sourceFrame.minY
-            ),
-            location: value.location
+            value: value,
+            frames: rowFrames
         )
     }
 }

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -72,7 +72,7 @@ final class CodexUsageMapperTests: XCTestCase {
             CcusageDay(date: "2026-02-01", totalTokens: 300, costUSD: 1.0)
         ])
 
-        CodexUsageMapper.appendTokenUsage(
+        CcusageSpendMapper.appendTokenUsage(
             usage,
             to: &lines,
             now: makeDate("2026-02-20T16:00:00.000Z")
@@ -81,6 +81,13 @@ final class CodexUsageMapperTests: XCTestCase {
         XCTAssertEqual(text(lines, "Today"), "$0.75 · 150 tokens")
         XCTAssertEqual(text(lines, "Yesterday"), "0 tokens")
         XCTAssertEqual(text(lines, "Last 30 Days"), "$1.75 · 450 tokens")
+    }
+
+    // Regression: dollar amounts must group thousands (e.g. "$1,200.00") consistently with the
+    // headline, which formats through `Formatters.currency`. Credit lines previously used a bare
+    // `$%.2f` that dropped the separator.
+    func testCreditsLabelGroupsThousands() {
+        XCTAssertEqual(CodexUsageMapper.creditsLabel(remaining: 30000), "$1,200.00 · 30,000 credits")
     }
 
     private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {

--- a/Tests/OpenUsageTests/ProviderMarksTests.swift
+++ b/Tests/OpenUsageTests/ProviderMarksTests.swift
@@ -6,24 +6,20 @@ final class ProviderMarksTests: XCTestCase {
     func testGrokResolvesToVectorMarkNotBoltFallback() {
         let mark = ProviderMarks.mark(for: "grok")
         XCTAssertNotNil(mark, "Grok must load a real vector mark instead of the bolt.fill fallback")
-        XCTAssertEqual(mark?.viewBox.width ?? 0, 527.27, accuracy: 0.01)
-        XCTAssertEqual(mark?.viewBox.height ?? 0, 578.68, accuracy: 0.01)
+        XCTAssertFalse(mark?.path.isEmpty ?? true, "Grok mark must carry SVG path data")
     }
 
-    func testDevinUsesItsOwnViewBoxSoItFillsTheFrame() {
+    func testDevinResolvesToVectorMark() {
         let mark = ProviderMarks.mark(for: "devin")
         XCTAssertNotNil(mark)
-        // Devin's source art is authored in a 44x50 box; honoring it is what makes the icon fill.
-        XCTAssertEqual(mark?.viewBox.width ?? 0, 44, accuracy: 0.01)
-        XCTAssertEqual(mark?.viewBox.height ?? 0, 50, accuracy: 0.01)
+        XCTAssertFalse(mark?.path.isEmpty ?? true, "Devin mark must carry SVG path data")
     }
 
-    func testHundredUnitMarksAreUnchanged() {
+    func testStandardProviderMarksLoad() {
         for id in ["claude", "codex", "cursor"] {
             let mark = ProviderMarks.mark(for: id)
             XCTAssertNotNil(mark, "\(id) should load")
-            XCTAssertEqual(mark?.viewBox.width ?? 0, 100, accuracy: 0.01)
-            XCTAssertEqual(mark?.viewBox.height ?? 0, 100, accuracy: 0.01)
+            XCTAssertFalse(mark?.path.isEmpty ?? true, "\(id) mark must carry SVG path data")
         }
     }
 }

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -277,6 +277,76 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(todayData.infoNote, WidgetData.ccusageEstimateNote)
     }
 
+    /// `resolveText` builds the resolved row from the descriptor's sample but must reset the fields a
+    /// fresh text row never inherits (here `preservesRawText`, `limitNoun`, `resetsAt`,
+    /// `periodDurationMs`) to their `WidgetData` defaults — otherwise a verbatim-dollars sample would
+    /// leak its raw-text flag and a stray limit noun into the resolved value.
+    func testResolveTextResetsNonInheritedSampleFields() async {
+        let provider = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+        var sample = WidgetData(title: "Extra Usage", icon: provider.icon, kind: .dollars, used: 0, limit: nil)
+        sample.preservesRawText = true
+        sample.limitNoun = "cap"
+        sample.resetsAt = Date(timeIntervalSince1970: 1_800_000_000)
+        sample.periodDurationMs = 123_456
+        let descriptor = WidgetDescriptor(id: "codex.credits", providerID: provider.id,
+                                          metricLabel: "Credits", sample: sample)
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.text(label: "Credits", value: "$40.00 · 1,000 credits")]
+            )
+        )
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            defaults: makeUserDefaults("resolve-text-reset")
+        )
+        await store.refreshAll()
+        let data = store.data(for: descriptor)
+
+        XCTAssertEqual(data.used, 40.0)
+        // preservesRawText still drives the verbatim override above, but the resolved row's own flag
+        // resets to its default.
+        XCTAssertFalse(data.preservesRawText)
+        XCTAssertEqual(data.valueTextOverride, "$40.00 · 1,000 credits")
+        XCTAssertNil(data.limitNoun)
+        XCTAssertNil(data.resetsAt)
+        XCTAssertNil(data.periodDurationMs)
+    }
+
+    /// A `.percent` text row defaults a missing sample limit to a 100 scale and never carries an
+    /// `unboundedValueWord`, even when the sample (incorrectly) had one.
+    func testResolveTextPercentDefaultsLimitAndDropsUnboundedWord() async {
+        let provider = Provider(id: "p", displayName: "P", icon: .providerMark("p"))
+        var sample = WidgetData(title: "Usage", icon: provider.icon, kind: .percent, used: 0, limit: nil)
+        sample.unboundedValueWord = "left"
+        let descriptor = WidgetDescriptor(id: "p.usage", providerID: provider.id,
+                                          metricLabel: "Usage", sample: sample)
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.text(label: "Usage", value: "42")]
+            )
+        )
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            defaults: makeUserDefaults("resolve-text-percent")
+        )
+        await store.refreshAll()
+        let data = store.data(for: descriptor)
+
+        XCTAssertEqual(data.used, 42)
+        XCTAssertEqual(data.limit, 100)
+        XCTAssertNil(data.unboundedValueWord)
+    }
+
     func testUsesFreshCachedSnapshotInsteadOfRefreshingProvider() async {
         let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("codex"))
         let descriptor = WidgetDescriptor(

--- a/Tests/OpenUsageTests/WidgetRegistryTests.swift
+++ b/Tests/OpenUsageTests/WidgetRegistryTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import OpenUsage
+
+final class WidgetRegistryTests: XCTestCase {
+    private func provider(_ id: String) -> Provider {
+        Provider(id: id, displayName: id.capitalized, icon: .providerMark(id))
+    }
+
+    private func descriptor(_ id: String, provider: Provider) -> WidgetDescriptor {
+        WidgetDescriptor(
+            id: id,
+            providerID: provider.id,
+            metricLabel: id,
+            sample: WidgetData(title: id, icon: provider.icon, kind: .percent, used: 0, limit: 100)
+        )
+    }
+
+    func testLookupsReturnExpectedEntries() {
+        let claude = provider("claude")
+        let codex = provider("codex")
+        let session = descriptor("claude.session", provider: claude)
+        let weekly = descriptor("claude.weekly", provider: claude)
+        let codexSession = descriptor("codex.session", provider: codex)
+        let registry = WidgetRegistry(
+            providers: [claude, codex],
+            descriptors: [session, weekly, codexSession]
+        )
+
+        XCTAssertEqual(registry.descriptor(id: "claude.weekly"), weekly)
+        XCTAssertNil(registry.descriptor(id: "missing"))
+        XCTAssertEqual(registry.provider(id: "codex"), codex)
+        XCTAssertNil(registry.provider(id: "missing"))
+    }
+
+    /// The precomputed per-provider list must preserve the original `descriptors` array order — the UI's
+    /// metric ordering depends on it, so this guards the O(1) refactor against silent reordering.
+    func testDescriptorsForProviderPreserveOriginalOrder() {
+        let claude = provider("claude")
+        let codex = provider("codex")
+        // Interleave two providers so a naive grouping that didn't preserve order could still pass for a
+        // single contiguous run.
+        let c1 = descriptor("claude.session", provider: claude)
+        let x1 = descriptor("codex.session", provider: codex)
+        let c2 = descriptor("claude.weekly", provider: claude)
+        let x2 = descriptor("codex.weekly", provider: codex)
+        let c3 = descriptor("claude.extra", provider: claude)
+        let registry = WidgetRegistry(
+            providers: [claude, codex],
+            descriptors: [c1, x1, c2, x2, c3]
+        )
+
+        XCTAssertEqual(
+            registry.descriptors(for: "claude").map(\.id),
+            ["claude.session", "claude.weekly", "claude.extra"]
+        )
+        XCTAssertEqual(
+            registry.descriptors(for: "codex").map(\.id),
+            ["codex.session", "codex.weekly"]
+        )
+        XCTAssertEqual(registry.descriptors(for: "missing"), [])
+    }
+
+    /// With duplicate ids, both single-entry lookups resolve to the first match — matching the original
+    /// `.first { $0.id == id }` accessors so the refactor can't change which descriptor/provider wins.
+    func testDuplicateIDsResolveToFirstMatch() {
+        let p1 = Provider(id: "dup", displayName: "First", icon: .providerMark("a"))
+        let p2 = Provider(id: "dup", displayName: "Second", icon: .providerMark("b"))
+        let d1 = WidgetDescriptor(id: "dup.m", providerID: "dup", metricLabel: "First",
+                                  sample: WidgetData(title: "First", icon: .symbol("1"), kind: .count, used: 1, limit: nil))
+        let d2 = WidgetDescriptor(id: "dup.m", providerID: "dup", metricLabel: "Second",
+                                  sample: WidgetData(title: "Second", icon: .symbol("2"), kind: .count, used: 2, limit: nil))
+        let registry = WidgetRegistry(providers: [p1, p2], descriptors: [d1, d2])
+
+        XCTAssertEqual(registry.provider(id: "dup")?.displayName, "First")
+        // WidgetDescriptor equality is id-only; compare the sample to prove the first one wins.
+        XCTAssertEqual(registry.descriptor(id: "dup.m")?.sample.title, "First")
+    }
+}


### PR DESCRIPTION
Audit-driven cleanup of the swift edition: dead code, DRY violations, and a few hot-path allocations. **No user-facing behavior change** except two intentional fixes — currency now groups thousands consistently (e.g. `$1,234.56`) and the drag-lift preview matches the live row in every density.

Build is clean (0 warnings), **all 201 tests pass**, and the app launches and authenticates live providers end-to-end.

## High
- **Currency consistency** — six `String(format: "$%.2f", …)` sites now route through `Formatters.currency`, so secondary/text lines group thousands like the headline does.
- **Drag-lift preview drift** — the reorder preview hand-rebuilt the Customize/dashboard rows and had already drifted (hard-coded padding vs. density-derived). It now renders the same shared row/card builder, so it matches in every density.

## Medium
- `WidgetRegistry`: O(1) id / provider / per-provider lookup maps (original order preserved) instead of linear scans in `@Observable` computed properties.
- Cache the ISO8601 / CSV date formatters (`OpenUsageISO8601`, `CursorUsageCSV`).
- `WidgetGroupedListView`: resolve each row's `WidgetData` once per render.
- `CustomizeView`: drop the per-drag-tick title rescan.
- Shared `ProviderParse.decodeJSONWithHexFallback` (Claude/Codex auth) and `ProviderParse.jwtPayload` (Cursor/Grok auth) — security-adjacent decode logic was duplicated.
- `WidgetDataStore.resolveText`: one builder for the dollars/count/percent cases.
- **Cross-provider coupling** — moved the shared ccusage daily-spend logic into a new `CcusageSpendMapper` so `ClaudeProvider` no longer calls into `CodexUsageMapper`.
- Extracted `MeasuredScrollScreen` for the duplicated measure-and-scroll scaffold.

## Low
- Shared helpers: `MetricPeriod` (window lengths), `String.titleCased` (plan names), `MetricLine.appendNoDataIfNeeded`, `CcusageRunner.sinceString`, `Theme.cardSurface`, `settingsSwitchStyle`, `ReorderLift.make`, `UserDefaultsBacked`.
- Cosmetic: fixed the no-op math in `centsToDollars`; build JSON coders once in `ProviderSnapshotCache`; reuse `ProviderParse.number` in `CcusageRunner`; bind Codex error JSON once.
- Dead code removed: `ProviderMark.viewBox` + parser, `GrokAuthEntry.email`, `ClaudeAuthStore`'s unused `suppressMissingWarn`, `SystemProcessRunner.run` default args, Grok `base64URLData`.

## Deliberately skipped
- `CursorPricingEntry.applyMaxModeUplift` — its comment documents it as an intentional v1 deferral.
- Collapsing the five `XxxMappedUsage` structs — Grok's has no `plan` field and the names are self-documenting; unifying would churn every provider + test for a net readability loss.

## Tests
Added `WidgetRegistryTests`, `resolveText` field-inheritance tests, and a currency-grouping regression; repointed `ProviderMarksTests` off the removed `viewBox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly internal refactor and DRY with tests; intentional changes are currency formatting and drag-preview parity, not auth or refresh behavior.
> 
> **Overview**
> Audit-driven refactor across providers, stores, and SwiftUI surfaces. **Intentional user-visible fixes:** dollar text now uses **`Formatters.currency`** everywhere (thousands grouping, e.g. `$1,200.00` on Codex credits), and reorder **drag-lift previews** share the same row/card builders as the live dashboard and Customize screens so they track density and layout.
> 
> **Provider layer:** New **`CcusageSpendMapper`** and **`CcusageRunner.sinceString`** replace duplicated ccusage token/spend logic (Claude no longer calls **`CodexUsageMapper`**). **`MetricLine.appendNoDataIfNeeded`**, **`MetricPeriod`**, and **`String.titleCased`** centralize placeholders, window ms, and plan labels. Auth parsing consolidates on **`ProviderParse.decodeJSONWithHexFallback`** and **`ProviderParse.jwtPayload`**; **`centsToDollars`** math is corrected. Dead fields removed (**`GrokAuthEntry.email`**, **`ProviderMark.viewBox`**).
> 
> **Performance / structure:** **`WidgetRegistry`** precomputes lookup maps; **`WidgetGroupedListView`** resolves each row’s **`WidgetData`** once; cached ISO8601/CSV date formatters; **`ProviderSnapshotCache`** holds encoders/decoders; **`MeasuredScrollScreen`** dedupes scroll+measure scaffolding.
> 
> **UI:** **`Theme.cardSurface`**, **`settingsSwitchStyle`**, **`CustomizeMetricRow`**, **`DashboardMetricCard`**, **`ReorderLift.make`**. **`WidgetDataStore.resolveText`** uses a shared **`textData`** builder with explicit field resets. **`UserDefaultsBacked`** + **`enumValue`** for persisted settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdaf6180cc7c9e35cea004cc6f85939b83708f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors out dead code, removes duplication, and reduces allocations across providers and views. No behavior change except: currency now groups thousands consistently (e.g. "$1,234.56") and drag-lift previews match the live rows in all densities.

- **Bug Fixes**
  - Routed all dollar formatting through Formatters.currency for consistent thousands grouping.
  - Reorder preview now uses the same row/card builder as the live UI, fixing density drift.

- **Refactors**
  - Performance: `WidgetRegistry` precomputes O(1) lookups; `WidgetGroupedListView` resolves each row once; cached date formatters in `OpenUsageISO8601` and `CursorUsageCSV`.
  - Shared helpers: `MetricPeriod`, `CcusageSpendMapper`, `ProviderParse.decodeJSONWithHexFallback` and `jwtPayload`, and `CcusageRunner.sinceString`.
  - UI reuse: `CustomizeMetricRow`, `DashboardMetricCard`, `MeasuredScrollScreen`, and `Theme.cardSurface`; `ReorderLift.make` centralizes lift creation.
  - Cleanup: removed unused SVG `viewBox` plumbing and other dead code; unified enum-default reads via `UserDefaultsBacked`.

<sup>Written for commit 8bdaf6180cc7c9e35cea004cc6f85939b83708f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ccusage CLI integration to track token usage and spending.
  * Introduced placeholder badge display when no usage data is available.
  * Added standardized card styling and layout helpers for consistent UI appearance.

* **Improvements**
  * Enhanced currency and token formatting with consistent thousand separators and improved labels.
  * Optimized performance with cached formatters and precomputed lookup maps.
  * Refactored settings persistence for appearance and time format selections.
  * Streamlined provider authentication and credential parsing.

* **Bug Fixes**
  * Improved error response handling in token refresh logic.
  * Enhanced date parsing to support multiple format variations across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->