### PR TITLE
Fix white flicker on screen switches with an offset pager

### DIFF
--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -7,6 +7,17 @@ enum PopoverScreen: Hashable, Sendable {
     case dashboard
     case customize
     case settings
+
+    /// Left-to-right order for the popover's horizontal screen-switch slide: the dashboard is home on
+    /// the left, with Customize and Settings to its right. The slide reads its direction from these
+    /// ranks — a higher-ranked target enters from the trailing edge, a lower one from the leading edge.
+    var slideRank: Int {
+        switch self {
+        case .dashboard: 0
+        case .customize: 1
+        case .settings: 2
+        }
+    }
 }
 
 /// Mutable layout: which widgets are enabled, provider order, and each provider's metric order.
@@ -17,7 +28,20 @@ final class LayoutStore {
     var placed: [PlacedWidget]
     /// Which in-popover screen is showing. Lives here (not per-view state) so the footer buttons,
     /// the Esc handler, and the popover-closed reset all drive the same mode.
-    var screen = PopoverScreen.dashboard
+    var screen = PopoverScreen.dashboard {
+        didSet {
+            guard screen != oldValue else { return }
+            // Recorded synchronously with the change — not via SwiftUI's `onChange`, which fires a
+            // frame later and would let the popover paint the destination before the slide begins.
+            // DashboardView reads these on its very next render to slide in from the screen being left.
+            screenSlideFrom = oldValue
+            screenSlideID &+= 1
+        }
+    }
+    /// Supports DashboardView's horizontal screen-switch slide: the screen being left, plus a counter
+    /// that ticks on every switch so the view can detect and animate each transition. UI-only; not persisted.
+    private(set) var screenSlideFrom = PopoverScreen.dashboard
+    private(set) var screenSlideID = 0
     /// Whether the Customize screen (per-provider metric toggles + reorder) is showing — a bridge
     /// over `screen` for the many call sites that think in terms of edit mode.
     var isEditing: Bool {

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -23,6 +23,13 @@ struct DashboardView: View {
     @State private var hasMeasuredCustomizeContent = false
     @State private var hasMeasuredSettingsContent = false
     @State private var reorderLift: ReorderLift?
+    /// Horizontal screen-switch slide: 0 shows the outgoing screen, 1 the incoming one. Drives both the
+    /// page offset and the interpolated popover height, so the slide and the resize share one spring.
+    @State private var slideProgress: CGFloat = 1
+    /// The `layout.screenSlideID` whose slide has begun animating. Until it catches up to the store's
+    /// id, a freshly-started transition pins to the outgoing screen so the first frame never flashes
+    /// the destination.
+    @State private var animatedSlideID = 0
     /// Reset to the top whenever the popover closes, so it never reopens mid-scroll.
     @State private var dashboardScrollPosition = ScrollPosition(edge: .top)
     /// Drives the footer's "Next update in Nm" so it reflects the chosen cadence and updates live
@@ -85,14 +92,29 @@ struct DashboardView: View {
         return min(contentHeight, maxScrollHeight)
     }
 
-    private var popoverHeight: CGFloat {
-        let scrollHeight: CGFloat
-        switch layout.screen {
-        case .dashboard: scrollHeight = dashboardScrollHeight
-        case .customize: scrollHeight = customizeScrollHeight
-        case .settings: scrollHeight = settingsScrollHeight
+    private func scrollHeight(for screen: PopoverScreen) -> CGFloat {
+        switch screen {
+        case .dashboard: dashboardScrollHeight
+        case .customize: customizeScrollHeight
+        case .settings: settingsScrollHeight
         }
-        return scrollHeight + chromeHeight
+    }
+
+    private var popoverHeight: CGFloat {
+        scrollHeight(for: layout.screen) + chromeHeight
+    }
+
+    /// The popover height to apply while a screen-switch slide is playing: it interpolates from the
+    /// outgoing screen's height to the incoming one's on `slideProgress` — the *same* value that drives
+    /// the horizontal offset — so the box resizing and the screens sliding read as one coordinated
+    /// motion instead of two animations on separate clocks. At rest it's simply the current screen's
+    /// height; before the slide actually starts it sits at the outgoing screen's height to match the
+    /// pinned offset, so nothing jumps ahead of the slide.
+    private var animatedPopoverHeight: CGFloat {
+        guard isSliding else { return popoverHeight }
+        let fromHeight = scrollHeight(for: layout.screenSlideFrom) + chromeHeight
+        guard animatedSlideID == layout.screenSlideID else { return fromHeight }
+        return fromHeight + slideProgress * (popoverHeight - fromHeight)
     }
 
     /// Cold-start estimate for Customize content. Without this, the first click into Customize starts from an
@@ -131,7 +153,7 @@ struct DashboardView: View {
         modeBody
             .frame(width: Self.popoverWidth)
             .safeAreaBar(edge: .bottom, spacing: 0) { footerBar }
-            .frame(height: popoverHeight, alignment: .top)
+            .frame(height: animatedPopoverHeight, alignment: .top)
             .overlay(alignment: .topLeading) {
                 if let reorderLift {
                     ReorderLiftPreview(lift: reorderLift)
@@ -153,13 +175,25 @@ struct DashboardView: View {
                     if !visible { resetTransientState() }
                 }
             )
-            .animation(Motion.modeSwitch, value: layout.screen)
             // A screen switch can tear the list down mid-drag, in which case the gesture's
             // `onEnded` never fires — clear the lift here or its overlay survives onto the new
             // screen.
             .onChange(of: layout.screen) {
                 reorderLift = nil
                 layout.cancelDrag()
+            }
+            // Each screen switch: pin to the outgoing screen for one render (`slideProgress = 0`),
+            // then spring to the incoming one on the next runloop tick. Deferring the animation one
+            // tick is what makes it animate — setting 0 then 1 in the same closure collapses to a
+            // no-op (SwiftUI animates from the last *committed* value). `slideProgress` drives the
+            // page offset and the interpolated height together, so the slide and the resize are one motion.
+            .onChange(of: layout.screenSlideID) { _, id in
+                guard id != 0 else { return }
+                slideProgress = 0
+                animatedSlideID = id
+                Task { @MainActor in
+                    withAnimation(Motion.spring) { slideProgress = 1 }
+                }
             }
             .onChange(of: layout.customizeGroups.map { group in
                 "\(group.provider.id):\(group.metrics.map(\.id).joined(separator: ","))"
@@ -180,9 +214,66 @@ struct DashboardView: View {
         dashboardScrollPosition.scrollTo(edge: .top)
     }
 
-    @ViewBuilder
+    /// The popover's screens as a horizontal pager. At rest only the current screen is mounted (one
+    /// page at offset 0), so drag-reorder's coordinate math and the footer's scroll-edge underlap are
+    /// exactly what they'd be with the screen rendered alone. During a switch the outgoing and incoming
+    /// screens are both mounted, ordered left-to-right by `slideRank`, and slid by a pure offset.
+    ///
+    /// Why an offset and not a SwiftUI `.transition`: the cards' fill is translucent `.quaternary`
+    /// glass. Any transition carrying `.opacity` composites a screen into a transparency layer where
+    /// that material has no vibrant backdrop to sample and resolves to its opaque near-white base — a
+    /// white flash across the grey cards (the regression this removes; it has no clean SwiftUI fix).
+    /// A pure offset never touches opacity, so the glass keeps sampling the live popover backdrop. The
+    /// pages are a `ForEach` keyed by screen, so the incoming page keeps its identity (and scroll
+    /// position) when the slide collapses back to one page. `.animation(nil, value:)` stops the
+    /// one-frame structural re-layout at the start of a switch from inheriting the footer buttons'
+    /// mode-switch animation — only `slideProgress` animates the offset (and, in step, the height).
     private var modeBody: some View {
-        switch layout.screen {
+        let pages = slidePages
+        return HStack(alignment: .top, spacing: 0) {
+            ForEach(pages, id: \.self) { screen in
+                screenView(screen)
+                    .frame(width: Self.popoverWidth)
+                    .frame(maxHeight: .infinity, alignment: .top)
+            }
+        }
+        .frame(width: Self.popoverWidth, alignment: .leading)
+        .offset(x: slideOffset(pages))
+        .animation(nil, value: layout.screenSlideID)
+    }
+
+    /// True from the moment `layout.screen` changes until the slide reaches the incoming screen.
+    private var isSliding: Bool {
+        layout.screenSlideID != 0
+            && (layout.screenSlideID != animatedSlideID || slideProgress < 1)
+    }
+
+    /// One page at rest (the current screen); the two involved screens in left-to-right rank order
+    /// while a switch animates.
+    private var slidePages: [PopoverScreen] {
+        guard isSliding else { return [layout.screen] }
+        let from = layout.screenSlideFrom
+        let to = layout.screen
+        return from.slideRank < to.slideRank ? [from, to] : [to, from]
+    }
+
+    /// Horizontal offset that places the outgoing screen at `slideProgress == 0` and the incoming one
+    /// at `1`. Pinned to the outgoing screen until this transition's animation has actually started, so
+    /// the first frame after a switch shows the screen being left — never a flash of the destination.
+    private func slideOffset(_ pages: [PopoverScreen]) -> CGFloat {
+        guard isSliding, pages.count > 1 else { return 0 }
+        let fromOffset = -CGFloat(pages.firstIndex(of: layout.screenSlideFrom) ?? 0) * Self.popoverWidth
+        let toOffset = -CGFloat(pages.firstIndex(of: layout.screen) ?? 0) * Self.popoverWidth
+        let progress = animatedSlideID == layout.screenSlideID ? slideProgress : 0
+        return fromOffset + progress * (toOffset - fromOffset)
+    }
+
+    /// Builds one screen. Kept identity-stable across the slide via the `ForEach` key in `modeBody`.
+    @ViewBuilder
+    private func screenView(_ screen: PopoverScreen) -> some View {
+        switch screen {
+        case .dashboard:
+            scrollingDashboard
         case .customize:
             CustomizeView(
                 contentHeight: $customizeContentHeight,
@@ -190,16 +281,11 @@ struct DashboardView: View {
                 reorderSpaceName: Self.reorderSpace,
                 reorderLift: $reorderLift
             )
-            .transition(.move(edge: .trailing).combined(with: .opacity))
         case .settings:
             SettingsScreen(
                 contentHeight: $settingsContentHeight,
                 hasMeasuredContent: $hasMeasuredSettingsContent
             )
-            .transition(.move(edge: .trailing).combined(with: .opacity))
-        case .dashboard:
-            scrollingDashboard
-                .transition(.move(edge: .leading).combined(with: .opacity))
         }
     }
 


### PR DESCRIPTION
## Problem

Switching between Dashboard ↔ Customize ↔ Settings flashed the grey provider cards **white** during the slide. The transition was `.move(edge:).combined(with: .opacity)`; the `.opacity` component composites each screen into a transparency layer where the cards' translucent `.quaternary` glass fill has no vibrant backdrop to sample, so it resolves to its opaque near-white base for the length of the fade. There is no clean SwiftUI fix for a material flashing under an opacity animation, so the transition can't carry opacity at all.

## Fix

Replace the cross-fade with a **transition-scoped horizontal offset pager** — the standard flicker-free "navigation push" pattern (pure position animation, no opacity):

- **No opacity** → the glass cards never enter a transparency layer, so they can't flash white.
- **Direction-aware**: forward (Dashboard→Customize→Settings) enters from the trailing edge; back enters from the leading edge (`PopoverScreen.slideRank`).
- **At rest only the current screen is mounted**, at its natural position — so drag-reorder's coordinate math and the footer's scroll-edge underlap are untouched. The second screen mounts only *during* the slide, then collapses away. Pages are a `ForEach` keyed by screen, so the incoming page keeps its identity (and scroll position).
- `LayoutStore.screen`'s `didSet` records the outgoing screen + a transition id **synchronously**, so the first render after a switch already shows the screen being left (an `onChange` fires a frame late and would flash the destination).
- The popover **height interpolates** from the outgoing to the incoming screen on the same `slideProgress`, so the slide and the resize are one coordinated spring rather than two animations on separate clocks.

## Testing

- `swift build` clean; `swift test` — 201 pass, 1 pre-existing skip.
- Manually verified via `script/build_and_run.sh`: no white flash on any switch (forward or back), drag-reorder and scrolling intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only popover navigation animation; no persistence, auth, or data-path changes.
> 
> **Overview**
> Fixes a **white flash** on Dashboard ↔ Customize ↔ Settings transitions caused by `.move` + `.opacity` transitions compositing translucent `.quaternary` glass cards into a layer with no vibrant backdrop.
> 
> **`LayoutStore`** adds `PopoverScreen.slideRank` for slide direction, and records `screenSlideFrom` + `screenSlideID` synchronously in `screen`'s `didSet` so the first frame after a switch shows the outgoing screen (not a one-frame-late `onChange` flash of the destination).
> 
> **`DashboardView`** replaces per-screen SwiftUI transitions with a **horizontal offset pager**: at rest only the current screen is mounted; during a switch both pages slide on pure `offset` (no opacity). Popover height **interpolates** on the same `slideProgress` spring as the offset. Animation is kicked on the next runloop tick after pinning `slideProgress` to 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c92efe5783d7cdff05ab2c21ed3b9c49854231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates the white flicker when switching between Dashboard, Customize, and Settings by replacing the cross-fade with a direction-aware horizontal slide. Uses pure position animation and ties popover height to the slide for a smooth, flicker-free transition.

- **Bug Fixes**
  - Replaced `.move(edge:).combined(with: .opacity)` with a pure offset pager to stop glass cards flashing white.
  - Slide direction reads from `PopoverScreen.slideRank` (forward enters from trailing; back from leading).
  - `LayoutStore` now records `screenSlideFrom` and `screenSlideID` in `screen`’s didSet to show the outgoing screen on the first frame.
  - Pager mounts only the current screen at rest; mounts both during a switch, keyed by screen to preserve identity and scroll; popover height interpolates on the same progress for a single spring.

<sup>Written for commit 20c92efe5783d7cdff05ab2c21ed3b9c49854231. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

