### PR TITLE
refactor: remove dead code, fix stale comments, dedupe HTTP status guard

### DIFF
--- a/Sources/OpenUsage/Models/MenuBarContent.swift
+++ b/Sources/OpenUsage/Models/MenuBarContent.swift
@@ -10,7 +10,6 @@ struct MenuBarContent: Equatable {
         let id: String          // descriptor id
         let label: String       // metric label, e.g. "Session" (shown when a provider has two metrics)
         let value: String       // tray display: a "%" for bounded metrics, the raw value (e.g. "$5.23") for unbounded, or the no-data marker
-        let kind: MetricKind
         let fraction: Double     // 0...1 fill, meaningful for bounded metrics (drives the bars)
         let isBounded: Bool      // has a limit → has a fill, so it can render as a bar
         let hasData: Bool
@@ -85,7 +84,6 @@ enum MenuBarContentBuilder {
             id: descriptor.id,
             label: trayLabel(descriptor.metricLabel),
             value: trayValue(data),
-            kind: data.kind,
             fraction: data.fraction,
             isBounded: data.isBounded,
             hasData: data.hasData

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -10,12 +10,11 @@ enum ClaudeUsageMapper {
     static let weeklyPeriodMs = MetricPeriod.weekMs
 
     static func mapUsageResponse(_ response: HTTPResponse, credentials: ClaudeOAuth, now: Date = Date()) throws -> ClaudeMappedUsage {
-        guard (200..<300).contains(response.statusCode) else {
-            if response.statusCode == 401 || response.statusCode == 403 {
-                throw ClaudeAuthError.tokenExpired
-            }
-            throw ClaudeUsageError.requestFailed(response.statusCode)
-        }
+        try ProviderAuthRetry.requireSuccess(
+            response,
+            authExpired: ClaudeAuthError.tokenExpired,
+            requestFailed: { ClaudeUsageError.requestFailed($0) }
+        )
 
         guard let body = ProviderParse.jsonObject(response.body) else {
             throw ClaudeUsageError.invalidResponse

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -13,12 +13,11 @@ enum CodexUsageMapper {
     static let creditUSDRate = 0.04
 
     static func mapUsageResponse(_ response: HTTPResponse, now: Date = Date()) throws -> CodexMappedUsage {
-        guard (200..<300).contains(response.statusCode) else {
-            if response.statusCode == 401 || response.statusCode == 403 {
-                throw CodexAuthError.tokenExpired
-            }
-            throw CodexUsageError.requestFailed(response.statusCode)
-        }
+        try ProviderAuthRetry.requireSuccess(
+            response,
+            authExpired: CodexAuthError.tokenExpired,
+            requestFailed: { CodexUsageError.requestFailed($0) }
+        )
 
         guard let body = ProviderParse.jsonObject(response.body) else {
             throw CodexUsageError.invalidResponse

--- a/Sources/OpenUsage/Providers/Cursor/CursorModelManifest.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorModelManifest.swift
@@ -17,35 +17,23 @@ struct CursorModelManifest: Decodable, Sendable {
     static let empty = CursorModelManifest(retrievedAt: "", pricing: [:], aliasRules: [])
 }
 
+/// Only the fields the spend imputation actually uses are decoded. `JSONDecoder` ignores the
+/// manifest's other keys (display name, provider/family ids, max-mode uplift, long-context
+/// multipliers) — the cost model deliberately bills at the base model rate and cannot apply
+/// max-mode or long-context adjustments from row totals (see `CursorPricing.estimatedCostDollars`).
 struct CursorModelManifestPricingEntry: Decodable, Sendable {
-    let displayName: String
-    let provider: String
-    let familyID: String
     let familyDisplayName: String
     let inputPerMillion: Double
     let cacheWritePerMillion: Double
     let cacheReadPerMillion: Double
     let outputPerMillion: Double
-    let applyMaxModeUplift: Bool
-    let longContextInputThreshold: Int?
-    let longContextInputMultiplier: Double?
-    let longContextOutputMultiplier: Double?
-    let longContextCachedInputMultiplier: Double?
 
     enum CodingKeys: String, CodingKey {
-        case displayName = "display_name"
-        case provider
-        case familyID = "family_id"
         case familyDisplayName = "family_display_name"
         case inputPerMillion = "input_per_million"
         case cacheWritePerMillion = "cache_write_per_million"
         case cacheReadPerMillion = "cache_read_per_million"
         case outputPerMillion = "output_per_million"
-        case applyMaxModeUplift = "apply_max_mode_uplift"
-        case longContextInputThreshold = "long_context_input_threshold"
-        case longContextInputMultiplier = "long_context_input_multiplier"
-        case longContextOutputMultiplier = "long_context_output_multiplier"
-        case longContextCachedInputMultiplier = "long_context_cached_input_multiplier"
     }
 }
 

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -69,12 +69,11 @@ final class CursorProvider: ProviderRuntime {
         }
 
         let usageResponse = try await fetchUsageWithRetry(accessToken: accessToken, authState: &authState)
-        guard (200..<300).contains(usageResponse.statusCode) else {
-            if usageResponse.statusCode == 401 || usageResponse.statusCode == 403 {
-                throw CursorAuthError.tokenExpired
-            }
-            throw CursorUsageError.requestFailed(usageResponse.statusCode)
-        }
+        try ProviderAuthRetry.requireSuccess(
+            usageResponse,
+            authExpired: CursorAuthError.tokenExpired,
+            requestFailed: { CursorUsageError.requestFailed($0) }
+        )
         guard let usage = ProviderParse.jsonObject(usageResponse.body) else {
             throw CursorUsageError.invalidResponse
         }

--- a/Sources/OpenUsage/Providers/Grok/GrokUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokUsageMapper.swift
@@ -6,12 +6,11 @@ struct GrokMappedUsage: Equatable, Sendable {
 
 enum GrokUsageMapper {
     static func mapBillingResponse(_ response: HTTPResponse) throws -> GrokMappedUsage {
-        if response.statusCode == 401 || response.statusCode == 403 {
-            throw GrokAuthError.expired
-        }
-        guard (200..<300).contains(response.statusCode) else {
-            throw GrokUsageError.requestFailed(response.statusCode)
-        }
+        try ProviderAuthRetry.requireSuccess(
+            response,
+            authExpired: GrokAuthError.expired,
+            requestFailed: { GrokUsageError.requestFailed($0) }
+        )
         guard let body = ProviderParse.jsonObject(response.body),
               let config = body["config"] as? [String: Any],
               let usedUnits = unitsValue(config["used"]),

--- a/Sources/OpenUsage/Providers/ProviderAuthRetry.swift
+++ b/Sources/OpenUsage/Providers/ProviderAuthRetry.swift
@@ -13,8 +13,21 @@ import Foundation
 @MainActor
 enum ProviderAuthRetry {
     /// The statuses that mean "the token is bad" rather than "the request failed".
-    static func isAuthFailure(_ response: HTTPResponse) -> Bool {
+    nonisolated static func isAuthFailure(_ response: HTTPResponse) -> Bool {
         response.statusCode == 401 || response.statusCode == 403
+    }
+
+    /// Triage a response that should carry a usable body: a 401/403 means the token went bad (throw
+    /// `authExpired`), any other non-2xx is a request failure (throw `requestFailed(status)`), and a
+    /// 2xx returns without throwing. Centralizes the guard the Claude/Codex/Grok mappers and
+    /// `CursorProvider` each re-spelled inline, routing the auth-status check through `isAuthFailure`.
+    nonisolated static func requireSuccess(
+        _ response: HTTPResponse,
+        authExpired: Error,
+        requestFailed: (Int) -> Error
+    ) throws {
+        guard !isAuthFailure(response) else { throw authExpired }
+        guard (200..<300).contains(response.statusCode) else { throw requestFailed(response.statusCode) }
     }
 
     /// - Parameters:

--- a/Sources/OpenUsage/Services/LocalUsageServer.swift
+++ b/Sources/OpenUsage/Services/LocalUsageServer.swift
@@ -50,11 +50,6 @@ final class LocalUsageServer {
         self.listener = listener
     }
 
-    func stop() {
-        listener?.cancel()
-        listener = nil
-    }
-
     private func accept(_ connection: NWConnection) {
         connection.start(queue: queue)
         guard activeConnections < Self.maxConcurrentConnections else {

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -142,7 +142,6 @@ final class LayoutStore {
         syncPlacedOrder(persistChanges: false)
     }
 
-    var providers: [Provider] { registry.providers }
     func provider(id: String) -> Provider? { registry.provider(id: id) }
 
     func descriptor(for widget: PlacedWidget) -> WidgetDescriptor? {

--- a/Sources/OpenUsage/Support/Formatters.swift
+++ b/Sources/OpenUsage/Support/Formatters.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-/// Small display helpers. Mock data is mostly pre-formatted; these keep currency consistent.
+/// Shared display formatters for live usage data: the mode-aware deadline/reset phrasing
+/// (`deadlineLabel`, `bareDeadline`, `resetRelativeLabel`, `resetAbsoluteLabel`), compact durations,
+/// and USD currency.
 enum Formatters {
     static func currency(_ amount: Double, fractionDigits: Int = 2) -> String {
         let f = NumberFormatter()

--- a/Sources/OpenUsage/Support/LogFile.swift
+++ b/Sources/OpenUsage/Support/LogFile.swift
@@ -13,17 +13,21 @@ import os
 /// rotated once before the first write. If opening/rotating fails the sink fails loudly to `os.Logger`
 /// at error and disables itself for the session — never crashes, never silently spins.
 final class LogFile: @unchecked Sendable {
-    /// Production log file: `~/Library/Logs/OpenUsage/OpenUsage.log`. Resolved via `FileManager`, never
-    /// hardcoded from `$HOME`. The `Logs/OpenUsage` subfolder is a literal (not bundle-id-keyed), so the
-    /// dev and release builds agree on the same file — acceptable since they are separate builds.
-    static let url: URL = defaultDirectory().appendingPathComponent("OpenUsage.log")
-
-    /// The shared production sink. Other code logs through `AppLog`, which writes here.
+    /// The shared production sink. Other code logs through `AppLog`, which writes here. Resolves
+    /// `~/Library/Logs/OpenUsage/OpenUsage.log` via `FileManager`, never hardcoded from `$HOME`; the
+    /// `Logs/OpenUsage` subfolder is a literal (not bundle-id-keyed), so the dev and release builds
+    /// agree on the same file — acceptable since they are separate builds.
     static let shared = LogFile(directory: defaultDirectory(), fileName: "OpenUsage.log")
+
+    /// The advertised log path (logged at startup, copied/revealed from Settings). Derived from the
+    /// shared sink so the path shown to the user always equals where logs are actually written.
+    static let url: URL = shared.fileURL
 
     static let defaultMaxBytes = 10_000_000
 
-    private let fileURL: URL
+    /// Where this sink actually writes. Exposed (read-only) so `url` can derive the advertised path
+    /// from the single source of truth rather than recomputing it.
+    let fileURL: URL
     private let archiveURL: URL
     private let directory: URL
     private let maxBytes: Int

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -133,11 +133,12 @@ struct DashboardView: View {
 
     /// Cold-start estimate for Settings content, same role as the Customize estimate above. The
     /// constants mirror `SettingsScreen`: five sections (a caption header over a card) holding
-    /// nine fixed control rows plus one row per registered provider.
+    /// eleven fixed control rows (Startup 2, Appearance 4, Usage Display 2, Advanced 3) plus one
+    /// row per registered provider.
     private var estimatedSettingsContentHeight: CGFloat {
         let sectionCount: CGFloat = 5
         let sectionHeaderHeight: CGFloat = 16
-        let fixedRowCount: CGFloat = 9
+        let fixedRowCount: CGFloat = 11
         let rowCount = fixedRowCount + CGFloat(container.registry.providers.count)
         let verticalPadding: CGFloat = 24
         return verticalPadding

--- a/Tests/OpenUsageTests/LogFileTests.swift
+++ b/Tests/OpenUsageTests/LogFileTests.swift
@@ -25,6 +25,12 @@ final class LogFileTests: XCTestCase {
         )
     }
 
+    func testAdvertisedURLMatchesSharedSinkPath() {
+        // `LogFile.url` is what the app advertises (startup log, Settings copy/reveal); it must equal
+        // where the shared sink actually writes so the two can never drift to different files.
+        XCTAssertEqual(LogFile.url, LogFile.shared.fileURL)
+    }
+
     func testAppendCreatesFileAndWritesLine() throws {
         let log = LogFile(directory: tempDir, fileName: "OpenUsage.log")
         log.open()

--- a/Tests/OpenUsageTests/MenuBarContentTests.swift
+++ b/Tests/OpenUsageTests/MenuBarContentTests.swift
@@ -22,7 +22,6 @@ final class MenuBarContentTests: XCTestCase {
         XCTAssertEqual(content.groups[0].metrics.map(\.id), ["a.m1", "a.m2"])
         XCTAssertEqual(content.groups[0].metrics[0].label, "Session")
         XCTAssertEqual(content.groups[0].metrics[0].value, m1.sample.valueText)
-        XCTAssertEqual(content.groups[0].metrics[0].kind, .percent)
         XCTAssertEqual(content.groups[1].metrics.map(\.id), ["b.m1"])
     }
 

--- a/Tests/OpenUsageTests/MenuBarStripMemoTests.swift
+++ b/Tests/OpenUsageTests/MenuBarStripMemoTests.swift
@@ -28,7 +28,7 @@ final class MenuBarStripMemoTests: XCTestCase {
     private func makeContent(value: String) -> MenuBarContent {
         let metric = MenuBarContent.Metric(
             id: "claude.session", label: "Session", value: value,
-            kind: .percent, fraction: 0.42, isBounded: true, hasData: true
+            fraction: 0.42, isBounded: true, hasData: true
         )
         return MenuBarContent(
             groups: [MenuBarContent.Group(

--- a/Tests/OpenUsageTests/MenuBarStripTrimTests.swift
+++ b/Tests/OpenUsageTests/MenuBarStripTrimTests.swift
@@ -36,9 +36,9 @@ final class MenuBarStripTrimTests: XCTestCase {
                     icon: .providerMark("claude"),
                     metrics: [
                         MenuBarContent.Metric(id: "claude.session", label: "Session", value: "99%",
-                                              kind: .percent, fraction: 0.01, isBounded: true, hasData: true),
+                                              fraction: 0.01, isBounded: true, hasData: true),
                         MenuBarContent.Metric(id: "claude.weekly", label: "Weekly", value: "87%",
-                                              kind: .percent, fraction: 0.13, isBounded: true, hasData: true)
+                                              fraction: 0.13, isBounded: true, hasData: true)
                     ]
                 )
             ],

--- a/Tests/OpenUsageTests/ProviderAuthRetryTests.swift
+++ b/Tests/OpenUsageTests/ProviderAuthRetryTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers `ProviderAuthRetry.requireSuccess`, the shared non-2xx triage the Claude/Codex/Grok mappers
+/// and `CursorProvider` route through: 401/403 → the provider's auth-expired error, any other non-2xx →
+/// the provider's request-failed error (carrying the status), and a 2xx returns without throwing.
+final class ProviderAuthRetryTests: XCTestCase {
+    private enum SampleError: Error, Equatable {
+        case authExpired
+        case requestFailed(Int)
+    }
+
+    private func requireSuccess(status: Int) throws {
+        let response = HTTPResponse(statusCode: status, headers: [:], body: Data())
+        try ProviderAuthRetry.requireSuccess(
+            response,
+            authExpired: SampleError.authExpired,
+            requestFailed: { SampleError.requestFailed($0) }
+        )
+    }
+
+    func testSuccessStatusesDoNotThrow() throws {
+        for status in [200, 201, 204, 299] {
+            try requireSuccess(status: status)
+        }
+    }
+
+    func testUnauthorizedAndForbiddenThrowAuthExpired() {
+        for status in [401, 403] {
+            XCTAssertThrowsError(try requireSuccess(status: status)) { error in
+                XCTAssertEqual(error as? SampleError, .authExpired)
+            }
+        }
+    }
+
+    func testOtherNon2xxThrowRequestFailedWithStatus() {
+        for status in [400, 404, 429, 500, 503] {
+            XCTAssertThrowsError(try requireSuccess(status: status)) { error in
+                XCTAssertEqual(error as? SampleError, .requestFailed(status))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Cleanups from a code-hygiene audit of the Swift sources. Each finding was verified against the whole repo (Sources + Tests, including protocol/SwiftUI/Codable/string-lookup paths) before being acted on. No behavior changes — dead-code removal, stale-comment fixes, and one behavior-preserving refactor.

### Dead code
- **`LocalUsageServer.stop()`** — zero callers; the loopback server is documented to live for the whole app session and has no shutdown path.
- **`MenuBarContent.Metric.kind`** — populated by the builder but never read in production; it's derived from the same `WidgetData` fields already in the synthesized `Equatable`, so it carried no rendering or memo-cache behavior.
- **`LayoutStore.providers`** — unused pass-through; every caller already reaches `registry.providers` directly.
- **`CursorModelManifestPricingEntry`** — drop 8 decoded-but-unused fields (display name, provider/family ids, max-mode uplift, the four long-context multipliers). `estimatedCostDollars` deliberately bills at the base rate and can't apply these from row totals. `JSONDecoder` ignores the extra keys, so the bundled `model_manifest.json` is unchanged.

### Misleading comments
- **`DashboardView.estimatedSettingsContentHeight`** — the comment + `fixedRowCount` claimed 9 fixed rows, but `SettingsScreen` renders 11 (the Advanced/logging section was added after the estimate was written). The cold-start height seed was ~2 rows short; constant and comment corrected.
- **`Formatters`** — the header described an obsolete "mostly mock currency helper" state; it's now the shared live-data deadline/reset/duration + currency formatter set.

### DRY
- **`ProviderAuthRetry.requireSuccess`** — the `401/403 → tokenExpired, other non-2xx → requestFailed` guard was copy-pasted across the Claude, Codex, and Grok mappers and re-implemented in `CursorProvider`. Extracted one helper that routes the auth-status check through the already-existing `isAuthFailure`; per-provider error values stay parameters, so behavior is identical (Devin is intentionally excluded — it switches auth *sources* rather than throwing).
- **`LogFile.url`** — now derives from `shared.fileURL` instead of recomputing the path independently, so the path advertised to the user (startup log, Settings copy/reveal) can't drift from where logs are actually written.

## Tests
- New `ProviderAuthRetryTests` covering the 2xx / 401-403 / other-non-2xx branches of `requireSuccess`.
- New `LogFile` regression asserting `LogFile.url == LogFile.shared.fileURL`.
- Updated menu-bar fixtures for the removed `Metric.kind` field.

Verified locally (this PR targets `swift`, where build/test CI does not run):
- `swift build` — clean.
- `swift test` — **245 XCTest + swift-testing suite, 0 failures** (1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly deletions and comment fixes; the shared `requireSuccess` helper is behavior-equivalent to the inlined guards and is covered by new unit tests. Settings cold-start height estimate changes layout math only, not persisted settings.
> 
> **Overview**
> Swift hygiene pass: **dead code removal**, **comment corrections**, and a **behavior-preserving** HTTP response triage refactor.
> 
> **Removed unused surface area:** `LocalUsageServer.stop()`, `LayoutStore.providers`, and `MenuBarContent.Metric.kind` (never read by renderers). **`CursorModelManifestPricingEntry`** now decodes only the pricing fields spend imputation uses; extra manifest keys are ignored by `JSONDecoder`.
> 
> **DRY auth/HTTP handling:** New **`ProviderAuthRetry.requireSuccess`** (with **`nonisolated`** `isAuthFailure`) replaces duplicated 401/403 vs other non-2xx guards in Claude, Codex, Grok mappers and **`CursorProvider`**. **`LogFile.url`** is derived from **`shared.fileURL`** so Settings/startup paths cannot drift from the real log sink.
> 
> **UI polish:** **`DashboardView.estimatedSettingsContentHeight`** fixed from 9 → **11** fixed rows to match **`SettingsScreen`**. **`Formatters`** module comment updated to reflect live-data formatters.
> 
> **Tests:** **`ProviderAuthRetryTests`**, **`LogFile`** advertised-path regression, menu-bar fixtures updated for removed **`kind`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524e07e8f1971156defb5b316743aa6751a00a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated HTTP response validation logic across providers for improved reliability and consistency.
  * Streamlined internal data models and improved logging system path references.

* **Tests**
  * Expanded test coverage for authentication handling and system configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->