### PR TITLE
fix(format): unify Extra Usage number formatting via MetricFormatter (#658)

### DIFF
--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -17,7 +17,7 @@ struct WidgetData: Hashable {
     let icon: IconSource
     let kind: MetricKind
     let used: Double
-    let limit: Double?         // nil => unbounded (number tile)
+    var limit: Double?         // nil => unbounded (number tile); cleared when a .values line resolves
     var countSuffix: String?   // e.g. "credits", "requests"
     var valuePrefix: String?   // e.g. "~" for forecasts
     var displayMode: WidgetDisplayMode = .used

--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -18,17 +18,22 @@ extension WidgetDescriptor {
     }
 
     /// Bounded dollar meter whose subtitle reads "$<limit> <limitNoun>" (noun defaults to "limit").
+    /// `valueWord` is the trailing word for the *uncapped* fallback: a tile like Claude's Extra Usage is a
+    /// meter when the provider reports a monthly cap (`.progress`) but an unbounded "$1.2K spent" row
+    /// (`.values`) when it doesn't, and that row needs a word. It's inert for the bounded rendering.
     static func boundedDollars(
         id: String,
         provider: Provider,
         title: String,
         metricLabel: String? = nil,
         limit: Double,
-        limitNoun: String? = nil
+        limitNoun: String? = nil,
+        valueWord: String? = nil
     ) -> WidgetDescriptor {
         make(id: id, provider: provider, metricLabel: metricLabel ?? title,
              sample: WidgetData(title: title, icon: provider.icon,
-                                kind: .dollars, used: 0, limit: limit, limitNoun: limitNoun))
+                                kind: .dollars, used: 0, limit: limit, limitNoun: limitNoun,
+                                unboundedValueWord: valueWord))
     }
 
     /// Bounded count meter (e.g. requests per billing cycle). `periodDurationMs` lets the subtitle

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -26,7 +26,7 @@ final class ClaudeProvider: ProviderRuntime {
             .percent(id: "claude.session", provider: provider, title: "Session"),
             .percent(id: "claude.weekly", provider: provider, title: "Weekly"),
             .percent(id: "claude.sonnet", provider: provider, title: "Sonnet"),
-            .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100)
+            .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent")
         ] + WidgetDescriptor.spendTiles(provider: provider) + [.usageTrend(provider: provider)]
     }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -109,7 +109,9 @@ enum ClaudeUsageMapper {
                 format: .dollars
             ))
         } else if used > 0 {
-            lines.append(.text(label: "Extra usage spent", value: Formatters.currency(used)))
+            // No monthly cap: an unbounded spend, carried raw so it formats through `MetricFormatter`
+            // (compact like the spend tiles, e.g. "$1.2K spent") instead of a baked full-currency string.
+            lines.append(.values(label: "Extra usage spent", values: [MetricValue(number: used, kind: .dollars)]))
         }
     }
 

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -87,9 +87,6 @@ enum CursorUsageMapper {
                 resetsAt: cycle.resetsAt,
                 periodDurationMs: cycle.periodDurationMs
             ))
-            if let bonusSpendCents = ProviderParse.number(planUsage["bonusSpend"]), bonusSpendCents > 0 {
-                lines.append(.text(label: "Bonus spend", value: Formatters.currency(ProviderParse.centsToDollars(bonusSpendCents))))
-            }
         } else {
             lines.append(.progress(
                 label: "Total usage",

--- a/Sources/OpenUsage/Providers/Devin/DevinUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinUsageMapper.swift
@@ -28,7 +28,7 @@ enum DevinUsageMapper {
         let weeklyRemaining = ProviderParse.number(planStatus["weeklyQuotaRemainingPercent"])
         let dailyReset = hideDailyQuota ? nil : unixSecondsToDate(planStatus["dailyQuotaResetAtUnix"])
         let weeklyReset = unixSecondsToDate(planStatus["weeklyQuotaResetAtUnix"])
-        let extraUsageBalance = formatDollarsFromMicros(planStatus["overageBalanceMicros"])
+        let extraUsageBalance = dollarsFromMicros(planStatus["overageBalanceMicros"])
 
         var lines: [MetricLine] = []
         if !hideDailyQuota,
@@ -61,7 +61,9 @@ enum DevinUsageMapper {
         }
 
         if let extraUsageBalance {
-            lines.append(.text(label: "Extra usage balance", value: extraUsageBalance))
+            // Carried raw (not a baked currency string) so it formats through `MetricFormatter` and picks
+            // up the same compact "$1.2K left" shorthand as the spend tiles.
+            lines.append(.values(label: "Extra usage balance", values: [MetricValue(number: extraUsageBalance, kind: .dollars)]))
         }
 
         guard !lines.isEmpty else {
@@ -89,12 +91,11 @@ enum DevinUsageMapper {
         return Date(timeIntervalSince1970: seconds)
     }
 
-    /// An overage balance as a currency string; `nil` only when the field is missing or non-numeric
-    /// (truly no data). A present balance of zero renders "$0.00" — a real, measured zero — not "No data".
-    private static func formatDollarsFromMicros(_ value: Any?) -> String? {
-        guard var micros = ProviderParse.number(value) else { return nil }
-        micros = max(0, micros)
-        return Formatters.currency(micros / 1_000_000)
+    /// An overage balance in dollars; `nil` only when the field is missing or non-numeric (truly no
+    /// data). A present balance of zero stays a real, measured zero (renders "$0.00") — not "No data".
+    private static func dollarsFromMicros(_ value: Any?) -> Double? {
+        guard let micros = ProviderParse.number(value) else { return nil }
+        return max(0, micros) / 1_000_000
     }
 
     private static func readTrimmedString(_ value: Any?) -> String? {

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -301,6 +301,11 @@ final class WidgetDataStore {
             // trailing word) comes from the descriptor's sample; the live numbers come from the line.
             var data = descriptor.sample
             data.values = values
+            // A `.values` line is unbounded by definition (see `MetricLine`), so it never renders as a
+            // meter even when the descriptor's gallery sample carries a placeholder limit — e.g. Claude's
+            // `claude.extra` is `boundedDollars` for its capped `.progress` case but feeds an uncapped
+            // `.values` row when there's no monthly cap.
+            data.limit = nil
             // Optional expiry instants (Codex rate-limit-reset credits): surfaced in the row's hover
             // tooltip (see `expiryTooltip`), with the row re-rendering on the clock tick so they stay live.
             data.expiriesAt = expiriesAt

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -74,6 +74,29 @@ final class ClaudeUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Extra usage spent")?.limit, 10)
     }
 
+    func testUncappedExtraUsageIsAnUnboundedValuesRow() throws {
+        // No `monthly_limit`: the spend has no cap, so it's an unbounded `.values` row (which formats
+        // through `MetricFormatter`, matching the spend tiles) rather than a baked full-currency `.text`.
+        let response = HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data(#"{"extra_usage":{"is_enabled":true,"used_credits":123456}}"#.utf8)
+        )
+
+        let mapped = try ClaudeUsageMapper.mapUsageResponse(
+            response,
+            credentials: ClaudeOAuth(subscriptionType: "max")
+        )
+
+        guard case .values(_, let values, _, _)? = mapped.lines.first(where: { $0.label == "Extra usage spent" }) else {
+            return XCTFail("Expected an Extra usage spent .values line")
+        }
+        XCTAssertEqual(values.count, 1)
+        XCTAssertEqual(values.first?.kind, .dollars)
+        XCTAssertEqual(try XCTUnwrap(values.first?.number), 1234.56, accuracy: 0.0001)
+        XCTAssertNil(progress(mapped.lines, "Extra usage spent"))
+    }
+
     func testMapsResetsAtFromMicrosecondTimestampWithoutTimezone() throws {
         let response = HTTPResponse(
             statusCode: 200,

--- a/Tests/OpenUsageTests/CursorProviderTests.swift
+++ b/Tests/OpenUsageTests/CursorProviderTests.swift
@@ -89,6 +89,33 @@ final class CursorUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Requests")?.limit, 500)
         XCTAssertEqual(progress(mapped.lines, "Requests")?.periodDurationMs, CursorUsageMapper.billingPeriodMs)
     }
+
+    func testTeamAccountEmitsDollarTotalUsageAndNoOrphanedBonusSpendLine() throws {
+        // Team accounts report Total usage as a dollar meter and may carry a `bonusSpend` field. No
+        // widget descriptor matches a "Bonus spend" label, so emitting one produced a line that could
+        // never render. Regression: the mapper must not emit that orphaned line even when bonusSpend > 0.
+        let mapped = try CursorUsageMapper.mapUsage(
+            usage: [
+                "enabled": true,
+                "billingCycleStart": 1_770_000_000_000,
+                "billingCycleEnd": 1_772_592_000_000,
+                "planUsage": [
+                    "limit": 40_000,
+                    "totalSpend": 10_000,
+                    "bonusSpend": 2_500
+                ]
+            ],
+            planName: "Team",
+            creditGrants: nil,
+            stripeBalanceCents: 0
+        )
+
+        XCTAssertEqual(mapped.plan, "Team")
+        let total = try XCTUnwrap(progress(mapped.lines, "Total usage"))
+        XCTAssertEqual(total.used, 100, accuracy: 0.001)    // $100.00 spent (totalSpend, cents → dollars)
+        XCTAssertEqual(total.limit, 400, accuracy: 0.001)   // of a $400.00 limit
+        XCTAssertFalse(mapped.lines.contains { $0.label == "Bonus spend" })
+    }
 }
 
 @MainActor

--- a/Tests/OpenUsageTests/DevinProviderTests.swift
+++ b/Tests/OpenUsageTests/DevinProviderTests.swift
@@ -59,7 +59,7 @@ final class DevinUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Daily quota")?.periodDurationMs, DevinUsageMapper.dayPeriodMs)
         XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.used, 60)
         XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.periodDurationMs, DevinUsageMapper.weekPeriodMs)
-        XCTAssertEqual(text(mapped.lines, "Extra usage balance"), "$964.22")
+        XCTAssertEqual(try XCTUnwrap(dollars(mapped.lines, "Extra usage balance")), 964.22, accuracy: 0.0001)
         XCTAssertNotNil(progress(mapped.lines, "Weekly quota")?.resetsAt)
     }
 
@@ -71,9 +71,9 @@ final class DevinUsageMapperTests: XCTestCase {
 
         let mapped = try DevinUsageMapper.mapUserStatus(userStatus)
 
-        // A present balance of zero is a real, measured value → "$0.00", not "No data" (that's reserved
+        // A present balance of zero is a real, measured value → 0, not "No data" (that's reserved
         // for the field being absent entirely).
-        XCTAssertEqual(text(mapped.lines, "Extra usage balance"), "$0.00")
+        XCTAssertEqual(dollars(mapped.lines, "Extra usage balance"), 0)
     }
 
     func testUsesHiddenDailyQuotaAsWeeklyUsageWhenWeeklyIsAbsent() throws {
@@ -92,7 +92,7 @@ final class DevinUsageMapperTests: XCTestCase {
         // The hidden daily quota fills the missing Weekly row and is still flipped from "remaining"
         // to "used": 30% remaining -> 70% used (not passed through raw as 30).
         XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.used, 70)
-        XCTAssertEqual(text(mapped.lines, "Extra usage balance"), "$964.22")
+        XCTAssertEqual(try XCTUnwrap(dollars(mapped.lines, "Extra usage balance")), 964.22, accuracy: 0.0001)
     }
 
     func testThrowsQuotaUnavailableWhenNoDisplayableFieldsExist() {
@@ -114,11 +114,12 @@ final class DevinUsageMapperTests: XCTestCase {
         return (used, limit, resetsAt, periodDurationMs)
     }
 
-    private func text(_ lines: [MetricLine], _ label: String) -> String? {
-        guard case .text(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
+    /// The first dollar value's raw number on a `.values` line (the shape extra-usage balance now uses).
+    private func dollars(_ lines: [MetricLine], _ label: String) -> Double? {
+        guard case .values(_, let values, _, _) = lines.first(where: { $0.label == label }) else {
             return nil
         }
-        return value
+        return values.first(where: { $0.kind == .dollars })?.number
     }
 }
 

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -228,6 +228,43 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(data.menuBarValue, "1")      // tray — the real count, never "0"
     }
 
+    func testUncappedExtraUsageRendersCompactAndUnbounded() async {
+        // Regression (#658): Claude's `claude.extra` is a `boundedDollars` descriptor (a meter when the
+        // provider reports a monthly cap), but an uncapped spend arrives as a `.values` line. It must
+        // resolve to an unbounded tile — the sample's placeholder limit dropped — and read in the same
+        // compact shorthand as the spend tiles ("$1.2K spent"), not full currency, in both row and tray.
+        let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let descriptor = WidgetDescriptor.boundedDollars(
+            id: "claude.extra", provider: provider, title: "Extra Usage",
+            metricLabel: "Extra usage spent", limit: 100, valueWord: "spent"
+        )
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.values(label: "Extra usage spent",
+                                values: [MetricValue(number: 1234.56, kind: .dollars)])]
+            )
+        )
+        let defaults = makeUserDefaults("claude-extra")
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() }),
+            defaults: defaults
+        )
+        await store.refreshAll()
+
+        let data = store.data(for: descriptor)
+        XCTAssertTrue(data.hasData)
+        XCTAssertFalse(data.isBounded)                          // sample's limit: 100 dropped for a .values row
+        XCTAssertEqual(data.unboundedDetail, "$1.2K spent")     // popover row — compact, not "$1,234.56"
+        XCTAssertEqual(data.menuBarValue, "$1.2K")              // tray — same shorthand
+        XCTAssertEqual(data.unboundedTooltip, "$1,234.56")      // hover still reveals the exact figure
+    }
+
     func testCreditValuesFloorAndClampBalance() {
         var data = WidgetData(title: "Extra Usage", icon: .providerMark("codex"), kind: .dollars, used: 0, limit: nil)
         data.values = CodexUsageMapper.creditValues(remaining: 820.9)


### PR DESCRIPTION
## Description

Spend tiles (Today / Yesterday / Last 30 Days) format through `MetricFormatter` and abbreviate large amounts (`$1.2K`, `41.3M`), but the **"Extra usage"** lines used the legacy `.text()` shape with a pre-baked `Formatters.currency()` string that never abbreviated — so the same popover could show `$1,234.56` right next to `$1.2K`. `MetricFormatter` is documented as the single source of truth; these `.text()` lines bypassed it.

This migrates the Extra Usage lines to the raw `.values()` shape so they flow through `MetricFormatter` and read consistently in both the tray and the popover.

- **Claude "Extra usage spent"** (uncapped case): `.text(Formatters.currency(used))` → `.values([MetricValue(number: used, kind: .dollars)])`. Reads `$1.2K spent` in the row, `$1.2K` in the tray, with the exact figure in the hover tooltip.
- **Devin "Extra usage balance"**: `.text` → `.values`; `formatDollarsFromMicros` → `dollarsFromMicros` now returns a `Double` instead of a formatted string.
- **`WidgetDataStore.resolve`**: a `.values` line is unbounded by definition (per `MetricLine`'s contract), so the resolved tile's `limit` is now cleared. This prevents Claude's hybrid `claude.extra` descriptor — `boundedDollars` because it's a real meter when the API reports a monthly cap (`.progress`) — from rendering the *uncapped* row as a misleading `$X / $100` meter. Required making `WidgetData.limit` a `var` (consistent with how the store already stamps `displayMode`/`resetDisplayMode`).
- **`boundedDollars` factory**: gains an optional `valueWord` (`"spent"`) for the uncapped fallback row; inert for the bounded meter rendering.

### Bonus cleanup: orphaned Cursor "Bonus spend" line

While verifying the `.text`→`.values` surface, found that `CursorUsageMapper` emitted a `"Bonus spend"` line on team-account refreshes, but **no `WidgetDescriptor` matches its `metricLabel`** — so it could never render (undocumented, untested). Removed the dead emission. Surfacing it would be a new always-visible tile the owner hasn't requested; if wanted later it's a deliberate one-line `.values` descriptor + a docs row.

## Related Issue

Fixes #658

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `swift build` and it succeeded
- [x] I ran `swift test` and all tests pass (363 tests, 0 failures, 1 skipped)
- [ ] I tested the change locally with `./script/build_and_run.sh`

Regression tests added:
- Claude uncapped Extra Usage → `.values` (mapper-level) and end-to-end render (`testUncappedExtraUsageRendersCompactAndUnbounded`: unbounded, `"$1.2K spent"` row, `"$1.2K"` tray, exact `"$1,234.56"` tooltip).
- Devin balance updated to the `.values` shape.
- Cursor team **dollar** `Total usage` path (previously untested) + asserts no orphaned `Bonus spend` line.

## Notes for reviewers

- The optional/stretch goal from #658 (a *global* compact-vs-full user setting at the `MetricFormatter` layer) is **not** included — it touches the settings UI, persistence, and `MetricFormatter`'s signature across all call sites, and is better as its own change.
- No user-visible behavior doc changes needed: `docs/dashboard.md` already states big numbers are abbreviated universally; this just makes the Extra Usage rows honor that. The removed Cursor line was never documented.

## Checklist

- [x] I read CONTRIBUTING.md
- [x] My PR targets the `swift` branch (Swift edition's active development line per AGENTS.md; `main` is the frozen Tauri edition)
- [x] **Behavior change?** Docs already describe the now-consistent behavior; no `docs/` change required
- [x] I did not introduce new dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and mapping-only changes with broad test coverage; no auth, persistence, or network contract changes beyond dropping an unused Cursor line.
> 
> **Overview**
> Fixes inconsistent dollar display where **Extra usage** rows showed full currency (`$1,234.56`) next to spend tiles that abbreviate (`$1.2K`).
> 
> **Claude** uncapped extra spend and **Devin** extra balance now emit raw **`.values`** dollar metrics instead of **`.text`** with pre-formatted strings, so popover rows, menu bar, and tooltips all go through **`MetricFormatter`**. **`WidgetDataStore`** clears **`limit`** when resolving **`.values`** so hybrid tiles like **`claude.extra`** (meter when capped, unbounded when not) no longer render a bogus **`$X / $100`** bar; **`boundedDollars`** gains optional **`valueWord: "spent"`** for the uncapped row.
> 
> **Cursor** stops emitting a **"Bonus spend"** metric line that had no matching widget descriptor.
> 
> Regression tests cover mapper shapes, team Cursor totals, and end-to-end compact **"$1.2K spent"** rendering for uncapped Claude extra usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b54c12991246f934d31337846bb5358f5f06e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->