### PR TITLE
fix(claude): try all credential sources with fallback on auth failure (#687)

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -43,6 +43,21 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
             return "Token expired. Run `claude` to log in again."
         }
     }
+
+    /// Whether a failure on one credential source should fall through to the next one rather than
+    /// failing the whole refresh. An expired/revoked token in the preferred source (a stale keychain
+    /// entry from a prior login that later "locked out") must not shadow a fresh token an external
+    /// `claude` re-login wrote to a different source — so the token-is-bad cases allow a fallback,
+    /// while "no credentials at all" does not (there is nothing better to try). Mirrors
+    /// `CodexAuthError.allowsAuthFallback`.
+    var allowsAuthFallback: Bool {
+        switch self {
+        case .sessionExpired, .tokenExpired:
+            return true
+        case .notLoggedIn:
+            return false
+        }
+    }
 }
 
 struct ClaudeOAuthConfig: Hashable, Sendable {
@@ -78,21 +93,31 @@ struct ClaudeAuthStore: Sendable {
         self.now = now
     }
 
-    func loadCredentials() -> ClaudeCredentialState? {
-        let envAccessToken = envText("CLAUDE_CODE_OAUTH_TOKEN")
-        let stored = loadStoredCredentials()
-        guard let envAccessToken else {
-            return stored
+    /// All credential sources currently on disk/keychain, freshest first, for the refresh loop to try in
+    /// order. The provider probes each and — on an auth-expiry error (`ClaudeAuthError.allowsAuthFallback`)
+    /// — falls through to the next, so an external `claude` re-login is picked up no matter which source
+    /// it lands in, even when a stale/locked-out token still sits in another. Re-read on every refresh;
+    /// nothing is cached in memory.
+    func loadCredentialCandidates() -> [ClaudeCredentialState] {
+        // An explicit env token overrides everything and is inference-only (no live usage call), so there
+        // is no auth failure to fall back from — return the single env-wrapped candidate.
+        if let envAccessToken = envText("CLAUDE_CODE_OAUTH_TOKEN") {
+            let stored = orderedStoredCandidates().first
+            var oauth = stored?.oauth ?? ClaudeOAuth()
+            oauth.accessToken = envAccessToken
+            return [ClaudeCredentialState(
+                oauth: oauth,
+                source: stored?.source ?? .environment,
+                fullData: stored?.fullData,
+                inferenceOnly: true
+            )]
         }
+        return orderedStoredCandidates()
+    }
 
-        var oauth = stored?.oauth ?? ClaudeOAuth()
-        oauth.accessToken = envAccessToken
-        return ClaudeCredentialState(
-            oauth: oauth,
-            source: stored?.source ?? .environment,
-            fullData: stored?.fullData,
-            inferenceOnly: true
-        )
+    /// The first (freshest) credential candidate. Kept for callers that only need a single source.
+    func loadCredentials() -> ClaudeCredentialState? {
+        loadCredentialCandidates().first
     }
 
     func needsRefresh(_ oauth: ClaudeOAuth) -> Bool {
@@ -189,10 +214,30 @@ struct ClaudeAuthStore: Sendable {
         ProviderParse.decodeJSONWithHexFallback(text, as: ClaudeCredentialsFile.self)
     }
 
-    private func loadStoredCredentials() -> ClaudeCredentialState? {
-        if let keychain = loadKeychainCredentials() { return keychain }
-        if let file = loadFileCredentials() { return file }
-        return nil
+    /// Keychain and file credentials, ordered freshest-first by access-token expiry. A later expiry means
+    /// a more recent login, so a fresh external re-login is preferred over a stale token still sitting in
+    /// another source. The sort is stable, so when expiries tie — or are both absent — keychain stays
+    /// ahead of file, preserving the historical precedence. The source kind (never the token) is logged
+    /// so a "locked out" report can be diagnosed from which source was chosen.
+    private func orderedStoredCandidates() -> [ClaudeCredentialState] {
+        var candidates: [ClaudeCredentialState] = []
+        if let keychain = loadKeychainCredentials() { candidates.append(keychain) }
+        if let file = loadFileCredentials() { candidates.append(file) }
+
+        let ordered = candidates.enumerated().sorted { lhs, rhs in
+            let lhsExpiry = lhs.element.oauth.expiresAt ?? -.greatestFiniteMagnitude
+            let rhsExpiry = rhs.element.oauth.expiresAt ?? -.greatestFiniteMagnitude
+            if lhsExpiry == rhsExpiry { return lhs.offset < rhs.offset }
+            return lhsExpiry > rhsExpiry
+        }.map(\.element)
+
+        if ordered.count > 1 {
+            let labels = ordered.map { sourceLabel($0.source) }.joined(separator: ", ")
+            AppLog.debug(LogTag.auth("claude"), "credential candidates (freshest first): \(labels)")
+        } else if let only = ordered.first {
+            AppLog.debug(LogTag.auth("claude"), "credential source: \(sourceLabel(only.source))")
+        }
+        return ordered
     }
 
     private func loadFileCredentials() -> ClaudeCredentialState? {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -31,22 +31,37 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     func refresh() async -> ProviderSnapshot {
-        guard let state = await loadOffMainActor({ [authStore] in authStore.loadCredentials() }),
-              state.oauth.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-        else {
+        let candidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
+            .filter { $0.oauth.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
+        guard !candidates.isEmpty else {
             AppLog.info(LogTag.auth("claude"), "no access token, not logged in")
             return ProviderSnapshot.error(provider: provider, message: ClaudeAuthError.notLoggedIn.localizedDescription)
         }
 
-        AppLog.info(LogTag.plugin("claude"), "refresh start")
+        AppLog.info(LogTag.plugin("claude"), "refresh start (\(candidates.count) credential source\(candidates.count == 1 ? "" : "s"))")
         let start = Date()
-        do {
-            let snapshot = try await probe(state: state)
-            AppLog.info(LogTag.plugin("claude"), "refresh end (\(Int(Date().timeIntervalSince(start) * 1000))ms)")
-            return snapshot
-        } catch {
-            return ProviderSnapshot.error(provider: provider, message: error.localizedDescription)
+        // Probe each credential source in freshest-first order. An auth-expiry failure on one source (a
+        // stale/locked-out token that an external `claude` re-login replaced in another source) falls
+        // through to the next rather than failing the whole refresh; any non-auth error (rate limit,
+        // request/transport failure) surfaces immediately so a real outage is never masked as a retry.
+        var lastFallbackError: Error?
+        for state in candidates {
+            do {
+                let snapshot = try await probe(state: state)
+                AppLog.info(LogTag.plugin("claude"), "refresh end (\(Int(Date().timeIntervalSince(start) * 1000))ms)")
+                return snapshot
+            } catch let error as ClaudeAuthError where error.allowsAuthFallback {
+                AppLog.warn(LogTag.auth("claude"), "credential source failed (\(error)); falling back to next source if any")
+                lastFallbackError = error
+                continue
+            } catch {
+                return ProviderSnapshot.error(provider: provider, message: error.localizedDescription)
+            }
         }
+        return ProviderSnapshot.error(
+            provider: provider,
+            message: (lastFallbackError ?? ClaudeAuthError.notLoggedIn).localizedDescription
+        )
     }
 
     private func probe(state initialState: ClaudeCredentialState) async throws -> ProviderSnapshot {

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -32,6 +32,28 @@ final class ClaudeAuthStoreTests: XCTestCase {
         XCTAssertEqual(credentials?.oauth.subscriptionType, "max")
     }
 
+    func testPrefersFresherFileTokenOverStaleKeychain() {
+        // #687: keychain is the historical default source, but when the file holds a token with a later
+        // expiry (a more recent external `claude` login), it must be tried first so a stale keychain
+        // entry can no longer shadow the fresh login. Ordering still keeps both candidates available.
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"file-token","expiresAt":4102444800000,"subscriptionType":"pro"}}"#
+        ])
+        let keychain = ServiceKeychain()
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files,
+            keychain: keychain
+        )
+        let hashedService = store.keychainServiceCandidates().first!
+        keychain.currentUserValues[hashedService] = #"{"claudeAiOauth":{"accessToken":"keychain-token","expiresAt":4070908800000,"subscriptionType":"max"}}"#
+
+        let candidates = store.loadCredentialCandidates()
+
+        XCTAssertEqual(candidates.map(\.oauth.accessToken), ["file-token", "keychain-token"])
+        XCTAssertEqual(store.loadCredentials()?.oauth.accessToken, "file-token")
+    }
+
     func testEnvironmentTokenIsInferenceOnly() {
         let store = ClaudeAuthStore(
             environment: FakeEnvironment(["CLAUDE_CODE_OAUTH_TOKEN": "env-token"]),
@@ -256,6 +278,101 @@ final class ClaudeProviderTests: XCTestCase {
         let saved = files.files["/tmp/claude/.credentials.json"] ?? ""
         XCTAssertTrue(saved.contains("fresh-token"))
         XCTAssertTrue(saved.contains("refresh-2"))
+    }
+
+    func testFallsBackToFileWhenKeychainTokenIsLockedOut() async {
+        // #687: a stale/locked-out token sits in the keychain (its refresh token is server-revoked →
+        // invalid_grant → "session expired") while a fresh external `claude` re-login wrote a working
+        // token to the file. The refresh must fall through to the file source and recover instead of
+        // surfacing the stale keychain error until the app is restarted.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"fresh-access","refreshToken":"fresh-refresh","expiresAt":4070908800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let keychain = ServiceKeychain()
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files,
+            keychain: keychain,
+            now: { now }
+        )
+        // The stale keychain token even has a *later* expiry than the file token, so freshest-first
+        // ordering still probes it first — proving the recovery comes from the auth-failure fallback,
+        // not just from reordering.
+        let hashedService = authStore.keychainServiceCandidates().first!
+        keychain.currentUserValues[hashedService] = #"{"claudeAiOauth":{"accessToken":"stale-access","refreshToken":"stale-refresh","expiresAt":4102444800000,"subscriptionType":"max","scopes":["user:profile"]}}"#
+
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                let authorization = request.headers["Authorization"] ?? ""
+                guard authorization.contains("fresh-access") else {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":42,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            // Refresh endpoint: only the stale candidate reaches here, and its refresh token is revoked.
+            return HTTPResponse(statusCode: 400, headers: [:], body: Data(#"{"error":"invalid_grant"}"#.utf8))
+        }
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(
+                processRunner: FakeProcessRunner(),
+                homeDirectory: { URL(fileURLWithPath: "/Users/test") }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        // Recovered from the file source: plan + usage reflect the fresh token, with no error badge.
+        XCTAssertEqual(snapshot.plan, "Pro")
+        XCTAssertEqual(Self.progress(snapshot.lines, "Session")?.used, 42)
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+    }
+
+    func testSurfacesAuthErrorWhenAllCredentialSourcesAreExpired() async {
+        // The fallback must not mask a genuine all-sources-expired state: when both keychain and file
+        // tokens are revoked, the refresh fails loudly with the auth error rather than silently
+        // recovering or dropping it.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"file-stale","refreshToken":"file-refresh","expiresAt":4070908800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let keychain = ServiceKeychain()
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files,
+            keychain: keychain,
+            now: { now }
+        )
+        let hashedService = authStore.keychainServiceCandidates().first!
+        keychain.currentUserValues[hashedService] = #"{"claudeAiOauth":{"accessToken":"keychain-stale","refreshToken":"keychain-refresh","expiresAt":4102444800000,"subscriptionType":"max","scopes":["user:profile"]}}"#
+
+        // Every usage call 401s and every refresh is revoked → both sources are dead.
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+            }
+            return HTTPResponse(statusCode: 400, headers: [:], body: Data(#"{"error":"invalid_grant"}"#.utf8))
+        }
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(
+                processRunner: FakeProcessRunner(),
+                homeDirectory: { URL(fileURLWithPath: "/Users/test") }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.sessionExpired.localizedDescription)
     }
 
     func testRateLimitedResponseMapsToRetryBadgeNotError() async {

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -15,13 +15,13 @@ Tracks your Claude subscription limits using the login you already have from Cla
 
 ## Where credentials come from
 
-Sign in once with Claude Code; OpenUsage reads the same credentials, in this order:
+Sign in once with Claude Code; OpenUsage reads the same credentials. It checks every place Claude Code can store them and prefers the most recent login:
 
 1. `CLAUDE_CODE_OAUTH_TOKEN` environment variable
-2. `~/.claude/.credentials.json` (or `$CLAUDE_CONFIG_DIR/.credentials.json`)
-3. The macOS keychain entries Claude Code maintains
+2. The macOS keychain entry Claude Code maintains
+3. `~/.claude/.credentials.json` (or `$CLAUDE_CONFIG_DIR/.credentials.json`)
 
-Tokens are refreshed automatically; rotated tokens are written back where they came from.
+If one source holds an expired or "locked out" token, OpenUsage falls back to the others — so signing in again with `claude` outside the app is picked up on the next refresh, without restarting OpenUsage. Tokens are refreshed automatically; rotated tokens are written back where they came from.
 
 ## The spend tiles
 
@@ -35,4 +35,4 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Claude Code 
 
 ## Under the hood
 
-`GET https://api.anthropic.com/api/oauth/usage` with the Claude Code OAuth token; refresh via `platform.claude.com/v1/oauth/token`. A 401/403 triggers one token refresh and retry.
+`GET https://api.anthropic.com/api/oauth/usage` with the Claude Code OAuth token; refresh via `platform.claude.com/v1/oauth/token`. A 401/403 triggers one token refresh and retry. If that still fails because the token is expired or revoked, OpenUsage retries with the next credential source before reporting an error.


### PR DESCRIPTION
## Description

After a Claude token "locks out" (refresh token server-revoked → `invalid_grant` → *Session expired*), re-logging in via the external `claude` CLI was **not picked up until the app was restarted**.

**Root cause** — not a stale in-memory cache: `loadCredentials()` is re-read every refresh and the manual ⌘R uses `force: true` (bypassing the snapshot cache + failure backoff). The defect is *source selection*:

- `ClaudeAuthStore.loadStoredCredentials()` returned **keychain strictly before file**, picked the first source with a non-empty access token, and stopped.
- `ClaudeProvider.refresh()` probed that **one** source and never fell back.

So when the stale token sits in the preferred source and the fresh login landed in the other, the app keeps re-selecting the dead blob on every refresh. `CodexProvider` already gathers all candidates and falls back on auth-expiry errors — **Claude was the only provider without this** (Grok is file-only by design; Devin switches sources on 401).

**Fix** (mirrors the Codex pattern):
- Add `ClaudeAuthError.allowsAuthFallback` (`sessionExpired` / `tokenExpired` ⇒ fall back; `notLoggedIn` ⇒ don't).
- `loadCredentialCandidates()` returns *all* sources, ordered **freshest-first by token expiry**, with **keychain-before-file as the stable tiebreak** so historical precedence holds when expiries tie/are absent. A fresher file now beats a stale keychain.
- `refresh()` probes each candidate, falling through on an auth-expiry error and surfacing any non-auth error (rate limit, WAF/request failure) immediately; if **every** source is expired it fails loudly with the auth error.
- Log the chosen source kind per load (never the token) and each fallback, so a "locked out" report is diagnosable.

Net effect: an external re-login in **either** source is effective on the next refresh — no restart.

## Related Issue

Fixes #687

## Type of Change

- [x] Bug fix
- [x] Documentation

## Testing

- [x] I ran `swift build` and it succeeded
- [x] I ran `swift test` and all tests pass (363 pass, 1 live test skipped)
- [ ] I tested the change locally with `./script/build_and_run.sh`

New regression tests: freshest-first ordering; the core #687 case (stale keychain with a *later* expiry → falls back to fresh file and recovers); and all-sources-expired fails loudly.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My PR targets the `main` branch — **targets `swift`** instead (active development line for the Swift edition per AGENTS.md)
- [x] **Behavior change?** I updated the matching `docs/` page(s) in this same PR — `docs/providers/claude.md` (its credential order was also already wrong: it listed file before keychain)
- [x] I did not introduce new dependencies without justification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth credential selection and refresh error handling for Claude; mistakes could pick wrong tokens or mask real outages, but behavior mirrors Codex and is covered by new regression tests.
> 
> **Overview**
> Fixes **#687**: after a Claude session locks out, re-logging in via the external `claude` CLI was ignored until OpenUsage restarted because refresh only ever probed **one** credential source (keychain before file).
> 
> **`ClaudeAuthStore`** now exposes `loadCredentialCandidates()` — all keychain + file sources, sorted **freshest-first by token expiry** (keychain still wins ties). `ClaudeAuthError.allowsAuthFallback` marks `sessionExpired` / `tokenExpired` as retryable on the next source; `notLoggedIn` is not. `loadCredentials()` is unchanged for single-source callers (first candidate).
> 
> **`ClaudeProvider.refresh()`** loops candidates in order: auth-expiry failures fall through; rate limits and other errors fail immediately; if every source is dead, the user still sees the auth error.
> 
> Docs in `docs/providers/claude.md` describe multi-source preference and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b4008a350b4bdb1b0d4c543f39587457d59ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->