### PR TITLE
fix(menubar): enlarge provider glyphs in the Text strip

### DIFF
--- a/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
+++ b/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
@@ -148,21 +148,27 @@ private struct MenuBarTextStrip: View {
         }
     }
 
+    /// Side length of the glyph box. Sized to fill the strip's height so the mark reads at the same
+    /// scale as the dual-line metric block beside it (the single number is shorter), instead of
+    /// floating small in the middle. `ProviderIconShape` already normalizes every mark to its true
+    /// bounding box, so a near-zero `inset` here makes each provider fill this box uniformly.
+    private static let glyphSide: CGFloat = 16
+
     @ViewBuilder
     private func glyph(_ icon: IconSource) -> some View {
         switch icon {
         case .providerMark(let id):
             if let mark = ProviderMarks.mark(for: id) {
-                ProviderIconShape(pathData: mark.path)
+                ProviderIconShape(pathData: mark.path, inset: 0.04)
                     .fill(Color.black)
-                    .frame(width: 14, height: 14)
+                    .frame(width: Self.glyphSide, height: Self.glyphSide)
             } else {
-                Circle().fill(Color.black).frame(width: 13, height: 13)
+                Circle().fill(Color.black).frame(width: Self.glyphSide - 1, height: Self.glyphSide - 1)
             }
         case .symbol(let name):
             Image(systemName: name)
-                .font(.system(size: 12, weight: .semibold))
-                .frame(width: 14, height: 14)
+                .font(.system(size: 14, weight: .semibold))
+                .frame(width: Self.glyphSide, height: Self.glyphSide)
         }
     }
 }


### PR DESCRIPTION
## What

Provider marks in the Text-style menu-bar strip were rendering small — a 14pt box with the default `0.14` inset left the actual artwork at only ~10pt, noticeably shorter than the dual-line metric block beside it.

This grows the glyph box to **16pt** and drops the inset to **0.04**, so each mark fills the strip height and reads at the same scale as the text. The SF Symbol fallback and the circle fallback scale up to match.

## Consistency

No SVG edits needed. `ProviderIconShape` already normalizes every mark to its **true path bounding box** (not the source `viewBox`), so all five providers land at the same height regardless of how much whitespace each source SVG bakes in. The smaller inset just lets them all fill the bigger box uniformly.

Scoped to the menu-bar call site only — the popover/gallery `ProviderIcon` and section headers keep the default `0.14` inset.

## Verification

- `swift build` clean
- `swift test --filter MenuBarStrip` — 6/6 pass (trim + memo)
- Built, signed, and launched the dev app; confirmed the larger, uniform glyphs in the live menu bar

> Note: CI build/test runs only on PRs into `main`, not `swift`, so this was verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Menu-bar presentation-only tweak in one renderer; no auth, data, or shared icon defaults changed.
> 
> **Overview**
> **Enlarges menu-bar Text strip icons** so provider marks visually match the dual-line metric block instead of sitting small in the middle.
> 
> Introduces a shared **16pt** `glyphSide` (up from 14pt) and passes **`inset: 0.04`** into `ProviderIconShape` for provider marks so artwork fills the box; SF Symbol and circle fallbacks use the same frame (symbol font 12→14). Popover/gallery `ProviderIcon` keeps the default inset—change is limited to `MenuBarTextStrip.glyph`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38cf0729bd378e96121f50ea8439578dca7ae31e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make provider glyphs in the menu-bar Text strip full-height and aligned with the adjacent metrics, fixing the too-small look. Marks now read at the same scale and are consistent across providers.

- **Bug Fixes**
  - Set glyph box to 16pt and inset to 0.04 for `ProviderIconShape`.
  - Scaled SF Symbol and circle fallbacks to match; change is scoped to the menu-bar Text strip only.

<sup>Written for commit 38cf0729bd378e96121f50ea8439578dca7ae31e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

