### PR TITLE
feat(footer): collapse Customize button into a More menu

### DIFF
--- a/Sources/OpenUsage/Support/AboutPanel.swift
+++ b/Sources/OpenUsage/Support/AboutPanel.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+/// Presents the standard macOS About panel for the footer menu's "About OpenUsage" item.
+///
+/// As a menu-bar accessory app, OpenUsage is not the active app while the popover is showing, so the
+/// app is activated first — otherwise the panel would open behind whatever app currently owns the
+/// foreground. The panel pulls the app icon, name, and version (`CFBundleShortVersionString` — the
+/// same string `AppInfo.version` surfaces in the footer) straight from the bundle; we only supply the
+/// credits line, naming the maintainers and linking the GitHub repo.
+enum AboutPanel {
+    @MainActor
+    static func present() {
+        NSApp.activate(ignoringOtherApps: true)
+        NSApplication.shared.orderFrontStandardAboutPanel(options: [.credits: credits])
+    }
+
+    /// Centered, secondary-styled credits with the same two links as the rest of the app: the author's
+    /// page and the GitHub repo. The standard panel renders `.link`-attributed runs as clickable.
+    private static var credits: NSAttributedString {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+
+        let base: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 11),
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .paragraphStyle: paragraph,
+        ]
+
+        let credits = NSMutableAttributedString()
+        credits.append(NSAttributedString(string: "Created by ", attributes: base))
+        credits.append(link("Robin Ebers", "https://itsbyrob.in/x", base: base))
+        credits.append(NSAttributedString(string: "\nMaintained also by ", attributes: base))
+        credits.append(link("Mert", "https://github.com/validatedev", base: base))
+        credits.append(NSAttributedString(string: " & ", attributes: base))
+        credits.append(link("David", "https://github.com/davidarny", base: base))
+        credits.append(NSAttributedString(string: "\n\nOpen source on ", attributes: base))
+        credits.append(link("GitHub", "https://github.com/robinebers/openusage", base: base))
+        return credits
+    }
+
+    private static func link(_ text: String, _ urlString: String, base: [NSAttributedString.Key: Any]) -> NSAttributedString {
+        var attributes = base
+        if let url = URL(string: urlString) {
+            attributes[.link] = url
+        }
+        return NSAttributedString(string: text, attributes: attributes)
+    }
+}

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -1,26 +1,22 @@
+import AppKit
 import SwiftUI
 
-/// Footer Customize + Settings round glass buttons. Each toggles its in-popover screen: the active
-/// screen's button becomes a prominent checkmark "Done", clicking it returns to the dashboard, and
-/// clicking the other button switches screens directly.
+/// Footer "More" menu + Settings round glass buttons. The Settings button is unchanged: it toggles
+/// the in-popover Settings screen and its active state becomes a prominent checkmark "Done". The
+/// leading control is the same round glass button that pops a "More" pull-down (Customize Metrics /
+/// About / Quit); while the Customize screen is open it morphs into the prominent "Done" button that
+/// returns to the dashboard, so Customize keeps a visible exit (Esc also backs out).
 struct HeaderView: View {
     @Environment(LayoutStore.self) private var layout
+    /// Anchors the "More" pull-down under its button. `@State` keeps one stable instance.
+    @State private var moreMenuAnchor = PopUpMenuAnchor()
 
     var body: some View {
         // Group the adjacent glass buttons so the system samples them coherently (glass cannot sample
         // other glass). The gap stays wider than the container's merge distance, so they read as two
         // distinct circles rather than blending into one pill.
         HStack(spacing: 12) {
-            roundButton(
-                layout.screen == .customize ? "Done" : "Customize",
-                systemImage: layout.screen == .customize ? "checkmark" : "slider.horizontal.3",
-                // Prominent (accent-filled) glass marks the active screen; plain glass otherwise.
-                prominent: layout.screen == .customize
-            ) {
-                toggle(.customize)
-            }
-            // Plain Return (not .defaultAction, which would restyle the glass button as default).
-            .keyboardShortcut(.return, modifiers: [])
+            leadingControl
 
             roundButton(
                 layout.screen == .settings ? "Done" : "Settings",
@@ -33,6 +29,45 @@ struct HeaderView: View {
             .keyboardShortcut(",", modifiers: .command)
         }
         .glassButtonGroup(spacing: 4)
+    }
+
+    /// While the Customize screen is open the slot is the prominent "Done" button — clicking it (or ⏎)
+    /// returns to the dashboard, matching how the old Customize button behaved. Otherwise it's the
+    /// "More" button: the same round glass control, opening a pull-down whose "Customize Metrics" item
+    /// is the way into Customize.
+    @ViewBuilder
+    private var leadingControl: some View {
+        if layout.screen == .customize {
+            roundButton("Done", systemImage: "checkmark", prominent: true) {
+                toggle(.customize)
+            }
+            // Plain Return (not .defaultAction, which would restyle the glass button as default).
+            .keyboardShortcut(.return, modifiers: [])
+        } else {
+            roundButton("More", systemImage: "ellipsis", prominent: false) {
+                presentMoreMenu()
+            }
+            // The anchor view fills the button's frame so the menu drops from directly under it.
+            .background(PopUpMenuAnchorView(anchor: moreMenuAnchor))
+        }
+    }
+
+    /// Builds and pops the "More" pull-down as a native `NSMenu`, so the trigger stays the exact glass
+    /// `roundButton` (a SwiftUI `Menu` styled as a button does not match it). Quit carries the standard
+    /// ⌘Q equivalent.
+    private func presentMoreMenu() {
+        let menu = NSMenu()
+        menu.addItem(ClosureMenuItem(title: "Customize Metrics", systemSymbol: "slider.horizontal.3") {
+            toggle(.customize)
+        })
+        menu.addItem(.separator())
+        menu.addItem(ClosureMenuItem(title: "About OpenUsage", systemSymbol: "info.circle") {
+            AboutPanel.present()
+        })
+        menu.addItem(ClosureMenuItem(title: "Quit OpenUsage", systemSymbol: "power", keyEquivalent: "q") {
+            NSApplication.shared.terminate(nil)
+        })
+        moreMenuAnchor.present(menu)
     }
 
     private func toggle(_ screen: PopoverScreen) {

--- a/Sources/OpenUsage/Views/PopUpMenuAnchor.swift
+++ b/Sources/OpenUsage/Views/PopUpMenuAnchor.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+
+/// Bridges a SwiftUI glass button to a native `NSMenu` pull-down. A SwiftUI `Menu` styled as a button
+/// won't match the footer's round glass buttons — `.menuStyle(.button)` reserves its own indicator
+/// chrome and shape — so instead the footer keeps its exact `roundButton` (the proven glass control)
+/// and pops a real `NSMenu` anchored to it. Only the menu presentation crosses into AppKit; the button
+/// itself stays pure SwiftUI.
+///
+/// Popping a real `NSMenu` also plays nicely with the popover, which already keeps itself open when an
+/// `NSMenu`-backed window appears (see `StatusItemController.shouldKeepPopoverOpen`).
+
+/// Holds the hosted anchor view so the button's action can pop a menu positioned under it. `@State`
+/// keeps one instance stable across re-renders; the view reference is weak so it never outlives layout.
+@MainActor
+final class PopUpMenuAnchor {
+    weak var view: NSView?
+
+    /// Drops `menu` from the anchor's bottom-leading corner. SwiftUI hosts representables in flipped
+    /// views, so `bounds.maxY` is the button's bottom edge — the menu opens downward from there, and
+    /// macOS flips it upward automatically near the screen edge.
+    func present(_ menu: NSMenu) {
+        guard let view else { return }
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: view.bounds.maxY + 4), in: view)
+    }
+}
+
+/// A zero-cost background view that captures its hosted `NSView` into the shared anchor. Placed via
+/// `.background(...)`, it fills the button's frame, so the captured view's bounds match the button.
+struct PopUpMenuAnchorView: NSViewRepresentable {
+    let anchor: PopUpMenuAnchor
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        anchor.view = view
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        anchor.view = nsView
+    }
+}
+
+/// An `NSMenuItem` that runs a closure when selected, so menus can be built inline without a separate
+/// target/action object. `keyEquivalent` defaults to none; when set it uses the ⌘ modifier (the
+/// standard for menu shortcuts like ⌘Q).
+@MainActor
+final class ClosureMenuItem: NSMenuItem {
+    private let handler: () -> Void
+
+    init(title: String, systemSymbol: String? = nil, keyEquivalent: String = "", handler: @escaping () -> Void) {
+        self.handler = handler
+        super.init(title: title, action: #selector(fire), keyEquivalent: keyEquivalent)
+        target = self
+        if let systemSymbol {
+            image = NSImage(systemSymbolName: systemSymbol, accessibilityDescription: nil)
+        }
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) is not used")
+    }
+
+    @objc private func fire() {
+        handler()
+    }
+}

--- a/Sources/OpenUsage/Views/PopUpMenuAnchor.swift
+++ b/Sources/OpenUsage/Views/PopUpMenuAnchor.swift
@@ -16,9 +16,9 @@ import SwiftUI
 final class PopUpMenuAnchor {
     weak var view: NSView?
 
-    /// Drops `menu` from the anchor's bottom-leading corner. SwiftUI hosts representables in flipped
-    /// views, so `bounds.maxY` is the button's bottom edge — the menu opens downward from there, and
-    /// macOS flips it upward automatically near the screen edge.
+    /// Drops `menu` from the anchor's bottom-leading corner. The anchor is a flipped view (see
+    /// `FlippedAnchorView`), so `bounds.maxY` is the button's bottom edge — the menu opens downward
+    /// from there, and macOS flips it upward automatically near the screen edge.
     func present(_ menu: NSMenu) {
         guard let view else { return }
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: view.bounds.maxY + 4), in: view)
@@ -31,7 +31,7 @@ struct PopUpMenuAnchorView: NSViewRepresentable {
     let anchor: PopUpMenuAnchor
 
     func makeNSView(context: Context) -> NSView {
-        let view = NSView()
+        let view = FlippedAnchorView()
         anchor.view = view
         return view
     }
@@ -39,6 +39,12 @@ struct PopUpMenuAnchorView: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {
         anchor.view = nsView
     }
+}
+
+/// A flipped anchor so `bounds.maxY` is the button's *bottom* edge — a plain `NSView` is unflipped
+/// (origin bottom-left), which would put `maxY` at the top and attach the menu to the wrong edge.
+private final class FlippedAnchorView: NSView {
+    override var isFlipped: Bool { true }
 }
 
 /// An `NSMenuItem` that runs a closure when selected, so menus can be built inline without a separate


### PR DESCRIPTION
Implements #636.

## What

Replaces the footer's **Customize** round-glass button with a **More** overflow menu (ellipsis). The **Settings** button and its ⌘, shortcut are unchanged.

Menu items:
- **Customize Metrics** — enters the Customize screen
- *(separator)*
- **About OpenUsage** — standard macOS About panel
- **Quit OpenUsage** (⌘Q)

## How

- The "More" control reuses the **exact** glass `roundButton` and pops a native `NSMenu`. A SwiftUI `Menu` styled as a button reserves its own indicator/shape chrome and won't match the round glass circles, so the trigger stays pure SwiftUI and only the menu presentation crosses into AppKit (`PopUpMenuAnchor`). A real `NSMenu` window is also exactly what the popover's existing `shouldKeepPopoverOpen` logic keeps the popover open for.
- While the Customize screen is open the slot **morphs into the prominent ✓ "Done" button** (⏎ to exit) so Customize keeps a visible exit; Esc still backs out too.
- `AboutPanel` presents `orderFrontStandardAboutPanel` (activating the accessory app first) with credits naming the maintainers and linking the repo.

## Notes

- Liquid Glass on Tahoe + the macOS 15 bordered fallback are both preserved (no new `#available` branches — the existing `glassButtonStyle()` helper covers it).
- ⌘Q lives on the menu item (active while the menu/popover is key); there's no app main menu, so it isn't a global hotkey — out of scope for this change.
- This PR targets `swift`, not the default branch, so the `Implements #636` reference won't auto-close the issue on merge — close manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Footer UI and navigation only; Quit calls `terminate` as expected for a menu-bar app with no new security or data paths.
> 
> **Overview**
> The footer’s leading **Customize** glass button is replaced by a **More** (ellipsis) control that opens a native pull-down while **Settings** and ⌘, stay the same.
> 
> **Customize Metrics** still enters the customize screen; when that screen is open the leading slot becomes the prominent **Done** button (Return), matching the old exit behavior. The menu also adds **About OpenUsage** via a new `AboutPanel` (activates the accessory app, then the standard About panel with maintainer/repo credits) and **Quit OpenUsage** with ⌘Q.
> 
> Presentation uses `PopUpMenuAnchor` / `ClosureMenuItem` so the trigger stays the existing round glass `roundButton` and an `NSMenu` drops under it—aligned with existing popover logic that keeps the popover open for menu-backed windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d2de3be36fb79e1bcd0cee9284f674556e86e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the footer’s Customize button with a “More” (ellipsis) menu while keeping the round-glass style. Also fixed the menu anchor to a flipped view so the pull‑down opens from the button’s bottom edge.

- **New Features**
  - “More” menu: Customize Metrics, About OpenUsage, Quit OpenUsage (⌘Q).
  - When Customize is open, the button becomes a prominent “Done” (Return exits; Esc also backs out).
  - Uses a native NSMenu anchored via PopUpMenuAnchor to match the glass button and keep the popover open.
  - Adds AboutPanel to show the standard macOS About panel with credits and repo links.

- **Bug Fixes**
  - Anchor uses a flipped view to ensure the menu drops from the button’s bottom edge on all screens.

<sup>Written for commit a6d2de3be36fb79e1bcd0cee9284f674556e86e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

