### PR TITLE
feat: split spend into cost/tokens, carry raw metric values (#641, #647)

### DIFF
--- a/Sources/OpenUsage/Models/MenuBarContent.swift
+++ b/Sources/OpenUsage/Models/MenuBarContent.swift
@@ -83,39 +83,11 @@ enum MenuBarContentBuilder {
         MenuBarContent.Metric(
             id: descriptor.id,
             label: trayLabel(descriptor.metricLabel),
-            value: trayValue(data),
+            value: data.menuBarValue,
             fraction: data.fraction,
             isBounded: data.isBounded,
             hasData: data.hasData
         )
-    }
-
-    /// The tray value: a bounded metric (anything with a bar) reads as a percentage for a quick glance —
-    /// regardless of unit, so Cursor Credits shows e.g. "67%" not "$12,923". Unbounded metrics
-    /// (today/yesterday spend, raw balances) keep their value, compacted for the tray. Follows the global
-    /// used/left meter style via `displayedValue`, and passes the no-data marker through.
-    private static func trayValue(_ data: WidgetData) -> String {
-        guard data.hasData else { return data.valueText }
-        if let limit = data.limit, limit > 0 {
-            let percent = max(0, Int((data.displayedValue / limit * 100).rounded()))
-            return "\(percent)%"
-        }
-        return compactValue(data.displayedValue, kind: data.kind, countSuffix: data.countSuffix)
-    }
-
-    /// Compact, glanceable formatting for unbounded tray values using the platform's standard compact
-    /// notation (12.9K / 3.4M / 1.2B). Values shown in full (< 1,000) drop their decimals. Pinned to
-    /// en_US so USD-denominated numbers render consistently regardless of system locale.
-    private static func compactValue(_ value: Double, kind: MetricKind, countSuffix: String?) -> String {
-        let locale = Locale(identifier: "en_US")
-        let number = abs(value) < 1000
-            ? value.formatted(.number.precision(.fractionLength(0)).locale(locale))
-            : value.formatted(.number.notation(.compactName).precision(.fractionLength(0...1)).locale(locale))
-        switch kind {
-        case .dollars: return "$\(number)"
-        case .count: return countSuffix.map { "\(number) \($0)" } ?? number
-        case .percent: return "\(number)%"
-        }
     }
 
     /// Tray-only label shortening (the dashboard keeps the full names): the long time-window metrics

--- a/Sources/OpenUsage/Models/MetricKind.swift
+++ b/Sources/OpenUsage/Models/MetricKind.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 /// How a metric's number is formatted. Mirrors OpenUsage's `format.kind`.
-enum MetricKind: Hashable, Sendable {
+///
+/// `String`-backed and `Codable` so it can ride on a `MetricValue` carried inside a cached
+/// `MetricLine` (see `MetricValue`).
+enum MetricKind: String, Hashable, Sendable, Codable {
     case percent      // used is 0...100
     case dollars      // used is an amount in USD
     case count        // used is an absolute count (with an optional suffix)

--- a/Sources/OpenUsage/Models/MetricLine.swift
+++ b/Sources/OpenUsage/Models/MetricLine.swift
@@ -63,6 +63,11 @@ enum ProgressFormat: Hashable, Sendable, Codable {
 
 enum MetricLine: Hashable, Sendable, Codable {
     case text(label: String, value: String, colorHex: String? = nil, subtitle: String? = nil)
+    /// An unbounded row carrying one or more raw numbers (see `MetricValue`) — the preferred shape for
+    /// numeric rows. The number is the source of truth; formatting and which value(s) to show happen at
+    /// the display edge, so the menu bar never has to re-parse a finished string. `.text` stays only for
+    /// genuinely string-y rows and a few descriptor-bounded dollar rows.
+    case values(label: String, values: [MetricValue], colorHex: String? = nil)
     case progress(
         label: String,
         used: Double,
@@ -78,6 +83,7 @@ enum MetricLine: Hashable, Sendable, Codable {
         switch self {
         case .text(let label, _, _, _),
              .progress(let label, _, _, _, _, _, _),
+             .values(let label, _, _),
              .badge(let label, _, _, _):
             return label
         }
@@ -105,6 +111,7 @@ enum MetricLine: Hashable, Sendable, Codable {
         case type
         case label
         case value
+        case values
         case used
         case limit
         case format
@@ -117,6 +124,7 @@ enum MetricLine: Hashable, Sendable, Codable {
 
     private enum LineType: String, Codable {
         case text
+        case values
         case progress
         case badge
     }
@@ -131,6 +139,12 @@ enum MetricLine: Hashable, Sendable, Codable {
                 value: try container.decode(String.self, forKey: .value),
                 colorHex: try container.decodeIfPresent(String.self, forKey: .colorHex),
                 subtitle: try container.decodeIfPresent(String.self, forKey: .subtitle)
+            )
+        case .values:
+            self = .values(
+                label: label,
+                values: try container.decode([MetricValue].self, forKey: .values),
+                colorHex: try container.decodeIfPresent(String.self, forKey: .colorHex)
             )
         case .progress:
             self = .progress(
@@ -161,6 +175,11 @@ enum MetricLine: Hashable, Sendable, Codable {
             try container.encode(value, forKey: .value)
             try container.encodeIfPresent(colorHex, forKey: .colorHex)
             try container.encodeIfPresent(subtitle, forKey: .subtitle)
+        case .values(let label, let values, let colorHex):
+            try container.encode(LineType.values, forKey: .type)
+            try container.encode(label, forKey: .label)
+            try container.encode(values, forKey: .values)
+            try container.encodeIfPresent(colorHex, forKey: .colorHex)
         case .progress(let label, let used, let limit, let format, let resetsAt, let periodDurationMs, let colorHex):
             try container.encode(LineType.progress, forKey: .type)
             try container.encode(label, forKey: .label)

--- a/Sources/OpenUsage/Models/MetricValue.swift
+++ b/Sources/OpenUsage/Models/MetricValue.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// One measured number on a metric row, carried raw so that formatting happens only at the display
+/// edge (see `MetricFormatter`) instead of being baked into a string the way `.text` rows used to.
+///
+/// A single row can hold several values — a daily-spend row carries dollars *and* tokens, a Codex
+/// credits row carries dollars *and* a credit count — and each widget chooses which to render via
+/// `ValueSelection`. That's what lets one row back a cost-only tile, a tokens-only tile, and a
+/// combined tile without the mapper emitting the data three times.
+struct MetricValue: Hashable, Sendable, Codable {
+    /// The raw magnitude: USD for `.dollars`, 0...100 for `.percent`, an absolute count otherwise.
+    var number: Double
+    /// How this number prints ($ / % / plain count). Distinct per value within a row, which is what
+    /// lets a widget pick "the dollars one" or "the count one" by kind.
+    var kind: MetricKind
+    /// Unit noun shown after the number ("tokens", "credits", "available"). `nil` renders the number
+    /// bare — a dollar amount takes its trailing word from the widget (`unboundedValueWord`) instead.
+    var label: String?
+    /// True when the number is imputed locally rather than measured or billed — it drives the ⓘ note.
+    /// Per value because a spend row's dollars are an estimate while its token count is real.
+    var estimated: Bool
+
+    init(number: Double, kind: MetricKind, label: String? = nil, estimated: Bool = false) {
+        self.number = number
+        self.kind = kind
+        self.label = label
+        self.estimated = estimated
+    }
+}
+
+/// Which of a row's values a widget renders — the seam that lets one `.values` row back several tiles
+/// (cost-only, tokens-only, both) while the data is produced exactly once.
+enum ValueSelection: Hashable, Sendable {
+    /// Every value, in order — the combined reading, e.g. "$4.08 · 1.2M tokens".
+    case all
+    /// Only the values of one kind: `.dollars` for a cost-only tile, `.count` for a tokens-only tile.
+    case kind(MetricKind)
+
+    func apply(to values: [MetricValue]) -> [MetricValue] {
+        switch self {
+        case .all:
+            return values
+        case .kind(let kind):
+            return values.filter { $0.kind == kind }
+        }
+    }
+}

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -41,8 +41,17 @@ struct WidgetData: Hashable {
     /// False when no real provider metric backs this tile. The view then shows a "No data" state
     /// instead of the descriptor's placeholder sample numbers. True for real data and gallery samples.
     var hasData: Bool = true
+    /// Raw numbers for an unbounded `.values` row (empty for meters and legacy `.text` rows). The view
+    /// formats these at render time instead of reading a baked string — see `unboundedDetail`.
+    var values: [MetricValue] = []
+    /// Which of `values` this widget renders — cost-only, tokens-only, or the combined `.all`. Set by
+    /// the descriptor factory, so one provider row can back several tiles and the mapper stays oblivious.
+    var selection: ValueSelection = .all
 
     var isBounded: Bool { limit != nil }
+
+    /// `values` projected through `selection` — exactly what this tile shows.
+    var selectedValues: [MetricValue] { selection.apply(to: values) }
 
     var displayedValue: Double {
         guard displayMode == .remaining, let limit else { return used }
@@ -154,7 +163,32 @@ struct WidgetData: Hashable {
     /// sample numbers as if they were measured usage.
     var valueText: String {
         guard hasData else { return Self.noDataHeadline }
-        return valueTextOverride ?? (valuePrefix ?? "") + format(displayedValue)
+        if let valueTextOverride { return valueTextOverride }
+        // A `.values` row's primary reading is its first selected value; meters and legacy `.text` rows
+        // fall through to the bounded/`used` formatting.
+        if let first = selectedValues.first {
+            return (valuePrefix ?? "") + MetricFormatter.number(first.number, kind: first.kind, style: .row)
+        }
+        return (valuePrefix ?? "") + format(displayedValue)
+    }
+
+    /// The menu-bar (tray) reading: a bounded metric glances as a percentage (regardless of unit, so
+    /// Cursor Credits reads "67%", not "$12,923"); an unbounded one shows its selected value compacted
+    /// (1.2M tokens / $3.4K) through the same formatter the popover uses. A status badge with no number
+    /// (e.g. Grok "Disabled") shows its text rather than a misleading "0".
+    var menuBarValue: String {
+        guard hasData else { return valueText }
+        if let limit, limit > 0 {
+            let percent = max(0, Int((displayedValue / limit * 100).rounded()))
+            return "\(percent)%"
+        }
+        if let first = selectedValues.first {
+            return MetricFormatter.string(for: first, style: .tray)
+        }
+        if let valueTextOverride { return valueTextOverride }
+        let number = MetricFormatter.number(displayedValue, kind: kind, style: .tray)
+        if kind == .count, let countSuffix { return "\(number) \(countSuffix)" }
+        return number
     }
 
     /// Large headline on bounded tiles (e.g. `95% left`, `5% used`).
@@ -216,6 +250,21 @@ struct WidgetData: Hashable {
     var unboundedDetail: String {
         guard hasData else { return Self.noDataSubtitle }
         if let valueTextOverride { return valueTextOverride }
+        let selected = selectedValues
+        if !selected.isEmpty {
+            // One value: a lone dollar amount takes the widget's trailing word ("$4.08 spent",
+            // "$1,503 left"); any other single value carries its own unit label ("1.2M tokens",
+            // "1 available"). Several values join into the combined reading ("$4.08 · 1.2M tokens").
+            if selected.count == 1 {
+                let value = selected[0]
+                if value.kind == .dollars, let word = unboundedValueWord {
+                    return "\(MetricFormatter.number(value.number, kind: .dollars, style: .row)) \(word)"
+                }
+                return MetricFormatter.string(for: value, style: .row)
+            }
+            return selected.map { MetricFormatter.string(for: $0, style: .row) }.joined(separator: " · ")
+        }
+        // Legacy unbounded `.text` rows (e.g. Devin extra balance): "<value> <suffix> <word>".
         let word = unboundedValueWord ?? displayMode.label.lowercased()
         if kind == .count, let countSuffix {
             return "\(valueText) \(countSuffix) \(word)"
@@ -229,22 +278,25 @@ struct WidgetData: Hashable {
         return subtitleOverride
     }
 
+    /// Full, un-abbreviated values for the row's hover tooltip — the exact numbers the compact row
+    /// shortens (e.g. "$2,059.07 · 1,506,025,363"). `nil` when nothing is abbreviated (every value is
+    /// already shown in full), so a row like "2" or "$30.88 · 772 credits" gets no redundant tooltip.
+    var unboundedTooltip: String? {
+        guard hasData else { return nil }
+        let selected = selectedValues
+        guard selected.contains(where: { abs($0.number) >= 1000 }) else { return nil }
+        return selected.map { MetricFormatter.string(for: $0, style: .full) }.joined(separator: " · ")
+    }
+
     var resetLabel: String? {
         guard let resetsAt else { return nil }
         return Formatters.resetRelativeLabel(until: resetsAt)
     }
 
+    /// Bounded headline / legacy `.text` formatting, delegated to the shared formatter so the popover
+    /// and the tray always agree. Unbounded `.values` rows format their values directly (`unboundedDetail`).
     private func format(_ value: Double) -> String {
-        switch kind {
-        case .percent:
-            return "\(Int(value.rounded()))%"
-        case .dollars:
-            // Always show cents. A spend estimate of $180.17 must read "$180.17", never "$180" — dropping
-            // the cents for amounts ≥ $100 made our estimates look wrong next to tools that show cents.
-            return Formatters.currency(value, fractionDigits: 2)
-        case .count:
-            return value.formatted(.number.precision(.fractionLength(0...1)).locale(Locale(identifier: "en_US")))
-        }
+        MetricFormatter.number(value, kind: kind, style: .full)
     }
 }
 

--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -48,20 +48,58 @@ extension WidgetDescriptor {
                                 periodDurationMs: periodDurationMs))
     }
 
-    /// Unbounded spend tile reading "$12.34 spent". `estimated` adds the ⓘ explaining the number
-    /// is imputed locally (ccusage) rather than billed; server-backed spend stays clean.
-    static func spend(
+    /// Unbounded numeric row backed by a provider `.values` line. `selection` decides which of the
+    /// row's values this tile renders (cost-only, tokens-only, or the combined `.all`); `valueWord` is
+    /// the trailing word for a lone dollar value ("spent", "left"). The ⓘ for a locally-estimated
+    /// dollar amount is data-driven (set when a shown value is `estimated`), so it isn't a parameter.
+    static func values(
         id: String,
         provider: Provider,
         title: String,
         metricLabel: String? = nil,
-        estimated: Bool = false
+        selection: ValueSelection = .all,
+        valueWord: String? = nil
     ) -> WidgetDescriptor {
-        make(id: id, provider: provider, metricLabel: metricLabel ?? title,
-             sample: WidgetData(title: title, icon: provider.icon,
-                                kind: .dollars, used: 0, limit: nil,
-                                unboundedValueWord: "spent",
-                                infoNote: estimated ? WidgetData.ccusageEstimateNote : nil))
+        // `kind` is unused for `.values` rendering (each value carries its own), but a count-only tile
+        // reads tidier seeded as `.count`; everything else defaults to `.dollars`.
+        let kind: MetricKind = { if case .kind(let only) = selection { return only }; return .dollars }()
+        var sample = WidgetData(title: title, icon: provider.icon, kind: kind, used: 0, limit: nil,
+                                unboundedValueWord: valueWord)
+        sample.selection = selection
+        return make(id: id, provider: provider, metricLabel: metricLabel ?? title, sample: sample)
+    }
+
+    /// Cost-only spend tile reading "$12.34 spent" — the dollars of a `.values` spend row.
+    static func spend(
+        id: String,
+        provider: Provider,
+        title: String,
+        metricLabel: String? = nil
+    ) -> WidgetDescriptor {
+        values(id: id, provider: provider, title: title, metricLabel: metricLabel,
+               selection: .kind(.dollars), valueWord: "spent")
+    }
+
+    /// Tokens-only tile reading "1.2M tokens" — the count of a `.values` spend row. No trailing word
+    /// (the value carries its own "tokens" unit) and no ⓘ (token counts are measured, not estimated).
+    static func tokenSpend(
+        id: String,
+        provider: Provider,
+        title: String,
+        metricLabel: String? = nil
+    ) -> WidgetDescriptor {
+        values(id: id, provider: provider, title: title, metricLabel: metricLabel, selection: .kind(.count))
+    }
+
+    /// Combined tile reading "$4.08 · 1.2M tokens" (spend) or "$32.84 · 821 credits" (Codex credits) —
+    /// every value of a `.values` row, joined.
+    static func combined(
+        id: String,
+        provider: Provider,
+        title: String,
+        metricLabel: String? = nil
+    ) -> WidgetDescriptor {
+        values(id: id, provider: provider, title: title, metricLabel: metricLabel, selection: .all)
     }
 
     /// Unbounded dollar balance with a custom trailing word (e.g. "$1,503.00 left").
@@ -75,35 +113,6 @@ extension WidgetDescriptor {
         make(id: id, provider: provider, metricLabel: metricLabel ?? title,
              sample: WidgetData(title: title, icon: provider.icon,
                                 kind: .dollars, used: 0, limit: nil, unboundedValueWord: valueWord))
-    }
-
-    /// Unbounded dollar row rendered verbatim from the provider's `.text` line (e.g. Codex credits
-    /// "$32.84 · 821 credits"); the parsed dollars still feed the menu-bar compact value.
-    static func verbatimDollars(
-        id: String,
-        provider: Provider,
-        title: String,
-        metricLabel: String? = nil
-    ) -> WidgetDescriptor {
-        var sample = WidgetData(title: title, icon: provider.icon,
-                                kind: .dollars, used: 0, limit: nil)
-        sample.preservesRawText = true
-        return make(id: id, provider: provider, metricLabel: metricLabel ?? title, sample: sample)
-    }
-
-    /// Unbounded count rendered verbatim from the provider's `.text` line (e.g. Codex rate-limit
-    /// resets "1 available"); the parsed count still feeds the menu-bar tile's compact value, so the
-    /// tray and the popover never diverge.
-    static func verbatimCount(
-        id: String,
-        provider: Provider,
-        title: String,
-        metricLabel: String? = nil
-    ) -> WidgetDescriptor {
-        var sample = WidgetData(title: title, icon: provider.icon,
-                                kind: .count, used: 0, limit: nil)
-        sample.preservesRawText = true
-        return make(id: id, provider: provider, metricLabel: metricLabel ?? title, sample: sample)
     }
 
     /// Unbounded count resolved from a provider `.badge` line via `valueTextOverride`

--- a/Sources/OpenUsage/Providers/CcusageSpendMapper.swift
+++ b/Sources/OpenUsage/Providers/CcusageSpendMapper.swift
@@ -15,13 +15,10 @@ enum CcusageSpendMapper {
         lines.append(dayUsageLine(label: "Yesterday", entry: yesterdayEntry))
 
         let totalTokens = usage.daily.reduce(0) { $0 + $1.totalTokens }
-        let costValues = usage.daily.compactMap(\.costUSD)
-        let totalCost = costValues.isEmpty ? nil : costValues.reduce(0, +)
+        let costSamples = usage.daily.compactMap(\.costUSD)
+        let totalCost = costSamples.isEmpty ? nil : costSamples.reduce(0, +)
         if totalTokens > 0 {
-            lines.append(.text(
-                label: "Last 30 Days",
-                value: costAndTokensLabel(tokens: totalTokens, costUSD: totalCost)
-            ))
+            lines.append(.values(label: "Last 30 Days", values: spendValues(tokens: totalTokens, costUSD: totalCost)))
         }
     }
 
@@ -58,33 +55,20 @@ enum CcusageSpendMapper {
     }
 
     private static func dayUsageLine(label: String, entry: CcusageDay?) -> MetricLine {
-        .text(label: label, value: costAndTokensLabel(tokens: entry?.totalTokens ?? 0, costUSD: entry?.costUSD))
+        .values(label: label, values: spendValues(tokens: entry?.totalTokens ?? 0, costUSD: entry?.costUSD))
     }
 
-    private static func costAndTokensLabel(tokens: Int, costUSD: Double?) -> String {
-        var parts: [String] = []
+    /// One period's spend as raw values: the estimated dollars (only when ccusage priced the period)
+    /// followed by the measured token count. The token value carries no unit label — the row reads
+    /// "$4.08 · 41.3M", with the count understood as tokens from context. A cost-only tile renders the
+    /// dollars (with the ⓘ), a tokens-only tile the count (no ⓘ), and a combined tile both — all from
+    /// this one row, no fused string and nothing for the menu bar to re-parse.
+    private static func spendValues(tokens: Int, costUSD: Double?) -> [MetricValue] {
+        var values: [MetricValue] = []
         if let costUSD {
-            parts.append(Formatters.currency(costUSD))
+            values.append(MetricValue(number: costUSD, kind: .dollars, estimated: true))
         }
-        parts.append("\(formatTokens(tokens)) tokens")
-        return parts.joined(separator: " · ")
-    }
-
-    private static func formatTokens(_ tokens: Int) -> String {
-        let absValue = abs(tokens)
-        let sign = tokens < 0 ? "-" : ""
-        let units: [(threshold: Double, divisor: Double, suffix: String)] = [
-            (1_000_000_000, 1_000_000_000, "B"),
-            (1_000_000, 1_000_000, "M"),
-            (1_000, 1_000, "K")
-        ]
-        for unit in units where Double(absValue) >= unit.threshold {
-            let scaled = Double(absValue) / unit.divisor
-            let formatted = scaled >= 10
-                ? String(Int(scaled.rounded()))
-                : String(format: "%.1f", scaled).replacingOccurrences(of: ".0", with: "")
-            return sign + formatted + unit.suffix
-        }
-        return "\(tokens)"
+        values.append(MetricValue(number: Double(tokens), kind: .count))
+        return values
     }
 }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -27,9 +27,17 @@ final class ClaudeProvider: ProviderRuntime {
             .percent(id: "claude.weekly", provider: provider, title: "Weekly"),
             .percent(id: "claude.sonnet", provider: provider, title: "Sonnet"),
             .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100),
-            .spend(id: "claude.today", provider: provider, title: "Today", estimated: true),
-            .spend(id: "claude.yesterday", provider: provider, title: "Yesterday", estimated: true),
-            .spend(id: "claude.last30", provider: provider, title: "Last 30 Days", estimated: true)
+            // Existing spend tiles now render the full row (cost + tokens) — the token half used to be
+            // computed and then dropped. Cost-only and tokens-only splits are opt-in (off by default).
+            .combined(id: "claude.today", provider: provider, title: "Today"),
+            .combined(id: "claude.yesterday", provider: provider, title: "Yesterday"),
+            .combined(id: "claude.last30", provider: provider, title: "Last 30 Days"),
+            .spend(id: "claude.today.cost", provider: provider, title: "Today Cost", metricLabel: "Today"),
+            .spend(id: "claude.yesterday.cost", provider: provider, title: "Yesterday Cost", metricLabel: "Yesterday"),
+            .spend(id: "claude.last30.cost", provider: provider, title: "Last 30 Days Cost", metricLabel: "Last 30 Days"),
+            .tokenSpend(id: "claude.today.tokens", provider: provider, title: "Today Tokens", metricLabel: "Today"),
+            .tokenSpend(id: "claude.yesterday.tokens", provider: provider, title: "Yesterday Tokens", metricLabel: "Yesterday"),
+            .tokenSpend(id: "claude.last30.tokens", provider: provider, title: "Last 30 Days Tokens", metricLabel: "Last 30 Days")
         ]
     }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -25,11 +25,19 @@ final class CodexProvider: ProviderRuntime {
         [
             .percent(id: "codex.session", provider: provider, title: "Session"),
             .percent(id: "codex.weekly", provider: provider, title: "Weekly"),
-            .verbatimCount(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
-            .verbatimDollars(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
-            .spend(id: "codex.today", provider: provider, title: "Today", estimated: true),
-            .spend(id: "codex.yesterday", provider: provider, title: "Yesterday", estimated: true),
-            .spend(id: "codex.last30", provider: provider, title: "Last 30 Days", estimated: true)
+            .values(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
+            .combined(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
+            // Existing spend tiles now render the full row (cost + tokens); cost-only and tokens-only
+            // splits are opt-in (off by default).
+            .combined(id: "codex.today", provider: provider, title: "Today"),
+            .combined(id: "codex.yesterday", provider: provider, title: "Yesterday"),
+            .combined(id: "codex.last30", provider: provider, title: "Last 30 Days"),
+            .spend(id: "codex.today.cost", provider: provider, title: "Today Cost", metricLabel: "Today"),
+            .spend(id: "codex.yesterday.cost", provider: provider, title: "Yesterday Cost", metricLabel: "Yesterday"),
+            .spend(id: "codex.last30.cost", provider: provider, title: "Last 30 Days Cost", metricLabel: "Last 30 Days"),
+            .tokenSpend(id: "codex.today.tokens", provider: provider, title: "Today Tokens", metricLabel: "Today"),
+            .tokenSpend(id: "codex.yesterday.tokens", provider: provider, title: "Yesterday Tokens", metricLabel: "Yesterday"),
+            .tokenSpend(id: "codex.last30.tokens", provider: provider, title: "Last 30 Days Tokens", metricLabel: "Last 30 Days")
         ]
     }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -71,17 +71,17 @@ enum CodexUsageMapper {
         appendAdditionalRateLimits(from: body, to: &lines, now: now)
         appendReviewLimit(from: body, to: &lines, now: now)
 
-        // On-demand rate-limit reset credits ("N available"), shown before Credits — mirrors the JS
-        // plugin (PR #577). A verbatim `.text` line (backed by a `verbatimCount` widget tile) so every
-        // surface resolves from one value: the dashboard/popover read "N available" while the menu-bar
-        // tile shows the parsed count — they never diverge.
+        // On-demand rate-limit reset credits, shown before Credits — mirrors the JS plugin (PR #577).
+        // A `.values` row carries the raw count (no unit label — the row just reads "2"), so the popover
+        // and the menu-bar tile show that same number — no string to re-parse, no tray-reads-0 bug.
         if let resets = readResetCredits(body), resets >= 0 {
             let count = Int(resets.rounded(.down))
-            lines.append(.text(label: "Rate Limit Resets", value: "\(count) available"))
+            lines.append(.values(label: "Rate Limit Resets",
+                                 values: [MetricValue(number: Double(count), kind: .count)]))
         }
 
         if let remaining = readCreditsRemaining(response: response, body: body) {
-            lines.append(.text(label: "Credits", value: creditsLabel(remaining: remaining)))
+            lines.append(.values(label: "Credits", values: creditValues(remaining: remaining)))
         }
 
         // The "no usage data" badge is appended by `CodexProvider.probe` *after* the ccusage spend
@@ -173,12 +173,15 @@ enum CodexUsageMapper {
         return Int(seconds * 1000)
     }
 
-    /// "$32.84 · 821 credits" — dollar value first (remaining × 4¢), then the raw credit count.
-    /// Mirrors the JS plugin's refactored credits display; negative balances clamp to zero.
-    static func creditsLabel(remaining: Double) -> String {
+    /// Codex flex credits as raw values: the dollar value (remaining × 4¢) then the credit count, shown
+    /// combined as "$32.84 · 821 credits". Negative balances clamp to zero.
+    static func creditValues(remaining: Double) -> [MetricValue] {
         let credits = max(0, Int(remaining.rounded(.down)))
         let usd = Double(credits) * creditUSDRate
-        return Formatters.currency(usd) + " · \(credits.formatted(.number.locale(Locale(identifier: "en_US")))) credits"
+        return [
+            MetricValue(number: usd, kind: .dollars),
+            MetricValue(number: Double(credits), kind: .count, label: "credits")
+        ]
     }
 
     /// On-demand reset credits from `rate_limit_reset_credits.available_count`. `ProviderParse.number`

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -203,10 +203,10 @@ enum CursorUsageMapper {
         return (false, "")
     }
 
-    /// Append Today / Yesterday / Last 30 Days spend as unbounded `.text` dollar lines, aggregated over
-    /// local-calendar day boundaries. Always appends all three (formatted with a leading "$", including
-    /// "$0.00") so a genuine zero day reads truthfully; callers only invoke this when the CSV fetched and
-    /// parsed, so failures append nothing and the tiles fall back to "No data".
+    /// Append Today / Yesterday / Last 30 Days spend as unbounded `.values` dollar lines, aggregated over
+    /// local-calendar day boundaries. Always appends all three (including a genuine $0.00) so a zero day
+    /// reads truthfully; callers only invoke this when the CSV fetched and parsed, so failures append
+    /// nothing and the tiles fall back to "No data".
     static func appendSpendLines(rows: [CursorUsageCSVRow], now: Date, to lines: inout [MetricLine]) {
         let calendar = Calendar.current
         let startOfToday = calendar.startOfDay(for: now)
@@ -229,15 +229,16 @@ enum CursorUsageMapper {
             }
         }
 
-        lines.append(.text(label: "Today", value: spendDollars(today)))
-        lines.append(.text(label: "Yesterday", value: spendDollars(yesterday)))
-        lines.append(.text(label: "Last 30 Days", value: spendDollars(last30Days)))
+        lines.append(spendLine(label: "Today", dollars: today))
+        lines.append(spendLine(label: "Yesterday", dollars: yesterday))
+        lines.append(spendLine(label: "Last 30 Days", dollars: last30Days))
     }
 
-    /// Sum dollars then snap to integer cents once (avoiding per-row rounding loss and final float
-    /// drift), and always format with a "$" so `WidgetDataStore.firstCurrencyAmount` parses it.
-    private static func spendDollars(_ dollars: Double) -> String {
-        Formatters.currency(Double(CursorPricing.toCents(dollars)) / 100)
+    /// One Cursor spend day as a single dollar value, snapped to integer cents once (avoiding per-row
+    /// rounding loss and float drift) before being carried raw. No `estimated` flag — Cursor spend is
+    /// server-priced, so these tiles stay clean (no ⓘ), unlike the ccusage-derived ones.
+    private static func spendLine(label: String, dollars: Double) -> MetricLine {
+        .values(label: label, values: [MetricValue(number: Double(CursorPricing.toCents(dollars)) / 100, kind: .dollars)])
     }
 
     static func stripeBalanceCents(from response: HTTPResponse?) -> Double {

--- a/Sources/OpenUsage/Services/LocalUsageAPI.swift
+++ b/Sources/OpenUsage/Services/LocalUsageAPI.swift
@@ -96,6 +96,15 @@ enum LocalUsageAPI {
                 try container.encode(value, forKey: .value)
                 try container.encode(color, forKey: .color)        // explicit null, like the original
                 try container.encode(subtitle, forKey: .subtitle)
+            case .values(let label, let values, let color):
+                // Serialize as the original `text` shape (one combined `value` string) so existing
+                // local-API integrations keep working: dollars in full, counts compact — exactly the
+                // string the mapper used to produce (e.g. "$5.17 · 9.2M tokens").
+                try container.encode("text", forKey: .type)
+                try container.encode(label, forKey: .label)
+                try container.encode(Self.legacyValueString(values), forKey: .value)
+                try container.encode(color, forKey: .color)
+                try container.encode(String?.none, forKey: .subtitle)
             case .progress(let label, let used, let limit, let format, let resetsAt, let periodDurationMs, let color):
                 try container.encode("progress", forKey: .type)
                 try container.encode(label, forKey: .label)
@@ -112,6 +121,14 @@ enum LocalUsageAPI {
                 try container.encode(color, forKey: .color)
                 try container.encode(subtitle, forKey: .subtitle)
             }
+        }
+
+        /// The legacy combined string for a `.values` row: each value formatted (dollars full so cents
+        /// survive, counts compact like the mapper's old `formatTokens`) and joined with " · ".
+        private static func legacyValueString(_ values: [MetricValue]) -> String {
+            values
+                .map { MetricFormatter.string(for: $0, style: $0.kind == .count ? .tray : .full) }
+                .joined(separator: " · ")
         }
     }
 }

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -17,7 +17,11 @@ struct ProviderSnapshotCache {
 
     init(
         userDefaults: UserDefaults = .standard,
-        storageKey: String = "openusage.providerSnapshots.v2",
+        // v3: spend / Codex credits / rate-limit-resets rows moved from `.text` (a parsed display string)
+        // to `.values` (raw numbers). Bumping the key drops pre-upgrade caches so the new `.values`-based
+        // widgets never try to resolve a stale `.text` line — which would misread the fused string
+        // (tokens tile showing the dollar amount, combined dropping tokens) until the first refresh.
+        storageKey: String = "openusage.providerSnapshots.v3",
         ttl: TimeInterval = RefreshSetting.interval,
         now: @escaping () -> Date = Date.init
     ) {

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -230,7 +230,9 @@ final class WidgetDataStore {
             // trailing word) comes from the descriptor's sample; the live numbers come from the line.
             var data = descriptor.sample
             data.values = values
-            data.hasData = true
+            // A tile whose selection finds no value (e.g. a cost-only tile on a day ccusage couldn't
+            // price) has nothing real to show — render "No data" rather than a misleading $0.00 / 0.
+            data.hasData = !data.selectedValues.isEmpty
             // The ⓘ is data-driven: it shows when a *shown* value is locally estimated (a spend row's
             // dollars) and stays off for a measured one (its tokens), so the tokens-only tile reads clean.
             data.infoNote = data.selectedValues.contains(where: \.estimated)

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -225,6 +225,18 @@ final class WidgetDataStore {
             )
         case .text(_, let value, _, _):
             return resolveText(value, descriptor: descriptor)
+        case .values(_, let values, _):
+            // The number is carried raw — no regex re-parse. Presentation (title, icon, selection,
+            // trailing word) comes from the descriptor's sample; the live numbers come from the line.
+            var data = descriptor.sample
+            data.values = values
+            data.hasData = true
+            // The ⓘ is data-driven: it shows when a *shown* value is locally estimated (a spend row's
+            // dollars) and stays off for a measured one (its tokens), so the tokens-only tile reads clean.
+            data.infoNote = data.selectedValues.contains(where: \.estimated)
+                ? WidgetData.ccusageEstimateNote
+                : descriptor.sample.infoNote
+            return data
         case .badge(_, let text, _, let subtitle):
             var data = descriptor.sample
             data.valueTextOverride = text

--- a/Sources/OpenUsage/Support/MetricFormatter.swift
+++ b/Sources/OpenUsage/Support/MetricFormatter.swift
@@ -35,10 +35,10 @@ enum MetricFormatter {
                 }
                 return "$" + value.formatted(.number.precision(.fractionLength(0)).locale(locale))
             case .row:
-                // Abbreviate four figures and up ("$2.06K") so the row can't carry "$2,059.07" beside a
-                // token count, but keep two decimals so it still reads as money; full cents below $1k.
+                // Abbreviate four figures and up ("$2.1K") so the row can't carry "$2,059.07" beside a
+                // token count — one decimal, matching the token counts next to it; full cents below $1k.
                 if abs(value) >= 1000 {
-                    return "$" + value.formatted(.number.notation(.compactName).precision(.fractionLength(2)).locale(locale))
+                    return "$" + value.formatted(.number.notation(.compactName).precision(.fractionLength(0...1)).locale(locale))
                 }
                 return Formatters.currency(value, fractionDigits: 2)
             case .full:

--- a/Sources/OpenUsage/Support/MetricFormatter.swift
+++ b/Sources/OpenUsage/Support/MetricFormatter.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// The single place a number becomes display text. Every surface — popover rows, the menu-bar strip,
+/// the gallery — formats through here, so a value can never read one way in the tray and another in
+/// the popover, and there is exactly one definition of "compact" (12.9K / 3.4M / 1.2B).
+///
+/// This replaces the scattered number→string logic that used to live in `WidgetData.format`, the
+/// menu bar's `compactValue`, and the providers' own `formatTokens` / credit-label builders.
+enum MetricFormatter {
+    /// Three surfaces, three needs:
+    /// - `.tray` — the menu-bar strip: shortest. Whole dollars under $1,000, abbreviated above; counts abbreviated.
+    /// - `.row` — the popover row: abbreviated like the tray, but money keeps cents / two decimals ("$2.06K", "$40.76").
+    /// - `.full` — tooltips and bounded headlines: every digit, grouped ("$2,059.07", "56,904,995").
+    enum Style {
+        case tray
+        case row
+        case full
+    }
+
+    /// Pinned to en_US so USD-denominated values render identically regardless of system locale, which
+    /// matches the menu bar's long-standing behavior.
+    private static let locale = Locale(identifier: "en_US")
+
+    /// A bare number in the given kind and style (no unit label).
+    static func number(_ value: Double, kind: MetricKind, style: Style) -> String {
+        switch kind {
+        case .percent:
+            return "\(Int(value.rounded()))%"
+        case .dollars:
+            switch style {
+            case .tray:
+                // Shortest: whole dollars under $1k ("$130"), abbreviated above ("$1.2M").
+                if abs(value) >= 1000 {
+                    return "$" + value.formatted(.number.notation(.compactName).precision(.fractionLength(0...1)).locale(locale))
+                }
+                return "$" + value.formatted(.number.precision(.fractionLength(0)).locale(locale))
+            case .row:
+                // Abbreviate four figures and up ("$2.06K") so the row can't carry "$2,059.07" beside a
+                // token count, but keep two decimals so it still reads as money; full cents below $1k.
+                if abs(value) >= 1000 {
+                    return "$" + value.formatted(.number.notation(.compactName).precision(.fractionLength(2)).locale(locale))
+                }
+                return Formatters.currency(value, fractionDigits: 2)
+            case .full:
+                return Formatters.currency(value, fractionDigits: 2)
+            }
+        case .count:
+            // Tray and row abbreviate at the thousands (token counts run into the billions); the full
+            // form keeps every digit for the tooltip. Below 1,000 keeps up to one decimal either way, so
+            // a fractional balance (e.g. 820.6) survives.
+            if style != .full, abs(value) >= 1000 {
+                return value.formatted(.number.notation(.compactName).precision(.fractionLength(0...1)).locale(locale))
+            }
+            return value.formatted(.number.precision(.fractionLength(0...1)).locale(locale))
+        }
+    }
+
+    /// A value with its unit label appended, e.g. "772 credits". Token, dollar, and percent values
+    /// carry no label and render bare ("56.9M", "$4.08", "95%") — those rows show no unit, by design.
+    static func string(for value: MetricValue, style: Style) -> String {
+        let text = number(value.number, kind: value.kind, style: style)
+        guard let label = value.label, !label.isEmpty else { return text }
+        return "\(text) \(label)"
+    }
+}

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -257,6 +257,9 @@ struct WidgetRowView: View {
             }
             .multilineTextAlignment(.trailing)
         }
+        // Hovering the row reveals the exact figures the compact value shortens ("$2,059.07 ·
+        // 1,506,025,363"); empty string when nothing's abbreviated, so no redundant tooltip appears.
+        .help(data.unboundedTooltip ?? "")
     }
 
     /// Small ⓘ next to the label; on hover it explains the row's `infoNote` (e.g. that a ccusage dollar

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -171,7 +171,9 @@ final class ClaudeProviderTests: XCTestCase {
 
         XCTAssertEqual(snapshot.plan, "Pro")
         XCTAssertNotNil(snapshot.lines.first(where: { $0.label == "Session" }))
-        XCTAssertEqual(text(snapshot.lines, "Today"), "$0.25 · 150 tokens")
+        XCTAssertEqual(values(snapshot.lines, "Today"),
+                       [MetricValue(number: 0.25, kind: .dollars, estimated: true),
+                        MetricValue(number: 150, kind: .count)])
         XCTAssertEqual(processRunner.lastCcusageEnvironment?["CLAUDE_CONFIG_DIR"], "/tmp/claude")
         XCTAssertTrue(httpClient.requests.contains { $0.url.absoluteString == "https://api.anthropic.com/api/oauth/usage" })
     }
@@ -293,11 +295,11 @@ final class ClaudeProviderTests: XCTestCase {
         return value
     }
 
-    private func text(_ lines: [MetricLine], _ label: String) -> String? {
-        guard case .text(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
+    private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {
+        guard case .values(_, let values, _) = lines.first(where: { $0.label == label }) else {
             return nil
         }
-        return value
+        return values
     }
 
     private static func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -94,8 +94,8 @@ final class CodexUsageMapperTests: XCTestCase {
     func testCreditValuesRenderGroupedThousands() {
         var data = WidgetData(title: "Extra Usage", icon: .providerMark("codex"), kind: .dollars, used: 0, limit: nil)
         data.values = CodexUsageMapper.creditValues(remaining: 30000)
-        // The row abbreviates ("$1.20K · 30K credits"); the hover tooltip keeps every digit.
-        XCTAssertEqual(data.unboundedDetail, "$1.20K · 30K credits")
+        // The row abbreviates ("$1.2K · 30K credits"); the hover tooltip keeps every digit.
+        XCTAssertEqual(data.unboundedDetail, "$1.2K · 30K credits")
         XCTAssertEqual(data.unboundedTooltip, "$1,200.00 · 30,000 credits")
     }
 

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -60,7 +60,8 @@ final class CodexUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 50)
         // Credits lead with the dollar value (4¢/credit), then the raw count — no inverted fake cap.
         XCTAssertNil(progress(mapped.lines, "Credits"))
-        XCTAssertEqual(text(mapped.lines, "Credits"), "$4.00 · 100 credits")
+        XCTAssertEqual(values(mapped.lines, "Credits"),
+                       [MetricValue(number: 4.0, kind: .dollars), MetricValue(number: 100, kind: .count, label: "credits")])
         XCTAssertNotNil(progress(mapped.lines, "Session")?.resetsAt)
         XCTAssertEqual(progress(mapped.lines, "Session")?.periodDurationMs, CodexUsageMapper.sessionPeriodMs)
     }
@@ -78,16 +79,24 @@ final class CodexUsageMapperTests: XCTestCase {
             now: makeDate("2026-02-20T16:00:00.000Z")
         )
 
-        XCTAssertEqual(text(lines, "Today"), "$0.75 · 150 tokens")
-        XCTAssertEqual(text(lines, "Yesterday"), "0 tokens")
-        XCTAssertEqual(text(lines, "Last 30 Days"), "$1.75 · 450 tokens")
+        XCTAssertEqual(values(lines, "Today"),
+                       [MetricValue(number: 0.75, kind: .dollars, estimated: true),
+                        MetricValue(number: 150, kind: .count)])
+        XCTAssertEqual(values(lines, "Yesterday"), [MetricValue(number: 0, kind: .count)])
+        XCTAssertEqual(values(lines, "Last 30 Days"),
+                       [MetricValue(number: 1.75, kind: .dollars, estimated: true),
+                        MetricValue(number: 450, kind: .count)])
     }
 
     // Regression: dollar amounts must group thousands (e.g. "$1,200.00") consistently with the
     // headline, which formats through `Formatters.currency`. Credit lines previously used a bare
     // `$%.2f` that dropped the separator.
-    func testCreditsLabelGroupsThousands() {
-        XCTAssertEqual(CodexUsageMapper.creditsLabel(remaining: 30000), "$1,200.00 · 30,000 credits")
+    func testCreditValuesRenderGroupedThousands() {
+        var data = WidgetData(title: "Extra Usage", icon: .providerMark("codex"), kind: .dollars, used: 0, limit: nil)
+        data.values = CodexUsageMapper.creditValues(remaining: 30000)
+        // The row abbreviates ("$1.20K · 30K credits"); the hover tooltip keeps every digit.
+        XCTAssertEqual(data.unboundedDetail, "$1.20K · 30K credits")
+        XCTAssertEqual(data.unboundedTooltip, "$1,200.00 · 30,000 credits")
     }
 
     func testShowsRateLimitResetsBeforeCredits() throws {
@@ -104,7 +113,7 @@ final class CodexUsageMapperTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
-        XCTAssertEqual(text(mapped.lines, "Rate Limit Resets"), "1 available")
+        XCTAssertEqual(values(mapped.lines, "Rate Limit Resets"), [MetricValue(number: 1, kind: .count)])
 
         let resetIndex = mapped.lines.firstIndex { $0.label == "Rate Limit Resets" }
         let creditsIndex = mapped.lines.firstIndex { $0.label == "Credits" }
@@ -124,7 +133,7 @@ final class CodexUsageMapperTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
-        XCTAssertEqual(text(mapped.lines, "Rate Limit Resets"), "0 available")
+        XCTAssertEqual(values(mapped.lines, "Rate Limit Resets"), [MetricValue(number: 0, kind: .count)])
     }
 
     func testOmitsRateLimitResetsWhenCountMalformed() throws {
@@ -136,7 +145,7 @@ final class CodexUsageMapperTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
-        XCTAssertNil(text(mapped.lines, "Rate Limit Resets"))
+        XCTAssertNil(values(mapped.lines, "Rate Limit Resets"))
     }
 
     private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
@@ -146,11 +155,11 @@ final class CodexUsageMapperTests: XCTestCase {
         return (used, limit, resetsAt, periodDurationMs)
     }
 
-    private func text(_ lines: [MetricLine], _ label: String) -> String? {
-        guard case .text(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
+    private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {
+        guard case .values(_, let values, _) = lines.first(where: { $0.label == label }) else {
             return nil
         }
-        return value
+        return values
     }
 
     private func makeDate(_ value: String) -> Date {
@@ -183,17 +192,19 @@ final class CodexProviderTests: XCTestCase {
         // ...but local ccusage spend exists, so the snapshot shows the spend lines and NOT the
         // "No usage data" badge. Regression: the mapper used to append the badge *before* the ccusage
         // lines, leaving a contradictory badge-plus-spend snapshot.
-        XCTAssertEqual(text(snapshot.lines, "Today"), "$0.25 · 150 tokens")
+        XCTAssertEqual(values(snapshot.lines, "Today"),
+                       [MetricValue(number: 0.25, kind: .dollars, estimated: true),
+                        MetricValue(number: 150, kind: .count)])
         XCTAssertFalse(snapshot.lines.contains { line in
             if case .badge(_, let value, _, _) = line { return value == "No usage data" }
             return false
         })
     }
 
-    private func text(_ lines: [MetricLine], _ label: String) -> String? {
-        guard case .text(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
+    private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {
+        guard case .values(_, let values, _) = lines.first(where: { $0.label == label }) else {
             return nil
         }
-        return value
+        return values
     }
 }

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -209,17 +209,17 @@ final class CursorSpendProviderTests: XCTestCase {
         let cursor = CursorProvider()
         let descriptor = try! XCTUnwrap(cursor.widgetDescriptors.first { $0.id == "cursor.today" })
 
-        for (value, expectedDetail) in [("$12.34", "$12.34 spent"), ("$0.00", "$0.00 spent")] {
+        for (dollars, expectedValue, expectedDetail) in [(12.34, "$12.34", "$12.34 spent"), (0.0, "$0.00", "$0.00 spent")] {
             let runtime = TestProviderRuntime(
                 provider: cursor.provider,
                 descriptors: [descriptor],
                 snapshot: ProviderSnapshot(
                     providerID: cursor.provider.id,
                     displayName: cursor.provider.displayName,
-                    lines: [.text(label: "Today", value: value)]
+                    lines: [.values(label: "Today", values: [MetricValue(number: dollars, kind: .dollars)])]
                 )
             )
-            let defaults = isolatedDefaults("render-\(value)")
+            let defaults = isolatedDefaults("render-\(expectedValue)")
             let store = WidgetDataStore(
                 registry: WidgetRegistry(providers: [cursor.provider], descriptors: [descriptor]),
                 providers: [runtime],
@@ -234,7 +234,7 @@ final class CursorSpendProviderTests: XCTestCase {
             let used = store.data(for: descriptor)
 
             XCTAssertTrue(remaining.hasData)
-            XCTAssertEqual(remaining.valueText, value)
+            XCTAssertEqual(remaining.valueText, expectedValue)
             XCTAssertEqual(remaining.unboundedDetail, expectedDetail)
             // Cursor spend comes from the server CSV export, so it reads as a bare "$X spent" line:
             // no subtitle and no estimate ⓘ (that's reserved for ccusage tiles).
@@ -291,8 +291,13 @@ final class CursorSpendProviderTests: XCTestCase {
 // MARK: - Shared test helpers (file-private; mirror CursorProviderTests)
 
 private func textValue(_ lines: [MetricLine], _ label: String) -> String? {
-    guard case .text(_, let value, _, _) = lines.first(where: { $0.label == label }) else { return nil }
-    return value
+    guard let line = lines.first(where: { $0.label == label }) else { return nil }
+    if case .text(_, let value, _, _) = line { return value }
+    // Cursor spend is now a `.values` row carrying a single dollar value; render it in full.
+    if case .values(_, let values, _) = line, let dollars = values.first(where: { $0.kind == .dollars }) {
+        return MetricFormatter.number(dollars.number, kind: .dollars, style: .full)
+    }
+    return nil
 }
 
 private func makeCursorJWT(sub: String = "google-oauth2|user", exp: Double = 9_999_999_999) -> String {

--- a/Tests/OpenUsageTests/LocalUsageAPITests.swift
+++ b/Tests/OpenUsageTests/LocalUsageAPITests.swift
@@ -16,7 +16,10 @@ final class LocalUsageAPITests: XCTestCase {
                 .progress(label: "Session", used: 42, limit: 100, format: .percent,
                           resetsAt: OpenUsageISO8601.date(from: "2026-03-26T13:00:00.161Z"),
                           periodDurationMs: 18_000_000),
-                .text(label: "Today", value: "$5.17 · 9.2M tokens")
+                .values(label: "Today", values: [
+                    MetricValue(number: 5.17, kind: .dollars),
+                    MetricValue(number: 9_200_000, kind: .count)
+                ])
             ],
             refreshedAt: refreshedAt
         )
@@ -62,7 +65,7 @@ final class LocalUsageAPITests: XCTestCase {
         XCTAssertTrue(progress.keys.contains("color"))        // explicit null, like the original
 
         let text = try XCTUnwrap(lines.first { $0["type"] as? String == "text" })
-        XCTAssertEqual(text["value"] as? String, "$5.17 · 9.2M tokens")
+        XCTAssertEqual(text["value"] as? String, "$5.17 · 9.2M")
         XCTAssertTrue(text.keys.contains("subtitle"))
     }
 

--- a/Tests/OpenUsageTests/MetricFormatterTests.swift
+++ b/Tests/OpenUsageTests/MetricFormatterTests.swift
@@ -9,9 +9,9 @@ final class MetricFormatterTests: XCTestCase {
         // Tray: whole dollars under $1k, abbreviated above.
         XCTAssertEqual(MetricFormatter.number(42, kind: .dollars, style: .tray), "$42")
         XCTAssertEqual(MetricFormatter.number(2059.07, kind: .dollars, style: .tray), "$2.1K")
-        // Row: full cents under $1k, abbreviated with two decimals above.
+        // Row: full cents under $1k, abbreviated with one decimal above (matching token counts).
         XCTAssertEqual(MetricFormatter.number(40.76, kind: .dollars, style: .row), "$40.76")
-        XCTAssertEqual(MetricFormatter.number(2059.07, kind: .dollars, style: .row), "$2.06K")
+        XCTAssertEqual(MetricFormatter.number(2059.07, kind: .dollars, style: .row), "$2.1K")
         // Full: every digit, grouped.
         XCTAssertEqual(MetricFormatter.number(2059.07, kind: .dollars, style: .full), "$2,059.07")
     }

--- a/Tests/OpenUsageTests/MetricFormatterTests.swift
+++ b/Tests/OpenUsageTests/MetricFormatterTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import OpenUsage
+
+/// The one number→text place. `.tray` is the menu-bar form (shortest), `.row` the popover form
+/// (abbreviated but money keeps cents), `.full` the exact tooltip/headline form. These cases pin the
+/// behavior the old `WidgetData.format`, `MenuBarContent.compactValue`, and `formatTokens` each had.
+final class MetricFormatterTests: XCTestCase {
+    func testDollarsAbbreviateAboveAThousandPerStyle() {
+        // Tray: whole dollars under $1k, abbreviated above.
+        XCTAssertEqual(MetricFormatter.number(42, kind: .dollars, style: .tray), "$42")
+        XCTAssertEqual(MetricFormatter.number(2059.07, kind: .dollars, style: .tray), "$2.1K")
+        // Row: full cents under $1k, abbreviated with two decimals above.
+        XCTAssertEqual(MetricFormatter.number(40.76, kind: .dollars, style: .row), "$40.76")
+        XCTAssertEqual(MetricFormatter.number(2059.07, kind: .dollars, style: .row), "$2.06K")
+        // Full: every digit, grouped.
+        XCTAssertEqual(MetricFormatter.number(2059.07, kind: .dollars, style: .full), "$2,059.07")
+    }
+
+    func testCountsAbbreviateInTrayAndRowButKeepEveryDigitInFull() {
+        XCTAssertEqual(MetricFormatter.number(56_904_995, kind: .count, style: .tray), "56.9M")
+        XCTAssertEqual(MetricFormatter.number(56_904_995, kind: .count, style: .row), "56.9M")
+        XCTAssertEqual(MetricFormatter.number(56_904_995, kind: .count, style: .full), "56,904,995")
+        XCTAssertEqual(MetricFormatter.number(1_485_201_513, kind: .count, style: .row), "1.5B")
+        // Below 1,000, up to one decimal survives (a fractional credit balance).
+        XCTAssertEqual(MetricFormatter.number(820.6, kind: .count, style: .row), "820.6")
+    }
+
+    func testPercentRoundsToWholeInEveryStyle() {
+        XCTAssertEqual(MetricFormatter.number(95, kind: .percent, style: .full), "95%")
+        XCTAssertEqual(MetricFormatter.number(95.4, kind: .percent, style: .tray), "95%")
+    }
+
+    func testValueStringAppendsUnitLabelWhenPresent() {
+        let credits = MetricValue(number: 772, kind: .count, label: "credits")
+        XCTAssertEqual(MetricFormatter.string(for: credits, style: .row), "772 credits")
+        XCTAssertEqual(MetricFormatter.string(for: credits, style: .full), "772 credits")
+        // Tokens carry no label, so nothing is appended in any style.
+        let tokens = MetricValue(number: 56_904_995, kind: .count)
+        XCTAssertEqual(MetricFormatter.string(for: tokens, style: .row), "56.9M")
+        XCTAssertEqual(MetricFormatter.string(for: tokens, style: .full), "56,904,995")
+    }
+}

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -307,10 +307,11 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(combinedData.unboundedTooltip, "$478.00 · 891,000")
         XCTAssertEqual(combinedData.infoNote, WidgetData.ccusageEstimateNote)
 
-        // A day with tokens but no priced cost: the cost tile reads $0.00 with no ⓘ.
+        // A day with tokens but no priced cost: the cost-only tile finds no dollar value, so it reads
+        // "No data" rather than a misleading $0.00.
         let todayData = store.data(for: todayCost)
-        XCTAssertEqual(todayData.valueText, "$0.00")
-        XCTAssertNil(todayData.infoNote)
+        XCTAssertFalse(todayData.hasData)
+        XCTAssertEqual(todayData.valueText, WidgetData.noDataHeadline)
     }
 
     /// `resolveText` builds the resolved row from the descriptor's sample but must reset the fields a

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -153,26 +153,13 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(requests.boundedSubtitle, "Resets in 30d")
     }
 
-    func testCreditsRenderDollarValueWithRawCountInvariantToMeterStyle() async {
-        // Codex flex credits lead with the dollar value (4¢/credit): the provider line arrives as
-        // "$40.00 · 1,000 credits" and the row shows it verbatim (no Used/Left flipping), while the
-        // parsed dollar amount still feeds the menu bar's compact value.
+    func testCreditsRenderDollarAndCountCombinedInvariantToMeterStyle() async {
+        // Codex flex credits show the dollar value and the raw count combined ("$40.00 · 1,000
+        // credits"), invariant to the Used/Left meter style, while the dollar value drives the menu
+        // bar's compact reading — all from one `.values` row, no string re-parse.
         let provider = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
-        let descriptor = WidgetDescriptor(
-            id: "codex.credits",
-            providerID: provider.id,
-            metricLabel: "Credits",
-            sample: {
-                var sample = WidgetData(
-                    title: "Extra Usage",
-                    icon: provider.icon,
-                    kind: .dollars,
-                    used: 0,
-                    limit: nil
-                )
-                sample.preservesRawText = true
-                return sample
-            }()
+        let descriptor = WidgetDescriptor.combined(
+            id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"
         )
         let runtime = TestProviderRuntime(
             provider: provider,
@@ -180,7 +167,7 @@ final class WidgetDataStoreTests: XCTestCase {
             snapshot: ProviderSnapshot(
                 providerID: provider.id,
                 displayName: provider.displayName,
-                lines: [.text(label: "Credits", value: CodexUsageMapper.creditsLabel(remaining: 1000))]
+                lines: [.values(label: "Credits", values: CodexUsageMapper.creditValues(remaining: 1000))]
             )
         )
         let defaults = makeUserDefaults("codex-credits")
@@ -195,8 +182,8 @@ final class WidgetDataStoreTests: XCTestCase {
         store.meterStyle = .remaining
         let remaining = store.data(for: descriptor)
         XCTAssertFalse(remaining.isBounded)
-        XCTAssertEqual(remaining.unboundedDetail, "$40.00 · 1,000 credits")
-        XCTAssertEqual(remaining.used, 40.0)   // parsed dollars → compact tray value
+        XCTAssertEqual(remaining.unboundedDetail, "$40.00 · 1K credits")
+        XCTAssertEqual(remaining.menuBarValue, "$40")   // dollar value → compact tray reading
         XCTAssertNil(remaining.unboundedSubtitle)
 
         store.meterStyle = .used
@@ -205,13 +192,11 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(used.headline, remaining.headline)
     }
 
-    func testRateLimitResetsTileShowsCountInTrayAndRawTextInPopover() async {
-        // Regression: the menu-bar tile and the popover row must resolve from one value. The provider
-        // line is "1 available" — the popover shows it verbatim while the tray uses the parsed count.
-        // A prior bug backed the tile with display text only, leaving `used` at 0, so a pinned tile
-        // read "0" while the popover correctly read "1 available".
+    func testRateLimitResetsTileShowsCountInTrayAndPopover() async {
+        // Regression (#641): the menu-bar tile and the popover row resolve from one raw number, so a
+        // pinned tile can't read "0" while the popover reads "1". The count is carried raw.
         let provider = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
-        let descriptor = WidgetDescriptor.verbatimCount(
+        let descriptor = WidgetDescriptor.values(
             id: "codex.rateLimitResets",
             provider: provider,
             title: "Rate Limit Resets",
@@ -223,7 +208,8 @@ final class WidgetDataStoreTests: XCTestCase {
             snapshot: ProviderSnapshot(
                 providerID: provider.id,
                 displayName: provider.displayName,
-                lines: [.text(label: "Rate Limit Resets", value: "1 available")]
+                lines: [.values(label: "Rate Limit Resets",
+                                values: [MetricValue(number: 1, kind: .count)])]
             )
         )
         let defaults = makeUserDefaults("codex-resets")
@@ -238,13 +224,16 @@ final class WidgetDataStoreTests: XCTestCase {
         let data = store.data(for: descriptor)
         XCTAssertTrue(data.hasData)
         XCTAssertFalse(data.isBounded)
-        XCTAssertEqual(data.unboundedDetail, "1 available")   // popover row
-        XCTAssertEqual(data.displayedValue, 1)                // menu-bar tile's compact value
+        XCTAssertEqual(data.unboundedDetail, "1")   // popover row — bare count, no unit label
+        XCTAssertEqual(data.menuBarValue, "1")      // tray — the real count, never "0"
     }
 
-    func testCreditsLabelFloorsAndClampsBalance() {
-        XCTAssertEqual(CodexUsageMapper.creditsLabel(remaining: 820.9), "$32.80 · 820 credits")
-        XCTAssertEqual(CodexUsageMapper.creditsLabel(remaining: -5), "$0.00 · 0 credits")
+    func testCreditValuesFloorAndClampBalance() {
+        var data = WidgetData(title: "Extra Usage", icon: .providerMark("codex"), kind: .dollars, used: 0, limit: nil)
+        data.values = CodexUsageMapper.creditValues(remaining: 820.9)
+        XCTAssertEqual(data.unboundedDetail, "$32.80 · 820 credits")
+        data.values = CodexUsageMapper.creditValues(remaining: -5)
+        XCTAssertEqual(data.unboundedDetail, "$0.00 · 0 credits")
     }
 
     func testCreditsRenderUpToOneDecimalPlace() {
@@ -262,39 +251,33 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(credits.unboundedDetail, "820.6 credits left")
     }
 
-    func testCcusageAmountTilesShowLocalEstimateWithAndWithoutSpend() async {
+    func testCcusageSpendSplitsIntoCostTokensAndCombined() async {
+        // One `.values` spend row backs three tiles: cost-only (dollars + ⓘ), tokens-only (the
+        // measured count, no ⓘ), and combined (both, ⓘ because a shown value is estimated).
         let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("codex"))
-        let sample = { (id: String, title: String) in
-            WidgetDescriptor(
-                id: id,
-                providerID: provider.id,
-                metricLabel: title,
-                sample: WidgetData(
-                    title: title,
-                    icon: provider.icon,
-                    kind: .dollars,
-                    used: 0,
-                    limit: nil,
-                    unboundedValueWord: "spent",
-                    infoNote: WidgetData.ccusageEstimateNote
-                )
-            )
-        }
-        let last30 = sample("test.last30", "Last 30 Days")
-        let today = sample("test.today", "Today")
+        let cost = WidgetDescriptor.spend(id: "test.last30", provider: provider, title: "Last 30 Days")
+        let tokens = WidgetDescriptor.tokenSpend(id: "test.last30.tokens", provider: provider,
+                                                 title: "Tokens", metricLabel: "Last 30 Days")
+        let combined = WidgetDescriptor.combined(id: "test.last30.combined", provider: provider,
+                                                 title: "Combined", metricLabel: "Last 30 Days")
+        let todayCost = WidgetDescriptor.spend(id: "test.today", provider: provider, title: "Today")
+        let descriptors = [cost, tokens, combined, todayCost]
         let runtime = TestProviderRuntime(
             provider: provider,
-            descriptors: [last30, today],
+            descriptors: descriptors,
             snapshot: ProviderSnapshot(
                 providerID: provider.id,
                 displayName: provider.displayName,
                 lines: [
-                    .text(label: "Last 30 Days", value: "$478.00 · 891K tokens"),
-                    .text(label: "Today", value: "0 tokens")
+                    .values(label: "Last 30 Days", values: [
+                        MetricValue(number: 478.0, kind: .dollars, estimated: true),
+                        MetricValue(number: 891_000, kind: .count)
+                    ]),
+                    .values(label: "Today", values: [MetricValue(number: 0, kind: .count)])
                 ]
             )
         )
-        let registry = WidgetRegistry(providers: [provider], descriptors: [last30, today])
+        let registry = WidgetRegistry(providers: [provider], descriptors: descriptors)
         let cache = ProviderSnapshotCache(
             userDefaults: makeUserDefaults("ccusage-estimate"),
             storageKey: "snapshots",
@@ -304,14 +287,30 @@ final class WidgetDataStoreTests: XCTestCase {
         let store = WidgetDataStore(registry: registry, providers: [runtime], cache: cache)
         await store.refreshAll()
 
-        let last30Data = store.data(for: last30)
-        XCTAssertEqual(last30Data.valueText, "$478.00")
-        XCTAssertEqual(last30Data.infoNote, WidgetData.ccusageEstimateNote)
-        XCTAssertNil(last30Data.unboundedSubtitle)
+        // Cost-only: the dollars, with the ⓘ (locally estimated).
+        let costData = store.data(for: cost)
+        XCTAssertEqual(costData.valueText, "$478.00")
+        XCTAssertEqual(costData.unboundedDetail, "$478.00 spent")
+        XCTAssertEqual(costData.infoNote, WidgetData.ccusageEstimateNote)
 
-        let todayData = store.data(for: today)
+        // Tokens-only: the measured count, abbreviated and unlabeled, no ⓘ; the tooltip has every digit.
+        let tokenData = store.data(for: tokens)
+        XCTAssertEqual(tokenData.unboundedDetail, "891K")
+        XCTAssertEqual(tokenData.menuBarValue, "891K")
+        XCTAssertEqual(tokenData.unboundedTooltip, "891,000")
+        XCTAssertNil(tokenData.infoNote)
+
+        // Combined: both values joined; the tray glances at the leading dollar value, the tooltip is full.
+        let combinedData = store.data(for: combined)
+        XCTAssertEqual(combinedData.unboundedDetail, "$478.00 · 891K")
+        XCTAssertEqual(combinedData.menuBarValue, "$478")
+        XCTAssertEqual(combinedData.unboundedTooltip, "$478.00 · 891,000")
+        XCTAssertEqual(combinedData.infoNote, WidgetData.ccusageEstimateNote)
+
+        // A day with tokens but no priced cost: the cost tile reads $0.00 with no ⓘ.
+        let todayData = store.data(for: todayCost)
         XCTAssertEqual(todayData.valueText, "$0.00")
-        XCTAssertEqual(todayData.infoNote, WidgetData.ccusageEstimateNote)
+        XCTAssertNil(todayData.infoNote)
     }
 
     /// `resolveText` builds the resolved row from the descriptor's sample but must reset the fields a

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -25,8 +25,13 @@ of the number, not by the provider:
   - `.dollars` for a capped dollar amount (credits with a ceiling),
   - `.count(suffix:)` for a capped count (e.g. requests per cycle).
   - Add `resetsAt` when the window resets at a known time, and `periodDurationMs` for the cycle length.
-- **`.text`** — an unbounded value shown as-is, like `$12.34 spent`. Use it when there's no limit to draw a
-  bar against.
+- **`.values`** — an unbounded row carrying one or more raw numbers (each a `MetricValue`: a number, its
+  kind, an optional unit label like `"tokens"`). Use it for any limitless numeric row — a spend day carries
+  dollars *and* tokens, Codex credits carry dollars *and* a count. The widget picks which to show
+  (cost-only, tokens-only, or both) via its descriptor, and formatting happens at the display edge, so the
+  menu bar never re-parses a string. Prefer this for numbers.
+- **`.text`** — a value shown as-is, like `$12.34 spent`. Use it only for genuinely string-y rows, or a
+  capped dollar amount whose limit lives on the descriptor.
 - **`.badge`** — a short status pill, like `Disabled` or a pay-as-you-go cap. Use it for state rather than
   a fillable number.
 
@@ -42,7 +47,7 @@ silently.
    mapper, conforming to `ProviderRuntime`. Reuse the shared helpers in `Support/` (`ProviderParse` for
    JSON/number/percent parsing, `OpenUsageISO8601` for timestamps) instead of copying them.
 3. **Declare its widgets.** Expose the provider's metrics as `WidgetDescriptor`s using the factories in
-   `WidgetDescriptor+Factories.swift` (`percent`, `boundedDollars`, `spend`, `badge`, and so on).
+   `WidgetDescriptor+Factories.swift` (`percent`, `boundedDollars`, `spend`, `tokenSpend`, `combined`, `values`, `badge`, and so on).
 4. **Register it.** Add the provider to the list in `AppContainer`.
 5. **Test it.** Add focused tests under `Tests/OpenUsageTests/`, including a mapper test that feeds a
    sample API response and checks the resulting metric lines.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -14,7 +14,7 @@ The popover that opens from the menu bar icon. Providers are sections; each sect
 - Once the balance is spent — actually empty, or so close it rounds to `0` (like `0% left` or `$0.00`) — the bar stays red and the flame reads `Limit reached`, no matter how gentle the burn rate looked. A visibly empty bar never shows a calmer color.
 - **Hover the bar**, the spare note, or the flame for the pace projection at reset — the one number not already on the row: a blue bar shows the cushion you're on course to finish with (`~35% left at reset`), a yellow bar the usage it complements the spare note with (`~92% used at reset`), a red bar how far past the limit you're projected to land (`~12% over limit at reset`, or `~100% used at reset` when you're projected to finish right at it). Once spent it reads `Limit reached`.
 
-**Metrics without a limit** (daily spend, balances) show as a single line like `$4.08 spent`. A small ⓘ next to the name means the number is estimated locally rather than billed — hover it for details.
+**Metrics without a limit** (daily spend, balances) show as a single line like `$4.08 spent` or `1.2M`. The daily spend rows (Today / Yesterday / Last 30 Days) come in three flavors you can add from Customize — cost (`$4.08 spent`), tokens (`1.2M`), or both (`$4.08 · 1.2M`). Big numbers are abbreviated to keep rows tidy (`$2.06K`, `1.5B`) — **hover the row** to see the exact figures. A small ⓘ next to the name means a dollar figure is estimated locally rather than billed — hover it for details; token counts are measured, so they carry no ⓘ.
 
 Rows with a reset date tick every 30 seconds, so countdowns and pace stay live between refreshes.
 

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -47,7 +47,7 @@ Methods other than `GET`/`OPTIONS` return **405**; unknown routes return **404**
     {
       "type": "text",
       "label": "Today",
-      "value": "$5.17 · 9.2M tokens",
+      "value": "$5.17 · 9.2M",
       "color": null,
       "subtitle": null
     },

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -10,7 +10,7 @@ Tracks your Claude subscription limits using the login you already have from Cla
 | Weekly | 7-day window usage |
 | Sonnet | Separate weekly Sonnet limit (plan-dependent) |
 | Extra Usage | Extra-usage credits spent against your monthly cap |
-| Today / Yesterday / Last 30 Days | Local spend estimates (see below) |
+| Today / Yesterday / Last 30 Days | Local spend, as cost, tokens, or both (see below) |
 | Plan | Your plan name (optional widget) |
 
 ## Where credentials come from
@@ -25,7 +25,7 @@ Tokens are refreshed automatically; rotated tokens are written back where they c
 
 ## The spend tiles
 
-Today / Yesterday / Last 30 Days are computed **locally** from your Claude Code logs by running `ccusage` through whichever JavaScript package runner you already have — [Bun](https://bun.sh) (`bunx`) is preferred, otherwise `pnpm dlx`, `yarn dlx`, `npm exec`, or `npx`. The dollars are estimated from token counts — that's what the ⓘ on those rows means. No log data leaves your Mac.
+Today / Yesterday / Last 30 Days are computed **locally** from your Claude Code logs by running `ccusage` through whichever JavaScript package runner you already have — [Bun](https://bun.sh) (`bunx`) is preferred, otherwise `pnpm dlx`, `yarn dlx`, `npm exec`, or `npx`. Each period is available as a cost tile (`$4.08 spent`), a tokens tile (`1.2M`), or a combined tile (`$4.08 · 1.2M`) — add whichever you want from Customize. The dollars are estimated from token counts (that's the ⓘ); the token counts themselves are measured. No log data leaves your Mac.
 
 ## Troubleshooting
 

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -8,9 +8,9 @@ Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI
 |---|---|
 | Session | 5-hour rolling window usage |
 | Weekly | 7-day window usage |
-| Rate Limit Resets | On-demand rate-limit reset credits, shown as e.g. `1 available` |
+| Rate Limit Resets | On-demand rate-limit reset credits, shown as a count (e.g. `2`) |
 | Extra Usage | Flex credits, shown verbatim as dollars + credits (e.g. `$31.84 · 796 credits`) |
-| Today / Yesterday / Last 30 Days | Local spend estimates (see below) |
+| Today / Yesterday / Last 30 Days | Local spend, as cost, tokens, or both (see below) |
 | Plan | Your plan name (optional widget) |
 
 ## Where credentials come from
@@ -19,7 +19,7 @@ Sign in once with the Codex CLI (`codex`); OpenUsage reads the same auth files (
 
 ## The spend tiles
 
-Today / Yesterday / Last 30 Days are computed **locally** from your Codex logs by running `ccusage` through whichever JavaScript package runner you already have — [Bun](https://bun.sh) (`bunx`) is preferred, otherwise `pnpm dlx`, `yarn dlx`, `npm exec`, or `npx`. The dollars are estimated from token counts — that's the ⓘ on those rows. No log data leaves your Mac.
+Today / Yesterday / Last 30 Days are computed **locally** from your Codex logs by running `ccusage` through whichever JavaScript package runner you already have — [Bun](https://bun.sh) (`bunx`) is preferred, otherwise `pnpm dlx`, `yarn dlx`, `npm exec`, or `npx`. Each period is available as a cost tile (`$4.08 spent`), a tokens tile (`1.2M`), or a combined tile (`$4.08 · 1.2M`) — add whichever you want from Customize. The dollars are estimated from token counts (that's the ⓘ); the token counts themselves are measured. No log data leaves your Mac.
 
 ## Troubleshooting
 
@@ -31,4 +31,4 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Codex logs b
 
 `GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry.
 
-When the response includes `rate_limit_reset_credits.available_count`, OpenUsage shows that count as the "Rate Limit Resets" row (e.g. `1 available`), placed before Credits.
+When the response includes `rate_limit_reset_credits.available_count`, OpenUsage shows that count as the "Rate Limit Resets" row (e.g. `2`), placed before Credits.


### PR DESCRIPTION
## Description

Reworks how unbounded numeric rows carry and render their values, then uses that to split the daily-spend tiles into cost / tokens / combined. One model change underpins both linked issues: a row now carries its **raw numbers** (`MetricValue`) instead of a pre-formatted string, and a single `MetricFormatter` formats at the display edge.

**Why:** the old spend rows fused dollars + tokens into one string (`"$4.08 · 1.2M tokens"`) and the resolver then regex-parsed a number back out of it — so the token half was computed and silently dropped, and the menu bar could read `0` when a string wasn't parseable (#641). Carrying the number as the source of truth fixes both and makes the cost/tokens split fall out naturally (#647).

### What changed
- **`MetricLine.values([MetricValue])`** — new row type carrying raw numbers (number + kind + optional unit label + `estimated`). Replaces the fused/parsed strings for daily spend, Codex **Credits**, and Codex **Rate Limit Resets**. The menu bar no longer re-parses display text, so the "pinned tile reads 0" class of bug is gone (#641).
- **Cost / tokens / combined spend tiles** — one provider row backs three tiles via `ValueSelection` (`.kind(.dollars)`, `.kind(.count)`, `.all`). The existing `*.today` / `*.yesterday` / `*.last30` IDs now render the **combined** value (tokens were previously dropped); cost-only and tokens-only splits are opt-in (#647). Grok (#646) can register a token row with no cost — same shape, fewer values.
- **One formatter, three surfaces** — `MetricFormatter` with `.tray` (menu bar, shortest), `.row` (popover, abbreviated but money keeps cents), `.full` (exact). Large numbers abbreviate in the row (`$2.06K`, `1.5B`); **hovering a row shows the exact figures**. Tokens render unlabeled everywhere; credits keep `credits`; resets reads as a bare count (`2`). This replaces the scattered `WidgetData.format`, the menu bar's `compactValue`, and the providers' `formatTokens` / credit-label builders.
- **Data-driven ⓘ** — the "estimated locally" note shows on imputed dollars and stays off measured token counts, so a tokens-only tile is clean.
- **Local HTTP API** unchanged on the wire — `.values` rows serialize as the original `text` shape (`"$5.17 · 9.2M"`) so existing integrations keep working.

## Related Issue

Fixes #641
Fixes #647

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] New provider
- [x] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [x] I ran `swift build` and it succeeded
- [x] I ran `swift test` and all tests pass (279 tests, 0 failures)
- [x] I tested the change locally with `./script/build_and_run.sh`

## Screenshots

UI change verified live in the popover. Before → after for the spend rows:

- `Last 30 Days` — before: nothing but `$2,054.12 spent` (tokens dropped); after: `$2,054.12 · 1.5B` (hover → `$2,054.12 · 1,506,025,363`).
- `Today` — `$35.81 · 48.7M`; `Rate Limit Resets` — `2`; `Extra Usage` — `$30.88 · 772 credits` (unchanged).
- Menu bar stays short (`$478`, not `$478.00`).

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the **`swift`** branch (the Swift edition's active line; the template default `main` is the Tauri edition)
- [x] **Behavior change?** I updated the matching `docs/` pages (`dashboard.md`, `providers/claude.md`, `providers/codex.md`, `adding-a-provider.md`, `local-http-api.md`)
- [x] I did not introduce new dependencies without justification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide UI and data-model change across metrics, caching, and default widget behavior (combined spend vs cost-only); mitigated by tests and API wire compatibility, but regressions in formatting or pinned menu-bar tiles are plausible.
> 
> **Overview**
> Unbounded numeric metrics move from pre-formatted **`.text`** strings to **`MetricLine.values`** carrying **`MetricValue`** (number, kind, optional label, `estimated`). **`WidgetData`** gains `values`, **`ValueSelection`**, and display helpers (`menuBarValue`, `unboundedDetail`, `unboundedTooltip`); the menu bar reads **`data.menuBarValue`** instead of local tray formatting.
> 
> **`MetricFormatter`** centralizes tray / row / full formatting and replaces scattered logic in **`WidgetData`**, **`MenuBarContent`**, and provider string builders. **`WidgetDataStore`** resolves `.values` without regex parsing; cost-only tiles show **No data** when the selected kind is missing (e.g. no priced ccusage day).
> 
> Mappers emit raw values for ccusage spend, Cursor spend, Codex credits, and rate-limit resets. Descriptor factories add **`.values`**, **`.spend`**, **`.tokenSpend`**, **`.combined`**; Claude/Codex default **Today/Yesterday/Last 30** tiles show **cost + tokens**, with optional cost-only and tokens-only widget IDs.
> 
> Provider snapshot cache bumps to **v3** so stale `.text` caches are dropped. **Local HTTP API** still serializes `.values` as legacy combined `text` values. Row hover uses **`unboundedTooltip`** for full figures when abbreviated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be1723bb53255e0532ec8c21ef08d23a44e192a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unbounded numeric rows now carry raw values, and daily spend tiles can show cost, tokens, or both from a single provider row. This fixes “pinned tile reads 0” (#641), restores tokens that were dropped (#647), shows “No data” when cost is missing, bumps the snapshot cache to v3, and standardizes row dollar abbreviations to one decimal.

- **New Features**
  - Added `MetricLine.values` with `MetricValue`; used for daily spend, Codex Credits, and Rate Limit Resets.
  - `ValueSelection` lets one row back cost-only, tokens-only, or combined tiles.
  - Introduced `MetricFormatter` with `.tray`/`.row`/`.full`; rows abbreviate large numbers, hover shows exact figures; row dollars now abbreviate to one decimal (`$2,059.07` → `$2.1K`).
  - New descriptors: `.spend` (cost), `.tokenSpend` (tokens), `.combined` (both). Claude/Codex default spend tiles now render combined; split variants are available.
  - Menu bar uses `WidgetData.menuBarValue`: percentages for bounded rows, selected value for unbounded ones.
  - Local HTTP API stays backward compatible: `.values` serialize to the legacy combined `value` string (e.g. `"$5.17 · 9.2M"`).
  - Rate Limit Resets render as a bare count so tray and popover show the same number.

- **Bug Fixes**
  - Removed string re-parsing; pinned tiles no longer show 0 (#641).
  - Preserved and rendered tokens alongside cost (#647).
  - Cost-only tiles read “No data” when the row has no priced cost (addresses #648).
  - Bumped provider snapshot cache to v3 to avoid stale post-upgrade data.

<sup>Written for commit 5be1723bb53255e0532ec8c21ef08d23a44e192a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

