### PR TITLE
fix(refresh): stop runaway refresh storm that drops the menu-bar item

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -38,6 +38,9 @@ final class AppContainer {
             isProviderEnabled: { [enablement] in enablement.isEnabled($0) },
             orderedDescriptors: { [layout] in layout.visiblePlaced.compactMap { layout.descriptor(for: $0) } }
         )
+        // Re-enabling a provider should fetch it promptly, so clear any leftover failure backoff before
+        // the enablement wake refreshes. `weak` breaks the cycle (dataStore already captures enablement).
+        enablement.onProviderEnabled = { [weak dataStore] id in dataStore?.clearFailureBackoff(for: id) }
         self.registry = registry
         self.enablement = enablement
         self.layout = layout

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -68,9 +68,15 @@ final class AppContainer {
         }
     }
 
-    /// Sleep for the refresh interval, but wake early on any `UserDefaults` change so a settings change
-    /// (e.g. enabling a provider) is reflected on the next pass instead of waiting out the full interval.
-    /// Each pass still honors the cache, so an early wake only hits the network once a snapshot expired.
+    /// Sleep for the refresh interval, but wake early when the user enables/disables a provider so a
+    /// newly-enabled provider is fetched promptly instead of waiting out the full interval. Each pass still
+    /// honors the cache (and the per-provider failure backoff), so an early wake only hits the network for
+    /// a provider whose snapshot has actually expired.
+    ///
+    /// Deliberately scoped to `ProviderEnablementStore.didChangeNotification` — NOT the firehose
+    /// `UserDefaults.didChangeNotification`, which fires for the app's own snapshot-cache writes, Sparkle's
+    /// update bookkeeping, and unrelated global-domain changes from other processes. Waking on that, with
+    /// no minimum interval before re-refreshing, collapsed the fixed 5-minute cadence into a refresh storm.
     private static func waitForNextRefresh() async {
         let interval = RefreshSetting.interval
         await withTaskGroup(of: Void.self) { group in
@@ -78,7 +84,7 @@ final class AppContainer {
                 try? await Task.sleep(for: .seconds(interval))
             }
             group.addTask {
-                for await _ in NotificationCenter.default.notifications(named: UserDefaults.didChangeNotification) {
+                for await _ in NotificationCenter.default.notifications(named: ProviderEnablementStore.didChangeNotification) {
                     break
                 }
             }

--- a/Sources/OpenUsage/Stores/ProviderEnablementStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderEnablementStore.swift
@@ -10,6 +10,17 @@ import Observation
 final class ProviderEnablementStore {
     private static let storageKey = "openusage.disabledProviders.v1"
 
+    /// Posted when the enabled-provider set actually changes. The refresh loop listens for this to wake
+    /// early and fetch a newly-enabled provider promptly, instead of waiting out the full interval —
+    /// WITHOUT subscribing to the firehose `UserDefaults.didChangeNotification`, which also fires for the
+    /// app's own snapshot-cache writes, Sparkle's update bookkeeping, and unrelated global-domain changes
+    /// from other processes. Waking on that (with no minimum interval) collapsed the fixed 5-minute
+    /// cadence into a refresh storm.
+    ///
+    /// `nonisolated` so the refresh loop's background task can name it without hopping to the main actor
+    /// (it's an immutable, `Sendable` constant — like Foundation's own notification names).
+    nonisolated static let didChangeNotification = Notification.Name("ProviderEnablementDidChange")
+
     private(set) var disabledIDs: Set<String>
     private let defaults: UserDefaults
 
@@ -21,11 +32,15 @@ final class ProviderEnablementStore {
     func isEnabled(_ id: String) -> Bool { !disabledIDs.contains(id) }
 
     func setEnabled(_ enabled: Bool, for id: String) {
+        let before = disabledIDs
         if enabled {
             disabledIDs.remove(id)
         } else {
             disabledIDs.insert(id)
         }
+        // A no-op toggle (re-setting the same value) shouldn't persist or wake the refresh loop.
+        guard disabledIDs != before else { return }
         defaults.set(Array(disabledIDs), forKey: Self.storageKey)
+        NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
     }
 }

--- a/Sources/OpenUsage/Stores/ProviderEnablementStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderEnablementStore.swift
@@ -21,6 +21,12 @@ final class ProviderEnablementStore {
     /// (it's an immutable, `Sendable` constant — like Foundation's own notification names).
     nonisolated static let didChangeNotification = Notification.Name("ProviderEnablementDidChange")
 
+    /// Called with a provider's id the moment the user turns it ON (not on disable, not on a no-op
+    /// re-set). `AppContainer` wires this to clear that provider's failure backoff, so the enablement
+    /// wake's refresh actually probes it instead of being suppressed by a backoff left over from a
+    /// failure just before it was turned off.
+    var onProviderEnabled: (@MainActor (String) -> Void)?
+
     private(set) var disabledIDs: Set<String>
     private let defaults: UserDefaults
 
@@ -41,6 +47,9 @@ final class ProviderEnablementStore {
         // A no-op toggle (re-setting the same value) shouldn't persist or wake the refresh loop.
         guard disabledIDs != before else { return }
         defaults.set(Array(disabledIDs), forKey: Self.storageKey)
+        // Clear the backoff BEFORE the wake notification, so the refresh it triggers actually probes the
+        // just-enabled provider instead of skipping it as recently-failed.
+        if enabled { onProviderEnabled?(id) }
         NotificationCenter.default.post(name: Self.didChangeNotification, object: nil)
     }
 }

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -14,9 +14,19 @@ final class WidgetDataStore {
     /// The user's widget order (already enablement-filtered) that drives the menu-bar value. Injected
     /// so the store reads `LayoutStore.visiblePlaced` without owning it; defaults to registry order.
     private let orderedDescriptors: @MainActor () -> [WidgetDescriptor]
+    /// Clock for the failure-backoff window. Injected so tests can advance time deterministically.
+    private let now: () -> Date
 
     private static let meterStyleKey = "meterStyle"
     private static let resetDisplayModeKey = "resetDisplayMode"
+    /// How long a provider that just failed is skipped before the loop will probe it again. A failed
+    /// refresh isn't cached, so — unlike a success, which the snapshot cache gates for an interval —
+    /// nothing else stops the loop from re-probing a broken provider (logged-out Devin/Grok especially)
+    /// on every wake, spawning subprocesses and network calls in a tight loop. This negative-cache caps a
+    /// failing provider to one probe per window. Shorter than the refresh interval, so the normal
+    /// 5-minute heartbeat always retries; it only suppresses the sub-interval re-probes a wake burst
+    /// would cause. The manual `force` refresh (⌘R) always bypasses it.
+    private static let failureRetryBackoff: TimeInterval = 60
 
     var snapshots: [String: ProviderSnapshot] = [:]
     var refreshingProviderIDs: Set<String> = []
@@ -29,6 +39,10 @@ final class WidgetDataStore {
     /// renders it as a warning indicator beside the provider name; the last good snapshot keeps
     /// displaying (stale-while-revalidate) instead of being replaced by dead "No data" rows.
     var providerErrors: [String: String] = [:]
+
+    /// Per-provider earliest next-probe time after a failure (see `failureRetryBackoff`). Not part of
+    /// observable UI state, so it's excluded from `@Observable` tracking.
+    @ObservationIgnored private var failureRetryAfter: [String: Date] = [:]
 
     /// Global meter style: whether every bounded tile (and the menu-bar value) renders as "used" or
     /// "left/remaining". Persisted so the choice survives relaunch; defaults to `.remaining`.
@@ -48,7 +62,8 @@ final class WidgetDataStore {
         cache: ProviderSnapshotCache = ProviderSnapshotCache(),
         defaults: UserDefaults = .standard,
         isProviderEnabled: @escaping @MainActor (String) -> Bool = { _ in true },
-        orderedDescriptors: (@MainActor () -> [WidgetDescriptor])? = nil
+        orderedDescriptors: (@MainActor () -> [WidgetDescriptor])? = nil,
+        now: @escaping () -> Date = Date.init
     ) {
         self.registry = registry
         self.providersByID = Dictionary(uniqueKeysWithValues: providers.map { ($0.provider.id, $0) })
@@ -56,6 +71,7 @@ final class WidgetDataStore {
         self.defaults = defaults
         self.isProviderEnabled = isProviderEnabled
         self.orderedDescriptors = orderedDescriptors ?? { registry.descriptors }
+        self.now = now
         self.meterStyle = defaults.enumValue(forKey: Self.meterStyleKey, default: .remaining)
         self.resetDisplayMode = defaults.enumValue(forKey: Self.resetDisplayModeKey, default: .relative)
         // Stale-while-revalidate: load whatever was cached (expired included) so the menu bar and
@@ -93,12 +109,15 @@ final class WidgetDataStore {
         let refreshed = outcomes.filter { $0 == .refreshed }.count
         let failed = outcomes.filter { $0 == .failed }.count
         let cached = outcomes.filter { $0 == .cacheHit }.count
-        AppLog.info(.refresh, "batch end (\(durationMs)ms, \(refreshed) ok / \(failed) failed / \(cached) cached)")
+        let backedOff = outcomes.filter { $0 == .backedOff }.count
+        AppLog.info(.refresh, "batch end (\(durationMs)ms, \(refreshed) ok / \(failed) failed / \(cached) cached / \(backedOff) backed off)")
     }
 
     /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch
-    /// from real outcomes rather than cumulative error state.
-    enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped }
+    /// from real outcomes rather than cumulative error state. `.backedOff` is a probe deliberately skipped
+    /// because the provider failed within the last `failureRetryBackoff` — distinct from `.skipped`
+    /// (disabled / unknown / already in flight) so a wake-burst's suppression is visible in the logs.
+    enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
 
     @discardableResult
     func refresh(providerID: String, force: Bool = false) async -> RefreshOutcome {
@@ -113,6 +132,13 @@ final class WidgetDataStore {
             return .cacheHit
         }
         if !force { AppLog.debug(.refresh, "cache miss \(providerID)") }
+
+        // A provider that just failed isn't cached, so nothing else stops the loop from re-probing it on
+        // every wake. Hold off until its backoff expires; the manual `force` refresh ignores the backoff.
+        if !force, let retryAfter = failureRetryAfter[providerID], now() < retryAfter {
+            AppLog.debug(.refresh, "backoff skip \(providerID) (failed <\(Int(Self.failureRetryBackoff))s ago)")
+            return .backedOff
+        }
 
         guard let provider = providersByID[providerID] else { return .skipped }
         // Skip if an in-flight refresh already owns this provider (e.g. the background timer racing the
@@ -130,12 +156,16 @@ final class WidgetDataStore {
             // Failed refresh: surface the error but keep the last good snapshot on screen rather than
             // collapsing every row to "No data". The provider error string is already user-safe.
             providerErrors[providerID] = message
+            // Negative-cache the failure so a wake burst can't re-probe this provider in a tight loop.
+            failureRetryAfter[providerID] = now().addingTimeInterval(Self.failureRetryBackoff)
             AppLog.warn(.refresh, "\(providerID) failed: \(message)")
             return .failed
         }
         if providerErrors[providerID] != nil {
             providerErrors[providerID] = nil
         }
+        // Recovered: drop any backoff so the provider resumes the normal cadence immediately.
+        failureRetryAfter[providerID] = nil
         snapshots[providerID] = snapshot
         cache.store(snapshot)
         AppLog.info(.refresh, "\(providerID) ok (\(durationMs)ms)")

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -172,6 +172,14 @@ final class WidgetDataStore {
         return .refreshed
     }
 
+    /// Clears a provider's failure backoff so the next pass probes it immediately. Called when the user
+    /// re-enables a provider: the enablement wake exists to fetch promptly, so a stale backoff from a
+    /// failure just before it was turned off must not suppress that fetch (the loop wouldn't otherwise
+    /// retry until the 5-minute heartbeat). The periodic loop never calls this — only the user action does.
+    func clearFailureBackoff(for providerID: String) {
+        failureRetryAfter[providerID] = nil
+    }
+
     /// The provider's latest refresh error, or `nil` when its last refresh succeeded.
     func errorMessage(for providerID: String) -> String? {
         providerErrors[providerID]

--- a/Tests/OpenUsageTests/FailureBackoffTests.swift
+++ b/Tests/OpenUsageTests/FailureBackoffTests.swift
@@ -80,6 +80,25 @@ final class FailureBackoffTests: XCTestCase {
         XCTAssertEqual(runtime.refreshCount, 3)
     }
 
+    func testClearingBackoffAllowsImmediateReprobe() async {
+        // The re-enable path: clearing the backoff must let the very next pass probe, even inside the
+        // window, so a just-re-enabled provider isn't stuck on stale data until the 5-minute heartbeat.
+        var clock = Date(timeIntervalSince1970: 1_800_000_000)
+        let runtime = makeFailingRuntime()
+        let store = makeStore(runtime: runtime, clock: { clock })
+
+        await store.refreshAll()                       // fail → backoff
+        XCTAssertEqual(runtime.refreshCount, 1)
+
+        clock = clock.addingTimeInterval(5)
+        await store.refreshAll()                       // inside window → suppressed
+        XCTAssertEqual(runtime.refreshCount, 1)
+
+        store.clearFailureBackoff(for: runtime.provider.id)
+        await store.refreshAll()                       // backoff cleared → probes immediately
+        XCTAssertEqual(runtime.refreshCount, 2)
+    }
+
     // MARK: - Helpers
 
     private func makeFailingRuntime() -> CountingProviderRuntime {

--- a/Tests/OpenUsageTests/FailureBackoffTests.swift
+++ b/Tests/OpenUsageTests/FailureBackoffTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the per-provider failure backoff: a refresh that fails is negatively cached for a short
+/// window, so an over-eager refresh loop (e.g. a wake burst) can't re-probe a broken provider — the
+/// logged-out Devin/Grok case — in a tight subprocess/network loop. The normal heartbeat and the manual
+/// `force` refresh still retry as expected.
+@MainActor
+final class FailureBackoffTests: XCTestCase {
+    func testFailedProviderIsNotReprobedWithinBackoffWindow() async {
+        var clock = Date(timeIntervalSince1970: 1_800_000_000)
+        let runtime = makeFailingRuntime()
+        let store = makeStore(runtime: runtime, clock: { clock })
+
+        // First wake probes and fails.
+        await store.refreshAll()
+        XCTAssertEqual(runtime.refreshCount, 1)
+        XCTAssertNotNil(store.errorMessage(for: runtime.provider.id))
+
+        // Rapid subsequent wakes inside the backoff window must NOT re-probe.
+        clock = clock.addingTimeInterval(5)
+        await store.refreshAll()
+        clock = clock.addingTimeInterval(5)
+        await store.refreshAll()
+        XCTAssertEqual(runtime.refreshCount, 1)
+
+        // Once the window elapses, the normal cadence retries.
+        clock = clock.addingTimeInterval(60)
+        await store.refreshAll()
+        XCTAssertEqual(runtime.refreshCount, 2)
+    }
+
+    func testManualForceRefreshBypassesFailureBackoff() async {
+        var clock = Date(timeIntervalSince1970: 1_800_000_000)
+        let runtime = makeFailingRuntime()
+        let store = makeStore(runtime: runtime, clock: { clock })
+
+        await store.refreshAll()
+        XCTAssertEqual(runtime.refreshCount, 1)
+
+        // ⌘R / footer refresh: the user just fixed auth and wants an immediate retry.
+        clock = clock.addingTimeInterval(1)
+        await store.refreshAll(force: true)
+        XCTAssertEqual(runtime.refreshCount, 2)
+    }
+
+    func testSuccessClearsBackoffSoLaterWakesAreNotSuppressed() async {
+        var clock = Date(timeIntervalSince1970: 1_800_000_000)
+        let provider = Provider(id: "devin", displayName: "Devin", icon: .providerMark("devin"))
+        let descriptor = WidgetDescriptor(
+            id: "devin.weekly", providerID: provider.id, metricLabel: "Weekly quota",
+            sample: WidgetData(title: "Weekly", icon: provider.icon, kind: .percent, used: 0, limit: 100)
+        )
+        // The success snapshot is intentionally stale (an old `refreshedAt`), so the snapshot cache never
+        // masks the behavior under test — whether pass 3 probes is then governed solely by the backoff.
+        let okSnapshot = ProviderSnapshot(
+            providerID: provider.id, displayName: provider.displayName,
+            lines: [.progress(label: "Weekly quota", used: 12, limit: 100, format: .percent)],
+            refreshedAt: Date(timeIntervalSince1970: 0)
+        )
+        let runtime = SequenceProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshots: [.error(provider: provider, message: "Not logged in"), okSnapshot]
+        )
+        let store = makeStore(provider: provider, descriptor: descriptor, runtime: runtime, clock: { clock })
+
+        await store.refreshAll()                       // pass 1: fails → backoff until +60s
+        XCTAssertEqual(runtime.refreshCount, 1)
+
+        clock = clock.addingTimeInterval(1)
+        await store.refreshAll(force: true)            // pass 2: forced success inside the window → clears backoff
+        XCTAssertEqual(runtime.refreshCount, 2)
+        XCTAssertNil(store.errorMessage(for: provider.id))
+
+        // Pass 3 is still inside the original 60s window: had the success NOT cleared the backoff, this
+        // would be suppressed (count stays 2). It probes, proving the backoff was cleared on recovery.
+        clock = clock.addingTimeInterval(1)
+        await store.refreshAll()
+        XCTAssertEqual(runtime.refreshCount, 3)
+    }
+
+    // MARK: - Helpers
+
+    private func makeFailingRuntime() -> CountingProviderRuntime {
+        let provider = Provider(id: "devin", displayName: "Devin", icon: .providerMark("devin"))
+        let descriptor = WidgetDescriptor(
+            id: "devin.weekly", providerID: provider.id, metricLabel: "Weekly quota",
+            sample: WidgetData(title: "Weekly", icon: provider.icon, kind: .percent, used: 0, limit: 100)
+        )
+        return CountingProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: .error(provider: provider, message: "Not logged in")
+        )
+    }
+
+    private func makeStore(
+        runtime: some ProviderRuntime,
+        clock: @escaping () -> Date
+    ) -> WidgetDataStore {
+        makeStore(provider: runtime.provider, descriptor: runtime.widgetDescriptors[0], runtime: runtime, clock: clock)
+    }
+
+    private func makeStore(
+        provider: Provider,
+        descriptor: WidgetDescriptor,
+        runtime: some ProviderRuntime,
+        clock: @escaping () -> Date
+    ) -> WidgetDataStore {
+        let suite = makeUserDefaults("backoff")
+        return WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: suite, storageKey: "snapshots", ttl: 600, now: clock),
+            defaults: suite,
+            now: clock
+        )
+    }
+
+    private func makeUserDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.Backoff.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}
+
+/// Returns a different snapshot per call (then repeats the last), so a test can model a provider that
+/// fails and later recovers — which `CountingProviderRuntime` (one fixed snapshot) can't express.
+@MainActor
+final class SequenceProviderRuntime: ProviderRuntime {
+    let provider: Provider
+    let widgetDescriptors: [WidgetDescriptor]
+    private let snapshots: [ProviderSnapshot]
+    private(set) var refreshCount = 0
+
+    init(provider: Provider, descriptors: [WidgetDescriptor], snapshots: [ProviderSnapshot]) {
+        self.provider = provider
+        self.widgetDescriptors = descriptors
+        self.snapshots = snapshots
+    }
+
+    func refresh() async -> ProviderSnapshot {
+        let snapshot = snapshots[min(refreshCount, snapshots.count - 1)]
+        refreshCount += 1
+        return snapshot
+    }
+}

--- a/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
+++ b/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
@@ -43,6 +43,28 @@ final class ProviderEnablementStoreTests: XCTestCase {
         XCTAssertTrue(reloaded.isEnabled("grok"))
     }
 
+    // MARK: - Early-refresh signal
+
+    func testRealChangePostsDidChangeNotification() {
+        let store = ProviderEnablementStore(defaults: makeDefaults("notify-change"))
+        let posted = XCTNSNotificationExpectation(name: ProviderEnablementStore.didChangeNotification)
+
+        store.setEnabled(false, for: "codex")   // enabled -> disabled: a real change
+
+        wait(for: [posted], timeout: 1)
+    }
+
+    func testNoOpToggleDoesNotPostDidChangeNotification() {
+        // The refresh loop wakes on this notification; a redundant toggle must not wake it (and re-probe).
+        let store = ProviderEnablementStore(defaults: makeDefaults("notify-noop"))
+        let notPosted = XCTNSNotificationExpectation(name: ProviderEnablementStore.didChangeNotification)
+        notPosted.isInverted = true
+
+        store.setEnabled(true, for: "codex")    // already enabled (empty suite): a no-op
+
+        wait(for: [notPosted], timeout: 0.2)
+    }
+
     private func makeDefaults(_ name: String) -> UserDefaults {
         let suiteName = "OpenUsageTests.Enablement.\(name).\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
+++ b/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
@@ -65,6 +65,19 @@ final class ProviderEnablementStoreTests: XCTestCase {
         wait(for: [notPosted], timeout: 0.2)
     }
 
+    func testOnProviderEnabledFiresOnEnableOnly() {
+        // Wired to clear the failure backoff; must fire on a real enable, never on disable or a no-op.
+        let store = ProviderEnablementStore(defaults: makeDefaults("on-enable"))
+        var enabledIDs: [String] = []
+        store.onProviderEnabled = { enabledIDs.append($0) }
+
+        store.setEnabled(false, for: "codex")   // disable: must NOT fire
+        store.setEnabled(true, for: "codex")    // enable: fires with "codex"
+        store.setEnabled(true, for: "codex")    // already enabled (no-op): must NOT fire
+
+        XCTAssertEqual(enabledIDs, ["codex"])
+    }
+
     private func makeDefaults(_ name: String) -> UserDefaults {
         let suiteName = "OpenUsageTests.Enablement.\(name).\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Why

A beta tester (v0.7.0-beta.10, build 74, macOS 27) reported the menu-bar icon **disappearing while the app keeps running**. Their AI's read pointed at status-item retention; the code disproves that (the controller and `NSStatusItem` are held strongly, and the log shows the item was re-created fine after a Sparkle relaunch). The real defect their logs captured is a **refresh storm**.

## Root cause

`AppContainer.waitForNextRefresh()` raced the 5-minute sleep against **`UserDefaults.didChangeNotification`** and re-refreshed on whichever won, with **no minimum-interval floor**. That notification is not "the user changed a setting" — it fires for:

- the app's **own** snapshot-cache writes (the cache is UserDefaults-backed),
- **Sparkle's** update bookkeeping (release build), and
- unrelated **global-domain** changes from other processes (`.standard` observes `NSGlobalDomain`).

So any defaults churn collapsed the fixed cadence into a tight loop. **Failed providers compound it**: error snapshots are never cached (`ProviderSnapshotCache.store` skips them), so a logged-out Devin/Grok was *fully re-probed every iteration* — Devin spawns a `sqlite3` subprocess + network call, Grok does a network call + log scan. The observed burst was ~50 passes in ~4s ≈ a subprocess/network storm that saturates the main actor and, on macOS 26/27's reworked menu bar, can get the status item dropped.

## What changed

- **Scope the early-wake trigger.** New `nonisolated ProviderEnablementStore.didChangeNotification`, posted only when the enabled-provider set actually changes (no-op toggles skip both persist and post). The refresh loop now wakes on *that* instead of the global notification. Enabling a provider is the only setting that warrants an early fetch; everything else re-renders from existing data.
- **Per-provider failure backoff.** A provider that fails is negatively cached for 60s (`failureRetryBackoff`), so a wake burst can't re-probe it in a tight loop. `force`/⌘R bypasses it, success clears it, and the normal 5-minute heartbeat still retries. New `.backedOff` outcome is surfaced in the `batch end (… / N backed off)` log for field diagnosis.

Net effect: the only things that hit the network are the heartbeat (when the cache is actually stale) and manual refresh — and neither can hammer a failing provider.

## Test plan

- `swift test` — **309 pass**, 0 failures (1 pre-existing skip).
- New `FailureBackoffTests`: within-window suppression, retry-after-window, `force` bypass, success-clears-backoff. New enablement notification tests: real change posts, no-op doesn't.
- Built + launched the dev bundle: status item ready, all 5 providers refresh once at launch, then **quiet** (no storm). Toggling a provider off/on in Settings correctly woke the loop once per toggle, cache-gated (0 real probes) — Fix 1 confirmed in the running app.

## Follow-up (not in this PR)

**Status-item resilience** — disable automatic termination for the windowless `LSUIElement` agent and detect/recreate a dropped `NSStatusItem`. That targets the *disappearance itself* (an AppKit/macOS-27 event this storm aggravates) and needs a macOS-27 runtime check, so it's tracked separately. Draft until that lands or we decide to ship this independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a refresh storm that hammered providers and could make the menu bar icon disappear. The loop now wakes only on real provider enablement changes, backs off failed providers, and clears backoff on re-enable so the wake fetches immediately.

- **Bug Fixes**
  - Wake early only on `ProviderEnablementStore.didChangeNotification`; stop listening to `UserDefaults.didChangeNotification`.
  - Add a 60s per‑provider failure backoff; `force`/⌘R bypasses, success clears, and the 5‑minute heartbeat still retries; log `.backedOff` in the batch summary.
  - Clear failure backoff when a provider is re‑enabled (`ProviderEnablementStore.onProviderEnabled` → `WidgetDataStore.clearFailureBackoff`, wired in `AppContainer`) so the enablement wake probes right away.
  - Add tests for enablement notifications, backoff suppression/retry, force bypass, success clearing backoff, and re‑enable clearing backoff.

<sup>Written for commit 138489df51ab4de39c789f19674d30183ca865b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core background refresh loop and provider fetch gating; behavior changes are intentional but affect menu-bar updates and network/subprocess load under failure and settings toggles.
> 
> **Overview**
> Fixes a **refresh storm** where the periodic loop woke on every `UserDefaults` change (snapshot cache, Sparkle, global domain) and immediately re-ran full passes, hammering failing providers that are not cached on error.
> 
> The refresh sleep now wakes early only on **`ProviderEnablementStore.didChangeNotification`**, posted when enablement actually changes (no-op toggles skip persist and notification). Re-enabling a provider clears its **60s failure backoff** via `onProviderEnabled` so the early wake can probe instead of skipping a stale backoff.
> 
> **`WidgetDataStore`** adds per-provider negative caching after failures: skipped probes log as `.backedOff`, **⌘R / `force`** bypasses backoff, success clears it, and the normal interval still retries after the window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138489df51ab4de39c789f19674d30183ca865b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->