### PR TITLE
feat(dashboard): extend Usage Trend sparkline to Cursor and Grok (#688)

### DIFF
--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -27,7 +27,7 @@ final class CursorProvider: ProviderRuntime {
             .percent(id: "cursor.auto", provider: provider, title: "Auto Limits", metricLabel: "Auto usage"),
             .percent(id: "cursor.api", provider: provider, title: "API Usage", metricLabel: "API usage"),
             .boundedDollars(id: "cursor.onDemand", provider: provider, title: "Extra Usage", metricLabel: "On-demand", limit: 100)
-        ] + WidgetDescriptor.spendTiles(provider: provider)
+        ] + WidgetDescriptor.spendTiles(provider: provider) + [.usageTrend(provider: provider)]
     }
 
     func refresh() async -> ProviderSnapshot {

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -226,7 +226,12 @@ enum CursorUsageMapper {
                 costUSD: Double(CursorPricing.toCents(costByDay[day] ?? 0)) / 100
             )
         }
-        SpendTileMapper.appendTokenUsage(DailyUsageSeries(daily: daily), to: &lines, now: now, estimated: false)
+        let series = DailyUsageSeries(daily: daily)
+        SpendTileMapper.appendTokenUsage(series, to: &lines, now: now, estimated: false)
+        // Cursor's tokens come from the server-priced usage CSV, not a local CLI log, so the trend
+        // note names that source rather than the "estimated from local logs" line the ccusage/Grok
+        // providers use. Tokens are measured either way, so there's no ⓘ.
+        SpendTileMapper.appendUsageTrend(series, to: &lines, now: now, note: "From your Cursor usage history")
     }
 
     private static func dayKey(from date: Date, calendar: Calendar) -> String {

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -26,7 +26,7 @@ final class GrokProvider: ProviderRuntime {
             .percent(id: "grok.creditsUsed", provider: provider, title: "Monthly", metricLabel: "Credits used"),
             .badge(id: "grok.payAsYouGo", provider: provider, title: "Extra Usage", metricLabel: "Pay as you go")
             // Local spend tiles, estimated from the Grok CLI log (see GrokLogUsageScanner).
-        ] + WidgetDescriptor.spendTiles(provider: provider)
+        ] + WidgetDescriptor.spendTiles(provider: provider) + [.usageTrend(provider: provider)]
     }
 
     func refresh() async -> ProviderSnapshot {
@@ -69,6 +69,8 @@ final class GrokProvider: ProviderRuntime {
         // `scan` is awaited so its whole-file read + parse runs off the main actor.
         if let tokenUsage = await logUsageScanner.scan(daysBack: 30, now: now()) {
             SpendTileMapper.appendTokenUsage(tokenUsage, to: &mapped.lines, now: now())
+            SpendTileMapper.appendUsageTrend(tokenUsage, to: &mapped.lines, now: now(),
+                                             note: "Estimated from local logs at API rates")
         }
 
         return ProviderSnapshot.make(provider: provider, plan: plan, lines: mapped.lines, refreshedAt: now())

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -10,8 +10,8 @@ enum DefaultLayout {
         "claude.session", "claude.weekly", "claude.trend",
         "codex.session", "codex.weekly", "codex.trend",
         "devin.weekly", "devin.daily",
-        "grok.creditsUsed",
-        "cursor.usage", "cursor.auto", "cursor.api"
+        "grok.creditsUsed", "grok.trend",
+        "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend"
     ]
 
     /// Metrics pinned to the menu bar on first launch, so the app shows real numbers out of the box

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -135,6 +135,36 @@ final class CursorSpendRangeTests: XCTestCase {
         XCTAssertEqual(values(lines, "Last 30 Days"), zero)
     }
 
+    func testAppendSpendLinesAlsoAppendsUsageTrend() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let cal = Calendar.current
+        let rows = [
+            makeRow(date: now, cost: 1.00, tokens: 100),                                           // today
+            makeRow(date: cal.date(byAdding: .day, value: -1, to: now)!, cost: 2.00, tokens: 200)  // yesterday
+        ]
+
+        var lines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, to: &lines)
+
+        guard case .chart(let label, let points, let note) = lines.first(where: { $0.label == "Usage Trend" }) else {
+            return XCTFail("expected a Usage Trend chart line")
+        }
+        XCTAssertEqual(label, "Usage Trend")
+        // Cursor's tokens come from the server-priced CSV, so the note names that source, not local logs.
+        XCTAssertEqual(note, "From your Cursor usage history")
+        XCTAssertEqual(points.count, 31, "one bar per calendar day across the 31-day window")
+        XCTAssertEqual(points.last?.value, 100, "today's tokens land on the last bar")
+        XCTAssertEqual(points[29].value, 200, "yesterday's tokens land on the second-to-last bar")
+    }
+
+    func testNoRowsLeavesNoUsageTrend() {
+        // A fetched-but-empty export is a real zero for the spend tiles, but the trend has nothing to
+        // draw, so no chart line is appended (the row falls back to "No data").
+        var lines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: [], now: Date(), to: &lines)
+        XCTAssertNil(lines.first(where: { $0.label == "Usage Trend" }))
+    }
+
     private func makeRow(date: Date, cost: Double, tokens: Int) -> CursorUsageCSVRow {
         CursorUsageCSVRow(
             date: date,

--- a/Tests/OpenUsageTests/GrokProviderTests.swift
+++ b/Tests/OpenUsageTests/GrokProviderTests.swift
@@ -404,6 +404,75 @@ final class GrokProviderTests: XCTestCase {
         XCTAssertNotNil(values(snapshot.lines, "Yesterday"))          // yesterday had real usage
     }
 
+    func testRefreshAppendsUsageTrendFromLog() async {
+        let now = OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!
+        let files = FakeFiles([
+            GrokAuthStore.authPath: #"{"https://auth.x.ai::client":{"key":"token","refresh_token":"refresh","expires_at":"2026-07-01T00:00:00.000Z"}}"#
+        ])
+        let httpClient = RecordingHTTPClient { request in
+            if request.url == GrokUsageClient.billingURL {
+                return HTTPResponse(statusCode: 200, headers: [:], body: billingBody(used: 2500, monthlyLimit: 10000, onDemandCap: 0))
+            }
+            if request.url == GrokUsageClient.settingsURL {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"subscription_tier_display":"SuperGrok Heavy"}"#.utf8))
+            }
+            return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+        // 1M input today (06-18), 1M output yesterday (06-17).
+        let log = """
+        {"ts":"2026-06-18T09:00:00.000Z","pid":1,"msg":"model changed","ctx":{"model":"grok-build"}}
+        {"ts":"2026-06-18T10:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"cached_prompt_tokens":0,"completion_tokens":0,"reasoning_tokens":0}}
+        {"ts":"2026-06-17T09:00:00.000Z","pid":2,"msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
+        {"ts":"2026-06-17T10:00:00.000Z","pid":2,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":0,"cached_prompt_tokens":0,"completion_tokens":1000000,"reasoning_tokens":0}}
+        """
+        let scanner = GrokLogUsageScanner(
+            files: FakeFiles(["/home/test/.grok/logs/unified.jsonl": log]),
+            environment: FakeEnvironment(),
+            homeDirectory: { URL(fileURLWithPath: "/home/test") }
+        )
+        let provider = GrokProvider(
+            authStore: GrokAuthStore(files: files, now: { now }),
+            usageClient: GrokUsageClient(httpClient: httpClient),
+            logUsageScanner: scanner,
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        guard case .chart(_, let points, let note) = snapshot.lines.first(where: { $0.label == "Usage Trend" }) else {
+            return XCTFail("expected a Usage Trend chart line")
+        }
+        XCTAssertEqual(note, "Estimated from local logs at API rates")
+        XCTAssertEqual(points.count, 31)
+        XCTAssertEqual(points.last?.value, 1_000_000, "today's tokens land on the last bar")
+        XCTAssertEqual(points[29].value, 1_000_000, "yesterday's tokens land on the second-to-last bar")
+    }
+
+    func testRefreshWithoutLogAppendsNoUsageTrend() async {
+        let now = OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!
+        let files = FakeFiles([
+            GrokAuthStore.authPath: #"{"https://auth.x.ai::client":{"key":"token","refresh_token":"refresh","expires_at":"2026-07-01T00:00:00.000Z"}}"#
+        ])
+        let httpClient = RecordingHTTPClient { request in
+            if request.url == GrokUsageClient.billingURL {
+                return HTTPResponse(statusCode: 200, headers: [:], body: billingBody(used: 2500, monthlyLimit: 10000, onDemandCap: 0))
+            }
+            if request.url == GrokUsageClient.settingsURL {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"subscription_tier_display":"SuperGrok Heavy"}"#.utf8))
+            }
+            return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+        let provider = GrokProvider(
+            authStore: GrokAuthStore(files: files, now: { now }),
+            usageClient: GrokUsageClient(httpClient: httpClient),
+            logUsageScanner: noLogScanner(),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+        XCTAssertNil(snapshot.lines.first(where: { $0.label == "Usage Trend" }), "no log means no trend chart")
+    }
+
     private func noLogScanner() -> GrokLogUsageScanner {
         GrokLogUsageScanner(files: FakeFiles(), environment: FakeEnvironment(), homeDirectory: { URL(fileURLWithPath: "/home/none") })
     }

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -16,7 +16,7 @@ The popover that opens from the menu bar icon. Providers are sections; each sect
 
 **Metrics without a limit** (daily spend, balances) show as a single line like `$4.08 spent` or `1.2M tokens`. The daily spend rows (Today / Yesterday / Last 30 Days) come in three flavors you can add from Customize — cost (`$4.08 spent`), tokens (`1.2M tokens`), or both (`$4.08 · 1.2M tokens`). A day with no usage is a real zero, so it reads `$0.00 · 0 tokens` (not "No data" — that's only when the data can't be loaded at all). Big numbers are abbreviated to keep rows tidy (`$2.06K`, `1.5B`) — **hover the row** to see the exact figures. A small ⓘ next to the name means a dollar figure is estimated locally rather than billed — hover it for details; token counts are measured, so they carry no ⓘ.
 
-**Usage Trend** (Claude and Codex) is a small bar chart of the last 30 days of token usage — one bar per day, drawn from the same local logs as the spend rows. **Hover it** for the peak day, the date range, and the source. It's on by default; turn it off or reorder it from Customize like any other metric. It can't be pinned to the menu bar — the strip shows single values, not a chart.
+**Usage Trend** (Claude, Codex, Cursor, and Grok) is a small bar chart of the last 30 days of token usage — one bar per day, drawn from the same source as that provider's spend rows (local logs for Claude / Codex / Grok, your usage history for Cursor). **Hover it** for the peak day, the date range, and the source. It's on by default; turn it off or reorder it from Customize like any other metric. It can't be pinned to the menu bar — the strip shows single values, not a chart.
 
 Rows with a reset date tick every 30 seconds, so countdowns and pace stay live between refreshes.
 


### PR DESCRIPTION
## Summary

Extends the **Usage Trend** sparkline (added for Claude and Codex in #669) to **Cursor** and **Grok**. Closes #688.

Both providers already build the exact per-day token series the trend needs and feed it to `SpendTileMapper.appendTokenUsage` for the Today / Yesterday / Last 30 Days tiles — so this reuses that same `DailyUsageSeries` and `SpendTileMapper.appendUsageTrend`, not a new data pipeline.

## Changes

- **Grok** — append the trend after the spend tiles in `GrokProvider.probe`, using the same `"Estimated from local logs at API rates"` note as Claude/Codex (its tokens come from the local Grok CLI log).
- **Cursor** — append the trend inside `CursorUsageMapper.appendSpendLines` with a source-appropriate note, `"From your Cursor usage history"` — Cursor's tokens come from the server-priced usage CSV, not a local log. Tokens are measured either way, so there's no estimate ⓘ.
- Both `widgetDescriptors` gain `.usageTrend(provider:)` (non-pinnable), on by default via `DefaultLayout` (`grok.trend`, `cursor.trend`), matching `claude.trend` / `codex.trend`.
- The local HTTP API already serializes `.chart` as the original app's `barChart` shape with no per-provider gating, so it carries through unchanged.
- Docs: `docs/dashboard.md` now lists all four providers and both sources.

## Decisions (from the issue)

1. **Cursor source note** — server-priced CSV, so `"From your Cursor usage history"` rather than the local-logs note.
2. **Grok on-by-default** — like its spend tiles, the trend depends on the local Grok CLI log; with no log it shows "No data". Shipped on-by-default, matching #669's call for Claude/Codex.
3. **Cursor token semantics** — `CursorTokenUsage.total` sums all four token buckets (input/cache-write/cache-read/output), a meaningful per-day token count to chart.

## Tests

- `CursorSpendTests`: `appendSpendLines` now also appends a `Usage Trend` chart line (right note, 31-day window, per-day bars); empty rows append no chart.
- `GrokProviderTests`: `refresh()` appends the trend from the log; no log → no chart line.
- Full suite green: **370 tests pass**.

## Verification

Built and ran the dev app, confirmed via the local API that both providers emit a live 31-point `barChart`:

| Provider | Points | Note |
|---|---|---|
| Cursor | 31 (30 non-zero), latest Jun 23 = 3.6M tokens | From your Cursor usage history |
| Grok | 31 (11 non-zero), Jun 22 = 9.7M tokens | Estimated from local logs at API rates |

> Note: during verification the trend first appeared as "No data" after launch — root-caused to the snapshot cache serving the previous session's data and suppressing the launch refresh, not a bug in this change. Filed separately as #697.

## Acceptance criteria

- [x] Usage Trend renders for Cursor and Grok with live data — same inline sparkline + hover detail as Claude/Codex.
- [x] Customizable (toggle / reorder / hide), not pinnable.
- [x] No-data fallback shows "No data", never the gallery sample.
- [x] Tests + docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive dashboard metrics on existing spend series with no auth or billing logic changes; behavior when data is missing is explicitly tested.
> 
> **Overview**
> Brings the **Usage Trend** 31-day token sparkline to **Cursor** and **Grok**, matching Claude/Codex by reusing the same `DailyUsageSeries` and `SpendTileMapper.appendUsageTrend` path already used for spend tiles—no new data pipeline.
> 
> **Cursor** registers `.usageTrend` on the provider and builds the chart inside `CursorUsageMapper.appendSpendLines` when usage CSV rows exist, with hover note **"From your Cursor usage history"** (server CSV, not local logs). **Grok** appends the trend after a successful CLI log scan with **"Estimated from local logs at API rates"**; no log means no chart line. **`DefaultLayout`** enables `cursor.trend` and `grok.trend` by default.
> 
> Tests cover chart shape, notes, empty-data behavior, and **`docs/dashboard.md`** documents all four providers and their data sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f28cd9320a445c364ae5b92fa9a5e6ee589d9b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->