### PR TITLE
feat(footer): fold Settings + Check for Updates into the More menu

### DIFF
--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -1,63 +1,81 @@
 import AppKit
 import SwiftUI
 
-/// Footer "More" menu + Settings round glass buttons. The Settings button is unchanged: it toggles
-/// the in-popover Settings screen and its active state becomes a prominent checkmark "Done". The
-/// leading control is the same round glass button that pops a "More" pull-down (Customize Metrics /
-/// About / Quit); while the Customize screen is open it morphs into the prominent "Done" button that
-/// returns to the dashboard, so Customize keeps a visible exit (Esc also backs out).
+/// The footer's lone round glass control plus the "More" pull-down behind it. On the dashboard the
+/// button pops the pull-down (Customize / Settings / Check for Updates / About / Quit); on the Customize
+/// or Settings screen it morphs into the prominent checkmark "Done" that returns to the dashboard, so
+/// each screen keeps a visible exit (Esc/⏎ also back out). Settings folded from its own gear button into
+/// the menu, so a hidden ⌘, button preserves that system shortcut from anywhere in the popover.
 struct HeaderView: View {
     @Environment(LayoutStore.self) private var layout
+    @Environment(UpdaterController.self) private var updater
     /// Anchors the "More" pull-down under its button. `@State` keeps one stable instance.
     @State private var moreMenuAnchor = PopUpMenuAnchor()
 
     var body: some View {
-        // Group the adjacent glass buttons so the system samples them coherently (glass cannot sample
-        // other glass). The gap stays wider than the container's merge distance, so they read as two
-        // distinct circles rather than blending into one pill.
-        HStack(spacing: 12) {
-            leadingControl
-
-            roundButton(
-                layout.screen == .settings ? "Done" : "Settings",
-                systemImage: layout.screen == .settings ? "checkmark" : "gearshape",
-                prominent: layout.screen == .settings
-            ) {
-                toggle(.settings)
-            }
-            // The system-wide Settings key equivalent, scoped to the popover being key.
-            .keyboardShortcut(",", modifiers: .command)
-        }
-        .glassButtonGroup(spacing: 4)
+        leadingControl
+            .glassButtonGroup(spacing: 4)
+            // Carries the ⌘, Settings shortcut now that there's no dedicated gear button (see below).
+            .background(settingsShortcut)
     }
 
-    /// While the Customize screen is open the slot is the prominent "Done" button — clicking it (or
-    /// pressing ⏎, which `PopoverKeyReader` routes for the whole popover) returns to the dashboard.
-    /// Otherwise it's the "More" button: the same round glass control, opening a pull-down whose
-    /// "Customize Metrics" item is the way into Customize.
+    /// On the dashboard this is the "More" button, opening the pull-down whose "Customize" and "Settings"
+    /// items are the ways into those screens. On any other screen it morphs into the prominent "Done"
+    /// button that returns to the dashboard (clicking it, or pressing ⏎/Esc, which `PopoverKeyReader`
+    /// routes for the whole popover).
     @ViewBuilder
     private var leadingControl: some View {
-        if layout.screen == .customize {
-            roundButton("Done", systemImage: "checkmark", prominent: true) {
-                toggle(.customize)
-            }
-        } else {
+        if layout.screen == .dashboard {
             roundButton("More", systemImage: "ellipsis", prominent: false) {
                 presentMoreMenu()
             }
             // The anchor view fills the button's frame so the menu drops from directly under it.
             .background(PopUpMenuAnchorView(anchor: moreMenuAnchor))
+        } else {
+            roundButton("Done", systemImage: "checkmark", prominent: true) {
+                withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
+            }
         }
     }
 
+    /// Keeps the system ⌘, Settings shortcut working from anywhere in the popover. The menu's Settings
+    /// item shows ⌘, too, but a menu key equivalent only fires while that menu is open — this hidden,
+    /// zero-size button carries the shortcut the rest of the time. It never draws.
+    private var settingsShortcut: some View {
+        Button("") { toggle(.settings) }
+            .keyboardShortcut(",", modifiers: .command)
+            .frame(width: 0, height: 0)
+            .hidden()
+            .accessibilityHidden(true)
+    }
+
     /// Builds and pops the "More" pull-down as a native `NSMenu`, so the trigger stays the exact glass
-    /// `roundButton` (a SwiftUI `Menu` styled as a button does not match it). Quit carries the standard
-    /// ⌘Q equivalent.
+    /// `roundButton` (a SwiftUI `Menu` styled as a button does not match it). Items mirror their
+    /// in-popover shortcuts: Settings ⌘,, Customize ⏎, Quit ⌘Q. `autoenablesItems = false` lets the
+    /// Check for Updates item stay greyed when Sparkle can't currently check — e.g. dev builds with no
+    /// feed, or while a check is already in flight.
     private func presentMoreMenu() {
         let menu = NSMenu()
-        menu.addItem(ClosureMenuItem(title: "Customize Metrics", systemSymbol: "slider.horizontal.3") {
-            toggle(.customize)
+        menu.autoenablesItems = false
+
+        menu.addItem(ClosureMenuItem(title: "Settings", systemSymbol: "gearshape", keyEquivalent: ",") {
+            toggle(.settings)
         })
+
+        let customize = ClosureMenuItem(title: "Customize", systemSymbol: "slider.horizontal.3", keyEquivalent: "\r") {
+            toggle(.customize)
+        }
+        // The bare Return that `PopoverKeyReader` already routes to Customize. Clearing the mask keeps it
+        // showing as ⏎ rather than the ⌘⏎ that NSMenuItem renders by default.
+        customize.keyEquivalentModifierMask = []
+        menu.addItem(customize)
+
+        let checkForUpdates = ClosureMenuItem(title: "Check for Updates…", systemSymbol: "arrow.triangle.2.circlepath") {
+            updater.checkForUpdates()
+        }
+        checkForUpdates.isEnabled = updater.canCheckForUpdates
+        menu.addItem(checkForUpdates)
+
         menu.addItem(.separator())
         menu.addItem(ClosureMenuItem(title: "About OpenUsage", systemSymbol: "info.circle") {
             AboutPanel.present()
@@ -79,7 +97,7 @@ struct HeaderView: View {
     /// `buttonBorderShape(.circle)` keeps the circular shape while preserving
     /// the glass highlight/shadow that `clipShape` would crop. Prominent = accent-filled glass for an
     /// active toggle state. The icon-only `Label` keeps the title for accessibility; the equal frame
-    /// keeps both circles the same diameter regardless of glyph width.
+    /// keeps the circle a consistent diameter regardless of glyph width.
     private func roundButton(
         _ title: String,
         systemImage: String,
@@ -93,7 +111,7 @@ struct HeaderView: View {
         return Button(action: action) { label }
             .glassButtonStyle(prominent: prominent)
             .buttonBorderShape(.circle)
-            // The popover's only two buttons: a larger control costs nothing and gives a bigger target.
+            // The footer's only button: a larger control costs nothing and gives a bigger target.
             .controlSize(.large)
             .help(title)
     }


### PR DESCRIPTION
## What

Collapses the footer to a single round glass control and folds **Settings** into the **More** pull-down, alongside a new **Check for Updates…** item.

```
Settings              ⌘,
Customize             ⏎
Check for Updates…
──────────
About OpenUsage
Quit OpenUsage        ⌘Q
```

## Why

The footer carried two glass buttons (More + a dedicated Settings gear). Settings, Customize, and the updater are all low-frequency actions, so they belong together in one menu — leaving a single, clean control in the footer.

## Details

- **Single footer button.** The leading control morphs into the prominent checkmark **Done** on *any* non-dashboard screen (previously only Customize), so Settings keeps a visible exit now that its gear button is gone. Esc/⏎ still back out, unchanged.
- **Shortcuts shown in the menu.** Settings shows ⌘,, Customize shows ⏎ (modifier mask cleared so it doesn't render as ⌘⏎), Quit shows ⌘Q. The actual Return handling stays in `PopoverKeyReader`.
- **Check for Updates…** calls `UpdaterController.checkForUpdates()`; greyed when `!canCheckForUpdates` (e.g. dev builds with no Sparkle feed) via `menu.autoenablesItems = false`.
- **⌘, preserved everywhere.** A hidden zero-size button carries the system Settings shortcut from anywhere in the popover, since a menu key equivalent only fires while its menu is open.

## Testing

- `swift build` clean; `swift test` — 291 pass, 1 skipped.
- Verified in a dev build: menu order/shortcuts, Settings/Customize navigation + Done exit, Esc/⏎/⌘,/⌘Q. The updater path can only be exercised end-to-end on a signed+notarized release build; here it correctly shows disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Popover footer and menu UX only; no auth, data, or core provider logic changes.
> 
> **Overview**
> The popover footer goes from **two** round glass buttons (More + Settings gear) to **one** control. On the dashboard it still opens the native **More** menu; on Customize or Settings it becomes the prominent **Done** checkmark that returns to the dashboard (previously only Customize showed Done).
> 
> **Settings** moves into the More menu (with ⌘, on the item). A hidden zero-size button keeps **⌘,** working from anywhere in the popover when the menu is closed. The menu adds **Check for Updates…** via `UpdaterController`, disabled when `!canCheckForUpdates`, with `autoenablesItems = false` so Sparkle can grey it out. **Customize** is renamed from "Customize Metrics" and shows bare ⏎ in the menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8615fa9cc8bca717e5aedbedf304f1cd3f73646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapsed the footer to a single round glass button. Moved Settings into the More menu and added a new Check for Updates item. The button becomes Done on non-dashboard screens for a clear exit.

- **New Features**
  - More menu: Settings ⌘,, Customize ⏎, Check for Updates…, — separator — About OpenUsage, Quit ⌘Q.
  - Check for Updates calls UpdaterController.checkForUpdates() and is disabled when unavailable (e.g., dev builds).
  - Preserves ⌘, globally via a hidden button so the shortcut works even when the menu isn’t open.
  - Esc/Return still back out; Customize shows ⏎ by clearing the modifier mask; Done is prominent on Settings/Customize.

<sup>Written for commit a8615fa9cc8bca717e5aedbedf304f1cd3f73646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

