### PR TITLE
Settings: drop Refresh Every, move Style into Appearance as Menu Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Each provider reads the credentials already on your machine (keychain, auth file
 - **Dashboard popover.** Provider-grouped meters with live reset countdowns, pace indicators, and context menus (pin, hide, used⟷left, countdown⟷exact resets, refresh).
 - **Global shortcut.** Toggle the popover from anywhere — record any combo in Settings.
 - **Customize.** Add/remove widgets, drag-reorder providers and metrics.
-- **Stale-while-revalidate.** Cached values display instantly at launch; refresh runs on your chosen interval.
+- **Stale-while-revalidate.** Cached values display instantly at launch; refresh runs every 5 minutes.
 - **[Local HTTP API](docs/local-http-api.md).** Other apps can read your usage as JSON from `127.0.0.1:6736` (`/v1/usage`), same format as the original app. It is loopback-only and serves usage numbers, never credentials; note that browser pages can read it too — see the [privacy note](docs/local-http-api.md#cors-and-privacy).
 - **[Proxy support](docs/proxy.md).** Route provider requests through SOCKS5 or HTTP(S) via `~/.openusage/config.json`.
-- **Native settings.** Launch at login, global shortcut, refresh interval, theme, density, 12/24-hour time — see [Settings](docs/settings.md).
+- **Native settings.** Launch at login, global shortcut, menu style, theme, density, 12/24-hour time — see [Settings](docs/settings.md).
 - **[Automatic updates](docs/updates.md).** Signed, notarized in-app updates via Sparkle, with an optional early access channel.
 
 ## Documentation

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -55,7 +55,7 @@ final class AppContainer {
 
     deinit { refreshTask.cancel() }
 
-    /// Drives live updates: refresh on launch, then again every chosen interval. Each pass honors the
+    /// Drives live updates: refresh on launch, then again every refresh interval. Each pass honors the
     /// cache, so it only hits the network once a snapshot has actually expired. `@Observable` propagates
     /// the resulting snapshot changes to the menu-bar label and any open widgets, so the UI refreshes on
     /// its own instead of only when the popover opens.
@@ -68,10 +68,11 @@ final class AppContainer {
         }
     }
 
-    /// Sleep for the user's chosen refresh interval, but wake early on any `UserDefaults` change so a new
-    /// "Refresh every" choice takes effect on the next pass instead of after the old, longer interval.
+    /// Sleep for the refresh interval, but wake early on any `UserDefaults` change so a settings change
+    /// (e.g. enabling a provider) is reflected on the next pass instead of waiting out the full interval.
+    /// Each pass still honors the cache, so an early wake only hits the network once a snapshot expired.
     private static func waitForNextRefresh() async {
-        let interval = RefreshSetting.interval()
+        let interval = RefreshSetting.interval
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
                 try? await Task.sleep(for: .seconds(interval))

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -7,10 +7,10 @@ struct ProviderSnapshotCache {
 
     private let userDefaults: UserDefaults
     private let storageKey: String
-    /// TTL is dynamic so it can track the user's chosen refresh interval. A snapshot stays fresh for
-    /// exactly one interval, which (read from the same `UserDefaults`) is what lets cached data survive
-    /// a relaunch without an immediate refetch and expire precisely when the next refresh is due.
-    private let ttlProvider: () -> TimeInterval
+    /// A snapshot stays fresh for exactly one refresh interval, which is what lets cached data survive a
+    /// relaunch without an immediate refetch and expire precisely when the next refresh is due. Tests
+    /// inject a fixed TTL for a deterministic freshness window.
+    private let ttl: TimeInterval
     private let now: () -> Date
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -18,12 +18,12 @@ struct ProviderSnapshotCache {
     init(
         userDefaults: UserDefaults = .standard,
         storageKey: String = "openusage.providerSnapshots.v2",
-        ttlProvider: (() -> TimeInterval)? = nil,
+        ttl: TimeInterval = RefreshSetting.interval,
         now: @escaping () -> Date = Date.init
     ) {
         self.userDefaults = userDefaults
         self.storageKey = storageKey
-        self.ttlProvider = ttlProvider ?? { RefreshSetting.interval(from: userDefaults) }
+        self.ttl = ttl
         self.now = now
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -31,21 +31,6 @@ struct ProviderSnapshotCache {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         self.decoder = decoder
-    }
-
-    /// Fixed-TTL convenience used by tests that want a deterministic freshness window.
-    init(
-        userDefaults: UserDefaults = .standard,
-        storageKey: String = "openusage.providerSnapshots.v2",
-        ttl: TimeInterval,
-        now: @escaping () -> Date = Date.init
-    ) {
-        self.init(
-            userDefaults: userDefaults,
-            storageKey: storageKey,
-            ttlProvider: { ttl },
-            now: now
-        )
     }
 
     /// Every stored snapshot for the given providers, including expired ones. Display uses this
@@ -72,7 +57,7 @@ struct ProviderSnapshotCache {
     }
 
     private func isValid(_ snapshot: ProviderSnapshot) -> Bool {
-        now().timeIntervalSince(snapshot.refreshedAt) < ttlProvider()
+        now().timeIntervalSince(snapshot.refreshedAt) < ttl
     }
 
     private func loadPayload() -> Payload {

--- a/Sources/OpenUsage/Stores/RefreshSetting.swift
+++ b/Sources/OpenUsage/Stores/RefreshSetting.swift
@@ -2,22 +2,11 @@ import Foundation
 
 /// Single source of truth for the background refresh cadence.
 ///
-/// The General settings picker, the periodic refresh loop, and the snapshot-cache TTL all read the
-/// cadence through here so they can never disagree: the cache treats a snapshot as fresh for exactly
-/// one refresh interval, and the loop re-fetches when that window elapses.
+/// The periodic refresh loop and the snapshot-cache TTL both read the cadence through here so they can
+/// never disagree: the cache treats a snapshot as fresh for exactly one refresh interval, and the loop
+/// re-fetches when that window elapses. The cadence is fixed — there's no user-facing control — so the
+/// two always line up.
 enum RefreshSetting {
-    static let key = "refreshMinutes"
-    static let allowedMinutes = [5, 10, 15, 30]
     static let defaultMinutes = 5
-
-    /// The persisted choice, validated. An absent key reads back as `0`, which (like any out-of-range
-    /// value) falls back to the default so callers always get a sane cadence.
-    static func minutes(from defaults: UserDefaults = .standard) -> Int {
-        let stored = defaults.integer(forKey: key)
-        return allowedMinutes.contains(stored) ? stored : defaultMinutes
-    }
-
-    static func interval(from defaults: UserDefaults = .standard) -> TimeInterval {
-        TimeInterval(minutes(from: defaults) * 60)
-    }
+    static let interval = TimeInterval(defaultMinutes * 60)
 }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -25,9 +25,6 @@ struct DashboardView: View {
     @State private var reorderLift: ReorderLift?
     /// Reset to the top whenever the popover closes, so it never reopens mid-scroll.
     @State private var dashboardScrollPosition = ScrollPosition(edge: .top)
-    /// Drives the footer's "Next update in Nm" so it reflects the chosen cadence and updates live
-    /// when the General settings picker changes it. Same key/default as the periodic refresh loop.
-    @AppStorage(RefreshSetting.key) private var refreshMinutes = RefreshSetting.defaultMinutes
     /// Row rhythm and the Customize height seed track the global density setting live.
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
@@ -329,12 +326,12 @@ struct DashboardView: View {
     }
 
     /// "Updating…" during an in-flight refresh, otherwise a live countdown to the next scheduled pass
-    /// (last completed pass + the chosen interval). Falls back to a full interval before the first pass.
+    /// (last completed pass + the refresh interval). Falls back to a full interval before the first pass.
     private func updateStatusText(now: Date) -> String {
         if isUpdating {
             return "Updating…"
         }
-        let interval = TimeInterval(refreshMinutes * 60)
+        let interval = RefreshSetting.interval
         let base = dataStore.lastRefreshAt ?? now
         let remaining = max(0, base.addingTimeInterval(interval).timeIntervalSince(now))
         let totalSeconds = Int(remaining.rounded(.up))

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -25,7 +25,6 @@ struct SettingsScreen: View {
     /// friendly line under the row.
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var launchAtLoginError: String?
-    @AppStorage(RefreshSetting.key) private var refreshMinutes = RefreshSetting.defaultMinutes
     @AppStorage(AppearanceSetting.key) private var appearance = AppearanceSetting.system
     @AppStorage(TimeFormatSetting.key) private var timeFormat = TimeFormatSetting.auto
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
@@ -94,6 +93,9 @@ struct SettingsScreen: View {
                 }
             }
             section("Appearance") {
+                row("Menu Style") {
+                    picker($layout.menuBarStyle, options: MenuBarStyle.allCases, label: \.label)
+                }
                 row("Theme") {
                     picker($appearance, options: AppearanceSetting.allCases, label: \.label)
                         // NSApp-level so the popover panel restyles too (it ignores preferredColorScheme).
@@ -114,14 +116,6 @@ struct SettingsScreen: View {
                 }
                 row("Reset Times") {
                     picker($store.resetDisplayMode, options: ResetDisplayMode.allCases, label: \.label)
-                }
-            }
-            section("Menu Bar") {
-                row("Style") {
-                    picker($layout.menuBarStyle, options: MenuBarStyle.allCases, label: \.label)
-                }
-                row("Refresh Every") {
-                    picker($refreshMinutes, options: RefreshSetting.allowedMinutes, label: { "\($0) minutes" })
                 }
             }
             section("Providers") {

--- a/Tests/OpenUsageTests/RefreshSettingTests.swift
+++ b/Tests/OpenUsageTests/RefreshSettingTests.swift
@@ -1,45 +1,25 @@
 import XCTest
 @testable import OpenUsage
 
-/// Covers the refresh cadence as a single source of truth: `RefreshSetting` validation, and the snapshot
-/// cache TTL tracking the chosen interval (so cached data survives a relaunch within the interval and a
-/// shorter interval immediately invalidates older snapshots).
+/// Covers the refresh cadence as the single source of truth: `RefreshSetting`'s fixed interval, and the
+/// snapshot cache treating a snapshot as fresh for exactly one interval (so cached data survives a
+/// relaunch within the interval and is refetched once past it).
 @MainActor
 final class RefreshSettingTests: XCTestCase {
-    // MARK: - RefreshSetting validation
+    // MARK: - Fixed cadence
 
-    func testAbsentKeyFallsBackToDefault() {
-        let defaults = makeDefaults("absent")
-        XCTAssertEqual(RefreshSetting.minutes(from: defaults), RefreshSetting.defaultMinutes)
-        XCTAssertEqual(RefreshSetting.minutes(from: defaults), 5)
-        XCTAssertEqual(RefreshSetting.interval(from: defaults), 300)
-    }
-
-    func testValidStoredValueIsReturned() {
-        let defaults = makeDefaults("valid")
-        for minutes in RefreshSetting.allowedMinutes {
-            defaults.set(minutes, forKey: RefreshSetting.key)
-            XCTAssertEqual(RefreshSetting.minutes(from: defaults), minutes)
-            XCTAssertEqual(RefreshSetting.interval(from: defaults), TimeInterval(minutes * 60))
-        }
-    }
-
-    func testInvalidStoredValueFallsBackToDefault() {
-        let defaults = makeDefaults("invalid")
-        for bogus in [0, 1, 7, 20, 60, -5] {
-            defaults.set(bogus, forKey: RefreshSetting.key)
-            XCTAssertEqual(RefreshSetting.minutes(from: defaults), RefreshSetting.defaultMinutes)
-        }
+    func testCadenceIsFixedAtFiveMinutes() {
+        XCTAssertEqual(RefreshSetting.defaultMinutes, 5)
+        XCTAssertEqual(RefreshSetting.interval, 300)
     }
 
     // MARK: - Cache TTL tied to the interval
 
-    func testCacheReusedAcrossRestartWithinChosenInterval() async {
+    func testCacheReusedAcrossRestartWithinInterval() async {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let suite = makeDefaults("restart-within")
-        suite.set(5, forKey: RefreshSetting.key) // 5 min interval => 300s TTL
 
-        // A prior session left a snapshot 4 minutes ago.
+        // A prior session left a snapshot 4 minutes ago — inside the 5-minute interval.
         storeSnapshot(used: 20, age: 240, into: suite, now: now)
 
         let runtime = makeRuntime(used: 80)
@@ -50,12 +30,11 @@ final class RefreshSettingTests: XCTestCase {
         XCTAssertNotNil(store.snapshots["test"])
     }
 
-    func testCacheExpiresPastChosenInterval() async {
+    func testCacheExpiresPastInterval() async {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let suite = makeDefaults("restart-expired")
-        suite.set(5, forKey: RefreshSetting.key) // 5 min interval => 300s TTL
 
-        // A prior session left a snapshot 6 minutes ago — older than the interval.
+        // A prior session left a snapshot 6 minutes ago — older than the 5-minute interval.
         storeSnapshot(used: 20, age: 360, into: suite, now: now)
 
         let runtime = makeRuntime(used: 80)
@@ -63,24 +42,6 @@ final class RefreshSettingTests: XCTestCase {
         await store.refreshAll()
 
         XCTAssertEqual(runtime.refreshCount, 1) // past interval => refetched
-    }
-
-    func testShorteningIntervalInvalidatesPreviouslyValidSnapshot() {
-        let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let suite = makeDefaults("shorten")
-        let cache = ProviderSnapshotCache(userDefaults: suite, storageKey: "snapshots", now: { now })
-        cache.store(ProviderSnapshot(
-            providerID: "test",
-            displayName: "Test",
-            lines: [.progress(label: "Session", used: 20, limit: 100, format: .percent)],
-            refreshedAt: now.addingTimeInterval(-480) // 8 minutes old
-        ))
-
-        suite.set(10, forKey: RefreshSetting.key) // 600s TTL => 480 < 600, still fresh
-        XCTAssertNotNil(cache.snapshot(providerID: "test"))
-
-        suite.set(5, forKey: RefreshSetting.key) // 300s TTL => 480 >= 300, now expired
-        XCTAssertNil(cache.snapshot(providerID: "test"))
     }
 
     // MARK: - Helpers
@@ -115,7 +76,7 @@ final class RefreshSettingTests: XCTestCase {
         )
     }
 
-    /// Builds a store backed by the *dynamic* cache (TTL read live from `suite`) — the relaunch case.
+    /// Builds a store backed by a cache at the default (fixed) refresh-interval TTL — the relaunch case.
     private func makeStore(runtime: CountingProviderRuntime, suite: UserDefaults, now: Date) -> WidgetDataStore {
         WidgetDataStore(
             registry: WidgetRegistry(providers: [runtime.provider], descriptors: runtime.widgetDescriptors),

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -13,7 +13,7 @@ Pin from any row's right-click menu, or from the pin that appears when hovering 
 
 ## Styles
 
-Settings → Menu Bar → Style:
+Settings → Appearance → Menu Style:
 
 - **Text** — provider icon plus values; two pinned metrics from the same provider stack as a labeled pair.
 - **Bars** — compact vertical bars, one per pinned metric that has a limit (metrics without limits only appear in Text style).

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -2,10 +2,9 @@
 
 ## When data updates
 
-- All enabled providers refresh together: at launch, then on the interval you pick in Settings (5–30 minutes). Providers fetch in parallel — one slow provider doesn't delay the others.
+- All enabled providers refresh together: at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Providers fetch in parallel — one slow provider doesn't delay the others.
 - The popover footer shows `Next update in Nm`. **Clicking it (or ⌘R)** refreshes immediately, skipping the cache.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.
-- Changing the interval in Settings takes effect right away.
 
 ## Caching
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -13,6 +13,7 @@ Settings lives inside the popover — there is no separate window. Open it with 
 
 | Setting | Options | What it does |
 |---|---|---|
+| Menu Style | Text / Bars | How pinned metrics render in the menu bar. See [Menu bar](menu-bar.md). |
 | Theme | System / Light / Dark | App-wide appearance override for the popover. |
 | Density | Default / Compact | Default breathes; Compact is a real information-dense mode — text steps down one size, rows and provider sections pull together, and Customize / Settings rows tighten with them. In both, consecutive one-line metrics (Today / Yesterday / …) pull together; Compact pulls harder. |
 | Time Format | Auto / 12-hour / 24-hour | How exact times read (e.g. "Resets today at 6:38 PM" vs "18:38"). Auto follows the system. |
@@ -23,13 +24,6 @@ Settings lives inside the popover — there is no separate window. Open it with 
 |---|---|---|
 | Show Usage As | Used / Left | Whether bounded metrics read "48% used" or "52% left" — same toggle as clicking a headline. |
 | Reset Times | Countdown / Exact time | "Resets in 3h 25m" vs "Resets today at 6:38 PM" — same toggle as clicking a reset label. |
-
-## Menu Bar
-
-| Setting | Options | What it does |
-|---|---|---|
-| Style | Text / Bars | How pinned metrics render in the menu bar. See [Menu bar](menu-bar.md). |
-| Refresh Every | 5 / 10 / 15 / 30 minutes | Background refresh cadence. Also controls how long cached values count as fresh. See [Refreshing](refreshing.md). |
 
 ## Providers
 


### PR DESCRIPTION
## Summary

Implements [#611](https://github.com/robinebers/openusage/issues/611): the two-row **Menu Bar** settings section was over-scoped, and **Refresh Every** is a knob almost nobody touches.

- **Removed the Menu Bar section.** Its visual-style control moves to the **top of Appearance** as **Menu Style** (Text / Bars). Persistence stays on `LayoutStore.menuBarStyle` — no key rename.
- **Removed Refresh Every.** Background refresh is now fixed at the **5-minute default**. `RefreshSetting` drops its `UserDefaults` key, `allowedMinutes`, and validation, exposing just `defaultMinutes` and a fixed `interval`. The refresh loop, snapshot-cache TTL, and footer countdown all still read through that single helper — just without a user-facing control, so any previously-stored `refreshMinutes` is ignored.
- **Simplified `ProviderSnapshotCache`.** With the TTL no longer dynamic, the closure-based `ttlProvider` + dual init collapse to a plain `ttl: TimeInterval = RefreshSetting.interval`.

### Resulting Appearance section

| Row | Options |
|---|---|
| Menu Style | Text / Bars |
| Theme | System / Light / Dark |
| Density | Default / Compact |
| Time Format | Auto / 12-hour / 24-hour |

## Docs

`docs/settings.md` (Menu Bar section removed, Menu Style added under Appearance), `docs/menu-bar.md` (path → *Settings → Appearance → Menu Style*), `docs/refreshing.md` (cadence fixed at 5 min), and two now-stale lines in `README.md`.

## Testing

- `swift build` ✅
- `swift test` ✅ (199 tests, 0 failures). `RefreshSettingTests` rewritten for the fixed cadence: dropped stored-value-validation and dynamic-TTL tests; kept cache fresh/expired coverage against the fixed 300s TTL.
- Launched the dev build and confirmed in the popover: Menu Style is the first Appearance row, no Menu Bar section, no Refresh Every row, footer reads "Next update in 5m".

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings and documentation simplification with no auth or credential changes; users who chose 10–30 minute refresh will silently get 5 minutes until they notice.
> 
> **Overview**
> Removes the **Menu Bar** settings section and folds **Menu Style** (Text / Bars) into **Appearance** as the first row; `LayoutStore.menuBarStyle` is unchanged.
> 
> **Refresh Every** is gone: background refresh and snapshot-cache TTL are fixed at **5 minutes** via `RefreshSetting.interval`. `UserDefaults` validation, `allowedMinutes`, and dynamic TTL in `ProviderSnapshotCache` are removed; the periodic loop and dashboard footer countdown read the same constant. `UserDefaults.didChangeNotification` still wakes the refresh loop early so toggling providers does not wait out the full interval.
> 
> Docs and README describe the fixed cadence and the new settings layout; `RefreshSettingTests` now assert the fixed 300s TTL instead of per-user intervals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da7c69cf31e2badab33946f8e65750880366d3a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies Settings by removing Refresh Every and moving menu bar style into Appearance as Menu Style. Refresh cadence is fixed at 5 minutes; the refresh loop, cache TTL, and footer countdown are aligned. Closes #611.

- **Refactors**
  - Moved menu bar style to Appearance as "Menu Style" (Text / Bars); persistence stays on `LayoutStore.menuBarStyle`.
  - Removed Refresh Every; `RefreshSetting` now only has `defaultMinutes` and a fixed `interval`.
  - Simplified `ProviderSnapshotCache` to a fixed `ttl` (no closure, no dual init).
  - Updated README and docs; adjusted tests to the fixed 5-minute cadence.

- **Migration**
  - No action needed. Any stored `refreshMinutes` is ignored. No keys were renamed.

<sup>Written for commit da7c69cf31e2badab33946f8e65750880366d3a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

