### PR TITLE
Unify popover max height across Customize and Settings (#591)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ This Swift edition is replacing the original Tauri app. Until the cutover, both 
 - Providers implement the small `ProviderRuntime` protocol: an auth store reads credentials already on the user's machine, a usage client calls the provider's API, and a mapper normalizes the response into `MetricLine` values. The UI renders those normalized values.
 - See `docs/` for behavior docs and the developer docs (architecture overview, adding a provider).
 
+## Running / Testing Changes
+
+- There is no hot reload. The app is a long-lived menu-bar process, so **every code change requires a full rebuild and restart of the running app** to take effect — kill the running instance, rebuild, and relaunch before testing.
+
 ## Documentation
 
 - Logic changes must update any docs in `docs/` that describe the affected behavior.

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -52,16 +52,11 @@ struct DashboardView: View {
     /// One width across both densities — switching density shouldn't move the popover's left edge.
     private static let popoverWidth: CGFloat = 320
 
-    /// Never grow taller than 85% of the *hosting* screen's usable height; scroll beyond that.
+    /// Never grow taller than 85% of the *hosting* screen's usable height; scroll beyond that. All
+    /// three screens (dashboard, Customize, Settings) share this one cap so they feel consistent —
+    /// each fits its content exactly until it would exceed the cap, then scrolls.
     private var maxHeight: CGFloat {
         floor(usableHeight * 0.85)
-    }
-
-    /// Customize is a management surface, not the data view: cap it at half the screen so it reads
-    /// as a compact editor and clearly scrolls, instead of towering like the dashboard. (Settings
-    /// instead tracks the dashboard's own height — see `settingsScrollHeight`.)
-    private var maxCustomizeHeight: CGFloat {
-        floor(usableHeight * 0.5)
     }
 
     /// The pinned footer lives outside the scroll region, so the scroll area's cap is the popover cap
@@ -74,10 +69,6 @@ struct DashboardView: View {
         max(120, maxHeight - chromeHeight)
     }
 
-    private var maxCustomizeScrollHeight: CGFloat {
-        max(120, maxCustomizeHeight - chromeHeight)
-    }
-
     /// The scroll area fits its content exactly until it would exceed the cap, then it scrolls.
     private var dashboardScrollHeight: CGFloat {
         min(listContentHeight, maxScrollHeight)
@@ -85,7 +76,7 @@ struct DashboardView: View {
 
     private var customizeScrollHeight: CGFloat {
         let contentHeight = hasMeasuredCustomizeContent ? customizeContentHeight : estimatedCustomizeContentHeight
-        return min(contentHeight, maxCustomizeScrollHeight)
+        return min(contentHeight, maxScrollHeight)
     }
 
     /// Settings fits its content exactly, like the dashboard and Customize, up to the global cap.


### PR DESCRIPTION
## What

The popover's three screens were clamped against two different ceilings: the dashboard and **Settings** used **85%** of the usable screen height, but **Customize** used **50%**. Once content was tall enough to hit the cap, Customize topped out and scrolled at half-height while Settings grew freely — the inconsistent max heights reported in [#591](https://github.com/robinebers/openusage/issues/591).

This removes the special-case `maxCustomizeHeight` / `maxCustomizeScrollHeight` (the deliberate "compact editor" 50% cap) and clamps `customizeScrollHeight` against the shared `maxScrollHeight`. All three screens — dashboard, Customize, Settings — now fit their content exactly up to one common 85% ceiling, then scroll.

## Why

The 50% cap was intentional (it's commented as keeping Customize a "compact editor"), but the issue pushes back on that: users expect Customize and Settings to feel consistent. Decision was to unify upward to 85% to match Settings/dashboard.

## Notes for reviewer

- Everything below the cap was already shared (same `MeasuredScrollScreen`, same `min(content, cap)` logic); neither `CustomizeView` nor `SettingsScreen` imposes an internal frame cap, so this single constant was the entire divergence.
- The `animatedPopoverHeight` slide interpolation is unaffected — it reads whatever per-screen height the cap produces.
- With the 50% cap gone, Customize can now grow tall on small screens. Worth an eyeball, but it's the intended outcome.
- Also documents in `AGENTS.md` that the menu-bar app has no hot reload — every change needs a full rebuild + restart to test.

`swift build` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized popover layout constant change with no auth, data, or API impact; Customize may appear taller on small screens by design.
> 
> **Overview**
> **Customize** no longer uses a separate **50%** screen-height cap; it now shares the same **85%** usable-height limit as the dashboard and **Settings**, so all three popover screens grow with content until that ceiling and then scroll.
> 
> The special-case `maxCustomizeHeight` / `maxCustomizeScrollHeight` helpers are removed; `customizeScrollHeight` clamps against `maxScrollHeight` like the other screens. Comments on `maxHeight` are updated to describe the unified behavior.
> 
> `AGENTS.md` adds a **Running / Testing Changes** note: the menu-bar app has no hot reload—rebuild and restart after every change to verify UI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abff606d30dee8641fba6c54c79011aa7791645e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the popover max height across Dashboard, Customize, and Settings to 85% of usable screen height for consistent behavior. Removes the Customize 50% cap (now clamped to the shared max) and adds a note in `AGENTS.md` that changes require a full rebuild and restart.

<sup>Written for commit abff606d30dee8641fba6c54c79011aa7791645e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

