### PR TITLE
fix(tooltip): reveal hover tooltips after a short delay, not the slow native one

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -289,6 +289,9 @@ final class StatusItemController: NSObject {
     }
 
     private func hidePanel() {
+        // The popover's SwiftUI tree survives `orderOut`, so a tooltip the cursor was resting on gets
+        // no hover-exit and would orphan on screen — clear it here, the one chokepoint every close hits.
+        HoverTooltips.dismissAll()
         panel.orderOut(nil)
         stopOutsideClickMonitors()
         statusItem.button?.highlight(false)

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -47,6 +47,12 @@ struct WidgetData: Hashable {
     /// Which of `values` this widget renders — cost-only, tokens-only, or the combined `.all`. Set by
     /// the descriptor factory, so one provider row can back several tiles and the mapper stays oblivious.
     var selection: ValueSelection = .all
+    /// True only for the Today / Yesterday / Last 30 Days spend tiles, where the row's values accumulate
+    /// over a time window so an all-zero reading means "nothing was used." Balance/availability rows
+    /// (Codex Rate Limit Resets, an exhausted Extra Usage credit) read zero when *depleted*, not idle, so
+    /// they leave this false and never get the "No usage in this period" note. Set by the spend-tile
+    /// factory; rides the descriptor sample through `WidgetDataStore.resolve`.
+    var isUsagePeriod: Bool = false
 
     var isBounded: Bool { limit != nil }
 

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -288,6 +288,15 @@ struct WidgetData: Hashable {
         return selected.map { MetricFormatter.string(for: $0, style: .full) }.joined(separator: " · ")
     }
 
+    /// True for a zero-usage period — has data, but every selected value is zero (a row reading
+    /// "$0.00 · 0 tokens"). Distinct from "no data" and from small non-zero usage, so the row can show
+    /// a "no usage" note rather than a figures reveal.
+    var isZeroUsage: Bool {
+        guard hasData else { return false }
+        let selected = selectedValues
+        return !selected.isEmpty && selected.allSatisfy { $0.number == 0 }
+    }
+
     var resetLabel: String? {
         guard let resetsAt else { return nil }
         return Formatters.resetRelativeLabel(until: resetsAt)

--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -58,7 +58,8 @@ extension WidgetDescriptor {
         title: String,
         metricLabel: String? = nil,
         selection: ValueSelection = .all,
-        valueWord: String? = nil
+        valueWord: String? = nil,
+        isUsagePeriod: Bool = false
     ) -> WidgetDescriptor {
         // `kind` is unused for `.values` rendering (each value carries its own), but a count-only tile
         // reads tidier seeded as `.count`; everything else defaults to `.dollars`.
@@ -66,6 +67,7 @@ extension WidgetDescriptor {
         var sample = WidgetData(title: title, icon: provider.icon, kind: kind, used: 0, limit: nil,
                                 unboundedValueWord: valueWord)
         sample.selection = selection
+        sample.isUsagePeriod = isUsagePeriod
         return make(id: id, provider: provider, metricLabel: metricLabel ?? title, sample: sample)
     }
 
@@ -75,9 +77,11 @@ extension WidgetDescriptor {
         id: String,
         provider: Provider,
         title: String,
-        metricLabel: String? = nil
+        metricLabel: String? = nil,
+        isUsagePeriod: Bool = false
     ) -> WidgetDescriptor {
-        values(id: id, provider: provider, title: title, metricLabel: metricLabel, selection: .all)
+        values(id: id, provider: provider, title: title, metricLabel: metricLabel, selection: .all,
+               isUsagePeriod: isUsagePeriod)
     }
 
     /// The three local-spend tiles every spend-tracking provider exposes — Today / Yesterday / Last 30
@@ -85,9 +89,9 @@ extension WidgetDescriptor {
     /// `<provider>.today|yesterday|last30`, so the set is identical across Claude / Codex / Cursor / Grok.
     static func spendTiles(provider: Provider) -> [WidgetDescriptor] {
         [
-            .combined(id: "\(provider.id).today", provider: provider, title: "Today"),
-            .combined(id: "\(provider.id).yesterday", provider: provider, title: "Yesterday"),
-            .combined(id: "\(provider.id).last30", provider: provider, title: "Last 30 Days")
+            .combined(id: "\(provider.id).today", provider: provider, title: "Today", isUsagePeriod: true),
+            .combined(id: "\(provider.id).yesterday", provider: provider, title: "Yesterday", isUsagePeriod: true),
+            .combined(id: "\(provider.id).last30", provider: provider, title: "Last 30 Days", isUsagePeriod: true)
         ]
     }
 

--- a/Sources/OpenUsage/Views/CustomizeView.swift
+++ b/Sources/OpenUsage/Views/CustomizeView.swift
@@ -163,7 +163,7 @@ struct CustomizeView: View {
         .foregroundStyle(pinned ? Color.accentColor : Color.secondary)
         .opacity(visible ? (blocked ? 0.35 : 1) : 0)
         .allowsHitTesting(visible)
-        .help(pinHelp(metric))
+        .hoverTooltip(pinHelp(metric))
         .animation(Motion.spring, value: visible)
         .animation(Motion.spring, value: pinned)
     }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -157,6 +157,10 @@ struct DashboardView: View {
             .frame(width: Self.popoverWidth)
             .pinnedFooter(spacing: 0) { footerBar }
             .frame(height: animatedPopoverHeight, alignment: .top)
+            // Draws every `.hoverTooltip(_:)` bubble at the popover root, above the content and footer
+            // but escaping each screen's scroll-view clipping. Sits inside the reduce-transparency
+            // environment below so the bubble matches the popover's glass/solid form.
+            .hoverTooltipContainer()
             // Paint the surface behind the content (and footer) and tell every descendant whether
             // glass is on, so the fallbacks and the meter tints render in step. Both go on the
             // outermost level of the chain so the footer, header buttons, and scroll content inherit.
@@ -424,7 +428,7 @@ struct DashboardView: View {
         }
         .buttonStyle(.plain)
         .keyboardShortcut("r", modifiers: .command)
-        .help("Refresh now (⌘R)")
+        .hoverTooltip("Refresh now (⌘R)")
         .disabled(isUpdating)
     }
 

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -229,6 +229,9 @@ struct DashboardView: View {
     }
 
     private func resetTransientState() {
+        // Backstop for any popover-close path the status-item controller's hide doesn't cover: clear a
+        // tooltip the cursor was resting on, since the closed popover fires no hover-exit.
+        HoverTooltips.dismissAll()
         if layout.screen != .dashboard { layout.screen = .dashboard }
         reorderLift = nil
         layout.cancelDrag()

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -157,10 +157,6 @@ struct DashboardView: View {
             .frame(width: Self.popoverWidth)
             .pinnedFooter(spacing: 0) { footerBar }
             .frame(height: animatedPopoverHeight, alignment: .top)
-            // Draws every `.hoverTooltip(_:)` bubble at the popover root, above the content and footer
-            // but escaping each screen's scroll-view clipping. Sits inside the reduce-transparency
-            // environment below so the bubble matches the popover's glass/solid form.
-            .hoverTooltipContainer()
             // Paint the surface behind the content (and footer) and tell every descendant whether
             // glass is on, so the fallbacks and the meter tints render in step. Both go on the
             // outermost level of the chain so the footer, header buttons, and scroll content inherit.

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -95,6 +95,6 @@ struct HeaderView: View {
             .buttonBorderShape(.circle)
             // The popover's only two buttons: a larger control costs nothing and gives a bigger target.
             .controlSize(.large)
-            .help(title)
+            .hoverTooltip(title)
     }
 }

--- a/Sources/OpenUsage/Views/HoverTooltip.swift
+++ b/Sources/OpenUsage/Views/HoverTooltip.swift
@@ -126,13 +126,23 @@ private final class TooltipPresenter {
     private var pendingID: UUID?
     private var revealTask: Task<Void, Never>?
 
-    /// Mirrors the native tooltip: a real wait on the first hover, then near-instant reshows for a
-    /// short grace window after one was last shown ("quick mode").
-    private let initialDelay: Duration = .milliseconds(350)
-    private let quickDelay: Duration = .milliseconds(60)
-    private let quickWindow: Duration = .milliseconds(1500)
-    private let clock = ContinuousClock()
-    private var lastHideAt: ContinuousClock.Instant?
+    /// One consistent dwell before any new tooltip target shows. There's no fast-reshow "quick mode":
+    /// sweeping the cursor across adjacent labels would otherwise flash a burst of tooltips, since once
+    /// one is up every sibling it passes over would reveal near-instantly.
+    ///
+    /// 400ms is a deliberate value, not a guess. It's the overlap of the hover-intent windows in the
+    /// research (Nielsen Norman Group puts reliable intent at 300-500ms of cursor stillness, the
+    /// Müller-Tomfelde dwell study at 350-600ms) and sits on the Doherty threshold (~400ms), the line
+    /// between feeling responsive and feeling slow. The longer 500-700ms defaults in Radix (700),
+    /// Base UI (600), and Windows (500) are tempting for a dense list of targets like these rows, but
+    /// every one of them pairs its long first-reveal delay with an instant reshow for neighbours, and
+    /// that reshow grouping is precisely the quick mode we removed because it caused the sweep cascade.
+    /// Without reshow, every hover (including a deliberate row-by-row read) pays this delay in full, so
+    /// the value belongs at the responsive end of the intent window, not the long end. 300ms sits at the
+    /// floor of that window and fires a little too readily on a slow drag across rows. If deliberate
+    /// neighbour-to-neighbour reading ever feels laggy, raise this to 500ms before reintroducing any
+    /// reshow shortcut, since a tuned reshow risks reopening the original complaint.
+    private let revealDelay: Duration = .milliseconds(400)
 
     /// Space above the cursor; the panel's bottom edge sits this far above the pointer.
     private let cursorGap: CGFloat = 10
@@ -198,19 +208,29 @@ private final class TooltipPresenter {
             }
             return
         }
-        if shownID != nil {                         // a tooltip is up for another target — switch now
+        // A hovered descendant outranks the parent already on screen: hand off immediately, since the
+        // dwell was already earned on the parent (e.g. the clear button inside the Settings shortcut
+        // field). Reading `active[shownID]` ties this to the shown target still being hovered, so
+        // "deeper" means a genuine parent→child handoff, not a stale depth comparison.
+        if let shownID, let shown = active[shownID], top.value.depth > shown.depth {
             present(top.value)
-            shownID = top.key
+            self.shownID = top.key
             shownText = top.value.text
             cancelPending()
             return
+        }
+        // Any other switch (a same-depth sibling or a shallower target) hides the current bubble and
+        // makes the new target re-earn the full dwell, so sweeping across sibling labels while one is
+        // up doesn't retarget the tooltip on every pass.
+        if shownID != nil {
+            hide()
         }
         if pendingID == top.key { return }          // already scheduled for this target
         cancelPending()
         pendingID = top.key
         let target = top.value
         let id = top.key
-        let delay = isInQuickMode ? quickDelay : initialDelay
+        let delay = revealDelay
         revealTask = Task { [weak self] in
             try? await Task.sleep(for: delay)
             guard !Task.isCancelled, let self else { return }
@@ -222,11 +242,6 @@ private final class TooltipPresenter {
         }
     }
 
-    private var isInQuickMode: Bool {
-        guard let lastHideAt else { return false }
-        return clock.now - lastHideAt < quickWindow
-    }
-
     private func cancelPending() {
         revealTask?.cancel()
         revealTask = nil
@@ -234,7 +249,6 @@ private final class TooltipPresenter {
     }
 
     private func hide() {
-        if shownID != nil { lastHideAt = clock.now }   // open the quick-mode window only after a real show
         shownID = nil
         shownText = nil
         if panel.isVisible { panel.orderOut(nil) }

--- a/Sources/OpenUsage/Views/HoverTooltip.swift
+++ b/Sources/OpenUsage/Views/HoverTooltip.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+/// An in-app replacement for SwiftUI's `.help()` tooltip. The native tooltip has a long,
+/// system-controlled first-hover delay (~1.5-2s before the first tooltip in a window appears; it
+/// reshows later ones almost instantly) that no public API shortens, so the row's exact figures felt
+/// slow to reveal on the first hover. This shows a styled bubble after a short, fixed delay we own.
+///
+/// Two pieces: `.hoverTooltip(_:)` on a hover target reports its text and frame, and a single
+/// `.hoverTooltipContainer()` at the popover root draws the bubble. The bubble is drawn at the root,
+/// not inside the hovered view, so it escapes the dashboard/settings/customize scroll views — those
+/// clip their content, so an in-row bubble would be cut off near a scroll edge. The target publishes
+/// its text and bounds up the tree via an anchor preference; the container resolves that anchor in its
+/// own geometry, places the bubble just below the target (flipping above when it would overflow the
+/// bottom), and clamps it inside the popover.
+
+/// The active tooltip's text plus an anchor on the hovered view's frame. Only one element is hovered
+/// at a time, so at most one request is live.
+private struct TooltipRequest {
+    let text: String
+    let anchor: Anchor<CGRect>
+}
+
+private struct TooltipRequestKey: PreferenceKey {
+    static let defaultValue: TooltipRequest? = nil
+    static func reduce(value: inout TooltipRequest?, nextValue: () -> TooltipRequest?) {
+        // Last non-nil wins; targets that aren't showing contribute nil, so the live one survives.
+        if let next = nextValue() { value = next }
+    }
+}
+
+extension View {
+    /// Shows `text` in a custom hover tooltip after a short delay. `nil` or empty shows nothing, so the
+    /// many `someTooltip ?? ""` call sites keep their "no tooltip when blank" behavior. The text is also
+    /// exposed as an accessibility hint — the part `.help()` contributed to VoiceOver.
+    func hoverTooltip(_ text: String?) -> some View {
+        modifier(HoverTooltipModifier(text: text))
+    }
+
+    /// Draws the hover tooltip for any `.hoverTooltip(_:)` target beneath this point. Apply once, at the
+    /// popover root, above the scroll views so the bubble can extend past their clipped bounds.
+    func hoverTooltipContainer() -> some View {
+        overlayPreferenceValue(TooltipRequestKey.self) { request in
+            GeometryReader { proxy in
+                if let request {
+                    TooltipBubble(text: request.text, target: proxy[request.anchor], bounds: proxy.size)
+                }
+            }
+            // Never intercept the hover or clicks of the rows beneath, or the bubble would steal the
+            // hover that spawned it and flicker.
+            .allowsHitTesting(false)
+        }
+    }
+}
+
+private struct HoverTooltipModifier: ViewModifier {
+    let text: String?
+    @State private var isShowing = false
+    @State private var revealTask: Task<Void, Never>?
+
+    /// Delay before the bubble appears. Short enough to feel responsive on the first hover (the native
+    /// tooltip's slow first appearance is the whole reason this exists), long enough that brushing the
+    /// cursor across rows doesn't flash bubbles.
+    private static let revealDelay: Duration = .milliseconds(350)
+
+    /// `nil` (no tooltip) for a missing or blank string, collapsing the two "absent" cases.
+    private var resolved: String? {
+        guard let text, !text.isEmpty else { return nil }
+        return text
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .accessibilityHint(resolved ?? "")
+            .onHover { inside in
+                guard resolved != nil else { return }
+                if inside { scheduleReveal() } else { cancelReveal() }
+            }
+            .onDisappear { cancelReveal() }
+            .anchorPreference(key: TooltipRequestKey.self, value: .bounds) { anchor in
+                guard isShowing, let resolved else { return nil }
+                return TooltipRequest(text: resolved, anchor: anchor)
+            }
+    }
+
+    private func scheduleReveal() {
+        revealTask?.cancel()
+        revealTask = Task { @MainActor in
+            try? await Task.sleep(for: Self.revealDelay)
+            guard !Task.isCancelled else { return }
+            isShowing = true
+        }
+    }
+
+    private func cancelReveal() {
+        revealTask?.cancel()
+        revealTask = nil
+        isShowing = false
+    }
+}
+
+/// The tooltip bubble, positioned in the container's coordinate space. Sizing hugs short text on one
+/// line yet wraps long copy at a cap — neither a plain `frame(maxWidth:)` (always fills to the cap)
+/// nor `fixedSize` (never wraps) gives that alone, so a hidden single-line probe measures the natural
+/// width and the visible label is framed to `min(natural, cap)`.
+private struct TooltipBubble: View {
+    let text: String
+    let target: CGRect
+    let bounds: CGSize
+    @Environment(\.reduceTransparencyEffective) private var reduceTransparency
+    @State private var idealTextWidth: CGFloat = 0
+    @State private var bubbleSize: CGSize = .zero
+
+    private static let font = Font.system(size: 12)
+    private static let hPadding: CGFloat = 7
+    private static let vPadding: CGFloat = 4
+    private static let cornerRadius: CGFloat = 6
+    /// Vertical gap between the target and the bubble.
+    private static let gap: CGFloat = 4
+    /// Keep-clear inset from the popover edges.
+    private static let margin: CGFloat = 8
+    private static let maxBubbleWidth: CGFloat = 240
+
+    private var maxTextWidth: CGFloat {
+        max(40, min(Self.maxBubbleWidth, bounds.width - 2 * Self.margin) - 2 * Self.hPadding)
+    }
+
+    private var textWidth: CGFloat {
+        min(idealTextWidth, maxTextWidth)
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            // Probe: single-line natural width, never drawn. Lets the visible label hug short text
+            // yet wrap long copy at the cap.
+            Text(text)
+                .font(Self.font)
+                .fixedSize()
+                .hidden()
+                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { idealTextWidth = $0 }
+
+            if idealTextWidth > 0 {
+                bubble
+                    .onGeometryChange(for: CGSize.self) { $0.size } action: { bubbleSize = $0 }
+                    .offset(x: originX, y: originY)
+                    // Hidden until measured so the bubble never flashes at the origin before it's placed.
+                    .opacity(bubbleSize == .zero ? 0 : 1)
+                    .animation(.easeOut(duration: 0.1), value: bubbleSize == .zero)
+            }
+        }
+    }
+
+    private var bubble: some View {
+        let shape = RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+        return Text(text)
+            .font(Self.font)
+            .foregroundStyle(.primary)
+            .multilineTextAlignment(.leading)
+            // +1 guards against a rounding-induced wrap when the label is framed to its own ideal width.
+            .frame(width: ceil(textWidth) + 1, alignment: .leading)
+            .padding(.horizontal, Self.hPadding)
+            .padding(.vertical, Self.vPadding)
+            .background {
+                // Solid in the reduced-transparency form (matching the popover's own solid surface),
+                // a frosted material otherwise so the bubble reads like a native tooltip on glass.
+                if reduceTransparency {
+                    shape.fill(Color(nsColor: .windowBackgroundColor))
+                } else {
+                    shape.fill(.regularMaterial)
+                }
+            }
+            .overlay { shape.strokeBorder(.separator, lineWidth: 0.5) }
+            .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
+    }
+
+    /// Leading-aligned to the target, clamped so the bubble never pokes past either side edge.
+    private var originX: CGFloat {
+        let maxX = max(Self.margin, bounds.width - bubbleSize.width - Self.margin)
+        return min(max(target.minX, Self.margin), maxX)
+    }
+
+    /// Below the target by default; flips above when the bubble would overflow the bottom and there's
+    /// room up top, otherwise clamps below into bounds.
+    private var originY: CGFloat {
+        let below = target.maxY + Self.gap
+        let above = target.minY - Self.gap - bubbleSize.height
+        if below + bubbleSize.height <= bounds.height - Self.margin { return below }
+        if above >= Self.margin { return above }
+        return max(Self.margin, min(below, bounds.height - bubbleSize.height - Self.margin))
+    }
+}

--- a/Sources/OpenUsage/Views/HoverTooltip.swift
+++ b/Sources/OpenUsage/Views/HoverTooltip.swift
@@ -13,18 +13,37 @@ import SwiftUI
 /// own geometry, places the bubble just below the target (flipping above when it would overflow the
 /// bottom), and clamps it inside the popover.
 
-/// The active tooltip's text plus an anchor on the hovered view's frame. Only one element is hovered
-/// at a time, so at most one request is live.
+/// The active tooltip's text, an anchor on the hovered view's frame, and its nesting depth. A hover
+/// over a nested control sits inside both the child and its container, so both publish a request after
+/// the delay; the depth lets the more specific (deeper) one win.
 private struct TooltipRequest {
     let text: String
     let anchor: Anchor<CGRect>
+    let depth: Int
 }
 
 private struct TooltipRequestKey: PreferenceKey {
     static let defaultValue: TooltipRequest? = nil
     static func reduce(value: inout TooltipRequest?, nextValue: () -> TooltipRequest?) {
-        // Last non-nil wins; targets that aren't showing contribute nil, so the live one survives.
-        if let next = nextValue() { value = next }
+        // Keep the deepest live request so a nested control's tooltip beats its container's (the ⓘ note
+        // over the row figures, or "Clear Shortcut" over the shortcut field) regardless of preference
+        // traversal order. Targets that aren't showing contribute nil and drop out.
+        guard let next = nextValue() else { return }
+        guard let current = value else { value = next; return }
+        if next.depth > current.depth { value = next }
+    }
+}
+
+/// Nesting depth of a `.hoverTooltip` target. Each target bumps it for its descendants, so a child's
+/// request outranks its container's in `TooltipRequestKey.reduce`.
+private struct TooltipDepthKey: EnvironmentKey {
+    static let defaultValue = 0
+}
+
+private extension EnvironmentValues {
+    var tooltipDepth: Int {
+        get { self[TooltipDepthKey.self] }
+        set { self[TooltipDepthKey.self] = newValue }
     }
 }
 
@@ -54,6 +73,7 @@ extension View {
 
 private struct HoverTooltipModifier: ViewModifier {
     let text: String?
+    @Environment(\.tooltipDepth) private var depth
     @State private var isShowing = false
     @State private var revealTask: Task<Void, Never>?
 
@@ -70,6 +90,9 @@ private struct HoverTooltipModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            // Descendants nest one level deeper, so a child target outranks this one when a hover sits
+            // inside both.
+            .environment(\.tooltipDepth, depth + 1)
             .accessibilityHint(resolved ?? "")
             .onHover { inside in
                 guard resolved != nil else { return }
@@ -78,7 +101,7 @@ private struct HoverTooltipModifier: ViewModifier {
             .onDisappear { cancelReveal() }
             .anchorPreference(key: TooltipRequestKey.self, value: .bounds) { anchor in
                 guard isShowing, let resolved else { return nil }
-                return TooltipRequest(text: resolved, anchor: anchor)
+                return TooltipRequest(text: resolved, anchor: anchor, depth: depth)
             }
     }
 

--- a/Sources/OpenUsage/Views/HoverTooltip.swift
+++ b/Sources/OpenUsage/Views/HoverTooltip.swift
@@ -7,11 +7,13 @@ import SwiftUI
 ///
 /// It's drawn in its own borderless, non-activating, click-through `NSPanel` — not a SwiftUI overlay.
 /// A SwiftUI overlay lives inside the popover's window and is clipped to it (and to the dashboard's
-/// scroll view), so it can't float freely the way a tooltip must. The panel sits at `.popUpMenu` level
-/// (above the status-item popover), never becomes key and never activates the app (shown via
+/// scroll view), so it can't float freely the way a tooltip must. The panel sits at `.popUpMenu` — the
+/// same level as the status-item popover — so it shows over the popover by being ordered in front, not
+/// by a higher level. It never becomes key and never activates the app (shown via
 /// `orderFrontRegardless()`), which is the documented carve-out that keeps it from dismissing the
 /// transient popover; `ignoresMouseEvents` makes it click-through so it can't steal the hover that
-/// spawned it.
+/// spawned it. The popover closing doesn't move the cursor or tear down the (surviving) SwiftUI tree,
+/// so `HoverTooltips.dismissAll()` clears any live tooltip from the status-item controller's hide path.
 ///
 /// Usage: `.hoverTooltip(_:)` on any hover target. No root container is needed — the panel is a
 /// separate window owned by `TooltipPresenter`.
@@ -46,6 +48,9 @@ private struct HoverTooltipModifier: ViewModifier {
     /// Stable per-target identity, so the presenter can track which targets are currently hovered and
     /// drop this one on exit.
     @State private var id = UUID()
+    /// Whether the cursor is currently inside this target, so `onChange(of: resolved)` knows whether to
+    /// act when the text changes without a hover event firing.
+    @State private var isHovering = false
 
     /// `nil` (no tooltip) for a missing or blank string, collapsing the two "absent" cases.
     private var resolved: String? {
@@ -62,18 +67,40 @@ private struct HoverTooltipModifier: ViewModifier {
             // Continuous (not plain `onHover`) so the presenter always has the live hover state; it
             // reads the cursor itself at show time, so the reported location is unused here.
             .onContinuousHover { phase in
-                guard let resolved else { return }
                 switch phase {
                 case .active:
-                    TooltipPresenter.shared.enter(id: id, text: resolved, depth: depth,
-                                                  reduceTransparency: reduceTransparency)
+                    isHovering = true
+                    syncPresenter()
                 case .ended:
+                    // Always exit, regardless of `resolved`: if the text went nil/empty while hovered,
+                    // a guarded-out `.ended` would leave this target in the presenter and its tooltip
+                    // would linger.
+                    isHovering = false
                     TooltipPresenter.shared.exit(id: id)
                 }
             }
+            // Text can change while the cursor sits still (e.g. a meter tooltip refreshing to a no-tip
+            // state on its 30s tick), with no hover event to react to — reconcile so the bubble updates
+            // or clears.
+            .onChange(of: resolved) { syncPresenter() }
             // A row can be torn down (scroll, screen switch, popover close) without an `.ended`, so
             // clear our entry here too or the panel could linger.
-            .onDisappear { TooltipPresenter.shared.exit(id: id) }
+            .onDisappear {
+                isHovering = false
+                TooltipPresenter.shared.exit(id: id)
+            }
+    }
+
+    /// Reflect the current hover state into the presenter: show this target's text while hovered, drop
+    /// it when there's no text. A no-op when not hovered (so a text change off-hover does nothing).
+    private func syncPresenter() {
+        guard isHovering else { return }
+        if let resolved {
+            TooltipPresenter.shared.enter(id: id, text: resolved, depth: depth,
+                                          reduceTransparency: reduceTransparency)
+        } else {
+            TooltipPresenter.shared.exit(id: id)
+        }
     }
 }
 
@@ -92,8 +119,10 @@ private final class TooltipPresenter {
     /// Targets the cursor is currently inside. More than one only while a hover sits in both a child
     /// and its container; the deepest wins.
     private var active: [UUID: Target] = [:]
-    /// The target currently on screen, and the one a pending reveal is scheduled for.
+    /// The target currently on screen (and its text, to detect a live text change), and the one a
+    /// pending reveal is scheduled for.
     private var shownID: UUID?
+    private var shownText: String?
     private var pendingID: UUID?
     private var revealTask: Task<Void, Never>?
 
@@ -122,7 +151,7 @@ private final class TooltipPresenter {
         // host has an intrinsic size to report; the bubble is `.fixedSize()`, so that equals the size we
         // set and the host can't grow the panel out from under us.
         panel.isFloatingPanel = true
-        panel.level = .popUpMenu                          // above the status-item popover (.statusBar)
+        panel.level = .popUpMenu                          // same level as the status-item popover; wins by being ordered front
         panel.hidesOnDeactivate = false
         panel.isReleasedWhenClosed = false
         panel.ignoresMouseEvents = true                   // click-through; never intercepts the hover
@@ -145,6 +174,15 @@ private final class TooltipPresenter {
         refresh()
     }
 
+    /// Clear everything. Called when the popover closes: its SwiftUI tree (and our hover state) survives
+    /// `orderOut`, so no `.ended`/`.onDisappear` fires for a target the cursor was resting on, and a
+    /// shown tooltip would otherwise orphan on screen with a pending reveal possibly firing afterward.
+    func dismissAll() {
+        active.removeAll()
+        cancelPending()
+        hide()
+    }
+
     /// Reconcile the panel with the deepest active target. Cheap and idempotent, so the per-pixel
     /// `onContinuousHover` calls mostly hit an early return.
     private func refresh() {
@@ -153,10 +191,17 @@ private final class TooltipPresenter {
             hide()
             return
         }
-        if shownID == top.key { return }            // already showing the right one — don't reposition
+        if shownID == top.key {                     // already the right target on screen
+            if shownText != top.value.text {        // its text changed live — re-present, don't reposition away
+                present(top.value)
+                shownText = top.value.text
+            }
+            return
+        }
         if shownID != nil {                         // a tooltip is up for another target — switch now
             present(top.value)
             shownID = top.key
+            shownText = top.value.text
             cancelPending()
             return
         }
@@ -171,6 +216,7 @@ private final class TooltipPresenter {
             guard !Task.isCancelled, let self else { return }
             self.present(target)
             self.shownID = id
+            self.shownText = target.text
             self.pendingID = nil
             self.revealTask = nil
         }
@@ -190,6 +236,7 @@ private final class TooltipPresenter {
     private func hide() {
         if shownID != nil { lastHideAt = clock.now }   // open the quick-mode window only after a real show
         shownID = nil
+        shownText = nil
         if panel.isVisible { panel.orderOut(nil) }
     }
 
@@ -210,7 +257,10 @@ private final class TooltipPresenter {
         var y = cursor.y + cursorGap
         let screen = NSScreen.screens.first { $0.frame.contains(cursor) } ?? NSScreen.main
         if let visible = screen?.visibleFrame {
-            x = min(max(x, visible.minX), visible.maxX - size.width)
+            // Clamp leading edge into the visible frame. The `min` keeps the trailing edge in, the outer
+            // `max` keeps the leading edge in even when the bubble is wider than the screen (it would
+            // otherwise land off the left edge — a reversed-bounds clamp).
+            x = max(visible.minX, min(x, visible.maxX - size.width))
             if y + size.height > visible.maxY {
                 y = cursor.y - cursorGap - size.height
             }
@@ -219,6 +269,13 @@ private final class TooltipPresenter {
         return NSPoint(x: x, y: y)
     }
 
+}
+
+/// Seam for non-SwiftUI code (the status-item controller) to clear any visible tooltip when the popover
+/// closes — `TooltipPresenter` is private.
+@MainActor
+enum HoverTooltips {
+    static func dismissAll() { TooltipPresenter.shared.dismissAll() }
 }
 
 /// Never becomes key or main, so showing it can't pull focus and dismiss the transient popover.

--- a/Sources/OpenUsage/Views/HoverTooltip.swift
+++ b/Sources/OpenUsage/Views/HoverTooltip.swift
@@ -165,9 +165,12 @@ private struct TooltipBubble: View {
                 bubble
                     .onGeometryChange(for: CGSize.self) { $0.size } action: { bubbleSize = $0 }
                     .offset(x: originX, y: originY)
-                    // Hidden until measured so the bubble never flashes at the origin before it's placed.
+                    // Invisible until measured, then it appears already in its final, in-bounds
+                    // position. Deliberately not animated: the offset depends on the measured size, so
+                    // animating its first change would slide the bubble in from an unplaced spot (it
+                    // would briefly sit out of bounds). A native-style pop avoids that.
                     .opacity(bubbleSize == .zero ? 0 : 1)
-                    .animation(.easeOut(duration: 0.1), value: bubbleSize == .zero)
+                    .transaction { $0.animation = nil }
             }
         }
     }
@@ -201,13 +204,13 @@ private struct TooltipBubble: View {
         return min(max(target.minX, Self.margin), maxX)
     }
 
-    /// Below the target by default; flips above when the bubble would overflow the bottom and there's
-    /// room up top, otherwise clamps below into bounds.
+    /// Above the target by default, so the cursor (resting on the target) doesn't overlay the bubble;
+    /// flips below when there's no room up top, otherwise clamps into bounds.
     private var originY: CGFloat {
-        let below = target.maxY + Self.gap
         let above = target.minY - Self.gap - bubbleSize.height
-        if below + bubbleSize.height <= bounds.height - Self.margin { return below }
+        let below = target.maxY + Self.gap
         if above >= Self.margin { return above }
-        return max(Self.margin, min(below, bounds.height - bubbleSize.height - Self.margin))
+        if below + bubbleSize.height <= bounds.height - Self.margin { return below }
+        return max(Self.margin, min(above, bounds.height - bubbleSize.height - Self.margin))
     }
 }

--- a/Sources/OpenUsage/Views/HoverTooltip.swift
+++ b/Sources/OpenUsage/Views/HoverTooltip.swift
@@ -1,41 +1,33 @@
+import AppKit
 import SwiftUI
 
-/// An in-app replacement for SwiftUI's `.help()` tooltip. The native tooltip has a long,
-/// system-controlled first-hover delay (~1.5-2s before the first tooltip in a window appears; it
-/// reshows later ones almost instantly) that no public API shortens, so the row's exact figures felt
-/// slow to reveal on the first hover. This shows a styled bubble after a short, fixed delay we own.
+/// A hover tooltip that behaves like the native `.help()` tooltip but appears after a delay we control
+/// (the native one waits ~1.5-2s on the first hover, with no public API to shorten) and is placed
+/// above the cursor, centered on it.
 ///
-/// Two pieces: `.hoverTooltip(_:)` on a hover target reports its text and frame, and a single
-/// `.hoverTooltipContainer()` at the popover root draws the bubble. The bubble is drawn at the root,
-/// not inside the hovered view, so it escapes the dashboard/settings/customize scroll views — those
-/// clip their content, so an in-row bubble would be cut off near a scroll edge. The target publishes
-/// its text and bounds up the tree via an anchor preference; the container resolves that anchor in its
-/// own geometry, places the bubble just below the target (flipping above when it would overflow the
-/// bottom), and clamps it inside the popover.
+/// It's drawn in its own borderless, non-activating, click-through `NSPanel` — not a SwiftUI overlay.
+/// A SwiftUI overlay lives inside the popover's window and is clipped to it (and to the dashboard's
+/// scroll view), so it can't float freely the way a tooltip must. The panel sits at `.popUpMenu` level
+/// (above the status-item popover), never becomes key and never activates the app (shown via
+/// `orderFrontRegardless()`), which is the documented carve-out that keeps it from dismissing the
+/// transient popover; `ignoresMouseEvents` makes it click-through so it can't steal the hover that
+/// spawned it.
+///
+/// Usage: `.hoverTooltip(_:)` on any hover target. No root container is needed — the panel is a
+/// separate window owned by `TooltipPresenter`.
 
-/// The active tooltip's text, an anchor on the hovered view's frame, and its nesting depth. A hover
-/// over a nested control sits inside both the child and its container, so both publish a request after
-/// the delay; the depth lets the more specific (deeper) one win.
-private struct TooltipRequest {
-    let text: String
-    let anchor: Anchor<CGRect>
-    let depth: Int
-}
-
-private struct TooltipRequestKey: PreferenceKey {
-    static let defaultValue: TooltipRequest? = nil
-    static func reduce(value: inout TooltipRequest?, nextValue: () -> TooltipRequest?) {
-        // Keep the deepest live request so a nested control's tooltip beats its container's (the ⓘ note
-        // over the row figures, or "Clear Shortcut" over the shortcut field) regardless of preference
-        // traversal order. Targets that aren't showing contribute nil and drop out.
-        guard let next = nextValue() else { return }
-        guard let current = value else { value = next; return }
-        if next.depth > current.depth { value = next }
+extension View {
+    /// Shows `text` in a hover tooltip after a short delay, positioned above the cursor. `nil` or empty
+    /// shows nothing, so the many `someTooltip ?? ""` call sites keep their "no tooltip when blank"
+    /// behavior. The text is also exposed as an accessibility hint — the part `.help()` gave VoiceOver.
+    func hoverTooltip(_ text: String?) -> some View {
+        modifier(HoverTooltipModifier(text: text))
     }
 }
 
-/// Nesting depth of a `.hoverTooltip` target. Each target bumps it for its descendants, so a child's
-/// request outranks its container's in `TooltipRequestKey.reduce`.
+/// Per-target nesting depth so a nested control's tooltip beats its container's when a hover sits in
+/// both (e.g. the clear button inside the Settings shortcut field). Each target bumps it for its
+/// descendants; `TooltipPresenter` shows the deepest active one.
 private struct TooltipDepthKey: EnvironmentKey {
     static let defaultValue = 0
 }
@@ -47,40 +39,13 @@ private extension EnvironmentValues {
     }
 }
 
-extension View {
-    /// Shows `text` in a custom hover tooltip after a short delay. `nil` or empty shows nothing, so the
-    /// many `someTooltip ?? ""` call sites keep their "no tooltip when blank" behavior. The text is also
-    /// exposed as an accessibility hint — the part `.help()` contributed to VoiceOver.
-    func hoverTooltip(_ text: String?) -> some View {
-        modifier(HoverTooltipModifier(text: text))
-    }
-
-    /// Draws the hover tooltip for any `.hoverTooltip(_:)` target beneath this point. Apply once, at the
-    /// popover root, above the scroll views so the bubble can extend past their clipped bounds.
-    func hoverTooltipContainer() -> some View {
-        overlayPreferenceValue(TooltipRequestKey.self) { request in
-            GeometryReader { proxy in
-                if let request {
-                    TooltipBubble(text: request.text, target: proxy[request.anchor], bounds: proxy.size)
-                }
-            }
-            // Never intercept the hover or clicks of the rows beneath, or the bubble would steal the
-            // hover that spawned it and flicker.
-            .allowsHitTesting(false)
-        }
-    }
-}
-
 private struct HoverTooltipModifier: ViewModifier {
     let text: String?
     @Environment(\.tooltipDepth) private var depth
-    @State private var isShowing = false
-    @State private var revealTask: Task<Void, Never>?
-
-    /// Delay before the bubble appears. Short enough to feel responsive on the first hover (the native
-    /// tooltip's slow first appearance is the whole reason this exists), long enough that brushing the
-    /// cursor across rows doesn't flash bubbles.
-    private static let revealDelay: Duration = .milliseconds(350)
+    @Environment(\.reduceTransparencyEffective) private var reduceTransparency
+    /// Stable per-target identity, so the presenter can track which targets are currently hovered and
+    /// drop this one on exit.
+    @State private var id = UUID()
 
     /// `nil` (no tooltip) for a missing or blank string, collapsing the two "absent" cases.
     private var resolved: String? {
@@ -94,100 +59,190 @@ private struct HoverTooltipModifier: ViewModifier {
             // inside both.
             .environment(\.tooltipDepth, depth + 1)
             .accessibilityHint(resolved ?? "")
-            .onHover { inside in
-                guard resolved != nil else { return }
-                if inside { scheduleReveal() } else { cancelReveal() }
+            // Continuous (not plain `onHover`) so the presenter always has the live hover state; it
+            // reads the cursor itself at show time, so the reported location is unused here.
+            .onContinuousHover { phase in
+                guard let resolved else { return }
+                switch phase {
+                case .active:
+                    TooltipPresenter.shared.enter(id: id, text: resolved, depth: depth,
+                                                  reduceTransparency: reduceTransparency)
+                case .ended:
+                    TooltipPresenter.shared.exit(id: id)
+                }
             }
-            .onDisappear { cancelReveal() }
-            .anchorPreference(key: TooltipRequestKey.self, value: .bounds) { anchor in
-                guard isShowing, let resolved else { return nil }
-                return TooltipRequest(text: resolved, anchor: anchor, depth: depth)
-            }
-    }
-
-    private func scheduleReveal() {
-        revealTask?.cancel()
-        revealTask = Task { @MainActor in
-            try? await Task.sleep(for: Self.revealDelay)
-            guard !Task.isCancelled else { return }
-            isShowing = true
-        }
-    }
-
-    private func cancelReveal() {
-        revealTask?.cancel()
-        revealTask = nil
-        isShowing = false
+            // A row can be torn down (scroll, screen switch, popover close) without an `.ended`, so
+            // clear our entry here too or the panel could linger.
+            .onDisappear { TooltipPresenter.shared.exit(id: id) }
     }
 }
 
-/// The tooltip bubble, positioned in the container's coordinate space. Sizing hugs short text on one
-/// line yet wraps long copy at a cap — neither a plain `frame(maxWidth:)` (always fills to the cap)
-/// nor `fixedSize` (never wraps) gives that alone, so a hidden single-line probe measures the natural
-/// width and the visible label is framed to `min(natural, cap)`.
-private struct TooltipBubble: View {
-    let text: String
-    let target: CGRect
-    let bounds: CGSize
-    @Environment(\.reduceTransparencyEffective) private var reduceTransparency
-    @State private var idealTextWidth: CGFloat = 0
-    @State private var bubbleSize: CGSize = .zero
+/// Owns the single reused tooltip panel and decides which hovered target is shown. Main-actor isolated:
+/// every entry point is a SwiftUI hover callback (already on the main actor) and it only touches AppKit.
+@MainActor
+private final class TooltipPresenter {
+    static let shared = TooltipPresenter()
 
-    private static let font = Font.system(size: 12)
-    private static let hPadding: CGFloat = 7
-    private static let vPadding: CGFloat = 4
-    private static let cornerRadius: CGFloat = 6
-    /// Vertical gap between the target and the bubble.
-    private static let gap: CGFloat = 4
-    /// Keep-clear inset from the popover edges.
-    private static let margin: CGFloat = 8
-    private static let maxBubbleWidth: CGFloat = 240
-
-    private var maxTextWidth: CGFloat {
-        max(40, min(Self.maxBubbleWidth, bounds.width - 2 * Self.margin) - 2 * Self.hPadding)
+    private struct Target {
+        let text: String
+        let depth: Int
+        let reduceTransparency: Bool
     }
 
-    private var textWidth: CGFloat {
-        min(idealTextWidth, maxTextWidth)
+    /// Targets the cursor is currently inside. More than one only while a hover sits in both a child
+    /// and its container; the deepest wins.
+    private var active: [UUID: Target] = [:]
+    /// The target currently on screen, and the one a pending reveal is scheduled for.
+    private var shownID: UUID?
+    private var pendingID: UUID?
+    private var revealTask: Task<Void, Never>?
+
+    /// Mirrors the native tooltip: a real wait on the first hover, then near-instant reshows for a
+    /// short grace window after one was last shown ("quick mode").
+    private let initialDelay: Duration = .milliseconds(350)
+    private let quickDelay: Duration = .milliseconds(60)
+    private let quickWindow: Duration = .milliseconds(1500)
+    private let clock = ContinuousClock()
+    private var lastHideAt: ContinuousClock.Instant?
+
+    /// Space above the cursor; the panel's bottom edge sits this far above the pointer.
+    private let cursorGap: CGFloat = 10
+
+    private let host = NSHostingView(rootView: AnyView(EmptyView()))
+    private let panel = NonKeyPanel(
+        contentRect: .zero,
+        styleMask: [.borderless, .nonactivatingPanel],   // set once at init; toggling later desyncs activation
+        backing: .buffered,
+        defer: false
+    )
+
+    private init() {
+        // Configure the panel up front (not lazily) so the hosting view is in a window from the start
+        // and `fittingSize` measures correctly on the first show. Default sizing options stay on so the
+        // host has an intrinsic size to report; the bubble is `.fixedSize()`, so that equals the size we
+        // set and the host can't grow the panel out from under us.
+        panel.isFloatingPanel = true
+        panel.level = .popUpMenu                          // above the status-item popover (.statusBar)
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.ignoresMouseEvents = true                   // click-through; never intercepts the hover
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true                            // window shadow follows the bubble's rounded shape
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        panel.animationBehavior = .none
+        panel.contentView = host
     }
 
-    var body: some View {
-        ZStack(alignment: .topLeading) {
-            // Probe: single-line natural width, never drawn. Lets the visible label hug short text
-            // yet wrap long copy at the cap.
-            Text(text)
-                .font(Self.font)
-                .fixedSize()
-                .hidden()
-                .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { idealTextWidth = $0 }
+    func enter(id: UUID, text: String, depth: Int, reduceTransparency: Bool) {
+        active[id] = Target(text: text, depth: depth, reduceTransparency: reduceTransparency)
+        refresh()
+    }
 
-            if idealTextWidth > 0 {
-                bubble
-                    .onGeometryChange(for: CGSize.self) { $0.size } action: { bubbleSize = $0 }
-                    .offset(x: originX, y: originY)
-                    // Invisible until measured, then it appears already in its final, in-bounds
-                    // position. Deliberately not animated: the offset depends on the measured size, so
-                    // animating its first change would slide the bubble in from an unplaced spot (it
-                    // would briefly sit out of bounds). A native-style pop avoids that.
-                    .opacity(bubbleSize == .zero ? 0 : 1)
-                    .transaction { $0.animation = nil }
-            }
+    func exit(id: UUID) {
+        guard active[id] != nil else { return }
+        active[id] = nil
+        refresh()
+    }
+
+    /// Reconcile the panel with the deepest active target. Cheap and idempotent, so the per-pixel
+    /// `onContinuousHover` calls mostly hit an early return.
+    private func refresh() {
+        guard let top = active.max(by: { $0.value.depth < $1.value.depth }) else {
+            cancelPending()
+            hide()
+            return
+        }
+        if shownID == top.key { return }            // already showing the right one — don't reposition
+        if shownID != nil {                         // a tooltip is up for another target — switch now
+            present(top.value)
+            shownID = top.key
+            cancelPending()
+            return
+        }
+        if pendingID == top.key { return }          // already scheduled for this target
+        cancelPending()
+        pendingID = top.key
+        let target = top.value
+        let id = top.key
+        let delay = isInQuickMode ? quickDelay : initialDelay
+        revealTask = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled, let self else { return }
+            self.present(target)
+            self.shownID = id
+            self.pendingID = nil
+            self.revealTask = nil
         }
     }
 
-    private var bubble: some View {
-        let shape = RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
-        return Text(text)
-            .font(Self.font)
+    private var isInQuickMode: Bool {
+        guard let lastHideAt else { return false }
+        return clock.now - lastHideAt < quickWindow
+    }
+
+    private func cancelPending() {
+        revealTask?.cancel()
+        revealTask = nil
+        pendingID = nil
+    }
+
+    private func hide() {
+        if shownID != nil { lastHideAt = clock.now }   // open the quick-mode window only after a real show
+        shownID = nil
+        if panel.isVisible { panel.orderOut(nil) }
+    }
+
+    private func present(_ target: Target) {
+        host.rootView = AnyView(TooltipBubble(text: target.text, reduceTransparency: target.reduceTransparency))
+        host.layoutSubtreeIfNeeded()
+        let size = host.fittingSize
+        panel.setContentSize(size)
+        panel.setFrameOrigin(origin(for: size, cursor: NSEvent.mouseLocation))
+        panel.orderFrontRegardless()                   // show without activating the app or taking key
+    }
+
+    /// Above the cursor and centered on it, clamped to the cursor's screen; flips below the cursor when
+    /// it would clip the top. All math in Cocoa screen coordinates (bottom-left origin, y grows up),
+    /// matching `NSEvent.mouseLocation` and `NSScreen.visibleFrame`.
+    private func origin(for size: CGSize, cursor: NSPoint) -> NSPoint {
+        var x = cursor.x - size.width / 2
+        var y = cursor.y + cursorGap
+        let screen = NSScreen.screens.first { $0.frame.contains(cursor) } ?? NSScreen.main
+        if let visible = screen?.visibleFrame {
+            x = min(max(x, visible.minX), visible.maxX - size.width)
+            if y + size.height > visible.maxY {
+                y = cursor.y - cursorGap - size.height
+            }
+            y = max(y, visible.minY)
+        }
+        return NSPoint(x: x, y: y)
+    }
+
+}
+
+/// Never becomes key or main, so showing it can't pull focus and dismiss the transient popover.
+private final class NonKeyPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+/// The bubble drawn inside the panel: a frosted material on glass, a solid fill under Reduce
+/// Transparency, with a hairline border. Sizes to its content (`fittingSize` drives the panel size);
+/// the panel's window shadow supplies the drop shadow.
+private struct TooltipBubble: View {
+    let text: String
+    let reduceTransparency: Bool
+
+    var body: some View {
+        let shape = RoundedRectangle(cornerRadius: 6, style: .continuous)
+        Text(text)
+            .font(.system(size: 12))
             .foregroundStyle(.primary)
-            .multilineTextAlignment(.leading)
-            // +1 guards against a rounding-induced wrap when the label is framed to its own ideal width.
-            .frame(width: ceil(textWidth) + 1, alignment: .leading)
-            .padding(.horizontal, Self.hPadding)
-            .padding(.vertical, Self.vPadding)
+            .fixedSize()
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
             .background {
-                // Solid in the reduced-transparency form (matching the popover's own solid surface),
-                // a frosted material otherwise so the bubble reads like a native tooltip on glass.
                 if reduceTransparency {
                     shape.fill(Color(nsColor: .windowBackgroundColor))
                 } else {
@@ -195,22 +250,5 @@ private struct TooltipBubble: View {
                 }
             }
             .overlay { shape.strokeBorder(.separator, lineWidth: 0.5) }
-            .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
-    }
-
-    /// Leading-aligned to the target, clamped so the bubble never pokes past either side edge.
-    private var originX: CGFloat {
-        let maxX = max(Self.margin, bounds.width - bubbleSize.width - Self.margin)
-        return min(max(target.minX, Self.margin), maxX)
-    }
-
-    /// Above the target by default, so the cursor (resting on the target) doesn't overlay the bubble;
-    /// flips below when there's no room up top, otherwise clamps into bounds.
-    private var originY: CGFloat {
-        let above = target.minY - Self.gap - bubbleSize.height
-        let below = target.maxY + Self.gap
-        if above >= Self.margin { return above }
-        if below + bubbleSize.height <= bounds.height - Self.margin { return below }
-        return max(Self.margin, min(above, bounds.height - bubbleSize.height - Self.margin))
     }
 }

--- a/Sources/OpenUsage/Views/ProviderSectionHeader.swift
+++ b/Sources/OpenUsage/Views/ProviderSectionHeader.swift
@@ -47,7 +47,7 @@ struct ProviderSectionHeader<Trailing: View>: View {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(Theme.notice)
-                    .help(warning)
+                    .hoverTooltip(warning)
                     .accessibilityLabel(warning)
             }
             Spacer(minLength: 8)

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -88,7 +88,7 @@ struct SettingsScreen: View {
                 // Click-to-record field; its ⓧ clears the combo and disables the shortcut.
                 row("Global Shortcut") {
                     ShortcutRecorderField(name: .togglePopover)
-                        .help("Open OpenUsage from anywhere")
+                        .hoverTooltip("Open OpenUsage from anywhere")
                 }
             }
             section("Appearance") {
@@ -114,7 +114,7 @@ struct SettingsScreen: View {
                 row("Reduce Transparency") {
                     Toggle("", isOn: $reduceTransparency)
                         .settingsSwitchStyle()
-                        .help("Use a solid background instead of Liquid Glass for better readability")
+                        .hoverTooltip("Use a solid background instead of Liquid Glass for better readability")
                         .onChange(of: reduceTransparency) {
                             NotificationCenter.default.post(name: ReduceTransparencySetting.didChangeNotification, object: nil)
                         }
@@ -145,7 +145,7 @@ struct SettingsScreen: View {
                     row("Beta Updates") {
                         Toggle("", isOn: $updater.betaChannelEnabled)
                             .settingsSwitchStyle()
-                            .help("Receive pre-release builds before they ship to everyone")
+                            .hoverTooltip("Receive pre-release builds before they ship to everyone")
                     }
                     // No version label here — the footer already shows it. The frame goes on the label so
                     // the glass background stretches the full row width instead of hugging the text.

--- a/Sources/OpenUsage/Views/ShortcutRecorderField.swift
+++ b/Sources/OpenUsage/Views/ShortcutRecorderField.swift
@@ -56,7 +56,7 @@ struct ShortcutRecorderField: View {
                         .imageScale(.medium)
                 }
                 .buttonStyle(.plain)
-                .help("Clear Shortcut")
+                .hoverTooltip("Clear Shortcut")
                 .accessibilityLabel("Clear Shortcut")
             }
         }

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -257,9 +257,9 @@ struct WidgetRowView: View {
             }
             .multilineTextAlignment(.trailing)
         }
-        // Hovering the row reveals the exact figures the compact value shortens ("$2,059.07 ·
-        // 1,506,025,363"); empty string when nothing's abbreviated, so no redundant tooltip appears.
-        .hoverTooltip(data.unboundedTooltip)
+        // No row-level hover tooltip: the value text is the row's payload, not an affordance, so
+        // hovering it shouldn't pop anything. The ⓘ beside the label is the row's only hover target
+        // (its `infoNote`), which is where extra detail belongs.
     }
 
     /// Small ⓘ next to the label; on hover it explains the row's `infoNote` (e.g. that a ccusage dollar

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -139,7 +139,7 @@ struct WidgetRowView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
-                .help(state.tooltip ?? "")
+                .hoverTooltip(state.tooltip)
         case .noData, .healthy, .level:
             EmptyView()
         }
@@ -166,7 +166,7 @@ struct WidgetRowView: View {
             }
         }
         .foregroundStyle(.secondary)
-        .help(state.tooltip ?? "")
+        .hoverTooltip(state.tooltip)
         .accessibilityLabel(accessibility)
 
         if let action {
@@ -207,7 +207,7 @@ struct WidgetRowView: View {
                     .contentTransition(.numericText())
             }
             .buttonStyle(.plain)
-            .help(data.meterStyleTooltip ?? "")
+            .hoverTooltip(data.meterStyleTooltip)
         } else {
             Text(data.headline)
                 .foregroundStyle(.primary)
@@ -226,7 +226,7 @@ struct WidgetRowView: View {
                     Text(text).foregroundStyle(.secondary)
                 }
                 .buttonStyle(.plain)
-                .help(data.resetTooltip ?? "")
+                .hoverTooltip(data.resetTooltip)
             } else {
                 Text(text).foregroundStyle(.secondary)
             }
@@ -259,7 +259,7 @@ struct WidgetRowView: View {
         }
         // Hovering the row reveals the exact figures the compact value shortens ("$2,059.07 ·
         // 1,506,025,363"); empty string when nothing's abbreviated, so no redundant tooltip appears.
-        .help(data.unboundedTooltip ?? "")
+        .hoverTooltip(data.unboundedTooltip)
     }
 
     /// Small ⓘ next to the label; on hover it explains the row's `infoNote` (e.g. that a ccusage dollar
@@ -271,7 +271,7 @@ struct WidgetRowView: View {
             Image(systemName: "info.circle")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .help(note)
+                .hoverTooltip(note)
                 .accessibilityLabel(note)
         }
     }
@@ -329,7 +329,7 @@ struct WidgetRowView: View {
         .frame(height: density.meterHeight)
         .animation(Motion.spring, value: data.fraction)
         .accessibilityHidden(true)
-        .help(state.tooltip ?? "")
+        .hoverTooltip(state.tooltip)
     }
 
     private static let paceTickWidth: CGFloat = 2

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -293,12 +293,15 @@ struct WidgetRowView: View {
     }
 
     /// The hover text for an unbounded row, shared by the row itself and its ⓘ: the exact figures when
-    /// there's usage to reveal, or a "no usage" note on a zero-usage period so an empty row
+    /// there's usage to reveal, or a "no usage" note on a zero spend period so an empty row
     /// ("$0.00 · 0 tokens") still pops something (and carries an ⓘ). `nil` for a small, already-full,
     /// non-zero row, which has nothing to add.
     private var unboundedHoverText: String? {
         if let figures = data.unboundedTooltip { return figures }
-        return data.isZeroUsage ? "No usage in this period" : nil
+        // The "no usage" note only fits a spend period (Today / Yesterday / Last 30 Days), where a zero
+        // genuinely means nothing was used. A balance row that reads 0 (Codex Rate Limit Resets, an
+        // exhausted Extra Usage credit) is depleted, not idle, so it gets no note and no ⓘ.
+        return data.isZeroUsage && data.isUsagePeriod ? "No usage in this period" : nil
     }
 
     /// Full-width capsule meter — the Tahoe-era level-indicator form (capsule, full-height

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -111,7 +111,7 @@ struct WidgetRowView: View {
                 .font(labelFont)
                 .foregroundStyle(.primary)
                 .lineLimit(1)
-            infoIcon
+            infoIcon(data.infoNote)
             warning(state)
         }
     }
@@ -246,6 +246,11 @@ struct WidgetRowView: View {
                     .contentTransition(.numericText())
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
+                    // Hover target is the value text itself (and the ⓘ), not the whole row — the same
+                    // per-element pattern the bounded row uses for "x left" and "Resets in …". Reveals
+                    // the exact figures the compact value shortens, or "No usage in this period" on a
+                    // zero row; nil (no tooltip) on a small, already-full, non-zero row.
+                    .hoverTooltip(unboundedHoverText)
                 if let subtitle = data.unboundedSubtitle {
                     // Secondary, not tertiary: the subtitle is informational ("on-device estimate"),
                     // and tertiary is reserved for inactive content on glass.
@@ -257,22 +262,20 @@ struct WidgetRowView: View {
             }
             .multilineTextAlignment(.trailing)
         }
-        // No row-level hover tooltip: the value text is the row's payload, not an affordance, so
-        // hovering it shouldn't pop anything. The ⓘ beside the label is the row's only hover target
-        // (its `infoNote`), which is where extra detail belongs.
     }
 
-    /// Small ⓘ next to the label; on hover it explains the row's `infoNote` (e.g. that a ccusage dollar
-    /// figure is an estimated API cost). Renders nothing when the metric has no note.
+    /// Small ⓘ next to the label; on hover it shows the supplied detail (a bounded row's `infoNote`,
+    /// or an unbounded row's exact figures). Renders nothing when there's no detail, so an icon only
+    /// appears where there's something to reveal.
     @ViewBuilder
-    private var infoIcon: some View {
-        if let note = data.infoNote {
+    private func infoIcon(_ tooltip: String?) -> some View {
+        if let tooltip, !tooltip.isEmpty {
             // Secondary so the affordance stays discoverable on glass; tertiary is for inactive content.
             Image(systemName: "info.circle")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .hoverTooltip(note)
-                .accessibilityLabel(note)
+                .hoverTooltip(tooltip)
+                .accessibilityLabel(tooltip)
         }
     }
 
@@ -285,8 +288,17 @@ struct WidgetRowView: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
-            infoIcon
+            infoIcon(unboundedHoverText)
         }
+    }
+
+    /// The hover text for an unbounded row, shared by the row itself and its ⓘ: the exact figures when
+    /// there's usage to reveal, or a "no usage" note on a zero-usage period so an empty row
+    /// ("$0.00 · 0 tokens") still pops something (and carries an ⓘ). `nil` for a small, already-full,
+    /// non-zero row, which has nothing to add.
+    private var unboundedHoverText: String? {
+        if let figures = data.unboundedTooltip { return figures }
+        return data.isZeroUsage ? "No usage in this period" : nil
     }
 
     /// Full-width capsule meter — the Tahoe-era level-indicator form (capsule, full-height

--- a/Tests/OpenUsageTests/WidgetUsagePeriodTests.swift
+++ b/Tests/OpenUsageTests/WidgetUsagePeriodTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import OpenUsage
+
+/// The "No usage in this period" note (and its ⓘ) is scoped to spend-period rows — Today / Yesterday /
+/// Last 30 Days — through `WidgetData.isUsagePeriod`. A balance/availability row that happens to read
+/// zero (Codex "Rate Limit Resets" with none available, an exhausted "Extra Usage" credit) is depleted,
+/// not idle, so it stays off the note even though every selected value is zero.
+@MainActor
+final class WidgetUsagePeriodTests: XCTestCase {
+    private let provider = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+
+    func testSpendTilesAreUsagePeriods() {
+        let tiles = WidgetDescriptor.spendTiles(provider: provider)
+        XCTAssertEqual(tiles.count, 3)
+        XCTAssertTrue(tiles.allSatisfy { $0.sample.isUsagePeriod })
+    }
+
+    func testValuesAndCombinedDefaultToNotUsagePeriod() {
+        // The exact shape the Codex balance rows use: `.values(...)` for Rate Limit Resets and
+        // `.combined(...)` for Extra Usage credits, neither opting into a usage period.
+        let resets = WidgetDescriptor.values(id: "codex.rateLimitResets", provider: provider,
+                                             title: "Rate Limit Resets", metricLabel: "Rate Limit Resets")
+        let credits = WidgetDescriptor.combined(id: "codex.credits", provider: provider,
+                                                title: "Extra Usage", metricLabel: "Credits")
+        XCTAssertFalse(resets.sample.isUsagePeriod)
+        XCTAssertFalse(credits.sample.isUsagePeriod)
+    }
+
+    func testCodexBalanceRowsAreNotUsagePeriods() {
+        let descriptors = CodexProvider().widgetDescriptors
+        XCTAssertEqual(descriptors.first { $0.id == "codex.rateLimitResets" }?.sample.isUsagePeriod, false)
+        XCTAssertEqual(descriptors.first { $0.id == "codex.credits" }?.sample.isUsagePeriod, false)
+        // The spend tiles on the same provider do carry the flag.
+        XCTAssertEqual(descriptors.first { $0.id == "codex.today" }?.sample.isUsagePeriod, true)
+    }
+
+    /// A depleted balance (every value zero, not a usage period): `isZeroUsage` is still true, but the
+    /// note gate `isZeroUsage && isUsagePeriod` is false, so no "No usage in this period" note shows.
+    func testZeroBalanceRowIsGatedOutOfTheNote() {
+        var row = WidgetData(title: "Rate Limit Resets", icon: .symbol("clock"), kind: .count, used: 0,
+                             limit: nil, values: [MetricValue(number: 0, kind: .count)])
+        row.isUsagePeriod = false
+        XCTAssertTrue(row.isZeroUsage)
+        XCTAssertFalse(row.isZeroUsage && row.isUsagePeriod)
+    }
+
+    /// A zero spend day (every value zero, a usage period): both true, so the note shows.
+    func testZeroSpendPeriodKeepsTheNote() {
+        var row = WidgetData(title: "Today", icon: .symbol("clock"), kind: .dollars, used: 0, limit: nil,
+                             values: [MetricValue(number: 0, kind: .dollars),
+                                      MetricValue(number: 0, kind: .count)])
+        row.isUsagePeriod = true
+        XCTAssertTrue(row.isZeroUsage)
+        XCTAssertTrue(row.isZeroUsage && row.isUsagePeriod)
+    }
+}

--- a/Tests/OpenUsageTests/WidgetZeroUsageTests.swift
+++ b/Tests/OpenUsageTests/WidgetZeroUsageTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import OpenUsage
+
+/// `WidgetData.isZeroUsage` distinguishes a real zero-usage period (every selected value is 0) from
+/// "no data" and from small non-zero usage, so an empty row ("$0.00 · 0 tokens") can carry a "no usage"
+/// note instead of a figures reveal.
+final class WidgetZeroUsageTests: XCTestCase {
+    private func row(values: [MetricValue], hasData: Bool = true) -> WidgetData {
+        WidgetData(title: "Today", icon: .symbol("clock"), kind: .count, used: 0, limit: nil,
+                   hasData: hasData, values: values)
+    }
+
+    func testAllZeroValuesAreZeroUsage() {
+        let data = row(values: [MetricValue(number: 0, kind: .dollars),
+                                MetricValue(number: 0, kind: .count)])
+        XCTAssertTrue(data.isZeroUsage)
+    }
+
+    func testSmallNonZeroValuesAreNotZeroUsage() {
+        let data = row(values: [MetricValue(number: 5, kind: .dollars),
+                                MetricValue(number: 200, kind: .count)])
+        XCTAssertFalse(data.isZeroUsage)
+    }
+
+    func testNoDataIsNotZeroUsage() {
+        let data = row(values: [MetricValue(number: 0, kind: .count)], hasData: false)
+        XCTAssertFalse(data.isZeroUsage)
+    }
+
+    func testEmptyValuesAreNotZeroUsage() {
+        XCTAssertFalse(row(values: []).isZeroUsage)
+    }
+}


### PR DESCRIPTION
## Summary

Hovering a metric row reveals extra detail (exact un-abbreviated figures, pace projections, reset times, notes), but it relied on SwiftUI's native `.help()` tooltip, whose **first** hover in a window takes ~1.5–2s to appear. That delay is AppKit's, with no public API to shorten it. This replaces `.help()` everywhere with a custom hover tooltip we control — fast, positioned above the cursor, and drawn as a real floating window so it behaves like the native tooltip without the lag.

## Why not just shorten the native delay

`.help()` bridges to `NSView.toolTip`, and the long wait is AppKit's *initial* tooltip delay (the first tooltip in a window is slow; later ones reshow almost instantly). There's no public API for it, and the undocumented `NSInitialToolTipDelay` default is unreliable on recent macOS (a comparable Swift menu-bar app reports it has no effect; Apple stopped honoring it in Monterey 12.0–12.3). So a custom tooltip is the only dependable path — confirmed via research and an oracle/Codex review pass.

## Design

**A floating `NSPanel`, not a SwiftUI overlay.** A SwiftUI overlay lives inside the popover's window and is clipped to it (and to the dashboard's scroll view), so a bubble near a popover edge gets cut off. The tooltip is instead drawn in a single reused, borderless **`.nonactivatingPanel`** hosting an `NSHostingView` — the same thing the native tooltip is internally:

- Sits at `.popUpMenu` level, the same level as the status-item popover, so it shows in front by being ordered front.
- `ignoresMouseEvents` (click-through, so it can't steal the hover that spawned it) and never becomes key / never activates the app (`orderFrontRegardless`). Apple documents that a panel which becomes key only when needed won't dismiss a transient popover, so the popover stays open while a tooltip shows.
- Positioned in screen coordinates **above the cursor, centered on its x**, clamped to the cursor's screen and flipped below when it would clip the top.

**A `@MainActor TooltipPresenter`** owns the panel, fed by `.onContinuousHover` from each `.hoverTooltip(_:)` target. It shows the **deepest** hovered target (so a nested control's tooltip beats its container's — e.g. the clear ✕ inside the Settings shortcut field) after a ~350ms delay, with a native-style quick-mode reshow for a moment after one was shown. It clears itself when the popover closes (the popover's SwiftUI tree survives `orderOut`, so this is driven from the close path rather than a hover-exit).

**Per-element hover targets.** Unbounded rows hover on the value text and the ⓘ as separate targets — matching the bounded rows where "x left" and "Resets in …" are each their own target — so the empty gap between label and value pops nothing.

## Content

- **Exact figures** reveal on hovering the value text or its ⓘ (`$3,941.06 · 4,251,300,607 tokens`).
- **Zero-usage rows** (`$0.00 · 0 tokens`) show "No usage in this period" on both the value text and an ⓘ, so empty periods still read as intentional. `WidgetData.isZeroUsage` distinguishes a real zero period from no-data and from small non-zero usage (which gets no tooltip).
- All other `.help()` call sites (footer, header buttons, Settings, Customize, provider headers, shortcut field) are converted to `.hoverTooltip()` so every tooltip is fast and consistent.
- Accessibility is preserved via `.accessibilityHint`, the part `.help()` contributed to VoiceOver.

## Review fixes folded in (oracle + Codex)

- **P0** — closing the popover while hovering a target no longer orphans a tooltip or leaks state; `TooltipPresenter.dismissAll()` runs from the popover-close path with a backstop on popover-hidden.
- **P1** — a target whose tooltip text goes nil while hovered (e.g. a meter tooltip refreshing into `.level`) now always exits; `onChange(of:)` reconciles when text vanishes/changes with the cursor still on the target, and a shown target re-presents on a live text change.
- **P1** — positioning clamp fixed so a bubble wider than the screen stays on-screen.
- **P2** — corrected the doc note on panel layering (ordering, not level).

## Testing

- `swift build` clean; `WidgetZeroUsageTests` (zero vs no-data vs small non-zero) passes.
- Ran the app and hovered across the dashboard, Settings, and Customize: tooltip appears promptly above the cursor, floats free of the popover/scroll bounds, the popover stays open while it shows, nested targets resolve to the deepest, and it clears on popover close.
