### PR TITLE
feat(codex): show rate limit resets

### DIFF
--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -91,6 +91,21 @@ extension WidgetDescriptor {
         return make(id: id, provider: provider, metricLabel: metricLabel ?? title, sample: sample)
     }
 
+    /// Unbounded count rendered verbatim from the provider's `.text` line (e.g. Codex rate-limit
+    /// resets "1 available"); the parsed count still feeds the menu-bar tile's compact value, so the
+    /// tray and the popover never diverge.
+    static func verbatimCount(
+        id: String,
+        provider: Provider,
+        title: String,
+        metricLabel: String? = nil
+    ) -> WidgetDescriptor {
+        var sample = WidgetData(title: title, icon: provider.icon,
+                                kind: .count, used: 0, limit: nil)
+        sample.preservesRawText = true
+        return make(id: id, provider: provider, metricLabel: metricLabel ?? title, sample: sample)
+    }
+
     /// Unbounded count resolved from a provider `.badge` line via `valueTextOverride`
     /// (e.g. Grok pay-as-you-go).
     static func badge(

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -25,7 +25,7 @@ final class CodexProvider: ProviderRuntime {
         [
             .percent(id: "codex.session", provider: provider, title: "Session"),
             .percent(id: "codex.weekly", provider: provider, title: "Weekly"),
-            .badge(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
+            .verbatimCount(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
             .verbatimDollars(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
             .spend(id: "codex.today", provider: provider, title: "Today", estimated: true),
             .spend(id: "codex.yesterday", provider: provider, title: "Yesterday", estimated: true),

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -25,6 +25,7 @@ final class CodexProvider: ProviderRuntime {
         [
             .percent(id: "codex.session", provider: provider, title: "Session"),
             .percent(id: "codex.weekly", provider: provider, title: "Weekly"),
+            .badge(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
             .verbatimDollars(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
             .spend(id: "codex.today", provider: provider, title: "Today", estimated: true),
             .spend(id: "codex.yesterday", provider: provider, title: "Yesterday", estimated: true),

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -72,14 +72,12 @@ enum CodexUsageMapper {
         appendReviewLimit(from: body, to: &lines, now: now)
 
         // On-demand rate-limit reset credits ("N available"), shown before Credits — mirrors the JS
-        // plugin (PR #577). Rendered as a badge so it can also back a pinnable widget tile verbatim.
+        // plugin (PR #577). A verbatim `.text` line (backed by a `verbatimCount` widget tile) so every
+        // surface resolves from one value: the dashboard/popover read "N available" while the menu-bar
+        // tile shows the parsed count — they never diverge.
         if let resets = readResetCredits(body), resets >= 0 {
             let count = Int(resets.rounded(.down))
-            lines.append(.badge(
-                label: "Rate Limit Resets",
-                text: "\(count) available",
-                colorHex: count > 0 ? "#22c55e" : "#a3a3a3"
-            ))
+            lines.append(.text(label: "Rate Limit Resets", value: "\(count) available"))
         }
 
         if let remaining = readCreditsRemaining(response: response, body: body) {

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -71,6 +71,17 @@ enum CodexUsageMapper {
         appendAdditionalRateLimits(from: body, to: &lines, now: now)
         appendReviewLimit(from: body, to: &lines, now: now)
 
+        // On-demand rate-limit reset credits ("N available"), shown before Credits — mirrors the JS
+        // plugin (PR #577). Rendered as a badge so it can also back a pinnable widget tile verbatim.
+        if let resets = readResetCredits(body), resets >= 0 {
+            let count = Int(resets.rounded(.down))
+            lines.append(.badge(
+                label: "Rate Limit Resets",
+                text: "\(count) available",
+                colorHex: count > 0 ? "#22c55e" : "#a3a3a3"
+            ))
+        }
+
         if let remaining = readCreditsRemaining(response: response, body: body) {
             lines.append(.text(label: "Credits", value: creditsLabel(remaining: remaining)))
         }
@@ -170,6 +181,13 @@ enum CodexUsageMapper {
         let credits = max(0, Int(remaining.rounded(.down)))
         let usd = Double(credits) * creditUSDRate
         return Formatters.currency(usd) + " · \(credits.formatted(.number.locale(Locale(identifier: "en_US")))) credits"
+    }
+
+    /// On-demand reset credits from `rate_limit_reset_credits.available_count`. `ProviderParse.number`
+    /// returns nil for missing/null/non-numeric values, so malformed counts are skipped (matches JS).
+    private static func readResetCredits(_ body: [String: Any]) -> Double? {
+        guard let resets = body["rate_limit_reset_credits"] as? [String: Any] else { return nil }
+        return ProviderParse.number(resets["available_count"])
     }
 
     private static func readCreditsRemaining(response: HTTPResponse, body: [String: Any]) -> Double? {

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -245,7 +245,10 @@ final class WidgetDataStore {
                             unboundedValueWord: sample.unboundedValueWord)
         case .count:
             guard let count = Self.firstNumber(in: value) else { return sample }
+            // A raw-text descriptor shows the provider's line verbatim (the parsed count above still
+            // feeds the menu bar's compact value); otherwise the value is reformatted from `used`.
             return textData(sample, kind: .count, used: count, limit: sample.limit,
+                            valueTextOverride: sample.preservesRawText ? value : nil,
                             unboundedValueWord: sample.unboundedValueWord)
         case .percent:
             guard let percent = Self.firstNumber(in: value) else { return sample }

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -104,8 +104,7 @@ final class CodexUsageMapperTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
-        XCTAssertEqual(badge(mapped.lines, "Rate Limit Resets")?.text, "1 available")
-        XCTAssertEqual(badge(mapped.lines, "Rate Limit Resets")?.colorHex, "#22c55e")
+        XCTAssertEqual(text(mapped.lines, "Rate Limit Resets"), "1 available")
 
         let resetIndex = mapped.lines.firstIndex { $0.label == "Rate Limit Resets" }
         let creditsIndex = mapped.lines.firstIndex { $0.label == "Credits" }
@@ -116,7 +115,7 @@ final class CodexUsageMapperTests: XCTestCase {
         }
     }
 
-    func testShowsZeroRateLimitResetsAsMutedBadge() throws {
+    func testShowsZeroRateLimitResets() throws {
         let body = Data(#"{ "rate_limit_reset_credits": { "available_count": 0 } }"#.utf8)
         let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
 
@@ -125,8 +124,7 @@ final class CodexUsageMapperTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
-        XCTAssertEqual(badge(mapped.lines, "Rate Limit Resets")?.text, "0 available")
-        XCTAssertEqual(badge(mapped.lines, "Rate Limit Resets")?.colorHex, "#a3a3a3")
+        XCTAssertEqual(text(mapped.lines, "Rate Limit Resets"), "0 available")
     }
 
     func testOmitsRateLimitResetsWhenCountMalformed() throws {
@@ -138,7 +136,7 @@ final class CodexUsageMapperTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
-        XCTAssertNil(badge(mapped.lines, "Rate Limit Resets"))
+        XCTAssertNil(text(mapped.lines, "Rate Limit Resets"))
     }
 
     private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
@@ -153,13 +151,6 @@ final class CodexUsageMapperTests: XCTestCase {
             return nil
         }
         return value
-    }
-
-    private func badge(_ lines: [MetricLine], _ label: String) -> (text: String, colorHex: String?)? {
-        guard case .badge(_, let text, let colorHex, _) = lines.first(where: { $0.label == label }) else {
-            return nil
-        }
-        return (text, colorHex)
     }
 
     private func makeDate(_ value: String) -> Date {

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -90,6 +90,57 @@ final class CodexUsageMapperTests: XCTestCase {
         XCTAssertEqual(CodexUsageMapper.creditsLabel(remaining: 30000), "$1,200.00 · 30,000 credits")
     }
 
+    func testShowsRateLimitResetsBeforeCredits() throws {
+        let body = Data("""
+        {
+          "rate_limit_reset_credits": { "available_count": 1 },
+          "credits": { "balance": 100 }
+        }
+        """.utf8)
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            response,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertEqual(badge(mapped.lines, "Rate Limit Resets")?.text, "1 available")
+        XCTAssertEqual(badge(mapped.lines, "Rate Limit Resets")?.colorHex, "#22c55e")
+
+        let resetIndex = mapped.lines.firstIndex { $0.label == "Rate Limit Resets" }
+        let creditsIndex = mapped.lines.firstIndex { $0.label == "Credits" }
+        XCTAssertNotNil(resetIndex)
+        XCTAssertNotNil(creditsIndex)
+        if let resetIndex, let creditsIndex {
+            XCTAssertLessThan(resetIndex, creditsIndex)
+        }
+    }
+
+    func testShowsZeroRateLimitResetsAsMutedBadge() throws {
+        let body = Data(#"{ "rate_limit_reset_credits": { "available_count": 0 } }"#.utf8)
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            response,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertEqual(badge(mapped.lines, "Rate Limit Resets")?.text, "0 available")
+        XCTAssertEqual(badge(mapped.lines, "Rate Limit Resets")?.colorHex, "#a3a3a3")
+    }
+
+    func testOmitsRateLimitResetsWhenCountMalformed() throws {
+        let body = Data(#"{ "rate_limit_reset_credits": { "available_count": null } }"#.utf8)
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            response,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertNil(badge(mapped.lines, "Rate Limit Resets"))
+    }
+
     private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
         guard case .progress(_, let used, let limit, _, let resetsAt, let periodDurationMs, _) = lines.first(where: { $0.label == label }) else {
             return nil
@@ -102,6 +153,13 @@ final class CodexUsageMapperTests: XCTestCase {
             return nil
         }
         return value
+    }
+
+    private func badge(_ lines: [MetricLine], _ label: String) -> (text: String, colorHex: String?)? {
+        guard case .badge(_, let text, let colorHex, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return (text, colorHex)
     }
 
     private func makeDate(_ value: String) -> Date {

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -205,6 +205,43 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(used.headline, remaining.headline)
     }
 
+    func testRateLimitResetsTileShowsCountInTrayAndRawTextInPopover() async {
+        // Regression: the menu-bar tile and the popover row must resolve from one value. The provider
+        // line is "1 available" — the popover shows it verbatim while the tray uses the parsed count.
+        // A prior bug backed the tile with display text only, leaving `used` at 0, so a pinned tile
+        // read "0" while the popover correctly read "1 available".
+        let provider = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+        let descriptor = WidgetDescriptor.verbatimCount(
+            id: "codex.rateLimitResets",
+            provider: provider,
+            title: "Rate Limit Resets",
+            metricLabel: "Rate Limit Resets"
+        )
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.text(label: "Rate Limit Resets", value: "1 available")]
+            )
+        )
+        let defaults = makeUserDefaults("codex-resets")
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() }),
+            defaults: defaults
+        )
+        await store.refreshAll()
+
+        let data = store.data(for: descriptor)
+        XCTAssertTrue(data.hasData)
+        XCTAssertFalse(data.isBounded)
+        XCTAssertEqual(data.unboundedDetail, "1 available")   // popover row
+        XCTAssertEqual(data.displayedValue, 1)                // menu-bar tile's compact value
+    }
+
     func testCreditsLabelFloorsAndClampsBalance() {
         XCTAssertEqual(CodexUsageMapper.creditsLabel(remaining: 820.9), "$32.80 · 820 credits")
         XCTAssertEqual(CodexUsageMapper.creditsLabel(remaining: -5), "$0.00 · 0 credits")

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -8,6 +8,7 @@ Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI
 |---|---|
 | Session | 5-hour rolling window usage |
 | Weekly | 7-day window usage |
+| Rate Limit Resets | On-demand rate-limit reset credits, shown as e.g. `1 available` |
 | Extra Usage | Flex credits, shown verbatim as dollars + credits (e.g. `$31.84 · 796 credits`) |
 | Today / Yesterday / Last 30 Days | Local spend estimates (see below) |
 | Plan | Your plan name (optional widget) |
@@ -29,3 +30,5 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Codex logs b
 ## Under the hood
 
 `GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry.
+
+When the response includes `rate_limit_reset_credits.available_count`, OpenUsage shows that count as the "Rate Limit Resets" row (e.g. `1 available`), placed before Credits.


### PR DESCRIPTION
## What Changed

Ports the on-demand **rate-limit reset credits** feature from the JS/Tauri edition (merged in [#577](https://github.com/robinebers/openusage/pull/577)) into the native Swift edition.

- `CodexUsageMapper` reads `rate_limit_reset_credits.available_count` from the `wham/usage` response and appends a **Rate Limit Resets** row (e.g. `1 available`) **before** Credits. Malformed/`null` counts are skipped via `ProviderParse.number` (matches the JS guard).
- Exposed as a pinnable menu-bar widget tile (`codex.rateLimitResets`), available in the Add-Widget gallery — not placed/pinned by default, matching how `codex.credits` behaves.

## Implementation note (value plumbing)

The metric is a **verbatim `.text` row** backed by a new `verbatimCount` widget descriptor — the count-flavored twin of the existing `verbatimDollars` used by Credits. This keeps every surface resolving from one `WidgetData`:

- popover / dashboard row → `1 available`
- menu-bar tile → `1` (compact)

An earlier revision modeled this as a `.badge`, which carries only a display string and left `used = 0`, so a pinned tile read `0` while the popover read `1 available`. Switching to the `verbatimCount`/`.text` path (which sets the numeric `used` *and* preserves the raw text) fixed that divergence.

The deeper smell that made the bug possible — formatting a number into a string in the mapper, then re-parsing it back out for the tile — is pre-existing (Credits does the same) and tracked as follow-up tech-debt in **#641**.

## Why

Codex grants on-demand rate-limit resets, but the Swift edition ignored the new usage API field. Tracks issue #597 (migrated from the Swift tracker).

## Verification

- `swift build` — clean.
- `swift test` — 248 passed, 1 pre-existing skip, 0 failures.
  - `CodexUsageMapperTests`: resets shown before Credits (`1 available`); zero count (`0 available`); malformed/`null` omitted.
  - `WidgetDataStoreTests`: regression test asserting the tile resolves `displayedValue == 1` (tray) **and** `unboundedDetail == "1 available"` (popover) from one `WidgetData`.
- Manually verified against the live API: pinned tile reads `1`, popover row reads `1 available`.

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)