### PR TITLE
feat: add retirement notice banner to overview

### DIFF
--- a/docs/retirement-notice.md
+++ b/docs/retirement-notice.md
@@ -1,0 +1,19 @@
+# Retirement Notice
+
+The overview shows a banner at the top, above all providers, letting users know this
+build is retired and pointing them to the new app.
+
+## Behavior
+- Appears at the top of the overview (above the provider list and the empty state).
+- Has a "Get the New App" link and a dismiss (x) button.
+- Dismissing stores the current time in `settings.json` under
+  `retirementNoticeDismissedAt`.
+- The banner reappears once 7 days have passed since the last dismissal.
+- If it has never been dismissed, it is shown.
+
+## Where it lives
+- UI: `src/components/retirement-notice.tsx`, rendered by `src/pages/overview.tsx`.
+- Persistence + 7-day logic: `src/lib/settings.ts`
+  (`loadRetirementNoticeDismissedAt`, `saveRetirementNoticeDismissedAt`,
+  `shouldShowRetirementNotice`).
+- The "Get the New App" button opens `NEW_APP_URL` (https://www.openusage.ai).

--- a/docs/retirement-notice.md
+++ b/docs/retirement-notice.md
@@ -10,6 +10,7 @@ build is retired and pointing them to the new app.
   `retirementNoticeDismissedAt`.
 - The banner reappears once 7 days have passed since the last dismissal.
 - If it has never been dismissed, it is shown.
+- If the stored state can't be read, it fails open (shows the banner) and logs the error.
 
 ## Where it lives
 - UI: `src/components/retirement-notice.tsx`, rendered by `src/pages/overview.tsx`.

--- a/src/components/retirement-notice.test.tsx
+++ b/src/components/retirement-notice.test.tsx
@@ -62,12 +62,11 @@ describe("RetirementNotice", () => {
     expect(typeof settingsState.saveMock.mock.calls[0][0]).toBe("number")
   })
 
-  it("stays hidden when load fails", async () => {
+  it("shows the notice when load fails (fail open)", async () => {
     settingsState.loadMock.mockRejectedValue(new Error("boom"))
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     render(<RetirementNotice />)
-    await waitFor(() => expect(settingsState.loadMock).toHaveBeenCalled())
-    expect(screen.queryByText("OpenUsage Has Moved")).not.toBeInTheDocument()
+    expect(await screen.findByText("OpenUsage Has Moved")).toBeInTheDocument()
     errorSpy.mockRestore()
   })
 })

--- a/src/components/retirement-notice.test.tsx
+++ b/src/components/retirement-notice.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+import { RetirementNotice } from "@/components/retirement-notice"
+
+const openerState = vi.hoisted(() => ({
+  openUrlMock: vi.fn(() => Promise.resolve()),
+}))
+
+const settingsState = vi.hoisted(() => ({
+  loadMock: vi.fn<[], Promise<number | null>>(() => Promise.resolve(null)),
+  saveMock: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: openerState.openUrlMock,
+}))
+
+vi.mock("@/lib/settings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/settings")>()
+  return {
+    ...actual,
+    loadRetirementNoticeDismissedAt: settingsState.loadMock,
+    saveRetirementNoticeDismissedAt: settingsState.saveMock,
+  }
+})
+
+describe("RetirementNotice", () => {
+  beforeEach(() => {
+    openerState.openUrlMock.mockClear()
+    settingsState.loadMock.mockReset()
+    settingsState.loadMock.mockResolvedValue(null)
+    settingsState.saveMock.mockClear()
+  })
+
+  it("shows the notice when never dismissed", async () => {
+    render(<RetirementNotice />)
+    expect(await screen.findByText("OpenUsage Has Moved")).toBeInTheDocument()
+  })
+
+  it("stays hidden when dismissed within the interval", async () => {
+    settingsState.loadMock.mockResolvedValue(Date.now())
+    render(<RetirementNotice />)
+    await waitFor(() => expect(settingsState.loadMock).toHaveBeenCalled())
+    expect(screen.queryByText("OpenUsage Has Moved")).not.toBeInTheDocument()
+  })
+
+  it("opens the new app link", async () => {
+    render(<RetirementNotice />)
+    await screen.findByText("OpenUsage Has Moved")
+    await userEvent.click(screen.getByRole("button", { name: "Get the New App" }))
+    expect(openerState.openUrlMock).toHaveBeenCalledWith("https://www.openusage.ai")
+  })
+
+  it("persists a timestamp and hides on dismiss", async () => {
+    render(<RetirementNotice />)
+    await screen.findByText("OpenUsage Has Moved")
+    await userEvent.click(screen.getByRole("button", { name: "Dismiss" }))
+    expect(screen.queryByText("OpenUsage Has Moved")).not.toBeInTheDocument()
+    await waitFor(() => expect(settingsState.saveMock).toHaveBeenCalledTimes(1))
+    expect(typeof settingsState.saveMock.mock.calls[0][0]).toBe("number")
+  })
+
+  it("stays hidden when load fails", async () => {
+    settingsState.loadMock.mockRejectedValue(new Error("boom"))
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    render(<RetirementNotice />)
+    await waitFor(() => expect(settingsState.loadMock).toHaveBeenCalled())
+    expect(screen.queryByText("OpenUsage Has Moved")).not.toBeInTheDocument()
+    errorSpy.mockRestore()
+  })
+})

--- a/src/components/retirement-notice.tsx
+++ b/src/components/retirement-notice.tsx
@@ -24,6 +24,9 @@ export function RetirementNotice() {
         setVisible(shouldShowRetirementNotice(dismissedAt, Date.now()))
       } catch (error) {
         console.error("Failed to load retirement notice state:", error)
+        // Fail open: a load error shouldn't silently swallow the retirement
+        // reminder, so show it rather than hiding it.
+        if (isMounted) setVisible(true)
       }
     }
 

--- a/src/components/retirement-notice.tsx
+++ b/src/components/retirement-notice.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react"
+import { openUrl } from "@tauri-apps/plugin-opener"
+import { X } from "lucide-react"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  loadRetirementNoticeDismissedAt,
+  saveRetirementNoticeDismissedAt,
+  shouldShowRetirementNotice,
+} from "@/lib/settings"
+
+const NEW_APP_URL = "https://www.openusage.ai"
+
+export function RetirementNotice() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const evaluate = async () => {
+      try {
+        const dismissedAt = await loadRetirementNoticeDismissedAt()
+        if (!isMounted) return
+        setVisible(shouldShowRetirementNotice(dismissedAt, Date.now()))
+      } catch (error) {
+        console.error("Failed to load retirement notice state:", error)
+      }
+    }
+
+    evaluate()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  if (!visible) return null
+
+  const handleGetNewApp = () => {
+    openUrl(NEW_APP_URL).catch(console.error)
+  }
+
+  const handleDismiss = async () => {
+    setVisible(false)
+    try {
+      await saveRetirementNoticeDismissedAt(Date.now())
+    } catch (error) {
+      console.error("Failed to save retirement notice dismissal:", error)
+    }
+  }
+
+  return (
+    <Alert className="relative mb-3 p-3 border-destructive/50 dark:border-destructive">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        onClick={handleDismiss}
+        aria-label="Dismiss"
+        className="absolute right-1.5 top-1.5 text-muted-foreground"
+      >
+        <X />
+      </Button>
+      <AlertTitle className="pr-6 text-sm">OpenUsage Has Moved</AlertTitle>
+      <AlertDescription className="mt-1 text-xs text-muted-foreground">
+        This version is retired and won't receive any updates. Switch to the new
+        app by clicking the button below.
+      </AlertDescription>
+      <Button
+        type="button"
+        size="xs"
+        onClick={handleGetNewApp}
+        className="mt-2 w-full"
+      >
+        Get the New App
+      </Button>
+    </Alert>
+  )
+}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -19,8 +19,12 @@ import {
   loadMenubarMetric,
   loadPluginSettings,
   loadResetTimerDisplayMode,
+  loadRetirementNoticeDismissedAt,
   loadStartOnLogin,
   loadTimeFormatMode,
+  RETIREMENT_NOTICE_INTERVAL_MS,
+  saveRetirementNoticeDismissedAt,
+  shouldShowRetirementNotice,
   migrateLegacyTraySettings,
   migrateWindsurfToDevin,
   loadThemeMode,
@@ -431,5 +435,35 @@ describe("settings", () => {
   it("falls back to default for invalid start on login value", async () => {
     storeState.set("startOnLogin", "invalid")
     await expect(loadStartOnLogin()).resolves.toBe(DEFAULT_START_ON_LOGIN)
+  })
+
+  it("loads null retirement notice dismissal when missing", async () => {
+    await expect(loadRetirementNoticeDismissedAt()).resolves.toBeNull()
+  })
+
+  it("ignores invalid retirement notice dismissal value", async () => {
+    storeState.set("retirementNoticeDismissedAt", "nope")
+    await expect(loadRetirementNoticeDismissedAt()).resolves.toBeNull()
+  })
+
+  it("saves and loads retirement notice dismissal timestamp", async () => {
+    await saveRetirementNoticeDismissedAt(1234)
+    await expect(loadRetirementNoticeDismissedAt()).resolves.toBe(1234)
+  })
+
+  it("shows retirement notice when never dismissed", () => {
+    expect(shouldShowRetirementNotice(null, Date.now())).toBe(true)
+  })
+
+  it("hides retirement notice within the interval", () => {
+    const now = Date.now()
+    expect(shouldShowRetirementNotice(now - 1000, now)).toBe(false)
+  })
+
+  it("re-shows retirement notice after the interval elapses", () => {
+    const now = Date.now()
+    expect(
+      shouldShowRetirementNotice(now - RETIREMENT_NOTICE_INTERVAL_MS, now)
+    ).toBe(true)
   })
 })

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -466,4 +466,14 @@ describe("settings", () => {
       shouldShowRetirementNotice(now - RETIREMENT_NOTICE_INTERVAL_MS, now)
     ).toBe(true)
   })
+
+  it("shows retirement notice for a future dismissal timestamp", () => {
+    const now = Date.now()
+    expect(shouldShowRetirementNotice(now + 60_000, now)).toBe(true)
+  })
+
+  it("ignores a negative retirement notice dismissal value", async () => {
+    storeState.set("retirementNoticeDismissedAt", -5)
+    await expect(loadRetirementNoticeDismissedAt()).resolves.toBeNull()
+  })
 })

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -39,6 +39,10 @@ const LEGACY_TRAY_ICON_STYLE_KEY = "trayIconStyle";
 const LEGACY_TRAY_SHOW_PERCENTAGE_KEY = "trayShowPercentage";
 const GLOBAL_SHORTCUT_KEY = "globalShortcut";
 const START_ON_LOGIN_KEY = "startOnLogin";
+const RETIREMENT_NOTICE_DISMISSED_AT_KEY = "retirementNoticeDismissedAt";
+
+// How long a dismissal lasts before the retirement notice is shown again (7 days).
+export const RETIREMENT_NOTICE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export const DEFAULT_AUTO_UPDATE_INTERVAL: AutoUpdateIntervalMinutes = 15;
 export const DEFAULT_THEME_MODE: ThemeMode = "system";
@@ -380,4 +384,23 @@ export async function loadStartOnLogin(): Promise<boolean> {
 export async function saveStartOnLogin(value: boolean): Promise<void> {
   await store.set(START_ON_LOGIN_KEY, value);
   await store.save();
+}
+
+export async function loadRetirementNoticeDismissedAt(): Promise<number | null> {
+  const stored = await store.get<unknown>(RETIREMENT_NOTICE_DISMISSED_AT_KEY);
+  if (typeof stored === "number" && Number.isFinite(stored)) return stored;
+  return null;
+}
+
+export async function saveRetirementNoticeDismissedAt(value: number): Promise<void> {
+  await store.set(RETIREMENT_NOTICE_DISMISSED_AT_KEY, value);
+  await store.save();
+}
+
+export function shouldShowRetirementNotice(
+  dismissedAt: number | null,
+  now: number
+): boolean {
+  if (dismissedAt == null) return true;
+  return now - dismissedAt >= RETIREMENT_NOTICE_INTERVAL_MS;
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -388,7 +388,9 @@ export async function saveStartOnLogin(value: boolean): Promise<void> {
 
 export async function loadRetirementNoticeDismissedAt(): Promise<number | null> {
   const stored = await store.get<unknown>(RETIREMENT_NOTICE_DISMISSED_AT_KEY);
-  if (typeof stored === "number" && Number.isFinite(stored)) return stored;
+  if (typeof stored === "number" && Number.isFinite(stored) && stored >= 0) {
+    return stored;
+  }
   return null;
 }
 
@@ -402,5 +404,8 @@ export function shouldShowRetirementNotice(
   now: number
 ): boolean {
   if (dismissedAt == null) return true;
+  // A dismissal in the future (clock skew or a manual settings edit) is
+  // invalid; show the notice instead of hiding it indefinitely.
+  if (dismissedAt > now) return true;
   return now - dismissedAt >= RETIREMENT_NOTICE_INTERVAL_MS;
 }

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -1,4 +1,5 @@
 import { ProviderCard } from "@/components/provider-card"
+import { RetirementNotice } from "@/components/retirement-notice"
 import type { PluginDisplayState } from "@/lib/plugin-types"
 import type { DisplayMode, ResetTimerDisplayMode, TimeFormatMode } from "@/lib/settings"
 
@@ -19,36 +20,35 @@ export function OverviewPage({
   timeFormatMode = "auto",
   onResetTimerDisplayModeToggle,
 }: OverviewPageProps) {
-  if (plugins.length === 0) {
-    return (
-      <div className="text-center text-muted-foreground py-8">
-        No providers enabled
-      </div>
-    )
-  }
-
   return (
     <div>
-      {plugins.map((plugin, index) => (
-        <ProviderCard
-          key={plugin.meta.id}
-          name={plugin.meta.name}
-          plan={plugin.data?.plan}
-          showSeparator={index < plugins.length - 1}
-          loading={plugin.loading}
-          error={plugin.error}
-          lines={plugin.data?.lines ?? []}
-          skeletonLines={plugin.meta.lines}
-          lastManualRefreshAt={plugin.lastManualRefreshAt}
-          lastUpdatedAt={plugin.lastUpdatedAt}
-          onRetry={onRetryPlugin ? () => onRetryPlugin(plugin.meta.id) : undefined}
-          scopeFilter="overview"
-          displayMode={displayMode}
-          resetTimerDisplayMode={resetTimerDisplayMode}
-          timeFormatMode={timeFormatMode}
-          onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
-        />
-      ))}
+      <RetirementNotice />
+      {plugins.length === 0 ? (
+        <div className="text-center text-muted-foreground py-8">
+          No providers enabled
+        </div>
+      ) : (
+        plugins.map((plugin, index) => (
+          <ProviderCard
+            key={plugin.meta.id}
+            name={plugin.meta.name}
+            plan={plugin.data?.plan}
+            showSeparator={index < plugins.length - 1}
+            loading={plugin.loading}
+            error={plugin.error}
+            lines={plugin.data?.lines ?? []}
+            skeletonLines={plugin.meta.lines}
+            lastManualRefreshAt={plugin.lastManualRefreshAt}
+            lastUpdatedAt={plugin.lastUpdatedAt}
+            onRetry={onRetryPlugin ? () => onRetryPlugin(plugin.meta.id) : undefined}
+            scopeFilter="overview"
+            displayMode={displayMode}
+            resetTimerDisplayMode={resetTimerDisplayMode}
+            timeFormatMode={timeFormatMode}
+            onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+          />
+        ))
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a dismissible "OpenUsage Has Moved" banner pinned to the top of the overview, above all providers, telling users this build is retired and pointing them to the new app at https://www.openusage.ai.
- Dismissing persists a timestamp to `settings.json` (`retirementNoticeDismissedAt`); the banner reappears after 7 days. Self-contained component plus small persistence helpers in `settings.ts`, no changes to the preferences store / bootstrap / prop chain.
- Banner uses the existing shadcn `Alert` with a destructive (red) border, a full-width "Get the New App" button, and an X dismiss control.

## Test plan
- [x] `npx vitest run` (1135 passing) including new `shouldShowRetirementNotice` cases and a `retirement-notice` component test (show/hide, dismiss persistence, link, load-failure path)
- [x] `npm run build` (tsc + vite build) clean
- [ ] Verify banner appears at top of overview, button opens openusage.ai, dismiss hides it and it returns after 7 days

## Docs
- Added `docs/retirement-notice.md` describing placement and the 7-day re-show behavior.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dismissible retirement banner to the Overview that points users to https://www.openusage.ai. Dismissal lasts 7 days, then the banner returns.

- **New Features**
  - Banner pinned at the top of the Overview with “Get the New App” and dismiss (X), above providers and the empty state.
  - Dismiss saves `retirementNoticeDismissedAt` in `settings.json`; `shouldShowRetirementNotice` re-shows after 7 days.
  - New `RetirementNotice` component and helpers in `src/lib/settings.ts`; tests and docs included.

- **Bug Fixes**
  - Robust handling of dismissal state: fail open on read errors and treat future/negative timestamps as invalid to prevent indefinite hiding.

<sup>Written for commit 7d51e5b0a8c8a4f939ecc2887fce71f93fd8b8d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismissible “Retirement Notice” banner at the top of the overview with a **“Get the New App”** link.
  * Dismissal is remembered and the banner reappears after **7 days**; it shows by default if never dismissed.

* **Documentation**
  * Added documentation describing the banner behavior, persistence, re-display rules, and safe fallback when stored state can’t be read.

* **Tests**
  * Added automated tests covering banner visibility, dismiss behavior, link opening, persistence timing logic, and fail-open behavior with error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->