### PR TITLE
feat(codex): show rate-limit reset credits with per-credit expiry

### DIFF
--- a/Sources/OpenUsage/Models/MetricLine.swift
+++ b/Sources/OpenUsage/Models/MetricLine.swift
@@ -67,7 +67,12 @@ enum MetricLine: Hashable, Sendable, Codable {
     /// numeric rows. The number is the source of truth; formatting and which value(s) to show happen at
     /// the display edge, so the menu bar never has to re-parse a finished string. `.text` stays only for
     /// genuinely string-y rows and a few descriptor-bounded dollar rows.
-    case values(label: String, values: [MetricValue], colorHex: String? = nil)
+    ///
+    /// `expiriesAt` carries zero or more future expiry instants the row surfaces in its hover tooltip —
+    /// used for the Codex rate-limit-reset-credits row ("2 available", with each credit's expiry listed
+    /// on hover). Carried as raw `Date`s (not baked strings) so they count down on the popover's clock
+    /// tick and honor the global relative/absolute reset mode, like a bounded row's reset countdown.
+    case values(label: String, values: [MetricValue], colorHex: String? = nil, expiriesAt: [Date] = [])
     case progress(
         label: String,
         used: Double,
@@ -83,7 +88,7 @@ enum MetricLine: Hashable, Sendable, Codable {
         switch self {
         case .text(let label, _, _, _),
              .progress(let label, _, _, _, _, _, _),
-             .values(let label, _, _),
+             .values(let label, _, _, _),
              .badge(let label, _, _, _):
             return label
         }
@@ -121,6 +126,7 @@ enum MetricLine: Hashable, Sendable, Codable {
         case limit
         case format
         case resetsAt
+        case expiriesAt
         case periodDurationMs
         case colorHex
         case subtitle
@@ -149,7 +155,8 @@ enum MetricLine: Hashable, Sendable, Codable {
             self = .values(
                 label: label,
                 values: try container.decode([MetricValue].self, forKey: .values),
-                colorHex: try container.decodeIfPresent(String.self, forKey: .colorHex)
+                colorHex: try container.decodeIfPresent(String.self, forKey: .colorHex),
+                expiriesAt: try container.decodeIfPresent([Date].self, forKey: .expiriesAt) ?? []
             )
         case .progress:
             self = .progress(
@@ -180,11 +187,12 @@ enum MetricLine: Hashable, Sendable, Codable {
             try container.encode(value, forKey: .value)
             try container.encodeIfPresent(colorHex, forKey: .colorHex)
             try container.encodeIfPresent(subtitle, forKey: .subtitle)
-        case .values(let label, let values, let colorHex):
+        case .values(let label, let values, let colorHex, let expiriesAt):
             try container.encode(LineType.values, forKey: .type)
             try container.encode(label, forKey: .label)
             try container.encode(values, forKey: .values)
             try container.encodeIfPresent(colorHex, forKey: .colorHex)
+            if !expiriesAt.isEmpty { try container.encode(expiriesAt, forKey: .expiriesAt) }
         case .progress(let label, let used, let limit, let format, let resetsAt, let periodDurationMs, let colorHex):
             try container.encode(LineType.progress, forKey: .type)
             try container.encode(label, forKey: .label)

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -24,6 +24,10 @@ struct WidgetData: Hashable {
     /// Global relative/absolute reset display, stamped by `WidgetDataStore` (like `displayMode`).
     var resetDisplayMode: ResetDisplayMode = .relative
     var resetsAt: Date?
+    /// Zero or more future expiry instants surfaced in the row's hover tooltip (Codex rate-limit-reset
+    /// credits — one entry per still-available credit). Empty for every other row. Kept as raw `Date`s so
+    /// the tooltip formats live and follows the global relative/absolute mode (see `expiryTooltip`).
+    var expiriesAt: [Date] = []
     var periodDurationMs: Int?
     var valueTextOverride: String?
     var subtitleOverride: String?
@@ -260,7 +264,7 @@ struct WidgetData: Hashable {
         if !selected.isEmpty {
             // One value: a lone dollar amount takes the widget's trailing word ("$4.08 spent",
             // "$1,503 left"); any other single value carries its own unit label ("1.2M tokens",
-            // "1 available"). Several values join into the combined reading ("$4.08 · 1.2M tokens").
+            // "2 available"). Several values join into the combined reading ("$4.08 · 1.2M tokens").
             if selected.count == 1 {
                 let value = selected[0]
                 if value.kind == .dollars, let word = unboundedValueWord {
@@ -276,6 +280,40 @@ struct WidgetData: Hashable {
             return "\(valueText) \(countSuffix) \(word)"
         }
         return "\(valueText) \(word)"
+    }
+
+    /// A soonest-expiry inside this window flips the row to a warning state (the ⚠ triangle next to the
+    /// count) — a reset credit you're about to lose if you don't use it.
+    static let expiryWarningWindow: TimeInterval = 24 * 60 * 60
+
+    /// True when the soonest still-available reset credit expires within `expiryWarningWindow` (a past-due
+    /// one counts too). Drives the row's warning triangle; recomputes on the popover's 30s tick because
+    /// the row keeps ticking while it carries expiries.
+    var hasImminentExpiry: Bool {
+        guard hasData, let soonest = expiriesAt.min() else { return false }
+        return soonest.timeIntervalSince(Date()) <= Self.expiryWarningWindow
+    }
+
+    /// Hover tooltip for a row carrying expiry instants (the Codex reset-credit row, "2 available"):
+    /// when each credit's reset will expire, following the global relative/absolute mode. One credit →
+    /// "Reset expires in 12d 18h" (relative) / "Reset expires Feb 15 at 3:45 PM" (absolute); several →
+    /// a numbered list under a "Resets expire in:" / "Resets expire:" header. `nil` when the row carries
+    /// no expiries, so non-reset rows fall through to their figures tooltip.
+    var expiryTooltip: String? {
+        guard hasData, !expiriesAt.isEmpty else { return nil }
+        let now = Date()
+        let sorted = expiriesAt.sorted()
+        if sorted.count == 1 {
+            return Formatters.deadlineLabel("Reset expires", at: sorted[0], mode: resetDisplayMode, now: now)
+        }
+        let entries = sorted.enumerated().compactMap { index, date -> String? in
+            Formatters.whenLabel(at: date, mode: resetDisplayMode, now: now).map { "\(index + 1). \($0)" }
+        }
+        guard !entries.isEmpty else { return nil }
+        // The header carries the verb; "in" only fits the relative durations beneath it (absolute
+        // entries already read "Feb 15 at 3:45 PM").
+        let header = resetDisplayMode == .relative ? "Resets expire in:" : "Resets expire:"
+        return ([header] + entries).joined(separator: "\n")
     }
 
     /// Secondary line under an unbounded row's detail (e.g. "on-device estimate"); nil with no real data.

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -76,7 +76,13 @@ final class CodexProvider: ProviderRuntime {
         }
 
         let response = try await fetchUsageWithRetry(accessToken: accessToken, authState: &authState)
-        var mapped = try CodexUsageMapper.mapUsageResponse(response, now: now())
+        // The access token may have rotated during the usage fetch's refresh-and-retry; read the live one.
+        let currentToken = authState.auth.tokens?.accessToken ?? accessToken
+        let resetCredits = await fetchResetCreditsBestEffort(
+            accessToken: currentToken,
+            accountID: authState.auth.tokens?.accountID
+        )
+        var mapped = try CodexUsageMapper.mapUsageResponse(response, resetCredits: resetCredits, now: now())
 
         let since = CcusageRunner.sinceString(daysBack: 30, from: now())
         let tokenUsage = await ccusageRunner.query(provider: .codex, since: since, homePath: authStore.codexHome())
@@ -92,6 +98,19 @@ final class CodexProvider: ProviderRuntime {
             lines: mapped.lines,
             refreshedAt: now()
         )
+    }
+
+    /// Fetches the on-demand reset-credit balance (and per-credit expiry) without ever failing the
+    /// refresh: this is supplementary to the usage metrics, so a network error, timeout, or non-2xx just
+    /// yields `nil` and the mapper falls back to the count embedded in the usage body. Logged, not thrown —
+    /// the user still gets Session/Weekly/Credits even if this endpoint is down.
+    private func fetchResetCreditsBestEffort(accessToken: String, accountID: String?) async -> HTTPResponse? {
+        do {
+            return try await usageClient.fetchResetCredits(accessToken: accessToken, accountID: accountID)
+        } catch {
+            AppLog.warn(LogTag.plugin("codex"), "reset-credit fetch failed; using usage-body count: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     private func fetchUsageWithRetry(accessToken: String, authState: inout CodexAuthState) async throws -> HTTPResponse {

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageClient.swift
@@ -10,6 +10,7 @@ struct CodexUsageClient: Sendable {
     static let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
     static let refreshURL = URL(string: "https://auth.openai.com/oauth/token")!
     static let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+    static let resetCreditsURL = URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!
 
     var http: any HTTPClient
 
@@ -87,6 +88,30 @@ struct CodexUsageClient: Sendable {
         return try await http.send(HTTPRequest(
             method: "GET",
             url: Self.usageURL,
+            headers: headers,
+            timeout: 10
+        ))
+    }
+
+    /// On-demand rate-limit reset credits, including each credit's expiry — a separate endpoint from
+    /// `usage` (the usage body's `rate_limit_reset_credits` carries only the count, no expiry list). The
+    /// extra headers mirror the Codex desktop client, which the endpoint expects. Best-effort: the
+    /// provider tolerates a failure here and falls back to the usage body's count.
+    func fetchResetCredits(accessToken: String, accountID: String?) async throws -> HTTPResponse {
+        var headers = [
+            "Authorization": "Bearer \(accessToken)",
+            "Accept": "application/json",
+            "User-Agent": "OpenUsage",
+            "OpenAI-Beta": "codex-1",
+            "originator": "Codex Desktop"
+        ]
+        if let accountID, !accountID.isEmpty {
+            headers["ChatGPT-Account-Id"] = accountID
+        }
+
+        return try await http.send(HTTPRequest(
+            method: "GET",
+            url: Self.resetCreditsURL,
             headers: headers,
             timeout: 10
         ))

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -214,15 +214,17 @@ enum CodexUsageMapper {
     }
 
     /// The dictionary the count and expiry list are read from: the dedicated endpoint's body when it
-    /// returned a usable payload (2xx, parseable, carrying `available_count`), otherwise the usage body's
-    /// embedded object.
+    /// returned a usable payload (2xx, parseable, carrying a *numeric* `available_count`), otherwise the
+    /// usage body's embedded object. The count is validated with `ProviderParse.number` rather than a bare
+    /// nil-check: a JSON `null` decodes to `NSNull` (non-nil), so a bare check would select a dedicated
+    /// body whose count is unusable and drop the row instead of falling back to the usage-body count.
     private static func resetCreditsSource(
         body: [String: Any],
         resetCredits: HTTPResponse?
     ) -> [String: Any]? {
         if let resetCredits, (200..<300).contains(resetCredits.statusCode),
            let dedicated = ProviderParse.jsonObject(resetCredits.body),
-           dedicated["available_count"] != nil {
+           ProviderParse.number(dedicated["available_count"]) != nil {
             return dedicated
         }
         return body["rate_limit_reset_credits"] as? [String: Any]

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -230,13 +230,19 @@ enum CodexUsageMapper {
         return body["rate_limit_reset_credits"] as? [String: Any]
     }
 
-    /// Every `expires_at` among the still-available credits, sorted soonest-first. Only
-    /// `status == "available"` credits count (a spent/expired credit's expiry is irrelevant to the
-    /// "N available" the row shows). `expires_at` is parsed as an ISO-8601 string or an epoch number.
+    /// Every still-available credit's `expires_at`, sorted soonest-first. `status` is optional upstream,
+    /// so a credit is kept when it's explicitly "available" *or* carries no status at all — only an
+    /// explicitly non-available state (e.g. "consumed"/"expired") is dropped. Filtering hard on
+    /// `== "available"` would otherwise blank the whole expiry list (tooltip + 24h warning) for responses
+    /// that omit status, even though `available_count` reported credits. `expires_at` is parsed as an
+    /// ISO-8601 string or an epoch number.
     private static func availableExpiries(in value: Any?) -> [Date] {
         guard let credits = value as? [[String: Any]] else { return [] }
         return credits
-            .filter { ($0["status"] as? String) == "available" }
+            .filter { credit in
+                guard let status = credit["status"] as? String else { return true }
+                return status == "available"
+            }
             .compactMap { parseExpiry($0["expires_at"]) }
             .sorted()
     }

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -12,7 +12,11 @@ enum CodexUsageMapper {
     /// (mirrors the JS plugin's `CREDIT_USD_RATE`).
     static let creditUSDRate = 0.04
 
-    static func mapUsageResponse(_ response: HTTPResponse, now: Date = Date()) throws -> CodexMappedUsage {
+    static func mapUsageResponse(
+        _ response: HTTPResponse,
+        resetCredits: HTTPResponse? = nil,
+        now: Date = Date()
+    ) throws -> CodexMappedUsage {
         try ProviderAuthRetry.requireSuccess(
             response,
             authExpired: CodexAuthError.tokenExpired,
@@ -72,12 +76,15 @@ enum CodexUsageMapper {
         appendReviewLimit(from: body, to: &lines, now: now)
 
         // On-demand rate-limit reset credits, shown before Credits — mirrors the JS plugin (PR #577).
-        // A `.values` row carries the raw count (no unit label — the row just reads "2"), so the popover
-        // and the menu-bar tile show that same number — no string to re-parse, no tray-reads-0 bug.
-        if let resets = readResetCredits(body), resets >= 0 {
-            let count = Int(resets.rounded(.down))
-            lines.append(.values(label: "Rate Limit Resets",
-                                 values: [MetricValue(number: Double(count), kind: .count)]))
+        // The row reads "2 available" (the count is carried raw, so the menu-bar tile reads the same
+        // number); each still-available credit's expiry rides along in `expiriesAt` and surfaces in the
+        // row's hover tooltip ("Resets expire in: …").
+        if let resets = readResetCredits(body: body, resetCredits: resetCredits) {
+            lines.append(.values(
+                label: "Rate Limit Resets",
+                values: [MetricValue(number: Double(resets.count), kind: .count, label: "available")],
+                expiriesAt: resets.expiries
+            ))
         }
 
         if let remaining = readCreditsRemaining(response: response, body: body) {
@@ -187,11 +194,59 @@ enum CodexUsageMapper {
         ]
     }
 
-    /// On-demand reset credits from `rate_limit_reset_credits.available_count`. `ProviderParse.number`
-    /// returns nil for missing/null/non-numeric values, so malformed counts are skipped (matches JS).
-    private static func readResetCredits(_ body: [String: Any]) -> Double? {
-        guard let resets = body["rate_limit_reset_credits"] as? [String: Any] else { return nil }
-        return ProviderParse.number(resets["available_count"])
+    /// On-demand reset credits: the floored available count plus each still-available credit's expiry
+    /// (sorted soonest-first, for the row's hover tooltip).
+    ///
+    /// Prefers the dedicated `/rate-limit-reset-credits` payload (the only source that carries the
+    /// per-credit expiry list); falls back to the usage body's embedded `rate_limit_reset_credits`
+    /// object (count only) when that fetch was unavailable — mirroring the JS plugin. `ProviderParse.number`
+    /// returns nil for missing/null/non-numeric counts, so a malformed count skips the row entirely.
+    static func readResetCredits(
+        body: [String: Any],
+        resetCredits: HTTPResponse?
+    ) -> (count: Int, expiries: [Date])? {
+        guard let source = resetCreditsSource(body: body, resetCredits: resetCredits),
+              let count = ProviderParse.number(source["available_count"]), count >= 0
+        else {
+            return nil
+        }
+        return (Int(count.rounded(.down)), availableExpiries(in: source["credits"]))
+    }
+
+    /// The dictionary the count and expiry list are read from: the dedicated endpoint's body when it
+    /// returned a usable payload (2xx, parseable, carrying `available_count`), otherwise the usage body's
+    /// embedded object.
+    private static func resetCreditsSource(
+        body: [String: Any],
+        resetCredits: HTTPResponse?
+    ) -> [String: Any]? {
+        if let resetCredits, (200..<300).contains(resetCredits.statusCode),
+           let dedicated = ProviderParse.jsonObject(resetCredits.body),
+           dedicated["available_count"] != nil {
+            return dedicated
+        }
+        return body["rate_limit_reset_credits"] as? [String: Any]
+    }
+
+    /// Every `expires_at` among the still-available credits, sorted soonest-first. Only
+    /// `status == "available"` credits count (a spent/expired credit's expiry is irrelevant to the
+    /// "N available" the row shows). `expires_at` is parsed as an ISO-8601 string or an epoch number.
+    private static func availableExpiries(in value: Any?) -> [Date] {
+        guard let credits = value as? [[String: Any]] else { return [] }
+        return credits
+            .filter { ($0["status"] as? String) == "available" }
+            .compactMap { parseExpiry($0["expires_at"]) }
+            .sorted()
+    }
+
+    private static func parseExpiry(_ value: Any?) -> Date? {
+        if let string = value as? String, let date = OpenUsageISO8601.date(from: string) {
+            return date
+        }
+        if let seconds = ProviderParse.number(value) {
+            return Date(timeIntervalSince1970: seconds)
+        }
+        return nil
     }
 
     private static func readCreditsRemaining(response: HTTPResponse, body: [String: Any]) -> Double? {

--- a/Sources/OpenUsage/Services/LocalUsageAPI.swift
+++ b/Sources/OpenUsage/Services/LocalUsageAPI.swift
@@ -96,7 +96,7 @@ enum LocalUsageAPI {
                 try container.encode(value, forKey: .value)
                 try container.encode(color, forKey: .color)        // explicit null, like the original
                 try container.encode(subtitle, forKey: .subtitle)
-            case .values(let label, let values, let color):
+            case .values(let label, let values, let color, let expiriesAt):
                 // Serialize as the original `text` shape (one combined `value` string) so existing
                 // local-API integrations keep working: dollars in full, counts compact — exactly the
                 // string the mapper used to produce (e.g. "$5.17 · 9.2M tokens").
@@ -105,6 +105,9 @@ enum LocalUsageAPI {
                 try container.encode(Self.legacyValueString(values), forKey: .value)
                 try container.encode(color, forKey: .color)
                 try container.encodeNil(forKey: .subtitle)
+                // Expose the soonest expiry (Codex reset credits) as ISO-8601 so consumers get the next
+                // one without us baking a display string — same `resetsAt` field a progress row uses.
+                try container.encodeIfPresent(expiriesAt.min().map(OpenUsageISO8601.string(from:)), forKey: .resetsAt)
             case .progress(let label, let used, let limit, let format, let resetsAt, let periodDurationMs, let color):
                 try container.encode("progress", forKey: .type)
                 try container.encode(label, forKey: .label)

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -21,7 +21,11 @@ struct ProviderSnapshotCache {
         // to `.values` (raw numbers). Bumping the key drops pre-upgrade caches so the new `.values`-based
         // widgets never try to resolve a stale `.text` line — which would misread the fused string
         // (tokens tile showing the dollar amount, combined dropping tokens) until the first refresh.
-        storageKey: String = "openusage.providerSnapshots.v3",
+        // v4/v5: `.values` rows gained Codex reset-credit expiry data — v4 carried a single `resetsAt`,
+        // v5 replaced it with an `expiriesAt` list (one per available credit, shown in the row's
+        // tooltip). Old payloads decode cleanly (the absent key → empty list), but the bump refetches
+        // once so the expiries show immediately on upgrade instead of after the cached snapshot expires.
+        storageKey: String = "openusage.providerSnapshots.v5",
         ttl: TimeInterval = RefreshSetting.interval,
         now: @escaping () -> Date = Date.init
     ) {

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -263,11 +263,14 @@ final class WidgetDataStore {
             )
         case .text(_, let value, _, _):
             return resolveText(value, descriptor: descriptor)
-        case .values(_, let values, _):
+        case .values(_, let values, _, let expiriesAt):
             // The number is carried raw — no regex re-parse. Presentation (title, icon, selection,
             // trailing word) comes from the descriptor's sample; the live numbers come from the line.
             var data = descriptor.sample
             data.values = values
+            // Optional expiry instants (Codex rate-limit-reset credits): surfaced in the row's hover
+            // tooltip (see `expiryTooltip`), with the row re-rendering on the clock tick so they stay live.
+            data.expiriesAt = expiriesAt
             // A tile whose selection finds no value (e.g. a cost-only tile on a day ccusage couldn't
             // price) has nothing real to show — render "No data" rather than a misleading $0.00 / 0.
             data.hasData = !data.selectedValues.isEmpty

--- a/Sources/OpenUsage/Support/Formatters.swift
+++ b/Sources/OpenUsage/Support/Formatters.swift
@@ -27,14 +27,31 @@ enum Formatters {
         now: Date = Date(),
         calendar: Calendar = .current
     ) -> String? {
+        guard let when = whenLabel(at: date, mode: mode, now: now, calendar: calendar) else { return nil }
+        if when == imminent { return "\(prefix) \(when)" }
+        switch mode {
+        case .relative: return "\(prefix) in \(when)"
+        case .absolute: return "\(prefix) \(when)"
+        }
+    }
+
+    /// The verb-less "when" phrase shared by `deadlineLabel` (which prefixes a verb) and the
+    /// reset-credit tooltip (which lists bare entries): `.relative` → "2d 6h" / `imminent`;
+    /// `.absolute` → "today at 5:30 PM" / "tomorrow at 9:00 AM" / "Feb 15 at 3:45 PM" / `imminent`
+    /// (past-due or ≤5 min out). `nil` only when the duration is non-finite.
+    static func whenLabel(
+        at date: Date,
+        mode: ResetDisplayMode,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> String? {
         switch mode {
         case .relative:
             let seconds = date.timeIntervalSince(now)
-            if seconds <= 5 * 60 { return "\(prefix) soon" }
-            guard let duration = compactDuration(seconds) else { return nil }
-            return "\(prefix) in \(duration)"
+            if seconds <= 5 * 60 { return imminent }
+            return compactDuration(seconds)
         case .absolute:
-            guard date.timeIntervalSince(now) > 0 else { return "\(prefix) soon" }
+            guard date.timeIntervalSince(now) > 0 else { return imminent }
             let dayDiff = calendar.dateComponents(
                 [.day],
                 from: calendar.startOfDay(for: now),
@@ -42,12 +59,16 @@ enum Formatters {
             ).day ?? 0
             // The wall-clock part honors the user's Auto/12h/24h time-format setting.
             let time = TimeFormatSetting.current.shortTime(date)
-            if dayDiff <= 0 { return "\(prefix) today at \(time)" }
-            if dayDiff == 1 { return "\(prefix) tomorrow at \(time)" }
+            if dayDiff <= 0 { return "today at \(time)" }
+            if dayDiff == 1 { return "tomorrow at \(time)" }
             let day = date.formatted(.dateTime.month(.abbreviated).day())
-            return "\(prefix) \(day) at \(time)"
+            return "\(day) at \(time)"
         }
     }
+
+    /// The collapsed phrase for a deadline that's past-due or within ~5 minutes — too close to print a
+    /// useful countdown. Shared so `deadlineLabel` and any bare-`whenLabel` caller agree on the wording.
+    static let imminent = "soon"
 
     static func resetRelativeLabel(until resetsAt: Date, now: Date = Date()) -> String? {
         deadlineLabel("Resets", at: resetsAt, mode: .relative, now: now)

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -45,7 +45,7 @@ struct WidgetRowView: View {
         // original app uses — instead of waiting for the next data refresh. TimelineView only schedules
         // ticks while the popover is actually visible. Rows without a reset date are static.
         Group {
-            if data.resetsAt != nil {
+            if data.resetsAt != nil || !data.expiriesAt.isEmpty {
                 TimelineView(.periodic(from: .now, by: 30)) { _ in
                     rowContent
                 }
@@ -240,17 +240,20 @@ struct WidgetRowView: View {
             labelColumn
             Spacer(minLength: 12)
             VStack(alignment: .trailing, spacing: 2) {
-                Text(data.unboundedDetail)
-                    .font(supportingFont)
-                    .foregroundStyle(.primary) // the value is the row's payload — match the bounded headline
-                    .contentTransition(.numericText())
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-                    // Hover target is the value text itself (and the ⓘ), not the whole row — the same
-                    // per-element pattern the bounded row uses for "x left" and "Resets in …". Reveals
-                    // the exact figures the compact value shortens, or "No usage in this period" on a
-                    // zero row; nil (no tooltip) on a small, already-full, non-zero row.
-                    .hoverTooltip(unboundedHoverText)
+                HStack(spacing: 4) {
+                    expiryWarningIcon
+                    Text(data.unboundedDetail)
+                        .font(supportingFont)
+                        .foregroundStyle(.primary) // the value is the row's payload — match the bounded headline
+                        .contentTransition(.numericText())
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                        // Hover target is the value text itself (and the ⓘ), not the whole row — the same
+                        // per-element pattern the bounded row uses for "x left" and "Resets in …". Reveals
+                        // the exact figures the compact value shortens, or "No usage in this period" on a
+                        // zero row; nil (no tooltip) on a small, already-full, non-zero row.
+                        .hoverTooltip(unboundedHoverText)
+                }
                 if let subtitle = data.unboundedSubtitle {
                     // Secondary, not tertiary: the subtitle is informational ("on-device estimate"),
                     // and tertiary is reserved for inactive content on glass.
@@ -261,6 +264,20 @@ struct WidgetRowView: View {
                 }
             }
             .multilineTextAlignment(.trailing)
+        }
+    }
+
+    /// Amber warning triangle shown just before the value when a reset credit is about to expire
+    /// (`hasImminentExpiry`). Carries the same expiry tooltip as the value, so hovering it reveals which
+    /// credits are expiring and when. Renders nothing otherwise.
+    @ViewBuilder
+    private var expiryWarningIcon: some View {
+        if data.hasImminentExpiry {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: density.supportingPointSize - 1))
+                .foregroundStyle(severityColor(.warning))
+                .hoverTooltip(unboundedHoverText)
+                .accessibilityLabel("A reset credit is expiring soon")
         }
     }
 
@@ -297,6 +314,9 @@ struct WidgetRowView: View {
     /// ("$0.00 · 0 tokens") still pops something (and carries an ⓘ). `nil` for a small, already-full,
     /// non-zero row, which has nothing to add.
     private var unboundedHoverText: String? {
+        // The reset-credit row's per-credit expiry breakdown takes precedence (it's the whole point of
+        // the ⓘ on "2 available"); its tiny count never has a figures tooltip anyway.
+        if let expiry = data.expiryTooltip { return expiry }
         if let figures = data.unboundedTooltip { return figures }
         // The "no usage" note only fits a spend period (Today / Yesterday / Last 30 Days), where a zero
         // genuinely means nothing was used. A balance row that reads 0 (Codex Rate Limit Resets, an

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -331,7 +331,7 @@ final class ClaudeProviderTests: XCTestCase {
     }
 
     private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {
-        guard case .values(_, let values, _) = lines.first(where: { $0.label == label }) else {
+        guard case .values(_, let values, _, _) = lines.first(where: { $0.label == label }) else {
             return nil
         }
         return values

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -204,6 +204,39 @@ final class CodexUsageMapperTests: XCTestCase {
         ])
     }
 
+    func testExpiriesPreservedWhenStatusOmitted() throws {
+        // `status` is optional upstream — a credit with `expires_at` but no `status` must still count
+        // toward the expiry list (otherwise the tooltip and the 24h warning vanish for that response
+        // shape). An explicitly non-available credit is still dropped. (Regression for the Codex-flagged
+        // "preserve expiries when status is omitted".)
+        let usage = HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8))
+        let resetCredits = HTTPResponse(statusCode: 200, headers: [:], body: Data("""
+        {
+          "available_count": 2,
+          "credits": [
+            { "expires_at": "2026-02-20T19:00:00.000Z" },
+            { "expires_at": "2026-02-20T17:30:00.000Z" },
+            { "status": "consumed", "expires_at": "2026-02-20T16:10:00.000Z" }
+          ]
+        }
+        """.utf8))
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            usage,
+            resetCredits: resetCredits,
+            now: OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        )
+
+        guard case .values(_, _, _, let expiriesAt) = mapped.lines.first(where: { $0.label == "Rate Limit Resets" }) else {
+            return XCTFail("expected a Rate Limit Resets values line")
+        }
+        // The two status-less credits are kept (sorted); the "consumed" one is dropped.
+        XCTAssertEqual(expiriesAt, [
+            OpenUsageISO8601.date(from: "2026-02-20T17:30:00.000Z")!,
+            OpenUsageISO8601.date(from: "2026-02-20T19:00:00.000Z")!
+        ])
+    }
+
     func testFallsBackToUsageBodyCountWhenDedicatedFetchUnavailable() throws {
         // No dedicated response (the fetch failed): the count falls back to the usage body's embedded
         // object, and with no expiry list `expiriesAt` is empty.

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -223,6 +223,25 @@ final class CodexUsageMapperTests: XCTestCase {
         XCTAssertTrue(expiriesAt.isEmpty)
     }
 
+    func testDedicatedNullCountFallsBackToUsageBodyCount() throws {
+        // A 2xx dedicated payload whose `available_count` is JSON null (NSNull, which is non-nil) must NOT
+        // be selected as the source — doing so would drop the whole row. It falls back to the usage body's
+        // valid embedded count instead. (Regression for the bot-flagged NSNull nil-check.)
+        let usage = HTTPResponse(statusCode: 200, headers: [:],
+                                 body: Data(#"{ "rate_limit_reset_credits": { "available_count": 2 } }"#.utf8))
+        let resetCredits = HTTPResponse(statusCode: 200, headers: [:],
+                                        body: Data(#"{ "available_count": null }"#.utf8))
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            usage,
+            resetCredits: resetCredits,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertEqual(values(mapped.lines, "Rate Limit Resets"),
+                       [MetricValue(number: 2, kind: .count, label: "available")])
+    }
+
     func testDedicatedNon2xxFallsBackToUsageBodyCount() throws {
         // A non-2xx dedicated response is ignored (treated as unavailable), so the count falls back to
         // the usage body — never a dropped row just because the extra endpoint erred.

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -147,7 +147,8 @@ final class CodexUsageMapperTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
-        XCTAssertEqual(values(mapped.lines, "Rate Limit Resets"), [MetricValue(number: 1, kind: .count)])
+        XCTAssertEqual(values(mapped.lines, "Rate Limit Resets"),
+                       [MetricValue(number: 1, kind: .count, label: "available")])
 
         let resetIndex = mapped.lines.firstIndex { $0.label == "Rate Limit Resets" }
         let creditsIndex = mapped.lines.firstIndex { $0.label == "Credits" }
@@ -167,7 +168,76 @@ final class CodexUsageMapperTests: XCTestCase {
             now: Date(timeIntervalSince1970: 1_800_000_000)
         )
 
-        XCTAssertEqual(values(mapped.lines, "Rate Limit Resets"), [MetricValue(number: 0, kind: .count)])
+        XCTAssertEqual(values(mapped.lines, "Rate Limit Resets"),
+                       [MetricValue(number: 0, kind: .count, label: "available")])
+    }
+
+    func testDedicatedEndpointSuppliesCountAndSortedExpiries() throws {
+        // The dedicated endpoint carries the per-credit expiry list the usage body lacks, so the count
+        // comes from it and `expiriesAt` holds every still-available credit's expiry, sorted soonest
+        // first. A non-"available" credit (the "consumed" one here) is excluded entirely.
+        let usage = HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8))
+        let resetCredits = HTTPResponse(statusCode: 200, headers: [:], body: Data("""
+        {
+          "available_count": 2,
+          "credits": [
+            { "status": "available", "expires_at": "2026-02-20T19:00:00.000Z" },
+            { "status": "available", "expires_at": "2026-02-20T17:30:00.000Z" },
+            { "status": "consumed", "expires_at": "2026-02-20T16:10:00.000Z" }
+          ]
+        }
+        """.utf8))
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            usage,
+            resetCredits: resetCredits,
+            now: OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        )
+
+        guard case .values(_, let vals, _, let expiriesAt) = mapped.lines.first(where: { $0.label == "Rate Limit Resets" }) else {
+            return XCTFail("expected a Rate Limit Resets values line")
+        }
+        XCTAssertEqual(vals, [MetricValue(number: 2, kind: .count, label: "available")])
+        XCTAssertEqual(expiriesAt, [
+            OpenUsageISO8601.date(from: "2026-02-20T17:30:00.000Z")!,
+            OpenUsageISO8601.date(from: "2026-02-20T19:00:00.000Z")!
+        ])
+    }
+
+    func testFallsBackToUsageBodyCountWhenDedicatedFetchUnavailable() throws {
+        // No dedicated response (the fetch failed): the count falls back to the usage body's embedded
+        // object, and with no expiry list `expiriesAt` is empty.
+        let usage = HTTPResponse(statusCode: 200, headers: [:],
+                                 body: Data(#"{ "rate_limit_reset_credits": { "available_count": 3 } }"#.utf8))
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            usage,
+            resetCredits: nil,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        guard case .values(_, let vals, _, let expiriesAt) = mapped.lines.first(where: { $0.label == "Rate Limit Resets" }) else {
+            return XCTFail("expected a Rate Limit Resets values line")
+        }
+        XCTAssertEqual(vals, [MetricValue(number: 3, kind: .count, label: "available")])
+        XCTAssertTrue(expiriesAt.isEmpty)
+    }
+
+    func testDedicatedNon2xxFallsBackToUsageBodyCount() throws {
+        // A non-2xx dedicated response is ignored (treated as unavailable), so the count falls back to
+        // the usage body — never a dropped row just because the extra endpoint erred.
+        let usage = HTTPResponse(statusCode: 200, headers: [:],
+                                 body: Data(#"{ "rate_limit_reset_credits": { "available_count": 1 } }"#.utf8))
+        let resetCredits = HTTPResponse(statusCode: 500, headers: [:], body: Data("<html>oops</html>".utf8))
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            usage,
+            resetCredits: resetCredits,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertEqual(values(mapped.lines, "Rate Limit Resets"),
+                       [MetricValue(number: 1, kind: .count, label: "available")])
     }
 
     func testOmitsRateLimitResetsWhenCountMalformed() throws {
@@ -190,7 +260,7 @@ final class CodexUsageMapperTests: XCTestCase {
     }
 
     private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {
-        guard case .values(_, let values, _) = lines.first(where: { $0.label == label }) else {
+        guard case .values(_, let values, _, _) = lines.first(where: { $0.label == label }) else {
             return nil
         }
         return values
@@ -236,7 +306,7 @@ final class CodexProviderTests: XCTestCase {
     }
 
     private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {
-        guard case .values(_, let values, _) = lines.first(where: { $0.label == label }) else {
+        guard case .values(_, let values, _, _) = lines.first(where: { $0.label == label }) else {
             return nil
         }
         return values

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -146,7 +146,7 @@ final class CursorSpendRangeTests: XCTestCase {
     }
 
     private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {
-        guard case .values(_, let values, _) = lines.first(where: { $0.label == label }) else { return nil }
+        guard case .values(_, let values, _, _) = lines.first(where: { $0.label == label }) else { return nil }
         return values
     }
 }
@@ -311,7 +311,7 @@ private func textValue(_ lines: [MetricLine], _ label: String) -> String? {
     guard let line = lines.first(where: { $0.label == label }) else { return nil }
     if case .text(_, let value, _, _) = line { return value }
     // Cursor spend is now a `.values` row carrying a single dollar value; render it in full.
-    if case .values(_, let values, _) = line, let dollars = values.first(where: { $0.kind == .dollars }) {
+    if case .values(_, let values, _, _) = line, let dollars = values.first(where: { $0.kind == .dollars }) {
         return MetricFormatter.number(dollars.number, kind: .dollars, style: .full)
     }
     return nil

--- a/Tests/OpenUsageTests/GrokProviderTests.swift
+++ b/Tests/OpenUsageTests/GrokProviderTests.swift
@@ -409,7 +409,7 @@ final class GrokProviderTests: XCTestCase {
     }
 
     private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {
-        guard case .values(_, let values, _) = lines.first(where: { $0.label == label }) else { return nil }
+        guard case .values(_, let values, _, _) = lines.first(where: { $0.label == label }) else { return nil }
         return values
     }
 }

--- a/Tests/OpenUsageTests/ResetDisplayTests.swift
+++ b/Tests/OpenUsageTests/ResetDisplayTests.swift
@@ -49,6 +49,72 @@ final class ResetDisplayTests: XCTestCase {
         XCTAssertEqual(data.resetTooltip?.hasPrefix("Resets in "), true)      // opposite = relative
     }
 
+    func testExpiryTooltipSingleCreditFollowsTimeSetting() {
+        // One reset credit: the row reads "1 available" and the hover tooltip is a single line. Relative
+        // → "Reset expires in 12d 18h"; absolute → a wall-clock phrase ("Reset expires … at …").
+        var data = WidgetData(title: "Rate Limit Resets", icon: .symbol("clock"),
+                              kind: .count, used: 0, limit: nil)
+        data.values = [MetricValue(number: 1, kind: .count, label: "available")]
+        data.expiriesAt = [Date().addingTimeInterval(12 * 24 * 3600 + 18 * 3600)] // ~12d18h out
+
+        XCTAssertEqual(data.unboundedDetail, "1 available")
+
+        data.resetDisplayMode = .relative
+        XCTAssertEqual(data.expiryTooltip, "Reset expires in 12d 18h")
+
+        data.resetDisplayMode = .absolute
+        XCTAssertEqual(data.expiryTooltip?.hasPrefix("Reset expires "), true)
+        XCTAssertEqual(data.expiryTooltip?.contains(" at "), true)        // wall-clock, not "in"
+    }
+
+    func testExpiryTooltipMultipleCreditsIsNumberedList() {
+        // Several credits: the tooltip is a numbered list under a header, sorted soonest-first, each
+        // entry following the global mode. The row itself still reads just the count.
+        var data = WidgetData(title: "Rate Limit Resets", icon: .symbol("clock"),
+                              kind: .count, used: 0, limit: nil)
+        data.values = [MetricValue(number: 2, kind: .count, label: "available")]
+        data.expiriesAt = [
+            Date().addingTimeInterval(12 * 24 * 3600 + 18 * 3600), // ~12d18h
+            Date().addingTimeInterval(22 * 24 * 3600 + 12 * 3600)  // ~22d12h
+        ]
+        data.resetDisplayMode = .relative
+
+        XCTAssertEqual(data.unboundedDetail, "2 available")
+        XCTAssertEqual(data.expiryTooltip, "Resets expire in:\n1. 12d 18h\n2. 22d 12h")
+    }
+
+    func testHasImminentExpiryTracksWarningWindow() {
+        // The warning triangle fires when the soonest credit expires within `expiryWarningWindow`.
+        // Anchored to the constant so it survives the eventual 21d→24h revert.
+        var data = WidgetData(title: "Rate Limit Resets", icon: .symbol("clock"),
+                              kind: .count, used: 0, limit: nil)
+        data.values = [MetricValue(number: 2, kind: .count, label: "available")]
+
+        // Soonest just inside the window → warning (even though a later credit is well outside it).
+        data.expiriesAt = [
+            Date().addingTimeInterval(WidgetData.expiryWarningWindow - 3600),
+            Date().addingTimeInterval(WidgetData.expiryWarningWindow + 10 * 24 * 3600)
+        ]
+        XCTAssertTrue(data.hasImminentExpiry)
+
+        // Every credit comfortably outside the window → no warning.
+        data.expiriesAt = [Date().addingTimeInterval(WidgetData.expiryWarningWindow + 24 * 3600)]
+        XCTAssertFalse(data.hasImminentExpiry)
+
+        // No expiries at all → no warning.
+        data.expiriesAt = []
+        XCTAssertFalse(data.hasImminentExpiry)
+    }
+
+    func testNoExpiryTooltipWhenNoExpiries() {
+        // The empty state — "0 available" — and any row without expiries carry no expiry tooltip.
+        var data = WidgetData(title: "Rate Limit Resets", icon: .symbol("clock"),
+                              kind: .count, used: 0, limit: nil)
+        data.values = [MetricValue(number: 0, kind: .count, label: "available")]
+        XCTAssertEqual(data.unboundedDetail, "0 available")
+        XCTAssertNil(data.expiryTooltip)
+    }
+
     func testDeadlineLabelSharesFormatAcrossPrefixesAndModes() {
         let calendar = utcCalendar()
         let now = calendar.date(from: DateComponents(year: 2024, month: 6, day: 1, hour: 12))!

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -8,7 +8,7 @@ Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI
 |---|---|
 | Session | 5-hour rolling window usage |
 | Weekly | 7-day window usage |
-| Rate Limit Resets | On-demand rate-limit reset credits, shown as a count (e.g. `2`) |
+| Rate Limit Resets | On-demand rate-limit reset credits, shown as a count (e.g. `2 available`); hover for each credit's expiry, with a warning triangle when one is about to expire |
 | Extra Usage | Flex credits, shown verbatim as dollars + credits (e.g. `$31.84 · 796 credits`) |
 | Today / Yesterday / Last 30 Days | Local spend, as cost, tokens, or both (see below) |
 | Plan | Your plan name (optional widget) |
@@ -31,4 +31,4 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Codex logs b
 
 `GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry.
 
-When the response includes `rate_limit_reset_credits.available_count`, OpenUsage shows that count as the "Rate Limit Resets" row (e.g. `2`), placed before Credits.
+The "Rate Limit Resets" row (placed before Credits) shows the on-demand reset-credit count, e.g. `2 available`. OpenUsage also makes a best-effort `GET https://chatgpt.com/backend-api/wham/rate-limit-reset-credits` call — the dedicated endpoint that lists each credit's expiry — and surfaces those on hover (`Reset expires in 12d 18h`, or a numbered `Resets expire in:` list for several), following the global relative/absolute time setting. A warning triangle appears beside the count when the soonest credit is within 24 hours of expiring. If that call fails, the row falls back to the count embedded in the usage body (`rate_limit_reset_credits.available_count`) with no expiry tooltip. An empty balance reads `0 available`.


### PR DESCRIPTION
## What & why

Implements #653 — surface Codex on-demand **rate-limit reset credits** in the Codex card, including **when** each credit expires (the original ask: the count alone isn't actionable without the expiry).

The row reads **`2 available`**. Hovering it shows each still-available credit's expiry, and a **warning triangle** appears beside the count when the soonest credit is within **24 hours** of expiring.

| State | Row | Tooltip |
|---|---|---|
| Several credits | `2 available` (⚠️ if soonest < 24h) | `Resets expire in:` / `1. 12d 18h` / `2. 22d 12h` |
| One credit | `1 available` | `Reset expires in 12d 18h` |
| Empty | `0 available` | — |

Everything follows the global **relative/absolute** time setting (absolute → `Reset expires Mar 3 at 5:30 PM`).

## How

- **New best-effort fetch** of the dedicated `GET /wham/rate-limit-reset-credits` endpoint — it carries the per-credit expiry list that the usage body's `rate_limit_reset_credits` lacks. A failure or non-2xx falls back to the usage body's count with no expiry tooltip, so the refresh never fails over this supplementary call (mirrors the JS plugin behavior the issue referenced).
- Collect every `status == "available"` credit's expiry and carry them as raw `[Date]` on the `.values` metric line (`expiriesAt`). Formatting happens live at the display edge, so the tooltip counts down on the popover's 30s tick.
- Added a shared `Formatters.whenLabel` (verb-less "when" phrase) and refactored `deadlineLabel` onto it, so the bare list entries and the prefixed reset countdowns share one definition.
- The warning threshold is `WidgetData.expiryWarningWindow` (24h), driving `hasImminentExpiry` → the amber `exclamationmark.triangle.fill`.
- Bumped the snapshot cache key (`v3` → `v5`) for the new `.values` expiry field.

## Reviewer notes

- The reset-credits fetch adds **one extra network request per Codex refresh** — intended (the dedicated endpoint is the only source of expiry data).
- `expiryWarningWindow` ships at the production **24h** (it was temporarily 21d during local visual testing; reverted before this PR).
- Cache-key bump means one clean refetch on upgrade.
- Tests: new coverage in `CodexProviderTests` (dedicated endpoint + sorted expiries, fallbacks) and `ResetDisplayTests` (tooltip single/multi/none, imminent-expiry window, shared `whenLabel`). Full suite: 331 passing.
- Docs: `docs/providers/codex.md` updated.

## Verification

Built and run locally (signed dev `.app`); confirmed the row, the hover tooltip in both time modes, and the warning triangle. Note: the repo's `script/build_and_run.sh` currently crashes at the `actool` icon-compile step on macOS 27 (unrelated to this change — `swift build` is fine); I launched via a copy that skips that cosmetic step. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Supplementary Codex network call with graceful fallback; display and model extensions are backward-compatible (empty `expiriesAt` default).
> 
> **Overview**
> Codex **rate-limit reset credits** now display as **`N available`** instead of a bare count, with **per-credit expiry** on hover and a **24h warning triangle** when the soonest credit is about to expire.
> 
> Each Codex refresh adds a **best-effort** `GET` to `/wham/rate-limit-reset-credits` (Codex desktop headers). Failures do not fail the refresh; the mapper falls back to the usage body’s `available_count` with no expiry tooltip. Dedicated responses supply sorted `expiriesAt` on `.values` metric lines (raw `Date`s, encoded in cache v5).
> 
> **UI plumbing:** `WidgetData` builds live `expiryTooltip` from global relative/absolute mode; rows with expiries tick every 30s like reset countdowns. `Formatters.whenLabel` shares deadline phrasing with reset labels. The local HTTP API exposes the **soonest** expiry as `resetsAt` on the legacy text-shaped wire row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f0862d6ddc33a9e2e54d96a1fda417026aab30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Codex rate‑limit reset credits as “N available,” with each credit’s expiry on hover and a warning when the soonest expiry is within 24h. Fetches the dedicated reset‑credits endpoint and falls back to the usage body count if unavailable.

- **New Features**
  - Tooltip lists per‑credit expiries and respects the global relative/absolute time setting (single: “Reset expires …”; multiple: numbered list); updates every 30s.
  - Warning triangle appears when the soonest expiry is within 24h.
  - Best‑effort GET https://chatgpt.com/backend-api/wham/rate-limit-reset-credits; on error or non‑2xx, uses the usage body’s count. Added `expiriesAt` to `.values` and `Formatters.whenLabel`; snapshot cache bumped to `v5`. One extra network request per Codex refresh.

- **Bug Fixes**
  - Validate the dedicated endpoint’s `available_count` is numeric before using it; otherwise fall back to the usage body’s count to avoid dropping the row when the field is `null`.

<sup>Written for commit a87115f26baf79d346d13a566a43988c0bc848f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/robinebers/openusage/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

