### PR TITLE
fix(dashboard): restore estimate note on spend-row ⓘ tooltip (#683)

### DIFF
--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -338,6 +338,31 @@ struct WidgetData: Hashable {
         return selected.map { MetricFormatter.string(for: $0, style: .full) }.joined(separator: " · ")
     }
 
+    /// Hover text for an unbounded row's **value** (and the expiry-warning icon): the per-credit expiry
+    /// breakdown on a reset-credit row, else the exact figures the compact value shortens, else a "no
+    /// usage" note on a zero spend period (so an empty "$0.00 · 0 tokens" row still reveals something).
+    /// `nil` for a small, already-full, non-zero row, which has nothing to add. This is deliberately the
+    /// figures/expiry hover — `infoNote` (the estimate disclaimer) never displaces it on the value.
+    var unboundedValueTooltip: String? {
+        // The reset-credit row's per-credit expiry breakdown takes precedence (it's the whole point of
+        // the ⓘ on "2 available"); its tiny count never has a figures tooltip anyway.
+        if let expiry = expiryTooltip { return expiry }
+        if let figures = unboundedTooltip { return figures }
+        // The "no usage" note only fits a spend period (Today / Yesterday / Last 30 Days), where a zero
+        // genuinely means nothing was used. A balance row that reads 0 (Codex Rate Limit Resets, an
+        // exhausted Extra Usage credit) is depleted, not idle, so it gets no note and no ⓘ.
+        return isZeroUsage && isUsagePeriod ? "No usage in this period" : nil
+    }
+
+    /// Hover text for an unbounded row's **label ⓘ**: the estimate disclaimer (`infoNote`) takes
+    /// precedence for locally-imputed spend rows ("Estimated locally, so it may be off."), falling back
+    /// to the figures/expiry hover so reset-credit rows still surface their per-credit expiry list and
+    /// non-estimated rows keep their figures. Separated from `unboundedValueTooltip` so the value on the
+    /// right always reveals the full numbers regardless of what the label ⓘ explains.
+    var unboundedLabelTooltip: String? {
+        infoNote ?? unboundedValueTooltip
+    }
+
     /// True for a zero-usage period — has data, but every selected value is zero (a row reading
     /// "$0.00 · 0 tokens"). Distinct from "no data" and from small non-zero usage, so the row can show
     /// a "no usage" note rather than a figures reveal.

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -256,7 +256,7 @@ struct WidgetRowView: View {
                         // per-element pattern the bounded row uses for "x left" and "Resets in …". Reveals
                         // the exact figures the compact value shortens, or "No usage in this period" on a
                         // zero row; nil (no tooltip) on a small, already-full, non-zero row.
-                        .hoverTooltip(unboundedHoverText)
+                        .hoverTooltip(data.unboundedValueTooltip)
                 }
                 if let subtitle = data.unboundedSubtitle {
                     // Secondary, not tertiary: the subtitle is informational ("on-device estimate"),
@@ -280,7 +280,7 @@ struct WidgetRowView: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: density.supportingPointSize - 1))
                 .foregroundStyle(severityColor(.warning))
-                .hoverTooltip(unboundedHoverText)
+                .hoverTooltip(data.unboundedValueTooltip)
                 .accessibilityLabel("A reset credit is expiring soon")
         }
     }
@@ -309,23 +309,10 @@ struct WidgetRowView: View {
                 .foregroundStyle(.primary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
-            infoIcon(unboundedHoverText)
+            // The label ⓘ explains the row (the estimate disclaimer for locally-imputed spend), while the
+            // value on the right keeps the full-figures/expiry hover — see `unboundedLabelTooltip`.
+            infoIcon(data.unboundedLabelTooltip)
         }
-    }
-
-    /// The hover text for an unbounded row, shared by the row itself and its ⓘ: the exact figures when
-    /// there's usage to reveal, or a "no usage" note on a zero spend period so an empty row
-    /// ("$0.00 · 0 tokens") still pops something (and carries an ⓘ). `nil` for a small, already-full,
-    /// non-zero row, which has nothing to add.
-    private var unboundedHoverText: String? {
-        // The reset-credit row's per-credit expiry breakdown takes precedence (it's the whole point of
-        // the ⓘ on "2 available"); its tiny count never has a figures tooltip anyway.
-        if let expiry = data.expiryTooltip { return expiry }
-        if let figures = data.unboundedTooltip { return figures }
-        // The "no usage" note only fits a spend period (Today / Yesterday / Last 30 Days), where a zero
-        // genuinely means nothing was used. A balance row that reads 0 (Codex Rate Limit Resets, an
-        // exhausted Extra Usage credit) is depleted, not idle, so it gets no note and no ⓘ.
-        return data.isZeroUsage && data.isUsagePeriod ? "No usage in this period" : nil
     }
 
     /// Full-width capsule meter — the Tahoe-era level-indicator form (capsule, full-height

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -311,6 +311,15 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(combinedData.unboundedTooltip, "$478.00 · 891,000 tokens")
         XCTAssertEqual(combinedData.infoNote, WidgetData.ccusageEstimateNote)
 
+        // The label ⓘ carries the estimate disclaimer (regression: #683), while the value on the right
+        // keeps the full figures — the two tooltips must not be the same string.
+        XCTAssertEqual(combinedData.unboundedLabelTooltip, WidgetData.ccusageEstimateNote)
+        XCTAssertEqual(combinedData.unboundedValueTooltip, "$478.00 · 891,000 tokens")
+        XCTAssertEqual(costData.unboundedLabelTooltip, WidgetData.ccusageEstimateNote)
+        // The measured tokens tile has no estimate, so its label ⓘ falls back to the figures hover.
+        XCTAssertNil(tokenData.infoNote)
+        XCTAssertEqual(tokenData.unboundedLabelTooltip, "891,000 tokens")
+
         // An unpriced day (real tokens, no dollar): the cost-only tile finds no dollar value, so it reads
         // "No data" rather than a fabricated $0.00.
         let todayData = store.data(for: todayCost)


### PR DESCRIPTION
## Problem

Fixes #683. The ⓘ (info) icon next to **Today**, **Yesterday**, and **Last 30 Days** (the ccusage-based spend tiles) was showing the same full-precision figures tooltip as the value on the right (e.g. `$12.04 · 9,581,174 tokens`) instead of the estimate disclaimer **"Estimated locally, so it may be off."**

This is a regression — the ⓘ used to carry the estimate explanation. It affects Claude, Codex, and Grok spend rows where dollars are locally imputed from CLI log tokens.

## Root cause

`WidgetDataStore.resolve` correctly sets `data.infoNote = ccusageEstimateNote` on `.values` rows whose selected dollar value is `estimated`. But in `WidgetRowView.labelColumn`, the label's `infoIcon(...)` was hardcoded to `unboundedHoverText` (the figures/expiry hover shared with the value column) and never consulted `data.infoNote`.

## Fix

Split the unbounded hover text into two `WidgetData` properties so the label ⓘ and the value each get the right affordance:

- **`unboundedValueTooltip`** — expiry breakdown → exact figures → "No usage in this period" note. This is the value (and expiry-warning icon) hover; behavior unchanged, just lifted out of the view so it's testable.
- **`unboundedLabelTooltip`** — `infoNote ?? unboundedValueTooltip`. The estimate disclaimer wins on the label, while reset-credit rows (no `infoNote`) still fall back to their per-credit expiry list and non-estimated rows (Cursor) keep their figures.

The value column keeps the full figures/expiry tooltip (desirable, unchanged).

### Result
- Label ⓘ on an estimated spend row → "Estimated locally, so it may be off."
- Hovering the value → full figures (unchanged).
- Reset-credit rows ("N available") → per-credit expiry list on the ⓘ (unchanged).
- Cursor (server-priced, non-estimated) → figures fallback (unchanged).

The doc at `docs/dashboard.md` already described this intended behavior, so no doc change was needed — this brings the code back in line with it.

## Tests

Extended `testCcusageSpendSplitsIntoCostTokensAndCombined` to assert the label tooltip carries the estimate note while the value tooltip stays the full figures, plus that the measured tokens tile falls back to figures. Full suite: 360 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooltip copy and view wiring only; behavior is covered by unit tests and does not touch data resolution or auth.
> 
> **Overview**
> Fixes a regression where the label **ⓘ** on ccusage spend rows (Today / Yesterday / Last 30 Days) showed the same full-precision figures tooltip as the value instead of **"Estimated locally, so it may be off."**
> 
> The shared view helper `unboundedHoverText` is replaced with two `WidgetData` properties: **`unboundedValueTooltip`** (expiry → full figures → zero-period note; used on the value and expiry warning) and **`unboundedLabelTooltip`** (`infoNote` first, then that same figures/expiry chain). `WidgetRowView` wires the label ⓘ to the latter and the trailing value to the former.
> 
> Tests in `testCcusageSpendSplitsIntoCostTokensAndCombined` assert estimated tiles get the disclaimer on the label and full figures on the value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f761ad6ba7e3b1532d7cb50e50f5eb228a06f2a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->