### PR TITLE
feat(settings): default Reduce Transparency on for readability

### DIFF
--- a/Sources/OpenUsage/Stores/ReduceTransparencySetting.swift
+++ b/Sources/OpenUsage/Stores/ReduceTransparencySetting.swift
@@ -1,9 +1,10 @@
 import Foundation
 
-/// Opt-in switch that drops the popover's Liquid Glass for a solid, higher-contrast surface — the
-/// fix for "I can't read it over a busy desktop" without taking glass away from everyone (it's off
-/// by default). Stored as a plain `Bool` under one `UserDefaults.standard` key, so it doesn't need
-/// the `UserDefaultsBacked` enum machinery; this namespace just holds the key and a live reader.
+/// Switch that drops the popover's Liquid Glass for a solid, higher-contrast surface — the fix for
+/// "I can't read it over a busy desktop". It's *on* by default for readability; users who prefer
+/// glass can turn it off in Settings. Stored as a plain `Bool` under one `UserDefaults.standard`
+/// key, so it doesn't need the `UserDefaultsBacked` enum machinery; this namespace just holds the
+/// key and a live reader.
 ///
 /// The app toggle is OR'd with macOS's own *Reduce Transparency* accessibility setting at the view
 /// layer (`DashboardView`), so a user who has the system setting on gets the solid surface even if
@@ -19,9 +20,11 @@ enum ReduceTransparencySetting {
     /// observed separately, via `NSWorkspace`.)
     static let didChangeNotification = Notification.Name("ReduceTransparencySettingDidChange")
 
-    /// The stored choice, read live from `UserDefaults.standard` (defaults to `false` when unset —
-    /// a missing bool key reads as `false`, which is exactly the "glass on" default we want).
+    /// The stored choice, read live from `UserDefaults.standard`. Defaults to `true` when unset
+    /// (fresh installs and existing users who never touched the toggle get the solid surface); an
+    /// explicit choice is preserved because the key then reads back as a non-nil object. The
+    /// `@AppStorage` sites that mirror this key default to `true` for the same reason.
     static var current: Bool {
-        UserDefaults.standard.bool(forKey: key)
+        UserDefaults.standard.object(forKey: key) as? Bool ?? true
     }
 }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -124,9 +124,9 @@ private struct GlassTint: ShapeStyle {
     }
 }
 
-/// Backs `cardSurface`. With Reduce Transparency *off* (the default) live cards keep the original
-/// look exactly: the translucent quaternary fill and no border, so the toggle-off appearance is
-/// unchanged from before this setting existed. With it *on*, cards take the frosted fill plus the
+/// Backs `cardSurface`. With Reduce Transparency *off* live cards keep the original glass look: the
+/// translucent quaternary fill and no border, so the toggle-off appearance is unchanged from before
+/// this setting existed. With it *on* (the default), cards take the frosted fill plus the
 /// hairline border so they stay distinct over the now-opaque popover (the border is what carries
 /// that separation in dark mode). The lifted drag preview always uses its own legible material and
 /// no border. A `ViewModifier` rather than a plain `View` func so it can read the environment flag.

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -39,7 +39,7 @@ struct DashboardView: View {
     /// Readability control. The app toggle is OR'd with macOS's own Reduce Transparency setting
     /// (`accessibilityReduceTransparency`) into one `effectiveReduceTransparency` flag, pushed down
     /// the tree so every surface renders in its solid form together.
-    @AppStorage(ReduceTransparencySetting.key) private var reduceTransparency = false
+    @AppStorage(ReduceTransparencySetting.key) private var reduceTransparency = true
     @Environment(\.accessibilityReduceTransparency) private var systemReduceTransparency
 
     private static let outerPadding: CGFloat = 14

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -25,7 +25,7 @@ struct SettingsScreen: View {
     @AppStorage(AppearanceSetting.key) private var appearance = AppearanceSetting.system
     @AppStorage(TimeFormatSetting.key) private var timeFormat = TimeFormatSetting.auto
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
-    @AppStorage(ReduceTransparencySetting.key) private var reduceTransparency = false
+    @AppStorage(ReduceTransparencySetting.key) private var reduceTransparency = true
     @AppStorage(LogLevelSetting.key) private var logLevel = LogLevelSetting.fallback
     /// Surfaced under the Advanced rows when copying the path or revealing the file fails.
     @State private var logActionError: String?

--- a/Tests/OpenUsageTests/ReduceTransparencySettingTests.swift
+++ b/Tests/OpenUsageTests/ReduceTransparencySettingTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the "on by default" semantics: an unset key reads as `true` (fresh installs and existing
+/// users who never touched the toggle get the solid surface), while an explicit choice is preserved
+/// in both directions. `current` reads `UserDefaults.standard` directly, so each test saves and
+/// restores the real key to stay hermetic.
+final class ReduceTransparencySettingTests: XCTestCase {
+    private var saved: Any?
+
+    override func setUp() {
+        super.setUp()
+        saved = UserDefaults.standard.object(forKey: ReduceTransparencySetting.key)
+    }
+
+    override func tearDown() {
+        if let saved {
+            UserDefaults.standard.set(saved, forKey: ReduceTransparencySetting.key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: ReduceTransparencySetting.key)
+        }
+        super.tearDown()
+    }
+
+    func testDefaultsToTrueWhenUnset() {
+        UserDefaults.standard.removeObject(forKey: ReduceTransparencySetting.key)
+        XCTAssertTrue(ReduceTransparencySetting.current)
+    }
+
+    func testExplicitFalseIsPreserved() {
+        UserDefaults.standard.set(false, forKey: ReduceTransparencySetting.key)
+        XCTAssertFalse(ReduceTransparencySetting.current)
+    }
+
+    func testExplicitTrueIsPreserved() {
+        UserDefaults.standard.set(true, forKey: ReduceTransparencySetting.key)
+        XCTAssertTrue(ReduceTransparencySetting.current)
+    }
+}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,7 +17,7 @@ Settings lives inside the popover — there is no separate window. Open it with 
 | Theme | System / Light / Dark | App-wide appearance override for the popover. |
 | Density | Default / Compact | Default breathes; Compact is a real information-dense mode — text steps down one size, rows and provider sections pull together, and Customize / Settings rows tighten with them. In both, consecutive one-line metrics (Today / Yesterday / …) pull together; Compact pulls harder. |
 | Time Format | Auto / 12-hour / 24-hour | How exact times read (e.g. "Resets today at 6:38 PM" vs "18:38"). Auto follows the system. |
-| Reduce Transparency | on/off | Off keeps the fully translucent Liquid Glass look (cards stay light and glassy). On makes the popover background solid and the cards frosted so they read better over a busy or bright desktop — the glass buttons and controls stay. Turns on automatically if you have macOS's own Reduce Transparency (System Settings → Accessibility → Display) enabled. |
+| Reduce Transparency | on/off | On by default. On makes the popover background solid and the cards frosted so they read better over a busy or bright desktop — the glass buttons and controls stay. Turn it off to get the fully translucent Liquid Glass look (cards stay light and glassy). Stays on regardless if you have macOS's own Reduce Transparency (System Settings → Accessibility → Display) enabled. |
 
 ## Usage Display
 


### PR DESCRIPTION
Closes #684

## What

Turns the in-app **Reduce Transparency** toggle **on by default**, so the popover ships with the solid, higher-contrast surface (frosted cards) instead of Liquid Glass — the readable-over-a-busy-desktop look.

## How

- `ReduceTransparencySetting.current` now reads `true` when the key is unset, via an object-existence check (`object(forKey:) as? Bool ?? true`). This means:
  - **Fresh installs** get the solid surface.
  - **Existing users who never touched the toggle** also get it (the key reads as absent).
  - **An explicit choice in either direction is preserved** — flipping it off and leaving it off reads back as a non-nil object, so those users keep glass.
- The two `@AppStorage` mirrors (`DashboardView`, `SettingsScreen`) default to `true` to match, keeping the SwiftUI views and the AppKit backdrop (`StatusItemController.applyReduceTransparency`, which reads `current`) in agreement.
- Updated the stale "off by default" comments (`ReduceTransparencySetting`, `Theme.swift`) and `docs/settings.md`.

No one-time migration is needed — `current`'s default applies to everyone who hasn't made an explicit choice, which is exactly the desired "on by default for new and existing untouched users" behavior.

## Test

- New `ReduceTransparencySettingTests`: unset → `true`, explicit `false` preserved, explicit `true` preserved.
- `swift build` and the new tests pass locally.

> Note: verified via build + unit tests only; the visual surface swap was not manually verified in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Appearance-only default change with explicit user choices preserved; no auth, data, or migration logic.
> 
> **Overview**
> **Reduce Transparency** is now **on by default**, so new installs and anyone who never touched the toggle get the solid popover and frosted cards instead of Liquid Glass.
> 
> `ReduceTransparencySetting.current` no longer uses `bool(forKey:)` (missing keys read as `false`); it uses `object(forKey:) as? Bool ?? true` so an absent key means solid, while an explicit `true` or `false` in `UserDefaults` is unchanged. **`DashboardView`** and **`SettingsScreen`** `@AppStorage` initial values match (`true`). Comments in **`Theme.swift`** / the setting store and **`docs/settings.md`** describe the new default.
> 
> **`ReduceTransparencySettingTests`** lock in unset → `true` and both explicit values preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f58c39dd53cc1bc9c1636f442d3fe349cf74e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->