### PR TITLE
Fix Codex/Devin usage bugs; cut dead code, DRY dup, stale docs

### DIFF
--- a/Sources/OpenUsage/App/UpdaterController.swift
+++ b/Sources/OpenUsage/App/UpdaterController.swift
@@ -7,10 +7,10 @@ import Sparkle
 
 /// Wraps Sparkle's standard updater so the rest of the app stays Sparkle-agnostic.
 ///
-/// The updater starts whenever the app runs from a packaged bundle that declares a `SUFeedURL`. Both
-/// the release build and the preview build ship one (the preview keeps automatic checks off), so the
-/// Settings "Updates" section is visible in both. Only a bare `swift run` — no bundle, no feed — leaves
-/// the updater dormant and hides the section. See `docs/updates.md` for the user-facing behavior.
+/// The updater starts whenever the app runs from a packaged bundle that declares a `SUFeedURL`. Only the
+/// signed release build bakes one in, so the Settings "Updates" section appears there alone. A bare
+/// `swift run` and the in-place dev build ship no feed, leaving the updater dormant and the section
+/// hidden. See `docs/updates.md` for the user-facing behavior.
 @MainActor
 @Observable
 final class UpdaterController {
@@ -60,7 +60,7 @@ final class UpdaterController {
     func start() {
         guard controller == nil else { return }
         guard Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") != nil else {
-            Self.logger.notice("Updater disabled: no SUFeedURL (unbundled or preview build)")
+            Self.logger.notice("Updater disabled: no SUFeedURL (unbundled or dev build)")
             return
         }
         let controller = SPUStandardUpdaterController(

--- a/Sources/OpenUsage/Models/MenuBarContent.swift
+++ b/Sources/OpenUsage/Models/MenuBarContent.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// Resolved, ordered, capped data for the menu-bar strip, built from the pinned metrics and their live
-/// values. The renderers consume this: `groups` drives the Text style (up to three provider groups, each
-/// with its 1–2 pinned metrics), `bars` drives the Bars style (the first four percentage metrics in
-/// order). `isEmpty` means render the plain app icon.
+/// values. The renderers consume this: `groups` drives the Text style (one segment per pinned provider,
+/// each with its 1–2 pinned metrics), `bars` drives the Bars style (the first four bounded metrics — any
+/// with a fill, not just percentages — in order). `isEmpty` means render the plain app icon.
 struct MenuBarContent: Equatable {
     /// One resolved pinned metric.
     struct Metric: Equatable {
@@ -30,8 +30,6 @@ struct MenuBarContent: Equatable {
     let groups: [Group]
     /// Bounded metrics (those with a fill) for the Bars style, flattened in order and capped to four.
     let bars: [Metric]
-
-    static let empty = MenuBarContent(groups: [], bars: [])
 
     /// Nothing is pinned, every pinned provider is disabled, or no pinned metric has data yet — the
     /// menu bar falls back to the app icon.

--- a/Sources/OpenUsage/Models/MenuBarStyle.swift
+++ b/Sources/OpenUsage/Models/MenuBarStyle.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// How the menu-bar item renders the pinned metrics: a `text` strip (provider icon + values, up to
-/// three providers side by side) or the compact `bars` glyph (up to four percentage bars). Chosen in
+/// How the menu-bar item renders the pinned metrics: a `text` strip (provider icon + values, one
+/// segment per pinned provider) or the compact `bars` glyph (up to four bounded-metric bars). Chosen in
 /// Settings and persisted by `LayoutStore`; defaults to `.text`.
 enum MenuBarStyle: String, Hashable, Sendable, CaseIterable {
     case text

--- a/Sources/OpenUsage/Models/WidgetDescriptor.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor.swift
@@ -12,18 +12,6 @@ struct WidgetDescriptor: Identifiable, Hashable {
     /// The one display name for this widget (tile + gallery).
     var title: String { sample.title }
 
-    init(
-        id: String,
-        providerID: String,
-        metricLabel: String,
-        sample: WidgetData
-    ) {
-        self.id = id
-        self.providerID = providerID
-        self.metricLabel = metricLabel
-        self.sample = sample
-    }
-
     static func == (lhs: WidgetDescriptor, rhs: WidgetDescriptor) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
 }

--- a/Sources/OpenUsage/Providers/CcusageSpendMapper.swift
+++ b/Sources/OpenUsage/Providers/CcusageSpendMapper.swift
@@ -11,8 +11,8 @@ enum CcusageSpendMapper {
         let todayEntry = usage.daily.first { dayKey(fromUsageDate: $0.date) == today }
         let yesterdayEntry = usage.daily.first { dayKey(fromUsageDate: $0.date) == yesterday }
 
-        lines.append(dayUsageLine(label: "Today", entry: todayEntry, includeZeroTokens: true))
-        lines.append(dayUsageLine(label: "Yesterday", entry: yesterdayEntry, includeZeroTokens: true))
+        lines.append(dayUsageLine(label: "Today", entry: todayEntry))
+        lines.append(dayUsageLine(label: "Yesterday", entry: yesterdayEntry))
 
         let totalTokens = usage.daily.reduce(0) { $0 + $1.totalTokens }
         let costValues = usage.daily.compactMap(\.costUSD)
@@ -25,12 +25,12 @@ enum CcusageSpendMapper {
         }
     }
 
-    static func dayKey(from date: Date) -> String {
+    private static func dayKey(from date: Date) -> String {
         let components = Calendar.current.dateComponents([.year, .month, .day], from: date)
         return String(format: "%04d-%02d-%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
     }
 
-    static func dayKey(fromUsageDate rawDate: String) -> String? {
+    private static func dayKey(fromUsageDate rawDate: String) -> String? {
         let value = rawDate.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !value.isEmpty else { return nil }
 
@@ -57,16 +57,11 @@ enum CcusageSpendMapper {
         return nil
     }
 
-    static func dayUsageLine(label: String, entry: CcusageDay?, includeZeroTokens: Bool) -> MetricLine {
-        let tokens = entry?.totalTokens ?? 0
-        let cost = entry?.costUSD
-        if tokens > 0 || includeZeroTokens {
-            return .text(label: label, value: costAndTokensLabel(tokens: tokens, costUSD: cost))
-        }
-        return .text(label: label, value: "")
+    private static func dayUsageLine(label: String, entry: CcusageDay?) -> MetricLine {
+        .text(label: label, value: costAndTokensLabel(tokens: entry?.totalTokens ?? 0, costUSD: entry?.costUSD))
     }
 
-    static func costAndTokensLabel(tokens: Int, costUSD: Double?) -> String {
+    private static func costAndTokensLabel(tokens: Int, costUSD: Double?) -> String {
         var parts: [String] = []
         if let costUSD {
             parts.append(Formatters.currency(costUSD))
@@ -75,7 +70,7 @@ enum CcusageSpendMapper {
         return parts.joined(separator: " · ")
     }
 
-    static func formatTokens(_ tokens: Int) -> String {
+    private static func formatTokens(_ tokens: Int) -> String {
         let absValue = abs(tokens)
         let sign = tokens < 0 ? "-" : ""
         let units: [(threshold: Double, divisor: Double, suffix: String)] = [

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageClient.swift
@@ -20,11 +20,11 @@ enum ClaudeUsageError: Error, LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .connectionFailed:
-            return "Usage request failed. Check your connection."
+            return ProviderUsageErrorText.connectionFailed
         case .invalidResponse:
-            return "Usage response invalid. Try again later."
+            return ProviderUsageErrorText.invalidResponse
         case .requestFailed(let statusCode):
-            return "Usage request failed (HTTP \(statusCode)). Try again later."
+            return ProviderUsageErrorText.requestFailed(statusCode: statusCode)
         }
     }
 }

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -86,6 +86,7 @@ final class CodexProvider: ProviderRuntime {
             CcusageSpendMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
         }
 
+        MetricLine.appendNoDataIfNeeded(&mapped.lines)
         return ProviderSnapshot(
             providerID: provider.id,
             displayName: provider.displayName,

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -17,7 +17,7 @@ enum CodexUsageMapper {
             if response.statusCode == 401 || response.statusCode == 403 {
                 throw CodexAuthError.tokenExpired
             }
-            throw CodexUsageError.requestFailed(statusCode: response.statusCode)
+            throw CodexUsageError.requestFailed(response.statusCode)
         }
 
         guard let body = ProviderParse.jsonObject(response.body) else {
@@ -76,8 +76,8 @@ enum CodexUsageMapper {
             lines.append(.text(label: "Credits", value: creditsLabel(remaining: remaining)))
         }
 
-        MetricLine.appendNoDataIfNeeded(&lines)
-
+        // The "no usage data" badge is appended by `CodexProvider.probe` *after* the ccusage spend
+        // lines, so an empty live response never yields a badge that coexists with Today/Yesterday.
         return CodexMappedUsage(plan: formatCodexPlan(body["plan_type"]), lines: lines)
     }
 
@@ -204,18 +204,18 @@ enum CodexUsageMapper {
 }
 
 enum CodexUsageError: Error, LocalizedError, Equatable {
-    case requestFailed(statusCode: Int)
+    case requestFailed(Int)
     case invalidResponse
     case connectionFailed
 
     var errorDescription: String? {
         switch self {
         case .requestFailed(let statusCode):
-            return "Usage request failed (HTTP \(statusCode)). Try again later."
+            return ProviderUsageErrorText.requestFailed(statusCode: statusCode)
         case .invalidResponse:
-            return "Usage response invalid. Try again later."
+            return ProviderUsageErrorText.invalidResponse
         case .connectionFailed:
-            return "Usage request failed. Check your connection."
+            return ProviderUsageErrorText.connectionFailed
         }
     }
 }

--- a/Sources/OpenUsage/Providers/Cursor/CursorPricing.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorPricing.swift
@@ -2,26 +2,18 @@ import Foundation
 
 /// Per-model token pricing entry. Rates are USD per million tokens.
 struct CursorPricingEntry: Sendable {
-    let displayName: String
-    let provider: String
-    let familyID: String
     let familyDisplayName: String
     let inputPerMillion: Double
     let cacheWritePerMillion: Double
     let cacheReadPerMillion: Double
     let outputPerMillion: Double
-    let applyMaxModeUplift: Bool
 
     init(manifestEntry: CursorModelManifestPricingEntry) {
-        self.displayName = manifestEntry.displayName
-        self.provider = manifestEntry.provider
-        self.familyID = manifestEntry.familyID
         self.familyDisplayName = manifestEntry.familyDisplayName
         self.inputPerMillion = manifestEntry.inputPerMillion
         self.cacheWritePerMillion = manifestEntry.cacheWritePerMillion
         self.cacheReadPerMillion = manifestEntry.cacheReadPerMillion
         self.outputPerMillion = manifestEntry.outputPerMillion
-        self.applyMaxModeUplift = manifestEntry.applyMaxModeUplift
     }
 }
 

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -244,9 +244,3 @@ final class CursorProvider: ProviderRuntime {
         )
     }
 }
-
-private extension String {
-    var nilIfEmpty: String? {
-        isEmpty ? nil : self
-    }
-}

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -17,11 +17,11 @@ enum CursorUsageError: Error, LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .connectionFailed:
-            return "Usage request failed. Check your connection."
+            return ProviderUsageErrorText.connectionFailed
         case .invalidResponse:
-            return "Usage response invalid. Try again later."
+            return ProviderUsageErrorText.invalidResponse
         case .requestFailed(let statusCode):
-            return "Usage request failed (HTTP \(statusCode)). Try again later."
+            return ProviderUsageErrorText.requestFailed(statusCode: statusCode)
         case .usageAfterRefreshFailed:
             return "Usage request failed after refresh. Try again."
         case .requestBasedUnavailable(let message):

--- a/Sources/OpenUsage/Providers/Devin/DevinAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinAuthStore.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 struct DevinAuth: Hashable, Sendable {
-    enum Source: String, Hashable, Sendable {
-        case credentialsFile = "credentials.toml"
-        case appState = "Devin app"
+    enum Source: Hashable, Sendable {
+        case credentialsFile
+        case appState
     }
 
     var apiKey: String

--- a/Sources/OpenUsage/Providers/Devin/DevinUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinUsageMapper.swift
@@ -50,9 +50,11 @@ enum DevinUsageMapper {
             ))
         } else if hideDailyQuota,
                   let dailyRemaining {
-            lines.append(usedQuotaLine(
+            // No weekly quota in the response: surface the (hidden) daily quota in the Weekly row so
+            // the tile stays meaningful. Still flipped from remaining→used, just like every quota row.
+            lines.append(quotaLine(
                 label: "Weekly quota",
-                used: dailyRemaining,
+                remaining: dailyRemaining,
                 resetsAt: weeklyReset,
                 periodDurationMs: weekPeriodMs
             ))
@@ -69,19 +71,12 @@ enum DevinUsageMapper {
         return DevinMappedUsage(plan: plan, lines: lines)
     }
 
+    /// Devin reports quota as percent *remaining*; the tile shows percent *used*, so every quota row
+    /// flips `100 - remaining` (clamped) — including the weekly-from-daily fallback above.
     private static func quotaLine(label: String, remaining: Double, resetsAt: Date?, periodDurationMs: Int) -> MetricLine {
-        usedQuotaLine(
-            label: label,
-            used: 100 - remaining,
-            resetsAt: resetsAt,
-            periodDurationMs: periodDurationMs
-        )
-    }
-
-    private static func usedQuotaLine(label: String, used: Double, resetsAt: Date?, periodDurationMs: Int) -> MetricLine {
         .progress(
             label: label,
-            used: ProviderParse.clampPercent(used),
+            used: ProviderParse.clampPercent(100 - remaining),
             limit: 100,
             format: .percent,
             resetsAt: resetsAt,

--- a/Sources/OpenUsage/Providers/ProviderUsageErrorText.swift
+++ b/Sources/OpenUsage/Providers/ProviderUsageErrorText.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Shared user-facing copy for the usage-error cases every provider's `UsageError` otherwise repeats
+/// verbatim (transport failure, malformed response, non-2xx status). Providers whose wording
+/// intentionally differs — e.g. Grok's "billing" phrasing — keep their own strings.
+enum ProviderUsageErrorText {
+    /// The request never completed (network/transport failure).
+    static let connectionFailed = "Usage request failed. Check your connection."
+    /// The response came back but could not be parsed.
+    static let invalidResponse = "Usage response invalid. Try again later."
+    /// The server returned a non-2xx status.
+    static func requestFailed(statusCode: Int) -> String {
+        "Usage request failed (HTTP \(statusCode)). Try again later."
+    }
+}

--- a/Sources/OpenUsage/Services/SystemClients.swift
+++ b/Sources/OpenUsage/Services/SystemClients.swift
@@ -184,9 +184,3 @@ func expandHome(_ path: String) -> String {
     return home + String(path.dropFirst())
 }
 
-private extension String {
-    var nilIfEmpty: String? {
-        isEmpty ? nil : self
-    }
-}
-

--- a/Sources/OpenUsage/Stores/AppearanceSetting.swift
+++ b/Sources/OpenUsage/Stores/AppearanceSetting.swift
@@ -12,7 +12,6 @@ enum AppearanceSetting: String, Hashable, Sendable, CaseIterable, UserDefaultsBa
     case dark
 
     static let key = "appearance"
-    static var defaultsKey: String { key }
     static var fallback: AppearanceSetting { .system }
 
     /// Posted by `applyCurrent()` after the app-level appearance is set, so the popover owner can

--- a/Sources/OpenUsage/Stores/TimeFormatSetting.swift
+++ b/Sources/OpenUsage/Stores/TimeFormatSetting.swift
@@ -8,7 +8,6 @@ enum TimeFormatSetting: String, Hashable, Sendable, CaseIterable, UserDefaultsBa
     case twentyFourHour = "24h"
 
     static let key = "timeFormat"
-    static var defaultsKey: String { key }
     static var fallback: TimeFormatSetting { .auto }
 
     // `current` (the user's current choice, read live) comes from `UserDefaultsBacked`.

--- a/Sources/OpenUsage/Stores/UserDefaultsBacked.swift
+++ b/Sources/OpenUsage/Stores/UserDefaultsBacked.swift
@@ -16,7 +16,7 @@ extension UserDefaults {
 /// instance-scoped key use `UserDefaults.enumValue(forKey:default:)` directly instead.
 protocol UserDefaultsBacked: RawRepresentable where RawValue == String {
     /// The `UserDefaults.standard` key this setting persists under.
-    static var defaultsKey: String { get }
+    static var key: String { get }
     /// The value used when the key is unset or holds an unrecognized raw value.
     static var fallback: Self { get }
 }
@@ -24,6 +24,6 @@ protocol UserDefaultsBacked: RawRepresentable where RawValue == String {
 extension UserDefaultsBacked {
     /// The stored choice, read live from `UserDefaults.standard` (falls back to `fallback`).
     static var current: Self {
-        UserDefaults.standard.enumValue(forKey: defaultsKey, default: fallback)
+        UserDefaults.standard.enumValue(forKey: key, default: fallback)
     }
 }

--- a/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
+++ b/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
@@ -86,7 +86,7 @@ enum MenuBarStripRenderer {
         return CGRect(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)
     }
 
-    /// The compact Bars glyph (≤4 percentage bars), or `nil` when no pinned metric is a percentage.
+    /// The compact Bars glyph (≤4 bounded-metric bars), or `nil` when no pinned metric has a fill.
     static func barsImage(for content: MenuBarContent) -> NSImage? {
         let fractions = content.bars.map(\.fraction)
         guard !fractions.isEmpty else { return nil }

--- a/Sources/OpenUsage/Support/ProviderParse.swift
+++ b/Sources/OpenUsage/Support/ProviderParse.swift
@@ -89,6 +89,11 @@ extension String {
         addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
     }
 
+    /// `nil` when the string is empty, otherwise the string itself — for treating "" as "missing".
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+
     /// Drop any trailing slashes, for joining base URLs and paths.
     var trimmingTrailingSlashes: String {
         var copy = self

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -129,8 +129,8 @@ struct SettingsScreen: View {
                     providerRow(provider)
                 }
             }
-            // Visible whenever the updater is active (release + preview builds ship a feed; only a bare
-            // `swift run` with no bundle hides this).
+            // Visible whenever the updater is active (only the signed release build ships a feed; the
+            // dev build and a bare `swift run`, with no feed, hide this).
             if updater.isActive {
                 section("Updates") {
                     row("Update Automatically") {

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -132,3 +132,43 @@ final class CcusageRunnerTests: XCTestCase {
         XCTAssertEqual(usage?.daily.first?.costUSD, 0.75)
     }
 }
+
+@MainActor
+final class CodexProviderTests: XCTestCase {
+    func testNoUsageDataBadgeIsDroppedWhenCcusageHasSpend() async {
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        // The live usage API returns nothing mappable (empty body -> no metric lines)...
+        let httpClient = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+        let provider = CodexProvider(
+            authStore: CodexAuthStore(
+                environment: FakeEnvironment(["CODEX_HOME": "/tmp/codex-home"]),
+                files: FakeFiles(["/tmp/codex-home/auth.json": #"{"tokens":{"access_token":"token"}}"#]),
+                keychain: FakeKeychain()
+            ),
+            usageClient: CodexUsageClient(http: httpClient),
+            ccusageRunner: CcusageRunner(
+                processRunner: FakeProcessRunner(),
+                homeDirectory: { URL(fileURLWithPath: "/Users/test") }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        // ...but local ccusage spend exists, so the snapshot shows the spend lines and NOT the
+        // "No usage data" badge. Regression: the mapper used to append the badge *before* the ccusage
+        // lines, leaving a contradictory badge-plus-spend snapshot.
+        XCTAssertEqual(text(snapshot.lines, "Today"), "$0.25 · 150 tokens")
+        XCTAssertFalse(snapshot.lines.contains { line in
+            if case .badge(_, let value, _, _) = line { return value == "No usage data" }
+            return false
+        })
+    }
+
+    private func text(_ lines: [MetricLine], _ label: String) -> String? {
+        guard case .text(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Tests/OpenUsageTests/DevinProviderTests.swift
+++ b/Tests/OpenUsageTests/DevinProviderTests.swift
@@ -69,13 +69,16 @@ final class DevinUsageMapperTests: XCTestCase {
         var planInfo = planStatus["planInfo"] as! [String: Any]
         planInfo["hideDailyQuota"] = true
         planStatus["planInfo"] = planInfo
+        planStatus["dailyQuotaRemainingPercent"] = 30
         planStatus.removeValue(forKey: "weeklyQuotaRemainingPercent")
         userStatus["planStatus"] = planStatus
 
         let mapped = try DevinUsageMapper.mapUserStatus(userStatus)
 
         XCTAssertNil(progress(mapped.lines, "Daily quota"))
-        XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.used, 100)
+        // The hidden daily quota fills the missing Weekly row and is still flipped from "remaining"
+        // to "used": 30% remaining -> 70% used (not passed through raw as 30).
+        XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.used, 70)
         XCTAssertEqual(text(mapped.lines, "Extra usage balance"), "$964.22")
     }
 

--- a/Tests/OpenUsageTests/MenuBarContentTests.swift
+++ b/Tests/OpenUsageTests/MenuBarContentTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import OpenUsage
 
 /// Covers `MenuBarContentBuilder`: it resolves pinned provider groups into Text groups (order, labels,
-/// and values preserved) and Bars entries (percentages only, first four in order), and reports empty
+/// and values preserved) and Bars entries (bounded metrics only, first four in order), and reports empty
 /// when nothing is pinned.
 @MainActor
 final class MenuBarContentTests: XCTestCase {

--- a/docs/providers/devin.md
+++ b/docs/providers/devin.md
@@ -6,8 +6,8 @@ Tracks your Devin quota using the login from the Devin CLI or the Devin app.
 
 | Metric | Meaning |
 |---|---|
-| Weekly | Weekly quota used |
-| Daily | Daily quota used (falls back to the weekly figure when Devin hides the daily one) |
+| Weekly | Weekly quota used (falls back to the daily figure when Devin reports no weekly quota) |
+| Daily | Daily quota used (hidden when Devin hides the daily quota) |
 | Extra Balance | Overage/extra-usage balance in dollars |
 | Plan | Your plan name (optional widget) |
 
@@ -23,7 +23,7 @@ If the CLI credentials fail but the app is signed in with a different account, t
 ## Troubleshooting
 
 - **"Not logged in"** — run `devin auth login`, or sign into the Devin app, then refresh.
-- **Daily shows the same as Weekly** — Devin sometimes doesn't expose a separate daily quota; the weekly figure is shown so the row stays meaningful.
+- **Weekly shows the daily figure** — when Devin reports no separate weekly quota, the daily quota is shown in the Weekly row so it stays meaningful.
 
 ## Under the hood
 


### PR DESCRIPTION
A repo audit for dead code, DRY violations, and stale comments/docs surfaced two real defects plus safe cleanup. All changes verified by `swift build` + the full test suite (**202 tests pass**, 1 pre-existing skip).

## 🔴 Runtime bugs (each with a regression test)
- **Codex "No usage data" badge** — `appendNoDataIfNeeded` ran *inside* `CodexUsageMapper`, before `CcusageSpendMapper` appended spend lines, so an empty live response could produce a badge **alongside** Today/Yesterday spend (a contradictory state, also served over the local HTTP API). Moved the call into `CodexProvider.probe` after ccusage, mirroring `ClaudeProvider`. New `CodexProviderTests.testNoUsageDataBadgeIsDroppedWhenCcusageHasSpend` pins it.
- **Devin remaining-as-used** — the weekly-from-daily quota fallback passed the *remaining* percent straight through as *used*, skipping the `100 - x` flip every other quota row applies (`100%` remaining rendered as `100%` used). Routed it through `quotaLine`; strengthened the existing test (`30%` remaining → `70%` used).

## Dead code
- Drop the unreachable `includeZeroTokens` branch in `CcusageSpendMapper` and privatize its internal helpers.
- Remove 4 write-only fields from `CursorPricingEntry`.
- Remove unused `MenuBarContent.empty` and `WidgetDescriptor`'s redundant memberwise init.
- Drop the unused `String` raw backing from `DevinAuth.Source`.

## DRY
- Extract the three identical provider usage-error strings into `ProviderUsageErrorText` (Grok/Devin keep their distinct wording) and standardize Codex's `requestFailed` label to match the other providers.
- Consolidate the duplicated `String.nilIfEmpty` into `ProviderParse`.

## Docs / comments
- Fix stale "preview build" updater docs/log + Settings comment (the Preview app was removed in `0ea6b97`).
- Correct `MenuBarContent`/`MenuBarStyle`/renderer "three providers / percentage bars" claims to the 6-pin budget + bounded-metric reality.
- Rewrite the backwards Daily/Weekly fallback description in `docs/providers/devin.md`.
- Rename `UserDefaultsBacked.defaultsKey` → `key` and drop the conformer bridges.

## Deliberately skipped
`CursorModelManifestSource` (single-impl protocol) — kept, as its file doc marks it an intentional 1:1 port of cursorcat's structure and a legitimate DI seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted provider mapping and refactor with regression tests; no auth or persistence behavior changes beyond corrected display logic.
> 
> **Overview**
> Fixes two usage-display bugs and trims duplicated or dead code across providers and settings.
> 
> **Codex** moves `appendNoDataIfNeeded` from `CodexUsageMapper` into `CodexProvider.probe` **after** ccusage spend lines are added, so an empty live API response no longer shows a **"No usage data"** badge alongside Today/Yesterday spend (aligned with Claude). A regression test covers this.
> 
> **Devin** routes the weekly-from-daily quota fallback through `quotaLine`, so **remaining** percent is flipped to **used** (`30%` remaining → `70%` used) like every other quota row; the test expectation is updated.
> 
> Shared **usage error** strings live in new `ProviderUsageErrorText` (Claude, Codex, Cursor); **`String.nilIfEmpty`** is centralized on `ProviderParse`. **`CcusageSpendMapper`** drops dead `includeZeroTokens` logic and privatizes helpers; **`CursorPricingEntry`** loses unused fields; **`UserDefaultsBacked`** uses `key` instead of `defaultsKey`.
> 
> Comments and **`docs/providers/devin.md`** are corrected for updater visibility (release-only feed, not preview), menu-bar **bounded-metric** bars vs old “three providers / percentage” wording, and Devin daily/weekly fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 250b2780ee50875ed79b0fa8f72a7cef96016933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two usage bugs (Codex badge ordering; Devin weekly quota calculation) and cleans up dead code, duplicated helpers, and stale docs. Unifies provider error text and corrects menu bar docs to match bounded-metric bars.

- **Bug Fixes**
  - Codex: moved "No usage data" badge to `CodexProvider.probe` after `Ccusage` spend so it never shows alongside Today/Yesterday; added a regression test.
  - Devin: weekly-from-daily fallback now flips remaining→used via `quotaLine` (e.g., 30% remaining → 70% used); test updated.

- **Refactors**
  - Removed dead/unused code and privatized helpers (`CcusageSpendMapper`, `CursorPricingEntry`, `MenuBarContent.empty`, `WidgetDescriptor` init, `DevinAuth.Source` raw `String`).
  - DRY: extracted shared usage-error text to `ProviderUsageErrorText`; consolidated `String.nilIfEmpty` into `ProviderParse`; standardized Codex `requestFailed` wording.
  - Docs: updated updater behavior; corrected menu bar/renderer descriptions to “per pinned provider / bounded metrics”; clarified Devin Daily/Weekly fallback; renamed `UserDefaultsBacked.defaultsKey` to `key`.

<sup>Written for commit 250b2780ee50875ed79b0fa8f72a7cef96016933. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

