### PR TITLE
fix: guard against a second app instance (duplicate menu-bar icon) (#635)

### DIFF
--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -25,6 +25,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Open/trim the file log, seed the cached level, and emit the startup line BEFORE anything
         // else logs, so the first lines of a session are captured.
         AppLog.bootstrap()
+        // Single-instance guard (#635): reject a duplicate before it grabs the local-API port
+        // (127.0.0.1:6736) or adds a second status item. `terminate(_:)` unwinds asynchronously and
+        // is cancellable, so we MUST return here — otherwise this method keeps running and creates
+        // the very duplicate it was meant to prevent.
+        if SingleInstanceGuard.deferToExistingInstance() {
+            AppLog.info(.lifecycle, "duplicate launch detected; handing off to the running instance and terminating")
+            NSApp.terminate(nil)
+            return
+        }
+        // Let only the `SMAppService` login item drive startup: opt out of AppKit's reopen-on-login
+        // so a reboot doesn't also restore us and race the login item into a duplicate (#635). The
+        // guard above resolves a lingering crashed copy; this removes the reboot race the guard alone
+        // can't reliably win (both launches register near-simultaneously).
+        NSApp.disableRelaunchOnLogin()
         // App-wide theme override (NSApp.appearance): the popover ignores SwiftUI's
         // preferredColorScheme, so the override is applied at the AppKit level once at launch;
         // the Theme picker on the Settings screen re-applies it on change.

--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -35,9 +35,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         // Let only the `SMAppService` login item drive startup: opt out of AppKit's reopen-on-login
-        // so a reboot doesn't also restore us and race the login item into a duplicate (#635). The
-        // guard above resolves a lingering crashed copy; this removes the reboot race the guard alone
-        // can't reliably win (both launches register near-simultaneously).
+        // so a reboot doesn't also restore us and race the login item in the first place. The guard
+        // above already resolves the race deterministically (lowest PID survives) even if both fire;
+        // this just avoids the wasted second launch.
         NSApp.disableRelaunchOnLogin()
         // App-wide theme override (NSApp.appearance): the popover ignores SwiftUI's
         // preferredColorScheme, so the override is applied at the AppKit level once at launch;

--- a/Sources/OpenUsage/App/SingleInstanceGuard.swift
+++ b/Sources/OpenUsage/App/SingleInstanceGuard.swift
@@ -1,0 +1,31 @@
+import AppKit
+
+/// Rejects a second copy of OpenUsage at launch (issue #635). macOS can fire two independent launch
+/// triggers on reboot — session restoration ("Reopen windows when logging back in") and the
+/// `SMAppService` login item — and a crashed or hung copy can linger holding `127.0.0.1:6736`.
+/// Without a guard either path yields a duplicate menu-bar icon (or, for an `LSUIElement` app, a
+/// launch that "does nothing"). The decision is split out from the live-workspace query so it can be
+/// unit-tested without a second running process.
+@MainActor
+enum SingleInstanceGuard {
+    /// Pure decision: another copy already owns the slot when some running PID sharing our bundle id
+    /// isn't our own. Our own PID is filtered out so a solo launch never counts itself.
+    static func isDuplicate(myPID: pid_t, runningPIDs: [pid_t]) -> Bool {
+        runningPIDs.contains { $0 != myPID }
+    }
+
+    /// Live check + handoff. When an existing instance owns the slot, hands focus to it and returns
+    /// `true` so the caller bows out before grabbing the local-API port or adding a status item.
+    /// Returns `false` (no-op) when we are the only copy, or when unbundled (`swift run`/preview) has
+    /// no bundle identifier to match against.
+    static func deferToExistingInstance() -> Bool {
+        guard let bundleID = Bundle.main.bundleIdentifier else { return false }
+        let me = NSRunningApplication.current
+        let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+        guard isDuplicate(myPID: me.processIdentifier, runningPIDs: running.map(\.processIdentifier)) else {
+            return false
+        }
+        running.first { $0.processIdentifier != me.processIdentifier }?.activate()
+        return true
+    }
+}

--- a/Sources/OpenUsage/App/SingleInstanceGuard.swift
+++ b/Sources/OpenUsage/App/SingleInstanceGuard.swift
@@ -8,24 +8,37 @@ import AppKit
 /// unit-tested without a second running process.
 @MainActor
 enum SingleInstanceGuard {
-    /// Pure decision: another copy already owns the slot when some running PID sharing our bundle id
-    /// isn't our own. Our own PID is filtered out so a solo launch never counts itself.
-    static func isDuplicate(myPID: pid_t, runningPIDs: [pid_t]) -> Bool {
-        runningPIDs.contains { $0 != myPID }
+    /// Pure decision: the PID of the instance we should yield to, or `nil` if we should keep running.
+    ///
+    /// Tie-break is deterministic — the lowest-PID instance is the survivor; every other copy yields
+    /// to it. This matters for the reboot race the guard targets: when two launches register at once,
+    /// a naive "yield if any other instance exists" rule makes *both* yield and terminate, leaving
+    /// zero running instances. Lowest-PID-wins guarantees exactly one survivor. (The one theoretical
+    /// hole — PID wraparound between an older instance's launch and ours — needs ~99k intervening PIDs
+    /// and is negligible.)
+    static func instanceToYieldTo(myPID: pid_t, runningPIDs: [pid_t]) -> pid_t? {
+        guard let lowestPeer = runningPIDs.filter({ $0 != myPID }).min(), lowestPeer < myPID else {
+            return nil
+        }
+        return lowestPeer
     }
 
-    /// Live check + handoff. When an existing instance owns the slot, hands focus to it and returns
-    /// `true` so the caller bows out before grabbing the local-API port or adding a status item.
-    /// Returns `false` (no-op) when we are the only copy, or when unbundled (`swift run`/preview) has
-    /// no bundle identifier to match against.
+    /// Live check + handoff. When another instance owns the slot, hands focus to the surviving copy
+    /// and returns `true` so the caller bows out before grabbing the local-API port or adding a status
+    /// item. Returns `false` (no-op) when we are the survivor, or when unbundled (`swift run`/preview)
+    /// has no bundle identifier to match against.
     static func deferToExistingInstance() -> Bool {
         guard let bundleID = Bundle.main.bundleIdentifier else { return false }
         let me = NSRunningApplication.current
         let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-        guard isDuplicate(myPID: me.processIdentifier, runningPIDs: running.map(\.processIdentifier)) else {
+        guard let survivorPID = instanceToYieldTo(
+            myPID: me.processIdentifier,
+            runningPIDs: running.map(\.processIdentifier)
+        ) else {
             return false
         }
-        running.first { $0.processIdentifier != me.processIdentifier }?.activate()
+        // Resolved from the same snapshot the decision used, so the survivor is still present.
+        running.first { $0.processIdentifier == survivorPID }?.activate()
         return true
     }
 }

--- a/Sources/OpenUsage/Support/AppLog.swift
+++ b/Sources/OpenUsage/Support/AppLog.swift
@@ -15,6 +15,7 @@ enum LogTag: String, Sendable {
     case statusItem = "statusitem"
     case localAPI = "localapi"
     case subprocess
+    case lifecycle
 
     /// Compound `[plugin:<id>]` / `[auth:<id>]` tags for per-provider lines.
     static func plugin(_ id: String) -> String { "plugin:\(id)" }

--- a/Tests/OpenUsageTests/SingleInstanceGuardTests.swift
+++ b/Tests/OpenUsageTests/SingleInstanceGuardTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the single-instance guard's decision logic (issue #635): given our PID and the PIDs of
+/// running apps sharing our bundle id, decide whether *this* launch is the duplicate that should bow
+/// out. The live `NSRunningApplication` query and the activate/terminate handoff are thin glue over
+/// this pure function and aren't unit-testable (they need a second running process).
+@MainActor
+final class SingleInstanceGuardTests: XCTestCase {
+    func testSoloLaunchIsNotADuplicate() {
+        // Only our own process is running — nothing to defer to.
+        XCTAssertFalse(SingleInstanceGuard.isDuplicate(myPID: 42, runningPIDs: [42]))
+    }
+
+    func testNoRunningAppsIsNotADuplicate() {
+        // Defensive: an empty workspace result must never read as a duplicate.
+        XCTAssertFalse(SingleInstanceGuard.isDuplicate(myPID: 42, runningPIDs: []))
+    }
+
+    func testAnotherInstanceIsADuplicate() {
+        // A second copy (pid 7) already owns the slot — we're the duplicate.
+        XCTAssertTrue(SingleInstanceGuard.isDuplicate(myPID: 42, runningPIDs: [7, 42]))
+    }
+
+    func testOurOwnPIDIsIgnoredAmongOthers() {
+        // Our PID appears in the list (we're registered too); it must be filtered out, and the other
+        // PID (99) must still mark us as the duplicate.
+        XCTAssertTrue(SingleInstanceGuard.isDuplicate(myPID: 42, runningPIDs: [42, 99]))
+    }
+}

--- a/Tests/OpenUsageTests/SingleInstanceGuardTests.swift
+++ b/Tests/OpenUsageTests/SingleInstanceGuardTests.swift
@@ -2,29 +2,46 @@ import XCTest
 @testable import OpenUsage
 
 /// Covers the single-instance guard's decision logic (issue #635): given our PID and the PIDs of
-/// running apps sharing our bundle id, decide whether *this* launch is the duplicate that should bow
-/// out. The live `NSRunningApplication` query and the activate/terminate handoff are thin glue over
-/// this pure function and aren't unit-testable (they need a second running process).
+/// running apps sharing our bundle id, decide which instance we should yield to (lowest-PID-wins), or
+/// `nil` to keep running. The live `NSRunningApplication` query and the activate/terminate handoff are
+/// thin glue over this pure function and aren't unit-testable (they need a second running process).
 @MainActor
 final class SingleInstanceGuardTests: XCTestCase {
-    func testSoloLaunchIsNotADuplicate() {
+    func testSoloLaunchYieldsToNobody() {
         // Only our own process is running — nothing to defer to.
-        XCTAssertFalse(SingleInstanceGuard.isDuplicate(myPID: 42, runningPIDs: [42]))
+        XCTAssertNil(SingleInstanceGuard.instanceToYieldTo(myPID: 42, runningPIDs: [42]))
     }
 
-    func testNoRunningAppsIsNotADuplicate() {
-        // Defensive: an empty workspace result must never read as a duplicate.
-        XCTAssertFalse(SingleInstanceGuard.isDuplicate(myPID: 42, runningPIDs: []))
+    func testNoRunningAppsYieldsToNobody() {
+        // Defensive: an empty workspace result must never make us yield.
+        XCTAssertNil(SingleInstanceGuard.instanceToYieldTo(myPID: 42, runningPIDs: []))
     }
 
-    func testAnotherInstanceIsADuplicate() {
-        // A second copy (pid 7) already owns the slot — we're the duplicate.
-        XCTAssertTrue(SingleInstanceGuard.isDuplicate(myPID: 42, runningPIDs: [7, 42]))
+    func testYieldsToALowerPIDInstance() {
+        // A copy with a lower PID (7) already owns the slot — we yield to it.
+        XCTAssertEqual(SingleInstanceGuard.instanceToYieldTo(myPID: 42, runningPIDs: [7, 42]), 7)
     }
 
-    func testOurOwnPIDIsIgnoredAmongOthers() {
-        // Our PID appears in the list (we're registered too); it must be filtered out, and the other
-        // PID (99) must still mark us as the duplicate.
-        XCTAssertTrue(SingleInstanceGuard.isDuplicate(myPID: 42, runningPIDs: [42, 99]))
+    func testYieldsToTheLowestWhenSeveralAreLower() {
+        // The survivor is the single lowest PID, not just any lower one.
+        XCTAssertEqual(SingleInstanceGuard.instanceToYieldTo(myPID: 42, runningPIDs: [20, 9, 42]), 9)
+    }
+
+    func testSurvivesWhenWeAreTheLowestPID() {
+        // A higher-PID peer (99) yields to us, not the other way around — we keep running.
+        XCTAssertNil(SingleInstanceGuard.instanceToYieldTo(myPID: 42, runningPIDs: [42, 99]))
+    }
+
+    /// The headline regression test for the reboot race (cubic P1 / Bugbot): two launches that both
+    /// observe both PIDs must resolve to *exactly one* survivor — never zero (both terminate) and
+    /// never two. With lowest-PID-wins, the higher-PID launch yields and the lower-PID launch keeps
+    /// running.
+    func testSimultaneousLaunchLeavesExactlyOneSurvivor() {
+        let both: [pid_t] = [100, 101]
+        let lowerYieldsTo = SingleInstanceGuard.instanceToYieldTo(myPID: 100, runningPIDs: both)
+        let higherYieldsTo = SingleInstanceGuard.instanceToYieldTo(myPID: 101, runningPIDs: both)
+
+        XCTAssertNil(lowerYieldsTo)            // pid 100 keeps running
+        XCTAssertEqual(higherYieldsTo, 100)    // pid 101 yields to it
     }
 }


### PR DESCRIPTION
Closes #635.

## Problem
The Swift edition had **no single-instance guard**, so macOS could run two copies of OpenUsage at once:
- **Duplicate-on-reboot:** session restoration ("Reopen windows when logging back in") and the `SMAppService` login item both launch the app → two menu-bar icons.
- **Crash / "won't reopen":** a lingering crashed/hung copy still held `127.0.0.1:6736` (we have a log of `[localapi] disabled: ... Address already in use`), and a fresh launch wasn't rejected — for an `LSUIElement` app this reads as "nothing happens."

## Fix
Two pieces with distinct jobs, both at the top of `applicationDidFinishLaunching` (before the local-API port grab and the status item):

1. **Single-instance guard** — if another instance with our bundle id is already running, hand focus to it (`activate()`) and `NSApp.terminate(nil)`. This fixes the lingering-crash case. We `return` immediately after `terminate(_:)` because it unwinds asynchronously and is cancellable — otherwise the method keeps running and creates the very duplicate it should prevent.
2. **`NSApp.disableRelaunchOnLogin()`** — opt out of AppKit's reopen-on-login so only the login item drives startup. This removes the reboot restore-vs-login-item race the guard alone can't reliably win (both launches register near-simultaneously).

The decision is split into a pure `SingleInstanceGuard.isDuplicate(myPID:runningPIDs:)` so it's unit-testable without a second running process. `bundleIdentifier` is handled with `guard let` (not force-unwrap) so unbundled `swift run`/preview doesn't crash. Handoff is logged under a new `[lifecycle]` tag.

## Acceptance
- [x] Launching a second copy results in exactly one running instance / one menu-bar icon (manual).
- [x] Regression test covering the guard logic — `SingleInstanceGuardTests` (4 cases: solo, empty, another instance, own-PID-filtered).
- [x] `swift build` + `swift test` clean (248 + 3 tests pass, 4 new).

## Honest residual risk
The guard's decision is verified by tests; the live-workspace timing is not. If `disableRelaunchOnLogin` weren't honored and both reboot triggers fired within the same registration window, a rare double-launch could still slip through. That's a timing property, not logic — `disableRelaunchOnLogin` is specifically there to close it, and manual double-launch + reboot covers the rest. I deliberately did not add a distributed file lock the issue didn't call for.

## Files
- `Sources/OpenUsage/App/SingleInstanceGuard.swift` (new)
- `Sources/OpenUsage/App/OpenUsageApp.swift` (guard wired into launch)
- `Sources/OpenUsage/Support/AppLog.swift` (`+ case lifecycle`)
- `Tests/OpenUsageTests/SingleInstanceGuardTests.swift` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core launch path and termination timing; logic is unit-tested but live workspace timing on reboot could still rarely race if both triggers fire together.
> 
> **Overview**
> Fixes duplicate OpenUsage instances (double menu-bar icons and port `127.0.0.1:6736` conflicts) by rejecting extra launches **before** the local API or status item is created.
> 
> At the start of `applicationDidFinishLaunching`, after `AppLog.bootstrap()`, **`SingleInstanceGuard.deferToExistingInstance()`** looks up other processes with the same bundle ID. If a peer with a **lower PID** is running, the new copy **activates** that instance, logs under **`[lifecycle]`**, calls **`NSApp.terminate(nil)`**, and **returns immediately** so launch does not continue after async terminate.
> 
> The guard uses **`instanceToYieldTo`** (lowest-PID-wins) so two simultaneous startups do not both exit. **`NSApp.disableRelaunchOnLogin()`** limits post-reboot startup to the `SMAppService` login item instead of session restore racing it. Unbundled runs skip the guard when there is no bundle identifier.
> 
> **`SingleInstanceGuardTests`** cover solo launch, empty PID list, yielding to lower PIDs, surviving as lowest PID, and the simultaneous-launch regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c4d6648883fc1cfeab5c8957e97f544158fea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate app launches on macOS with a single-instance guard. Also disable AppKit relaunch-on-login to stop double-start on reboot.

- **Bug Fixes**
  - Use lowest‑PID tie‑break to ensure exactly one survivor; detect peer by bundle id, activate the survivor, terminate, and return to avoid a second menu‑bar icon.
  - Call `NSApp.disableRelaunchOnLogin()` so only the `SMAppService` login item starts the app after reboot.
  - Expose pure `instanceToYieldTo(myPID:runningPIDs:)` and add `SingleInstanceGuardTests` (incl. simultaneous‑launch regression); add `[lifecycle]` log tag.

<sup>Written for commit d0c4d6648883fc1cfeab5c8957e97f544158fea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

