### PR TITLE
test: manual repro script for the single-instance guard (#635)

### DIFF
--- a/script/verify_single_instance.sh
+++ b/script/verify_single_instance.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Manual integration repro for the single-instance guard (issue #635, SingleInstanceGuard.swift).
+#
+# The guard rejects a second copy of OpenUsage at launch. The hard case it targets is a reboot, where
+# macOS session restoration ("Reopen windows when logging back in") and the SMAppService login item
+# fire two launches at once. But the guard never asks *why* a second launch happened — it only sees
+# "is another instance of my bundle id alive?". A reboot is just one way to produce concurrent
+# launches; `open -n` (force a new instance, bypassing LaunchServices' dedup) is another. So this
+# script exercises the exact guard code path WITHOUT a reboot.
+#
+# CI can't run this (no window server, no signing identity), so it is a local tool — not wired into
+# `swift test`. The deterministic decision (lowest-PID-wins tie-break) is unit-tested in
+# SingleInstanceGuardTests; this confirms the live wiring on a real signed .app.
+#
+# It drives the DEV build only (bundle id com.robinebers.openusage.dev), and counts/kills by bundle
+# PATH, so it never touches an installed com.robinebers.openusage. Requires the guard to be present in
+# the build (merge/checkout PR #637 first), otherwise every scenario "fails" because nothing dedupes.
+#
+# Usage: script/verify_single_instance.sh
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP="$ROOT_DIR/dist/OpenUsage.app"
+# Path-scoped so pgrep/pkill match only this dev build, never an installed copy of the same name.
+PATTERN="$APP/Contents/MacOS/OpenUsage"
+FAILED=0
+
+count() { pgrep -f "$PATTERN" 2>/dev/null | wc -l | tr -d ' '; }
+kill_dev() { pkill -f "$PATTERN" 2>/dev/null || true; }
+guard_logged_handoff() {
+  log show --last 30s --info --predicate 'process == "OpenUsage"' 2>/dev/null \
+    | grep -q "duplicate launch detected"
+}
+
+trap 'kill_dev; sleep 1' EXIT
+
+assert_eq() { # label expected actual
+  if [ "$2" = "$3" ]; then echo "  ✓ $1 (got $3)"; else echo "  ✗ $1 (expected $2, got $3)"; FAILED=1; fi
+}
+assert_ge() { # label min actual
+  if [ "$3" -ge "$2" ]; then echo "  ✓ $1 (got $3)"; else echo "  ✗ $1 (expected ≥ $2, got $3)"; FAILED=1; fi
+}
+
+if [ ! -d "$APP" ]; then
+  echo "==> staging dev app (dist/OpenUsage.app)…"
+  "$ROOT_DIR/script/build_and_run.sh" build
+fi
+
+echo "== A. a second launch is rejected (duplicate / lingering case) =="
+kill_dev; sleep 1
+open -n "$APP"; sleep 2          # instance 1 takes the slot
+open -n "$APP"; sleep 2          # instance 2 should detect it, hand off, and terminate
+assert_eq "exactly one instance survives" 1 "$(count)"
+if guard_logged_handoff; then echo "  ✓ guard logged the handoff"; else echo "  ⚠ no [lifecycle] handoff line found (verify manually)"; fi
+kill_dev; sleep 1
+
+echo "== B. simultaneous race ×15 (the reboot scenario) — must NEVER drop to zero =="
+# The regression this guards against: the old 'yield to any other instance' rule made both
+# simultaneous launches terminate (zero instances). With lowest-PID-wins the count is always ≥ 1.
+# A transient 2 is the NSRunningApplication ceiling (neither launch registered before the other
+# evaluated), not a logic bug — reported, not failed.
+ones=0; twos=0
+for i in $(seq 1 15); do
+  open -n "$APP" & open -n "$APP" &
+  wait; sleep 2
+  n="$(count)"
+  assert_ge "run $i never zero" 1 "$n"
+  [ "$n" = 1 ] && ones=$((ones + 1))
+  [ "$n" = 2 ] && twos=$((twos + 1))
+  kill_dev; sleep 1
+done
+echo "  → exactly-one: $ones/15   transient-two: $twos/15"
+
+echo "== C. a hung instance still holding 127.0.0.1:6736 (the crash report) =="
+kill_dev; sleep 1
+open -n "$APP"; sleep 2
+first="$(pgrep -f "$PATTERN" | head -1)"
+kill -STOP "$first" 2>/dev/null || true     # freeze instance 1; it keeps the port
+if lsof -nP -iTCP:6736 -sTCP:LISTEN >/dev/null 2>&1; then echo "  • port 6736 still held by the frozen instance"; else echo "  • (port not detected — continuing)"; fi
+open -n "$APP"; sleep 2
+assert_eq "new launch defers to the frozen instance" 1 "$(count)"
+kill -CONT "$first" 2>/dev/null || true
+kill_dev; sleep 1
+
+echo
+if [ "$FAILED" = 0 ]; then echo "PASS"; else echo "FAIL"; fi
+exit "$FAILED"


### PR DESCRIPTION
Companion to #637. Adds a **local integration repro** for the single-instance guard so its behavior can be verified **without rebooting**.

## Why this works without a reboot
The guard never asks *why* a second launch happened — it only checks "is another instance of my bundle id alive?". A reboot (session-restore + login item firing at once) is just one way to produce concurrent launches; `open -n` (force a new instance, bypassing LaunchServices' dedup) is another. So the script drives the *exact* guard code path on demand.

## `script/verify_single_instance.sh`
Three scenarios with pass/fail assertions. Drives the **dev** build only (`com.robinebers.openusage.dev`) and counts/kills by bundle **path**, so it never touches an installed `com.robinebers.openusage`:

| | scenario | assertion |
|---|---|---|
| **A** | second launch after one is running | exactly **1** survives + `[lifecycle]` handoff logged |
| **B** | two simultaneous launches ×15 (the reboot case) | count **never drops to 0** — the regression the lowest-PID tie-break fixes; a transient 2 (registration latency) is reported, not failed |
| **C** | hung instance frozen with `kill -STOP` still holding `:6736` | new launch **defers**, exactly 1 |

## Scope / caveats
- **Not run in CI** (no window server, no signing identity) and intentionally not wired into `swift test`. The deterministic decision is already unit-tested in `SingleInstanceGuardTests` (#637); this confirms the live wiring on a real signed `.app`.
- **Depends on #637** — the guard must be present in the build, or every scenario "fails" because nothing dedupes. Merge #637 first.
- The only thing this *can't* prove is whether `disableRelaunchOnLogin()` actually suppresses macOS session restoration — that's an OS behavior needing a real reboot, and the guard already covers the case where it doesn't.

`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New manual test script only; no runtime app or CI behavior changes.
> 
> **Overview**
> Adds **`script/verify_single_instance.sh`**, a **local-only** integration harness for the single-instance guard (companion to #637). It uses **`open -n`** on `dist/OpenUsage.app` to mimic concurrent launches without rebooting, scoped to the dev build via path-based `pgrep`/`pkill` so production installs are untouched.
> 
> The script runs **three asserted scenarios**: a second launch leaves exactly one process (optional check for a `[lifecycle]` handoff log line); **15 paired simultaneous launches** must never settle at zero instances (regression for lowest-PID-wins); and a **`kill -STOP`** frozen instance holding port **6736** should still win so a new launch defers. It can auto-stage the app via `script/build_and_run.sh build`, cleans up on exit, and is **not** wired into CI or `swift test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36497372c2bc4b4dc7dd87ee193d059648745eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local repro script to verify the single‑instance guard without rebooting, using `open -n` to drive concurrent launches against the dev app. This makes it easy to confirm the lowest‑PID tie‑break and live wiring without touching an installed build.

- **New Features**
  - Adds `script/verify_single_instance.sh` to test the guard on `com.robinebers.openusage.dev`.
  - Scenarios: second launch rejected; 15× simultaneous launches never drop to 0; hung instance on `:6736` defers.
  - Path-scoped counting/killing to avoid installed copies; not run in CI; requires the guard from #637.

<sup>Written for commit 36497372c2bc4b4dc7dd87ee193d059648745eee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

