### PR TITLE
feat(updates): check for updates hourly instead of daily

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -6,7 +6,7 @@ they install, so you always get a genuine, unmodified build.
 
 ## How it works
 
-- **Automatic checks.** The app quietly checks for a new version in the background (about once a day).
+- **Automatic checks.** The app quietly checks for a new version in the background (about once an hour).
   When one is found, it offers to download and install it. Because OpenUsage lives in the menu bar, it
   briefly shows a Dock icon while the update window is open, then hides again.
 - **Manual check.** Open **Settings → Updates** and click **Check for Updates…** at any time.

--- a/script/release.sh
+++ b/script/release.sh
@@ -129,6 +129,7 @@ cat >"$APP_CONTENTS/Info.plist" <<PLIST
   <key>SUFeedURL</key><string>$FEED_URL</string>
   <key>SUPublicEDKey</key><string>$SPARKLE_PUBLIC_KEY</string>
   <key>SUEnableAutomaticChecks</key><true/>
+  <key>SUScheduledCheckInterval</key><integer>3600</integer>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## What

Bake `SUScheduledCheckInterval=3600` into the release Info.plist so Sparkle schedules automatic update checks **every hour** instead of falling back to its 24-hour default.

```
<key>SUScheduledCheckInterval</key><integer>3600</integer>
```

## Why

During Early Access, the 24h default means a freshly-cut beta can sit unnoticed for almost a full day. After cutting `v0.7.0-beta.9` the running build hadn't prompted because its last scheduled check had just elapsed — leaving an ~11h wait for the next one. Hourly checks get Early Access testers prompted within an hour of a new build. `3600` is also Sparkle's hard floor (anything lower is clamped to 1 hour).

## Reviewer notes

- Takes effect for **builds cut after this change** (beta.10+). Already-installed builds keep their persisted `updateCheckInterval` until the next install.
- `SUScheduledCheckInterval` is the *initial* value; Sparkle persists `updateCheckInterval` in user defaults once a build has run.
- Applies to all builds from this Info.plist. Currently every build is a beta; consider bumping back toward daily (`86400`) at the public flip.
- Docs updated: `docs/updates.md` now says "about once an hour".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Sparkle configuration and documentation change with no impact on auth, data handling, or core app logic.
> 
> **Overview**
> Release builds now embed **`SUScheduledCheckInterval` = 3600** in the generated `Info.plist`, so Sparkle’s automatic background update checks run about **once per hour** instead of the framework’s default (~24h).
> 
> User-facing docs in **`docs/updates.md`** were updated to match (“about once an hour”). Only **new installs** from builds cut after this change pick up the new default; Sparkle may keep a persisted interval on already-running apps until they’re updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97357234648d7b6a2992283e7759c61383538909. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `SUScheduledCheckInterval` to `3600` in the release `Info.plist` so `Sparkle` checks for updates hourly instead of daily. Updated docs to say "about once an hour" to match.

- **Migration**
  - Effective for new builds only; existing installs keep their persisted interval until the next install.
  - Applies to all builds from this `Info.plist`; consider returning to daily (`86400`) for public release.

<sup>Written for commit 97357234648d7b6a2992283e7759c61383538909. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

