### PR TITLE
refactor: streamline Swift codebase for release (incl. #690)

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -1,4 +1,3 @@
-import SwiftUI
 import Foundation
 import Observation
 

--- a/Sources/OpenUsage/Models/DailyUsageSeries.swift
+++ b/Sources/OpenUsage/Models/DailyUsageSeries.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// A provider-neutral per-day token/cost series — the shared carrier every spend-tracking provider
+/// funnels through `SpendTileMapper` (the Today / Yesterday / Last 30 Days tiles and the Usage Trend
+/// chart).
+///
+/// Sources build it from very different inputs and hand `SpendTileMapper` the same shape so the tiles
+/// render identically regardless of origin: Claude/Codex from `ccusage` output (`CcusageRunner`),
+/// Cursor from its usage CSV export, Grok from its CLI log. The name is deliberately neutral — only
+/// the Claude/Codex path actually involves the ccusage package.
+///
+/// These are internal types with no serialization impact: the local HTTP API serializes `MetricLine`,
+/// not these.
+struct DailyUsageEntry: Hashable, Sendable {
+    var date: String
+    var totalTokens: Int
+    var costUSD: Double?
+}
+
+struct DailyUsageSeries: Hashable, Sendable {
+    var daily: [DailyUsageEntry]
+}

--- a/Sources/OpenUsage/Models/ProviderSnapshot.swift
+++ b/Sources/OpenUsage/Models/ProviderSnapshot.swift
@@ -26,6 +26,19 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
         lines.first { $0.label == label }
     }
 
+    /// The success-path counterpart to `error(provider:message:)`: derives `providerID`/`displayName`
+    /// from the provider so every runtime builds its snapshot the same way (`refreshedAt` is required
+    /// so each call passes its own `now()`).
+    static func make(provider: Provider, plan: String?, lines: [MetricLine], refreshedAt: Date) -> ProviderSnapshot {
+        ProviderSnapshot(
+            providerID: provider.id,
+            displayName: provider.displayName,
+            plan: plan,
+            lines: lines,
+            refreshedAt: refreshedAt
+        )
+    }
+
     static func error(provider: Provider, message: String) -> ProviderSnapshot {
         ProviderSnapshot(
             providerID: provider.id,

--- a/Sources/OpenUsage/Models/ResetDisplayMode.swift
+++ b/Sources/OpenUsage/Models/ResetDisplayMode.swift
@@ -11,7 +11,7 @@ enum ResetDisplayMode: String, Hashable, Sendable, CaseIterable {
     var label: String {
         switch self {
         case .relative: return "Countdown"
-        case .absolute: return "Exact time"
+        case .absolute: return "Exact Time"
         }
     }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -211,34 +211,40 @@ struct ClaudeAuthStore: Sendable {
     private func loadKeychainCredentials() -> ClaudeCredentialState? {
         // The service name is safe to log; NEVER log the returned credential blob / OAuth tokens.
         for service in keychainServiceCandidates() {
-            if let value = try? keychain.readGenericPasswordForCurrentUser(service: service),
-               let parsed = Self.parseCredentials(value),
-               let oauth = parsed.claudeAiOauth,
-               oauth.accessToken?.isEmpty == false {
-                AppLog.debug(.keychain, "read hit service=\(service)")
-                return ClaudeCredentialState(
-                    oauth: oauth,
-                    source: .keychainCurrentUser(service: service),
-                    fullData: parsed,
-                    inferenceOnly: false
-                )
+            if let state = credentialState(
+                from: try? keychain.readGenericPasswordForCurrentUser(service: service),
+                service: service, source: .keychainCurrentUser(service: service)
+            ) {
+                return state
             }
-
-            if let value = try? keychain.readGenericPassword(service: service),
-               let parsed = Self.parseCredentials(value),
-               let oauth = parsed.claudeAiOauth,
-               oauth.accessToken?.isEmpty == false {
-                AppLog.debug(.keychain, "read hit service=\(service)")
-                return ClaudeCredentialState(
-                    oauth: oauth,
-                    source: .keychainLegacy(service: service),
-                    fullData: parsed,
-                    inferenceOnly: false
-                )
+            if let state = credentialState(
+                from: try? keychain.readGenericPassword(service: service),
+                service: service, source: .keychainLegacy(service: service)
+            ) {
+                return state
             }
             AppLog.debug(.keychain, "read miss service=\(service)")
         }
         return nil
+    }
+
+    /// Parse one keychain hit into a credential state, or `nil` if it's absent / malformed / tokenless.
+    /// Shared by the current-user and legacy reads so they don't repeat the parse-guard-log-build block;
+    /// the keychain read itself stays at the call site to preserve the read order and error-swallowing.
+    private func credentialState(
+        from value: String?,
+        service: String,
+        source: ClaudeCredentialState.Source
+    ) -> ClaudeCredentialState? {
+        guard let value,
+              let parsed = Self.parseCredentials(value),
+              let oauth = parsed.claudeAiOauth,
+              oauth.accessToken?.isEmpty == false
+        else {
+            return nil
+        }
+        AppLog.debug(.keychain, "read hit service=\(service)")
+        return ClaudeCredentialState(oauth: oauth, source: source, fullData: parsed, inferenceOnly: false)
     }
 
     private func credentialsPath() -> String {
@@ -262,7 +268,7 @@ struct ClaudeAuthStore: Sendable {
     private func hashSuffix(_ value: String) -> String {
         let normalized = value.precomposedStringWithCanonicalMapping
         let digest = SHA256.hash(data: Data(normalized.utf8))
-        return digest.map { String(format: "%02x", $0) }.joined().prefix(8).description
+        return String(digest.map { String(format: "%02x", $0) }.joined().prefix(8))
     }
 }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -63,22 +63,13 @@ final class ClaudeProvider: ProviderRuntime {
             mapped = try await fetchLiveUsage(state: &state)
         }
 
-        let since = CcusageRunner.sinceString(daysBack: 30, from: now())
-        let tokenUsage = await ccusageRunner.query(provider: .claude, since: since, homePath: authStore.claudeHomeOverride())
-        if case .success(let usage) = tokenUsage {
-            SpendTileMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
-            SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines, now: now(),
-                                             note: "Estimated from local logs at API rates")
-        }
+        await SpendTileMapper.appendCcusageUsage(
+            using: ccusageRunner, provider: .claude, homePath: authStore.claudeHomeOverride(),
+            to: &mapped.lines, now: now()
+        )
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)
-        return ProviderSnapshot(
-            providerID: provider.id,
-            displayName: provider.displayName,
-            plan: mapped.plan,
-            lines: mapped.lines,
-            refreshedAt: now()
-        )
+        return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
     }
 
     private func fetchLiveUsage(state: inout ClaudeCredentialState) async throws -> ClaudeMappedUsage {

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -84,22 +84,13 @@ final class CodexProvider: ProviderRuntime {
         )
         var mapped = try CodexUsageMapper.mapUsageResponse(response, resetCredits: resetCredits, now: now())
 
-        let since = CcusageRunner.sinceString(daysBack: 30, from: now())
-        let tokenUsage = await ccusageRunner.query(provider: .codex, since: since, homePath: authStore.codexHome())
-        if case .success(let usage) = tokenUsage {
-            SpendTileMapper.appendTokenUsage(usage, to: &mapped.lines, now: now())
-            SpendTileMapper.appendUsageTrend(usage, to: &mapped.lines, now: now(),
-                                             note: "Estimated from local logs at API rates")
-        }
+        await SpendTileMapper.appendCcusageUsage(
+            using: ccusageRunner, provider: .codex, homePath: authStore.codexHome(),
+            to: &mapped.lines, now: now()
+        )
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)
-        return ProviderSnapshot(
-            providerID: provider.id,
-            displayName: provider.displayName,
-            plan: mapped.plan,
-            lines: mapped.lines,
-            refreshedAt: now()
-        )
+        return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
     }
 
     /// Fetches the on-demand reset-credit balance (and per-credit expiry) without ever failing the

--- a/Sources/OpenUsage/Providers/Cursor/CursorPricing.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorPricing.swift
@@ -59,12 +59,9 @@ enum CursorPricing {
 
     static func canonicalModel(for model: String) -> String? {
         let range = NSRange(model.startIndex..<model.endIndex, in: model)
-        for rule in aliasRules {
-            if rule.regex.firstMatch(in: model, range: range) != nil {
-                return rule.canonical
-            }
-        }
-        return nil
+        return aliasRules.first { rule in
+            rule.regex.firstMatch(in: model, range: range) != nil
+        }?.canonical
     }
 
     static func pricingEntry(for model: String) -> CursorPricingEntry? {

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -74,25 +74,27 @@ final class CursorProvider: ProviderRuntime {
         guard let usage = ProviderParse.jsonObject(usageResponse.body) else {
             throw CursorUsageError.invalidResponse
         }
+        // The access token may have rotated during the usage fetch's refresh-and-retry; read the live one.
+        let currentToken = authState.accessToken ?? accessToken
 
-        let (planName, planInfoUnavailable) = await fetchPlanName(accessToken: authState.accessToken ?? accessToken)
+        let (planName, planInfoUnavailable) = await fetchPlanName(accessToken: currentToken)
         let fallback = CursorUsageMapper.shouldUseRequestBasedFallback(
             usage: usage,
             planName: planName,
             planInfoUnavailable: planInfoUnavailable
         )
-        if fallback.0 {
+        if fallback.shouldFallback {
             let mapped = try await requestBasedResult(
-                accessToken: authState.accessToken ?? accessToken,
+                accessToken: currentToken,
                 planName: planName,
-                unavailableMessage: fallback.1
+                unavailableMessage: fallback.message
             )
             return snapshot(mapped)
         }
 
         if shouldTryGenericRequestFallback(usage: usage) {
             if let mapped = try? await requestBasedResult(
-                accessToken: authState.accessToken ?? accessToken,
+                accessToken: currentToken,
                 planName: planName,
                 unavailableMessage: "Cursor request-based usage data unavailable. Try again later."
             ) {
@@ -100,8 +102,8 @@ final class CursorProvider: ProviderRuntime {
             }
         }
 
-        let creditGrants = await fetchCreditGrants(accessToken: authState.accessToken ?? accessToken)
-        let stripeResponse = try? await usageClient.fetchStripeBalance(accessToken: authState.accessToken ?? accessToken)
+        let creditGrants = await fetchCreditGrants(accessToken: currentToken)
+        let stripeResponse = try? await usageClient.fetchStripeBalance(accessToken: currentToken)
         let stripeBalanceCents = CursorUsageMapper.stripeBalanceCents(from: stripeResponse ?? nil)
         var mapped = try CursorUsageMapper.mapUsage(
             usage: usage,
@@ -109,7 +111,7 @@ final class CursorProvider: ProviderRuntime {
             creditGrants: creditGrants,
             stripeBalanceCents: stripeBalanceCents
         )
-        await appendSpendLines(to: &mapped.lines, accessToken: authState.accessToken ?? accessToken)
+        await appendSpendLines(to: &mapped.lines, accessToken: currentToken)
         return snapshot(mapped)
     }
 
@@ -229,22 +231,15 @@ final class CursorProvider: ProviderRuntime {
 
     private func shouldTryGenericRequestFallback(usage: [String: Any]) -> Bool {
         guard usage["enabled"] as? Bool != false,
-              let planUsage = usage["planUsage"] as? [String: Any],
-              ProviderParse.number(planUsage["limit"]) == nil,
-              ProviderParse.number(planUsage["totalPercentUsed"]) == nil
+              let planUsage = usage["planUsage"] as? [String: Any]
         else {
             return false
         }
-        return true
+        return ProviderParse.number(planUsage["limit"]) == nil
+            && ProviderParse.number(planUsage["totalPercentUsed"]) == nil
     }
 
     private func snapshot(_ mapped: CursorMappedUsage) -> ProviderSnapshot {
-        ProviderSnapshot(
-            providerID: provider.id,
-            displayName: provider.displayName,
-            plan: mapped.plan,
-            lines: mapped.lines,
-            refreshedAt: now()
-        )
+        ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
     }
 }

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -171,7 +171,7 @@ enum CursorUsageMapper {
         usage: [String: Any],
         planName: String?,
         planInfoUnavailable: Bool
-    ) -> (Bool, String) {
+    ) -> (shouldFallback: Bool, message: String) {
         guard usage["enabled"] as? Bool != false else {
             return (false, "")
         }
@@ -182,14 +182,15 @@ enum CursorUsageMapper {
         let planUsageLimitMissing = hasPlanUsage && !hasPlanUsageLimit
         let hasTotalUsagePercent = planUsage.flatMap { ProviderParse.number($0["totalPercentUsed"]) } != nil
         let normalizedPlan = planName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        let planUsageUnusable = !hasPlanUsage || planUsageLimitMissing
 
-        if (!hasPlanUsage || planUsageLimitMissing) && normalizedPlan == "enterprise" {
+        if planUsageUnusable && normalizedPlan == "enterprise" {
             return (true, "Enterprise usage data unavailable. Try again later.")
         }
-        if (!hasPlanUsage || planUsageLimitMissing) && normalizedPlan == "team" {
+        if planUsageUnusable && normalizedPlan == "team" {
             return (true, "Team request-based usage data unavailable. Try again later.")
         }
-        if (!hasPlanUsage || planUsageLimitMissing) && !hasTotalUsagePercent && normalizedPlan.isEmpty && planInfoUnavailable {
+        if planUsageUnusable && !hasTotalUsagePercent && normalizedPlan.isEmpty && planInfoUnavailable {
             return (true, "Cursor request-based usage data unavailable. Try again later.")
         }
 
@@ -204,7 +205,7 @@ enum CursorUsageMapper {
     }
 
     /// Append the shared Today / Yesterday / Last 30 Days spend tiles from Cursor's CSV rows. The rows
-    /// are aggregated into one local-calendar-day `CcusageDailyUsage` and handed to `SpendTileMapper`
+    /// are aggregated into one local-calendar-day `DailyUsageSeries` and handed to `SpendTileMapper`
     /// — the same builder the Claude/Codex/Grok tiles use — so the output is identical apart from the
     /// `estimated: false` flag (Cursor spend is server-priced, so its dollars carry no ⓘ). Callers only
     /// invoke this when the CSV fetched and parsed, so a failure appends nothing and the tiles read
@@ -222,13 +223,13 @@ enum CursorUsageMapper {
         // Sum raw dollars per day, then snap to whole cents once — rounding per row would accumulate
         // sub-cent drift across a busy day.
         let daily = tokensByDay.keys.sorted(by: >).map { day in
-            CcusageDay(
+            DailyUsageEntry(
                 date: day,
                 totalTokens: tokensByDay[day] ?? 0,
                 costUSD: Double(CursorPricing.toCents(costByDay[day] ?? 0)) / 100
             )
         }
-        SpendTileMapper.appendTokenUsage(CcusageDailyUsage(daily: daily), to: &lines, now: now, estimated: false)
+        SpendTileMapper.appendTokenUsage(DailyUsageSeries(daily: daily), to: &lines, now: now, estimated: false)
     }
 
     private static func dayKey(from date: Date, calendar: Calendar) -> String {

--- a/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
@@ -89,13 +89,7 @@ final class DevinProvider: ProviderRuntime {
     }
 
     private func snapshot(from mapped: DevinMappedUsage) -> ProviderSnapshot {
-        ProviderSnapshot(
-            providerID: provider.id,
-            displayName: provider.displayName,
-            plan: mapped.plan,
-            lines: mapped.lines,
-            refreshedAt: now()
-        )
+        ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
     }
 }
 

--- a/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-/// Builds ccusage-style daily token/cost estimates for Grok from the Grok CLI's local log.
+/// Builds daily token/cost estimates for Grok from the Grok CLI's local log.
 ///
 /// Unlike Claude/Codex (whose spend tiles shell out to `ccusage`), Grok's token data lives in a
 /// single global append-only log, `~/.grok/logs/unified.jsonl`, on `shell.turn.inference_done` lines.
 /// Those lines carry token counts but no model id, so the scanner attributes each row to a model by
 /// tracking the "current model" per CLI process (`pid`) from the model-change events the CLI also
-/// logs. The output is the same `CcusageDailyUsage` shape the Claude/Codex spend tiles consume, so it
+/// logs. The output is the same `DailyUsageSeries` shape the Claude/Codex spend tiles consume, so it
 /// flows straight through `SpendTileMapper`.
 struct GrokLogUsageScanner: Sendable {
     var files: TextFileAccessing
@@ -39,7 +39,7 @@ struct GrokLogUsageScanner: Sendable {
     /// `async` and nonisolated (this is a plain `Sendable` struct, not `@MainActor`), so the whole-file
     /// read + parse runs off the main actor when a `@MainActor` provider `await`s it — the same way
     /// `CcusageRunner.query` keeps Claude/Codex's log work off the UI thread.
-    func scan(daysBack: Int = 30, now: Date = Date()) async -> CcusageDailyUsage? {
+    func scan(daysBack: Int = 30, now: Date = Date()) async -> DailyUsageSeries? {
         let path = logPath
         guard files.exists(path), let text = try? files.readText(path) else {
             return nil
@@ -56,7 +56,7 @@ struct GrokLogUsageScanner: Sendable {
     /// "current model" (tracked regardless of date, so a session straddling the `since` boundary stays
     /// attributed); each in-window `inference_done` row is priced against its `pid`'s current model and
     /// bucketed by local calendar day.
-    static func parse(_ text: String, since: Date) -> CcusageDailyUsage {
+    static func parse(_ text: String, since: Date) -> DailyUsageSeries {
         var modelByPID: [Int: String] = [:]
         var tokensByDay: [String: Int] = [:]
         var costByDay: [String: Double] = [:]
@@ -117,13 +117,13 @@ struct GrokLogUsageScanner: Sendable {
         }
 
         let days = tokensByDay.keys.sorted(by: >).map { day in
-            CcusageDay(
+            DailyUsageEntry(
                 date: day,
                 totalTokens: tokensByDay[day] ?? 0,
                 costUSD: pricedDays.contains(day) ? (costByDay[day] ?? 0) : nil
             )
         }
-        return CcusageDailyUsage(daily: days)
+        return DailyUsageSeries(daily: days)
     }
 
     /// The model id carried by a model-change event, or `nil` for any other line. The Grok CLI signals

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -71,13 +71,7 @@ final class GrokProvider: ProviderRuntime {
             SpendTileMapper.appendTokenUsage(tokenUsage, to: &mapped.lines, now: now())
         }
 
-        return ProviderSnapshot(
-            providerID: provider.id,
-            displayName: provider.displayName,
-            plan: plan,
-            lines: mapped.lines,
-            refreshedAt: now()
-        )
+        return ProviderSnapshot.make(provider: provider, plan: plan, lines: mapped.lines, refreshedAt: now())
     }
 
     private func fetchBillingWithRetry(accessToken: String, state: inout GrokAuthState) async throws -> HTTPResponse {

--- a/Sources/OpenUsage/Providers/SpendTileMapper.swift
+++ b/Sources/OpenUsage/Providers/SpendTileMapper.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Every spend-tracking provider funnels through here so the tiles render identically regardless of
 /// source: Claude / Codex / Grok feed token/cost from their CLI logs (estimated dollars, so the ⓘ),
 /// Cursor feeds server-priced dollars from its CSV export (`estimated: false`, no ⓘ). The data shape
-/// (`CcusageDailyUsage`) is the ccusage runner's output, reused as a neutral per-day carrier.
+/// (`DailyUsageSeries`) is a provider-neutral per-day carrier shared by every source.
 enum SpendTileMapper {
     /// Append the three spend tiles (Today / Yesterday / Last 30 Days). Callers only invoke this once the
     /// source was actually read, so a period with no usage is a real, measured zero — it renders
@@ -13,7 +13,7 @@ enum SpendTileMapper {
     /// `estimated` flags the dollar value as a local estimate (drives the ⓘ); pass `false` for
     /// server-priced sources like Cursor.
     static func appendTokenUsage(
-        _ usage: CcusageDailyUsage,
+        _ usage: DailyUsageSeries,
         to lines: inout [MetricLine],
         now: Date = Date(),
         estimated: Bool = true
@@ -41,10 +41,28 @@ enum SpendTileMapper {
     /// that day. Tokens are always measured (no estimate flag), so the chart needs only the per-day
     /// counts plus a source note. Appends nothing when the whole window is idle, so a source with no
     /// usage leaves "No data" rather than a flat row of zero bars.
-    static func appendUsageTrend(_ usage: CcusageDailyUsage, to lines: inout [MetricLine], now: Date = Date(), note: String) {
+    static func appendUsageTrend(_ usage: DailyUsageSeries, to lines: inout [MetricLine], now: Date = Date(), note: String) {
         let points = trendPoints(usage, now: now)
         guard !points.isEmpty else { return }
         lines.append(.chart(label: "Usage Trend", points: points, note: note))
+    }
+
+    /// Query `ccusage` for the last 30 days and, on success, append the spend tiles + usage-trend chart.
+    /// Claude and Codex both source their spend from `ccusage` and handle the result identically, so the
+    /// query → append sequence (and its "estimated from local logs" note) lives here once.
+    static func appendCcusageUsage(
+        using runner: CcusageRunner,
+        provider: CcusageProvider,
+        homePath: String?,
+        to lines: inout [MetricLine],
+        now: Date
+    ) async {
+        let since = CcusageRunner.sinceString(daysBack: 30, from: now)
+        guard case .success(let usage) = await runner.query(provider: provider, since: since, homePath: homePath) else {
+            return
+        }
+        appendTokenUsage(usage, to: &lines, now: now)
+        appendUsageTrend(usage, to: &lines, now: now, note: "Estimated from local logs at API rates")
     }
 
     /// Per-day token points across the queried window (today + the previous 30 days), oldest first.
@@ -54,7 +72,7 @@ enum SpendTileMapper {
     /// place instead of collapsing two non-adjacent days into neighbors, and the cap is calendar days,
     /// not active ones. Returns empty when nothing was used in the window — there's no trend to draw.
     /// Each point carries a "Jun 21" axis label and a pre-formatted "222M tokens" readout.
-    private static func trendPoints(_ usage: CcusageDailyUsage, now: Date) -> [MetricChartPoint] {
+    private static func trendPoints(_ usage: DailyUsageSeries, now: Date) -> [MetricChartPoint] {
         var tokensByDay: [String: Double] = [:]
         for day in usage.daily {
             let tokens = Double(day.totalTokens)
@@ -110,7 +128,7 @@ enum SpendTileMapper {
         return nil
     }
 
-    private static func dayUsageLine(label: String, entry: CcusageDay?, estimated: Bool) -> MetricLine {
+    private static func dayUsageLine(label: String, entry: DailyUsageEntry?, estimated: Bool) -> MetricLine {
         .values(label: label, values: spendValues(tokens: entry?.totalTokens ?? 0, costUSD: entry?.costUSD, estimated: estimated))
     }
 

--- a/Sources/OpenUsage/Services/CcusageRunner.swift
+++ b/Sources/OpenUsage/Services/CcusageRunner.swift
@@ -27,16 +27,6 @@ enum CcusageRunnerKind: CaseIterable, Sendable {
     }
 }
 
-struct CcusageDay: Hashable, Sendable {
-    var date: String
-    var totalTokens: Int
-    var costUSD: Double?
-}
-
-struct CcusageDailyUsage: Hashable, Sendable {
-    var daily: [CcusageDay]
-}
-
 enum CcusageRunnerError: Error, LocalizedError, Equatable {
     case noRunner
     case failed(String)
@@ -96,11 +86,11 @@ struct CcusageRunner {
     /// whose reason becomes the batch's `lastError`. A timeout is thrown (not returned) so the caller
     /// stops trying fallbacks — matching the Tauri host's "skip fallbacks on timeout".
     private enum Attempt {
-        case success(CcusageDailyUsage)
+        case success(DailyUsageSeries)
         case failed(CcusageRunnerError)
     }
 
-    func query(provider: CcusageProvider, since: String, homePath: String? = nil) async -> Result<CcusageDailyUsage, CcusageRunnerError> {
+    func query(provider: CcusageProvider, since: String, homePath: String? = nil) async -> Result<DailyUsageSeries, CcusageRunnerError> {
         let environment = ccusageEnvironment(provider: provider, homePath: homePath)
         var lastError: CcusageRunnerError = .noRunner
         // The cached runner kind already tried (and failed) this pass, so the fallback loop skips it
@@ -352,7 +342,7 @@ struct CcusageRunner {
         return nested
     }
 
-    static func parseOutput(_ stdout: String) -> CcusageDailyUsage? {
+    static func parseOutput(_ stdout: String) -> DailyUsageSeries? {
         guard let jsonText = extractLastJSONValue(stdout),
               let data = jsonText.data(using: .utf8),
               let raw = try? JSONSerialization.jsonObject(with: data)
@@ -370,7 +360,7 @@ struct CcusageRunner {
             return nil
         }
 
-        let days = dailyRaw.compactMap { entry -> CcusageDay? in
+        let days = dailyRaw.compactMap { entry -> DailyUsageEntry? in
             guard let object = entry as? [String: Any],
                   let date = object["date"] as? String
             else {
@@ -378,10 +368,10 @@ struct CcusageRunner {
             }
             let totalTokens = readInt(object["totalTokens"]) ?? 0
             let costUSD = readDouble(object["totalCost"]) ?? readDouble(object["costUSD"])
-            return CcusageDay(date: date, totalTokens: totalTokens, costUSD: costUSD)
+            return DailyUsageEntry(date: date, totalTokens: totalTokens, costUSD: costUSD)
         }
 
-        return CcusageDailyUsage(daily: days)
+        return DailyUsageSeries(daily: days)
     }
 
     static func extractLastJSONValue(_ stdout: String) -> String? {

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -275,7 +275,7 @@ final class LayoutStore {
     var pinnedCount: Int { pinnedMetricIDs.count }
 
     func pinnedCount(forProvider providerID: String) -> Int {
-        pinnedMetricIDs.reduce(0) { $0 + (registry.descriptor(id: $1)?.providerID == providerID ? 1 : 0) }
+        pinnedMetricIDs.count { registry.descriptor(id: $0)?.providerID == providerID }
     }
 
     /// Whether `descriptorID` can be newly pinned without breaking a cap. Already-pinned ids return

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -114,10 +114,10 @@ final class WidgetDataStore {
         let durationMs = Int(Date().timeIntervalSince(start) * 1000)
         // Count THIS batch's actual outcomes, not the long-lived `providerErrors` map (which persists
         // across passes, so reading it would miscount cache hits and stale earlier failures).
-        let refreshed = outcomes.filter { $0 == .refreshed }.count
-        let failed = outcomes.filter { $0 == .failed }.count
-        let cached = outcomes.filter { $0 == .cacheHit }.count
-        let backedOff = outcomes.filter { $0 == .backedOff }.count
+        let refreshed = outcomes.count { $0 == .refreshed }
+        let failed = outcomes.count { $0 == .failed }
+        let cached = outcomes.count { $0 == .cacheHit }
+        let backedOff = outcomes.count { $0 == .backedOff }
         AppLog.info(.refresh, "batch end (\(durationMs)ms, \(refreshed) ok / \(failed) failed / \(cached) cached / \(backedOff) backed off)")
     }
 

--- a/Sources/OpenUsage/Support/MetricFormatter.swift
+++ b/Sources/OpenUsage/Support/MetricFormatter.swift
@@ -27,21 +27,17 @@ enum MetricFormatter {
         case .percent:
             return "\(Int(value.rounded()))%"
         case .dollars:
+            // Tray and row abbreviate four figures and up ("$1.2M", "$2.1K") so neither carries
+            // "$2,059.07"; the full form (tooltips/headlines) always keeps grouped cents.
+            if abs(value) >= 1000, style != .full {
+                return "$" + value.formatted(.number.notation(.compactName).precision(.fractionLength(0...1)).locale(locale))
+            }
             switch style {
             case .tray:
-                // Shortest: whole dollars under $1k ("$130"), abbreviated above ("$1.2M").
-                if abs(value) >= 1000 {
-                    return "$" + value.formatted(.number.notation(.compactName).precision(.fractionLength(0...1)).locale(locale))
-                }
+                // Shortest below $1k: whole dollars ("$130").
                 return "$" + value.formatted(.number.precision(.fractionLength(0)).locale(locale))
-            case .row:
-                // Abbreviate four figures and up ("$2.1K") so the row can't carry "$2,059.07" beside a
-                // token count — one decimal, matching the token counts next to it; full cents below $1k.
-                if abs(value) >= 1000 {
-                    return "$" + value.formatted(.number.notation(.compactName).precision(.fractionLength(0...1)).locale(locale))
-                }
-                return Formatters.currency(value, fractionDigits: 2)
-            case .full:
+            case .row, .full:
+                // Full cents below $1k; the row's token-count neighbor stays readable.
                 return Formatters.currency(value, fractionDigits: 2)
             }
         case .count:

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -123,6 +123,7 @@ struct WidgetGroupedListView: View {
     /// the global reset-format flip, and a per-provider refresh — without a trip into Customize.
     @ViewBuilder
     private func rowMenu(_ descriptor: WidgetDescriptor, providerID: String) -> some View {
+        let data = dataStore.data(for: descriptor)
         if descriptor.pinnable {
             Button(layout.isPinned(descriptor.id) ? "Unpin" : "Pin to menu bar") {
                 if layout.isPinned(descriptor.id) {
@@ -137,14 +138,14 @@ struct WidgetGroupedListView: View {
         Button("Hide") {
             layout.setMetricEnabled(descriptor.id, false)
         }
-        if dataStore.data(for: descriptor).hasMeterStyleToggle {
+        if data.hasMeterStyleToggle {
             Button(dataStore.meterStyle == .remaining
                    ? "Show what's used"
                    : "Show what's left") {
                 dataStore.meterStyle.toggle()
             }
         }
-        if dataStore.data(for: descriptor).hasResetLabel {
+        if data.hasResetLabel {
             Button(dataStore.resetDisplayMode == .relative
                    ? "Show exact reset times"
                    : "Show reset countdowns") {

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -68,9 +68,9 @@ final class CodexUsageMapperTests: XCTestCase {
 
     func testAppendsTokenUsageLines() {
         var lines: [MetricLine] = []
-        let usage = CcusageDailyUsage(daily: [
-            CcusageDay(date: "2026-02-20", totalTokens: 150, costUSD: 0.75),
-            CcusageDay(date: "2026-02-01", totalTokens: 300, costUSD: 1.0)
+        let usage = DailyUsageSeries(daily: [
+            DailyUsageEntry(date: "2026-02-20", totalTokens: 150, costUSD: 0.75),
+            DailyUsageEntry(date: "2026-02-01", totalTokens: 300, costUSD: 1.0)
         ])
 
         SpendTileMapper.appendTokenUsage(
@@ -97,7 +97,7 @@ final class CodexUsageMapperTests: XCTestCase {
         // source). Fixed once in SpendTileMapper, so it holds for every provider that funnels through it.
         var lines: [MetricLine] = []
         SpendTileMapper.appendTokenUsage(
-            CcusageDailyUsage(daily: [CcusageDay(date: "2026-02-19", totalTokens: 0, costUSD: nil)]),
+            DailyUsageSeries(daily: [DailyUsageEntry(date: "2026-02-19", totalTokens: 0, costUSD: nil)]),
             to: &lines,
             now: makeDate("2026-02-20T16:00:00.000Z")
         )
@@ -114,7 +114,7 @@ final class CodexUsageMapperTests: XCTestCase {
         // zero — so the row shows just the labeled token count rather than a misleading "$0.00 ·".
         var lines: [MetricLine] = []
         SpendTileMapper.appendTokenUsage(
-            CcusageDailyUsage(daily: [CcusageDay(date: "2026-02-20", totalTokens: 1_200_000, costUSD: nil)]),
+            DailyUsageSeries(daily: [DailyUsageEntry(date: "2026-02-20", totalTokens: 1_200_000, costUSD: nil)]),
             to: &lines,
             now: makeDate("2026-02-20T16:00:00.000Z")
         )

--- a/Tests/OpenUsageTests/UsageTrendTests.swift
+++ b/Tests/OpenUsageTests/UsageTrendTests.swift
@@ -8,10 +8,10 @@ final class UsageTrendTests: XCTestCase {
     func testAppendUsageTrendZeroFillsTheCalendarWindow() throws {
         var lines: [MetricLine] = []
         SpendTileMapper.appendUsageTrend(
-            CcusageDailyUsage(daily: [
-                CcusageDay(date: "2026-06-21", totalTokens: 222_000_000, costUSD: nil),
-                CcusageDay(date: "2026-06-19", totalTokens: 500, costUSD: nil),
-                CcusageDay(date: "2026-06-20", totalTokens: 1_500_000, costUSD: nil)
+            DailyUsageSeries(daily: [
+                DailyUsageEntry(date: "2026-06-21", totalTokens: 222_000_000, costUSD: nil),
+                DailyUsageEntry(date: "2026-06-19", totalTokens: 500, costUSD: nil),
+                DailyUsageEntry(date: "2026-06-20", totalTokens: 1_500_000, costUSD: nil)
             ]),
             to: &lines,
             now: date(2026, 6, 21),
@@ -48,9 +48,9 @@ final class UsageTrendTests: XCTestCase {
         // collapsing the two active days into neighbors.
         var lines: [MetricLine] = []
         SpendTileMapper.appendUsageTrend(
-            CcusageDailyUsage(daily: [
-                CcusageDay(date: "2026-06-19", totalTokens: 500, costUSD: nil),
-                CcusageDay(date: "2026-06-21", totalTokens: 222_000_000, costUSD: nil)
+            DailyUsageSeries(daily: [
+                DailyUsageEntry(date: "2026-06-19", totalTokens: 500, costUSD: nil),
+                DailyUsageEntry(date: "2026-06-21", totalTokens: 222_000_000, costUSD: nil)
             ]),
             to: &lines, now: date(2026, 6, 21), note: "n"
         )
@@ -67,7 +67,7 @@ final class UsageTrendTests: XCTestCase {
         // idle days are zero bars rather than the chart stopping at the last active day.
         var lines: [MetricLine] = []
         SpendTileMapper.appendUsageTrend(
-            CcusageDailyUsage(daily: [CcusageDay(date: "2026-06-19", totalTokens: 500, costUSD: nil)]),
+            DailyUsageSeries(daily: [DailyUsageEntry(date: "2026-06-19", totalTokens: 500, costUSD: nil)]),
             to: &lines, now: date(2026, 6, 21), note: "n"
         )
 
@@ -81,11 +81,11 @@ final class UsageTrendTests: XCTestCase {
     func testTrendDropsDaysOlderThanTheWindow() {
         // 40 distinct days (May 1–31, then June 1–9) with today = 6/9. The window is the 31 days ending
         // today (5/10 … 6/9), so May 1–9 fall outside it and are dropped.
-        var daily = (1...31).map { CcusageDay(date: String(format: "2026-05-%02d", $0), totalTokens: $0 * 1000, costUSD: nil) }
-        daily += (1...9).map { CcusageDay(date: String(format: "2026-06-%02d", $0), totalTokens: $0 * 1000, costUSD: nil) }
+        var daily = (1...31).map { DailyUsageEntry(date: String(format: "2026-05-%02d", $0), totalTokens: $0 * 1000, costUSD: nil) }
+        daily += (1...9).map { DailyUsageEntry(date: String(format: "2026-06-%02d", $0), totalTokens: $0 * 1000, costUSD: nil) }
 
         var lines: [MetricLine] = []
-        SpendTileMapper.appendUsageTrend(CcusageDailyUsage(daily: daily), to: &lines, now: date(2026, 6, 9), note: "n")
+        SpendTileMapper.appendUsageTrend(DailyUsageSeries(daily: daily), to: &lines, now: date(2026, 6, 9), note: "n")
 
         guard case .chart(_, let points, _) = lines.first else { return XCTFail("expected a chart line") }
         XCTAssertEqual(points.count, 31)
@@ -98,9 +98,9 @@ final class UsageTrendTests: XCTestCase {
         // one bar carrying their summed tokens, not two bars splitting it.
         var lines: [MetricLine] = []
         SpendTileMapper.appendUsageTrend(
-            CcusageDailyUsage(daily: [
-                CcusageDay(date: "20260620", totalTokens: 1000, costUSD: nil),
-                CcusageDay(date: "2026-06-20", totalTokens: 500, costUSD: nil)
+            DailyUsageSeries(daily: [
+                DailyUsageEntry(date: "20260620", totalTokens: 1000, costUSD: nil),
+                DailyUsageEntry(date: "2026-06-20", totalTokens: 500, costUSD: nil)
             ]),
             to: &lines, now: date(2026, 6, 20), note: "n"
         )
@@ -113,12 +113,12 @@ final class UsageTrendTests: XCTestCase {
     func testAppendUsageTrendSkippedWhenWindowHasNoUsage() {
         // No rows at all, and rows that are all zero, both leave "No data" rather than a flat zero chart.
         var empty: [MetricLine] = []
-        SpendTileMapper.appendUsageTrend(CcusageDailyUsage(daily: []), to: &empty, now: date(2026, 6, 21), note: "n")
+        SpendTileMapper.appendUsageTrend(DailyUsageSeries(daily: []), to: &empty, now: date(2026, 6, 21), note: "n")
         XCTAssertTrue(empty.isEmpty, "no rows means no chart")
 
         var allZero: [MetricLine] = []
         SpendTileMapper.appendUsageTrend(
-            CcusageDailyUsage(daily: [CcusageDay(date: "2026-06-20", totalTokens: 0, costUSD: nil)]),
+            DailyUsageSeries(daily: [DailyUsageEntry(date: "2026-06-20", totalTokens: 0, costUSD: nil)]),
             to: &allZero, now: date(2026, 6, 21), note: "n"
         )
         XCTAssertTrue(allZero.isEmpty, "a fully idle window has no trend to draw")


### PR DESCRIPTION
## What this is

A **code-cleanup / streamlining pass** on the Swift edition ahead of the v0.7.x stable release — not a feature change. The beta was built fast, so this removes duplication, dead code, and a few over-built spots, and fixes naming/style drift. **Every change is behavior-preserving.**

`swift build` and `swift test` are green: **360 XCTest cases + swift-testing cases, 0 failures** (1 pre-existing skip).

## #690 — rename the provider-neutral daily carrier

Closes #690. `CcusageDailyUsage`/`CcusageDay` were named after the ccusage package but are a **provider-neutral per-day token/cost carrier** also built by Cursor (from its CSV export) and Grok (from its CLI log) — neither of which touches ccusage.

- `CcusageDailyUsage` → `DailyUsageSeries`, `CcusageDay` → `DailyUsageEntry`
- Moved out of `Services/CcusageRunner.swift` into a new `Models/DailyUsageSeries.swift`
- Genuinely ccusage-specific names (`CcusageRunner`, `CcusageProvider`, `CcusageRunnerError`, `parseOutput`) are **left intact**
- Updated the `SpendTileMapper` / Grok doc comments that previously conceded the mismatch

## Duplication (DRY)

- **`ProviderSnapshot.make(provider:plan:lines:refreshedAt:)`** — the success-path counterpart to the existing `error(provider:message:)`. All five providers now build their snapshot the same way instead of repeating the same memberwise init.
- **`SpendTileMapper.appendCcusageUsage(...)`** — Claude and Codex repeated the identical "query ccusage → append spend tiles → append usage-trend" block (and the same note literal). Now one shared call.
- **`ClaudeAuthStore.credentialState(from:service:source:)`** — the current-user and legacy keychain reads shared one parse/guard/log/build helper (the keychain read itself stays at the call site, preserving read order + error-swallowing).

## Simplification

- Hoisted Cursor's `authState.accessToken ?? accessToken` into a single `currentToken` local (was repeated 6×), matching Codex's existing idiom.
- Named `shouldUseRequestBasedFallback`'s tuple return (`shouldFallback`/`message`) instead of `.0`/`.1`.
- Folded Cursor's repeated `(!hasPlanUsage || planUsageLimitMissing)` into a `planUsageUnusable` local; `shouldTryGenericRequestFallback` returns its condition directly instead of `guard … else { return false }; return true`.
- Lifted `MetricFormatter`'s shared `>=1000` dollar-abbreviation branch above the style switch.
- `rowMenu` resolves `dataStore.data(for:)` once instead of twice.

## Idiom & style

- `canonicalModel` uses `first(where:)`; `pinnedCount(forProvider:)` and the refresh-batch tally use `count(where:)` instead of manual loops / `filter{}.count`.
- `hashSuffix` uses `String(...)` instead of `.description`.
- Title-cased the "Exact Time" reset-display picker label (matches every sibling label).

## Dead code

- Removed the unused `import SwiftUI` from `App/AppContainer.swift` — the file resolves entirely through `Foundation` + `Observation` (verified by building with it removed).

## How it was scoped

Found via two multi-agent audits: a five-dimension sweep (dead code, duplication, simplification, style, Swift idiom) and a second exhaustive per-area dead-code/unused-symbol sweep, with every candidate adversarially re-verified against the live tree. Higher-risk or low-value items were deliberately **left out** to keep this PR purely behavior-preserving — e.g.:
- Force-unwrapped env-var-derived URLs in `ClaudeAuthStore.oauthConfig()` (want a `throws` conversion that ripples into the credential-load path — better on its own).
- The write-only `CursorUsageCSVRow.maxMode` field — kept for parity with the upstream `cursorcat` port (its parsed value is still used for pricing; only the stored copy is unread).

## Notes for the issue author

@sharrmeen — thanks for the work on #690; this folds that rename in as part of a broader release-cleanup sweep so it can land directly on `swift`.