### PR TITLE
fix(popover): host the dashboard in a key-capable NSPanel (reliable Esc/Return)

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -2,84 +2,115 @@ import AppKit
 import KeyboardShortcuts
 import SwiftUI
 
-/// Owns the menu-bar status item and the popover that shows the dashboard.
+/// The dashboard's host window: a borderless, **non-activating** panel that can still become key.
 ///
-/// This deliberately does not use SwiftUI's `MenuBarExtra`: its `.window` panel never becomes a
-/// proper key window for text input (the Settings shortcut recorder silently ignored key presses)
-/// and there is no public API to present it programmatically — the MenuBarExtraAccess bridge
-/// drives a simulated status-item click that became a silent no-op on macOS 26+. A plain
-/// `NSStatusItem` + `NSPopover` gives a real key window and a real `show()`/`performClose()` pair
-/// the global shortcut can call directly.
+/// This is the fix for `NSPopover`'s fundamental limitation in a menu-bar accessory app. A popover's
+/// window is only key while the whole app is active, and activating an `LSUIElement` app is
+/// asynchronous — on macOS 26+ it lands several runloop ticks later or is denied — so the popover is
+/// on-screen but not key, the keystroke goes to the focused status-item button instead (Enter
+/// re-toggles it shut; Esc is lost), and you need a second click/keypress. A `.nonactivatingPanel`
+/// whose `canBecomeKey` is `true` becomes key the instant it's ordered front, *without* activating the
+/// app, so keyboard input (Esc/Return navigation, the Settings shortcut recorder) works on the first
+/// try. (The pattern keyboard-first menu-bar apps use; cross-checked via GitHits.)
+final class MenuBarPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+/// Owns the menu-bar status item and the panel that shows the dashboard.
+///
+/// Deliberately not SwiftUI's `MenuBarExtra`: its `.window` panel never became a proper key window for
+/// text input (the Settings shortcut recorder silently ignored key presses) and there is no public API
+/// to present it programmatically. A plain `NSStatusItem` + a key-capable `NSPanel` gives a real key
+/// window and a real show/hide pair the global shortcut can call directly.
 @MainActor
-final class StatusItemController: NSObject, NSPopoverDelegate {
+final class StatusItemController: NSObject {
     private let container: AppContainer
     private let updater: UpdaterController
     private let statusItem: NSStatusItem
-    private let popover: NSPopover
-    /// Closes the popover on clicks outside it. `.transient` popover behavior is unreliable for
-    /// accessory apps (the popover can swallow the first outside click or refuse to close), so the
-    /// popover is `.applicationDefined` and this monitor implements "click away closes" itself.
+    private let panel: MenuBarPanel
+    private let hostingController: NSHostingController<AnyView>
+    /// Tracks the SwiftUI content's ideal size so the panel resizes to it (the dashboard animates its
+    /// own height on mode switches). Replaces the `NSPopover` `preferredContentSize` auto-tracking.
+    private var contentSizeObservation: NSKeyValueObservation?
+    /// Closes the panel on clicks outside it (the panel is non-activating and dismissal is ours to
+    /// implement, the same model the old `.applicationDefined` popover used).
     private var outsideClickMonitors: [Any] = []
-    /// Token for the appearance-change observer. The center keeps block observers alive on its
-    /// own, but holding the token follows the documented removal pattern (and the other observers
-    /// in this codebase) should the controller ever stop living for the app's whole life.
+    /// Token for the appearance-change observer; held to follow the documented removal pattern.
     private var appearanceObserver: NSObjectProtocol?
-    /// Re-asserts popover key focus when the app finally becomes active — the backstop for the
-    /// macOS 26+ case where `NSApp.activate` lands past `makePopoverKey`'s retry window. See
-    /// `makePopoverKey`.
-    private var activationObserver: NSObjectProtocol?
+    /// Observers that re-evaluate Reduce Transparency: the in-app toggle and macOS's own setting.
+    private var reduceTransparencyObserver: NSObjectProtocol?
+    private var systemReduceObserver: NSObjectProtocol?
+    /// The two interchangeable backdrops behind the dashboard: Liquid Glass, or a solid surface when
+    /// Reduce Transparency is on. Exactly one is visible (see `applyReduceTransparency`).
+    private var glassBackdrop: NSVisualEffectView?
+    private var solidBackdrop: NSBox?
+    /// Panel top-left in screen coords, captured on show. The panel grows downward from here as the
+    /// content animates its height, so the top edge stays pinned just under the status-item button.
+    private var anchorTopLeft: NSPoint?
+
+    /// One width across both densities (matches `DashboardView.popoverWidth`).
+    private static let panelWidth: CGFloat = 320
+    /// Gap between the menu bar and the panel's top edge.
+    private static let topGap: CGFloat = 4
+    /// Corner radius of the panel surface; tuned to read like a system menu-bar popover.
+    private static let cornerRadius: CGFloat = 13
 
     init(container: AppContainer, updater: UpdaterController) {
         self.container = container
         self.updater = updater
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        self.popover = NSPopover()
+
+        let hosting = NSHostingController(
+            rootView: AnyView(
+                DashboardView()
+                    .environment(container)
+                    .environment(container.layout)
+                    .environment(container.dataStore)
+                    .environment(updater)
+            )
+        )
+        // The panel tracks SwiftUI's preferred size, so the dashboard's animated height changes
+        // (mode switches, content growth) resize the panel instead of clipping.
+        hosting.sizingOptions = .preferredContentSize
+        self.hostingController = hosting
+
+        self.panel = MenuBarPanel(
+            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: 400),
+            styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
         super.init()
 
-        popover.behavior = .applicationDefined
-        popover.animates = true
-        popover.delegate = self
-        // The popover inherits its appearance from the positioning view — the status-bar button —
-        // so the menu bar's appearance, not `NSApp.appearance`, would win. Pin the theme override
-        // here (nil for System) and track the Settings picker live.
-        popover.appearance = AppearanceSetting.current.nsAppearance
+        configurePanel()
+        configureStatusItem()
+        updateButtonImage()
+
         appearanceObserver = NotificationCenter.default.addObserver(
             forName: AppearanceSetting.didChangeNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.popover.appearance = AppearanceSetting.current.nsAppearance
+                self?.panel.appearance = AppearanceSetting.current.nsAppearance
             }
         }
-        activationObserver = NotificationCenter.default.addObserver(
-            forName: NSApplication.didBecomeActiveNotification,
+        reduceTransparencyObserver = NotificationCenter.default.addObserver(
+            forName: ReduceTransparencySetting.didChangeNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                guard let self, self.popover.isShown else { return }
-                self.makePopoverKey(attempts: Self.makeKeyAttempts)
-            }
+            MainActor.assumeIsolated { self?.applyReduceTransparency() }
         }
-        let host = NSHostingController(
-            rootView: DashboardView()
-                .environment(container)
-                .environment(container.layout)
-                .environment(container.dataStore)
-                .environment(updater)
-        )
-        // The popover tracks SwiftUI's preferred size, so the dashboard's animated height changes
-        // (mode switches, content growth) resize the popover instead of clipping.
-        host.sizingOptions = .preferredContentSize
-        popover.contentViewController = host
-
-        if let button = statusItem.button {
-            button.target = self
-            button.action = #selector(statusButtonClicked)
+        systemReduceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.applyReduceTransparency() }
         }
-
-        updateButtonImage()
 
         // Registered once here; the controller lives for the app's whole life.
         KeyboardShortcuts.onKeyUp(for: .togglePopover) { [weak self] in
@@ -87,13 +118,115 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             self?.togglePopover()
         }
 
-        // Esc on the dashboard (and the footer's close affordances) dismiss through the same
-        // code path as a status-item click.
+        // Esc on the dashboard (and the footer's close affordances) dismiss through the same code
+        // path as a status-item click.
         MenuBarPopover.dismissHandler = { [weak self] in
-            self?.closePopover()
+            self?.hidePanel()
         }
 
         AppLog.info(.statusItem, "Status item ready (button: \(self.statusItem.button != nil), shortcut: \(KeyboardShortcuts.getShortcut(for: .togglePopover)?.description ?? "none"))")
+    }
+
+    // MARK: - Panel configuration
+
+    private func configurePanel() {
+        panel.level = .popUpMenu
+        panel.hidesOnDeactivate = false
+        panel.hasShadow = true
+        panel.isMovable = false
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.animationBehavior = .none
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        // Pin the theme override (nil for System) so the menu bar's appearance doesn't win; tracked
+        // live by `appearanceObserver`.
+        panel.appearance = AppearanceSetting.current.nsAppearance
+
+        let container = NSView()
+
+        // Glass backdrop: the popover material sampling the desktop behind the window — the same
+        // Liquid Glass `NSPopover` rendered for free. Rounded via a resizable mask (a plain layer
+        // corner-radius leaves the window-server-composited blur square at the edges).
+        let glass = NSVisualEffectView()
+        glass.material = .popover
+        glass.blendingMode = .behindWindow
+        glass.state = .active
+        glass.maskImage = Self.roundedMaskImage(radius: Self.cornerRadius)
+        glass.autoresizingMask = [.width, .height]
+        glass.frame = container.bounds
+
+        // Solid backdrop for Reduce Transparency: shown instead of the glass. It fills the whole
+        // window, so a screen-switch resize can't briefly reveal glass beneath the content-sized
+        // SwiftUI surface (the bug this fixes). `NSBox.fillColor` tracks light/dark automatically.
+        let solid = NSBox()
+        solid.boxType = .custom
+        solid.titlePosition = .noTitle
+        solid.borderWidth = 0
+        solid.cornerRadius = Self.cornerRadius
+        solid.contentViewMargins = .zero
+        solid.fillColor = .windowBackgroundColor
+        solid.isHidden = true
+        solid.autoresizingMask = [.width, .height]
+        solid.frame = container.bounds
+
+        let host = hostingController.view
+        host.frame = container.bounds
+        host.autoresizingMask = [.width, .height]
+        host.wantsLayer = true
+        host.layer?.cornerRadius = Self.cornerRadius
+        host.layer?.cornerCurve = .continuous
+        host.layer?.masksToBounds = true
+
+        container.addSubview(glass)
+        container.addSubview(solid, positioned: .above, relativeTo: glass)
+        container.addSubview(host, positioned: .above, relativeTo: solid)
+        glassBackdrop = glass
+        solidBackdrop = solid
+
+        // A plain container VC owns the backdrop; the hosting controller is its child so SwiftUI gets
+        // a proper view-controller hierarchy. The panel itself is sized by `resizePanelToContent`.
+        let rootVC = NSViewController()
+        rootVC.view = container
+        rootVC.addChild(hostingController)
+        panel.contentViewController = rootVC
+
+        contentSizeObservation = hostingController.observe(\.preferredContentSize, options: [.new]) { [weak self] _, _ in
+            MainActor.assumeIsolated { self?.resizePanelToContent() }
+        }
+
+        applyReduceTransparency()
+    }
+
+    /// Reduce Transparency — the in-app toggle OR macOS's own accessibility setting — swaps the glass
+    /// backdrop for the solid one. The solid view fills the whole window, so it covers any strip the
+    /// content-sized SwiftUI surface hasn't caught up to during a screen-switch resize (which would
+    /// otherwise flash the glass). Both backdrops round identically, so the swap is invisible at rest.
+    private func applyReduceTransparency() {
+        let reduce = ReduceTransparencySetting.current
+            || NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+        glassBackdrop?.isHidden = reduce
+        solidBackdrop?.isHidden = !reduce
+    }
+
+    private func configureStatusItem() {
+        guard let button = statusItem.button else { return }
+        button.target = self
+        button.action = #selector(statusButtonClicked)
+    }
+
+    /// A resizable rounded-rectangle mask so the `behindWindow` glass gets clean rounded corners
+    /// (a plain layer corner-radius leaves the window-server-composited blur square at the edges).
+    private static func roundedMaskImage(radius: CGFloat) -> NSImage {
+        let side = radius * 2 + 1
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            NSColor.black.setFill()
+            NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius).fill()
+            return true
+        }
+        image.capInsets = NSEdgeInsets(top: radius, left: radius, bottom: radius, right: radius)
+        image.resizingMode = .stretch
+        return image
     }
 
     // MARK: - Status item image
@@ -122,73 +255,70 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             ?? MenuBarStripRenderer.fallbackIcon
     }
 
-    // MARK: - Popover
+    // MARK: - Show / hide
 
     @objc private func statusButtonClicked() {
         togglePopover()
     }
 
     func togglePopover() {
-        if popover.isShown {
-            closePopover()
+        if panel.isVisible {
+            hidePanel()
         } else {
-            showPopover()
+            showPanel()
         }
     }
 
-    private func showPopover() {
-        guard let button = statusItem.button else {
-            AppLog.error(.statusItem, "Cannot show popover: status item has no button")
+    private func showPanel() {
+        guard let button = statusItem.button, let buttonWindow = button.window else {
+            AppLog.error(.statusItem, "Cannot show panel: status item has no button")
             return
         }
-        // An inactive accessory app receives no keyboard input — without activation the popover looks
-        // focused but Esc/Return navigation and the shortcut recorder are dead.
-        NSApp.activate(ignoringOtherApps: true)
-        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        // Lay the content out first so the panel opens at the right size (no first-frame flash).
+        hostingController.view.layoutSubtreeIfNeeded()
+
+        let buttonRectOnScreen = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
+        anchorTopLeft = clampedTopLeft(below: buttonRectOnScreen, width: Self.panelWidth)
+        resizePanelToContent()
+
+        // `canBecomeKey` + `.nonactivatingPanel` makes this key without activating the app — no
+        // activation race, so the dashboard receives keys on the first try.
+        panel.makeKeyAndOrderFront(nil)
         button.highlight(true)
         startOutsideClickMonitors()
-        makePopoverKey(attempts: Self.makeKeyAttempts)
     }
 
-    /// Drives the popover window to key so it actually receives keystrokes. Activating an accessory
-    /// app via `NSApp.activate` is asynchronous and, on macOS 26+, can lag several runloop ticks or be
-    /// denied outright — and a window can't be key while its app is inactive, so a single `makeKey()`
-    /// after `show` often leaves the popover non-key (its Esc/Return navigation and the shortcut
-    /// recorder dead until a second click). So retry across a few ticks until the window is key; the
-    /// `didBecomeActiveNotification` observer in `init` is the backstop for activation that lands later
-    /// still. (Pattern verified via GitHits across several menu-bar apps — e.g. SpacePill, Stats.)
-    private static let makeKeyAttempts = 12
-    private func makePopoverKey(attempts: Int) {
-        guard popover.isShown,
-              let window = popover.contentViewController?.view.window else { return }
-        window.makeKey()
-        if !window.isKeyWindow {
-            window.makeKeyAndOrderFront(nil)
-        }
-        if window.isKeyWindow { return }
-        guard attempts > 1 else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.015) { [weak self] in
-            self?.makePopoverKey(attempts: attempts - 1)
-        }
-    }
-
-    /// While the popover is up, `animates` must stay off: with it on, every SwiftUI-driven
-    /// `preferredContentSize` update (the dashboard animates its height frame-by-frame on mode
-    /// switches) starts a fresh implicit popover resize animation, and the window lags and
-    /// rubber-bands behind the content. Off, the window tracks SwiftUI's animation exactly.
-    /// Show/close keep the system fade by flipping `animates` back on around them.
-    func popoverDidShow(_ notification: Notification) {
-        popover.animates = false
-    }
-
-    private func closePopover() {
-        popover.animates = true
-        popover.performClose(nil)
-    }
-
-    func popoverWillClose(_ notification: Notification) {
+    private func hidePanel() {
+        panel.orderOut(nil)
         stopOutsideClickMonitors()
         statusItem.button?.highlight(false)
+        anchorTopLeft = nil
+    }
+
+    /// Resizes the panel to the SwiftUI content's ideal size, keeping the top edge pinned under the
+    /// status-item button (macOS window origins are bottom-left, so the origin drops as height grows).
+    private func resizePanelToContent() {
+        let size = hostingController.preferredContentSize
+        guard size.width > 0, size.height > 0 else { return }
+        let origin: NSPoint
+        if let anchorTopLeft {
+            origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - size.height)
+        } else {
+            origin = panel.frame.origin
+        }
+        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+        panel.invalidateShadow()
+    }
+
+    /// Places the panel's top-left just below the button, clamped to the button's screen.
+    private func clampedTopLeft(below buttonRect: NSRect, width: CGFloat) -> NSPoint {
+        var x = buttonRect.minX
+        let topY = buttonRect.minY - Self.topGap
+        let screen = NSScreen.screens.first { $0.frame.intersects(buttonRect) } ?? NSScreen.main
+        if let visible = screen?.visibleFrame {
+            x = min(max(x, visible.minX + 8), visible.maxX - width - 8)
+        }
+        return NSPoint(x: x, y: topY)
     }
 
     // MARK: - Outside-click dismissal
@@ -197,27 +327,33 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         stopOutsideClickMonitors()
         let mask: NSEvent.EventTypeMask = [.leftMouseDown, .rightMouseDown, .otherMouseDown]
         if let local = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { [weak self] event in
-            // NSEvent is not Sendable: pull the window identity and location out before hopping
-            // to the actor. With no window, the location is already in screen coordinates.
+            // NSEvent is not Sendable: pull the window identity out before hopping to the actor.
             let windowID = event.window.map(ObjectIdentifier.init)
             let windowTypeName = event.window.map { String(describing: type(of: $0)) }
-            let screenPoint = event.window?.convertPoint(toScreen: event.locationInWindow) ?? event.locationInWindow
             MainActor.assumeIsolated {
-                guard let self,
-                      !self.shouldKeepPopoverOpen(windowID: windowID, windowTypeName: windowTypeName, screenPoint: screenPoint)
+                guard let self else { return }
+                // `NSEvent.mouseLocation` is the dependable screen-coordinate read (`locationInWindow`
+                // is unreliable for windowless / global events), so the status-button match is correct.
+                let screenPoint = NSEvent.mouseLocation
+                guard !self.shouldKeepPanelOpen(windowID: windowID, windowTypeName: windowTypeName, screenPoint: screenPoint)
                 else { return }
-                self.closePopover()
+                self.hidePanel()
             }
             return event
         }) {
             outsideClickMonitors.append(local)
         }
-        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: { [weak self] event in
-            // Global monitor events carry no window; the location is in screen coordinates.
-            let screenPoint = event.locationInWindow
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: { [weak self] _ in
             Task { @MainActor [weak self] in
-                guard let self, !self.isOnStatusButton(screenPoint: screenPoint) else { return }
-                self.closePopover()
+                guard let self else { return }
+                // Clicking the status item must NOT dismiss here — its own action toggles the panel.
+                // Dismissing on this click's mouse-down would close the panel, then the button action
+                // would reopen it on mouse-up (the close-then-reopen flicker). `NSEvent.mouseLocation`
+                // gives reliable screen coordinates for the status-button / in-panel checks.
+                let screenPoint = NSEvent.mouseLocation
+                guard !self.isOnStatusButton(screenPoint: screenPoint),
+                      !self.panel.frame.contains(screenPoint) else { return }
+                self.hidePanel()
             }
         }) {
             outsideClickMonitors.append(global)
@@ -231,18 +367,16 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         outsideClickMonitors = []
     }
 
-    /// In-app clicks that must not dismiss: anything inside the popover itself, the status-item
-    /// button (its own handler toggles — closing here too would cancel it out and reopen), and
-    /// menu windows (the Settings pickers' popup menus render in separate `NSMenu`-backed
-    /// windows). Status-item clicks can arrive with no window (the menu bar is composited by the
-    /// Window Server), so the button is also matched by screen position.
-    private func shouldKeepPopoverOpen(windowID: ObjectIdentifier?, windowTypeName: String?, screenPoint: NSPoint) -> Bool {
+    /// In-app clicks that must not dismiss: anything inside the panel itself, the status-item button
+    /// (its own handler toggles — closing here too would cancel it out and reopen), and menu windows
+    /// (the Settings pickers' popup menus and the footer's More menu render in separate `NSMenu`-backed
+    /// windows). Status-item clicks can arrive with no window (the menu bar is composited by the Window
+    /// Server), so the button is also matched by screen position.
+    private func shouldKeepPanelOpen(windowID: ObjectIdentifier?, windowTypeName: String?, screenPoint: NSPoint) -> Bool {
         if isOnStatusButton(screenPoint: screenPoint) { return true }
+        if panel.frame.contains(screenPoint) { return true }
         guard let windowID, let windowTypeName else { return false }
-        if let popoverWindow = popover.contentViewController?.view.window,
-           windowID == ObjectIdentifier(popoverWindow) {
-            return true
-        }
+        if windowID == ObjectIdentifier(panel) { return true }
         if let buttonWindow = statusItem.button?.window, windowID == ObjectIdentifier(buttonWindow) {
             return true
         }

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -24,6 +24,10 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// own, but holding the token follows the documented removal pattern (and the other observers
     /// in this codebase) should the controller ever stop living for the app's whole life.
     private var appearanceObserver: NSObjectProtocol?
+    /// Re-asserts popover key focus when the app finally becomes active — the backstop for the
+    /// macOS 26+ case where `NSApp.activate` lands past `makePopoverKey`'s retry window. See
+    /// `makePopoverKey`.
+    private var activationObserver: NSObjectProtocol?
 
     init(container: AppContainer, updater: UpdaterController) {
         self.container = container
@@ -46,6 +50,16 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         ) { [weak self] _ in
             MainActor.assumeIsolated {
                 self?.popover.appearance = AppearanceSetting.current.nsAppearance
+            }
+        }
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, self.popover.isShown else { return }
+                self.makePopoverKey(attempts: Self.makeKeyAttempts)
             }
         }
         let host = NSHostingController(
@@ -127,13 +141,35 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             AppLog.error(.statusItem, "Cannot show popover: status item has no button")
             return
         }
-        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-        // An inactive accessory app receives no text input; without activation the popover looks
-        // focused but clicks and the shortcut recorder are dead.
+        // An inactive accessory app receives no keyboard input — without activation the popover looks
+        // focused but Esc/Return navigation and the shortcut recorder are dead.
         NSApp.activate(ignoringOtherApps: true)
-        popover.contentViewController?.view.window?.makeKey()
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         button.highlight(true)
         startOutsideClickMonitors()
+        makePopoverKey(attempts: Self.makeKeyAttempts)
+    }
+
+    /// Drives the popover window to key so it actually receives keystrokes. Activating an accessory
+    /// app via `NSApp.activate` is asynchronous and, on macOS 26+, can lag several runloop ticks or be
+    /// denied outright — and a window can't be key while its app is inactive, so a single `makeKey()`
+    /// after `show` often leaves the popover non-key (its Esc/Return navigation and the shortcut
+    /// recorder dead until a second click). So retry across a few ticks until the window is key; the
+    /// `didBecomeActiveNotification` observer in `init` is the backstop for activation that lands later
+    /// still. (Pattern verified via GitHits across several menu-bar apps — e.g. SpacePill, Stats.)
+    private static let makeKeyAttempts = 12
+    private func makePopoverKey(attempts: Int) {
+        guard popover.isShown,
+              let window = popover.contentViewController?.view.window else { return }
+        window.makeKey()
+        if !window.isKeyWindow {
+            window.makeKeyAndOrderFront(nil)
+        }
+        if window.isKeyWindow { return }
+        guard attempts > 1 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.015) { [weak self] in
+            self?.makePopoverKey(attempts: attempts - 1)
+        }
     }
 
     /// While the popover is up, `animates` must stay off: with it on, every SwiftUI-driven

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -344,13 +344,15 @@ final class StatusItemController: NSObject {
             outsideClickMonitors.append(local)
         }
         if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: { [weak self] _ in
+            // Capture the click location NOW: `mouseLocation` read later (inside the Task) could be
+            // stale if the pointer moved before the hop, mis-deciding the status-button / in-panel
+            // checks. `NSPoint` is Sendable, so the captured value crosses into the Task safely.
+            let screenPoint = NSEvent.mouseLocation
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 // Clicking the status item must NOT dismiss here — its own action toggles the panel.
                 // Dismissing on this click's mouse-down would close the panel, then the button action
-                // would reopen it on mouse-up (the close-then-reopen flicker). `NSEvent.mouseLocation`
-                // gives reliable screen coordinates for the status-button / in-panel checks.
-                let screenPoint = NSEvent.mouseLocation
+                // would reopen it on mouse-up (the close-then-reopen flicker).
                 guard !self.isOnStatusButton(screenPoint: screenPoint),
                       !self.panel.frame.contains(screenPoint) else { return }
                 self.hidePanel()

--- a/Sources/OpenUsage/Stores/ReduceTransparencySetting.swift
+++ b/Sources/OpenUsage/Stores/ReduceTransparencySetting.swift
@@ -12,6 +12,13 @@ enum ReduceTransparencySetting {
     /// The `UserDefaults.standard` key this setting persists under.
     static let key = "reduceTransparency"
 
+    /// Posted when the in-app toggle flips, so the panel's AppKit glass backdrop
+    /// (`StatusItemController`) can swap to a solid surface live — `@AppStorage` reactivity only
+    /// re-renders the in-window content, not the window's own backdrop. Mirrors
+    /// `AppearanceSetting.didChangeNotification`. (macOS's *own* Reduce Transparency setting is
+    /// observed separately, via `NSWorkspace`.)
+    static let didChangeNotification = Notification.Name("ReduceTransparencySettingDidChange")
+
     /// The stored choice, read live from `UserDefaults.standard` (defaults to `false` when unset —
     /// a missing bool key reads as `false`, which is exactly the "glass on" default we want).
     static var current: Bool {

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -92,16 +92,14 @@ struct PopoverKeyReader: NSViewRepresentable {
         view.onReturn = onReturn
     }
 
-    /// Whether a bare-key keyDown belongs to the popover. The popover is normally the key window, so
-    /// the event carries its id. But on macOS 26+ an accessory app can briefly fail to take key focus
-    /// when the popover opens (the same activation race the Settings shortcut recorder re-asserts
-    /// focus to dodge), and the keyDown then arrives with no key window (`eventWindowID == nil`).
-    /// Treat that as the popover's too — while this monitor is installed the popover is the only
-    /// window in play — so the key still lands. A *different* non-nil window (e.g. an open NSMenu
-    /// that owns the keyDown) is not the popover's and is left alone.
+    /// Whether a bare-key keyDown belongs to the popover: its key window must *be* the panel. The
+    /// panel is a non-activating key window that takes focus the instant it opens, so a foreign key
+    /// window (an open About panel, a tracking `NSMenu` from the More menu or a Settings picker) — or
+    /// no key window at all — is correctly *not* the popover's, and Esc/Return leave it alone instead
+    /// of hijacking it. (An earlier build also claimed a nil key window, to paper over `NSPopover`'s
+    /// activation race; the `NSPanel` removed that race, so the strict match is correct and safer.)
     static func keyTargetsPopover(eventWindowID: ObjectIdentifier?, popoverWindowID: ObjectIdentifier) -> Bool {
-        guard let eventWindowID else { return true }
-        return eventWindowID == popoverWindowID
+        eventWindowID == popoverWindowID
     }
 
     final class MonitorView: NSView {
@@ -134,7 +132,8 @@ struct PopoverKeyReader: NSViewRepresentable {
                     // Only act while the popover is on-screen; the SwiftUI tree (and this monitor) can
                     // outlive a close, and `isVisible` stands in for `NSPopover.isShown`.
                     guard let self, let window = self.window, window.isVisible else { return false }
-                    // The key must target the popover (see `keyTargetsPopover` for the key-window race).
+                    // The key must target the popover — its key window must be the panel, so a key
+                    // pressed while a menu / About panel owns focus is left alone (see `keyTargetsPopover`).
                     guard PopoverKeyReader.keyTargetsPopover(
                         eventWindowID: eventWindowID,
                         popoverWindowID: ObjectIdentifier(window)

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -77,6 +77,18 @@ struct EscapeToCloseReader: NSViewRepresentable {
         (nsView as? MonitorView)?.onEscape = onEscape
     }
 
+    /// Whether an Esc keyDown belongs to the popover. The popover is normally the key window, so the
+    /// event carries its id. But on macOS 26+ an accessory app can briefly fail to take key focus
+    /// when the popover opens (the same activation race the Settings shortcut recorder re-asserts
+    /// focus to dodge), and the keyDown then arrives with no key window (`eventWindowID == nil`).
+    /// Treat that as the popover's too — while the Esc monitor is installed the popover is the only
+    /// window in play — so Esc still closes it reliably. A *different* non-nil window (e.g. an open
+    /// NSMenu that owns the keyDown) is not the popover's and is left alone.
+    static func escapeTargetsPopover(eventWindowID: ObjectIdentifier?, popoverWindowID: ObjectIdentifier) -> Bool {
+        guard let eventWindowID else { return true }
+        return eventWindowID == popoverWindowID
+    }
+
     final class MonitorView: NSView {
         var onEscape: (@MainActor () -> Bool)?
         private var monitor: Any?
@@ -93,8 +105,12 @@ struct EscapeToCloseReader: NSViewRepresentable {
                 guard event.keyCode == MonitorView.escapeKeyCode else { return event }
                 let eventWindowID = event.window.map(ObjectIdentifier.init)
                 let consumed = MainActor.assumeIsolated { () -> Bool in
-                    guard let self, let window = self.window,
-                          eventWindowID == ObjectIdentifier(window) else { return false }
+                    guard let self, let window = self.window else { return false }
+                    // Esc must target the popover (see `escapeTargetsPopover` for the key-window race).
+                    guard EscapeToCloseReader.escapeTargetsPopover(
+                        eventWindowID: eventWindowID,
+                        popoverWindowID: ObjectIdentifier(window)
+                    ) else { return false }
                     // A text control is editing, or the Settings shortcut recorder is capturing a
                     // combo: Esc belongs to it (cancel the capture), not to popover navigation.
                     if window.firstResponder is NSText || ShortcutRecorderField.isRecordingActive {

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -58,41 +58,58 @@ struct PopoverVisibilityReader: NSViewRepresentable {
     }
 }
 
-/// Handles Esc in the hosting menu-bar popover: a handler gets first refusal (e.g. backing out of
-/// Customize); when it declines, the popover is dismissed through `MenuBarPopover.dismiss`, the
-/// same path a status-item click takes — so it stays in sync, reopens in one click, and trips the
-/// visibility reset (cancelling edit mode + the jiggle).
-struct EscapeToCloseReader: NSViewRepresentable {
+/// Handles the popover's two bare navigation keys via a local key monitor. SwiftUI
+/// `.keyboardShortcut` is unreliable here — a hidden/zero-size shortcut button never registers, and
+/// even a visible default button only fires when the popover is the key window — so the popover's
+/// keyboard navigation rides this low-level monitor instead, which sees the raw keyDown the moment
+/// the app processes it.
+///
+/// - **Esc**: `onEscape` gets first refusal (e.g. backing out of Customize); when it declines, the
+///   popover is dismissed through `MenuBarPopover.dismiss`, the same path a status-item click takes
+///   — so it stays in sync, reopens in one click, and trips the visibility reset (cancelling edit
+///   mode + the jiggle).
+/// - **Return**: `onReturn` opens/closes Customize (the affordance the standalone Customize button
+///   carried before it folded into the More menu). Consuming the key here is also what stops a bare
+///   Return from falling through and dismissing the popover.
+struct PopoverKeyReader: NSViewRepresentable {
     /// Called first on Esc. Return `true` when the press was handled in-popover (Esc then does
     /// NOT close); return `false` to let the popover dismiss.
     var onEscape: @MainActor () -> Bool = { false }
+    /// Called on plain (unmodified) Return. Return `true` to consume it (e.g. toggling Customize);
+    /// `false` lets the key fall through to a focused control.
+    var onReturn: @MainActor () -> Bool = { false }
 
     func makeNSView(context: Context) -> NSView {
         let view = MonitorView()
         view.onEscape = onEscape
+        view.onReturn = onReturn
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        (nsView as? MonitorView)?.onEscape = onEscape
+        guard let view = nsView as? MonitorView else { return }
+        view.onEscape = onEscape
+        view.onReturn = onReturn
     }
 
-    /// Whether an Esc keyDown belongs to the popover. The popover is normally the key window, so the
-    /// event carries its id. But on macOS 26+ an accessory app can briefly fail to take key focus
+    /// Whether a bare-key keyDown belongs to the popover. The popover is normally the key window, so
+    /// the event carries its id. But on macOS 26+ an accessory app can briefly fail to take key focus
     /// when the popover opens (the same activation race the Settings shortcut recorder re-asserts
     /// focus to dodge), and the keyDown then arrives with no key window (`eventWindowID == nil`).
-    /// Treat that as the popover's too — while the Esc monitor is installed the popover is the only
-    /// window in play — so Esc still closes it reliably. A *different* non-nil window (e.g. an open
-    /// NSMenu that owns the keyDown) is not the popover's and is left alone.
-    static func escapeTargetsPopover(eventWindowID: ObjectIdentifier?, popoverWindowID: ObjectIdentifier) -> Bool {
+    /// Treat that as the popover's too — while this monitor is installed the popover is the only
+    /// window in play — so the key still lands. A *different* non-nil window (e.g. an open NSMenu
+    /// that owns the keyDown) is not the popover's and is left alone.
+    static func keyTargetsPopover(eventWindowID: ObjectIdentifier?, popoverWindowID: ObjectIdentifier) -> Bool {
         guard let eventWindowID else { return true }
         return eventWindowID == popoverWindowID
     }
 
     final class MonitorView: NSView {
         var onEscape: (@MainActor () -> Bool)?
+        var onReturn: (@MainActor () -> Bool)?
         private var monitor: Any?
         private static let escapeKeyCode: UInt16 = 53
+        private static let returnKeyCode: UInt16 = 36
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
@@ -102,19 +119,33 @@ struct EscapeToCloseReader: NSViewRepresentable {
             }
             guard window != nil else { return }
             monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-                guard event.keyCode == MonitorView.escapeKeyCode else { return event }
+                let keyCode = event.keyCode
+                guard keyCode == MonitorView.escapeKeyCode || keyCode == MonitorView.returnKeyCode else {
+                    return event
+                }
+                // Only bare Return navigates; ⌘⏎, ⌥⏎, etc. belong to other controls.
+                let isReturn = keyCode == MonitorView.returnKeyCode
+                if isReturn,
+                   !event.modifierFlags.intersection([.command, .option, .control, .shift]).isEmpty {
+                    return event
+                }
                 let eventWindowID = event.window.map(ObjectIdentifier.init)
                 let consumed = MainActor.assumeIsolated { () -> Bool in
-                    guard let self, let window = self.window else { return false }
-                    // Esc must target the popover (see `escapeTargetsPopover` for the key-window race).
-                    guard EscapeToCloseReader.escapeTargetsPopover(
+                    // Only act while the popover is on-screen; the SwiftUI tree (and this monitor) can
+                    // outlive a close, and `isVisible` stands in for `NSPopover.isShown`.
+                    guard let self, let window = self.window, window.isVisible else { return false }
+                    // The key must target the popover (see `keyTargetsPopover` for the key-window race).
+                    guard PopoverKeyReader.keyTargetsPopover(
                         eventWindowID: eventWindowID,
                         popoverWindowID: ObjectIdentifier(window)
                     ) else { return false }
                     // A text control is editing, or the Settings shortcut recorder is capturing a
-                    // combo: Esc belongs to it (cancel the capture), not to popover navigation.
+                    // combo: the key belongs to it (insert / cancel / record), not to popover nav.
                     if window.firstResponder is NSText || ShortcutRecorderField.isRecordingActive {
                         return false
+                    }
+                    if isReturn {
+                        return self.onReturn?() ?? false
                     }
                     if self.onEscape?() == true {
                         return true

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -172,11 +172,12 @@ struct DashboardView: View {
             .coordinateSpace(name: Self.reorderSpace)
             .background(ScreenHeightReader(usableHeight: $usableHeight))
             .background(
-                // Esc backs out of Customize / Settings first; only from the dashboard does it
-                // close the popover. Return toggles Customize (opens it from the dashboard/Settings,
-                // closes it from Customize) — the affordance the standalone Customize button carried
-                // before it folded into the More menu — and is always consumed so a bare Return never
-                // falls through to dismiss the popover.
+                // Esc backs out of Customize / Settings first; only from the dashboard does it close
+                // the popover. Return opens Customize from the dashboard (the affordance the standalone
+                // Customize button carried before it folded into the More menu) and returns to the
+                // dashboard from Customize or Settings — matching Esc and the prominent "Done" control,
+                // never jumping Settings → Customize. Always consumed, so a bare Return can't fall
+                // through and dismiss the popover.
                 PopoverKeyReader(
                     onEscape: {
                         guard layout.screen != .dashboard else { return false }
@@ -184,9 +185,8 @@ struct DashboardView: View {
                         return true
                     },
                     onReturn: {
-                        withAnimation(Motion.modeSwitch) {
-                            layout.screen = layout.screen == .customize ? .dashboard : .customize
-                        }
+                        let target: PopoverScreen = layout.screen == .dashboard ? .customize : .dashboard
+                        withAnimation(Motion.modeSwitch) { layout.screen = target }
                         return true
                     }
                 )

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -173,12 +173,23 @@ struct DashboardView: View {
             .background(ScreenHeightReader(usableHeight: $usableHeight))
             .background(
                 // Esc backs out of Customize / Settings first; only from the dashboard does it
-                // close the popover.
-                EscapeToCloseReader(onEscape: {
-                    guard layout.screen != .dashboard else { return false }
-                    withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
-                    return true
-                })
+                // close the popover. Return toggles Customize (opens it from the dashboard/Settings,
+                // closes it from Customize) — the affordance the standalone Customize button carried
+                // before it folded into the More menu — and is always consumed so a bare Return never
+                // falls through to dismiss the popover.
+                PopoverKeyReader(
+                    onEscape: {
+                        guard layout.screen != .dashboard else { return false }
+                        withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
+                        return true
+                    },
+                    onReturn: {
+                        withAnimation(Motion.modeSwitch) {
+                            layout.screen = layout.screen == .customize ? .dashboard : .customize
+                        }
+                        return true
+                    }
+                )
             )
             .background(
                 PopoverVisibilityReader { visible in

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -49,7 +49,23 @@ struct HeaderView: View {
             }
             // The anchor view fills the button's frame so the menu drops from directly under it.
             .background(PopUpMenuAnchorView(anchor: moreMenuAnchor))
+            // ⏎ still jumps straight into Customize, as it did before the standalone Customize
+            // button became this "More" menu. A key-only button restores that affordance without
+            // hijacking the visible control's menu action.
+            .background(enterCustomizeReturnKey)
         }
+    }
+
+    /// A zero-size, key-only button mapping plain ⏎ to entering Customize. Mounted only on the
+    /// non-Customize screens — the Customize "Done" button binds ⏎ there — so Return enters
+    /// Customize from the dashboard (or Settings) and exits it from Customize, the way the
+    /// standalone Customize button behaved before it folded into the More menu. The popover has no
+    /// text fields, so a plain-Return key equivalent can't steal Return from an editing control.
+    private var enterCustomizeReturnKey: some View {
+        Button { toggle(.customize) } label: { Color.clear.frame(width: 0, height: 0) }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.return, modifiers: [])
+            .accessibilityHidden(true)
     }
 
     /// Builds and pops the "More" pull-down as a native `NSMenu`, so the trigger stays the exact glass

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -31,41 +31,23 @@ struct HeaderView: View {
         .glassButtonGroup(spacing: 4)
     }
 
-    /// While the Customize screen is open the slot is the prominent "Done" button — clicking it (or ⏎)
-    /// returns to the dashboard, matching how the old Customize button behaved. Otherwise it's the
-    /// "More" button: the same round glass control, opening a pull-down whose "Customize Metrics" item
-    /// is the way into Customize.
+    /// While the Customize screen is open the slot is the prominent "Done" button — clicking it (or
+    /// pressing ⏎, which `PopoverKeyReader` routes for the whole popover) returns to the dashboard.
+    /// Otherwise it's the "More" button: the same round glass control, opening a pull-down whose
+    /// "Customize Metrics" item is the way into Customize.
     @ViewBuilder
     private var leadingControl: some View {
         if layout.screen == .customize {
             roundButton("Done", systemImage: "checkmark", prominent: true) {
                 toggle(.customize)
             }
-            // Plain Return (not .defaultAction, which would restyle the glass button as default).
-            .keyboardShortcut(.return, modifiers: [])
         } else {
             roundButton("More", systemImage: "ellipsis", prominent: false) {
                 presentMoreMenu()
             }
             // The anchor view fills the button's frame so the menu drops from directly under it.
             .background(PopUpMenuAnchorView(anchor: moreMenuAnchor))
-            // ⏎ still jumps straight into Customize, as it did before the standalone Customize
-            // button became this "More" menu. A key-only button restores that affordance without
-            // hijacking the visible control's menu action.
-            .background(enterCustomizeReturnKey)
         }
-    }
-
-    /// A zero-size, key-only button mapping plain ⏎ to entering Customize. Mounted only on the
-    /// non-Customize screens — the Customize "Done" button binds ⏎ there — so Return enters
-    /// Customize from the dashboard (or Settings) and exits it from Customize, the way the
-    /// standalone Customize button behaved before it folded into the More menu. The popover has no
-    /// text fields, so a plain-Return key equivalent can't steal Return from an editing control.
-    private var enterCustomizeReturnKey: some View {
-        Button { toggle(.customize) } label: { Color.clear.frame(width: 0, height: 0) }
-            .buttonStyle(.plain)
-            .keyboardShortcut(.return, modifiers: [])
-            .accessibilityHidden(true)
     }
 
     /// Builds and pops the "More" pull-down as a native `NSMenu`, so the trigger stays the exact glass

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -108,12 +108,16 @@ struct SettingsScreen: View {
                 row("Time Format") {
                     picker($timeFormat, options: TimeFormatSetting.allCases, label: \.label)
                 }
-                // Off keeps the stock Liquid Glass look; @AppStorage reactivity re-renders the
-                // popover live, so no onChange is needed.
+                // Off keeps the stock Liquid Glass look. `@AppStorage` re-renders the in-window content
+                // live, but the panel's backdrop is AppKit, so notify `StatusItemController` to swap
+                // its glass for a solid surface (otherwise the glass shows through during animations).
                 row("Reduce Transparency") {
                     Toggle("", isOn: $reduceTransparency)
                         .settingsSwitchStyle()
                         .help("Use a solid background instead of Liquid Glass for better readability")
+                        .onChange(of: reduceTransparency) {
+                            NotificationCenter.default.post(name: ReduceTransparencySetting.didChangeNotification, object: nil)
+                        }
                 }
             }
             section("Usage Display") {

--- a/Tests/OpenUsageTests/EscapeToCloseReaderTests.swift
+++ b/Tests/OpenUsageTests/EscapeToCloseReaderTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import OpenUsage
+
+/// `EscapeToCloseReader.escapeTargetsPopover` decides whether an Esc keyDown should dismiss the
+/// menu-bar popover. The nil-window case guards the macOS 26+ regression where the popover is
+/// visible but not key, so the keyDown carries no window and a strict identity check would have
+/// silently dropped it ("sometimes Esc doesn't close").
+final class EscapeToCloseReaderTests: XCTestCase {
+    /// Distinct instances stand in for windows; `ObjectIdentifier` gives each a stable identity.
+    private final class WindowStub {}
+
+    func testNilKeyWindowTargetsPopover() {
+        // No key window (the accessory-app activation race): Esc still belongs to the popover.
+        let popover = WindowStub()
+        XCTAssertTrue(
+            EscapeToCloseReader.escapeTargetsPopover(
+                eventWindowID: nil,
+                popoverWindowID: ObjectIdentifier(popover)
+            )
+        )
+    }
+
+    func testMatchingWindowTargetsPopover() {
+        // The normal path: the popover is key, so the keyDown carries its window id.
+        let popover = WindowStub()
+        XCTAssertTrue(
+            EscapeToCloseReader.escapeTargetsPopover(
+                eventWindowID: ObjectIdentifier(popover),
+                popoverWindowID: ObjectIdentifier(popover)
+            )
+        )
+    }
+
+    func testDifferentWindowDoesNotTargetPopover() {
+        // A different non-nil window (e.g. an open NSMenu) owns the keyDown — leave it alone.
+        let popover = WindowStub()
+        let other = WindowStub()
+        XCTAssertFalse(
+            EscapeToCloseReader.escapeTargetsPopover(
+                eventWindowID: ObjectIdentifier(other),
+                popoverWindowID: ObjectIdentifier(popover)
+            )
+        )
+    }
+}

--- a/Tests/OpenUsageTests/PopoverKeyReaderTests.swift
+++ b/Tests/OpenUsageTests/PopoverKeyReaderTests.swift
@@ -1,19 +1,19 @@
 import XCTest
 @testable import OpenUsage
 
-/// `EscapeToCloseReader.escapeTargetsPopover` decides whether an Esc keyDown should dismiss the
+/// `PopoverKeyReader.keyTargetsPopover` decides whether a bare Esc/Return keyDown should drive the
 /// menu-bar popover. The nil-window case guards the macOS 26+ regression where the popover is
 /// visible but not key, so the keyDown carries no window and a strict identity check would have
 /// silently dropped it ("sometimes Esc doesn't close").
-final class EscapeToCloseReaderTests: XCTestCase {
+final class PopoverKeyReaderTests: XCTestCase {
     /// Distinct instances stand in for windows; `ObjectIdentifier` gives each a stable identity.
     private final class WindowStub {}
 
     func testNilKeyWindowTargetsPopover() {
-        // No key window (the accessory-app activation race): Esc still belongs to the popover.
+        // No key window (the accessory-app activation race): the key still belongs to the popover.
         let popover = WindowStub()
         XCTAssertTrue(
-            EscapeToCloseReader.escapeTargetsPopover(
+            PopoverKeyReader.keyTargetsPopover(
                 eventWindowID: nil,
                 popoverWindowID: ObjectIdentifier(popover)
             )
@@ -24,7 +24,7 @@ final class EscapeToCloseReaderTests: XCTestCase {
         // The normal path: the popover is key, so the keyDown carries its window id.
         let popover = WindowStub()
         XCTAssertTrue(
-            EscapeToCloseReader.escapeTargetsPopover(
+            PopoverKeyReader.keyTargetsPopover(
                 eventWindowID: ObjectIdentifier(popover),
                 popoverWindowID: ObjectIdentifier(popover)
             )
@@ -36,7 +36,7 @@ final class EscapeToCloseReaderTests: XCTestCase {
         let popover = WindowStub()
         let other = WindowStub()
         XCTAssertFalse(
-            EscapeToCloseReader.escapeTargetsPopover(
+            PopoverKeyReader.keyTargetsPopover(
                 eventWindowID: ObjectIdentifier(other),
                 popoverWindowID: ObjectIdentifier(popover)
             )

--- a/Tests/OpenUsageTests/PopoverKeyReaderTests.swift
+++ b/Tests/OpenUsageTests/PopoverKeyReaderTests.swift
@@ -2,17 +2,18 @@ import XCTest
 @testable import OpenUsage
 
 /// `PopoverKeyReader.keyTargetsPopover` decides whether a bare Esc/Return keyDown should drive the
-/// menu-bar popover. The nil-window case guards the macOS 26+ regression where the popover is
-/// visible but not key, so the keyDown carries no window and a strict identity check would have
-/// silently dropped it ("sometimes Esc doesn't close").
+/// menu-bar popover: only when the event's key window IS the panel. The panel (a non-activating key
+/// window) reliably takes key focus on show, so a foreign key window — a tracking menu, the About
+/// panel — or no key window at all is left alone rather than hijacked.
 final class PopoverKeyReaderTests: XCTestCase {
     /// Distinct instances stand in for windows; `ObjectIdentifier` gives each a stable identity.
     private final class WindowStub {}
 
-    func testNilKeyWindowTargetsPopover() {
-        // No key window (the accessory-app activation race): the key still belongs to the popover.
+    func testNilKeyWindowIsNotPopover() {
+        // No key window is NOT the popover's: with the panel reliably key on show, a bare key with no
+        // key window belongs to nothing we should act on (so an open menu / About panel keeps its key).
         let popover = WindowStub()
-        XCTAssertTrue(
+        XCTAssertFalse(
             PopoverKeyReader.keyTargetsPopover(
                 eventWindowID: nil,
                 popoverWindowID: ObjectIdentifier(popover)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,9 +6,9 @@ A high-level map of how OpenUsage is put together, for people working on the cod
 ## The shape of the app
 
 OpenUsage is a single SwiftPM executable — there is no Xcode project. It's a menu-bar app: a SwiftUI
-interface hosted inside an AppKit status item and popover. The code is grouped by role:
+interface hosted inside an AppKit status item and panel. The code is grouped by role:
 
-- `App/` — startup and the AppKit bridge (status item, popover, the app entry point).
+- `App/` — startup and the AppKit bridge (status item, panel, the app entry point).
 - `Models/` — the small value types the rest of the app speaks in (`MetricLine`, `WidgetData`, descriptors).
 - `Providers/` — one folder per provider (Claude, Codex, Cursor, Devin, Grok).
 - `Stores/` — the mutable state the UI observes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,8 +52,13 @@ snapshot has actually expired.
 
 ## The AppKit bridge
 
-macOS menu-bar apps live in an `NSStatusItem` and show their content in an `NSPopover`. `App/` owns that
-AppKit layer and hosts the SwiftUI views inside it, so the bulk of the UI can stay plain SwiftUI.
+macOS menu-bar apps live in an `NSStatusItem`. OpenUsage shows its content in a custom, key-capable
+`NSPanel` rather than an `NSPopover`: a popover's window is only key while the whole app is active, and
+activating a menu-bar (accessory) app is asynchronous and unreliable on recent macOS, so a popover
+ends up unable to receive keystrokes until a second click. A non-activating `NSPanel` whose
+`canBecomeKey` is `true` takes key focus the instant it opens, so keyboard navigation and the Settings
+shortcut recorder just work. `App/` owns that AppKit layer and hosts the SwiftUI views inside it, so
+the bulk of the UI can stay plain SwiftUI.
 
 ## Platform support
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -25,7 +25,7 @@ Provider headers: **Refresh \<provider\> · Customize…**
 
 ## Customize
 
-The sliders button (or pressing **Return**) opens Customize: toggle metrics on/off, add ones that aren't placed yet, pin metrics for the menu bar, and drag to reorder. Drag-reorder also works directly on the dashboard — drag a row within its provider, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
+The More button's **Customize Metrics** item (or pressing **Return**) opens Customize: toggle metrics on/off, add ones that aren't placed yet, pin metrics for the menu bar, and drag to reorder. Drag-reorder also works directly on the dashboard — drag a row within its provider, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
 
 ## Keyboard
 


### PR DESCRIPTION
## Description

Fixes two reported bugs in the menu-bar dashboard — **Enter no longer opened Customize**, and **Esc often needed a second press** — and the root-cause fix turned into replacing `NSPopover` with a custom `NSPanel`.

### Root cause
An `NSPopover`'s window is only the key window while the **whole app is active**. For a menu-bar (accessory / `LSUIElement`) app, clicking the status item doesn't synchronously activate the app, and `NSApp.activate` is async — on macOS 26+ it lands several runloop ticks later or is denied. So the popover was on-screen but **not key**: keystrokes went to the focused status-item button instead (Enter re-toggled it shut; Esc was lost), and you needed a second click/keypress. This is a known `NSPopover` limitation — keyboard-first menu-bar apps use a custom panel instead.

### Fix
- **Key-capable `NSPanel`.** A non-activating `NSPanel` whose `canBecomeKey` is `true` takes key focus the instant it's ordered front, *without* activating the app — no activation race, no retry loop. Esc/Return (and the Settings shortcut recorder) work on the first try.
- **Keyboard nav via a local key monitor** (`PopoverKeyReader`): Esc backs out of Customize/Settings then closes; Return toggles Customize. SwiftUI `.keyboardShortcut` proved unreliable inside the panel.
- **Liquid Glass preserved** via an `NSVisualEffectView(.popover, .behindWindow)` backdrop (rounded mask); the panel tracks the SwiftUI content size and anchors under the status item.
- **Toggle without flicker:** the dismissal monitors use `NSEvent.mouseLocation`, so a status-item click is recognized and left to the button's own toggle (it was closing on mouse-down and reopening on mouse-up).
- **Reduce Transparency:** swaps the glass backdrop for a solid one that fills the whole window, so a screen-switch resize can't briefly reveal glass beneath the content-sized SwiftUI surface. Driven live by the in-app toggle + macOS's own setting.

The implementation patterns (nonactivating key panel, `makeKeyAndOrderFront`, status-item toggle, dismissal) were cross-checked against several open-source menu-bar apps.

## Related Issue

Follow-up enhancement filed: #654 (draggable + remembered panel position, now that it's a real window).

## Type of Change

- [x] Bug fix
- [x] Documentation

## Testing

- [x] `swift build` succeeds
- [x] `swift test` passes (291 tests; adds `PopoverKeyReaderTests`)
- [x] Verified on device (macOS 26+): Enter opens Customize and Esc closes reliably across repeated opens; no toggle flicker; Reduce Transparency stays solid through screen-switch animations in light + dark.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `swift` branch (Swift edition)
- [x] **Behavior change?** Updated `docs/architecture.md` (and `docs/dashboard.md`) in this same PR
- [x] I did not introduce new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large AppKit windowing change at the core menu-bar UX (focus, dismissal, sizing); behavior is well-tested but regressions on older macOS or edge cases (menus, About panel) are possible.
> 
> **Overview**
> Replaces **`NSPopover`** with a borderless **`MenuBarPanel`** (`NSPanel` with `canBecomeKey` and `.nonactivatingPanel`) so the menu-bar dashboard becomes key on first open without activating the accessory app—fixing **Return** not opening Customize and **Esc** needing a second press on recent macOS.
> 
> **`StatusItemController`** now owns panel show/hide, anchors under the status item, tracks SwiftUI `preferredContentSize`, and layers **glass vs solid** AppKit backdrops (with live updates from the Reduce Transparency toggle and system accessibility). Outside-click dismissal uses **`NSEvent.mouseLocation`** and skips the status button to avoid close-then-reopen flicker; **`NSApp.activate`** on show is removed.
> 
> **`EscapeToCloseReader`** becomes **`PopoverKeyReader`**, handling **Esc** and bare **Return** via a local key monitor with stricter key-window matching. **`ReduceTransparencySetting.didChangeNotification`** wires Settings to the panel backdrop. Docs and **`PopoverKeyReaderTests`** are added/updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7864c2a774ccc3a8c96c0dfb813a5a9f0fa814c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->