### PR TITLE
hardening: fix local-API crash + MainActor freeze; replace silent fallbacks with loud failures

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -231,17 +231,34 @@ final class StatusItemController: NSObject {
 
     // MARK: - Status item image
 
+    /// Coalesces re-render requests: a burst of snapshot writes (a multi-provider refresh pass) must
+    /// produce ~one re-render, not O(writes) MainActor Task hops + ImageRenderer passes. `nil` when idle.
+    private var pendingRenderTask: Task<Void, Never>?
+
     /// Re-renders the menu-bar strip whenever anything it reads changes (pins, live data, meter
-    /// style, menu-bar style). `withObservationTracking` re-arms itself after every change.
+    /// style, menu-bar style). `withObservationTracking`'s `onChange` is one-shot, so each render
+    /// re-arms it. The re-arm is debounced (see `scheduleButtonImageUpdate`).
     private func updateButtonImage() {
         let image = withObservationTracking {
             renderButtonImage()
         } onChange: { [weak self] in
             Task { @MainActor [weak self] in
-                self?.updateButtonImage()
+                self?.scheduleButtonImageUpdate()
             }
         }
         statusItem.button?.image = image
+    }
+
+    /// Debounce the re-render so a refresh-storm burst of snapshot writes collapses into a single
+    /// render once the burst settles, instead of one render per write — the feedback loop that can
+    /// starve the MainActor and drop the status item (the "menu bar disappears" failure mode).
+    private func scheduleButtonImageUpdate() {
+        pendingRenderTask?.cancel()
+        pendingRenderTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled else { return }
+            self?.updateButtonImage()
+        }
     }
 
     /// The pinned-metrics strip in the chosen style, or the app icon when nothing is pinned.

--- a/Sources/OpenUsage/Models/MetricLine.swift
+++ b/Sources/OpenUsage/Models/MetricLine.swift
@@ -89,9 +89,14 @@ enum MetricLine: Hashable, Sendable, Codable {
         }
     }
 
+    /// The badge label that marks a provider-level error line (produced by `ProviderSnapshot.error`).
+    /// Shared so the producer and `isError`'s detection are compile-time coupled and can't drift apart —
+    /// a silent drift would let a failed provider's error render as a normal pill and cache stale data.
+    static let errorBadgeLabel = "Error"
+
     var isError: Bool {
         if case .badge(let label, _, _, _) = self {
-            return label == "Error"
+            return label == Self.errorBadgeLabel
         }
         return false
     }

--- a/Sources/OpenUsage/Models/ProviderSnapshot.swift
+++ b/Sources/OpenUsage/Models/ProviderSnapshot.swift
@@ -30,7 +30,7 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
         ProviderSnapshot(
             providerID: provider.id,
             displayName: provider.displayName,
-            lines: [.badge(label: "Error", text: message, colorHex: "#EF4444")]
+            lines: [.badge(label: MetricLine.errorBadgeLabel, text: message, colorHex: "#EF4444")]
         )
     }
 }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -122,7 +122,10 @@ final class ClaudeProvider: ProviderRuntime {
                 AppLog.warn(LogTag.auth("claude"), "session expired (invalid_grant)")
                 throw ClaudeAuthError.sessionExpired
             }
-            throw ClaudeAuthError.tokenExpired
+            // A 400/401 without a recognized OAuth error code isn't necessarily an expired token — it
+            // can be an HTML proxy/WAF page or a gateway error. Surface the HTTP status rather than
+            // telling the user to re-login (which can't fix a transport/infra failure).
+            throw ClaudeUsageError.requestFailed(response.statusCode)
         }
         guard (200..<300).contains(response.statusCode) else {
             throw ClaudeUsageError.requestFailed(response.statusCode)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -31,7 +31,7 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     func refresh() async -> ProviderSnapshot {
-        guard let state = authStore.loadCredentials(),
+        guard let state = await loadOffMainActor({ [authStore] in authStore.loadCredentials() }),
               state.oauth.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         else {
             AppLog.info(LogTag.auth("claude"), "no access token, not logged in")

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -136,7 +136,15 @@ final class ClaudeProvider: ProviderRuntime {
         if let expiresIn = decoded.expiresIn {
             state.oauth.expiresAt = now().timeIntervalSince1970 * 1000 + expiresIn * 1000
         }
-        try? authStore.save(state)
+        // Fail loudly: a swallowed save leaves the OLD refresh token on disk after a rotation, so the
+        // next launch refreshes with a server-invalidated token and the user sees a misleading
+        // "session expired". The refreshed token still works for this session, so we log and continue
+        // rather than fail the live fetch.
+        do {
+            try authStore.save(state)
+        } catch {
+            AppLog.error(LogTag.auth("claude"), "failed to persist rotated credentials; using the refreshed token for this session only: \(error.localizedDescription)")
+        }
         AppLog.info(LogTag.auth("claude"), "token refresh ok (rotated)")
         return decoded.accessToken
     }

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -127,7 +127,15 @@ final class CodexProvider: ProviderRuntime {
             authState.auth.tokens?.idToken = idToken
         }
         authState.auth.lastRefresh = OpenUsageISO8601.string(from: now())
-        try? authStore.save(authState)
+        // Fail loudly: a swallowed save strands the rotated token on disk (next launch re-refreshes /
+        // can surface a false "token expired"). The refreshed token works for this session, so log and
+        // continue. This is also the only call site of authStore.save, so a genuinely undecodable
+        // payload (CodexAuthError.invalidAuthPayload) now surfaces in the log instead of vanishing.
+        do {
+            try authStore.save(authState)
+        } catch {
+            AppLog.error(LogTag.auth("codex"), "failed to persist rotated credentials; using the refreshed token for this session only: \(error.localizedDescription)")
+        }
         return response.accessToken
     }
 }

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -45,7 +45,7 @@ final class CodexProvider: ProviderRuntime {
             }
         }
 
-        if let keychainCandidate = authStore.loadKeychainAuth() {
+        if let keychainCandidate = await loadOffMainActor({ [authStore] in authStore.loadKeychainAuth() }) {
             do {
                 return try await probe(authState: keychainCandidate)
             } catch {

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageClient.swift
@@ -48,12 +48,19 @@ struct CodexUsageClient: Sendable {
             case "refresh_token_invalidated":
                 throw CodexAuthError.tokenRevoked
             default:
-                throw CodexAuthError.tokenExpired
+                // No recognized OAuth error code (often a non-JSON proxy/WAF page) — report the HTTP
+                // status rather than asserting token expiry the user can't fix by re-logging in.
+                throw CodexUsageError.requestFailed(response.statusCode)
             }
         }
 
-        guard (200..<300).contains(response.statusCode),
-              let body = ProviderParse.jsonObject(response.body),
+        // A non-2xx that isn't a 400/401 (a 5xx, a gateway error) is a request failure, not an expired
+        // token — surface the status. A 2xx whose body carries no usable access token is treated as a
+        // dead session (re-login is the right remedy).
+        guard (200..<300).contains(response.statusCode) else {
+            throw CodexUsageError.requestFailed(response.statusCode)
+        }
+        guard let body = ProviderParse.jsonObject(response.body),
               let accessToken = body["access_token"] as? String,
               !accessToken.isEmpty
         else {

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -173,8 +173,10 @@ enum CodexUsageMapper {
         return Int(seconds * 1000)
     }
 
-    /// Codex flex credits as raw values: the dollar value (remaining × 4¢) then the credit count, shown
-    /// combined as "$32.84 · 821 credits". Negative balances clamp to zero, so an exhausted balance reads
+    /// Codex flex credits as raw values: the floored credit count and its dollar value (count × 4¢),
+    /// shown combined as e.g. "$32.84 · 821 credits". The count is floored *before* pricing to match the
+    /// Codex CLI/plugin (so OpenUsage's dollar agrees with Codex's own), which keeps the two values
+    /// mutually consistent. Negative balances clamp to zero, so an exhausted balance reads
     /// "$0.00 · 0 credits" — a real, measured zero, not "No data".
     static func creditValues(remaining: Double) -> [MetricValue] {
         let credits = max(0, Int(remaining.rounded(.down)))

--- a/Sources/OpenUsage/Providers/Cursor/CursorPricing.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorPricing.swift
@@ -31,7 +31,15 @@ struct CursorTokenUsage: Sendable, Equatable {
 enum CursorPricing {
     private static let manifestSource: CursorModelManifestSource = CursorBundledModelManifestSource()
     private static let modelManifest: CursorModelManifest = {
-        (try? manifestSource.loadManifest()) ?? .empty
+        do {
+            return try manifestSource.loadManifest()
+        } catch {
+            // Loud-fail: an empty manifest silently prices every Cursor spend tile at $0 (every model
+            // becomes "unknown"). Surface the packaging/resource failure instead of masquerading
+            // damaged data as free usage.
+            AppLog.error(LogTag.plugin("cursor"), "pricing manifest load failed; Cursor spend will price at $0: \(error.localizedDescription)")
+            return .empty
+        }
     }()
 
     static let manifest: [String: CursorPricingEntry] = modelManifest.pricing.mapValues(CursorPricingEntry.init(manifestEntry:))

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -31,7 +31,7 @@ final class CursorProvider: ProviderRuntime {
     }
 
     func refresh() async -> ProviderSnapshot {
-        guard let state = authStore.loadAuthState() else {
+        guard let state = await loadOffMainActor({ [authStore] in authStore.loadAuthState() }) else {
             return ProviderSnapshot.error(provider: provider, message: CursorAuthError.notLoggedIn.localizedDescription)
         }
 

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -175,7 +175,15 @@ final class CursorProvider: ProviderRuntime {
         guard let accessToken = (body["access_token"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
             return nil
         }
-        try? authStore.saveAccessToken(accessToken, source: authState.source)
+        // Fail loudly, but do NOT interpolate the error: the Cursor token is persisted via a SQL
+        // statement that embeds the token, and a sqlite3 failure surfaces as stderr that could echo a
+        // fragment of that statement (JWTs aren't covered by log redaction). A generic error line keeps
+        // it loud without risking a token leak. The refreshed token still works for this session.
+        do {
+            try authStore.saveAccessToken(accessToken, source: authState.source)
+        } catch {
+            AppLog.error(LogTag.auth("cursor"), "failed to persist rotated access token to the Cursor state DB; using it for this session only")
+        }
         return accessToken
     }
 

--- a/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
@@ -43,7 +43,8 @@ final class DevinProvider: ProviderRuntime {
             }
         }
 
-        if let appAuth = authStore.loadAppAuth(),
+        let appAuth = await loadOffMainActor({ [authStore] in authStore.loadAppAuth() })
+        if let appAuth,
            credentials == nil || shouldAttemptAppAuth(appAuth, after: credentials) {
             sawAPIKey = true
             switch await attempt(auth: appAuth) {

--- a/Sources/OpenUsage/Providers/Grok/GrokAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokAuthStore.swift
@@ -80,7 +80,20 @@ struct GrokAuthStore: Sendable {
     }
 
     func save(_ state: GrokAuthState) throws {
-        var authObject = (try? files.readText(Self.authPath)).flatMap(Self.parseJSONObject) ?? Self.jsonObject(from: state.auth)
+        // Refuse to overwrite a present-but-unreadable/corrupt auth.json by rebuilding it from
+        // in-memory state — that would silently drop OTHER accounts' entries. A genuinely absent file
+        // (first write) is seeded from in-memory state instead.
+        var authObject: [String: Any]
+        if files.exists(Self.authPath) {
+            guard let existingText = try? files.readText(Self.authPath),
+                  let parsed = Self.parseJSONObject(existingText)
+            else {
+                throw GrokAuthError.invalidAuth
+            }
+            authObject = parsed
+        } else {
+            authObject = try Self.jsonObject(from: state.auth)
+        }
         var entryObject = authObject[state.entryKey] as? [String: Any] ?? [:]
         entryObject["key"] = state.entry.key
         if let refreshToken = state.entry.refreshToken {
@@ -164,12 +177,12 @@ struct GrokAuthStore: Sendable {
         expiresAt.timeIntervalSince(now()) <= Self.refreshBuffer
     }
 
-    private static func jsonObject(from auth: [String: GrokAuthEntry]) -> [String: Any] {
-        guard let data = try? JSONEncoder().encode(auth),
-              let rawObject = try? JSONSerialization.jsonObject(with: data),
-              let object = rawObject as? [String: Any]
-        else {
-            return [:]
+    private static func jsonObject(from auth: [String: GrokAuthEntry]) throws -> [String: Any] {
+        // Throw rather than returning `[:]` on failure: an empty base would make save() write a file
+        // containing only the current entry, destroying every other account's credentials.
+        let data = try JSONEncoder().encode(auth)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw GrokAuthError.invalidAuth
         }
         return object
     }

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -109,13 +109,23 @@ final class GrokProvider: ProviderRuntime {
                 clientID: authStore.clientID(entryKey: state.entryKey, entry: state.entry)
             )
         } catch {
+            // Log the real cause: a transport failure here is currently surfaced to the user as
+            // "auth expired" (loadAndProbe / the retry closure both map a nil refresh to .expired), so
+            // without this line the actual reason (network/DNS/timeout) is lost. (Refining the
+            // user-facing message to a request-failure is deferred — it needs a careful rework of the
+            // candidate-loop + retry-closure semantics.)
+            AppLog.warn(LogTag.auth("grok"), "token refresh request failed (transport): \(error.localizedDescription)")
             return nil
         }
 
-        guard (200..<300).contains(response.statusCode),
-              let decoded = usageClient.decodeRefreshResponse(response),
+        guard (200..<300).contains(response.statusCode) else {
+            AppLog.warn(LogTag.auth("grok"), "token refresh failed (HTTP \(response.statusCode))")
+            return nil
+        }
+        guard let decoded = usageClient.decodeRefreshResponse(response),
               !decoded.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
+            AppLog.warn(LogTag.auth("grok"), "token refresh returned an undecodable or empty access token")
             return nil
         }
 

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -131,7 +131,14 @@ final class GrokProvider: ProviderRuntime {
 
         let expiresAt = refreshExpiryDate(response: decoded, accessToken: accessToken)
         state.entry.expiresAt = OpenUsageISO8601.string(from: expiresAt)
-        try? authStore.save(state)
+        // Fail loudly: a swallowed save strands the rotated token on disk (next launch re-refreshes /
+        // can surface a false "auth expired"). The refreshed token works for this session, so log and
+        // continue rather than fail the live fetch.
+        do {
+            try authStore.save(state)
+        } catch {
+            AppLog.error(LogTag.auth("grok"), "failed to persist rotated credentials; using the refreshed token for this session only: \(error.localizedDescription)")
+        }
         return accessToken
     }
 

--- a/Sources/OpenUsage/Providers/Grok/GrokUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokUsageMapper.swift
@@ -16,11 +16,18 @@ enum GrokUsageMapper {
               let usedUnits = unitsValue(config["used"]),
               let limitUnits = unitsValue(config["monthlyLimit"]),
               limitUnits > 0,
-              let onDemandCapUnits = unitsValue(config["onDemandCap"]),
               let resetsAt = resetDate(config["billingPeriodEnd"])
         else {
             throw GrokUsageError.invalidResponse
         }
+
+        // A SuperGrok account with no pay-as-you-go has no `onDemandCap` field at all. Treat a
+        // missing/non-numeric cap as 0 → the "Disabled" badge below, instead of failing the whole
+        // guard and surfacing a misleading "Grok billing response changed." A present cap of 0
+        // already mapped to Disabled and still does.
+        // NOTE: free-tier accounts (monthlyLimit == 0) still throw `invalidResponse` here — that
+        // payload shape is unconfirmed; revisit with a real sample before relaxing `limitUnits > 0`.
+        let onDemandCapUnits = unitsValue(config["onDemandCap"]) ?? 0
 
         let usedPercent = ProviderParse.clampPercent((usedUnits / limitUnits) * 100)
         return GrokMappedUsage(lines: [

--- a/Sources/OpenUsage/Providers/ProviderRuntime.swift
+++ b/Sources/OpenUsage/Providers/ProviderRuntime.swift
@@ -24,3 +24,15 @@ protocol ProviderRuntime: AnyObject {
     func refresh() async -> ProviderSnapshot
 }
 
+/// Run a blocking, `Sendable` credential load off the MainActor.
+///
+/// Auth stores read credentials via the `security` (keychain) and `sqlite3` CLIs, whose `ProcessRunner`
+/// waits block the calling thread for up to ~5s each. Those loads run at the top of a provider's
+/// `@MainActor refresh()`, so calling them inline freezes the popover and the periodic-refresh loop for
+/// the whole subprocess window (Cursor issues several reads per refresh — up to ~25s). Offloading to a
+/// detached task moves the wait onto a background executor; the `Sendable` result crosses back cleanly.
+/// It is awaited immediately, so it reads like a normal call while no longer blocking the actor.
+func loadOffMainActor<T: Sendable>(_ load: @escaping @Sendable () -> T) async -> T {
+    await Task.detached(priority: .utility, operation: load).value
+}
+

--- a/Sources/OpenUsage/Services/LocalUsageAPI.swift
+++ b/Sources/OpenUsage/Services/LocalUsageAPI.swift
@@ -104,7 +104,7 @@ enum LocalUsageAPI {
                 try container.encode(label, forKey: .label)
                 try container.encode(Self.legacyValueString(values), forKey: .value)
                 try container.encode(color, forKey: .color)
-                try container.encode(String?.none, forKey: .subtitle)
+                try container.encodeNil(forKey: .subtitle)
             case .progress(let label, let used, let limit, let format, let resetsAt, let periodDurationMs, let color):
                 try container.encode("progress", forKey: .type)
                 try container.encode(label, forKey: .label)

--- a/Sources/OpenUsage/Services/LocalUsageServer.swift
+++ b/Sources/OpenUsage/Services/LocalUsageServer.swift
@@ -86,13 +86,25 @@ final class LocalUsageServer {
     }
 
     private func route(head: String) -> LocalUsageAPI.Response {
-        let requestLine = head.split(separator: "\r\n", maxSplits: 1)[0]
-        let parts = requestLine.split(separator: " ")
-        let method = parts.indices.contains(0) ? String(parts[0]) : ""
-        let path = parts.indices.contains(1) ? String(parts[1]) : "/"
+        let (method, path) = Self.parseRequestLine(head)
         // Path is secret-free (the loopback API serves only normalized usage); Debug-only.
         AppLog.debug(.localAPI, "\(method) \(path)")
         return LocalUsageAPI.respond(method: method, path: path, state: state())
+    }
+
+    /// Parse the HTTP request line into `(method, path)`. Tolerates an empty/malformed head: a
+    /// request that begins with `\r\n\r\n`, or carries invalid UTF-8 (decoded to `""` at the call
+    /// site), yields no request line — which must route to a normal `404` rather than trap. The
+    /// previous `head.split(...)[0]` force-index crashed the whole `@MainActor` menu-bar process on
+    /// any such loopback payload. `nonisolated` + pure so it's unit-testable without the listener.
+    nonisolated static func parseRequestLine(_ head: String) -> (method: String, path: String) {
+        guard let requestLine = head.split(separator: "\r\n", maxSplits: 1).first else {
+            return ("", "/")
+        }
+        let parts = requestLine.split(separator: " ")
+        let method = parts.indices.contains(0) ? String(parts[0]) : ""
+        let path = parts.indices.contains(1) ? String(parts[1]) : "/"
+        return (method, path)
     }
 
     private func finish(_ connection: NWConnection, with response: LocalUsageAPI.Response?) {

--- a/Sources/OpenUsage/Services/SystemClients.swift
+++ b/Sources/OpenUsage/Services/SystemClients.swift
@@ -112,26 +112,35 @@ struct SecurityKeychainAccessor: KeychainAccessing {
         self.processRunner = processRunner
     }
 
+    // `security find-generic-password` exits 44 (errSecItemNotFound) when no item matches — the
+    // legitimate "no credential stored" case. Any OTHER non-zero exit means a real failure (keychain
+    // locked or access denied, a cancelled unlock prompt) that must not be silently rendered as
+    // "not signed in".
+    private static let itemNotFoundExitCode: Int32 = 44
+
     func readGenericPassword(service: String) throws -> String? {
-        let result = try processRunner.run(
-            executable: "/usr/bin/security",
-            arguments: ["find-generic-password", "-s", service, "-w"],
-            environment: [:],
-            timeout: 5
-        )
-        guard result.succeeded else { return nil }
-        let value = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
+        try readPassword(["find-generic-password", "-s", service, "-w"], service: service)
     }
 
     func readGenericPasswordForCurrentUser(service: String) throws -> String? {
+        try readPassword(["find-generic-password", "-a", currentUserAccount(), "-s", service, "-w"], service: service)
+    }
+
+    private func readPassword(_ arguments: [String], service: String) throws -> String? {
         let result = try processRunner.run(
             executable: "/usr/bin/security",
-            arguments: ["find-generic-password", "-a", currentUserAccount(), "-s", service, "-w"],
+            arguments: arguments,
             environment: [:],
             timeout: 5
         )
-        guard result.succeeded else { return nil }
+        guard result.succeeded else {
+            if result.exitCode == Self.itemNotFoundExitCode { return nil }
+            // Log loudly here so a locked/denied keychain is diagnosable even though current callers
+            // `try?` this back to nil ("not signed in"). Surfacing a distinct user-facing "keychain
+            // locked" message needs the auth-load chains to propagate the throw (folded into H1).
+            AppLog.warn(.keychain, "read failed for service '\(service)' (exit \(result.exitCode))")
+            throw KeychainError.readFailed(result.stderr)
+        }
         let value = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
     }
@@ -168,11 +177,14 @@ struct SecurityKeychainAccessor: KeychainAccessing {
 
 enum KeychainError: Error, LocalizedError {
     case writeFailed(String)
+    case readFailed(String)
 
     var errorDescription: String? {
         switch self {
         case .writeFailed(let message):
             return message.isEmpty ? "Keychain write failed." : message
+        case .readFailed(let message):
+            return message.isEmpty ? "Keychain read failed." : message
         }
     }
 }

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -101,8 +101,7 @@ final class LayoutStore {
         self.isProviderEnabled = isProviderEnabled
 
         let initialPlaced: [PlacedWidget]
-        if let data = defaults.data(forKey: storageKey),
-           let saved = try? JSONDecoder().decode([PlacedWidget].self, from: data) {
+        if let saved = Self.decodeStored([PlacedWidget].self, from: defaults, forKey: storageKey) {
             initialPlaced = saved.filter { registry.descriptor(id: $0.descriptorID) != nil }
         } else {
             initialPlaced = DefaultLayout.metricIDs
@@ -112,8 +111,7 @@ final class LayoutStore {
         placed = initialPlaced
 
         let initialProviderOrder: [String]
-        if let data = defaults.data(forKey: providerOrderKey),
-           let saved = try? JSONDecoder().decode([String].self, from: data) {
+        if let saved = Self.decodeStored([String].self, from: defaults, forKey: providerOrderKey) {
             initialProviderOrder = saved
         } else {
             initialProviderOrder = registry.providers.map(\.id)
@@ -121,8 +119,7 @@ final class LayoutStore {
         providerOrder = initialProviderOrder
 
         let initialMetricOrder: [String: [String]]
-        if let data = defaults.data(forKey: metricOrderKey),
-           let saved = try? JSONDecoder().decode([String: [String]].self, from: data) {
+        if let saved = Self.decodeStored([String: [String]].self, from: defaults, forKey: metricOrderKey) {
             initialMetricOrder = Self.normalizedMetricOrder(saved, registry: registry, placed: initialPlaced)
         } else {
             initialMetricOrder = Self.defaultMetricOrder(registry: registry, placed: initialPlaced)
@@ -385,20 +382,37 @@ final class LayoutStore {
     }
 
     private func persist() {
-        if let data = try? JSONEncoder().encode(placed) {
-            defaults.set(data, forKey: storageKey)
-        }
+        persistEncodable(placed, forKey: storageKey)
     }
 
     private func persistProviderOrder() {
-        if let data = try? JSONEncoder().encode(providerOrder) {
-            defaults.set(data, forKey: providerOrderKey)
-        }
+        persistEncodable(providerOrder, forKey: providerOrderKey)
     }
 
     private func persistMetricOrder() {
-        if let data = try? JSONEncoder().encode(metricOrderByProvider) {
-            defaults.set(data, forKey: metricOrderKey)
+        persistEncodable(metricOrderByProvider, forKey: metricOrderKey)
+    }
+
+    /// Fail loudly: a swallowed encode would silently fail to persist a layout change with zero signal,
+    /// contradicting the project's loud-fail rule (and `ProviderSnapshotCache.save` one store over).
+    private func persistEncodable<T: Encodable>(_ value: T, forKey key: String) {
+        do {
+            defaults.set(try JSONEncoder().encode(value), forKey: key)
+        } catch {
+            AppLog.warn(.config, "failed to persist layout '\(key)': \(error.localizedDescription)")
+        }
+    }
+
+    /// Decode a persisted value, distinguishing "no data" (first launch — silent nil) from "present but
+    /// undecodable" (schema drift / corruption — warn loudly, then nil so init reseeds the default).
+    /// A silent reseed of the user's customized layout is exactly the invisible state loss the rule forbids.
+    private static func decodeStored<T: Decodable>(_ type: T.Type, from defaults: UserDefaults, forKey key: String) -> T? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            AppLog.warn(.config, "saved layout '\(key)' failed to decode; reseeding default: \(error.localizedDescription)")
+            return nil
         }
     }
 

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -35,7 +35,7 @@ final class LayoutStore {
             // frame later and would let the popover paint the destination before the slide begins.
             // DashboardView reads these on its very next render to slide in from the screen being left.
             screenSlideFrom = oldValue
-            screenSlideID &+= 1
+            screenSlideID += 1
         }
     }
     /// Supports DashboardView's horizontal screen-switch slide: the screen being left, plus a counter

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -72,12 +72,20 @@ struct ProviderSnapshotCache {
     }
 
     private func loadPayload() -> Payload {
-        guard let data = userDefaults.data(forKey: storageKey),
-              let payload = try? decoder.decode(Payload.self, from: data)
-        else {
+        // No stored data is the legitimate first-launch / cleared-cache case — recover to empty
+        // silently. Data present but undecodable is a real problem (post-upgrade schema drift, a
+        // half-written blob, a manual `defaults` edit): fail loudly, then recover to empty. A silent
+        // drop here empties ALL providers' caches at once and feeds the refresh storm. Mirrors the
+        // loud `save` path above.
+        guard let data = userDefaults.data(forKey: storageKey) else {
             return Payload(snapshots: [:])
         }
-        return payload
+        do {
+            return try decoder.decode(Payload.self, from: data)
+        } catch {
+            AppLog.warn(.cache, "cache decode failed, dropping stored snapshots: \(error.localizedDescription)")
+            return Payload(snapshots: [:])
+        }
     }
 
     private func save(_ payload: Payload) {

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -98,7 +98,10 @@ struct PopoverKeyReader: NSViewRepresentable {
     /// no key window at all — is correctly *not* the popover's, and Esc/Return leave it alone instead
     /// of hijacking it. (An earlier build also claimed a nil key window, to paper over `NSPopover`'s
     /// activation race; the `NSPanel` removed that race, so the strict match is correct and safer.)
-    static func keyTargetsPopover(eventWindowID: ObjectIdentifier?, popoverWindowID: ObjectIdentifier) -> Bool {
+    // `nonisolated`: a pure comparison of two Sendable `ObjectIdentifier`s. The enclosing struct is
+    // implicitly @MainActor (it stores @MainActor closures), which would otherwise wall this helper off
+    // from non-MainActor callers — including its own tests (3 verified [#ActorIsolatedCall] warnings).
+    nonisolated static func keyTargetsPopover(eventWindowID: ObjectIdentifier?, popoverWindowID: ObjectIdentifier) -> Bool {
         eventWindowID == popoverWindowID
     }
 

--- a/Sources/OpenUsage/Support/ProviderParse.swift
+++ b/Sources/OpenUsage/Support/ProviderParse.swift
@@ -3,9 +3,19 @@ import Foundation
 /// Shared, behavior-free parsing chores used by more than one provider. Consolidated here so a new
 /// provider reuses the same JSON/number/percent handling instead of copying it.
 enum ProviderParse {
-    /// Decode a top-level JSON object from raw response data.
+    /// Decode a top-level JSON object from raw response data. An empty body is a silent `nil` (the
+    /// common no-content case callers tolerate); a non-empty body that fails to parse is logged at
+    /// the boundary so a malformed external-API response (HTML error page, truncated/garbled JSON)
+    /// leaves a diagnostic instead of vanishing into an indistinguishable `nil`. A valid-but-non-object
+    /// payload (e.g. a JSON array) returns `nil` without a log — it parsed fine, it just isn't an object.
     static func jsonObject(_ data: Data) -> [String: Any]? {
-        (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        guard !data.isEmpty else { return nil }
+        do {
+            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        } catch {
+            AppLog.warn(.http, "response body is not valid JSON (\(data.count) bytes): \(error.localizedDescription)")
+            return nil
+        }
     }
 
     /// Permissive numeric read: accepts JSON numbers and numeric strings, rejecting non-finite values.

--- a/Sources/OpenUsage/Support/ResourceBundle.swift
+++ b/Sources/OpenUsage/Support/ResourceBundle.swift
@@ -21,12 +21,25 @@ extension Bundle {
             Bundle(for: ResourceBundleToken.self).bundleURL
         ]
         for case let base? in searchBases {
-            if let bundle = Bundle(url: base.appendingPathComponent(bundleName)) {
+            guard let bundle = Bundle(url: base.appendingPathComponent(bundleName)) else { continue }
+            if isValidOpenUsageResourceBundle(bundle) {
                 return bundle
             }
+            // `Bundle(url:)` succeeds for ANY directory at the path, not only a real resources bundle.
+            // A stale/empty same-named directory left by an earlier build would otherwise shadow the
+            // real one and make every resource URL nil (SF-Symbol icon fallbacks + a thrown Cursor
+            // manifest). Skip it loudly and keep searching the remaining bases.
+            AppLog.warn(.config, "ignoring resource bundle at \(base.lastPathComponent): missing expected resources")
         }
         return .module
     }()
+}
+
+/// Sentinel check: a valid OpenUsage resource bundle carries the bundled Cursor model manifest at its
+/// root (`.copy("Resources/model_manifest.json")`). Uses the same lookup the manifest loader relies on,
+/// so it can never reject the real shipped bundle.
+private func isValidOpenUsageResourceBundle(_ bundle: Bundle) -> Bool {
+    bundle.url(forResource: "model_manifest", withExtension: "json") != nil
 }
 
 private final class ResourceBundleToken {}

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -288,6 +288,41 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertEqual(badge(snapshot.lines, "Status")?.hasPrefix("Rate limited"), true)
     }
 
+    func testRefreshSurfacesRequestFailureForNonOAuthRefreshErrorBody() async {
+        // The usage call 401s (forcing a refresh); the refresh endpoint then returns a non-OAuth 400
+        // (an HTML proxy/WAF page). The snapshot must report a request failure, NOT "token expired" —
+        // a transport/infra error the user can't fix by re-logging in.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"stale-token","refreshToken":"refresh-1","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+            }
+            return HTTPResponse(statusCode: 400, headers: [:], body: Data("<html>Bad Gateway</html>".utf8))
+        }
+        let provider = ClaudeProvider(
+            authStore: ClaudeAuthStore(
+                environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+                files: files,
+                keychain: FakeKeychain(),
+                now: { now }
+            ),
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(
+                processRunner: FakeProcessRunner(),
+                homeDirectory: { URL(fileURLWithPath: "/Users/test") }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(badge(snapshot.lines, "Error"), ProviderUsageErrorText.requestFailed(statusCode: 400))
+        XCTAssertNotEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.tokenExpired.localizedDescription)
+    }
+
     private func badge(_ lines: [MetricLine], _ label: String) -> String? {
         guard case .badge(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
             return nil

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -242,3 +242,47 @@ final class CodexProviderTests: XCTestCase {
         return values
     }
 }
+
+final class CodexUsageClientRefreshTests: XCTestCase {
+    func testRefreshReportsRequestFailureForUnrecognizedErrorBody() async {
+        // A 400 carrying a non-OAuth body (an HTML proxy/WAF page) must surface as a request failure,
+        // not "Token expired. Run `codex` to log in again." — re-login can't fix a transport/infra error.
+        let http = FakeHTTPClient(response: HTTPResponse(statusCode: 400, headers: [:], body: Data("<html>Bad Gateway</html>".utf8)))
+        let client = CodexUsageClient(http: http)
+        do {
+            _ = try await client.refreshToken("refresh")
+            XCTFail("expected refreshToken to throw")
+        } catch let error as CodexUsageError {
+            XCTAssertEqual(error, .requestFailed(400))
+        } catch {
+            XCTFail("expected CodexUsageError.requestFailed, got \(error)")
+        }
+    }
+
+    func testRefreshReportsRequestFailureForNon4xxStatus() async {
+        let http = FakeHTTPClient(response: HTTPResponse(statusCode: 503, headers: [:], body: Data()))
+        let client = CodexUsageClient(http: http)
+        do {
+            _ = try await client.refreshToken("refresh")
+            XCTFail("expected refreshToken to throw")
+        } catch let error as CodexUsageError {
+            XCTAssertEqual(error, .requestFailed(503))
+        } catch {
+            XCTFail("expected CodexUsageError.requestFailed, got \(error)")
+        }
+    }
+
+    func testRefreshStillMapsKnownOAuthCodeToSessionExpired() async {
+        let body = Data(#"{"error":{"code":"refresh_token_expired"}}"#.utf8)
+        let http = FakeHTTPClient(response: HTTPResponse(statusCode: 400, headers: [:], body: body))
+        let client = CodexUsageClient(http: http)
+        do {
+            _ = try await client.refreshToken("refresh")
+            XCTFail("expected refreshToken to throw")
+        } catch let error as CodexAuthError {
+            XCTAssertEqual(error, .sessionExpired)
+        } catch {
+            XCTFail("expected CodexAuthError.sessionExpired, got \(error)")
+        }
+    }
+}

--- a/Tests/OpenUsageTests/GrokProviderTests.swift
+++ b/Tests/OpenUsageTests/GrokProviderTests.swift
@@ -51,6 +51,28 @@ final class GrokUsageMapperTests: XCTestCase {
         XCTAssertEqual(badge(mapped.lines, "Pay as you go")?.text, "Disabled")
         XCTAssertEqual(badge(mapped.lines, "Pay as you go")?.colorHex, "#a3a3a3")
     }
+
+    func testMapsMissingOnDemandCapAsDisabled() throws {
+        // A SuperGrok account with no pay-as-you-go omits `onDemandCap` entirely. Previously the
+        // all-or-nothing guard threw `invalidResponse` ("Grok billing response changed."); it must
+        // now render the Disabled badge instead, like a present cap of 0.
+        let body: [String: Any] = [
+            "config": [
+                "used": ["val": 2500],
+                "monthlyLimit": ["val": 10000],
+                "billingPeriodEnd": "2026-06-01T00:00:00+00:00"
+            ]
+        ]
+        let mapped = try GrokUsageMapper.mapBillingResponse(HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: try JSONSerialization.data(withJSONObject: body)
+        ))
+
+        XCTAssertEqual(progress(mapped.lines, "Credits used")?.used, 25)
+        XCTAssertEqual(badge(mapped.lines, "Pay as you go")?.text, "Disabled")
+        XCTAssertEqual(badge(mapped.lines, "Pay as you go")?.colorHex, "#a3a3a3")
+    }
 }
 
 final class GrokLogUsageScannerTests: XCTestCase {

--- a/Tests/OpenUsageTests/GrokProviderTests.swift
+++ b/Tests/OpenUsageTests/GrokProviderTests.swift
@@ -23,6 +23,23 @@ final class GrokAuthStoreTests: XCTestCase {
         XCTAssertEqual(candidates.first?.token, "token")
         XCTAssertEqual(candidates.first?.entryKey, "https://auth.x.ai::client")
     }
+
+    func testSaveRefusesToOverwriteACorruptAuthFile() throws {
+        // A present-but-corrupt auth.json must NOT be silently rebuilt from in-memory state (which
+        // would drop other accounts' entries). save() must throw and leave the file untouched.
+        let validJSON = #"{"https://auth.x.ai::client":{"key":"token","refresh_token":"refresh","expires_at":"2026-07-01T00:00:00.000Z"}}"#
+        let files = FakeFiles([GrokAuthStore.authPath: validJSON])
+        let store = GrokAuthStore(files: files, now: { OpenUsageISO8601.date(from: "2026-02-02T00:00:00.000Z")! })
+        var state = try XCTUnwrap(store.loadAuthCandidates().first)
+        state.entry.key = "rotated-token"
+
+        // Corrupt the file on disk, then attempt to persist the rotation.
+        let corrupt = "{ not valid json"
+        files.files[GrokAuthStore.authPath] = corrupt
+
+        XCTAssertThrowsError(try store.save(state))
+        XCTAssertEqual(files.files[GrokAuthStore.authPath], corrupt, "corrupt file must be left untouched, not clobbered")
+    }
 }
 
 final class GrokUsageMapperTests: XCTestCase {

--- a/Tests/OpenUsageTests/KeychainAccessorTests.swift
+++ b/Tests/OpenUsageTests/KeychainAccessorTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import OpenUsage
+
+final class KeychainAccessorTests: XCTestCase {
+    /// Returns a fixed `ProcessResult` for any invocation — lets us drive the accessor's exit-code
+    /// handling without a real `security` subprocess.
+    private struct StubRunner: ProcessRunning {
+        let result: ProcessResult
+        func run(executable: String, arguments: [String], environment: [String: String], timeout: TimeInterval) throws -> ProcessResult {
+            result
+        }
+    }
+
+    func testItemNotFoundExitReturnsNil() throws {
+        // Exit 44 (errSecItemNotFound) is the legitimate "no credential stored" case → nil.
+        let accessor = SecurityKeychainAccessor(processRunner: StubRunner(
+            result: ProcessResult(exitCode: 44, stdout: "", stderr: "The specified item could not be found in the keychain.")
+        ))
+        XCTAssertNil(try accessor.readGenericPassword(service: "Test"))
+    }
+
+    func testNonItemNotFoundFailureThrowsReadFailed() {
+        // A non-44 non-zero exit (locked keychain / access denied / cancelled unlock) must throw, not
+        // collapse into the same nil as "no credential" — otherwise it gets mislabeled "not signed in".
+        let accessor = SecurityKeychainAccessor(processRunner: StubRunner(
+            result: ProcessResult(exitCode: 51, stdout: "", stderr: "User interaction is not allowed.")
+        ))
+        XCTAssertThrowsError(try accessor.readGenericPassword(service: "Test")) { error in
+            guard case KeychainError.readFailed = error else {
+                return XCTFail("expected KeychainError.readFailed, got \(error)")
+            }
+        }
+    }
+
+    func testFoundValueIsReturnedTrimmed() throws {
+        let accessor = SecurityKeychainAccessor(processRunner: StubRunner(
+            result: ProcessResult(exitCode: 0, stdout: "secret-token\n", stderr: "")
+        ))
+        XCTAssertEqual(try accessor.readGenericPassword(service: "Test"), "secret-token")
+    }
+}

--- a/Tests/OpenUsageTests/LocalUsageAPITests.swift
+++ b/Tests/OpenUsageTests/LocalUsageAPITests.swift
@@ -107,3 +107,26 @@ final class LocalUsageAPITests: XCTestCase {
         XCTAssertEqual((try json(unknownRoute.body) as? [String: Any])?["error"] as? String, "not_found")
     }
 }
+
+final class LocalUsageServerRequestLineTests: XCTestCase {
+    func testParsesWellFormedRequestLine() {
+        let (method, path) = LocalUsageServer.parseRequestLine("GET /v1/usage HTTP/1.1\r\nHost: localhost\r\n")
+        XCTAssertEqual(method, "GET")
+        XCTAssertEqual(path, "/v1/usage")
+    }
+
+    func testEmptyHeadDegradesToDefaultsInsteadOfCrashing() {
+        // A request that begins with the CRLFCRLF terminator (or carries invalid UTF-8, decoded to "")
+        // yields an empty head. The previous `head.split(...)[0]` force-index trapped here, crashing
+        // the whole menu-bar process; it must now degrade to ("", "/") so the router returns a 404.
+        let (method, path) = LocalUsageServer.parseRequestLine("")
+        XCTAssertEqual(method, "")
+        XCTAssertEqual(path, "/")
+    }
+
+    func testRequestLineWithoutPathDefaultsPath() {
+        let (method, path) = LocalUsageServer.parseRequestLine("GET\r\n")
+        XCTAssertEqual(method, "GET")
+        XCTAssertEqual(path, "/")
+    }
+}

--- a/Tests/OpenUsageTests/StaleWhileRevalidateTests.swift
+++ b/Tests/OpenUsageTests/StaleWhileRevalidateTests.swift
@@ -184,6 +184,20 @@ final class StaleWhileRevalidateTests: XCTestCase {
         )
     }
 
+    func testCorruptCacheBlobRecoversToEmptyInsteadOfDroppingSilently() {
+        // A non-decodable blob under the cache key (post-upgrade schema drift, a half-written
+        // write, a manual `defaults` edit) must recover to an empty cache rather than crash — and,
+        // per the loud-fail rule, leave a warn. Previously `try?` dropped ALL providers' snapshots
+        // silently, which is the load-side feeder of the refresh storm.
+        let defaults = makeUserDefaults("corrupt-cache")
+        defaults.set(Data("not a valid snapshot payload".utf8), forKey: "snapshots")
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() })
+
+        let loaded = cache.loadSnapshots(providerIDs: ["test.alpha"])
+
+        XCTAssertTrue(loaded.isEmpty)
+    }
+
     private func makeUserDefaults(_ name: String) -> UserDefaults {
         let suiteName = "OpenUsageTests.StaleWhileRevalidate.\(name).\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## What this is

Implements the verified, code-checked findings from the hardening review (the to-do in `HANDOFF-REVIEW-CLAUDE.md`). Every change replaces a crash/freeze or a silent fallback with a loud, diagnosable failure per AGENTS.md, and each logic fix ships with a regression test. **9 commits, 317 tests green and warning-free throughout.**

## Fixes by severity

**HIGH**
- **Local-API crash guard** — `LocalUsageServer.route()` force-indexed `head.split(...)[0]`; an empty/invalid-UTF8 loopback HTTP head crashed the whole menu-bar process. Now parsed via a pure, tested `parseRequestLine` that degrades to a 404. (`6eb04e7`)
- **MainActor freeze** — each provider's `@MainActor refresh()` ran keychain/sqlite subprocesses inline (Cursor up to ~25s, Claude up to ~20s), freezing the popover + refresh loop for the whole wait. The blocking loads now run off the MainActor via a shared `loadOffMainActor` helper. (`3203733`)

**MEDIUM**
- **`ProviderSnapshotCache.loadPayload`** — a corrupt blob silently emptied *all* providers' caches (a refresh-storm feeder); now warns + recovers. (`54faf88`)
- **Credential save (×4 providers)** — `try? authStore.save` swallowed post-rotation write failures, stranding the old refresh token and surfacing a false "auth expired" with no log; now `do/catch + AppLog.error`. (`f390ffd`)
- **Keychain reads** — returned `nil` on any non-zero `security` exit, so a locked keychain looked identical to "not signed in"; now exit 44 → nil, anything else logs + throws `readFailed`. (`4159c18`)
- **Grok billing guard** — a SuperGrok account with no pay-as-you-go (`onDemandCap` absent) was mislabeled "Grok billing response changed."; now renders the Disabled badge. (`6eb04e7`)
- **Refresh misclassification** — Claude/Codex told users to re-login for any unrecognized 400/401 (HTML proxy page, gateway 5xx); now surface the real HTTP status. Grok logs the real failure cause. (`70d7cdd`, `b5d7b00`)
- **Status-item render debounce** — `withObservationTracking` re-armed on every snapshot write (a refresh-storm amplifier); now coalesced via a 50ms-debounced task. (`e503692`)
- **Cursor pricing manifest** — `(try? loadManifest()) ?? .empty` silently priced all Cursor spend at $0 on a corrupt/missing manifest; now loud-fails. (`6eb04e7`)

**LOW**
- `ProviderParse.jsonObject` logs a malformed (non-empty) body at the parse boundary. (`54faf88`)
- `LayoutStore` distinguishes "no data" from "undecodable" on load and loud-fails persistence (shared `decodeStored`/`persistEncodable`). (`e503692`)
- `GrokAuthStore.save` refuses to overwrite a corrupt `auth.json` (was rebuilding from in-memory state, dropping other accounts). (`b5d7b00`)
- `ResourceBundle` validates a resolved bundle carries `model_manifest.json` so a stale same-named bundle can't shadow the real one. (`e503692`)

**Cleanups**
- `MetricLine.errorBadgeLabel` shared constant (was a duplicated `"Error"` literal coupling `isError` ↔ `ProviderSnapshot.error`); accurate Codex credit doc-comment; `encodeNil`; `+=` over wrapping `&+=`; `nonisolated keyTargetsPopover` (silences 3 verified test warnings). (`09a59e0`, `3203733`)

## ⚠️ Needs manual verification (rebuild + restart)

The suite can't exercise these behavior changes — please confirm in a running build:
- **H1**: popover/menu-bar stays responsive during a refresh (no multi-second freeze).
- **M5**: the menu-bar strip still updates correctly after a refresh (debounced, ~50ms).

## Deferred / follow-ups (intentionally not in this PR)

- **Refresh-storm wake (M1)** — handled by the existing **#665** (`fix/refresh-storm-menubar`); this PR complements it (cache + status-item + subprocess sides). Land #665 for the wake itself.
- **Grok refresh user-facing message + L4 stale-token fall-through** — needs a careful rework of Grok's candidate-loop + retry-closure semantics; this PR adds the diagnostic logging only.
- **M4 user-facing "keychain locked" message** — needs the auth-load chains to propagate the throw (pairs with a broader async-ProcessRunner change).
- **C4** `ProviderSnapshot.finalized` factory (pure DRY across 5 providers); **C5** route `CursorUsageCSV` through `OpenUsageISO8601` (UTC-vs-local timezone semantics need a tested change).
- **Owner decisions**: Grok free-tier (`monthlyLimit == 0`) payload shape — confirm before relaxing that guard; Codex API-key-before-OAuth candidate ordering (R8).

## Notes

- Targets `swift`. No new dependencies. Files kept under the 500-LOC convention.
- Full triage (incl. findings verified as *not* bugs — e.g. the Cursor SQL/cookie "injection" is not attacker-controlled, the Codex credit flooring is an intentional CLI-matching port) is in `HANDOFF-REVIEW-CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MainActor scheduling, credential persistence, and multiple provider auth paths; behavior is mostly fail-loud and defensive, but refresh timing and error messaging changes need a quick manual check of popover responsiveness and menu-bar updates after refresh.
> 
> **Overview**
> This PR hardens the menu-bar app against **crashes, MainActor freezes, and silent data/auth loss**, with regression tests for the main logic fixes.
> 
> **Responsiveness & stability:** Blocking keychain/sqlite credential loads now run via **`loadOffMainActor`** during provider refresh so the popover and refresh loop are not frozen for multi-second subprocess waits. Menu-bar strip re-renders are **debounced (~50ms)** so burst snapshot writes coalesce instead of starving the MainActor. The loopback **`LocalUsageServer`** no longer force-indexes malformed HTTP heads; **`parseRequestLine`** degrades to a 404 instead of crashing the process.
> 
> **Auth & providers:** Post–token-rotation **`authStore.save`** failures are logged (Claude, Codex, Grok, Cursor) instead of swallowed. Claude/Codex refresh paths surface **HTTP request failures** for unrecognized 400/401 bodies (e.g. HTML/WAF) rather than “token expired.” Grok billing treats **missing `onDemandCap`** as disabled pay-as-you-go; **`GrokAuthStore.save`** refuses to overwrite corrupt `auth.json`. Keychain reads distinguish **exit 44 (not found)** from real failures (warn + **`KeychainError.readFailed`**).
> 
> **Persistence & parsing:** **`ProviderSnapshotCache`** and **`LayoutStore`** warn on corrupt decode and on failed encode; **`ProviderParse.jsonObject`** logs non-empty invalid JSON. Cursor pricing manifest load failures are logged; **`ResourceBundle`** skips invalid shadow bundles missing **`model_manifest.json`**. **`MetricLine.errorBadgeLabel`** couples error badge production and detection.
> 
> **Tests** cover local API request-line parsing, keychain exit codes, Claude/Codex refresh misclassification, Grok mapper/save behavior, and corrupt cache recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a59e08efa3c397651a48e09e5596d5468f57e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a local loopback API crash and removes UI freezes during refresh by offloading blocking credential reads. Also replaces silent fallbacks with loud, diagnosable failures across auth, cache, layout, and pricing.

- **Bug Fixes**
  - Local-API: safe request-line parsing returns 404 on empty/malformed heads instead of crashing.
  - Menu bar: 50ms debounce coalesces status-item renders to prevent refresh-storm lockups.
  - Keychain: exit 44 maps to nil; other failures log and throw instead of masquerading as “not signed in”.
  - Token refresh: Claude/Codex now surface requestFailed(status) for unrecognized 4xx/5xx instead of “token expired”; Grok logs real failure causes.
  - Credential rotation: persist failures now log errors (use refreshed token for current session) instead of being swallowed.
  - Cursor pricing: loud-fail manifest load instead of silently pricing all spend at $0.
  - Data integrity: cache decode warns and recovers to empty on corrupt blobs; layout decode/encode now warn loudly instead of silently dropping state.
  - Resources: validate the resolved bundle contains model_manifest.json to avoid stale-bundle shadowing.

- **Refactors**
  - Added a shared loadOffMainActor helper and moved blocking credential loads off the MainActor in Claude, Codex, Cursor, and Devin.
  - Introduced a shared MetricLine.errorBadgeLabel constant and minor cleanups (encodeNil, counters, comments).

<sup>Written for commit 09a59e08efa3c397651a48e09e5596d5468f57e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

