### PR TITLE
feat(dashboard): add Usage Trend sparkline for Claude and Codex

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -308,7 +308,9 @@ final class StatusItemController: NSObject {
     private func hidePanel() {
         // The popover's SwiftUI tree survives `orderOut`, so a tooltip the cursor was resting on gets
         // no hover-exit and would orphan on screen — clear it here, the one chokepoint every close hits.
+        // The Usage Trend hover popover is on the same survives-orderOut footing, so dismiss it too.
         HoverTooltips.dismissAll()
+        TrendHoverState.dismissAll()
         panel.orderOut(nil)
         stopOutsideClickMonitors()
         statusItem.button?.highlight(false)

--- a/Sources/OpenUsage/Models/MetricLine.swift
+++ b/Sources/OpenUsage/Models/MetricLine.swift
@@ -61,7 +61,7 @@ enum ProgressFormat: Hashable, Sendable, Codable {
     }
 }
 
-/// One column of a `.chart` line: a day's value, its axis label ("5/22"), and the pre-formatted
+/// One column of a `.chart` line: a day's value, its axis label ("Jun 21"), and the pre-formatted
 /// readout shown on hover ("222M tokens"). The producer formats `valueLabel` so the chart stays a dumb
 /// renderer of already-priced numbers, the same split the spend tiles use.
 struct MetricChartPoint: Hashable, Sendable, Codable {

--- a/Sources/OpenUsage/Models/MetricLine.swift
+++ b/Sources/OpenUsage/Models/MetricLine.swift
@@ -61,8 +61,26 @@ enum ProgressFormat: Hashable, Sendable, Codable {
     }
 }
 
+/// One column of a `.chart` line: a day's value, its axis label ("5/22"), and the pre-formatted
+/// readout shown on hover ("222M tokens"). The producer formats `valueLabel` so the chart stays a dumb
+/// renderer of already-priced numbers, the same split the spend tiles use.
+struct MetricChartPoint: Hashable, Sendable, Codable {
+    var value: Double
+    var label: String
+    var valueLabel: String?
+
+    /// The hover readout for this day: the producer's pre-formatted label, or a compact token count as a
+    /// fallback. One definition so the inline sparkline and the detail popover never format it differently.
+    var readout: String {
+        valueLabel ?? (MetricFormatter.number(value, kind: .count, style: .row) + " tokens")
+    }
+}
+
 enum MetricLine: Hashable, Sendable, Codable {
     case text(label: String, value: String, colorHex: String? = nil, subtitle: String? = nil)
+    /// A small day-by-day bar chart (the Usage Trend row). Carries the raw per-day points plus an
+    /// optional source note; the view formats and draws them. Unbounded, never pinned to the menu bar.
+    case chart(label: String, points: [MetricChartPoint], note: String? = nil)
     /// An unbounded row carrying one or more raw numbers (see `MetricValue`) — the preferred shape for
     /// numeric rows. The number is the source of truth; formatting and which value(s) to show happen at
     /// the display edge, so the menu bar never has to re-parse a finished string. `.text` stays only for
@@ -84,7 +102,8 @@ enum MetricLine: Hashable, Sendable, Codable {
         case .text(let label, _, _, _),
              .progress(let label, _, _, _, _, _, _),
              .values(let label, _, _),
-             .badge(let label, _, _, _):
+             .badge(let label, _, _, _),
+             .chart(let label, _, _):
             return label
         }
     }
@@ -125,6 +144,8 @@ enum MetricLine: Hashable, Sendable, Codable {
         case colorHex
         case subtitle
         case text
+        case points
+        case note
     }
 
     private enum LineType: String, Codable {
@@ -132,6 +153,7 @@ enum MetricLine: Hashable, Sendable, Codable {
         case values
         case progress
         case badge
+        case chart
     }
 
     init(from decoder: Decoder) throws {
@@ -168,6 +190,12 @@ enum MetricLine: Hashable, Sendable, Codable {
                 colorHex: try container.decodeIfPresent(String.self, forKey: .colorHex),
                 subtitle: try container.decodeIfPresent(String.self, forKey: .subtitle)
             )
+        case .chart:
+            self = .chart(
+                label: label,
+                points: try container.decode([MetricChartPoint].self, forKey: .points),
+                note: try container.decodeIfPresent(String.self, forKey: .note)
+            )
         }
     }
 
@@ -200,6 +228,11 @@ enum MetricLine: Hashable, Sendable, Codable {
             try container.encode(text, forKey: .text)
             try container.encodeIfPresent(colorHex, forKey: .colorHex)
             try container.encodeIfPresent(subtitle, forKey: .subtitle)
+        case .chart(let label, let points, let note):
+            try container.encode(LineType.chart, forKey: .type)
+            try container.encode(label, forKey: .label)
+            try container.encode(points, forKey: .points)
+            try container.encodeIfPresent(note, forKey: .note)
         }
     }
 }

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -53,6 +53,12 @@ struct WidgetData: Hashable {
     /// they leave this false and never get the "No usage in this period" note. Set by the spend-tile
     /// factory; rides the descriptor sample through `WidgetDataStore.resolve`.
     var isUsagePeriod: Bool = false
+    /// Per-day points for a Usage Trend row (empty for every other tile). Set true `isChart` flags the
+    /// row so the view draws the sparkline instead of the value layout; `chartNote` is the source line
+    /// shown on hover (e.g. "Estimated from local Claude logs at API rates.").
+    var isChart: Bool = false
+    var chartPoints: [MetricChartPoint] = []
+    var chartNote: String?
 
     var isBounded: Bool { limit != nil }
 

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -59,7 +59,7 @@ struct WidgetData: Hashable {
     var isUsagePeriod: Bool = false
     /// Per-day points for a Usage Trend row (empty for every other tile). Set true `isChart` flags the
     /// row so the view draws the sparkline instead of the value layout; `chartNote` is the source line
-    /// shown on hover (e.g. "Estimated from local Claude logs at API rates.").
+    /// shown on hover (e.g. "Estimated from local logs at API rates").
     var isChart: Bool = false
     var chartPoints: [MetricChartPoint] = []
     var chartNote: String?

--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -121,17 +121,36 @@ extension WidgetDescriptor {
                                 kind: .count, used: 0, limit: nil))
     }
 
+    /// The Usage Trend row: a day-by-day token sparkline backed by a provider `.chart` line. Not
+    /// pinnable — the tray can't draw a chart — but otherwise a normal Customize widget (toggle,
+    /// reorder, hide). The sample carries a few bars so it reads as a chart in the gallery.
+    static func usageTrend(provider: Provider) -> WidgetDescriptor {
+        var sample = WidgetData(title: "Usage Trend", icon: provider.icon, kind: .count, used: 0, limit: nil)
+        sample.isChart = true
+        sample.chartPoints = sampleTrendPoints
+        return make(id: "\(provider.id).trend", provider: provider, metricLabel: "Usage Trend",
+                    sample: sample, pinnable: false)
+    }
+
+    /// A gentle wave of sample bars so the gallery preview reads as a trend chart, never confused for
+    /// real usage (the dashboard renders real points or "No data", never this sample).
+    private static let sampleTrendPoints: [MetricChartPoint] = [
+        9, 14, 11, 22, 13, 18, 25, 16, 12, 28, 20, 15, 31, 19, 24
+    ].enumerated().map { MetricChartPoint(value: Double($0.element), label: "\($0.offset)") }
+
     private static func make(
         id: String,
         provider: Provider,
         metricLabel: String,
-        sample: WidgetData
+        sample: WidgetData,
+        pinnable: Bool = true
     ) -> WidgetDescriptor {
         WidgetDescriptor(
             id: id,
             providerID: provider.id,
             metricLabel: metricLabel,
-            sample: sample
+            sample: sample,
+            pinnable: pinnable
         )
     }
 }

--- a/Sources/OpenUsage/Models/WidgetDescriptor.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor.swift
@@ -8,6 +8,9 @@ struct WidgetDescriptor: Identifiable, Hashable {
     let providerID: String
     let metricLabel: String
     let sample: WidgetData
+    /// Whether this widget can be pinned to the menu-bar strip. False for tiles the tray can't render as
+    /// a value — the Usage Trend chart — so the pin affordance never offers a pin that would read "0".
+    var pinnable: Bool = true
 
     /// The one display name for this widget (tile + gallery).
     var title: String { sample.title }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -67,7 +67,7 @@ final class ClaudeProvider: ProviderRuntime {
         let tokenUsage = await ccusageRunner.query(provider: .claude, since: since, homePath: authStore.claudeHomeOverride())
         if case .success(let usage) = tokenUsage {
             SpendTileMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
-            SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines,
+            SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines, now: now(),
                                              note: "Estimated from local Claude logs at API rates.")
         }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -27,7 +27,7 @@ final class ClaudeProvider: ProviderRuntime {
             .percent(id: "claude.weekly", provider: provider, title: "Weekly"),
             .percent(id: "claude.sonnet", provider: provider, title: "Sonnet"),
             .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100)
-        ] + WidgetDescriptor.spendTiles(provider: provider)
+        ] + WidgetDescriptor.spendTiles(provider: provider) + [.usageTrend(provider: provider)]
     }
 
     func refresh() async -> ProviderSnapshot {
@@ -67,6 +67,8 @@ final class ClaudeProvider: ProviderRuntime {
         let tokenUsage = await ccusageRunner.query(provider: .claude, since: since, homePath: authStore.claudeHomeOverride())
         if case .success(let usage) = tokenUsage {
             SpendTileMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
+            SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines,
+                                             note: "Estimated from local Claude logs at API rates.")
         }
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -68,7 +68,7 @@ final class ClaudeProvider: ProviderRuntime {
         if case .success(let usage) = tokenUsage {
             SpendTileMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
             SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines, now: now(),
-                                             note: "Estimated from local Claude logs at API rates.")
+                                             note: "Estimated from local logs at API rates")
         }
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -27,7 +27,7 @@ final class CodexProvider: ProviderRuntime {
             .percent(id: "codex.weekly", provider: provider, title: "Weekly"),
             .values(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
             .combined(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits")
-        ] + WidgetDescriptor.spendTiles(provider: provider)
+        ] + WidgetDescriptor.spendTiles(provider: provider) + [.usageTrend(provider: provider)]
     }
 
     func refresh() async -> ProviderSnapshot {
@@ -82,6 +82,8 @@ final class CodexProvider: ProviderRuntime {
         let tokenUsage = await ccusageRunner.query(provider: .codex, since: since, homePath: authStore.codexHome())
         if case .success(let usage) = tokenUsage {
             SpendTileMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
+            SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines,
+                                             note: "Estimated from local Codex logs at API rates.")
         }
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -88,7 +88,7 @@ final class CodexProvider: ProviderRuntime {
         let tokenUsage = await ccusageRunner.query(provider: .codex, since: since, homePath: authStore.codexHome())
         if case .success(let usage) = tokenUsage {
             SpendTileMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
-            SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines,
+            SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines, now: now(),
                                              note: "Estimated from local Codex logs at API rates.")
         }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -89,7 +89,7 @@ final class CodexProvider: ProviderRuntime {
         if case .success(let usage) = tokenUsage {
             SpendTileMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
             SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines, now: now(),
-                                             note: "Estimated from local Codex logs at API rates.")
+                                             note: "Estimated from local logs at API rates")
         }
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)

--- a/Sources/OpenUsage/Providers/SpendTileMapper.swift
+++ b/Sources/OpenUsage/Providers/SpendTileMapper.swift
@@ -33,6 +33,45 @@ enum SpendTileMapper {
         lines.append(.values(label: "Last 30 Days", values: spendValues(tokens: totalTokens, costUSD: totalCost, estimated: estimated)))
     }
 
+    /// Append the Usage Trend chart line: one bar per day over the window, value = tokens used that day.
+    /// Tokens are always measured (no estimate flag), so the chart needs only the per-day counts plus a
+    /// source note. Appends nothing when there's no usable day, so a source we couldn't read leaves no
+    /// chart rather than an empty axis.
+    static func appendUsageTrend(_ usage: CcusageDailyUsage, to lines: inout [MetricLine], note: String) {
+        let points = trendPoints(usage)
+        guard !points.isEmpty else { return }
+        lines.append(.chart(label: "Usage Trend", points: points, note: note))
+    }
+
+    /// Per-day token points, chronological, capped to the most recent 31 (today + 30 days, matching the
+    /// query window). Tokens are summed per calendar day, so two source rows that normalize to the same
+    /// date (mixed formats) become one bar carrying their total rather than two bars splitting it. Days
+    /// without a usable token count are dropped, not zero-filled, so a gap reads as a gap. Each point
+    /// carries a "5/22" axis label (unique per day) and a pre-formatted "222M tokens" readout.
+    private static func trendPoints(_ usage: CcusageDailyUsage) -> [MetricChartPoint] {
+        var tokensByDay: [String: Double] = [:]
+        for day in usage.daily {
+            let tokens = Double(day.totalTokens)
+            guard tokens.isFinite, tokens >= 0, let key = dayKey(fromUsageDate: day.date) else { continue }
+            tokensByDay[key, default: 0] += tokens
+        }
+        return tokensByDay.keys.sorted().suffix(31).map { key in
+            let tokens = tokensByDay[key] ?? 0
+            return MetricChartPoint(
+                value: tokens,
+                label: monthDayLabel(fromDayKey: key),
+                valueLabel: MetricFormatter.number(tokens, kind: .count, style: .row) + " tokens"
+            )
+        }
+    }
+
+    /// "yyyy-MM-dd" → "M/d" (no leading zeros), the compact axis label the trend chart shows.
+    private static func monthDayLabel(fromDayKey key: String) -> String {
+        let parts = key.split(separator: "-")
+        guard parts.count == 3, let month = Int(parts[1]), let day = Int(parts[2]) else { return key }
+        return "\(month)/\(day)"
+    }
+
     private static func dayKey(from date: Date) -> String {
         let components = Calendar.current.dateComponents([.year, .month, .day], from: date)
         return String(format: "%04d-%02d-%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)

--- a/Sources/OpenUsage/Providers/SpendTileMapper.swift
+++ b/Sources/OpenUsage/Providers/SpendTileMapper.swift
@@ -53,7 +53,7 @@ enum SpendTileMapper {
     /// zero-filled, not dropped, so the sparkline stays calendar-true: a gap shows as a short bar in
     /// place instead of collapsing two non-adjacent days into neighbors, and the cap is calendar days,
     /// not active ones. Returns empty when nothing was used in the window — there's no trend to draw.
-    /// Each point carries a "5/22" axis label and a pre-formatted "222M tokens" readout.
+    /// Each point carries a "Jun 21" axis label and a pre-formatted "222M tokens" readout.
     private static func trendPoints(_ usage: CcusageDailyUsage, now: Date) -> [MetricChartPoint] {
         var tokensByDay: [String: Double] = [:]
         for day in usage.daily {
@@ -71,9 +71,8 @@ enum SpendTileMapper {
             let tokens = tokensByDay[key] ?? 0
             return MetricChartPoint(
                 value: tokens,
-                // "Jun 21", localized — the same compact month/day the rest of the app uses for dates
-                // (see Formatters.deadlineLabel), not a hardcoded "6/21".
-                label: day.formatted(.dateTime.month(.abbreviated).day()),
+                // The app's localized "Jun 21" month/day, not a hardcoded "6/21".
+                label: Formatters.monthDayLabel(day),
                 valueLabel: MetricFormatter.number(tokens, kind: .count, style: .row) + " tokens"
             )
         }

--- a/Sources/OpenUsage/Providers/SpendTileMapper.swift
+++ b/Sources/OpenUsage/Providers/SpendTileMapper.swift
@@ -71,17 +71,12 @@ enum SpendTileMapper {
             let tokens = tokensByDay[key] ?? 0
             return MetricChartPoint(
                 value: tokens,
-                label: monthDayLabel(fromDayKey: key),
+                // "Jun 21", localized — the same compact month/day the rest of the app uses for dates
+                // (see Formatters.deadlineLabel), not a hardcoded "6/21".
+                label: day.formatted(.dateTime.month(.abbreviated).day()),
                 valueLabel: MetricFormatter.number(tokens, kind: .count, style: .row) + " tokens"
             )
         }
-    }
-
-    /// "yyyy-MM-dd" → "M/d" (no leading zeros), the compact axis label the trend chart shows.
-    private static func monthDayLabel(fromDayKey key: String) -> String {
-        let parts = key.split(separator: "-")
-        guard parts.count == 3, let month = Int(parts[1]), let day = Int(parts[2]) else { return key }
-        return "\(month)/\(day)"
     }
 
     private static func dayKey(from date: Date) -> String {

--- a/Sources/OpenUsage/Providers/SpendTileMapper.swift
+++ b/Sources/OpenUsage/Providers/SpendTileMapper.swift
@@ -33,29 +33,41 @@ enum SpendTileMapper {
         lines.append(.values(label: "Last 30 Days", values: spendValues(tokens: totalTokens, costUSD: totalCost, estimated: estimated)))
     }
 
-    /// Append the Usage Trend chart line: one bar per day over the window, value = tokens used that day.
-    /// Tokens are always measured (no estimate flag), so the chart needs only the per-day counts plus a
-    /// source note. Appends nothing when there's no usable day, so a source we couldn't read leaves no
-    /// chart rather than an empty axis.
-    static func appendUsageTrend(_ usage: CcusageDailyUsage, to lines: inout [MetricLine], note: String) {
-        let points = trendPoints(usage)
+    /// Number of days before `now` the trend window spans; with `now` itself that's 31 calendar bars,
+    /// matching the ccusage `daysBack: 30` query window the daily rows come from.
+    private static let trendWindowDays = 30
+
+    /// Append the Usage Trend chart line: one bar per calendar day over the window, value = tokens used
+    /// that day. Tokens are always measured (no estimate flag), so the chart needs only the per-day
+    /// counts plus a source note. Appends nothing when the whole window is idle, so a source with no
+    /// usage leaves "No data" rather than a flat row of zero bars.
+    static func appendUsageTrend(_ usage: CcusageDailyUsage, to lines: inout [MetricLine], now: Date = Date(), note: String) {
+        let points = trendPoints(usage, now: now)
         guard !points.isEmpty else { return }
         lines.append(.chart(label: "Usage Trend", points: points, note: note))
     }
 
-    /// Per-day token points, chronological, capped to the most recent 31 (today + 30 days, matching the
-    /// query window). Tokens are summed per calendar day, so two source rows that normalize to the same
-    /// date (mixed formats) become one bar carrying their total rather than two bars splitting it. Days
-    /// without a usable token count are dropped, not zero-filled, so a gap reads as a gap. Each point
-    /// carries a "5/22" axis label (unique per day) and a pre-formatted "222M tokens" readout.
-    private static func trendPoints(_ usage: CcusageDailyUsage) -> [MetricChartPoint] {
+    /// Per-day token points across the queried window (today + the previous 30 days), oldest first.
+    /// Tokens are summed per calendar day, so two source rows that normalize to the same date (mixed
+    /// formats) become one bar carrying their total rather than two bars splitting it. Idle days are
+    /// zero-filled, not dropped, so the sparkline stays calendar-true: a gap shows as a short bar in
+    /// place instead of collapsing two non-adjacent days into neighbors, and the cap is calendar days,
+    /// not active ones. Returns empty when nothing was used in the window — there's no trend to draw.
+    /// Each point carries a "5/22" axis label and a pre-formatted "222M tokens" readout.
+    private static func trendPoints(_ usage: CcusageDailyUsage, now: Date) -> [MetricChartPoint] {
         var tokensByDay: [String: Double] = [:]
         for day in usage.daily {
             let tokens = Double(day.totalTokens)
             guard tokens.isFinite, tokens >= 0, let key = dayKey(fromUsageDate: day.date) else { continue }
             tokensByDay[key, default: 0] += tokens
         }
-        return tokensByDay.keys.sorted().suffix(31).map { key in
+        guard tokensByDay.values.contains(where: { $0 > 0 }) else { return [] }
+
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: now)
+        return (0...trendWindowDays).reversed().compactMap { offset -> MetricChartPoint? in
+            guard let day = calendar.date(byAdding: .day, value: -offset, to: today) else { return nil }
+            let key = dayKey(from: day)
             let tokens = tokensByDay[key] ?? 0
             return MetricChartPoint(
                 value: tokens,

--- a/Sources/OpenUsage/Services/LocalUsageAPI.swift
+++ b/Sources/OpenUsage/Services/LocalUsageAPI.swift
@@ -84,7 +84,7 @@ enum LocalUsageAPI {
         init(_ line: MetricLine) { self.line = line }
 
         enum CodingKeys: String, CodingKey {
-            case type, label, value, used, limit, format, resetsAt, periodDurationMs, color, subtitle, text
+            case type, label, value, used, limit, format, resetsAt, periodDurationMs, color, subtitle, text, points, note
         }
 
         func encode(to encoder: Encoder) throws {
@@ -120,6 +120,14 @@ enum LocalUsageAPI {
                 try container.encode(text, forKey: .text)
                 try container.encode(color, forKey: .color)
                 try container.encode(subtitle, forKey: .subtitle)
+            case .chart(let label, let points, let note):
+                // The original app's `barChart` line shape: per-day {label, value, valueLabel} points
+                // plus an optional source note, so existing local-API integrations read the trend too.
+                try container.encode("barChart", forKey: .type)
+                try container.encode(label, forKey: .label)
+                try container.encode(points, forKey: .points)
+                try container.encodeIfPresent(note, forKey: .note)
+                try container.encodeNil(forKey: .color)
             }
         }
 

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -7,8 +7,8 @@ import Foundation
 /// reconciles to plain registry order in `LayoutStore`.
 enum DefaultLayout {
     static let metricIDs: [String] = [
-        "claude.session", "claude.weekly",
-        "codex.session", "codex.weekly",
+        "claude.session", "claude.weekly", "claude.trend",
+        "codex.session", "codex.weekly", "codex.trend",
         "devin.weekly", "devin.daily",
         "grok.creditsUsed",
         "cursor.usage", "cursor.auto", "cursor.api"

--- a/Sources/OpenUsage/Stores/DensitySetting.swift
+++ b/Sources/OpenUsage/Stores/DensitySetting.swift
@@ -52,6 +52,10 @@ enum DensitySetting: String, Hashable, Sendable, CaseIterable {
     /// chunky slab next to them). Default's bar is one step taller to match its airier rhythm.
     var meterHeight: CGFloat { self == .compact ? 4 : 5 }
 
+    /// Usage Trend sparkline height. Steps down in Compact so the chart row tightens with the rest of
+    /// the card instead of standing taller than its neighbors.
+    var trendChartHeight: CGFloat { self == .compact ? 14 : 18 }
+
     /// Vertical padding on a text-only row.
     var textRowPadding: CGFloat { self == .compact ? 4 : 6 }
 

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -282,8 +282,8 @@ final class LayoutStore {
     /// `true`, so the toggle stays active for unpinning.
     func canPin(_ descriptorID: String) -> Bool {
         if pinnedMetricIDs.contains(descriptorID) { return true }
-        guard let providerID = registry.descriptor(id: descriptorID)?.providerID else { return false }
-        if pinnedCount(forProvider: providerID) >= Self.maxPinsPerProvider { return false }
+        guard let descriptor = registry.descriptor(id: descriptorID), descriptor.pinnable else { return false }
+        if pinnedCount(forProvider: descriptor.providerID) >= Self.maxPinsPerProvider { return false }
         return true
     }
 

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -239,7 +239,9 @@ final class WidgetDataStore {
             .filter { isProviderEnabled($0.providerID) }
             .lazy
             .map { self.data(for: $0) }
-            .first { $0.hasData }
+            // A chart tile has data but no scalar value, so it would read "0" here — skip it, the same
+            // way the tray bars skip it (it's non-pinnable).
+            .first { $0.hasData && !$0.isChart }
 
         guard let primary else { return WidgetData.noDataHeadline }
         return primary.valueText
@@ -281,6 +283,16 @@ final class WidgetDataStore {
             var data = descriptor.sample
             data.valueTextOverride = text
             data.subtitleOverride = subtitle
+            return data
+        case .chart(_, let points, let note):
+            // Presentation (title, icon) from the sample; the live per-day points from the line. No
+            // points means the source was read but had no usable day — render "No data", not an empty
+            // axis (and so the sample's gallery bars never leak onto the dashboard).
+            var data = descriptor.sample
+            data.isChart = true
+            data.chartPoints = points
+            data.chartNote = note
+            data.hasData = !points.isEmpty
             return data
         }
     }

--- a/Sources/OpenUsage/Support/Formatters.swift
+++ b/Sources/OpenUsage/Support/Formatters.swift
@@ -15,6 +15,12 @@ enum Formatters {
         return f.string(from: amount as NSNumber) ?? "$\(String(format: "%.\(fractionDigits)f", amount))"
     }
 
+    /// The app's compact month/day, e.g. "Jun 21" — localized, no year. Shared so every short calendar
+    /// date (reset deadlines, the Usage Trend axis) reads the same and changes in one place.
+    static func monthDayLabel(_ date: Date) -> String {
+        date.formatted(.dateTime.month(.abbreviated).day())
+    }
+
     /// The one mode-aware deadline phrase, shared by every "<verb> + when" label (reset countdowns,
     /// run-out projections): `.relative` → "<prefix> in 2d 6h", `.absolute` → "<prefix> today at
     /// 5:30 PM" / "<prefix> tomorrow at 9:00 AM" / "<prefix> Feb 15 at 3:45 PM" (ported from the
@@ -61,8 +67,7 @@ enum Formatters {
             let time = TimeFormatSetting.current.shortTime(date)
             if dayDiff <= 0 { return "today at \(time)" }
             if dayDiff == 1 { return "tomorrow at \(time)" }
-            let day = date.formatted(.dateTime.month(.abbreviated).day())
-            return "\(day) at \(time)"
+            return "\(monthDayLabel(date)) at \(time)"
         }
     }
 

--- a/Sources/OpenUsage/Views/CustomizeView.swift
+++ b/Sources/OpenUsage/Views/CustomizeView.swift
@@ -142,30 +142,34 @@ struct CustomizeView: View {
     /// instead of silently doing nothing.
     @ViewBuilder
     private func pinButton(_ metric: WidgetDescriptor) -> some View {
-        let pinned = layout.isPinned(metric.id)
-        let blocked = !layout.canPin(metric.id)   // false when pinned, so unpin always works
-        let visible = pinned || hoveredMetricID == metric.id
-        // No app haptic here: the physical click already plays its own press/release haptics, and an
-        // added pulse at mouse-up stacks against the release click and reads as a double vibration.
-        Button {
-            if blocked {
-                layout.notePinDenied(metric.id)
-            } else {
-                layout.togglePin(metric.id)
+        // A non-pinnable widget (the Usage Trend chart) shows no pin affordance at all — the tray can't
+        // render it, so offering a pin would only ever be denied.
+        if metric.pinnable {
+            let pinned = layout.isPinned(metric.id)
+            let blocked = !layout.canPin(metric.id)   // false when pinned, so unpin always works
+            let visible = pinned || hoveredMetricID == metric.id
+            // No app haptic here: the physical click already plays its own press/release haptics, and an
+            // added pulse at mouse-up stacks against the release click and reads as a double vibration.
+            Button {
+                if blocked {
+                    layout.notePinDenied(metric.id)
+                } else {
+                    layout.togglePin(metric.id)
+                }
+            } label: {
+                Image(systemName: pinned ? "pin.fill" : "pin")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
             }
-        } label: {
-            Image(systemName: pinned ? "pin.fill" : "pin")
-                .font(.system(size: 11, weight: .semibold))
-                .frame(width: 18, height: 18)
-                .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .foregroundStyle(pinned ? Color.accentColor : Color.secondary)
+            .opacity(visible ? (blocked ? 0.35 : 1) : 0)
+            .allowsHitTesting(visible)
+            .hoverTooltip(pinHelp(metric))
+            .animation(Motion.spring, value: visible)
+            .animation(Motion.spring, value: pinned)
         }
-        .buttonStyle(.plain)
-        .foregroundStyle(pinned ? Color.accentColor : Color.secondary)
-        .opacity(visible ? (blocked ? 0.35 : 1) : 0)
-        .allowsHitTesting(visible)
-        .hoverTooltip(pinHelp(metric))
-        .animation(Motion.spring, value: visible)
-        .animation(Motion.spring, value: pinned)
     }
 
     private func pinHelp(_ metric: WidgetDescriptor) -> String {

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -230,8 +230,10 @@ struct DashboardView: View {
 
     private func resetTransientState() {
         // Backstop for any popover-close path the status-item controller's hide doesn't cover: clear a
-        // tooltip the cursor was resting on, since the closed popover fires no hover-exit.
+        // tooltip the cursor was resting on, since the closed popover fires no hover-exit. The Usage
+        // Trend hover popover rides the same backstop.
         HoverTooltips.dismissAll()
+        TrendHoverState.dismissAll()
         if layout.screen != .dashboard { layout.screen = .dashboard }
         reorderLift = nil
         layout.cancelDrag()

--- a/Sources/OpenUsage/Views/UsageSparkline.swift
+++ b/Sources/OpenUsage/Views/UsageSparkline.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// The Usage Trend row: a compact, right-aligned day-by-day token sparkline that reads at a glance and
+/// keeps the card's row rhythm. Hovering reveals a larger, readable chart (`UsageTrendDetail`) with the
+/// peak, the date range, the source note, and per-bar highlight. The bars render already-priced per-day
+/// numbers (`MetricChartPoint`); this view never computes usage, only draws it.
+struct UsageSparkline: View {
+    let data: WidgetData
+    /// The row's per-day points (the producer already validated and capped them); held directly so the
+    /// bars, the popover, and the accessibility label all read one list.
+    private let points: [MetricChartPoint]
+
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @State private var hover = TrendHoverState()
+
+    /// Widest the bar strip grows to, and a floor so it can't collapse to a sliver next to a long title.
+    private static let maxChartWidth: CGFloat = 150
+    private static let minChartWidth: CGFloat = 90
+    /// Per-bar floor (matches the original app) so a dense window never squashes bars below visibility.
+    private static let minBarWidth: CGFloat = 2
+
+    init(data: WidgetData) {
+        self.data = data
+        self.points = data.chartPoints
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(data.title)
+                .font(.system(size: density.supportingPointSize, weight: .semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            // Anchor the popover to the bar strip (not the whole row), so its arrow points straight up
+            // at the chart rather than at the row's center, off to the left of the bars.
+            bars
+                .popover(isPresented: Binding(get: { hover.isPresented }, set: { hover.isPresented = $0 }),
+                         arrowEdge: .top) {
+                    UsageTrendDetail(title: data.title, points: points, note: data.chartNote) { inside in
+                        hover.detailHover(inside)
+                    }
+                }
+        }
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .onContinuousHover { phase in
+            if case .active = phase { hover.inlineHover(true) } else { hover.inlineHover(false) }
+        }
+        .onDisappear { hover.dismiss() }
+    }
+
+    private var bars: some View {
+        let maxValue = max(1, points.map(\.value).max() ?? 1)
+        // The bars use the same blue as a healthy meter (`Theme.meterFill(.normal)`, system blue softened
+        // for glass), so the trend reads as part of the card's visual language and tracks light/dark and
+        // the accessibility contrast settings like every other bar.
+        return HStack(alignment: .bottom, spacing: 1) {
+            // Keyed by the day label (unique — the producer collapses duplicate days) so a refresh that
+            // adds or drops a day re-lays-out cleanly instead of remapping bars by position.
+            ForEach(points, id: \.label) { point in
+                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                    .fill(Theme.meterFill(.normal))
+                    .frame(minWidth: Self.minBarWidth, maxWidth: .infinity)
+                    .frame(height: barHeight(point.value, max: maxValue))
+            }
+        }
+        .frame(minWidth: Self.minChartWidth, maxWidth: Self.maxChartWidth)
+        .frame(height: density.trendChartHeight, alignment: .bottom)
+    }
+
+    /// A bar's height: proportional to the window's peak, with a visible floor so a small non-zero day
+    /// never collapses to nothing, and a thin stub for a true zero so gaps still read as days.
+    private func barHeight(_ value: Double, max maxValue: Double) -> CGFloat {
+        let height = density.trendChartHeight
+        guard value > 0 else { return 2 }
+        let ratio = min(1, value / maxValue)
+        return max(height * 0.18, height * ratio)
+    }
+
+    private var accessibilityLabel: String {
+        guard let peak = points.max(by: { $0.value < $1.value }),
+              let first = points.first, let last = points.last else { return data.title }
+        return "\(data.title): \(points.count) days, \(first.label) to \(last.label), peak \(peak.readout)."
+    }
+}

--- a/Sources/OpenUsage/Views/UsageTrendDetail.swift
+++ b/Sources/OpenUsage/Views/UsageTrendDetail.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+
+/// The detail-on-demand popover for a Usage Trend row: a larger, readable bar chart with the peak (or
+/// the hovered day) called out, the window's date range, and the source note. Hovering a bar highlights
+/// it and swaps the readout to that exact day — the same detail-on-demand the original app shows.
+struct UsageTrendDetail: View {
+    let title: String
+    let points: [MetricChartPoint]
+    let note: String?
+    /// Reports whether the cursor is inside the popover, so the trigger can keep it open while the user
+    /// moves from the inline row into the chart, and close it once they leave both.
+    var onHoverChange: (Bool) -> Void
+
+    @State private var activeIndex: Int?
+
+    private static let chartHeight: CGFloat = 76
+    private static let width: CGFloat = 240
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            chart
+            axis
+            if let note, !note.isEmpty {
+                Text(note)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+        .frame(width: Self.width)
+        // A refresh can replace `points` while the popover is open; drop the selection so the highlight
+        // and readout never point at a day that shifted out from under the cursor.
+        .onChange(of: points) { activeIndex = nil }
+        .onContinuousHover { phase in
+            switch phase {
+            case .active: onHoverChange(true)
+            case .ended: onHoverChange(false); activeIndex = nil
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+            Spacer(minLength: 8)
+            Text(readout)
+                .font(.system(size: 11))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var chart: some View {
+        let maxValue = max(1, points.map(\.value).max() ?? 1)
+        // Same blue as a healthy meter; the hovered bar stays full-strength while the rest dim, so the
+        // selection reads without a second color.
+        return HStack(alignment: .bottom, spacing: 2) {
+            ForEach(points.indices, id: \.self) { index in
+                Color.clear
+                    .frame(maxWidth: .infinity)
+                    .frame(height: Self.chartHeight)
+                    // The full column is the hover target so even short bars are easy to hit.
+                    .overlay(alignment: .bottom) {
+                        RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                            .fill(Theme.meterFill(.normal))
+                            .frame(height: barHeight(points[index].value, max: maxValue))
+                            .opacity(activeIndex == nil || activeIndex == index ? 1 : 0.35)
+                    }
+                    .contentShape(Rectangle())
+                    .onContinuousHover { phase in
+                        if case .active = phase { activeIndex = index }
+                    }
+            }
+        }
+        .frame(height: Self.chartHeight)
+        // Clear the selection when the cursor leaves the bars for the header/axis/note (still inside the
+        // popover), so the readout falls back to the peak instead of freezing on the last bar.
+        .onContinuousHover { phase in if case .ended = phase { activeIndex = nil } }
+        .animation(.easeOut(duration: 0.12), value: activeIndex)
+    }
+
+    private var axis: some View {
+        HStack {
+            Text(points.first?.label ?? "")
+            Spacer()
+            Text(points.last?.label ?? "")
+        }
+        .font(.system(size: 10))
+        .monospacedDigit()
+        .foregroundStyle(.secondary)
+    }
+
+    private var peakIndex: Int? { points.indices.max { points[$0].value < points[$1].value } }
+
+    /// The hovered day, or the peak when nothing is hovered — the one figure the bars can't label.
+    private var readout: String {
+        if let activeIndex, points.indices.contains(activeIndex) {
+            return "\(points[activeIndex].label) · \(points[activeIndex].readout)"
+        }
+        if let peakIndex { return "peak \(points[peakIndex].readout)" }
+        return ""
+    }
+
+    private func barHeight(_ value: Double, max maxValue: Double) -> CGFloat {
+        guard value > 0 else { return 2 }
+        return max(Self.chartHeight * 0.06, Self.chartHeight * min(1, value / maxValue))
+    }
+}
+
+/// Drives the hover-revealed trend popover: opens after a short dwell while the inline row is hovered,
+/// and closes once the cursor has left BOTH the row and the popover (a brief grace lets the cursor
+/// travel between them). An `@Observable` reference type so a SwiftUI `View` can hold it in `@State`
+/// and bind `isPresented` to the popover — value-type closure capture can't track this state reliably.
+@MainActor
+@Observable
+final class TrendHoverState {
+    var isPresented = false
+
+    /// Every live coordinator, so the menu-bar panel's close path can dismiss any open trend popover —
+    /// the dashboard view tree (and this `@State`) survives the panel's `orderOut`, so `.onDisappear`
+    /// alone wouldn't fire and the popover could orphan or re-show on the next open.
+    @ObservationIgnored private static let live = NSHashTable<TrendHoverState>.weakObjects()
+
+    static func dismissAll() {
+        for state in live.allObjects { state.dismiss() }
+    }
+
+    @ObservationIgnored private var overInline = false
+    @ObservationIgnored private var overDetail = false
+    @ObservationIgnored private var showTask: Task<Void, Never>?
+    @ObservationIgnored private var hideTask: Task<Void, Never>?
+
+    /// 400ms reveal matches the app's hover-tooltip dwell (see `HoverTooltip`), so the trend popover
+    /// opens on the same deliberate intent as every other hover affordance; 180ms grace lets the cursor
+    /// cross from the row into the popover without it closing. Injectable so tests drive it without sleeps.
+    private let revealDelay: Duration
+    private let hideGrace: Duration
+
+    init(revealDelay: Duration = .milliseconds(400), hideGrace: Duration = .milliseconds(180)) {
+        self.revealDelay = revealDelay
+        self.hideGrace = hideGrace
+        Self.live.add(self)
+    }
+
+    func inlineHover(_ active: Bool) {
+        overInline = active
+        active ? scheduleShow() : scheduleHide()
+    }
+
+    func detailHover(_ inside: Bool) {
+        overDetail = inside
+        if inside { hideTask?.cancel(); hideTask = nil } else { scheduleHide() }
+    }
+
+    /// Force the popover shut (popover/dashboard teardown), so it can't orphan on screen.
+    func dismiss() {
+        showTask?.cancel(); showTask = nil
+        hideTask?.cancel(); hideTask = nil
+        overInline = false
+        overDetail = false
+        isPresented = false
+    }
+
+    private func scheduleShow() {
+        hideTask?.cancel(); hideTask = nil
+        guard !isPresented, showTask == nil else { return }
+        let delay = revealDelay
+        showTask = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            guard let self, !Task.isCancelled else { return }
+            if overInline { isPresented = true }
+            showTask = nil
+        }
+    }
+
+    private func scheduleHide() {
+        showTask?.cancel(); showTask = nil
+        hideTask?.cancel()
+        let delay = hideGrace
+        hideTask = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            guard let self, !Task.isCancelled else { return }
+            if !overInline, !overDetail { isPresented = false }
+            hideTask = nil
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -122,13 +122,15 @@ struct WidgetGroupedListView: View {
     /// the global reset-format flip, and a per-provider refresh — without a trip into Customize.
     @ViewBuilder
     private func rowMenu(_ descriptor: WidgetDescriptor, providerID: String) -> some View {
-        Button(layout.isPinned(descriptor.id) ? "Unpin" : "Pin to menu bar") {
-            if layout.isPinned(descriptor.id) {
-                layout.setPinned(false, for: descriptor.id)
-            } else if layout.canPin(descriptor.id) {
-                layout.setPinned(true, for: descriptor.id)
-            } else {
-                layout.notePinDenied(descriptor.id)
+        if descriptor.pinnable {
+            Button(layout.isPinned(descriptor.id) ? "Unpin" : "Pin to menu bar") {
+                if layout.isPinned(descriptor.id) {
+                    layout.setPinned(false, for: descriptor.id)
+                } else if layout.canPin(descriptor.id) {
+                    layout.setPinned(true, for: descriptor.id)
+                } else {
+                    layout.notePinDenied(descriptor.id)
+                }
             }
         }
         Button("Hide") {

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -75,7 +75,11 @@ struct WidgetRowView: View {
 
     @ViewBuilder
     private var rowContent: some View {
-        if data.isBounded {
+        if data.isChart, data.hasData {
+            // The sparkline owns its own label + bars; a chart with no real points falls through to the
+            // unbounded "No data" row below (and so the descriptor's gallery sample never leaks here).
+            UsageSparkline(data: data)
+        } else if data.isBounded {
             boundedRow
         } else {
             unboundedRow

--- a/Tests/OpenUsageTests/UsageTrendTests.swift
+++ b/Tests/OpenUsageTests/UsageTrendTests.swift
@@ -5,7 +5,7 @@ import XCTest
 /// chart `MetricLine`, and how it flows through the descriptor / data store (non-pinnable, no-data safe).
 @MainActor
 final class UsageTrendTests: XCTestCase {
-    func testAppendUsageTrendBuildsChronologicalTokenPoints() {
+    func testAppendUsageTrendZeroFillsTheCalendarWindow() {
         var lines: [MetricLine] = []
         SpendTileMapper.appendUsageTrend(
             CcusageDailyUsage(daily: [
@@ -14,6 +14,7 @@ final class UsageTrendTests: XCTestCase {
                 CcusageDay(date: "2026-06-20", totalTokens: 1_500_000, costUSD: nil)
             ]),
             to: &lines,
+            now: date(2026, 6, 21),
             note: "Estimated from local Claude logs at API rates."
         )
 
@@ -22,26 +23,68 @@ final class UsageTrendTests: XCTestCase {
         }
         XCTAssertEqual(label, "Usage Trend")
         XCTAssertEqual(note, "Estimated from local Claude logs at API rates.")
-        // Sorted ascending by date, regardless of input order.
-        XCTAssertEqual(points.map(\.label), ["6/19", "6/20", "6/21"])
-        XCTAssertEqual(points.map(\.value), [500, 1_500_000, 222_000_000])
+        // One bar per calendar day across the 31-day window (today + 30 back), oldest first.
+        XCTAssertEqual(points.count, 31)
+        XCTAssertEqual(points.first?.label, "5/22", "window starts 30 days before today")
+        XCTAssertEqual(points.last?.label, "6/21", "window ends today")
+        // The three active days carry their tokens; every other day is a zero bar, not a dropped gap.
+        XCTAssertEqual(points[28].value, 500)          // 6/19
+        XCTAssertEqual(points[29].value, 1_500_000)    // 6/20
+        XCTAssertEqual(points[30].value, 222_000_000)  // 6/21
+        XCTAssertEqual(points[0].value, 0, "an idle day is a zero bar")
         // Pre-formatted readouts: compact counts with a "tokens" unit.
-        XCTAssertEqual(points.map(\.valueLabel), ["500 tokens", "1.5M tokens", "222M tokens"])
+        XCTAssertEqual(points[28...30].map(\.valueLabel), ["500 tokens", "1.5M tokens", "222M tokens"])
+        XCTAssertEqual(points[0].valueLabel, "0 tokens")
     }
 
-    func testAppendUsageTrendKeepsTheMostRecent31Days() {
-        // 40 distinct days (May 1–31, then June 1–9). The chart keeps the most recent 31, dropping the
-        // oldest nine — so it starts at 5/10, not 5/1.
+    func testTrendZeroFillsGapsBetweenActiveDays() {
+        // Usage on 6/19 and 6/21 but none on 6/20: the gap stays in place as a zero bar rather than
+        // collapsing the two active days into neighbors.
+        var lines: [MetricLine] = []
+        SpendTileMapper.appendUsageTrend(
+            CcusageDailyUsage(daily: [
+                CcusageDay(date: "2026-06-19", totalTokens: 500, costUSD: nil),
+                CcusageDay(date: "2026-06-21", totalTokens: 222_000_000, costUSD: nil)
+            ]),
+            to: &lines, now: date(2026, 6, 21), note: "n"
+        )
+
+        guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
+        XCTAssertEqual(points[28].label, "6/19")
+        XCTAssertEqual(points[29].label, "6/20")
+        XCTAssertEqual(points[29].value, 0, "the gap day is a zero bar, not removed")
+        XCTAssertEqual(points[30].label, "6/21")
+    }
+
+    func testTrendWindowEndsAtTodayEvenWhenUsageIsOlder() {
+        // Last activity was 6/19 but today is 6/21: the window still ends today, so the two trailing
+        // idle days are zero bars rather than the chart stopping at the last active day.
+        var lines: [MetricLine] = []
+        SpendTileMapper.appendUsageTrend(
+            CcusageDailyUsage(daily: [CcusageDay(date: "2026-06-19", totalTokens: 500, costUSD: nil)]),
+            to: &lines, now: date(2026, 6, 21), note: "n"
+        )
+
+        guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
+        XCTAssertEqual(points.last?.label, "6/21")
+        XCTAssertEqual(points[28].value, 500, "the one active day keeps its tokens")
+        XCTAssertEqual(points[29].value, 0)
+        XCTAssertEqual(points[30].value, 0)
+    }
+
+    func testTrendDropsDaysOlderThanTheWindow() {
+        // 40 distinct days (May 1–31, then June 1–9) with today = 6/9. The window is the 31 days ending
+        // today (5/10 … 6/9), so May 1–9 fall outside it and are dropped.
         var daily = (1...31).map { CcusageDay(date: String(format: "2026-05-%02d", $0), totalTokens: $0 * 1000, costUSD: nil) }
         daily += (1...9).map { CcusageDay(date: String(format: "2026-06-%02d", $0), totalTokens: $0 * 1000, costUSD: nil) }
 
         var lines: [MetricLine] = []
-        SpendTileMapper.appendUsageTrend(CcusageDailyUsage(daily: daily), to: &lines, note: "n")
+        SpendTileMapper.appendUsageTrend(CcusageDailyUsage(daily: daily), to: &lines, now: date(2026, 6, 9), note: "n")
 
         guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
         XCTAssertEqual(points.count, 31)
-        XCTAssertEqual(points.first?.label, "5/10", "oldest nine days are dropped")
-        XCTAssertEqual(points.last?.label, "6/9", "most recent day is kept")
+        XCTAssertEqual(points.first?.label, "5/10", "days older than 30 back are outside the window")
+        XCTAssertEqual(points.last?.label, "6/9", "window ends today")
     }
 
     func testTrendAggregatesDuplicateDaysAndParsesCompactDates() {
@@ -53,19 +96,26 @@ final class UsageTrendTests: XCTestCase {
                 CcusageDay(date: "20260620", totalTokens: 1000, costUSD: nil),
                 CcusageDay(date: "2026-06-20", totalTokens: 500, costUSD: nil)
             ]),
-            to: &lines, note: "n"
+            to: &lines, now: date(2026, 6, 20), note: "n"
         )
 
         guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
-        XCTAssertEqual(points.count, 1, "same calendar day collapses to one bar")
-        XCTAssertEqual(points.first?.label, "6/20")
-        XCTAssertEqual(points.first?.value, 1500, "the day's tokens are summed, not split across bars")
+        XCTAssertEqual(points.last?.label, "6/20")
+        XCTAssertEqual(points.last?.value, 1500, "the day's tokens are summed, not split across bars")
     }
 
-    func testAppendUsageTrendSkippedWhenNoUsableDays() {
-        var lines: [MetricLine] = []
-        SpendTileMapper.appendUsageTrend(CcusageDailyUsage(daily: []), to: &lines, note: "n")
-        XCTAssertTrue(lines.isEmpty, "no days means no chart, not an empty axis")
+    func testAppendUsageTrendSkippedWhenWindowHasNoUsage() {
+        // No rows at all, and rows that are all zero, both leave "No data" rather than a flat zero chart.
+        var empty: [MetricLine] = []
+        SpendTileMapper.appendUsageTrend(CcusageDailyUsage(daily: []), to: &empty, now: date(2026, 6, 21), note: "n")
+        XCTAssertTrue(empty.isEmpty, "no rows means no chart")
+
+        var allZero: [MetricLine] = []
+        SpendTileMapper.appendUsageTrend(
+            CcusageDailyUsage(daily: [CcusageDay(date: "2026-06-20", totalTokens: 0, costUSD: nil)]),
+            to: &allZero, now: date(2026, 6, 21), note: "n"
+        )
+        XCTAssertTrue(allZero.isEmpty, "a fully idle window has no trend to draw")
     }
 
     func testChartLineCodableRoundTrips() throws {
@@ -164,6 +214,12 @@ final class UsageTrendTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// A fixed `now` at midday in the current calendar, so `startOfDay` math is stable regardless of the
+    /// machine's clock and the day-key strings line up with the hyphenated input dates.
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        Calendar.current.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
 
     private func makeDataStore(provider: Provider, descriptor: WidgetDescriptor) -> WidgetDataStore {
         let runtime = TestProviderRuntime(

--- a/Tests/OpenUsageTests/UsageTrendTests.swift
+++ b/Tests/OpenUsageTests/UsageTrendTests.swift
@@ -25,8 +25,10 @@ final class UsageTrendTests: XCTestCase {
         XCTAssertEqual(note, "Estimated from local Claude logs at API rates.")
         // One bar per calendar day across the 31-day window (today + 30 back), oldest first.
         XCTAssertEqual(points.count, 31)
-        XCTAssertEqual(points.first?.label, "5/22", "window starts 30 days before today")
-        XCTAssertEqual(points.last?.label, "6/21", "window ends today")
+        XCTAssertEqual(points.first?.label, dayLabel(2026, 5, 22), "window starts 30 days before today")
+        XCTAssertEqual(points.last?.label, dayLabel(2026, 6, 21), "window ends today")
+        // Labels use the app's localized month/day style, e.g. "Jun 21", not "6/21".
+        XCTAssertEqual(points.last?.label, date(2026, 6, 21).formatted(.dateTime.month(.abbreviated).day()))
         // The three active days carry their tokens; every other day is a zero bar, not a dropped gap.
         XCTAssertEqual(points[28].value, 500)          // 6/19
         XCTAssertEqual(points[29].value, 1_500_000)    // 6/20
@@ -50,10 +52,10 @@ final class UsageTrendTests: XCTestCase {
         )
 
         guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
-        XCTAssertEqual(points[28].label, "6/19")
-        XCTAssertEqual(points[29].label, "6/20")
+        XCTAssertEqual(points[28].label, dayLabel(2026, 6, 19))
+        XCTAssertEqual(points[29].label, dayLabel(2026, 6, 20))
         XCTAssertEqual(points[29].value, 0, "the gap day is a zero bar, not removed")
-        XCTAssertEqual(points[30].label, "6/21")
+        XCTAssertEqual(points[30].label, dayLabel(2026, 6, 21))
     }
 
     func testTrendWindowEndsAtTodayEvenWhenUsageIsOlder() {
@@ -66,7 +68,7 @@ final class UsageTrendTests: XCTestCase {
         )
 
         guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
-        XCTAssertEqual(points.last?.label, "6/21")
+        XCTAssertEqual(points.last?.label, dayLabel(2026, 6, 21))
         XCTAssertEqual(points[28].value, 500, "the one active day keeps its tokens")
         XCTAssertEqual(points[29].value, 0)
         XCTAssertEqual(points[30].value, 0)
@@ -83,8 +85,8 @@ final class UsageTrendTests: XCTestCase {
 
         guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
         XCTAssertEqual(points.count, 31)
-        XCTAssertEqual(points.first?.label, "5/10", "days older than 30 back are outside the window")
-        XCTAssertEqual(points.last?.label, "6/9", "window ends today")
+        XCTAssertEqual(points.first?.label, dayLabel(2026, 5, 10), "days older than 30 back are outside the window")
+        XCTAssertEqual(points.last?.label, dayLabel(2026, 6, 9), "window ends today")
     }
 
     func testTrendAggregatesDuplicateDaysAndParsesCompactDates() {
@@ -100,7 +102,7 @@ final class UsageTrendTests: XCTestCase {
         )
 
         guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
-        XCTAssertEqual(points.last?.label, "6/20")
+        XCTAssertEqual(points.last?.label, dayLabel(2026, 6, 20))
         XCTAssertEqual(points.last?.value, 1500, "the day's tokens are summed, not split across bars")
     }
 
@@ -219,6 +221,12 @@ final class UsageTrendTests: XCTestCase {
     /// machine's clock and the day-key strings line up with the hyphenated input dates.
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
         Calendar.current.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+
+    /// The expected axis label for a day, in the app's localized month/day style — computed the same way
+    /// the producer does, so the assertion holds in any test-machine locale.
+    private func dayLabel(_ year: Int, _ month: Int, _ day: Int) -> String {
+        date(year, month, day).formatted(.dateTime.month(.abbreviated).day())
     }
 
     private func makeDataStore(provider: Provider, descriptor: WidgetDescriptor) -> WidgetDataStore {

--- a/Tests/OpenUsageTests/UsageTrendTests.swift
+++ b/Tests/OpenUsageTests/UsageTrendTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the Usage Trend feature: the per-day token sparkline built from ccusage daily data, its
+/// chart `MetricLine`, and how it flows through the descriptor / data store (non-pinnable, no-data safe).
+@MainActor
+final class UsageTrendTests: XCTestCase {
+    func testAppendUsageTrendBuildsChronologicalTokenPoints() {
+        var lines: [MetricLine] = []
+        SpendTileMapper.appendUsageTrend(
+            CcusageDailyUsage(daily: [
+                CcusageDay(date: "2026-06-21", totalTokens: 222_000_000, costUSD: nil),
+                CcusageDay(date: "2026-06-19", totalTokens: 500, costUSD: nil),
+                CcusageDay(date: "2026-06-20", totalTokens: 1_500_000, costUSD: nil)
+            ]),
+            to: &lines,
+            note: "Estimated from local Claude logs at API rates."
+        )
+
+        guard case .chart(let label, let points, let note) = lines.first else {
+            return XCTFail("expected a chart line")
+        }
+        XCTAssertEqual(label, "Usage Trend")
+        XCTAssertEqual(note, "Estimated from local Claude logs at API rates.")
+        // Sorted ascending by date, regardless of input order.
+        XCTAssertEqual(points.map(\.label), ["6/19", "6/20", "6/21"])
+        XCTAssertEqual(points.map(\.value), [500, 1_500_000, 222_000_000])
+        // Pre-formatted readouts: compact counts with a "tokens" unit.
+        XCTAssertEqual(points.map(\.valueLabel), ["500 tokens", "1.5M tokens", "222M tokens"])
+    }
+
+    func testAppendUsageTrendKeepsTheMostRecent31Days() {
+        // 40 distinct days (May 1–31, then June 1–9). The chart keeps the most recent 31, dropping the
+        // oldest nine — so it starts at 5/10, not 5/1.
+        var daily = (1...31).map { CcusageDay(date: String(format: "2026-05-%02d", $0), totalTokens: $0 * 1000, costUSD: nil) }
+        daily += (1...9).map { CcusageDay(date: String(format: "2026-06-%02d", $0), totalTokens: $0 * 1000, costUSD: nil) }
+
+        var lines: [MetricLine] = []
+        SpendTileMapper.appendUsageTrend(CcusageDailyUsage(daily: daily), to: &lines, note: "n")
+
+        guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
+        XCTAssertEqual(points.count, 31)
+        XCTAssertEqual(points.first?.label, "5/10", "oldest nine days are dropped")
+        XCTAssertEqual(points.last?.label, "6/9", "most recent day is kept")
+    }
+
+    func testTrendAggregatesDuplicateDaysAndParsesCompactDates() {
+        // Two source rows that normalize to the same calendar day (8-digit + hyphenated) collapse into
+        // one bar carrying their summed tokens, not two bars splitting it.
+        var lines: [MetricLine] = []
+        SpendTileMapper.appendUsageTrend(
+            CcusageDailyUsage(daily: [
+                CcusageDay(date: "20260620", totalTokens: 1000, costUSD: nil),
+                CcusageDay(date: "2026-06-20", totalTokens: 500, costUSD: nil)
+            ]),
+            to: &lines, note: "n"
+        )
+
+        guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
+        XCTAssertEqual(points.count, 1, "same calendar day collapses to one bar")
+        XCTAssertEqual(points.first?.label, "6/20")
+        XCTAssertEqual(points.first?.value, 1500, "the day's tokens are summed, not split across bars")
+    }
+
+    func testAppendUsageTrendSkippedWhenNoUsableDays() {
+        var lines: [MetricLine] = []
+        SpendTileMapper.appendUsageTrend(CcusageDailyUsage(daily: []), to: &lines, note: "n")
+        XCTAssertTrue(lines.isEmpty, "no days means no chart, not an empty axis")
+    }
+
+    func testChartLineCodableRoundTrips() throws {
+        let line = MetricLine.chart(
+            label: "Usage Trend",
+            points: [MetricChartPoint(value: 1_500_000, label: "6/20", valueLabel: "1.5M tokens")],
+            note: "src"
+        )
+        let data = try JSONEncoder().encode(line)
+        let decoded = try JSONDecoder().decode(MetricLine.self, from: data)
+        XCTAssertEqual(decoded, line)
+    }
+
+    func testUsageTrendDescriptorIsNotPinnable() {
+        let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let descriptor = WidgetDescriptor.usageTrend(provider: provider)
+        XCTAssertEqual(descriptor.id, "claude.trend")
+        XCTAssertFalse(descriptor.pinnable)
+        XCTAssertTrue(descriptor.sample.isChart)
+
+        let suite = makeDefaults("pinnable")
+        let store = LayoutStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            defaults: suite,
+            storageKey: "layout"
+        )
+        XCTAssertFalse(store.canPin("claude.trend"), "a chart can't be drawn in the tray, so it can't be pinned")
+    }
+
+    func testDataStoreResolvesChartLineToAChartTile() {
+        let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let descriptor = WidgetDescriptor.usageTrend(provider: provider)
+        let store = makeDataStore(provider: provider, descriptor: descriptor)
+        store.snapshots["claude"] = ProviderSnapshot(
+            providerID: "claude", displayName: "Claude",
+            lines: [.chart(label: "Usage Trend",
+                           points: [MetricChartPoint(value: 5000, label: "6/20", valueLabel: "5K tokens")],
+                           note: "src")]
+        )
+
+        let data = store.data(for: descriptor)
+        XCTAssertTrue(data.isChart)
+        XCTAssertTrue(data.hasData)
+        XCTAssertEqual(data.chartPoints.count, 1)
+        XCTAssertEqual(data.chartNote, "src")
+    }
+
+    func testChartTileWithoutABackingLineRendersNoData() {
+        // The placed tile with no `.chart` line must NOT leak the descriptor's gallery sample bars onto
+        // the dashboard — it falls back to the no-data state.
+        let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let descriptor = WidgetDescriptor.usageTrend(provider: provider)
+        let store = makeDataStore(provider: provider, descriptor: descriptor)
+
+        let data = store.data(for: descriptor)
+        XCTAssertFalse(data.hasData)
+    }
+
+    // MARK: - Hover coordinator (TrendHoverState)
+
+    func testHoverStateOpensThenClosesAroundBothRegions() async {
+        let state = TrendHoverState(revealDelay: .milliseconds(1), hideGrace: .milliseconds(1))
+        XCTAssertFalse(state.isPresented)
+
+        state.inlineHover(true)
+        try? await Task.sleep(for: .milliseconds(40))
+        XCTAssertTrue(state.isPresented, "opens after the reveal dwell while the row is hovered")
+
+        // Cursor crosses from the row into the popover: the row exits and the popover enters within grace.
+        state.inlineHover(false)
+        state.detailHover(true)
+        try? await Task.sleep(for: .milliseconds(40))
+        XCTAssertTrue(state.isPresented, "stays open while the cursor is inside the popover")
+
+        state.detailHover(false)
+        try? await Task.sleep(for: .milliseconds(40))
+        XCTAssertFalse(state.isPresented, "closes once the cursor has left both the row and the popover")
+    }
+
+    func testHoverStateQuickPassDoesNotOpen() async {
+        let state = TrendHoverState(revealDelay: .milliseconds(60), hideGrace: .milliseconds(1))
+        state.inlineHover(true)
+        state.inlineHover(false)   // left before the reveal dwell elapsed
+        try? await Task.sleep(for: .milliseconds(90))
+        XCTAssertFalse(state.isPresented, "a quick pass over the row never opens the popover")
+    }
+
+    func testHoverStateDismissForcesClosed() async {
+        let state = TrendHoverState(revealDelay: .milliseconds(1), hideGrace: .milliseconds(1))
+        state.inlineHover(true)
+        try? await Task.sleep(for: .milliseconds(40))
+        XCTAssertTrue(state.isPresented)
+
+        state.dismiss()
+        XCTAssertFalse(state.isPresented, "teardown closes it immediately")
+    }
+
+    // MARK: - Helpers
+
+    private func makeDataStore(provider: Provider, descriptor: WidgetDescriptor) -> WidgetDataStore {
+        let runtime = TestProviderRuntime(
+            provider: provider, descriptors: [descriptor],
+            snapshot: ProviderSnapshot(providerID: provider.id, displayName: provider.displayName, lines: [])
+        )
+        return WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            defaults: makeDefaults("trend")
+        )
+    }
+
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.Trend.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/Tests/OpenUsageTests/UsageTrendTests.swift
+++ b/Tests/OpenUsageTests/UsageTrendTests.swift
@@ -5,7 +5,7 @@ import XCTest
 /// chart `MetricLine`, and how it flows through the descriptor / data store (non-pinnable, no-data safe).
 @MainActor
 final class UsageTrendTests: XCTestCase {
-    func testAppendUsageTrendZeroFillsTheCalendarWindow() {
+    func testAppendUsageTrendZeroFillsTheCalendarWindow() throws {
         var lines: [MetricLine] = []
         SpendTileMapper.appendUsageTrend(
             CcusageDailyUsage(daily: [
@@ -27,8 +27,12 @@ final class UsageTrendTests: XCTestCase {
         XCTAssertEqual(points.count, 31)
         XCTAssertEqual(points.first?.label, dayLabel(2026, 5, 22), "window starts 30 days before today")
         XCTAssertEqual(points.last?.label, dayLabel(2026, 6, 21), "window ends today")
-        // Labels use the app's localized month/day style, e.g. "Jun 21", not "6/21".
-        XCTAssertEqual(points.last?.label, date(2026, 6, 21).formatted(.dateTime.month(.abbreviated).day()))
+        XCTAssertEqual(Set(points.map(\.label)).count, 31, "every day in the window is a distinct bar")
+        // Labels are the app's month/day style ("Jun 21"), not the old hardcoded "6/21" — pinned without
+        // a locale-specific literal: no slash, and a month name rather than a bare number.
+        let lastLabel = try XCTUnwrap(points.last?.label)
+        XCTAssertFalse(lastLabel.contains("/"), "not the old numeric M/d format")
+        XCTAssertTrue(lastLabel.contains(where: \.isLetter), "carries a localized month name")
         // The three active days carry their tokens; every other day is a zero bar, not a dropped gap.
         XCTAssertEqual(points[28].value, 500)          // 6/19
         XCTAssertEqual(points[29].value, 1_500_000)    // 6/20
@@ -223,10 +227,10 @@ final class UsageTrendTests: XCTestCase {
         Calendar.current.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
     }
 
-    /// The expected axis label for a day, in the app's localized month/day style — computed the same way
-    /// the producer does, so the assertion holds in any test-machine locale.
+    /// The expected axis label for a day, in the app's localized month/day style — via the same shared
+    /// formatter the producer uses, so the slot-mapping assertions hold in any test-machine locale.
     private func dayLabel(_ year: Int, _ month: Int, _ day: Int) -> String {
-        date(year, month, day).formatted(.dateTime.month(.abbreviated).day())
+        Formatters.monthDayLabel(date(year, month, day))
     }
 
     private func makeDataStore(provider: Provider, descriptor: WidgetDescriptor) -> WidgetDataStore {

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -16,6 +16,8 @@ The popover that opens from the menu bar icon. Providers are sections; each sect
 
 **Metrics without a limit** (daily spend, balances) show as a single line like `$4.08 spent` or `1.2M tokens`. The daily spend rows (Today / Yesterday / Last 30 Days) come in three flavors you can add from Customize — cost (`$4.08 spent`), tokens (`1.2M tokens`), or both (`$4.08 · 1.2M tokens`). A day with no usage is a real zero, so it reads `$0.00 · 0 tokens` (not "No data" — that's only when the data can't be loaded at all). Big numbers are abbreviated to keep rows tidy (`$2.06K`, `1.5B`) — **hover the row** to see the exact figures. A small ⓘ next to the name means a dollar figure is estimated locally rather than billed — hover it for details; token counts are measured, so they carry no ⓘ.
 
+**Usage Trend** (Claude and Codex) is a small bar chart of the last 30 days of token usage — one bar per day, drawn from the same local logs as the spend rows. **Hover it** for the peak day, the date range, and the source. It's on by default; turn it off or reorder it from Customize like any other metric. It can't be pinned to the menu bar — the strip shows single values, not a chart.
+
 Rows with a reset date tick every 30 seconds, so countdowns and pace stay live between refreshes.
 
 ## Right-click menus

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -62,8 +62,8 @@ Methods other than `GET`/`OPTIONS` return **405**; unknown routes return **404**
       "type": "barChart",
       "label": "Usage Trend",
       "points": [
-        { "label": "3/25", "value": 1200000.0, "valueLabel": "1.2M tokens" },
-        { "label": "3/26", "value": 2400000.0, "valueLabel": "2.4M tokens" }
+        { "label": "Mar 25", "value": 1200000.0, "valueLabel": "1.2M tokens" },
+        { "label": "Mar 26", "value": 2400000.0, "valueLabel": "2.4M tokens" }
       ],
       "note": "Estimated from local Claude logs at API rates.",
       "color": null
@@ -73,7 +73,7 @@ Methods other than `GET`/`OPTIONS` return **405**; unknown routes return **404**
 }
 ```
 
-Line types are `progress`, `text`, `badge`, and `barChart`. A `barChart` line carries a `points` array — one `{ label, value, valueLabel? }` per day, oldest first — plus an optional `note`; `value` is the day's token count and `valueLabel` its pre-formatted readout. `fetchedAt` is when the snapshot was last fetched successfully (ISO 8601).
+Line types are `progress`, `text`, `badge`, and `barChart`. A `barChart` line carries a `points` array — one `{ label, value, valueLabel? }` per day, oldest first — plus an optional `note`; `value` is the day's token count, `valueLabel` its pre-formatted readout, and `label` a localized month/day (e.g. "Mar 25"). `fetchedAt` is when the snapshot was last fetched successfully (ISO 8601).
 
 ## Errors
 

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -57,13 +57,23 @@ Methods other than `GET`/`OPTIONS` return **405**; unknown routes return **404**
       "text": "2500 cap",
       "color": "#22c55e",
       "subtitle": null
+    },
+    {
+      "type": "barChart",
+      "label": "Usage Trend",
+      "points": [
+        { "label": "3/25", "value": 1200000.0, "valueLabel": "1.2M tokens" },
+        { "label": "3/26", "value": 2400000.0, "valueLabel": "2.4M tokens" }
+      ],
+      "note": "Estimated from local Claude logs at API rates.",
+      "color": null
     }
   ],
   "fetchedAt": "2026-03-26T11:16:29.000Z"
 }
 ```
 
-Line types are `progress`, `text`, and `badge`. `fetchedAt` is when the snapshot was last fetched successfully (ISO 8601).
+Line types are `progress`, `text`, `badge`, and `barChart`. A `barChart` line carries a `points` array — one `{ label, value, valueLabel? }` per day, oldest first — plus an optional `note`; `value` is the day's token count and `valueLabel` its pre-formatted readout. `fetchedAt` is when the snapshot was last fetched successfully (ISO 8601).
 
 ## Errors
 


### PR DESCRIPTION
## Summary

Adds the **Usage Trend** row for Claude and Codex: a compact day-by-day token sparkline that the Tauri edition already shows. Hovering it reveals a larger chart with the peak, the date range, and per-bar highlight.

The data is the per-day token series from the same `ccusage` call that already powers Today / Yesterday / Last 30 Days, so there's no new usage-history store to build (the groundwork [#659](https://github.com/robinebers/openusage/issues/659) worried about). For Claude and Codex that series already exists in `daily[]`.

## What changed

- **Model.** `MetricLine` gains a `.chart(label, points, note)` case and a `MetricChartPoint` (value, axis label, pre-formatted readout). `SpendTileMapper.appendUsageTrend` builds the points — tokens summed per calendar day, chronological, capped to the most recent 31 — and Claude/Codex append it right after the spend tiles.
- **View.** The inline row draws a right-aligned mini bar chart in the same blue as a healthy meter, so it reads as part of the card. Hovering opens a `.popover` (`UsageTrendDetail`) with the peak readout, the date range, the source note, and per-bar highlight; `TrendHoverState` coordinates the open/close dwell so it survives the cursor crossing from the row into the popover.
- **Configurable.** A first-class Customize widget — toggle, drag-reorder, hide — on by default for Claude and Codex. Not pinnable to the menu bar (the tray shows single values, not a chart), gated by a `pinnable` flag on the descriptor.
- **Local API.** Serialized as the original app's `barChart` line shape, so existing integrations read the trend too.

## Screenshots

https://github.com/user-attachments/assets/d0334907-bc86-4659-bbd1-7affe9631c7b

## Default on / off

It's **on by default** for Claude and Codex, matching the Tauri edition. One thing to flag: the spend tiles (Today / Yesterday / Last 30 Days) are deliberately *off* by default, so a user with no JavaScript runner (no `ccusage`) sees a "No data" Usage Trend row on those two providers until they install one or hide the row. Happy to flip it to off-by-default if we'd rather match the spend tiles — it's a one-line change in `DefaultLayout`.

## Testing

`swift test` passes (335 tests). `UsageTrendTests` covers the point builder (chronological order, per-day aggregation of duplicate dates, the 31-day cap, 8-digit date parsing), the `.chart` Codable round-trip, the non-pinnable descriptor, the no-data fallback (a placed tile with no backing line renders "No data", never the gallery sample), and the hover coordinator (opens after the dwell, stays open across the row→popover hand-off, closes once off both, force-dismiss on teardown).

Verified in the dev build against live Claude and Codex ccusage data: the inline sparkline renders, the hover popover opens above the chart with per-bar highlight, and it dismisses cleanly when the menu-bar panel closes.
