### PR TITLE
feat(dashboard): add provider-header drag handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .build/
 dist/
+node_modules/
 *.log
 .agents/worktrees/
 

--- a/Sources/OpenUsage/Stores/DensitySetting.swift
+++ b/Sources/OpenUsage/Stores/DensitySetting.swift
@@ -34,8 +34,9 @@ enum DensitySetting: String, Hashable, Sendable, CaseIterable {
     /// of reading as a second heavy line.
     var supportingPointSize: CGFloat { self == .compact ? 11 : 12 }
 
-    /// Provider name in the section header.
-    var headerPointSize: CGFloat { self == .compact ? 12 : 13 }
+    /// Provider name in the section header — a touch larger than the metric label below it so the
+    /// section title reads as the heaviest thing in the group.
+    var headerPointSize: CGFloat { self == .compact ? 13 : 14 }
 
     /// Provider mark in the section header.
     var headerIconSize: CGFloat { self == .compact ? 14 : 16 }
@@ -58,7 +59,7 @@ enum DensitySetting: String, Hashable, Sendable, CaseIterable {
     /// Top padding for a text-only row sitting directly under another text-only row — the
     /// neighbor-aware rule, active in **both** densities so runs of one-liners (Today / Yesterday /
     /// Last 30 Days) always read as one cluster; Compact pulls them a step harder.
-    var condensedTextRowTopPadding: CGFloat { self == .compact ? 2 : 3 }
+    var condensedTextRowTopPadding: CGFloat { self == .compact ? 1 : 2 }
 
     /// Spacing inside a bounded row between the label, the meter, and the reading line.
     var rowInnerSpacing: CGFloat { self == .compact ? 3 : 4 }

--- a/Sources/OpenUsage/Views/ProviderSectionHeader.swift
+++ b/Sources/OpenUsage/Views/ProviderSectionHeader.swift
@@ -20,23 +20,36 @@ struct ProviderSectionHeader<Trailing: View>: View {
     /// (dashboard only; `nil` in Customize / reorder previews, which never surface staleness). Its tooltip
     /// carries the precise age.
     var staleness: StalenessHint?
+    /// Dashboard-only: when true, a small dot-grid grip leads the name to signal the header line is
+    /// draggable (providers reorder by dragging the header). Off in Customize, which carries its own
+    /// trailing grip.
+    var showsDragHandle: Bool = false
     private let trailing: Trailing
 
     /// Header type and icon track the density setting like the rows do, so Compact shrinks the
     /// whole section anatomy — not just the rows under it.
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
-    init(provider: Provider, plan: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, @ViewBuilder trailing: () -> Trailing) {
+    init(provider: Provider, plan: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, showsDragHandle: Bool = false, @ViewBuilder trailing: () -> Trailing) {
         self.provider = provider
         self.plan = plan
         self.warning = warning
         self.refreshing = refreshing
         self.staleness = staleness
+        self.showsDragHandle = showsDragHandle
         self.trailing = trailing()
     }
 
     var body: some View {
         HStack(spacing: 5) {
+            // A grip leading the name marks the header line as draggable to reorder providers. The
+            // whole line still carries the gesture; this just makes the affordance discoverable.
+            if showsDragHandle {
+                // Purely a visual affordance (the whole header line carries the drag gesture). The
+                // extra trailing gap keeps the grip from crowding the provider name beside it.
+                DragHandleGrip()
+                    .padding(.trailing, 4)
+            }
             // Baseline-aligned pair: the plan badge is smaller type, so centering it against
             // the name leaves it floating high — text sits together only on a shared baseline.
             HStack(alignment: .firstTextBaseline, spacing: 5) {
@@ -83,15 +96,18 @@ struct ProviderSectionHeader<Trailing: View>: View {
                 .frame(width: density.headerIconSize, height: density.headerIconSize)
             trailing
         }
-        .padding(.horizontal, 4)
+        // With the grip leading, shave the left inset so the handle sits a touch closer to the card's
+        // left edge; Customize (no grip) keeps the symmetric inset so its name doesn't shift.
+        .padding(.leading, showsDragHandle ? 2 : 4)
+        .padding(.trailing, 4)
         .padding(.vertical, 2)
         .contentShape(Rectangle())
     }
 }
 
 extension ProviderSectionHeader where Trailing == EmptyView {
-    init(provider: Provider, plan: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil) {
-        self.init(provider: provider, plan: plan, warning: warning, refreshing: refreshing, staleness: staleness) { EmptyView() }
+    init(provider: Provider, plan: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, showsDragHandle: Bool = false) {
+        self.init(provider: provider, plan: plan, warning: warning, refreshing: refreshing, staleness: staleness, showsDragHandle: showsDragHandle) { EmptyView() }
     }
 }
 
@@ -118,5 +134,30 @@ struct ReorderGrip: View {
             .foregroundStyle(.tertiary)
             .frame(width: 16, height: 22)
             .contentShape(Rectangle())
+    }
+}
+
+/// The 2×3 dot-grid grip that leads the dashboard provider name. Kept quiet (tertiary) so it reads
+/// as an affordance hinting the header line can be dragged to reorder providers, not as a control
+/// competing with the name beside it.
+struct DragHandleGrip: View {
+    var body: some View {
+        VStack(spacing: 2) {
+            ForEach(0..<3) { _ in
+                HStack(spacing: 2) {
+                    dot
+                    dot
+                }
+            }
+        }
+        .frame(height: 22)
+        .contentShape(Rectangle())
+        .accessibilityHidden(true)
+    }
+
+    private var dot: some View {
+        Circle()
+            .fill(.tertiary)
+            .frame(width: 1.75, height: 1.75)
     }
 }

--- a/Sources/OpenUsage/Views/ReorderGeometry.swift
+++ b/Sources/OpenUsage/Views/ReorderGeometry.swift
@@ -76,7 +76,7 @@ struct ReorderLiftPreview: View {
         // Same anatomy as the live dashboard section (`WidgetGroupedListView.section` + `container`):
         // header over the shared metric card, at the density's header→card spacing.
         VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
-            ProviderSectionHeader(provider: provider, plan: plan)
+            ProviderSectionHeader(provider: provider, plan: plan, showsDragHandle: true)
                 .padding(.horizontal, 8)
 
             DashboardMetricCard(lifted: true) {

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -48,10 +48,11 @@ struct WidgetGroupedListView: View {
             plan: dataStore.plan(for: group.provider.id),
             warning: dataStore.errorMessage(for: group.provider.id),
             refreshing: dataStore.refreshingProviderIDs.contains(group.provider.id),
-            staleness: dataStore.stalenessHint(for: group.provider.id)
+            staleness: dataStore.stalenessHint(for: group.provider.id),
+            showsDragHandle: true
         )
-        // 8pt here (+ 4pt internal) so the provider header uses the same inset as the Customize screen —
-        // both land the provider name at the same offset from the popover edge.
+        // 8pt (+ 4pt internal) on both sides: insets the drag grip off the card's left edge and
+        // lines the provider mark up with the card's right content edge.
         .padding(.horizontal, 8)
         .highPriorityGesture(providerDragGesture(for: group))
         .contextMenu {


### PR DESCRIPTION
## Summary
- Lead each dashboard provider header with a quiet 2×3 dot grip so the drag-to-reorder affordance is discoverable. The whole header line still carries the gesture; the grip is purely visual (open-hand cursor was tried and removed, the grip is enough).
- Mirror the grip in the lifted reorder preview so the floating chip matches the live header.
- Nudge the grip a touch left (smaller left inset) and keep a small gap to the name; Customize keeps its symmetric inset so its name doesn't shift.
- Bump the provider-name point size slightly so the section title leads its group.
- Tighten the top padding between stacked text-only rows (Today / Yesterday / Last 30 Days) so runs of one-liners read as one cluster.
- chore: add `node_modules/` to `.gitignore`.

## Screenshots

<img width="344" height="406" alt="image" src="https://github.com/user-attachments/assets/965f888d-7791-41e8-ad37-9b2927be753e" />


## Test plan
- [ ] Build and run the menu-bar app (`./script/build_and_run.sh verify`).
- [ ] Open the dashboard popover and confirm the dot grip sits to the left of each provider name.
- [ ] Drag a provider header to reorder providers; confirm the floating preview shows the same grip.
- [ ] Confirm the Customize screen's provider names are unchanged (no grip, same inset).
- [ ] Check Compact and Regular densities both look right.

Made with [Cursor](https://cursor.com)