### PR TITLE
feat(logging): port the Tauri debug-logging system to the native app (#604)

### DIFF
--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -22,6 +22,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let updater = UpdaterController()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Open/trim the file log, seed the cached level, and emit the startup line BEFORE anything
+        // else logs, so the first lines of a session are captured.
+        AppLog.bootstrap()
         // App-wide theme override (NSApp.appearance): the popover ignores SwiftUI's
         // preferredColorScheme, so the override is applied at the AppKit level once at launch;
         // the Theme picker on the Settings screen re-applies it on change.

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -1,6 +1,5 @@
 import AppKit
 import KeyboardShortcuts
-import os
 import SwiftUI
 
 /// Owns the menu-bar status item and the popover that shows the dashboard.
@@ -13,8 +12,6 @@ import SwiftUI
 /// the global shortcut can call directly.
 @MainActor
 final class StatusItemController: NSObject, NSPopoverDelegate {
-    private static let logger = Logger(subsystem: "OpenUsage", category: "StatusItem")
-
     private let container: AppContainer
     private let updater: UpdaterController
     private let statusItem: NSStatusItem
@@ -72,7 +69,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
 
         // Registered once here; the controller lives for the app's whole life.
         KeyboardShortcuts.onKeyUp(for: .togglePopover) { [weak self] in
-            Self.logger.info("Global shortcut fired; toggling popover")
+            AppLog.info(.statusItem, "Global shortcut fired; toggling popover")
             self?.togglePopover()
         }
 
@@ -82,7 +79,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             self?.closePopover()
         }
 
-        Self.logger.info("Status item ready (button: \(self.statusItem.button != nil), shortcut: \(KeyboardShortcuts.getShortcut(for: .togglePopover)?.description ?? "none", privacy: .public))")
+        AppLog.info(.statusItem, "Status item ready (button: \(self.statusItem.button != nil), shortcut: \(KeyboardShortcuts.getShortcut(for: .togglePopover)?.description ?? "none"))")
     }
 
     // MARK: - Status item image
@@ -127,7 +124,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
 
     private func showPopover() {
         guard let button = statusItem.button else {
-            Self.logger.error("Cannot show popover: status item has no button")
+            AppLog.error(.statusItem, "Cannot show popover: status item has no button")
             return
         }
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)

--- a/Sources/OpenUsage/App/UpdaterController.swift
+++ b/Sources/OpenUsage/App/UpdaterController.swift
@@ -2,7 +2,6 @@ import AppKit
 import Combine
 import Foundation
 import Observation
-import os
 import Sparkle
 
 /// Wraps Sparkle's standard updater so the rest of the app stays Sparkle-agnostic.
@@ -18,8 +17,6 @@ final class UpdaterController {
     /// toggle here and the Sparkle channel delegate's `allowedChannels` — so the stored default is the
     /// single source of truth rather than a cached property.
     static let betaChannelDefaultsKey = "betaUpdatesEnabled"
-
-    private static let logger = Logger(subsystem: "OpenUsage", category: "Updater")
 
     // Two delegates on purpose: SPUUpdaterDelegate is main-actor isolated in Sparkle, while
     // SPUStandardUserDriverDelegate is nonisolated. Conforming to both from one class would infer a
@@ -41,7 +38,7 @@ final class UpdaterController {
         didSet {
             UserDefaults.standard.set(betaChannelEnabled, forKey: Self.betaChannelDefaultsKey)
             controller?.updater.resetUpdateCycle()
-            Self.logger.info("Update channel set to \(self.betaChannelEnabled ? "early access" : "stable", privacy: .public)")
+            AppLog.info(.updates, "channel set to \(self.betaChannelEnabled ? "early access" : "stable")")
         }
     }
 
@@ -60,7 +57,7 @@ final class UpdaterController {
     func start() {
         guard controller == nil else { return }
         guard Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") != nil else {
-            Self.logger.notice("Updater disabled: no SUFeedURL (unbundled or dev build)")
+            AppLog.info(.updates, "disabled: no SUFeedURL (unbundled or dev build)")
             return
         }
         let controller = SPUStandardUpdaterController(
@@ -78,7 +75,7 @@ final class UpdaterController {
             .sink { [weak self] value in
                 MainActor.assumeIsolated { self?.canCheckForUpdates = value }
             }
-        Self.logger.info("Updater started (feed present)")
+        AppLog.info(.updates, "started (feed present)")
     }
 
     /// User-initiated check. Shows Sparkle's standard UI (progress, release notes, install prompt).
@@ -96,6 +93,26 @@ private final class UpdaterChannelDelegate: NSObject, SPUUpdaterDelegate {
     /// default channel regardless, so stable users are never starved of stable releases.
     func allowedChannels(for updater: SPUUpdater) -> Set<String> {
         UserDefaults.standard.bool(forKey: UpdaterController.betaChannelDefaultsKey) ? ["beta"] : []
+    }
+
+    /// Records the result of each update cycle (per the issue's "Sparkle check result + channel"
+    /// item). `SUNoUpdateError`/`SUInstallationCanceledError` are normal outcomes, not failures, so
+    /// they log at Info; a genuine error (network, download) logs at Warn. The error is
+    /// framework-sourced (no secrets) but still routed through `AppLog` for one consistent format.
+    func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: Error?) {
+        let channel = UserDefaults.standard.bool(forKey: UpdaterController.betaChannelDefaultsKey) ? "early access" : "stable"
+        guard let error else {
+            AppLog.info(.updates, "check finished (channel=\(channel), no error)")
+            return
+        }
+        let code = (error as NSError).code
+        if code == Int(SUError.noUpdateError.rawValue) {
+            AppLog.info(.updates, "check finished (channel=\(channel), no update available)")
+        } else if code == Int(SUError.installationCanceledError.rawValue) {
+            AppLog.info(.updates, "check finished (channel=\(channel), user canceled)")
+        } else {
+            AppLog.warn(.updates, "check/download failed: \(error.localizedDescription)")
+        }
     }
 }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -116,6 +116,17 @@ struct ClaudeAuthStore: Sendable {
         case .environment:
             return
         }
+        // NEVER log the credential blob/tokens — only that a rotation was persisted, and to where.
+        AppLog.debug(LogTag.auth("claude"), "persisted rotated credentials (source=\(sourceLabel(state.source)))")
+    }
+
+    private func sourceLabel(_ source: ClaudeCredentialState.Source) -> String {
+        switch source {
+        case .file: "file"
+        case .keychainCurrentUser: "keychainCurrentUser"
+        case .keychainLegacy: "keychainLegacy"
+        case .environment: "environment"
+        }
     }
 
     func canFetchLiveUsage(_ state: ClaudeCredentialState) -> Bool {
@@ -198,11 +209,13 @@ struct ClaudeAuthStore: Sendable {
     }
 
     private func loadKeychainCredentials() -> ClaudeCredentialState? {
+        // The service name is safe to log; NEVER log the returned credential blob / OAuth tokens.
         for service in keychainServiceCandidates() {
             if let value = try? keychain.readGenericPasswordForCurrentUser(service: service),
                let parsed = Self.parseCredentials(value),
                let oauth = parsed.claudeAiOauth,
                oauth.accessToken?.isEmpty == false {
+                AppLog.debug(.keychain, "read hit service=\(service)")
                 return ClaudeCredentialState(
                     oauth: oauth,
                     source: .keychainCurrentUser(service: service),
@@ -215,6 +228,7 @@ struct ClaudeAuthStore: Sendable {
                let parsed = Self.parseCredentials(value),
                let oauth = parsed.claudeAiOauth,
                oauth.accessToken?.isEmpty == false {
+                AppLog.debug(.keychain, "read hit service=\(service)")
                 return ClaudeCredentialState(
                     oauth: oauth,
                     source: .keychainLegacy(service: service),
@@ -222,6 +236,7 @@ struct ClaudeAuthStore: Sendable {
                     inferenceOnly: false
                 )
             }
+            AppLog.debug(.keychain, "read miss service=\(service)")
         }
         return nil
     }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -37,11 +37,16 @@ final class ClaudeProvider: ProviderRuntime {
         guard let state = authStore.loadCredentials(),
               state.oauth.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         else {
+            AppLog.info(LogTag.auth("claude"), "no access token, not logged in")
             return ProviderSnapshot.error(provider: provider, message: ClaudeAuthError.notLoggedIn.localizedDescription)
         }
 
+        AppLog.info(LogTag.plugin("claude"), "refresh start")
+        let start = Date()
         do {
-            return try await probe(state: state)
+            let snapshot = try await probe(state: state)
+            AppLog.info(LogTag.plugin("claude"), "refresh end (\(Int(Date().timeIntervalSince(start) * 1000))ms)")
+            return snapshot
         } catch {
             return ProviderSnapshot.error(provider: provider, message: error.localizedDescription)
         }
@@ -101,6 +106,7 @@ final class ClaudeProvider: ProviderRuntime {
 
         // 429 can come back from either attempt; the helper hands both through unchanged.
         if response.statusCode == 429 {
+            AppLog.info(LogTag.plugin("claude"), "rate-limited")
             return ClaudeUsageMapper.rateLimitedUsage(
                 credentials: working.oauth,
                 retryAfterSeconds: ClaudeUsageMapper.parseRetryAfterSeconds(response, now: now())
@@ -110,11 +116,13 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     private func refreshAccessToken(state: inout ClaudeCredentialState, refreshToken: String) async throws -> String {
+        AppLog.info(LogTag.auth("claude"), "token refresh attempt")
         let response = try await usageClient.refreshToken(refreshToken, config: authStore.oauthConfig())
         if response.statusCode == 400 || response.statusCode == 401 {
             let body = (try? JSONSerialization.jsonObject(with: response.body)) as? [String: Any]
             let errorCode = body?["error"] as? String ?? body?["error_description"] as? String
             if errorCode == "invalid_grant" {
+                AppLog.warn(LogTag.auth("claude"), "session expired (invalid_grant)")
                 throw ClaudeAuthError.sessionExpired
             }
             throw ClaudeAuthError.tokenExpired
@@ -122,6 +130,7 @@ final class ClaudeProvider: ProviderRuntime {
         guard (200..<300).contains(response.statusCode) else {
             throw ClaudeUsageError.requestFailed(response.statusCode)
         }
+        // NEVER log decoded.accessToken / refreshToken — only the fact that a rotation happened.
         let decoded = try JSONDecoder().decode(ClaudeRefreshResponse.self, from: response.body)
         state.oauth.accessToken = decoded.accessToken
         if let refreshToken = decoded.refreshToken {
@@ -131,6 +140,7 @@ final class ClaudeProvider: ProviderRuntime {
             state.oauth.expiresAt = now().timeIntervalSince1970 * 1000 + expiresIn * 1000
         }
         try? authStore.save(state)
+        AppLog.info(LogTag.auth("claude"), "token refresh ok (rotated)")
         return decoded.accessToken
     }
 

--- a/Sources/OpenUsage/Providers/ProviderAuthRetry.swift
+++ b/Sources/OpenUsage/Providers/ProviderAuthRetry.swift
@@ -41,6 +41,7 @@ enum ProviderAuthRetry {
         }
         guard isAuthFailure(response) else { return response }
 
+        AppLog.debug(.auth, "\(response.statusCode) -> refreshing token, retrying once")
         let refreshed = try await refreshAccessToken()
 
         let retried: HTTPResponse
@@ -49,7 +50,10 @@ enum ProviderAuthRetry {
         } catch {
             throw retriedConnectionFailed ?? connectionFailed
         }
-        if isAuthFailure(retried) { throw authExpired }
+        if isAuthFailure(retried) {
+            AppLog.warn(.auth, "retry still unauthorized -> auth expired")
+            throw authExpired
+        }
         return retried
     }
 }

--- a/Sources/OpenUsage/Services/CcusageRunner.swift
+++ b/Sources/OpenUsage/Services/CcusageRunner.swift
@@ -59,8 +59,13 @@ struct CcusageRunner {
 
     func query(provider: CcusageProvider, since: String, homePath: String? = nil) async -> Result<CcusageDailyUsage, CcusageRunnerError> {
         guard let bunx = resolveBunx() else {
+            AppLog.warn(LogTag.plugin("ccusage"), "no package runner found")
             return .failure(.noRunner)
         }
+        // The args are secret-free; the resolved bunx path may carry the user's home, so Debug-only
+        // and routed through `redactLogMessage`.
+        AppLog.info(LogTag.plugin("ccusage"), "launch bunx \(provider.rawValue) daily")
+        AppLog.debug(LogTag.plugin("ccusage"), "resolved bunx \(LogRedaction.redactLogMessage(bunx))")
 
         let args = [
             "--silent",
@@ -83,15 +88,20 @@ struct CcusageRunner {
                 timeout: Self.timeout
             )
             guard result.succeeded else {
-                return .failure(.failed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)))
+                let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                AppLog.warn(LogTag.plugin("ccusage"), "failed: \(LogRedaction.redactLogMessage(stderr))")
+                return .failure(.failed(stderr))
             }
             guard let usage = Self.parseOutput(result.stdout) else {
+                AppLog.warn(LogTag.plugin("ccusage"), "invalid output")
                 return .failure(.invalidOutput)
             }
             return .success(usage)
         } catch ProcessRunnerError.timedOut {
+            AppLog.warn(LogTag.plugin("ccusage"), "timed out")
             return .failure(.timedOut)
         } catch {
+            AppLog.warn(LogTag.plugin("ccusage"), "failed: \(LogRedaction.redactLogMessage(error.localizedDescription))")
             return .failure(.failed(error.localizedDescription))
         }
     }

--- a/Sources/OpenUsage/Services/HTTPClient.swift
+++ b/Sources/OpenUsage/Services/HTTPClient.swift
@@ -22,6 +22,12 @@ protocol HTTPClient: Sendable {
     func send(_ request: HTTPRequest) async throws -> HTTPResponse
 }
 
+// NOTE: headers and successful-response bodies are NEVER logged — `Authorization`, `Cookie`, `Bearer`
+// headers and token-bearing bodies would leak. The Debug line carries the method, the redacted URL, and
+// the status code. On an HTTP error (>= 400) a redacted, truncated (<= 500 byte) preview of the body is
+// added at Debug to aid diagnosis — never the full body, and always run through `LogRedaction.bodyPreview`
+// first (which strips JWTs, api keys, and sensitive JSON values exactly like the Tauri host API did).
+
 struct URLSessionHTTPClient: HTTPClient {
     /// One session for every provider request, built once with the optional `~/.openusage/config.json`
     /// proxy applied (see `ProxyConfig`). Default configuration — same cookie/cache semantics as
@@ -30,6 +36,9 @@ struct URLSessionHTTPClient: HTTPClient {
         let configuration = URLSessionConfiguration.default
         if let proxy = ProxyConfig.current {
             configuration.proxyConfigurations = [proxy.proxyConfiguration()]
+            // Record that a proxy is in effect (useful in a support log). Scheme/host/port only —
+            // any embedded `user:pass` lives in separate fields and is never logged.
+            AppLog.info(.config, "proxy enabled \(proxy.scheme.rawValue)://\(proxy.host):\(proxy.port)")
         }
         return URLSession(configuration: configuration)
     }()
@@ -52,6 +61,12 @@ struct URLSessionHTTPClient: HTTPClient {
             headers[String(describing: key).lowercased()] = String(describing: value)
         }
 
+        let line = "\(request.method) \(LogRedaction.redactURL(request.url.absoluteString)) -> \(http.statusCode)"
+        if http.statusCode >= 400 {
+            AppLog.debug(.http, "\(line) body: \(LogRedaction.bodyPreview(String(decoding: data, as: UTF8.self)))")
+        } else {
+            AppLog.debug(.http, line)
+        }
         return HTTPResponse(statusCode: http.statusCode, headers: headers, body: data)
     }
 }

--- a/Sources/OpenUsage/Services/LocalUsageServer.swift
+++ b/Sources/OpenUsage/Services/LocalUsageServer.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Network
-import os
 
 /// Loopback-only HTTP/1.1 listener for the read-only usage API on `127.0.0.1:6736`. Starts with
 /// the app; when the port is already taken the feature is silently disabled for the session
@@ -11,7 +10,6 @@ final class LocalUsageServer {
     static let port: UInt16 = 6736
     private static let maxConcurrentConnections = 16
     private static let headLimit = 8192
-    private nonisolated static let logger = Logger(subsystem: "OpenUsage", category: "LocalUsageAPI")
 
     private let state: @MainActor () -> LocalUsageAPI.State
     private let queue = DispatchQueue(label: "openusage.local-api")
@@ -33,14 +31,14 @@ final class LocalUsageServer {
         do {
             listener = try NWListener(using: parameters)
         } catch {
-            Self.logger.info("Local usage API disabled: \(error.localizedDescription)")
+            AppLog.info(.localAPI, "disabled: \(error.localizedDescription)")
             return
         }
 
         listener.stateUpdateHandler = { state in
             if case .failed(let error) = state {
                 // Most commonly the port is already in use — silently disable for this session.
-                Self.logger.info("Local usage API disabled: \(error.localizedDescription)")
+                AppLog.info(.localAPI, "disabled: \(error.localizedDescription)")
             }
         }
         listener.newConnectionHandler = { connection in
@@ -97,6 +95,8 @@ final class LocalUsageServer {
         let parts = requestLine.split(separator: " ")
         let method = parts.indices.contains(0) ? String(parts[0]) : ""
         let path = parts.indices.contains(1) ? String(parts[1]) : "/"
+        // Path is secret-free (the loopback API serves only normalized usage); Debug-only.
+        AppLog.debug(.localAPI, "\(method) \(path)")
         return LocalUsageAPI.respond(method: method, path: path, state: state())
     }
 

--- a/Sources/OpenUsage/Services/ProcessRunner.swift
+++ b/Sources/OpenUsage/Services/ProcessRunner.swift
@@ -37,6 +37,10 @@ struct SystemProcessRunner: ProcessRunning {
             process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
         }
 
+        // Debug-only, basename + arg count only: arg *values* can carry paths/identifiers, so they
+        // are never logged here.
+        AppLog.debug(.subprocess, "launch \((executable as NSString).lastPathComponent) (\(arguments.count) args)")
+
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         process.standardOutput = stdoutPipe
@@ -65,6 +69,7 @@ struct SystemProcessRunner: ProcessRunning {
         process.waitUntilExit()
         let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
         let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        AppLog.debug(.subprocess, "exit \(process.terminationStatus)")
         return ProcessResult(exitCode: process.terminationStatus, stdout: stdout, stderr: stderr)
     }
 

--- a/Sources/OpenUsage/Stores/LogLevelSetting.swift
+++ b/Sources/OpenUsage/Stores/LogLevelSetting.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The persisted log level that gates the file log. A `String`-raw `UserDefaultsBacked` enum so it
+/// reads its stored choice through the same idiom as every other persisted setting.
+///
+/// The key (`logLevel`) and the lowercase raw values (`error`/`warn`/`info`/`debug`) mirror the
+/// original Tauri store so the strings stay grep-friendly and recognizable across the two editions.
+/// The fallback is `.info`, not the Tauri runtime's `Error` default: per issue #604 the release
+/// default stays quiet at Info, and Debug is something the user opts into. `Trace` is intentionally
+/// dropped — the issue's floor is Error/Warn/Info/Debug and `os.Logger` has no Trace tier — and
+/// `off` is not exposed (the tray never produced it).
+enum LogLevelSetting: String, Hashable, Sendable, CaseIterable, UserDefaultsBacked {
+    case error
+    case warn
+    case info
+    case debug
+
+    /// Mirrors the Tauri store key. Harmless to share the name: the two editions never read each
+    /// other's store.
+    static let key = "logLevel"
+
+    /// The value used when the key is unset or holds an unrecognized raw value. `.info` is the
+    /// release default per issue #604; Debug is opt-in only and never the implicit default.
+    static var fallback: LogLevelSetting { .info }
+
+    /// Title-case label for the Settings picker.
+    var label: String {
+        switch self {
+        case .error: "Error"
+        case .warn: "Warning"
+        case .info: "Info"
+        case .debug: "Debug"
+        }
+    }
+
+    /// Higher is more verbose. A line emitted at `lineLevel` is written to the file when
+    /// `lineLevel.severity <= self.severity` — i.e. the line is at least as severe as the floor.
+    var severity: Int {
+        switch self {
+        case .error: 0
+        case .warn: 1
+        case .info: 2
+        case .debug: 3
+        }
+    }
+}

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -38,26 +38,33 @@ struct ProviderSnapshotCache {
     /// still goes through the TTL-checked `snapshot(providerID:)`.
     func loadSnapshots(providerIDs: [String]) -> [String: ProviderSnapshot] {
         let providerIDSet = Set(providerIDs)
-        return loadPayload().snapshots.filter { providerID, _ in
+        let loaded = loadPayload().snapshots.filter { providerID, _ in
             providerIDSet.contains(providerID)
         }
+        AppLog.debug(.cache, "loaded \(loaded.count) snapshots from disk")
+        return loaded
     }
 
     func snapshot(providerID: String) -> ProviderSnapshot? {
         let snapshot = loadPayload().snapshots[providerID]
-        guard let snapshot, isValid(snapshot) else { return nil }
-        return snapshot
+        guard let snapshot else { return nil }
+        // Inlined the freshness check so the staleness can be logged (age vs ttl -> fresh|stale);
+        // behavior is identical to the prior `isValid` helper.
+        let age = now().timeIntervalSince(snapshot.refreshedAt)
+        let fresh = age < ttl
+        AppLog.debug(.cache, "\(providerID) staleness \(Int(age))s vs ttl \(Int(ttl))s -> \(fresh ? "fresh" : "stale")")
+        return fresh ? snapshot : nil
     }
 
     func store(_ snapshot: ProviderSnapshot) {
-        guard !snapshot.lines.contains(where: \.isError) else { return }
+        guard !snapshot.lines.contains(where: \.isError) else {
+            AppLog.debug(.cache, "skip write \(snapshot.providerID) (error snapshot)")
+            return
+        }
+        AppLog.debug(.cache, "write \(snapshot.providerID)")
         var payload = loadPayload()
         payload.snapshots[snapshot.providerID] = snapshot
         save(payload)
-    }
-
-    private func isValid(_ snapshot: ProviderSnapshot) -> Bool {
-        now().timeIntervalSince(snapshot.refreshedAt) < ttl
     }
 
     private func loadPayload() -> Payload {
@@ -70,8 +77,13 @@ struct ProviderSnapshotCache {
     }
 
     private func save(_ payload: Payload) {
-        guard let data = try? encoder.encode(payload) else { return }
-        userDefaults.set(data, forKey: storageKey)
+        // Fail loudly: a swallowed encode error would silently drop a snapshot from the cache. No
+        // behavior change (the write is still best-effort), but the failure is now visible.
+        do {
+            let data = try encoder.encode(payload)
+            userDefaults.set(data, forKey: storageKey)
+        } catch {
+            AppLog.warn(.cache, "encode failed, snapshot not persisted: \(error.localizedDescription)")
+        }
     }
 }
-

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -72,49 +72,74 @@ final class WidgetDataStore {
     func refreshAll(force: Bool = false) async {
         // `Task {}` from MainActor context inherits the isolation (a task-group child can't capture
         // the non-Sendable store), so: fire one task per provider, then await them all.
-        let tasks = registry.providers.map(\.id)
-            .filter { isProviderEnabled($0) }
-            .map { providerID in
-                Task { await self.refresh(providerID: providerID, force: force) }
-            }
+        let providerIDs = registry.providers.map(\.id).filter { isProviderEnabled($0) }
+        let start = Date()
+        AppLog.info(.refresh, "batch start (\(providerIDs.count) providers, force=\(force))")
+        let tasks = providerIDs.map { providerID in
+            Task { await self.refresh(providerID: providerID, force: force) }
+        }
+        var outcomes: [RefreshOutcome] = []
+        outcomes.reserveCapacity(tasks.count)
         for task in tasks {
-            await task.value
+            outcomes.append(await task.value)
         }
         // Stamp the end of the pass so the footer countdown targets the next scheduled refresh
         // (this time + one refresh interval), mirroring the periodic loop that sleeps one interval
         // after each pass.
         lastRefreshAt = Date()
+        let durationMs = Int(Date().timeIntervalSince(start) * 1000)
+        // Count THIS batch's actual outcomes, not the long-lived `providerErrors` map (which persists
+        // across passes, so reading it would miscount cache hits and stale earlier failures).
+        let refreshed = outcomes.filter { $0 == .refreshed }.count
+        let failed = outcomes.filter { $0 == .failed }.count
+        let cached = outcomes.filter { $0 == .cacheHit }.count
+        AppLog.info(.refresh, "batch end (\(durationMs)ms, \(refreshed) ok / \(failed) failed / \(cached) cached)")
     }
 
-    func refresh(providerID: String, force: Bool = false) async {
-        guard isProviderEnabled(providerID) else { return }
+    /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch
+    /// from real outcomes rather than cumulative error state.
+    enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped }
+
+    @discardableResult
+    func refresh(providerID: String, force: Bool = false) async -> RefreshOutcome {
+        guard isProviderEnabled(providerID) else { return .skipped }
         if !force, let cached = cache.snapshot(providerID: providerID) {
             // Skip the no-op write: `@Observable` doesn't compare values, so unconditionally
             // re-assigning an unchanged snapshot would re-render the menu-bar label every pass.
+            AppLog.debug(.refresh, "cache hit \(providerID)")
             if snapshots[providerID] != cached {
                 snapshots[providerID] = cached
             }
-            return
+            return .cacheHit
         }
+        if !force { AppLog.debug(.refresh, "cache miss \(providerID)") }
 
-        guard let provider = providersByID[providerID] else { return }
+        guard let provider = providersByID[providerID] else { return .skipped }
         // Skip if an in-flight refresh already owns this provider (e.g. the background timer racing the
         // first popover open), so we never fire duplicate network calls for the same provider.
-        guard !refreshingProviderIDs.contains(providerID) else { return }
+        guard !refreshingProviderIDs.contains(providerID) else {
+            AppLog.debug(.refresh, "cache skip \(providerID) (already in flight)")
+            return .skipped
+        }
         refreshingProviderIDs.insert(providerID)
+        defer { refreshingProviderIDs.remove(providerID) }
+        let start = Date()
         let snapshot = await provider.refresh()
+        let durationMs = Int(Date().timeIntervalSince(start) * 1000)
         if let message = Self.errorMessage(in: snapshot) {
             // Failed refresh: surface the error but keep the last good snapshot on screen rather than
-            // collapsing every row to "No data".
+            // collapsing every row to "No data". The provider error string is already user-safe.
             providerErrors[providerID] = message
-        } else {
-            if providerErrors[providerID] != nil {
-                providerErrors[providerID] = nil
-            }
-            snapshots[providerID] = snapshot
-            cache.store(snapshot)
+            AppLog.warn(.refresh, "\(providerID) failed: \(message)")
+            return .failed
         }
-        refreshingProviderIDs.remove(providerID)
+        if providerErrors[providerID] != nil {
+            providerErrors[providerID] = nil
+        }
+        snapshots[providerID] = snapshot
+        cache.store(snapshot)
+        AppLog.info(.refresh, "\(providerID) ok (\(durationMs)ms)")
+        return .refreshed
     }
 
     /// The provider's latest refresh error, or `nil` when its last refresh succeeded.

--- a/Sources/OpenUsage/Support/AppLog.swift
+++ b/Sources/OpenUsage/Support/AppLog.swift
@@ -1,0 +1,157 @@
+import Foundation
+import os
+
+/// Subsystem tags that prefix every log line, keeping lines grep-friendly (`[refresh]`, `[cache]`,
+/// `[plugin:claude]`, …). The raw value is the bracketed text and the `os.Logger` category.
+enum LogTag: String, Sendable {
+    case refresh
+    case cache
+    case http
+    case auth
+    case keychain
+    case menubar
+    case updates
+    case config
+    case statusItem = "statusitem"
+    case localAPI = "localapi"
+    case subprocess
+
+    /// Compound `[plugin:<id>]` / `[auth:<id>]` tags for per-provider lines.
+    static func plugin(_ id: String) -> String { "plugin:\(id)" }
+    static func auth(_ id: String) -> String { "auth:\(id)" }
+}
+
+/// The one consolidated logging facility. The user's `LogLevelSetting` is a single floor that governs
+/// BOTH sinks. Each call:
+///   1. drops the line immediately if its severity is below the current floor — before the message is
+///      even built (so the `@autoclosure` truly defers) and before any redaction runs,
+///   2. otherwise runs the message through `LogRedaction.redactLogMessage` as a lightweight last line
+///      of defense, then fans out to a per-category `os.Logger` and a grep-friendly `LogFile` line
+///      (`ISO8601 [LEVEL] [tag] msg`).
+///
+/// `redactLogMessage` is URL/body-unaware (matching the Tauri `redact_log_message`): any call site that
+/// logs a URL or response body MUST pre-redact it via `LogRedaction.redactURL` / `bodyPreview`.
+///
+/// `os.Logger` has no runtime level gate of its own, so the floor is enforced here for both sinks.
+/// Errors (severity 0) always clear any floor, so they are never suppressed. Raising the level to
+/// Debug in Settings is what surfaces debug lines in both the file and `log stream` (see
+/// `docs/debugging.md`) — matching #604's "Debug only when the user opts in".
+///
+/// The level is cached (not re-read from `UserDefaults` on every call, which would be wasteful on the
+/// hot `[http]`/`[cache]` paths) and refreshed by `reloadLevel()` from the Settings `.onChange` and at
+/// `bootstrap()`. A programmatic `UserDefaults` write outside the picker won't propagate until the next
+/// `reloadLevel()` — acceptable since the picker is the only writer.
+enum AppLog {
+    private enum Level: Int {
+        case error = 0
+        case warn = 1
+        case info = 2
+        case debug = 3
+
+        var label: String {
+            switch self {
+            case .error: "ERROR"
+            case .warn: "WARN"
+            case .info: "INFO"
+            case .debug: "DEBUG"
+            }
+        }
+
+        var osType: OSLogType {
+            switch self {
+            case .error: .error
+            case .warn: .default
+            case .info: .info
+            case .debug: .debug
+            }
+        }
+    }
+
+    /// Cached level floor (severity ordinal), guarded by a lock so any isolation can read it cheaply.
+    private static let levelLock = NSLock()
+    private nonisolated(unsafe) static var cachedSeverity = LogLevelSetting.fallback.severity
+
+    /// Per-category `os.Logger` cache, guarded by its own lock.
+    private static let loggerLock = NSLock()
+    private nonisolated(unsafe) static var loggers: [String: Logger] = [:]
+
+    /// The file sink. Injectable so tests can point it at a temp directory and assert what the level
+    /// gate actually writes; production uses the shared `~/Library/Logs/OpenUsage/OpenUsage.log` appender.
+    nonisolated(unsafe) static var sink: LogFile = .shared
+
+    // MARK: - Lifecycle
+
+    /// Open/trim the file, seed the cached level, and emit one startup line. Call FIRST at launch,
+    /// before any other subsystem logs. Idempotent in practice (the file `open()` is idempotent).
+    static func bootstrap() {
+        sink.open()
+        reloadLevel()
+        let level = LogLevelSetting.current
+        // Abbreviate `$HOME` to `~` so the path survives `redactLogMessage` (which masks `/Users/...`)
+        // and the startup line actually self-documents where the log lives.
+        let displayPath = (LogFile.url.path as NSString).abbreviatingWithTildeInPath
+        info(LogTag.config.rawValue,
+             "OpenUsage v\(AppInfo.version) starting (level=\(level.rawValue), log=\(displayPath))")
+    }
+
+    /// Re-read the persisted level into the cache. Invoked from the Settings picker `.onChange` so a
+    /// level change applies live with no restart (mirrors Tauri's `log::set_max_level`).
+    static func reloadLevel() {
+        apply(LogLevelSetting.current.severity)
+    }
+
+    /// Apply a level directly, bypassing `UserDefaults`. The seam tests use to exercise the gate
+    /// without racing on global `UserDefaults.standard` state.
+    static func reloadLevel(_ level: LogLevelSetting) {
+        apply(level.severity)
+    }
+
+    private static func apply(_ severity: Int) {
+        levelLock.lock()
+        cachedSeverity = severity
+        levelLock.unlock()
+    }
+
+    // MARK: - Public API
+
+    /// `@autoclosure` defers the interpolation: a line below the current level floor is dropped before
+    /// its message is built, so a `debug` line genuinely costs nothing when the level is Info.
+    static func error(_ tag: String, _ message: @autoclosure () -> String) { emit(.error, tag, message) }
+    static func warn(_ tag: String, _ message: @autoclosure () -> String) { emit(.warn, tag, message) }
+    static func info(_ tag: String, _ message: @autoclosure () -> String) { emit(.info, tag, message) }
+    static func debug(_ tag: String, _ message: @autoclosure () -> String) { emit(.debug, tag, message) }
+
+    // Convenience overloads for the typed tags (the common case).
+    static func error(_ tag: LogTag, _ message: @autoclosure () -> String) { emit(.error, tag.rawValue, message) }
+    static func warn(_ tag: LogTag, _ message: @autoclosure () -> String) { emit(.warn, tag.rawValue, message) }
+    static func info(_ tag: LogTag, _ message: @autoclosure () -> String) { emit(.info, tag.rawValue, message) }
+    static func debug(_ tag: LogTag, _ message: @autoclosure () -> String) { emit(.debug, tag.rawValue, message) }
+
+    // MARK: - Emit
+
+    private static func emit(_ level: Level, _ tag: String, _ message: () -> String) {
+        // Gate first: a line below the floor builds no message, runs no redaction, hits no sink. The
+        // floor governs both os_log and the file, so the level picker is a single honest knob. Errors
+        // (severity 0) clear any floor and are never suppressed.
+        levelLock.lock()
+        let floor = cachedSeverity
+        levelLock.unlock()
+        guard level.rawValue <= floor else { return }
+
+        let redacted = LogRedaction.redactLogMessage(message())
+
+        logger(for: tag).log(level: level.osType, "[\(tag, privacy: .public)] \(redacted, privacy: .public)")
+
+        let timestamp = OpenUsageISO8601.string(from: Date())
+        sink.append("\(timestamp) [\(level.label)] [\(tag)] \(redacted)")
+    }
+
+    private static func logger(for tag: String) -> Logger {
+        loggerLock.lock()
+        defer { loggerLock.unlock() }
+        if let existing = loggers[tag] { return existing }
+        let logger = Logger(subsystem: "OpenUsage", category: tag)
+        loggers[tag] = logger
+        return logger
+    }
+}

--- a/Sources/OpenUsage/Support/LogFile.swift
+++ b/Sources/OpenUsage/Support/LogFile.swift
@@ -1,0 +1,150 @@
+import Foundation
+import os
+
+/// Resolves the log file URL and owns a serial, lock-guarded `FileHandle` appender with single-archive
+/// rotation. `@unchecked Sendable` because all mutable state is guarded by an internal `NSLock`, so it
+/// can be written to from any isolation (the `Sendable` provider structs, the `@MainActor` UI, etc.) —
+/// the `nonisolated`-static-`Logger` precedent in `LocalUsageServer`, plus the lock for the handle.
+///
+/// Rotation matches the Tauri cap (`.max_file_size(10_000_000)`): when a write would exceed 10 MB the
+/// current file becomes `OpenUsage.1.log` and a fresh `OpenUsage.log` opens — bounding disk to ~20 MB
+/// while keeping one archive of recent history for user-submitted reports (a deliberate, minor
+/// improvement over Tauri's KeepOne, which discards all history). On launch an already-oversize file is
+/// rotated once before the first write. If opening/rotating fails the sink fails loudly to `os.Logger`
+/// at error and disables itself for the session — never crashes, never silently spins.
+final class LogFile: @unchecked Sendable {
+    /// Production log file: `~/Library/Logs/OpenUsage/OpenUsage.log`. Resolved via `FileManager`, never
+    /// hardcoded from `$HOME`. The `Logs/OpenUsage` subfolder is a literal (not bundle-id-keyed), so the
+    /// dev and release builds agree on the same file — acceptable since they are separate builds.
+    static let url: URL = defaultDirectory().appendingPathComponent("OpenUsage.log")
+
+    /// The shared production sink. Other code logs through `AppLog`, which writes here.
+    static let shared = LogFile(directory: defaultDirectory(), fileName: "OpenUsage.log")
+
+    static let defaultMaxBytes = 10_000_000
+
+    private let fileURL: URL
+    private let archiveURL: URL
+    private let directory: URL
+    private let maxBytes: Int
+    private let fallbackLogger = Logger(subsystem: "OpenUsage", category: "logfile")
+
+    private let lock = NSLock()
+    private var handle: FileHandle?
+    private var size = 0
+    private var disabled = false
+    private var opened = false
+
+    /// - Parameters:
+    ///   - directory: the folder the log file lives in (created on open if missing).
+    ///   - fileName: the log file name (the archive appends `.1` before the extension).
+    ///   - maxBytes: rotation cap; defaults to the 10 MB Tauri cap.
+    init(directory: URL, fileName: String, maxBytes: Int = defaultMaxBytes) {
+        self.directory = directory
+        self.fileURL = directory.appendingPathComponent(fileName)
+        self.maxBytes = maxBytes
+        let base = (fileName as NSString).deletingPathExtension
+        let ext = (fileName as NSString).pathExtension
+        let archiveName = ext.isEmpty ? "\(base).1" : "\(base).1.\(ext)"
+        self.archiveURL = directory.appendingPathComponent(archiveName)
+    }
+
+    static func defaultDirectory() -> URL {
+        // `.first` with a fallback rather than `[0]`: the lookup effectively always resolves on stock
+        // macOS, but a force-index would crash the app at launch (this runs during `bootstrap()`) if it
+        // ever returned empty in an unusual container. A non-ideal-but-valid directory keeps the app alive.
+        let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return library.appendingPathComponent("Logs/OpenUsage", isDirectory: true)
+    }
+
+    /// Create the directory and file, seed the in-memory size from disk, and perform the launch-time
+    /// trim (rotate once if an already-oversize file is left over from a long-dead session). Idempotent.
+    func open() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !opened else { return }
+        opened = true
+        do {
+            try openLocked()
+        } catch {
+            failLocked("open failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Append one already-formatted line (a newline is added). Rotates first if the line would push the
+    /// file past the cap. No-op once the sink is disabled.
+    func append(_ line: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !disabled else { return }
+        if !opened {
+            opened = true
+            do {
+                try openLocked()
+            } catch {
+                failLocked("open failed: \(error.localizedDescription)")
+                return
+            }
+        }
+        guard handle != nil else { return }
+
+        let data = Data("\(line)\n".utf8)
+        if size + data.count > maxBytes {
+            do {
+                try rotateLocked()
+            } catch {
+                failLocked("rotate failed: \(error.localizedDescription)")
+                return
+            }
+        }
+        // Re-fetch after a possible rotation, which swaps the handle out.
+        guard let liveHandle = handle else { return }
+        do {
+            try liveHandle.write(contentsOf: data)
+            size += data.count
+        } catch {
+            failLocked("write failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Locked internals (caller holds `lock`)
+
+    private func openLocked() throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        if !FileManager.default.fileExists(atPath: fileURL.path) {
+            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+        }
+        let handle = try FileHandle(forWritingTo: fileURL)
+        let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+        self.handle = handle
+        self.size = (attributes?[.size] as? Int) ?? 0
+        // Launch-time trim: a leftover oversize file is rotated once before the first write.
+        if self.size > maxBytes {
+            try rotateLocked()
+        } else {
+            try handle.seekToEnd()
+        }
+    }
+
+    private func rotateLocked() throws {
+        try handle?.close()
+        handle = nil
+        if FileManager.default.fileExists(atPath: archiveURL.path) {
+            try FileManager.default.removeItem(at: archiveURL)
+        }
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.moveItem(at: fileURL, to: archiveURL)
+        }
+        FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+        handle = try FileHandle(forWritingTo: fileURL)
+        size = 0
+    }
+
+    private func failLocked(_ message: String) {
+        fallbackLogger.error("File log sink disabled: \(message, privacy: .public)")
+        try? handle?.close()
+        handle = nil
+        disabled = true
+    }
+}

--- a/Sources/OpenUsage/Support/LogRedaction.swift
+++ b/Sources/OpenUsage/Support/LogRedaction.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+/// Net-new, faithful port of the Tauri redaction functions (`src-tauri/src/plugin_engine/host_api.rs`
+/// `redact_value`/`redact_url`/`redact_body`/`redact_log_message`). Pure, `Sendable`, no I/O.
+///
+/// `redactLogMessage` is the lightweight last line of defense every `AppLog` line passes through, but
+/// it is URL- and body-unaware by design (matching the Rust `redact_log_message`). Any caller that logs
+/// a URL or a response body MUST pre-redact it via `redactURL` / `bodyPreview` first — those handle the
+/// query-parameter and JSON-key surfaces `redactLogMessage` deliberately does not.
+///
+/// The regexes reproduce the exact Rust patterns (including the `{12,}` quantifier *after* the
+/// prefix, the optional-quote api-key variant in `redactBody` versus the no-quote variant in
+/// `redactLogMessage`, and the unique `account=` pass). They are compiled once as static `let`s.
+enum LogRedaction {
+    // MARK: - Value masking
+
+    /// Redact a sensitive value to `first4...last4`, or `[REDACTED]` when it is too short to mask
+    /// safely. Character-based (not byte-based) to match Rust's `char` semantics.
+    static func redactValue(_ value: String) -> String {
+        let chars = Array(value)
+        if chars.count <= 12 {
+            return "[REDACTED]"
+        }
+        let first4 = String(chars.prefix(4))
+        let last4 = String(chars.suffix(4))
+        return "\(first4)...\(last4)"
+    }
+
+    // MARK: - URL
+
+    /// Lowercased substring match list for sensitive query-parameter names (matches Rust's
+    /// `sensitive_params`). A parameter is redacted when its lowercased name *contains* any of these
+    /// and its value is non-empty; the original name casing is preserved.
+    private static let urlSensitiveParams = [
+        "key", "api_key", "apikey", "token", "access_token", "secret", "password",
+        "auth", "authorization", "bearer", "credential", "user", "user_id", "userid",
+        "account_id", "accountid", "profilearn", "profile_arn", "email", "login"
+    ]
+
+    /// Redact sensitive query parameters in a URL. Only the query string is touched; the path is
+    /// left intact (paths are handled by `redactBody`/`redactLogMessage`).
+    static func redactURL(_ url: String) -> String {
+        guard let queryStart = url.firstIndex(of: "?") else { return url }
+        let base = String(url[..<url.index(after: queryStart)]) // includes the '?'
+        let query = String(url[url.index(after: queryStart)...])
+
+        let redactedParams = query.split(separator: "&", omittingEmptySubsequences: false).map { rawParam -> String in
+            let param = String(rawParam)
+            guard let eqPos = param.firstIndex(of: "=") else { return param }
+            let name = String(param[..<eqPos])
+            let value = String(param[param.index(after: eqPos)...])
+            let nameLower = name.lowercased()
+            if !value.isEmpty, urlSensitiveParams.contains(where: { nameLower.contains($0) }) {
+                return "\(name)=\(redactValue(value))"
+            }
+            return param
+        }
+        return base + redactedParams.joined(separator: "&")
+    }
+
+    // MARK: - Body
+
+    /// JSON keys whose values are redacted in a body (matches Rust's `sensitive_keys`).
+    private static let jsonSensitiveKeys = [
+        "name", "password", "token", "access_token", "refresh_token", "secret", "api_key",
+        "apiKey", "authorization", "bearer", "credential", "session_token", "sessionToken",
+        "auth_token", "authToken", "id_token", "idToken", "accessToken", "refreshToken",
+        "user_id", "userId", "account_id", "accountId", "team_id", "teamId", "org_id", "orgId",
+        "account_display_name", "accountDisplayName", "payment_id", "paymentId", "profile_arn",
+        "profileArn", "email", "login", "analytics_tracking_id"
+    ]
+
+    /// Redact sensitive patterns in a response body for logging. Five ordered passes, matching the
+    /// Rust `redact_body`: JWT, quoted api-key, devin-session, the 36 JSON keys, then filesystem
+    /// paths. Redact BEFORE any truncation so a secret straddling the cut is still caught intact.
+    static func redactBody(_ body: String) -> String {
+        var result = body
+        result = replaceAll(jwtRegex, in: result) { redactValue($0) }
+        result = replaceAll(apiKeyQuotedRegex, in: result) { match in
+            let key = match.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            return redactValue(key)
+        }
+        result = replaceAll(devinRegex, in: result) { redactValue($0) }
+        for key in jsonSensitiveKeys {
+            // Match "key": "value" or "key":"value" — capture group 1 is the value.
+            guard let regex = jsonKeyRegexCache[key] else { continue }
+            result = replaceGroup1(regex, in: result) { value in
+                "\"\(key)\": \"\(redactValue(value))\""
+            }
+        }
+        result = pathRegex.stringByReplacingMatches(
+            in: result, range: NSRange(result.startIndex..., in: result), withTemplate: "[PATH]"
+        )
+        return result
+    }
+
+    /// Redact a body, then truncate to a Character-safe preview with a byte-count suffix. Mirrors the
+    /// Tauri host_api preview (`{}... ({} bytes total)`), measured on the *original* body's UTF-8
+    /// byte length. Any provider that ever needs to log a body MUST route it through here.
+    static func bodyPreview(_ body: String, limit: Int = 500) -> String {
+        let redacted = redactBody(body)
+        guard redacted.utf8.count > limit else { return redacted }
+        // UTF-8 safe truncation: include a character while its STARTING byte offset is < limit,
+        // mirroring Rust's `char_indices().take_while(|(i, _)| *i < limit)` exactly.
+        var truncated = ""
+        var byteOffset = 0
+        for character in redacted {
+            if byteOffset >= limit { break }
+            truncated.append(character)
+            byteOffset += String(character).utf8.count
+        }
+        return "\(truncated)... (\(body.utf8.count) bytes total)"
+    }
+
+    // MARK: - Log message
+
+    /// Lightweight redaction for free-form log messages. Five ordered passes matching the Rust
+    /// `redact_log_message`: JWT, the NO-QUOTE api-key variant, devin-session, the unique `account=`
+    /// pass, then filesystem paths.
+    static func redactLogMessage(_ message: String) -> String {
+        var result = message
+        result = replaceAll(jwtRegex, in: result) { redactValue($0) }
+        result = replaceAll(apiKeyBareRegex, in: result) { redactValue($0) }
+        result = replaceAll(devinRegex, in: result) { redactValue($0) }
+        result = replaceAccountEq(in: result)
+        result = pathRegex.stringByReplacingMatches(
+            in: result, range: NSRange(result.startIndex..., in: result), withTemplate: "[PATH]"
+        )
+        return result
+    }
+
+    // MARK: - Compiled patterns (EXACT Rust patterns, compiled once)
+
+    private static let jwtRegex = makeRegex(#"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#)
+    private static let apiKeyQuotedRegex = makeRegex(#"["']?(sk-|pk-|api_|key_|secret_)[A-Za-z0-9_-]{12,}["']?"#)
+    private static let apiKeyBareRegex = makeRegex(#"(sk-|pk-|api_|key_|secret_)[A-Za-z0-9_-]{12,}"#)
+    private static let devinRegex = makeRegex(#"devin-session-token\$[^\s"',}\]]+"#)
+    private static let accountRegex = makeRegex(#"(account=)([^,\s]+)"#)
+    private static let pathRegex = makeRegex(#"(/(?:Users|home|opt|private|var|tmp|Applications)/[^\s"')]+)"#)
+
+    /// One compiled regex per sensitive JSON key (`"<key>":\s*"([^"]+)"`), built once.
+    private static let jsonKeyRegexCache: [String: NSRegularExpression] = {
+        var cache: [String: NSRegularExpression] = [:]
+        for key in jsonSensitiveKeys {
+            let escaped = NSRegularExpression.escapedPattern(for: key)
+            cache[key] = makeRegex("\"\(escaped)\":\\s*\"([^\"]+)\"")
+        }
+        return cache
+    }()
+
+    private static func makeRegex(_ pattern: String) -> NSRegularExpression {
+        // Patterns are static literals ported verbatim from Rust; a failure here is a programmer
+        // error, so fail loudly rather than silently disabling redaction.
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            fatalError("LogRedaction: invalid regex pattern: \(pattern)")
+        }
+        return regex
+    }
+
+    // MARK: - Regex replacement helpers
+
+    /// Replace every full match of `regex` in `input` using `transform` on the matched substring.
+    /// Walks matches in reverse so earlier ranges stay valid as later ones are replaced.
+    private static func replaceAll(
+        _ regex: NSRegularExpression,
+        in input: String,
+        transform: (String) -> String
+    ) -> String {
+        let matches = regex.matches(in: input, range: NSRange(input.startIndex..., in: input))
+        guard !matches.isEmpty else { return input }
+        var result = input
+        for match in matches.reversed() {
+            guard let range = Range(match.range, in: result) else { continue }
+            result.replaceSubrange(range, with: transform(String(result[range])))
+        }
+        return result
+    }
+
+    /// Replace every match of `regex`, passing capture group 1 to `transform`. The whole match is
+    /// replaced with `transform`'s output. Reverse order keeps ranges valid.
+    private static func replaceGroup1(
+        _ regex: NSRegularExpression,
+        in input: String,
+        transform: (String) -> String
+    ) -> String {
+        let matches = regex.matches(in: input, range: NSRange(input.startIndex..., in: input))
+        guard !matches.isEmpty else { return input }
+        var result = input
+        for match in matches.reversed() {
+            guard match.numberOfRanges >= 2,
+                  let fullRange = Range(match.range, in: result),
+                  let groupRange = Range(match.range(at: 1), in: result)
+            else { continue }
+            let value = String(result[groupRange])
+            result.replaceSubrange(fullRange, with: transform(value))
+        }
+        return result
+    }
+
+    /// The `account=<value>` pass: keep the `account=` prefix, redact only the value (group 2).
+    private static func replaceAccountEq(in input: String) -> String {
+        let matches = accountRegex.matches(in: input, range: NSRange(input.startIndex..., in: input))
+        guard !matches.isEmpty else { return input }
+        var result = input
+        for match in matches.reversed() {
+            guard match.numberOfRanges >= 3,
+                  let fullRange = Range(match.range, in: result),
+                  let prefixRange = Range(match.range(at: 1), in: result),
+                  let valueRange = Range(match.range(at: 2), in: result)
+            else { continue }
+            let prefix = String(result[prefixRange])
+            let value = String(result[valueRange])
+            result.replaceSubrange(fullRange, with: "\(prefix)\(redactValue(value))")
+        }
+        return result
+    }
+}

--- a/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
+++ b/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
@@ -18,8 +18,10 @@ enum MenuBarStripRenderer {
     /// previously rendered instance.
     static func image(for content: MenuBarContent, style: MenuBarStyle) -> NSImage? {
         if let lastRender, lastRender.content == content, lastRender.style == style {
+            AppLog.debug(.menubar, "strip cache hit")
             return lastRender.image
         }
+        AppLog.debug(.menubar, "strip cache miss (rendering)")
         let image: NSImage?
         switch style {
         case .text: image = textImage(for: content)

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -1,6 +1,5 @@
 import AppKit
 import KeyboardShortcuts
-import os
 import ServiceManagement
 import SwiftUI
 
@@ -11,8 +10,6 @@ import SwiftUI
 /// System Settings. The footer already shows the version; the release build adds an "Updates" section
 /// (auto-check, beta channel, and a full-width manual check button).
 struct SettingsScreen: View {
-    private static let logger = Logger(subsystem: "OpenUsage", category: "Settings")
-
     @Environment(AppContainer.self) private var container
     @Environment(UpdaterController.self) private var updater
     /// Reported up so `DashboardView` can fit the popover to the settings content (clamped there).
@@ -28,6 +25,9 @@ struct SettingsScreen: View {
     @AppStorage(AppearanceSetting.key) private var appearance = AppearanceSetting.system
     @AppStorage(TimeFormatSetting.key) private var timeFormat = TimeFormatSetting.auto
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @AppStorage(LogLevelSetting.key) private var logLevel = LogLevelSetting.fallback
+    /// Surfaced under the Advanced rows when copying the path or revealing the file fails.
+    @State private var logActionError: String?
 
     /// Fills the region the dashboard's pinned footer leaves; reports its content height up so
     /// `DashboardView` can fit the popover to it (`settingsScrollHeight`). Same scroller treatment
@@ -69,9 +69,7 @@ struct SettingsScreen: View {
                                 }
                                 launchAtLoginError = nil
                             } catch {
-                                Self.logger.error(
-                                    "Launch at Login \(enabled ? "register" : "unregister", privacy: .public) failed: \(error.localizedDescription, privacy: .public)"
-                                )
+                                AppLog.error(.config, "Launch at Login \(enabled ? "register" : "unregister") failed: \(error.localizedDescription)")
                                 launchAtLoginError = "macOS wouldn't update Launch at Login. Check System Settings → Login Items."
                                 launchAtLogin = SMAppService.mainApp.status == .enabled
                             }
@@ -123,6 +121,7 @@ struct SettingsScreen: View {
                     providerRow(provider)
                 }
             }
+            advancedSection
             // Visible whenever the updater is active (only the signed release build ships a feed; the
             // dev build and a bare `swift run`, with no feed, hide this).
             if updater.isActive {
@@ -151,6 +150,58 @@ struct SettingsScreen: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
+    }
+
+    // MARK: - Advanced (logging)
+
+    /// Log-level control plus copy/reveal buttons for the file log. The file lives at a fixed path
+    /// (`~/Library/Logs/OpenUsage/OpenUsage.log`); raising the level here applies live (no restart) and
+    /// persists across launches. Default Info, Debug is opt-in.
+    private var advancedSection: some View {
+        section("Advanced") {
+            row("Log Level") {
+                picker($logLevel, options: LogLevelSetting.allCases, label: \.label)
+                    .onChange(of: logLevel) {
+                        // Apply the new floor to the file sink immediately, then record the transition.
+                        AppLog.reloadLevel()
+                        AppLog.info(.config, "Log level changed to \(logLevel.rawValue)")
+                    }
+            }
+            logButton("Copy Log Path") {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                guard pasteboard.setString(LogFile.url.path, forType: .string) else {
+                    logActionError = "Couldn't copy the log path to the clipboard."
+                    AppLog.warn(.config, "Copy log path failed")
+                    return
+                }
+                logActionError = nil
+            }
+            logButton("Reveal in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([LogFile.url])
+                logActionError = nil
+            }
+            if let logActionError {
+                // Same orange inline-notice idiom as the Startup section's error line.
+                Text(logActionError)
+                    .font(.caption)
+                    .foregroundStyle(Theme.notice)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    /// A full-width glass button row, matching the "Check for Updates…" idiom.
+    private func logButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title).frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.glass)
+        .controlSize(.regular)
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
     }
 
     // MARK: - Section / row scaffolding

--- a/Tests/OpenUsageTests/AppLogTests.swift
+++ b/Tests/OpenUsageTests/AppLogTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the crux of #604: the user's log level is a single floor that decides what actually reaches
+/// the file sink. The sink is pointed at a per-test temp file so we can read back exactly what the gate
+/// wrote. `AppLog.reloadLevel(_:)` applies a level without touching `UserDefaults.standard`, so these
+/// tests never race on global state.
+final class AppLogTests: XCTestCase {
+    private var tempDir: URL!
+    private var sink: LogFile!
+    private var originalSink: LogFile!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.AppLog.\(UUID().uuidString)", isDirectory: true)
+        sink = LogFile(directory: tempDir, fileName: "OpenUsage.log")
+        sink.open()
+        originalSink = AppLog.sink
+        AppLog.sink = sink
+    }
+
+    override func tearDownWithError() throws {
+        AppLog.sink = originalSink
+        AppLog.reloadLevel() // restore the real persisted floor for any later code
+        if let tempDir, FileManager.default.fileExists(atPath: tempDir.path) {
+            try FileManager.default.removeItem(at: tempDir)
+        }
+    }
+
+    private func fileContents() throws -> String {
+        try String(contentsOf: tempDir.appendingPathComponent("OpenUsage.log"), encoding: .utf8)
+    }
+
+    func testInfoFloorSuppressesDebugButKeepsInfoAndError() throws {
+        AppLog.reloadLevel(.info)
+        AppLog.debug(.cache, "debug-below-floor")
+        AppLog.info(.refresh, "info-at-floor")
+        AppLog.error(.http, "error-always")
+
+        let contents = try fileContents()
+        XCTAssertFalse(contents.contains("debug-below-floor"), contents)
+        XCTAssertTrue(contents.contains("info-at-floor"), contents)
+        XCTAssertTrue(contents.contains("error-always"), contents)
+    }
+
+    func testDebugFloorLetsDebugThrough() throws {
+        AppLog.reloadLevel(.debug)
+        AppLog.debug(.cache, "debug-now-visible")
+        XCTAssertTrue(try fileContents().contains("debug-now-visible"))
+    }
+
+    func testErrorFloorSuppressesEverythingButError() throws {
+        AppLog.reloadLevel(.error)
+        AppLog.warn(.http, "warn-below-error-floor")
+        AppLog.info(.refresh, "info-below-error-floor")
+        AppLog.error(.http, "error-still-written")
+
+        let contents = try fileContents()
+        XCTAssertFalse(contents.contains("warn-below-error-floor"), contents)
+        XCTAssertFalse(contents.contains("info-below-error-floor"), contents)
+        XCTAssertTrue(contents.contains("error-still-written"), contents)
+    }
+
+    func testWrittenLineCarriesLevelAndTag() throws {
+        AppLog.reloadLevel(.info)
+        AppLog.info(.refresh, "hello")
+        // Grep-friendly shape: `<timestamp> [INFO] [refresh] hello`.
+        let contents = try fileContents()
+        XCTAssertTrue(contents.contains("[INFO] [refresh] hello"), contents)
+    }
+
+    func testAutoclosureIsNotEvaluatedBelowFloor() {
+        AppLog.reloadLevel(.info)
+        var built = false
+        // `@autoclosure` wraps this call; the side effect fires only if `emit` actually builds the message.
+        func expensiveMessage() -> String {
+            built = true
+            return "expensive"
+        }
+        AppLog.debug(.cache, expensiveMessage())
+        XCTAssertFalse(built, "a below-floor debug line must not build its message")
+    }
+
+    func testSecretInLineIsRedactedBeforeWrite() throws {
+        AppLog.reloadLevel(.info)
+        AppLog.info(.auth, "refreshing with token=sk-1234567890abcdefghij")
+        let contents = try fileContents()
+        XCTAssertFalse(contents.contains("sk-1234567890abcdefghij"), contents)
+    }
+}

--- a/Tests/OpenUsageTests/LogFileTests.swift
+++ b/Tests/OpenUsageTests/LogFileTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the resolved path suffix (mirrors the Tauri `builds_log_file_path_from_log_dir` test) and
+/// the 10 MB single-archive rotation / launch-time trim. All file I/O is confined to a per-test temp
+/// directory — never touches `~/Library/Logs`.
+final class LogFileTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.LogFile.\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir, FileManager.default.fileExists(atPath: tempDir.path) {
+            try FileManager.default.removeItem(at: tempDir)
+        }
+    }
+
+    func testResolvedPathEndsWithExpectedSuffix() {
+        XCTAssertTrue(
+            LogFile.url.path.hasSuffix("Logs/OpenUsage/OpenUsage.log"),
+            "unexpected log path: \(LogFile.url.path)"
+        )
+    }
+
+    func testAppendCreatesFileAndWritesLine() throws {
+        let log = LogFile(directory: tempDir, fileName: "OpenUsage.log")
+        log.open()
+        log.append("2026-01-01T00:00:00Z [INFO] [config] hello")
+
+        let fileURL = tempDir.appendingPathComponent("OpenUsage.log")
+        let contents = try String(contentsOf: fileURL, encoding: .utf8)
+        XCTAssertTrue(contents.contains("[config] hello"), contents)
+        XCTAssertTrue(contents.hasSuffix("\n"))
+    }
+
+    func testRotationCreatesBackupWhenCapExceeded() throws {
+        // Small cap so a few lines trip rotation.
+        let cap = 200
+        let log = LogFile(directory: tempDir, fileName: "OpenUsage.log", maxBytes: cap)
+        log.open()
+        let line = String(repeating: "a", count: 80) // 81 bytes with newline
+        log.append(line) // 81
+        log.append(line) // 162
+        log.append(line) // would be 243 > 200 -> rotate first, then write to fresh file
+
+        let mainURL = tempDir.appendingPathComponent("OpenUsage.log")
+        let archiveURL = tempDir.appendingPathComponent("OpenUsage.1.log")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archiveURL.path), "archive should exist after rotation")
+
+        let archiveSize = (try FileManager.default.attributesOfItem(atPath: archiveURL.path)[.size] as? Int) ?? 0
+        let mainSize = (try FileManager.default.attributesOfItem(atPath: mainURL.path)[.size] as? Int) ?? 0
+        XCTAssertEqual(archiveSize, 162, "archive holds the two pre-rotation lines")
+        XCTAssertEqual(mainSize, 81, "fresh main file holds only the post-rotation line")
+    }
+
+    func testRotationKeepsOnlyOneArchive() throws {
+        let cap = 200
+        let log = LogFile(directory: tempDir, fileName: "OpenUsage.log", maxBytes: cap)
+        log.open()
+        let line = String(repeating: "b", count: 80)
+        // Enough lines to force two rotations; only one .1 archive should survive.
+        for _ in 0..<10 { log.append(line) }
+
+        let archiveURL = tempDir.appendingPathComponent("OpenUsage.1.log")
+        let secondArchiveURL = tempDir.appendingPathComponent("OpenUsage.2.log")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archiveURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: secondArchiveURL.path), "only one archive is retained")
+    }
+
+    func testLaunchTrimRotatesOversizeFileOnOpen() throws {
+        let cap = 100
+        let mainURL = tempDir.appendingPathComponent("OpenUsage.log")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        // Leftover oversize file from a long-dead session.
+        try Data(repeating: 0x61, count: cap + 50).write(to: mainURL)
+
+        let log = LogFile(directory: tempDir, fileName: "OpenUsage.log", maxBytes: cap)
+        log.open()
+
+        let archiveURL = tempDir.appendingPathComponent("OpenUsage.1.log")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: archiveURL.path), "oversize file should be rotated on open")
+        let mainSize = (try FileManager.default.attributesOfItem(atPath: mainURL.path)[.size] as? Int) ?? -1
+        XCTAssertEqual(mainSize, 0, "fresh main file starts empty after launch trim")
+    }
+}

--- a/Tests/OpenUsageTests/LogLevelSettingTests.swift
+++ b/Tests/OpenUsageTests/LogLevelSettingTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the level setting's release default reconciliation (the issue says Info, not the Tauri
+/// runtime's Error), raw-value parsing, the fallback for unrecognized/dropped values (`off`/`trace`),
+/// and the severity ordering the file-sink gate relies on. Hermetic per-test `UserDefaults` suites
+/// keep a real persisted `logLevel` from leaking in.
+final class LogLevelSettingTests: XCTestCase {
+    func testDefaultIsInfoWhenUnset() {
+        let defaults = makeDefaults("unset")
+        XCTAssertEqual(defaults.enumValue(forKey: LogLevelSetting.key, default: LogLevelSetting.fallback), .info)
+        XCTAssertEqual(LogLevelSetting.fallback, .info)
+    }
+
+    func testValidRawValuesParse() {
+        for level in LogLevelSetting.allCases {
+            XCTAssertEqual(LogLevelSetting(rawValue: level.rawValue), level)
+        }
+        // The raw values mirror the Tauri store strings.
+        XCTAssertEqual(LogLevelSetting(rawValue: "error"), .error)
+        XCTAssertEqual(LogLevelSetting(rawValue: "warn"), .warn)
+        XCTAssertEqual(LogLevelSetting(rawValue: "info"), .info)
+        XCTAssertEqual(LogLevelSetting(rawValue: "debug"), .debug)
+    }
+
+    func testUnrecognizedFallsBackToInfo() {
+        let defaults = makeDefaults("unrecognized")
+        for bogus in ["off", "trace", "garbage", "ERROR", ""] {
+            defaults.set(bogus, forKey: LogLevelSetting.key)
+            XCTAssertEqual(
+                defaults.enumValue(forKey: LogLevelSetting.key, default: LogLevelSetting.fallback),
+                .info,
+                "raw value \(bogus) should fall back to .info"
+            )
+        }
+    }
+
+    func testStoredValueRoundTrips() {
+        let defaults = makeDefaults("roundtrip")
+        for level in LogLevelSetting.allCases {
+            defaults.set(level.rawValue, forKey: LogLevelSetting.key)
+            XCTAssertEqual(defaults.enumValue(forKey: LogLevelSetting.key, default: LogLevelSetting.fallback), level)
+        }
+    }
+
+    func testSeverityOrdering() {
+        XCTAssertLessThan(LogLevelSetting.error.severity, LogLevelSetting.warn.severity)
+        XCTAssertLessThan(LogLevelSetting.warn.severity, LogLevelSetting.info.severity)
+        XCTAssertLessThan(LogLevelSetting.info.severity, LogLevelSetting.debug.severity)
+    }
+
+    func testLabelsAreTitleCase() {
+        XCTAssertEqual(LogLevelSetting.error.label, "Error")
+        XCTAssertEqual(LogLevelSetting.warn.label, "Warning")
+        XCTAssertEqual(LogLevelSetting.info.label, "Info")
+        XCTAssertEqual(LogLevelSetting.debug.label, "Debug")
+    }
+
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.LogLevel.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/Tests/OpenUsageTests/LogRedactionTests.swift
+++ b/Tests/OpenUsageTests/LogRedactionTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import OpenUsage
+
+/// The never-log-secrets regression guard. Each case mirrors a Rust test from
+/// `src-tauri/src/plugin_engine/host_api.rs` / `src-tauri/src/config.rs`, ported verbatim where a
+/// vector exists, so a subtle regex divergence (leak or over-redaction) trips here.
+final class LogRedactionTests: XCTestCase {
+    // MARK: - redactValue
+
+    func testRedactValueShortIsFullyRedacted() {
+        XCTAssertEqual(LogRedaction.redactValue("short"), "[REDACTED]")
+        // Exactly 12 characters is still fully redacted (boundary: <= 12).
+        XCTAssertEqual(LogRedaction.redactValue("abcdefghijkl"), "[REDACTED]")
+    }
+
+    func testRedactValueLongMasksEnds() {
+        // 13 characters: first4...last4. Mirrors the Rust `sk-1...cdef` vector.
+        XCTAssertEqual(LogRedaction.redactValue("sk-1234567890abcdef"), "sk-1...cdef")
+        XCTAssertEqual(LogRedaction.redactValue("abcdefghijklm"), "abcd...jklm")
+    }
+
+    // MARK: - redactURL
+
+    func testRedactURLSensitiveParamsOnly() {
+        let url = "https://api.example.com/v1?api_key=sk-1234567890abcdef&other=value"
+        let redacted = LogRedaction.redactURL(url)
+        XCTAssertTrue(redacted.contains("api_key=sk-1...cdef"), redacted)
+        XCTAssertTrue(redacted.contains("other=value"), redacted)
+    }
+
+    func testRedactURLUserParam() {
+        let url = "https://cursor.com/api/usage?user=user_abcdefghijklmnopqrstuvwxyz&limit=10"
+        let redacted = LogRedaction.redactURL(url)
+        XCTAssertTrue(redacted.contains("user=user...wxyz"), redacted)
+        XCTAssertTrue(redacted.contains("limit=10"), redacted)
+    }
+
+    func testRedactURLPreservesNonSensitiveParams() {
+        let url = "https://api.example.com/v1?limit=10&offset=20"
+        XCTAssertEqual(LogRedaction.redactURL(url), url)
+    }
+
+    func testRedactURLProfileArn() {
+        let url = "https://q.us-east-1.amazonaws.com/getUsageLimits?profileArn=arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK&origin=AI_EDITOR"
+        let redacted = LogRedaction.redactURL(url)
+        XCTAssertFalse(redacted.contains("699475941385"), redacted)
+        XCTAssertTrue(redacted.contains("origin=AI_EDITOR"), redacted)
+    }
+
+    func testRedactURLPreservesNameCaseAndSkipsEmptyValue() {
+        let redacted = LogRedaction.redactURL("https://x.com/a?Api_Key=&Token=secretsecretsecret")
+        XCTAssertTrue(redacted.contains("Api_Key="), redacted) // empty value left untouched
+        XCTAssertTrue(redacted.contains("Token=secr...cret"), redacted) // name casing preserved
+    }
+
+    func testRedactURLNoQueryUnchanged() {
+        XCTAssertEqual(LogRedaction.redactURL("https://api.example.com/v1"), "https://api.example.com/v1")
+    }
+
+    // MARK: - redactBody
+
+    func testRedactBodyJWT() {
+        let body = #"{"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertFalse(redacted.contains("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"), redacted)
+    }
+
+    func testRedactBodyApiKeys() {
+        let body = #"{"key": "sk-1234567890abcdefghij"}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertTrue(redacted.contains("sk-1...ghij"), redacted)
+    }
+
+    func testRedactBodyDevinSession() {
+        let body = #"metadata apiKey=devin-session-token$abcdefghijklmnopqrstuvwxyz123456"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertFalse(redacted.contains("devin-session-token$abcdefghijklmnopqrstuvwxyz123456"), redacted)
+        XCTAssertTrue(redacted.contains("devi...3456"), redacted)
+    }
+
+    func testRedactBodyJSONPassword() {
+        let body = #"{"password": "supersecretpassword123"}"#
+        XCTAssertFalse(LogRedaction.redactBody(body).contains("supersecretpassword123"))
+    }
+
+    func testRedactBodyUserIdAndEmail() {
+        let body = #"{"user_id": "user-iupzZ7KFykMLrnzpkHSq7wjo", "email": "rob@sunstory.com"}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertFalse(redacted.contains("user-iupzZ7KFykMLrnzpkHSq7wjo"), redacted)
+        XCTAssertFalse(redacted.contains("rob@sunstory.com"), redacted)
+        XCTAssertTrue(redacted.contains("user...7wjo"), redacted)
+        XCTAssertTrue(redacted.contains("rob@....com"), redacted)
+    }
+
+    func testRedactBodyCamelCaseIds() {
+        let body = #"{"userId": "user_abcdefghijklmnopqrstuvwxyz", "accountId": "acct_1234567890abcdef"}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertTrue(redacted.contains("user...wxyz"), redacted)
+        XCTAssertTrue(redacted.contains("acct...cdef"), redacted)
+    }
+
+    func testRedactBodyDevinOrgAndDisplayName() {
+        let body = #"{"orgId":"org-6b6e9de248db472bb25b296599ea3dc0","accountDisplayName":"rob@sunstory.com","devinInfo":{"org_id":"org-abcdef1234567890","account_display_name":"team@example.com"}}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertFalse(redacted.contains("org-6b6e9de248db472bb25b296599ea3dc0"), redacted)
+        XCTAssertFalse(redacted.contains("team@example.com"), redacted)
+        XCTAssertTrue(redacted.contains("org-...3dc0"), redacted)
+    }
+
+    func testRedactBodyTeamIdPaymentIdAndPaths() {
+        let body = #"{"teamId":"cc1ac023-9ff5-4c1f-a5a4-ae2a82df4243","paymentId":"cus_S5m1PGxjLWoc1c","binaryPath":"/opt/homebrew/bin/bunx","homePath":"/Users/rebers/.claude"}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertFalse(redacted.contains("cc1ac023-9ff5-4c1f-a5a4-ae2a82df4243"), redacted)
+        XCTAssertFalse(redacted.contains("cus_S5m1PGxjLWoc1c"), redacted)
+        XCTAssertFalse(redacted.contains("/opt/homebrew/bin/bunx"), redacted)
+        XCTAssertFalse(redacted.contains("/Users/rebers/.claude"), redacted)
+        XCTAssertTrue(redacted.contains("[PATH]"), redacted)
+    }
+
+    func testRedactBodyProfileArn() {
+        let body = #"{"profileArn":"arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK","profile_arn":"arn:aws:codewhisperer:us-east-1:699475941385:profile/EHGA3GRVQMUK"}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertFalse(redacted.contains("699475941385"), redacted)
+        XCTAssertTrue(redacted.contains("arn:...QMUK"), redacted)
+    }
+
+    func testRedactBodyLoginAndAnalyticsTrackingId() {
+        let body = #"{"login":"robinebers","analytics_tracking_id":"c9df3f012bb8c2eb7aae6868ee8da6cf"}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertFalse(redacted.contains("robinebers"), redacted)
+        XCTAssertFalse(redacted.contains("c9df3f012bb8c2eb7aae6868ee8da6cf"), redacted)
+        XCTAssertTrue(redacted.contains("[REDACTED]"), redacted)
+        XCTAssertTrue(redacted.contains("c9df...a6cf"), redacted)
+    }
+
+    func testRedactBodyNameField() {
+        let body = #"{"userStatus":{"name":"Robin Ebers","email":"rob@sunstory.com","planStatus":{}}}"#
+        let redacted = LogRedaction.redactBody(body)
+        XCTAssertFalse(redacted.contains("Robin Ebers"), redacted)
+        XCTAssertFalse(redacted.contains("rob@sunstory.com"), redacted)
+    }
+
+    // MARK: - bodyPreview truncation
+
+    func testBodyPreviewTruncatesWithByteCount() {
+        let body = String(repeating: "a", count: 700)
+        let preview = LogRedaction.bodyPreview(body)
+        XCTAssertTrue(preview.hasSuffix("... (700 bytes total)"), preview)
+        // Truncated content is at most the limit (500) characters before the marker.
+        let beforeMarker = preview.replacingOccurrences(of: "... (700 bytes total)", with: "")
+        XCTAssertLessThanOrEqual(beforeMarker.count, 500)
+    }
+
+    func testBodyPreviewShortReturnsRedactedWhole() {
+        let body = #"{"plan":"pro"}"#
+        XCTAssertEqual(LogRedaction.bodyPreview(body), body)
+    }
+
+    func testBodyPreviewRedactsBeforeTruncating() {
+        // A secret straddling the cut must still be caught: redaction runs before truncation.
+        let secret = "sk-1234567890abcdefghij"
+        let body = String(repeating: "x", count: 490) + secret + String(repeating: "y", count: 200)
+        let preview = LogRedaction.bodyPreview(body)
+        XCTAssertFalse(preview.contains(secret), preview)
+    }
+
+    // MARK: - redactLogMessage
+
+    func testRedactLogMessageJWTAndBareApiKey() {
+        let msg = "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U key=sk-1234567890abcdef"
+        let redacted = LogRedaction.redactLogMessage(msg)
+        XCTAssertFalse(redacted.contains("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"), redacted)
+        XCTAssertFalse(redacted.contains("sk-1234567890abcdef"), redacted)
+    }
+
+    func testRedactLogMessageDevinSession() {
+        let msg = "auth=devin-session-token$abcdefghijklmnopqrstuvwxyz123456"
+        let redacted = LogRedaction.redactLogMessage(msg)
+        XCTAssertFalse(redacted.contains("devin-session-token$abcdefghijklmnopqrstuvwxyz123456"), redacted)
+        XCTAssertTrue(redacted.contains("devi...3456"), redacted)
+    }
+
+    func testRedactLogMessageAccountEqAndPaths() {
+        let msg = "keychain read: service=Claude Code-credentials, account=rebers path=/opt/homebrew/bin/bunx home=/Users/rebers/.claude"
+        let redacted = LogRedaction.redactLogMessage(msg)
+        XCTAssertFalse(redacted.contains("account=rebers"), redacted)
+        XCTAssertFalse(redacted.contains("/opt/homebrew/bin/bunx"), redacted)
+        XCTAssertFalse(redacted.contains("/Users/rebers/.claude"), redacted)
+        XCTAssertTrue(redacted.contains("account=[REDACTED]"), redacted)
+        XCTAssertTrue(redacted.contains("[PATH]"), redacted)
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,3 +32,4 @@ How the app is built and how to extend it.
 - [Architecture](architecture.md) — composition root, stores, the provider pipeline, the AppKit bridge
 - [Adding a provider](adding-a-provider.md) — the metric contract and the register/test/document steps
 - [Debugging & capturing logs](debugging.md) — running a local build and streaming logs
+- [Logging](logging.md) — the file log, log levels, subsystem tags, and what is never logged

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -39,6 +39,14 @@ To read logs *after the fact* instead of live, use `log show` with a time window
 log show --last 10m --info --predicate 'process == "OpenUsage"'
 ```
 
+## Log file
+
+In addition to the unified log above, the app writes a file log to
+`~/Library/Logs/OpenUsage/OpenUsage.log` — this is what to send with a support report. It is capped at
+~10 MB with one `.1` archive. Raise the detail in **Settings -> Advanced -> Log Level** (use **Debug**
+for full detail), then grab the file with **Copy Log Path** or **Reveal in Finder** in that same
+section. See [Logging](logging.md) for the levels, subsystem tags, and the never-log-secrets guarantee.
+
 ## Tips
 
 - **A provider shows an error.** Reproduce with `logs` running, then check that provider's page in

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,62 @@
+# Logging
+
+OpenUsage keeps a file log so you can capture what the app was doing and share it with support when
+something misbehaves. Lines at or above your chosen level also go to the macOS unified log, so raising
+the level to Debug surfaces the extra detail in both places (see [Debugging](debugging.md) for
+`log stream`).
+
+## Where the log file lives
+
+```
+~/Library/Logs/OpenUsage/OpenUsage.log
+```
+
+The easiest way to grab it: open Settings -> Advanced and use **Copy Log Path** (puts the path on the
+clipboard) or **Reveal in Finder** (selects the file in a Finder window). No Terminal needed.
+
+## Changing the log level (Settings -> Advanced)
+
+The **Log Level** picker controls how much detail is written. Your choice persists across launches and
+takes effect immediately — no restart.
+
+| Level | What it captures |
+|---|---|
+| Error | Only failures. |
+| Warning | Failures plus things that look wrong but recovered. |
+| Info | The normal story: refresh start/end, per-provider results, cache and auth milestones. |
+| Debug | Everything, including per-request and per-cache-check detail. |
+
+The release default is **Info** — quiet but useful. **Debug** is opt-in; turn it on only while
+reproducing a problem, since it is much noisier.
+
+## Subsystem tags
+
+Every line is prefixed with a bracketed tag so the log is easy to grep:
+
+`[refresh]` `[cache]` `[http]` `[auth]` `[keychain]` `[menubar]` `[updates]` `[config]`
+`[subprocess]` `[localapi]`, plus per-provider tags like `[plugin:claude]` and `[auth:claude]`.
+
+For example, to follow just the refresh cycle:
+
+```sh
+grep '\[refresh\]' ~/Library/Logs/OpenUsage/OpenUsage.log
+```
+
+## What is never logged
+
+Secrets never reach the log. Access/refresh tokens, cookies, session tokens, and API keys are redacted
+before any line is written (a sensitive value becomes `first4...last4`, or `[REDACTED]` when too short
+to mask safely), and filesystem paths under your home directory are replaced with `[PATH]`. Response
+bodies are never logged in full; on an HTTP error the app may record a redacted, truncated (≤500 byte)
+preview at Debug to aid diagnosis — run through the same redaction first. The redaction rules match the
+original app's, and a test suite guards them.
+
+## File size cap
+
+The log is capped at ~10 MB. When it fills up, the current file is rotated to `OpenUsage.1.log` and a
+fresh `OpenUsage.log` starts, so a long-running session can never fill your disk (at most ~20 MB across
+the live file and one archive). An oversize file left over from a previous session is rotated once at
+launch.
+
+> Note: the dev build and a released build both write to the same `OpenUsage.log`. Running them at the
+> same time interleaves their lines — fine for normal use, worth knowing if you debug both at once.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -29,6 +29,16 @@ Settings lives inside the popover — there is no separate window. Open it with 
 
 One switch per provider. Turning a provider **off** hides it everywhere (dashboard, Customize, menu bar, the collection endpoint of the [local HTTP API](local-http-api.md)) and pauses its updates. Nothing is deleted — turning it back on restores its metrics and order.
 
+## Advanced
+
+| Setting | Options | What it does |
+|---|---|---|
+| Log Level | Error / Warning / Info / Debug | How much detail the app writes to its log file. Defaults to Info and persists across launches; raise to Debug while reproducing a problem. Applies immediately. |
+| Copy Log Path | button | Copies the log file path (`~/Library/Logs/OpenUsage/OpenUsage.log`) to the clipboard. |
+| Reveal in Finder | button | Opens a Finder window with the log file selected. |
+
+See [Logging](logging.md) for the full behavior: subsystem tags, the file size cap, and the guarantee that secrets are never written.
+
 ## Version
 
 The app version shows in the popover footer.


### PR DESCRIPTION
Closes #604.

## Why

The native rewrite had no debug logging — no file log, no level control, no secret redaction — which (per #582) left failed refreshes with no trace. This ports the prior Tauri logging plumbing (`src-tauri/src/tray.rs`, `log_path.rs`, `lib.rs`, and the `host_api.rs` redaction) into the Swift app, idiomatically.

## What

- **`AppLog`** — one consolidated facility. Fans out to per-subsystem `os.Logger` **and** a file at `~/Library/Logs/OpenUsage/OpenUsage.log`. A single `LogLevelSetting` floor governs both sinks; below-floor lines are dropped before the message is built (so the `@autoclosure` truly defers and hot paths pay nothing).
- **`LogLevelSetting`** — `UserDefaultsBacked` enum (Error / Warning / Info / Debug). Key `logLevel` and lowercase raw values mirror the Tauri store. **Release default Info; Debug is opt-in.** Persists across launches; applies live with no restart.
- **`LogRedaction`** — faithful port of the Tauri redaction (JWTs, `sk-`/`pk-`/`api_`/`key_`/`secret_` keys, devin session tokens, sensitive JSON keys, URL query params, home paths → `[PATH]`; values masked to `first4...last4`). Applied to every line; HTTP error responses log a redacted, truncated (≤500 byte) body preview.
- **`LogFile`** — 10 MB cap with one rollover archive (`OpenUsage.1.log`) + launch-time trim; fails loudly to `os.Logger` and disables itself rather than crashing.
- **Instrumentation** — grep-friendly `[subsystem]` tags across refresh (`[refresh]` batch start/end with real per-batch counts, per-provider ok/fail + duration), cache (`[cache]` load / staleness / write / skip), HTTP (`[http]` method + redacted URL + status), auth/keychain (`[auth]`/`[keychain]`, no secrets), updater (`[updates]`), and the menu-bar renderer (`[menubar]`, debug). The scattered ad-hoc `os.Logger` call sites were consolidated onto `AppLog`.

## Visual change (Settings → Advanced)

> Note: screenshot not auto-captured — the worktree is headless and the menu-bar popover can't be driven faithfully from here. Happy to attach one on request, or it's visible via `script/build_and_run.sh`.

A new **Advanced** section in Settings, reusing the existing `section` / `row` / `picker` / `.buttonStyle(.glass)` idioms (no new visual vocabulary):
- **Log Level** picker (Error / Warning / Info / Debug) — applies live and persists.
- **Copy Log Path** — puts the log path on the clipboard.
- **Reveal in Finder** — selects the file in Finder.
- An inline orange notice (matching the Startup section) if copy/reveal fails.

This is the issue's "locate the log file without Terminal" affordance; the Swift app has no classic `NSMenu` tray (it's `NSStatusItem` + `NSPopover`), so Settings → Advanced is the home rather than a tray submenu.

## Testing

- `swift build` clean; `swift test` → **241 tests pass** (1 pre-existing skip, 0 failures), plus the swift-testing suite green.
- New coverage: redaction vectors (ported from the Rust suite), the level-gate behavior (Debug suppressed at Info, errors never suppressed, autoclosure not evaluated below floor, secrets redacted before write), level persistence, and log-file path / rotation / launch-trim.

## Notes

- Rebased onto current `swift` (picks up #613 / the "drop Refresh Every" refactor; `ProviderSnapshotCache` reconciled to the new fixed-interval `RefreshSetting`).
- Docs updated: `docs/logging.md` (new), `docs/debugging.md`, `docs/settings.md`, `docs/README.md`.
- Scope: per-provider `[auth:<id>]` lines are wired for Claude; the other providers are covered generically through the shared `[auth]` / `[http]` / `[refresh]` choke points (thin per-provider lines are an easy fast-follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/keychain and HTTP logging paths where redaction mistakes could leak credentials; mitigated by ported redaction rules and a large regression test suite, but logging still runs on hot refresh/HTTP paths.
> 
> **Overview**
> Ports the missing **debug logging stack** from the Tauri app into the native Swift build: a single **`AppLog`** path that gates both **unified log** and a **rotating file** at `~/Library/Logs/OpenUsage/OpenUsage.log`, with **`LogRedaction`** applied on every line and stricter rules at HTTP/auth boundaries (no headers or success bodies; redacted error-body previews only).
> 
> **Launch** calls **`AppLog.bootstrap()`** first so early session lines are captured. Scattered **`os.Logger`** usage is replaced with tagged **`AppLog`** calls across refresh, cache, HTTP, subprocesses, Sparkle, Claude auth, and the loopback API. **`WidgetDataStore.refreshAll`** now logs batch timing and per-provider **`RefreshOutcome`** counts instead of inferring from stale error state.
> 
> **Settings → Advanced** adds a persisted **Log Level** picker (default **Info**, live **`reloadLevel()`**), plus **Copy Log Path** / **Reveal in Finder**. Sparkle’s channel delegate logs each update-cycle result.
> 
> New tests cover redaction vectors, level gating, file rotation, and settings parsing; **`docs/logging.md`** and related docs describe file location, tags, and the never-log-secrets policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80b034b759bd8dc49f9f0ac194a847418772f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the Tauri debug-logging system to the native Swift app. Adds a rotating file log with live level control, strict secret redaction, and clear subsystem tags to make refresh failures diagnosable.

- **New Features**
  - Unified `AppLog`: fans out to `os.Logger` and `~/Library/Logs/OpenUsage/OpenUsage.log` behind one `LogLevelSetting` floor (Error/Warning/Info/Debug; default Info; applies live).
  - Redaction: JWTs, `sk-`/`pk-`/`api_`/`key_`/`secret_`, devin session tokens, sensitive JSON keys and URL params, and filesystem paths are masked; HTTP errors include a redacted, ≤500‑byte body preview.
  - File sink: 10 MB cap with a single `.1` archive and launch‑time trim; disables on I/O failure instead of crashing.
  - Settings → Advanced: Log Level picker, Copy Log Path, Reveal in Finder.
  - Instrumentation: tagged lines across refresh, cache, http, auth/keychain, updates, menubar/status item, local API, subprocesses, plus per‑provider `plugin:<id>` and `auth:<id>`.

- **Refactors**
  - Consolidated ad‑hoc `os.Logger` calls onto `AppLog`; added cache/updater results and proxy notices; clearer cache write failures.
  - Docs: `docs/logging.md`, `docs/debugging.md`, `docs/settings.md`, `docs/README.md`.
  - Tests: redaction vectors, level gating (including autoclosure deferral), file path/rotation/trim.

<sup>Written for commit c80b034b759bd8dc49f9f0ac194a847418772f8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

