### PR TITLE
chore: Tauri-to-Swift rollout guardrails and release-tauri skill

### DIFF
--- a/.agents/skills/release-tauri/SKILL.md
+++ b/.agents/skills/release-tauri/SKILL.md
@@ -21,7 +21,7 @@ This skill cuts Tauri-edition releases only. Tauri stays on version lane `0.6.x`
 ### 1. Determine New Version
 
 - Read the current version from `package.json` and the latest git tag.
-- Default bump type is **patch** (e.g. 0.1.0 → 0.1.1). The user may override with major or minor.
+- Tauri is frozen on the `0.6.x` lane, so only **patch** bumps are allowed (e.g. `0.6.27` -> `0.6.28`). Do NOT do a minor or major bump: from `0.6.x` that produces `0.7.0`, which collides with Swift's lane and can hijack GitHub Latest. (Swift releases use the release-swift skill on the `swift` branch.)
 - Show the proposed new version and **confirm with the user** before proceeding.
 
 ### 2. Generate Changelog
@@ -100,12 +100,17 @@ gh release view v{new_version} --json isDraft,isPrerelease,assets \
 
 Require `isDraft=false`, `isPrerelease=false`, and assets including `latest.json` and a `.sig`. If it is still a draft with complete assets: `gh release edit v{new_version} --draft=false`.
 
-Before deleting any duplicate draft, reconcile it: compare its body and assets against the published release and migrate anything the published one is missing. (Release notes were lost this way for v0.6.1 and v0.6.8 - the published releases had blank bodies while the drafts held the changelog.) Migrate notes with `gh release edit v{new_version} --notes-file <file>`. Only then delete the duplicate draft:
+Before deleting any duplicate draft, reconcile it: compare its body and assets against the published release and migrate anything the published one is missing. (Release notes were lost this way for v0.6.1 and v0.6.8 - the published releases had blank bodies while the drafts held the changelog.) Migrate notes with `gh release edit v{new_version} --notes-file <file>`. Only then delete the duplicate draft. Guard the delete so it can NEVER remove the sole release for a tag - it only runs once a separate PUBLISHED (non-draft) release for that tag already exists:
 
 ```bash
-gh api repos/{owner}/{repo}/releases --paginate \
-  --jq '.[] | select(.draft and .tag_name=="v{new_version}") | .id' \
-  | xargs -I{} gh api -X DELETE repos/{owner}/{repo}/releases/{}
+tag="v{new_version}"
+if [ "$(gh release view "$tag" --json isDraft --jq '.isDraft')" = "false" ]; then
+  gh api repos/{owner}/{repo}/releases --paginate \
+    --jq '.[] | select(.draft and .tag_name=="'"$tag"'") | .id' \
+    | xargs -I{} gh api -X DELETE repos/{owner}/{repo}/releases/{}
+else
+  echo "No published release for $tag yet - publish it first; do NOT delete the draft."
+fi
 ```
 
 Definition of done: exactly one published, non-draft release for the tag, with updater assets AND the release notes present.

--- a/.agents/skills/release-tauri/SKILL.md
+++ b/.agents/skills/release-tauri/SKILL.md
@@ -100,6 +100,14 @@ gh release view v{new_version} --json isDraft,isPrerelease,assets \
 
 Require `isDraft=false`, `isPrerelease=false`, and assets including `latest.json` and a `.sig`. If it is still a draft with complete assets: `gh release edit v{new_version} --draft=false`.
 
+Publish the approved changelog onto the release. `tauri-action` creates the release with a generic default body, so you must set the notes explicitly - otherwise you ship the exact blank-body release this skill exists to prevent. Write the step 2 changelog to a file and apply it:
+
+```bash
+gh release edit v{new_version} --notes-file <changelog-file>
+```
+
+If the workflow failed before `tauri-action` created the release, there is nothing to verify - re-run the workflow (`gh run rerun <run-id> --failed`) and wait. Do NOT create the release by hand with `gh release create`: a manual release ships without the signed `.dmg`, `.sig`, and `latest.json` updater assets and breaks auto-update for every Tauri user.
+
 Before deleting any duplicate draft, reconcile it: compare its body and assets against the published release and migrate anything the published one is missing. (Release notes were lost this way for v0.6.1 and v0.6.8 - the published releases had blank bodies while the drafts held the changelog.) Migrate notes with `gh release edit v{new_version} --notes-file <file>`. Only then delete the duplicate draft. Guard the delete so it can NEVER remove the sole release for a tag - it only runs once a separate PUBLISHED (non-draft) release for that tag already exists:
 
 ```bash

--- a/.agents/skills/release-tauri/SKILL.md
+++ b/.agents/skills/release-tauri/SKILL.md
@@ -20,13 +20,13 @@ This skill cuts Tauri-edition releases only. Tauri stays on version lane `0.6.x`
 
 ### 1. Determine New Version
 
-- Read the current version from `package.json` and the latest git tag.
+- Read the current version from `package.json` and the latest **Tauri** tag: `git tag --list 'v0.6.*' --sort=-v:refname | head -1`. Do not use the repo-wide "latest tag" - it may now be a Swift `0.7.x` pre-release, which would skew the proposed version.
 - Tauri is frozen on the `0.6.x` lane, so only **patch** bumps are allowed (e.g. `0.6.27` -> `0.6.28`). Do NOT do a minor or major bump: from `0.6.x` that produces `0.7.0`, which collides with Swift's lane and can hijack GitHub Latest. (Swift releases use the release-swift skill on the `swift` branch.)
 - Show the proposed new version and **confirm with the user** before proceeding.
 
 ### 2. Generate Changelog
 
-Collect commits since the previous tag and build the changelog:
+Collect commits since the previous Tauri tag (the latest `v0.6.*` tag from step 1, not the repo-wide latest tag, which may be a Swift `0.7.x` release) and build the changelog:
 
 **Categorization rules:**
 
@@ -90,7 +90,7 @@ git push origin v{new_version}
 
 ### 7. Verify and publish (mandatory - never leave a draft)
 
-`tauri-action` creates the GitHub Release as a draft and only flips it to published when every matrix job (aarch64 + x86_64) completes. A failed, cancelled, or re-run job - or a manual `gh release create` racing CI - leaves an orphan draft. (This is why the repo had stale drafts for v0.6.1 and v0.6.8.) Always finish a release with:
+`publish.yml` runs `tauri-action` with `releaseDraft: false`, so a clean run publishes the release immediately. Drafts still slip through in practice: an interrupted, failed, or re-run matrix job (aarch64 + x86_64), or a manual `gh release create` racing CI, can leave an orphan draft for the tag. (This is how the repo ended up with stale drafts for v0.6.1 and v0.6.8.) So always finish a release by verifying it is actually published:
 
 ```bash
 gh run watch

--- a/.agents/skills/release-tauri/SKILL.md
+++ b/.agents/skills/release-tauri/SKILL.md
@@ -1,15 +1,20 @@
 ---
-name: release-tag
+name: release-tauri
 description: >-
-  Create a new release tag with version bump, generate a GitHub Release-style
-  changelog, update CHANGELOG.md, and publish a GitHub Release. Use when the
-  user asks to tag a release, bump the version, create a changelog, cut a
-  release, or publish release notes.
+  Cut a release of the Tauri edition of OpenUsage (main branch): version bump,
+  generate a GitHub Release-style changelog, update CHANGELOG.md, and publish a
+  GitHub Release. Use when the user asks to tag a Tauri release, bump the
+  version, create a changelog, cut a release, or publish release notes. Pairs
+  with release-swift (the native Swift edition on the swift branch).
 ---
 
-# Release Tag
+# Release Tauri
 
-Bump the project version, generate a categorized changelog with author attribution, tag the release, and publish to GitHub Releases.
+Bump the project version, generate a categorized changelog with author attribution, tag the release, and publish to GitHub Releases. This skill cuts the Tauri edition only.
+
+## Lane and scope
+
+This skill cuts Tauri-edition releases only. Tauri stays on version lane `0.6.x`; never bump to `0.7.x` (Swift's lane). The Tauri edition is frozen - in practice the next release is the final "goodbye" build with the retirement banner. The native Swift edition has its own skill (release-swift) on the `swift` branch.
 
 ## Workflow
 
@@ -83,16 +88,27 @@ git push origin {branch}
 git push origin v{new_version}
 ```
 
-### 7. Create GitHub Release
+### 7. Verify and publish (mandatory - never leave a draft)
 
-Do **not** create the release before the push — CI (e.g. tauri-action) may create its own release when it sees the tag. After the push, check whether the release already exists:
+`tauri-action` creates the GitHub Release as a draft and only flips it to published when every matrix job (aarch64 + x86_64) completes. A failed, cancelled, or re-run job - or a manual `gh release create` racing CI - leaves an orphan draft. (This is why the repo had stale drafts for v0.6.1 and v0.6.8.) Always finish a release with:
 
 ```bash
-gh release view v{new_version} -R {owner}/{repo} 2>/dev/null
+gh run watch
+gh release view v{new_version} --json isDraft,isPrerelease,assets \
+  --jq '{isDraft, isPrerelease, assets:[.assets[].name]}'
 ```
 
-- If it **does not** exist: `gh release create v{new_version} --title "v{new_version}" --notes "{changelog}"`
-- If it **already exists** (CI created it): `gh release edit v{new_version} --notes "{changelog}"` to add the release notes, then delete any leftover draft duplicates.
+Require `isDraft=false`, `isPrerelease=false`, and assets including `latest.json` and a `.sig`. If it is still a draft with complete assets: `gh release edit v{new_version} --draft=false`.
+
+Before deleting any duplicate draft, reconcile it: compare its body and assets against the published release and migrate anything the published one is missing. (Release notes were lost this way for v0.6.1 and v0.6.8 - the published releases had blank bodies while the drafts held the changelog.) Migrate notes with `gh release edit v{new_version} --notes-file <file>`. Only then delete the duplicate draft:
+
+```bash
+gh api repos/{owner}/{repo}/releases --paginate \
+  --jq '.[] | select(.draft and .tag_name=="v{new_version}") | .id' \
+  | xargs -I{} gh api -X DELETE repos/{owner}/{repo}/releases/{}
+```
+
+Definition of done: exactly one published, non-draft release for the tag, with updater assets AND the release notes present.
 
 ## Changelog Template
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,26 @@ Version: 0.31 (2026-06-10)
 
 > OpenUsage is a public-facing Tauri desktop app for tracking AI provider usage across plugins.
 
+## Rollout: Tauri to Swift (read first)
+
+OpenUsage is being rewritten as a native Swift app. During the transition, two editions ship from this one repo and stay fully independent:
+- Identity: Tauri is `com.sunstory.openusage`; Swift is `com.robinebers.openusage` (macOS treats them as different apps).
+- Updates: Tauri reads `latest.json` from GitHub's "Latest" release; Swift uses a Sparkle appcast on the `gh-pages` branch. They never cross.
+- Pipelines: `main` + `.github/workflows/publish.yml` (Tauri); `swift` + `.github/workflows/release.yml` (Swift). Active development now happens on `swift`.
+
+### Guardrails (do not break)
+- Version lanes: Tauri stays on `0.6.x`; the Swift rewrite owns `0.7.x` and up. One `vX.Y.Z` tag namespace is shared, so never reuse a number across editions.
+- Keep every Swift release marked as a GitHub pre-release until the owner explicitly approves going public. A non-prerelease Swift release becomes GitHub "Latest" and silently breaks the Tauri auto-updater (it fetches `releases/latest/download/latest.json`).
+- Cut Tauri tags from a `main` commit (runs `publish.yml`); cut Swift tags from a `swift` commit (runs `release.yml`). A tag only triggers the workflow present in the commit it points at.
+- Never leave a release in Draft. After every release, verify it is published with its assets (use the release-tauri skill here; the swift branch has its own release-swift skill).
+- The Tauri edition stays in this repo forever (frozen, never deleted).
+
+### Phases
+1. Now - private Swift testing. Testers install the Swift DMG by hand, then enable Settings > Updates > Early Access to get `v0.7.0-beta.N` builds via Sparkle. Tauri users are untouched.
+2. Goodbye Tauri release. Cut the final Tauri build (retirement banner) with the release-tauri skill, e.g. `v0.6.28`. It becomes "Latest", auto-updates all Tauri users, and shows the "OpenUsage Has Moved" banner. Ship this BEFORE Phase 3.
+3. Flip Swift public. When the owner approves, cut a Swift stable release for everyone with the swift branch's release-swift skill. Only here may a Swift release drop the pre-release flag.
+4. Preserve Tauri. Make `swift` the default branch (the new `main`); rename today's Tauri `main` to `tauri-legacy` and freeze it. Tauri code and tags stay in the repo permanently.
+
 ## Documentation
 
 - Logic changes must update any docs in `docs/` that describe the affected behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -719,6 +719,27 @@
 - [824e3da](https://github.com/robinebers/openusage/commit/824e3da) fix(plugin-engine): read whitelisted env vars from terminal zsh (#167) by @robinebers
 - [ffb8883](https://github.com/robinebers/openusage/commit/ffb8883) feat(analytics): implement Tauri runtime check for event tracking by @robinebers
 
+## v0.6.1
+
+### New Features
+- Add Z.ai (Zhipu AI) provider plugin — tracks GLM Coding session usage (%) and web search quotas ([#135](https://github.com/robinebers/openusage/pull/135)) by @pbuchman
+- Add start-on-login setting with OS autostart integration ([#161](https://github.com/robinebers/openusage/pull/161)) by @davidarny
+- Add optional plugin links and quick actions on provider cards ([#162](https://github.com/robinebers/openusage/pull/162)) by @davidarny
+
+### Bug Fixes
+- Factory plugin: support Droid encrypted file and macOS keychain auth fallback ([#159](https://github.com/robinebers/openusage/pull/159)) by @davidarny
+
+---
+
+### Changelog
+
+**Full Changelog**: [v0.6.0...v0.6.1](https://github.com/robinebers/openusage/compare/v0.6.0...v0.6.1)
+
+- [0ec23d7](https://github.com/robinebers/openusage/commit/0ec23d7) feat(zai): add Z.ai provider plugin (#135) by @pbuchman
+- [31e8b35](https://github.com/robinebers/openusage/commit/31e8b35) feat(settings): add start-on-login setting (#161) by @davidarny
+- [96aee9b](https://github.com/robinebers/openusage/commit/96aee9b) feat: add optional plugin links and quick actions (#162) by @davidarny
+- [3f7f914](https://github.com/robinebers/openusage/commit/3f7f914) fix(factory): support droid encrypted and keychain auth (#159) by @davidarny
+
 ## 0.6.0
 
 ### New Features


### PR DESCRIPTION
## Summary
Sets up the guardrails for running the Tauri and Swift editions side by side during the rewrite transition, on the `main` (Tauri) side.

- **AGENTS.md**: new "Rollout: Tauri to Swift" section at the top - version lanes (Tauri `0.6.x`, Swift `0.7.x`+), keep Swift releases pre-release until the public flip, cut tags from the right branch, never leave a release in Draft, and a four-phase rollout (private Swift testing -> final Tauri goodbye release -> flip Swift public -> preserve Tauri).
- **Skill rename `release-tag` -> `release-tauri`**: scoped to the Tauri `0.6.x` lane and the final goodbye release. The old soft "create the release" step is replaced by a mandatory verify-and-publish step so a release is never left in Draft again (this is what caused the stale `v0.6.1`/`v0.6.8` drafts).
- **CHANGELOG.md**: backfill the missing `v0.6.1` section (recovered from its orphan draft release).

## Context (done out-of-band, not in this PR)
The two orphan draft releases (`v0.6.1`, `v0.6.8`) were reconciled and removed via the GitHub API: their release notes (which lived only in the drafts) were copied onto the published releases, verified, then the drafts deleted. No drafts remain.

## Test plan
- [ ] Confirm the AGENTS.md rollout section reads correctly and the version lanes match intent (`0.7.x` for Swift).
- [ ] Confirm `release-tauri` skill frontmatter/name and the mandatory verification step.
- [ ] Confirm the `v0.6.1` CHANGELOG entry is in the right place and format.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guardrails for the Tauri-to-Swift transition and tightens the Tauri release flow with mandatory publish verification and release notes publication. Renames `release-tag` to `release-tauri`, documents the rollout, restores the missing `v0.6.1` in `CHANGELOG.md`, and scopes releases to Tauri’s `0.6.x` lane.

- **Migration**
  - Use `release-tauri` for Tauri `0.6.x` only (incl. the final goodbye); Swift uses `release-swift` on `swift`.
  - Keep all Swift releases as GitHub pre-releases until the public flip; tag from the branch you’re releasing (`main` for Tauri, `swift` for Swift).
  - After each Tauri release, verify exactly one published (non-draft) release with updater assets; only then remove any duplicate drafts.

- **Bug Fixes**
  - `release-tauri`: enforce patch-only bumps on `0.6.x`; scope version detection and changelog range to the latest `v0.6.*` tag (ignore Swift `0.7.x+`).
  - Publish the approved changelog onto the release; if CI fails, re-run the workflow instead of creating a release by hand (prevents missing signed updater assets).
  - Clarify draft behavior and guard cleanup: drafts stem from interrupted/racing runs; only delete drafts after a published release exists (never remove the sole release).

<sup>Written for commit dcf18db8d23916f5fdad3e6e9441d25e6ec2b31e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed rollout guidance for transitioning from the Tauri edition to the Swift edition, including phased steps and release/publishing guardrails.
  * Published v0.6.1 release notes with new features and bug fixes, including a full “v0.6.0…v0.6.1” comparison section.
  * Introduced an end-to-end Tauri release workflow document covering changelog preparation, approvals, and verification.

* **Release / Workflow Updates**
  * Enforced patch-only version bump rules for the Tauri lane (v0.6.x only), with required user confirmations.
  * Improved release verification to ensure non-draft/non-prerelease publication with required assets, and handled duplicate draft cleanup safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->