### PR TITLE
feat(menu-bar): drop global pin cap, keep two per provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each provider reads the credentials already on your machine (keychain, auth file
 
 ## Features
 
-- **Menu bar pins.** Pin up to 6 metrics; render as compact text or mini bars. The strip hides metrics with no data instead of showing placeholders.
+- **Menu bar pins.** Pin metrics to the menu bar (up to 2 per provider); render as compact text or mini bars. The strip hides metrics with no data instead of showing placeholders.
 - **Dashboard popover.** Provider-grouped meters with live reset countdowns, pace indicators, and context menus (pin, hide, used⟷left, countdown⟷exact resets, refresh).
 - **Global shortcut.** Toggle the popover from anywhere — record any combo in Settings.
 - **Customize.** Add/remove widgets, drag-reorder providers and metrics.

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -15,8 +15,8 @@ enum DefaultLayout {
     ]
 
     /// Metrics pinned to the menu bar on first launch, so the app shows real numbers out of the box
-    /// instead of a lone icon. Two per provider for Claude, Codex, and Cursor — the per-provider and
-    /// total pin caps (`LayoutStore.maxPinsPerProvider` / `maxTotalPins`). Filtered to the active
+    /// instead of a lone icon. Two per provider for Claude, Codex, and Cursor — the per-provider cap
+    /// (`LayoutStore.maxPinsPerProvider`). Filtered to the active
     /// registry by `LayoutStore`, like `metricIDs`.
     static let pinnedMetricIDs: [String] = [
         "claude.session", "claude.weekly",

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -59,8 +59,7 @@ final class LayoutStore {
 
     /// Descriptor ids pinned to the menu bar. Membership only — display order is derived from the
     /// provider + metric order above, so pins follow the same sequence shown in Customize. Capped via
-    /// `canPin` to one global budget of `maxTotalPins`, with at most `maxPinsPerProvider` per provider
-    /// (the strip stacks a provider's values in pairs).
+    /// `canPin` to at most `maxPinsPerProvider` per provider (the strip stacks a provider's values in pairs).
     private(set) var pinnedMetricIDs: Set<String>
 
     /// Transient explanation for a denied pin attempt (the WhatsApp-style "you can only pin N chats"
@@ -270,11 +269,9 @@ final class LayoutStore {
 
     // MARK: - Menu bar pins
 
-    /// One global pin budget: a single number the user can hold in their head ("up to 6 pins"). The
-    /// per-provider cap is a rendering constraint — the Text strip stacks a provider's values two to a
+    /// Per-provider cap is a rendering constraint — the Text strip stacks a provider's values two to a
     /// column, so a third would not fit the menu bar height.
     static let maxPinsPerProvider = 2
-    static let maxTotalPins = 6
 
     func isPinned(_ descriptorID: String) -> Bool { pinnedMetricIDs.contains(descriptorID) }
 
@@ -290,7 +287,6 @@ final class LayoutStore {
         if pinnedMetricIDs.contains(descriptorID) { return true }
         guard let providerID = registry.descriptor(id: descriptorID)?.providerID else { return false }
         if pinnedCount(forProvider: providerID) >= Self.maxPinsPerProvider { return false }
-        if pinnedCount >= Self.maxTotalPins { return false }
         return true
     }
 
@@ -302,7 +298,7 @@ final class LayoutStore {
            pinnedCount(forProvider: providerID) >= Self.maxPinsPerProvider {
             return "Up to \(Self.maxPinsPerProvider) pins per provider"
         }
-        return "All \(Self.maxTotalPins) pins already used"
+        return nil
     }
 
     /// Record a denied pin attempt so the footer can explain the cap (shown for a few seconds,

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -350,14 +350,14 @@ struct DashboardView: View {
     }
 
     /// Leading side of the footer. Normal mode shows the app name with the live "Next update in …"
-    /// line beneath it; Customize mode shows the pin budget ("4 of 6 pinned") in the same slot.
+    /// line beneath it; Customize mode shows the pin count ("4 pinned") in the same slot.
     /// Settings keeps the normal identity — the version line doubles as the About info there.
     /// A denied pin attempt swaps either line for the reason (in orange), played with the macOS
     /// deny shake — the wrong-password idiom — on every blocked click.
     @ViewBuilder
     private var footerIdentity: some View {
         if layout.isEditing {
-            Text(layout.pinLimitNotice ?? "\(layout.pinnedCount) of \(LayoutStore.maxTotalPins) pinned")
+            Text(layout.pinLimitNotice ?? "\(layout.pinnedCount) pinned")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(layout.pinLimitNotice == nil ? AnyShapeStyle(.secondary) : Theme.notice)
                 .denyShake(trigger: layout.pinNoticeShakeTrigger)

--- a/Tests/OpenUsageTests/MenuBarPinTests.swift
+++ b/Tests/OpenUsageTests/MenuBarPinTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 @testable import OpenUsage
 
-/// Covers the menu-bar pin model on `LayoutStore`: the ≤2-per-provider rendering cap, the global
-/// pin budget (`maxTotalPins`), denial reasons/notices, order derivation from the Customize order,
+/// Covers the menu-bar pin model on `LayoutStore`: the ≤2-per-provider rendering cap, denial
+/// reasons/notices, order derivation from the Customize order,
 /// disabled-provider handling, and persistence across relaunch.
 @MainActor
 final class MenuBarPinTests: XCTestCase {
@@ -42,35 +42,14 @@ final class MenuBarPinTests: XCTestCase {
         XCTAssertTrue(store.canPin("a.m1"))
     }
 
-    func testFourthProviderCanPinWhileBudgetHasRoom() {
-        // The old ≤3-provider rule is gone: with three providers pinned, a fourth provider can still
-        // pin as long as the global budget has slots — the lock-out that motivated the redesign.
-        let store = makeStore("fourthProvider")
-        store.setPinned(true, for: "a.m1")
-        store.setPinned(true, for: "b.m1")
-        store.setPinned(true, for: "c.m1")
-
-        XCTAssertTrue(store.canPin("d.m1"))
-        store.setPinned(true, for: "d.m1")
-        XCTAssertTrue(store.isPinned("d.m1"))
-    }
-
-    func testGlobalBudgetBlocksSeventhPin() {
-        let store = makeStore("globalBudget")
-        for id in ["a.m1", "a.m2", "b.m1", "b.m2", "c.m1", "c.m2"] {
-            store.setPinned(true, for: id)
+    func testEachProviderCanPinUpToTwo() {
+        let store = makeStore("manyProviders")
+        for provider in ["a", "b", "c", "d"] {
+            store.setPinned(true, for: "\(provider).m1")
+            store.setPinned(true, for: "\(provider).m2")
+            XCTAssertFalse(store.canPin("\(provider).m3"))
         }
-        XCTAssertEqual(store.pinnedCount, LayoutStore.maxTotalPins)
-
-        XCTAssertFalse(store.canPin("d.m1"))
-        store.setPinned(true, for: "d.m1")
-        XCTAssertFalse(store.isPinned("d.m1"))
-
-        // Freeing any slot lets the fourth provider pin.
-        store.setPinned(false, for: "c.m2")
-        XCTAssertTrue(store.canPin("d.m1"))
-        store.setPinned(true, for: "d.m1")
-        XCTAssertTrue(store.isPinned("d.m1"))
+        XCTAssertEqual(store.pinnedCount, 8)
     }
 
     func testPinDenialReasonsAndFooterNotice() {
@@ -82,22 +61,17 @@ final class MenuBarPinTests: XCTestCase {
         XCTAssertEqual(store.pinDenialReason("a.m3"), "Up to 2 pins per provider")
         XCTAssertNil(store.pinDenialReason("b.m1"))
 
-        for id in ["b.m1", "b.m2", "c.m1", "c.m2"] { store.setPinned(true, for: id) }
-        XCTAssertEqual(store.pinDenialReason("d.m1"), "All 6 pins already used")
+        XCTAssertNil(store.pinDenialReason("b.m1"))
 
         // A denied click surfaces the reason as the transient footer notice and bumps the shake
         // trigger every time, so repeat clicks re-shake even while the text is unchanged.
         XCTAssertNil(store.pinLimitNotice)
         XCTAssertEqual(store.pinNoticeShakeTrigger, 0)
-        store.notePinDenied("d.m1")
-        XCTAssertEqual(store.pinLimitNotice, "All 6 pins already used")
+        store.notePinDenied("a.m3")
+        XCTAssertEqual(store.pinLimitNotice, "Up to 2 pins per provider")
         XCTAssertEqual(store.pinNoticeShakeTrigger, 1)
-        store.notePinDenied("d.m1")
+        store.notePinDenied("a.m3")
         XCTAssertEqual(store.pinNoticeShakeTrigger, 2)
-
-        // …and an allowed pin never sets one.
-        store.setPinned(false, for: "c.m2")
-        XCTAssertNil(store.pinDenialReason("d.m1"))
     }
 
     func testUnpinFreesAProviderSlot() {

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -7,9 +7,9 @@ Pin your most important metrics straight into the menu bar strip.
 Pin from any row's right-click menu, or from the pin that appears when hovering rows in Customize.
 
 - On first launch the app ships with a default set of pins (Claude Session/Weekly, Codex Session/Weekly, Cursor Auto Limits/API Usage) so the strip shows numbers right away. Change them anytime; Reset in Customize restores this set.
-- **6 pins total** across all providers, at most **2 per provider**.
-- When a pin isn't allowed, the pin button stays clickable — clicking it shakes and shows the reason in the footer (e.g. "All 6 pins already used").
-- The Customize footer shows your budget: `n of 6 pinned`.
+- At most **2 pins per provider**.
+- When a pin isn't allowed, the pin button stays clickable — clicking it shakes and shows the reason in the footer (e.g. "Up to 2 pins per provider").
+- The Customize footer shows your count: `n pinned`.
 
 ## Styles
 


### PR DESCRIPTION
## Summary
- Removes the global limit of 6 menu bar pins.
- Keeps at most 2 pins per provider (menu bar layout constraint).
- Updates Customize footer copy, docs, and pin tests.

## Test plan
- [x] `swift test --filter MenuBarPinTests`
- [ ] Pin metrics from 4+ providers in Customize (2 each)
- [ ] Third pin on same provider shows denial shake + footer reason


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the global 6-pin limit while keeping the 2-per-provider cap. Users can pin metrics from any number of providers; the Customize footer now shows "n pinned" and denials only apply per provider.

- **New Features**
  - Dropped `maxTotalPins` in `LayoutStore`; updated `canPin` and `pinDenialReason` to enforce only 2 per provider.
  - `DashboardView` footer shows "n pinned"; denial text is "Up to 2 pins per provider" with shake.
  - Updated tests and docs to remove 6-pin references (`README.md`, `docs/menu-bar.md`).

<sup>Written for commit ede30ea929722ccdd47495c9ff3682f6fdfb2eb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

