### PR TITLE
feat(menubar): add right-click context menu with Settings and Quit

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -213,6 +213,9 @@ final class StatusItemController: NSObject {
         guard let button = statusItem.button else { return }
         button.target = self
         button.action = #selector(statusButtonClicked)
+        // Left-click toggles the popover; right-click (or control-click) drops the context menu.
+        // Both arrive through `statusButtonClicked`, which branches on the triggering event.
+        button.sendAction(on: [.leftMouseUp, .rightMouseUp])
     }
 
     /// A resizable rounded-rectangle mask so the `behindWindow` glass gets clean rounded corners
@@ -275,7 +278,47 @@ final class StatusItemController: NSObject {
     // MARK: - Show / hide
 
     @objc private func statusButtonClicked() {
-        togglePopover()
+        let event = NSApp.currentEvent
+        let isContextClick = event?.type == .rightMouseUp
+            || event?.modifierFlags.contains(.control) == true
+        if isContextClick {
+            showContextMenu()
+        } else {
+            togglePopover()
+        }
+    }
+
+    /// Right-click / control-click on the status item: a native menu mirroring the popover footer's
+    /// "More" items for Settings and Quit (same titles, symbols, and ⌘ shortcuts). Assigning
+    /// `statusItem.menu` for the span of one `performClick` shows the menu anchored under the item and
+    /// highlights the button, then clearing it restores the left-click toggle behavior.
+    private func showContextMenu() {
+        // The context menu is a distinct gesture from the left-click popover: close an open panel
+        // first so the menu opens over a clean state (no leftover button highlight, no live
+        // outside-click monitors racing the menu's own modal tracking).
+        if panel.isVisible { hidePanel() }
+
+        let menu = NSMenu()
+        menu.addItem(ClosureMenuItem(title: "Settings", systemSymbol: "gearshape", keyEquivalent: ",") { [weak self] in
+            self?.openSettings()
+        })
+        menu.addItem(.separator())
+        menu.addItem(ClosureMenuItem(title: "Quit OpenUsage", systemSymbol: "power", keyEquivalent: "q") {
+            NSApplication.shared.terminate(nil)
+        })
+
+        statusItem.menu = menu
+        statusItem.button?.performClick(nil)
+        statusItem.menu = nil
+    }
+
+    /// Opens the dashboard popover on the Settings screen — Settings is an in-popover screen, not a
+    /// separate window. The screen is set before showing the panel so it opens already sized to Settings.
+    private func openSettings() {
+        container.layout.screen = .settings
+        if !panel.isVisible {
+            showPanel()
+        }
     }
 
     func togglePopover() {

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -2,6 +2,10 @@
 
 Pin your most important metrics straight into the menu bar strip.
 
+## Right-clicking the icon
+
+Right-click (or control-click) the menu bar icon for a quick menu with **Settings** and **Quit**. Left-click opens the popover as usual.
+
 ## Pinning
 
 Pin from any row's right-click menu, or from the pin that appears when hovering rows in Customize.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-Settings lives inside the popover — there is no separate window. Open it with the gear button in the popover footer, or ⌘, while the popover is showing. The dashboard slides over to the Settings screen; the gear becomes a checkmark while you're there. Go back with the checkmark, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
+Settings lives inside the popover — there is no separate window. Open it with the gear button in the popover footer, ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen; the gear becomes a checkmark while you're there. Go back with the checkmark, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
 
 ## Startup
 


### PR DESCRIPTION
## What

Right-click (or control-click) the menu-bar icon to open a native context menu with **Settings** and **Quit**. Left-click keeps toggling the dashboard popover as before.

## How

- The status-item button sends its action on both `.leftMouseUp` and `.rightMouseUp`; `statusButtonClicked` branches on `NSApp.currentEvent` to choose the popover toggle or the context menu.
- **Settings** opens the popover on the in-app Settings screen (`layout.screen = .settings`), since Settings is a popover screen rather than a separate window. **Quit** calls `NSApplication.shared.terminate`.
- Menu items use the existing `ClosureMenuItem`, so titles, SF Symbols, and ⌘ shortcuts match the footer's More menu.
- Showing the menu closes an open popover first, which avoids a button-highlight desync and a flicker race with the outside-click monitor.

The menu uses the `statusItem.menu` + `performClick` idiom (the standard path for status-item menus: it anchors under the item and highlights the button), then clears `statusItem.menu` so left-click keeps firing the toggle action.

## Screenshots

<!-- Right-click the menu-bar icon and drop the menu screenshot here. -->

| Context menu |
| --- |
| <img width="460" height="230" alt="CleanShot 2026-06-21 at 15 43 56@2x" src="https://github.com/user-attachments/assets/b8846e97-9847-4e7d-b473-a695868a3b49" /> |

## Testing

- `swift build` and `swift build --build-tests` pass.
- Ran the dev build via `script/build_and_run.sh` staging (icon step skipped because of a local `actool` failure unrelated to this change); the status item launches and the process stays up. I did not drive the right-click menu interaction itself.

## Out of scope

Pre-existing, left untouched: `PopUpMenuAnchor.swift` docs reference `StatusItemController.shouldKeepPopoverOpen`, which was renamed to `shouldKeepPanelOpen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
