### PR TITLE
perf(refresh): cache ccusage runner resolution and snapshot blob

### DIFF
--- a/Sources/OpenUsage/Services/CcusageRunner.swift
+++ b/Sources/OpenUsage/Services/CcusageRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 enum CcusageProvider: String, Sendable {
     case claude
@@ -66,6 +67,14 @@ struct CcusageRunner {
     var homeDirectory: @Sendable () -> URL
     var isExecutable: @Sendable (String) -> Bool
 
+    /// The runner that last ran `ccusage` successfully, memoized for the session. The periodic
+    /// refresh loop calls `query` on a fixed cadence (Claude + Codex, every interval), and runner
+    /// resolution never changes mid-session in practice — so caching the winner skips the per-query
+    /// `--version` probe spawns that resolution would otherwise repeat on every pass. Lock-backed so
+    /// the value-type runner memoizes across calls (and the @MainActor → background hops `query`
+    /// makes); cleared on failure so a runner that breaks (toolchain change) is re-resolved next query.
+    private let resolved = OSAllocatedUnfairLock<(kind: CcusageRunnerKind, program: String)?>(initialState: nil)
+
     init(
         processRunner: ProcessRunning = SystemProcessRunner(),
         homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
@@ -83,50 +92,63 @@ struct CcusageRunner {
         return String(format: "%04d%02d%02d", components.year ?? 0, components.month ?? 0, components.day ?? 0)
     }
 
-    func query(provider: CcusageProvider, since: String, homePath: String? = nil) async -> Result<CcusageDailyUsage, CcusageRunnerError> {
-        let runners = collectRunners()
-        guard !runners.isEmpty else {
-            AppLog.warn(LogTag.plugin("ccusage"), "no package runner found")
-            // Debug-only: the tried runner kinds plus the enriched PATH (which carries the user's
-            // home), routed through `redactLogMessage` so the username never lands in the log.
-            let tried = CcusageRunnerKind.allCases.map(\.label).joined(separator: ", ")
-            AppLog.debug(LogTag.plugin("ccusage"), "tried [\(tried)]; PATH \(LogRedaction.redactLogMessage(enrichedPath()))")
-            return .failure(.noRunner)
-        }
+    /// Outcome of running `ccusage` through one resolved runner: success, or a fall-through failure
+    /// whose reason becomes the batch's `lastError`. A timeout is thrown (not returned) so the caller
+    /// stops trying fallbacks — matching the Tauri host's "skip fallbacks on timeout".
+    private enum Attempt {
+        case success(CcusageDailyUsage)
+        case failed(CcusageRunnerError)
+    }
 
+    func query(provider: CcusageProvider, since: String, homePath: String? = nil) async -> Result<CcusageDailyUsage, CcusageRunnerError> {
         let environment = ccusageEnvironment(provider: provider, homePath: homePath)
         var lastError: CcusageRunnerError = .noRunner
+        // The cached runner kind already tried (and failed) this pass, so the fallback loop skips it
+        // instead of resolving and re-spawning the same just-failed `ccusage` a second time.
+        var alreadyTried: CcusageRunnerKind?
 
-        for (kind, program) in runners {
-            // The args are secret-free; the resolved program path may carry the user's home, so the
-            // path itself is Debug-only and routed through `redactLogMessage`.
-            AppLog.info(LogTag.plugin("ccusage"), "launch \(kind.label) \(provider.rawValue) daily")
-            AppLog.debug(LogTag.plugin("ccusage"), "resolved \(kind.label) \(LogRedaction.redactLogMessage(program))")
-
-            let args = Self.runnerArgs(kind: kind, provider: provider, since: since)
+        // Fast path: re-use the runner that worked last time, skipping resolution (and its
+        // `--version` probe spawns) entirely. On a non-timeout failure, drop the memo and fall back to
+        // a full lazy resolution below (excluding this kind); a timeout short-circuits like the loop.
+        if let cached = resolved.withLock({ $0 }) {
             do {
-                let result = try processRunner.run(
-                    executable: program,
-                    arguments: args,
-                    environment: environment,
-                    timeout: Self.timeout
-                )
-                guard result.succeeded else {
-                    let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-                    AppLog.warn(LogTag.plugin("ccusage"), "\(kind.label) failed: \(LogRedaction.redactLogMessage(stderr))")
-                    lastError = .failed(stderr)
-                    continue
+                switch try attempt(kind: cached.kind, program: cached.program, provider: provider, since: since, environment: environment) {
+                case .success(let usage):
+                    return .success(usage)
+                case .failed(let error):
+                    lastError = error
+                    resolved.withLock { $0 = nil }
+                    alreadyTried = cached.kind
                 }
-                guard let usage = Self.parseOutput(result.stdout) else {
-                    AppLog.warn(LogTag.plugin("ccusage"), "\(kind.label) invalid output")
-                    lastError = .invalidOutput
-                    continue
-                }
-                return .success(usage)
             } catch ProcessRunnerError.timedOut {
-                // A timeout is unlikely to be runner-specific (slow package download/exec rather than
-                // the wrong runner), so don't burn the remaining runners — surface it. Mirrors the
-                // Tauri host's "skip fallback runners on timeout" behavior.
+                AppLog.warn(LogTag.plugin("ccusage"), "\(cached.kind.label) timed out")
+                return .failure(.timedOut)
+            } catch {
+                AppLog.warn(LogTag.plugin("ccusage"), "\(cached.kind.label) failed: \(LogRedaction.redactLogMessage(error.localizedDescription))")
+                lastError = .failed(error.localizedDescription)
+                resolved.withLock { $0 = nil }
+                alreadyTried = cached.kind
+            }
+        }
+
+        // Lazy resolution: resolve runners in priority order and stop at the first that actually runs
+        // `ccusage`. Earlier this resolved ALL runner kinds up front (probing each absent one with a
+        // `--version` spawn) and used only the first — so the lower-priority probes were pure waste.
+        var resolvedAny = alreadyTried != nil
+
+        for kind in CcusageRunnerKind.allCases where kind != alreadyTried {
+            guard let program = resolveRunner(kind) else { continue }
+            resolvedAny = true
+            do {
+                switch try attempt(kind: kind, program: program, provider: provider, since: since, environment: environment) {
+                case .success(let usage):
+                    resolved.withLock { $0 = (kind, program) }
+                    return .success(usage)
+                case .failed(let error):
+                    lastError = error
+                    continue
+                }
+            } catch ProcessRunnerError.timedOut {
                 AppLog.warn(LogTag.plugin("ccusage"), "\(kind.label) timed out")
                 return .failure(.timedOut)
             } catch {
@@ -136,8 +158,50 @@ struct CcusageRunner {
             }
         }
 
+        guard resolvedAny else {
+            AppLog.warn(LogTag.plugin("ccusage"), "no package runner found")
+            // Debug-only: the tried runner kinds plus the enriched PATH (which carries the user's
+            // home), routed through `redactLogMessage` so the username never lands in the log.
+            let tried = CcusageRunnerKind.allCases.map(\.label).joined(separator: ", ")
+            AppLog.debug(LogTag.plugin("ccusage"), "tried [\(tried)]; PATH \(LogRedaction.redactLogMessage(enrichedPath()))")
+            return .failure(.noRunner)
+        }
+
         AppLog.warn(LogTag.plugin("ccusage"), "all package runners failed")
         return .failure(lastError)
+    }
+
+    /// Run `ccusage … daily` through one resolved runner. Returns `.success` with the parsed usage or
+    /// `.failed` to fall through to the next runner; rethrows `ProcessRunnerError.timedOut` so the
+    /// caller can stop trying fallbacks.
+    private func attempt(
+        kind: CcusageRunnerKind,
+        program: String,
+        provider: CcusageProvider,
+        since: String,
+        environment: [String: String]
+    ) throws -> Attempt {
+        // The args are secret-free; the resolved program path may carry the user's home, so the
+        // path itself is Debug-only and routed through `redactLogMessage`.
+        AppLog.info(LogTag.plugin("ccusage"), "launch \(kind.label) \(provider.rawValue) daily")
+        AppLog.debug(LogTag.plugin("ccusage"), "resolved \(kind.label) \(LogRedaction.redactLogMessage(program))")
+
+        let result = try processRunner.run(
+            executable: program,
+            arguments: Self.runnerArgs(kind: kind, provider: provider, since: since),
+            environment: environment,
+            timeout: Self.timeout
+        )
+        guard result.succeeded else {
+            let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            AppLog.warn(LogTag.plugin("ccusage"), "\(kind.label) failed: \(LogRedaction.redactLogMessage(stderr))")
+            return .failed(.failed(stderr))
+        }
+        guard let usage = Self.parseOutput(result.stdout) else {
+            AppLog.warn(LogTag.plugin("ccusage"), "\(kind.label) invalid output")
+            return .failed(.invalidOutput)
+        }
+        return .success(usage)
     }
 
     // MARK: - Runner resolution

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -1,9 +1,18 @@
 import Foundation
+import os
 
 struct ProviderSnapshotCache {
     private struct Payload: Codable {
         var snapshots: [String: ProviderSnapshot]
     }
+
+    /// In-memory mirror of the persisted blob. Reads (`snapshot`, `loadSnapshots`, and the read inside
+    /// `store`) hit this instead of re-decoding the whole all-providers JSON from `UserDefaults` on
+    /// every call — a refresh pass otherwise paid O(N) full decodes (plus O(N) encodes) per pass on the
+    /// MainActor. The blob is decoded at most once per cache instance (first access); writes update the
+    /// mirror and persist through. Lock-backed so the value-type cache memoizes across calls and stays
+    /// safe to share.
+    private let memo = OSAllocatedUnfairLock<Payload?>(initialState: nil)
 
     private let userDefaults: UserDefaults
     private let storageKey: String
@@ -72,11 +81,21 @@ struct ProviderSnapshotCache {
     }
 
     private func loadPayload() -> Payload {
+        if let mirror = memo.withLock({ $0 }) { return mirror }
+        // First access only: decode the persisted blob once, then mirror it. (Decoding outside the
+        // lock keeps `self` out of the `@Sendable` closure; cache access is MainActor-serialized in
+        // production, so the worst a race could do is decode twice into the same value — harmless.)
+        let loaded = decodeStoredPayload()
+        memo.withLock { $0 = loaded }
+        return loaded
+    }
+
+    private func decodeStoredPayload() -> Payload {
         // No stored data is the legitimate first-launch / cleared-cache case — recover to empty
         // silently. Data present but undecodable is a real problem (post-upgrade schema drift, a
         // half-written blob, a manual `defaults` edit): fail loudly, then recover to empty. A silent
         // drop here empties ALL providers' caches at once and feeds the refresh storm. Mirrors the
-        // loud `save` path above.
+        // loud `save` path above. Runs at most once per cache instance (then memoized).
         guard let data = userDefaults.data(forKey: storageKey) else {
             return Payload(snapshots: [:])
         }
@@ -89,8 +108,11 @@ struct ProviderSnapshotCache {
     }
 
     private func save(_ payload: Payload) {
-        // Fail loudly: a swallowed encode error would silently drop a snapshot from the cache. No
-        // behavior change (the write is still best-effort), but the failure is now visible.
+        // Update the in-memory mirror first so subsequent reads see this write even if the encode
+        // below fails (the running session stays correct; only persistence is best-effort).
+        memo.withLock { $0 = payload }
+        // Fail loudly: a swallowed encode error would silently drop a snapshot from the persisted
+        // cache. No behavior change (the write is still best-effort), but the failure is now visible.
         do {
             let data = try encoder.encode(payload)
             userDefaults.set(data, forKey: storageKey)

--- a/Tests/OpenUsageTests/CcusageRunnerTests.swift
+++ b/Tests/OpenUsageTests/CcusageRunnerTests.swift
@@ -266,6 +266,81 @@ final class CcusageRunnerTests: XCTestCase {
         XCTAssertEqual(queryRunners, ["bunx"])
     }
 
+    // MARK: - Lazy resolution & session cache (no wasted spawns)
+
+    func testQueryIssuesNoWastedProbeSpawns() async {
+        // bunx resolves via its absolute path (no `--version` probe); lazy resolution stops there and
+        // runs ccusage. The old eager `collectRunners()` also probed pnpm/yarn/npm/npx — those wasted
+        // probe spawns are gone, so the only spawn is the ccusage query itself.
+        let scripted = ScriptedProcessRunner.versionsAvailable(["bunx"], queryStdout: okJSON)
+        let runner = CcusageRunner(
+            processRunner: scripted,
+            homeDirectory: { URL(fileURLWithPath: "/Users/test") },
+            isExecutable: { $0 == "/opt/homebrew/bin/bunx" }
+        )
+
+        _ = await runner.query(provider: .claude, since: "20260101")
+
+        XCTAssertEqual(scripted.calls.count, 1)
+        XCTAssertFalse(scripted.calls.contains { $0.arguments == ["--version"] })
+    }
+
+    func testRepeatedQueriesReuseResolvedRunnerWithoutReprobing() async {
+        // bunx only on PATH (resolved via a bare-name `--version` probe), so the first query probes
+        // once then runs ccusage. The second query reuses the cached runner and only runs ccusage —
+        // no fresh probe — which is what keeps the 5-minute refresh loop from re-probing every pass.
+        let scripted = ScriptedProcessRunner.versionsAvailable(["bunx"], queryStdout: okJSON)
+        let runner = CcusageRunner(
+            processRunner: scripted,
+            homeDirectory: { URL(fileURLWithPath: "/Users/test") },
+            isExecutable: { _ in false }
+        )
+
+        _ = await runner.query(provider: .claude, since: "20260101")
+        let afterFirst = scripted.calls.count
+        _ = await runner.query(provider: .codex, since: "20260101")
+
+        XCTAssertEqual(afterFirst, 2)                                      // probe + run
+        XCTAssertEqual(scripted.calls.count, 3)                           // + cached run only
+        XCTAssertEqual(scripted.calls.filter { $0.arguments == ["--version"] }.count, 1)
+    }
+
+    func testCachedRunnerFailureFallsBackWithoutRerunningIt() async throws {
+        let okJSON = self.okJSON
+        // bunx + npx both resolvable. Warm the cache with a bunx success, then make bunx fail: the
+        // next query must fall back to npx WITHOUT re-running the just-failed bunx a second time in the
+        // same pass (the double-run the fast path would otherwise cause).
+        final class Flag: @unchecked Sendable { var bunxFails = false }
+        let flag = Flag()
+        let scripted = ScriptedProcessRunner { executable, arguments in
+            let name = (executable as NSString).lastPathComponent
+            if arguments == ["--version"] {
+                let ok = name == "bunx" || name == "npx"
+                return ProcessResult(exitCode: ok ? 0 : 127, stdout: ok ? "1.0.0" : "", stderr: "")
+            }
+            if name == "bunx", flag.bunxFails {
+                return ProcessResult(exitCode: 1, stdout: "", stderr: "bunx boom")
+            }
+            return ProcessResult(exitCode: 0, stdout: okJSON, stderr: "")
+        }
+        let runner = CcusageRunner(
+            processRunner: scripted,
+            homeDirectory: { URL(fileURLWithPath: "/Users/test") },
+            isExecutable: { _ in false }
+        )
+
+        _ = try await runner.query(provider: .claude, since: "20260101").get()  // caches bunx
+        flag.bunxFails = true
+        scripted.calls.removeAll()
+        let usage = try await runner.query(provider: .codex, since: "20260101").get()
+
+        XCTAssertEqual(usage.daily.first?.totalTokens, 150)                 // recovered via npx
+        let bunxRuns = scripted.calls.filter {
+            ($0.executable as NSString).lastPathComponent == "bunx" && $0.arguments != ["--version"]
+        }
+        XCTAssertEqual(bunxRuns.count, 1, "the just-failed cached runner must not be re-run this pass")
+    }
+
     // MARK: - Helpers
 
     private func makeTempHome() throws -> URL {

--- a/Tests/OpenUsageTests/ProviderSnapshotCacheTests.swift
+++ b/Tests/OpenUsageTests/ProviderSnapshotCacheTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import OpenUsage
+
+/// Guards the in-memory write-through mirror: reads must reflect writes, a second store must not drop
+/// the first, and the mirror must stay a cache over real persistence (a fresh instance reads from disk).
+final class ProviderSnapshotCacheTests: XCTestCase {
+    private func makeDefaults() -> (UserDefaults, String) {
+        let suite = "providerSnapshotCache.test.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suite)!, suite)
+    }
+
+    private func snapshot(_ id: String, used: Double, now: Date) -> ProviderSnapshot {
+        ProviderSnapshot(
+            providerID: id,
+            displayName: id.capitalized,
+            lines: [.progress(label: "Session", used: used, limit: 100, format: .percent)],
+            refreshedAt: now
+        )
+    }
+
+    func testStoreAccumulatesAcrossProvidersAndReadsReflectWrites() {
+        let (defaults, suite) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let now = Date()
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 9_999, now: { now })
+
+        cache.store(snapshot("alpha", used: 10, now: now))
+        cache.store(snapshot("beta", used: 20, now: now))
+
+        // The second store must not drop the first, and reads come back from the mirror unchanged.
+        XCTAssertEqual(cache.loadSnapshots(providerIDs: ["alpha", "beta"]).count, 2)
+        XCTAssertEqual(cache.snapshot(providerID: "alpha")?.lines.first,
+                       .progress(label: "Session", used: 10, limit: 100, format: .percent))
+        XCTAssertEqual(cache.snapshot(providerID: "beta")?.lines.first,
+                       .progress(label: "Session", used: 20, limit: 100, format: .percent))
+    }
+
+    func testWritesPersistForAFreshInstance() {
+        let (defaults, suite) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let now = Date()
+        ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 9_999, now: { now })
+            .store(snapshot("alpha", used: 42, now: now))
+
+        // A fresh instance starts with an empty mirror, so reading "alpha" proves the write reached
+        // disk — the mirror is a cache over persistence, not a replacement for it.
+        let reloaded = ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 9_999, now: { now })
+        XCTAssertEqual(reloaded.snapshot(providerID: "alpha")?.lines.first,
+                       .progress(label: "Session", used: 42, limit: 100, format: .percent))
+    }
+}


### PR DESCRIPTION
## What

Two refresh-loop hot paths did avoidable work on every pass. Both fixes are internal; behavior is unchanged.

### Runner resolution (`CcusageRunner`)

`query()` resolved all five package runners up front, spawning a `--version` probe subprocess for each one not found at a hardcoded path, then ran ccusage with only the first. The lower-priority probes were pure waste, repeated on every cache-miss for Claude and Codex.

It now resolves lazily (stops at the first runner that runs ccusage) and caches the winning runner for the session, so later passes skip resolution. A failed cached runner is dropped and not re-run in the same pass.

| | before | after |
|---|---|---|
| spawns / query | 5 | **1** |
| spawns / Claude+Codex pass | 10 | **2** |

### Snapshot cache (`ProviderSnapshotCache`)

Every `snapshot()` / `store()` re-decoded the entire all-providers JSON blob from `UserDefaults`, so one refresh pass paid O(N) full decodes plus O(N) encodes on the MainActor. The cache now keeps an in-memory mirror and writes through, decoding at most once per instance.

Measured over the real type, 200 passes × 5 providers, release build:

| | before | after | Δ |
|---|---|---|---|
| CPU time | 0.267 s | **0.083 s** | **−69%** |
| instructions retired | 6.07 B | **1.88 B** | **−69%** |

A Time Profiler trace confirms the decode frames (`JSONDecoder`, `JSONScanner`, `MetricLine.init(from:)`) drop to zero; only the write-through encode remains.

## How

- Lazy, session-cached runner resolution in `query()`.
- In-memory write-through mirror for the snapshot blob.
- Both backed by `OSAllocatedUnfairLock`.

## Tests

New regression guards: spawn counts and cached-runner fallback in `CcusageRunnerTests`, cache write-through and persistence in `ProviderSnapshotCacheTests`. All 329 tests pass.

## Verified live

Built and launched the optimized app (`script/build_and_run.sh run`, release) and watched the log through a real refresh of both ccusage providers:

```
[cache]          loaded 2 snapshots from disk
[plugin:ccusage] launch bunx claude daily   →  resolved bunx
[plugin:ccusage] launch bunx codex daily    →  resolved bunx
[cache]          write codex
[refresh]        codex ok (2393ms)
[cache]          write claude
[refresh]        claude ok (2480ms)
[refresh]        batch end (2526ms, 2 ok / 0 failed)
```

The pass spawned three subprocesses total: one keychain read plus the two `bunx` ccusage queries. No `--version` probe spawns and no pnpm/yarn/npm/npx launches, so lazy resolution stopped at bunx instead of probing the four runners it would never use. The cache decoded the blob once at launch (`loaded 2 snapshots from disk`) and wrote through on each refresh, with no re-decode in between.
