### PR TITLE
feat(appearance): add Reduce Transparency setting for readability

### DIFF
--- a/Sources/OpenUsage/Stores/ReduceTransparencySetting.swift
+++ b/Sources/OpenUsage/Stores/ReduceTransparencySetting.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Opt-in switch that drops the popover's Liquid Glass for a solid, higher-contrast surface — the
+/// fix for "I can't read it over a busy desktop" without taking glass away from everyone (it's off
+/// by default). Stored as a plain `Bool` under one `UserDefaults.standard` key, so it doesn't need
+/// the `UserDefaultsBacked` enum machinery; this namespace just holds the key and a live reader.
+///
+/// The app toggle is OR'd with macOS's own *Reduce Transparency* accessibility setting at the view
+/// layer (`DashboardView`), so a user who has the system setting on gets the solid surface even if
+/// they never touch this toggle.
+enum ReduceTransparencySetting {
+    /// The `UserDefaults.standard` key this setting persists under.
+    static let key = "reduceTransparency"
+
+    /// The stored choice, read live from `UserDefaults.standard` (defaults to `false` when unset —
+    /// a missing bool key reads as `false`, which is exactly the "glass on" default we want).
+    static var current: Bool {
+        UserDefaults.standard.bool(forKey: key)
+    }
+}

--- a/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
+++ b/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
@@ -10,6 +10,12 @@ import SwiftUI
 /// distinction, the scroll view still scrolls. Nothing here hides a runtime error — each branch is a
 /// compile-time `#available` check, which is the intended way to back-deploy newer-SDK APIs.
 ///
+/// These gate purely on OS version — the Reduce Transparency setting deliberately does *not* drop
+/// the glass controls (that downgraded the macOS 26 look to the macOS 15 one). Reduce Transparency
+/// instead makes the *surface* opaque (`PopoverSurface`) and frosts the cards (`Theme.cardSurface`),
+/// so the glass buttons stay glass — just rendered over a solid backing, which is the normal
+/// in-window look.
+///
 /// Keeping every `#available(macOS 26, *)` check in this one file means the views (`HeaderView`,
 /// `SettingsScreen`, `DashboardView`) stay free of inline availability branches.
 extension View {

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -52,11 +52,13 @@ enum Theme {
     /// it passes instead of letting them bleed through a translucent fill.
     static let liftedCardFill = AnyShapeStyle(Material.regular)
 
-    /// Hairline outline on every live card. The frosted fill alone separates cards well in light
-    /// mode but barely at all in dark mode (a material lightens little over a dark background, so
-    /// card and popover end up nearly the same tone). A defined edge fixes that deterministically in
-    /// both modes — the same way macOS grouped boxes (System Settings, Control Center) read in dark
-    /// mode. `.separator` is the semantic hairline, so it tracks light/dark and Increase Contrast.
+    /// Hairline outline on live cards when Reduce Transparency is on. The frosted fill alone
+    /// separates cards well in light mode but barely at all in dark mode (a material lightens little
+    /// over a dark background, so card and popover end up nearly the same tone). A defined edge fixes
+    /// that deterministically in both modes — the same way macOS grouped boxes (System Settings,
+    /// Control Center) read in dark mode. `.separator` is the semantic hairline, so it tracks
+    /// light/dark and Increase Contrast. (Not drawn in the default glass state — see
+    /// `CardSurfaceModifier` — so the toggle-off look is unchanged.)
     static let cardBorder = AnyShapeStyle(.separator)
 
     /// The single corner radius for every metric/settings card surface and its lifted twin, so the
@@ -70,14 +72,14 @@ enum Theme {
 }
 
 extension View {
-    /// The grouped-card surface used for provider/settings cards: the card fill in the shared
-    /// rounded shape, with a hairline border on live cards so they stay distinct from the popover in
-    /// dark mode (see `Theme.cardBorder`). The live fill follows the Reduce Transparency setting —
-    /// translucent quaternary with glass on, frosted material with it off — via `CardSurfaceModifier`
-    /// (a modifier, not a plain func, so it can read the environment flag). Pass `lifted: true` for
-    /// the floating drag preview, which swaps the fill for the heavier lifted material and skips the
-    /// border (its shadow/`liftedRowSurface` hairline already detaches it). Routing every card site
-    /// through this keeps the live card and its lifted twin one shape.
+    /// The grouped-card surface used for provider/settings cards, in the shared rounded shape. The
+    /// live fill follows the Reduce Transparency setting via `CardSurfaceModifier` (a modifier, not a
+    /// plain func, so it can read the environment flag): the original translucent quaternary fill
+    /// with the toggle off, or the frosted material plus a hairline border with it on (so cards stay
+    /// distinct from the opaque popover, including dark mode). Pass `lifted: true` for the floating
+    /// drag preview, which swaps the fill for the heavier lifted material and skips the border (its
+    /// shadow/`liftedRowSurface` hairline already detaches it). Routing every card site through this
+    /// keeps the live card and its lifted twin one shape.
     func cardSurface(lifted: Bool = false) -> some View {
         modifier(CardSurfaceModifier(lifted: lifted))
     }
@@ -122,10 +124,12 @@ private struct GlassTint: ShapeStyle {
     }
 }
 
-/// Backs `cardSurface`: live cards take the frosted fill when Reduce Transparency is on and the
-/// translucent quaternary fill when it's off, plus the hairline border; the lifted drag preview
-/// always uses its own legible material and no border. A `ViewModifier` rather than a plain `View`
-/// func so it can read the environment flag.
+/// Backs `cardSurface`. With Reduce Transparency *off* (the default) live cards keep the original
+/// look exactly: the translucent quaternary fill and no border, so the toggle-off appearance is
+/// unchanged from before this setting existed. With it *on*, cards take the frosted fill plus the
+/// hairline border so they stay distinct over the now-opaque popover (the border is what carries
+/// that separation in dark mode). The lifted drag preview always uses its own legible material and
+/// no border. A `ViewModifier` rather than a plain `View` func so it can read the environment flag.
 private struct CardSurfaceModifier: ViewModifier {
     @Environment(\.reduceTransparencyEffective) private var reduceTransparency
     let lifted: Bool
@@ -134,10 +138,12 @@ private struct CardSurfaceModifier: ViewModifier {
     func body(content: Content) -> some View {
         if lifted {
             content.background(Theme.liftedCardFill, in: Theme.cardShape)
-        } else {
+        } else if reduceTransparency {
             content
-                .background(reduceTransparency ? Theme.frostedCardFill : Theme.cardFill, in: Theme.cardShape)
+                .background(Theme.frostedCardFill, in: Theme.cardShape)
                 .overlay { Theme.cardShape.strokeBorder(Theme.cardBorder, lineWidth: 0.5) }
+        } else {
+            content.background(Theme.cardFill, in: Theme.cardShape)
         }
     }
 }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -37,15 +37,27 @@ enum Theme {
     /// the system orange softened for glass like the meter fills.
     static let notice = glassTint(Color(nsColor: .systemOrange))
 
-    /// Card surface for the metric groups: a semantic quaternary fill over the system popover glass
-    /// (the Control Center module look). Semantic — not a hand-tuned solid — so the cards track
-    /// light/dark, Increase Contrast, Reduce Transparency, and the OS Liquid Glass transparency
-    /// setting automatically.
+    /// Card surface in the default (glass) state — toggle off: a barely-there semantic quaternary
+    /// tint, so cards read as light translucent panels over the live popover glass (the Control
+    /// Center module look). Semantic, so it tracks light/dark and accessibility settings.
     static let cardFill = AnyShapeStyle(.quaternary)
+
+    /// Card surface when Reduce Transparency is on — toggle on: a frosted material instead of the
+    /// barely-there tint, so each card reads as a distinct raised panel over the now-opaque popover.
+    /// `.thinMaterial` is the lightest frost that separates the card from the solid background; bump
+    /// to `.regularMaterial` here if cards need to read more solid.
+    static let frostedCardFill = AnyShapeStyle(Material.thin)
 
     /// Backing for lifted drag previews: material, so the floating card stays legible over the rows
     /// it passes instead of letting them bleed through a translucent fill.
     static let liftedCardFill = AnyShapeStyle(Material.regular)
+
+    /// Hairline outline on every live card. The frosted fill alone separates cards well in light
+    /// mode but barely at all in dark mode (a material lightens little over a dark background, so
+    /// card and popover end up nearly the same tone). A defined edge fixes that deterministically in
+    /// both modes — the same way macOS grouped boxes (System Settings, Control Center) read in dark
+    /// mode. `.separator` is the semantic hairline, so it tracks light/dark and Increase Contrast.
+    static let cardBorder = AnyShapeStyle(.separator)
 
     /// The single corner radius for every metric/settings card surface and its lifted twin, so the
     /// floating drag preview always matches the live card's shape.
@@ -58,12 +70,16 @@ enum Theme {
 }
 
 extension View {
-    /// The grouped-card surface used for provider/settings cards: the semantic quaternary fill in
-    /// the shared rounded shape. Pass `lifted: true` for the floating drag preview, which swaps the
-    /// fill for the legible material so the card reads over (not through) the rows it passes.
-    /// Routing every card site through this keeps the live card and its lifted twin one shape.
+    /// The grouped-card surface used for provider/settings cards: the card fill in the shared
+    /// rounded shape, with a hairline border on live cards so they stay distinct from the popover in
+    /// dark mode (see `Theme.cardBorder`). The live fill follows the Reduce Transparency setting —
+    /// translucent quaternary with glass on, frosted material with it off — via `CardSurfaceModifier`
+    /// (a modifier, not a plain func, so it can read the environment flag). Pass `lifted: true` for
+    /// the floating drag preview, which swaps the fill for the heavier lifted material and skips the
+    /// border (its shadow/`liftedRowSurface` hairline already detaches it). Routing every card site
+    /// through this keeps the live card and its lifted twin one shape.
     func cardSurface(lifted: Bool = false) -> some View {
-        background(lifted ? Theme.liftedCardFill : Theme.cardFill, in: Theme.cardShape)
+        modifier(CardSurfaceModifier(lifted: lifted))
     }
 
     /// A single-row lifted preview surface: the card fill plus the thin separator hairline that
@@ -94,8 +110,49 @@ private struct GlassTint: ShapeStyle {
     var strength: Double
 
     func resolve(in environment: EnvironmentValues) -> Color {
-        guard environment.colorSchemeContrast != .increased else { return color }
+        // Increase Contrast and Reduce Transparency both want the full-strength color: the first by
+        // Apple's rule (every custom color on glass needs a high-contrast variant), the second
+        // because in solid mode there's no glass to temper against, so the softened fade would just
+        // read as a washed-out bar.
+        guard environment.colorSchemeContrast != .increased,
+              !environment.reduceTransparencyEffective
+        else { return color }
         let neutral = environment.colorScheme == .dark ? Color(white: 0.16) : Color(white: 0.94)
         return color.mix(with: neutral, by: 1 - strength)
+    }
+}
+
+/// Backs `cardSurface`: live cards take the frosted fill when Reduce Transparency is on and the
+/// translucent quaternary fill when it's off, plus the hairline border; the lifted drag preview
+/// always uses its own legible material and no border. A `ViewModifier` rather than a plain `View`
+/// func so it can read the environment flag.
+private struct CardSurfaceModifier: ViewModifier {
+    @Environment(\.reduceTransparencyEffective) private var reduceTransparency
+    let lifted: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if lifted {
+            content.background(Theme.liftedCardFill, in: Theme.cardShape)
+        } else {
+            content
+                .background(reduceTransparency ? Theme.frostedCardFill : Theme.cardFill, in: Theme.cardShape)
+                .overlay { Theme.cardShape.strokeBorder(Theme.cardBorder, lineWidth: 0.5) }
+        }
+    }
+}
+
+/// Whether the popover is rendering in its solid, non-glass form — the app's Reduce Transparency
+/// toggle OR'd with macOS's own accessibility setting, resolved once in `DashboardView` and pushed
+/// down so every surface (cards, buttons, meter tints) reads the same answer. Defaults to `false`
+/// (full Liquid Glass) so nothing changes unless the flag is injected.
+private struct ReduceTransparencyEffectiveKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var reduceTransparencyEffective: Bool {
+        get { self[ReduceTransparencyEffectiveKey.self] }
+        set { self[ReduceTransparencyEffectiveKey.self] = newValue }
     }
 }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -36,6 +36,11 @@ struct DashboardView: View {
     @State private var dashboardScrollPosition = ScrollPosition(edge: .top)
     /// Row rhythm and the Customize height seed track the global density setting live.
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    /// Readability control. The app toggle is OR'd with macOS's own Reduce Transparency setting
+    /// (`accessibilityReduceTransparency`) into one `effectiveReduceTransparency` flag, pushed down
+    /// the tree so every surface renders in its solid form together.
+    @AppStorage(ReduceTransparencySetting.key) private var reduceTransparency = false
+    @Environment(\.accessibilityReduceTransparency) private var systemReduceTransparency
 
     private static let outerPadding: CGFloat = 14
     /// Breathing room between the bottom of the scrolling content and the pinned footer. Kept small
@@ -135,12 +140,12 @@ struct DashboardView: View {
 
     /// Cold-start estimate for Settings content, same role as the Customize estimate above. The
     /// constants mirror `SettingsScreen`: five sections (a caption header over a card) holding
-    /// eleven fixed control rows (Startup 2, Appearance 4, Usage Display 2, Advanced 3) plus one
+    /// twelve fixed control rows (Startup 2, Appearance 5, Usage Display 2, Advanced 3) plus one
     /// row per registered provider.
     private var estimatedSettingsContentHeight: CGFloat {
         let sectionCount: CGFloat = 5
         let sectionHeaderHeight: CGFloat = 16
-        let fixedRowCount: CGFloat = 11
+        let fixedRowCount: CGFloat = 12
         let rowCount = fixedRowCount + CGFloat(container.registry.providers.count)
         let verticalPadding: CGFloat = 24
         return verticalPadding
@@ -149,11 +154,25 @@ struct DashboardView: View {
             + (sectionCount - 1) * density.sectionSpacing
     }
 
+    /// The app's Reduce Transparency toggle OR macOS's own accessibility setting: either one drops
+    /// the popover to its solid, non-glass form. Resolved once here and injected so the surface,
+    /// controls, and meter tints all read the same answer.
+    private var effectiveReduceTransparency: Bool {
+        reduceTransparency || systemReduceTransparency
+    }
+
     var body: some View {
         modeBody
             .frame(width: Self.popoverWidth)
             .pinnedFooter(spacing: 0) { footerBar }
             .frame(height: animatedPopoverHeight, alignment: .top)
+            // Paint the surface behind the content (and footer) and tell every descendant whether
+            // glass is on, so the fallbacks and the meter tints render in step. Both go on the
+            // outermost level of the chain so the footer, header buttons, and scroll content inherit.
+            .background(
+                PopoverSurface(reduce: effectiveReduceTransparency)
+            )
+            .environment(\.reduceTransparencyEffective, effectiveReduceTransparency)
             .overlay(alignment: .topLeading) {
                 if let reorderLift {
                     ReorderLiftPreview(lift: reorderLift)
@@ -431,5 +450,26 @@ struct DashboardView: View {
             return "Next update in \(minutes)m"
         }
         return "Next update in \(totalSeconds)s"
+    }
+}
+
+/// The popover's backdrop: clear by default (so the system Liquid Glass shows through), an opaque
+/// window-colored fill when Reduce Transparency is on. With the default (glass on) it's
+/// `Color.clear` — the stock look, untouched. Never hit-tests so it can't steal clicks from the
+/// content above it.
+private struct PopoverSurface: View {
+    let reduce: Bool
+
+    var body: some View {
+        Group {
+            if reduce {
+                // Solid mode: the standard window background, so the popover reads like a normal
+                // opaque panel instead of sampling the desktop behind it.
+                Color(nsColor: .windowBackgroundColor)
+            } else {
+                Color.clear
+            }
+        }
+        .allowsHitTesting(false)
     }
 }

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -25,6 +25,7 @@ struct SettingsScreen: View {
     @AppStorage(AppearanceSetting.key) private var appearance = AppearanceSetting.system
     @AppStorage(TimeFormatSetting.key) private var timeFormat = TimeFormatSetting.auto
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @AppStorage(ReduceTransparencySetting.key) private var reduceTransparency = false
     @AppStorage(LogLevelSetting.key) private var logLevel = LogLevelSetting.fallback
     /// Surfaced under the Advanced rows when copying the path or revealing the file fails.
     @State private var logActionError: String?
@@ -106,6 +107,13 @@ struct SettingsScreen: View {
                 }
                 row("Time Format") {
                     picker($timeFormat, options: TimeFormatSetting.allCases, label: \.label)
+                }
+                // Off keeps the stock Liquid Glass look; @AppStorage reactivity re-renders the
+                // popover live, so no onChange is needed.
+                row("Reduce Transparency") {
+                    Toggle("", isOn: $reduceTransparency)
+                        .settingsSwitchStyle()
+                        .help("Use a solid background instead of Liquid Glass for better readability")
                 }
             }
             section("Usage Display") {

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,6 +17,7 @@ Settings lives inside the popover — there is no separate window. Open it with 
 | Theme | System / Light / Dark | App-wide appearance override for the popover. |
 | Density | Default / Compact | Default breathes; Compact is a real information-dense mode — text steps down one size, rows and provider sections pull together, and Customize / Settings rows tighten with them. In both, consecutive one-line metrics (Today / Yesterday / …) pull together; Compact pulls harder. |
 | Time Format | Auto / 12-hour / 24-hour | How exact times read (e.g. "Resets today at 6:38 PM" vs "18:38"). Auto follows the system. |
+| Reduce Transparency | on/off | Off keeps the fully translucent Liquid Glass look (cards stay light and glassy). On makes the popover background solid and the cards frosted so they read better over a busy or bright desktop — the glass buttons and controls stay. Turns on automatically if you have macOS's own Reduce Transparency (System Settings → Accessibility → Display) enabled. |
 
 ## Usage Display
 


### PR DESCRIPTION
## Summary

Some early testers find the Liquid Glass popover hard to read over busy or bright desktops. This adds an opt-in **Reduce Transparency** toggle in Settings → Appearance (off by default, so the stock look is unchanged for people who like the glass).

When on, it:
- paints a **solid popover background** instead of the see-through glass, and
- shows the usage **meter colors at full strength** (no glass softening).

Crucially, it **keeps the Liquid Glass controls** (glass buttons, footer, scroll-edge blur) on macOS 26 rather than falling back to the macOS 15 bordered look — so the app never looks downgraded. The toggle is OR'd with macOS's own *Reduce Transparency* accessibility setting, so the solid surface also engages automatically for users who have that enabled system-wide.

Cards get a hairline border and a frosted fill (thin material) when the toggle is on, so they stay distinct from the now-opaque popover in both light and dark mode. With the toggle off they keep the light translucent quaternary fill.

## Implementation notes

- New `ReduceTransparencySetting` (a `Bool` under `UserDefaults` key `reduceTransparency`).
- `DashboardView` resolves `effectiveReduceTransparency = app toggle || accessibilityReduceTransparency`, paints `PopoverSurface`, and injects a `reduceTransparencyEffective` environment value.
- `Theme` reads that flag for card fill (frosted vs. quaternary) and meter tint (un-softened); a hairline `cardBorder` keeps cards defined in dark mode.
- `LiquidGlassFallbacks` is unchanged in behavior — it still gates purely on OS version, so glass controls stay glass regardless of the toggle.
- Docs updated in `docs/settings.md`.

## Test plan

- [x] `swift build` clean
- [x] `swift test` green (245 tests, 1 skipped, 0 failures)
- [ ] Toggle off → unchanged Liquid Glass look (glassy cards, see-through popover)
- [ ] Toggle on → solid popover background, frosted/bordered cards, full-strength meters, glass buttons retained
- [ ] Dark mode: cards stay distinct from the popover in both states
- [ ] macOS System Settings → Accessibility → Display → Reduce transparency engages solid mode even with the app toggle off

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Reduce Transparency setting that swaps the popover’s glass for a solid background to improve readability while keeping the Liquid Glass controls. Off by default; respects macOS Reduce Transparency and shows meter colors at full strength when active.

- **New Features**
  - Toggle in Settings → Appearance; off by default.
  - Solid popover background; full-strength usage meter colors.
  - Keeps Liquid Glass controls; only the surface changes.
  - Honors macOS Accessibility → Reduce Transparency (app OR’d with system).
  - Cards use thin frost and a hairline border when enabled.

- **Bug Fixes**
  - Card frost and border now draw only when Reduce Transparency is on; default cards stay translucent and borderless.

<sup>Written for commit 9a1679bba2896de01dd1827fa833f656a1dd3e7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Reduce Transparency” toggle in Appearance to switch from translucent Liquid Glass to a solid/frosted popover with frosted card surfaces for better readability.
  * Automatically syncs with macOS “Reduce Transparency” accessibility settings.
* **Bug Fixes**
  * Improved live-card and popover rendering so glass-styled controls remain usable while transparency is reduced.
* **Documentation**
  * Updated settings documentation to describe the new toggle and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->