### PR TITLE
Top-leading back nav on Customize/Settings; unify Customize header

### DIFF
--- a/.agents/scheduled_tasks.lock
+++ b/.agents/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"8a4e7feb-d7fb-43ff-adb7-1723c7ede84b","pid":25265,"procStart":"Tue Jun 23 06:22:42 2026","acquiredAt":1782197312230}

--- a/.agents/scheduled_tasks.lock
+++ b/.agents/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8a4e7feb-d7fb-43ff-adb7-1723c7ede84b","pid":25265,"procStart":"Tue Jun 23 06:22:42 2026","acquiredAt":1782197312230}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 node_modules/
 *.log
 .agents/worktrees/
+.agents/scheduled_tasks.lock
 
 # Local environment files
 .env

--- a/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
+++ b/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
@@ -65,6 +65,18 @@ extension View {
         }
     }
 
+    /// Pins a bar above scrolling content (the Customize / Settings back nav bar). On macOS 26 this
+    /// uses `safeAreaBar`, which also feeds the native scroll-edge blur as content passes under it; on
+    /// macOS 15 it uses `safeAreaInset` (macOS 12+), which pins the bar identically but without the blur.
+    @ViewBuilder
+    func pinnedTopBar<Bar: View>(spacing: CGFloat, @ViewBuilder content: () -> Bar) -> some View {
+        if #available(macOS 26, *) {
+            safeAreaBar(edge: .top, spacing: spacing, content: content)
+        } else {
+            safeAreaInset(edge: .top, spacing: spacing, content: content)
+        }
+    }
+
     /// Applies the soft top scroll-edge effect on macOS 26. On macOS 15 there is no equivalent, so
     /// this is a no-op — the scroll view still scrolls and clips correctly, it just loses the blur.
     @ViewBuilder

--- a/Sources/OpenUsage/Views/CustomizeView.swift
+++ b/Sources/OpenUsage/Views/CustomizeView.swift
@@ -78,12 +78,13 @@ struct CustomizeView: View {
     }
 
     private func providerHeader(_ group: ProviderMetrics) -> some View {
-        ProviderSectionHeader(provider: group.provider) {
-            ReorderGrip()
-        }
+        // The exact same header as the dashboard (`WidgetGroupedListView.header`): the leading
+        // dot-grid drag handle marks the line as draggable, the provider mark sits trailing. Customize
+        // just omits the plan, warning, and "Outdated" staleness tag — the only things that differ here.
+        ProviderSectionHeader(provider: group.provider, showsDragHandle: true)
         // Align the header with the metric card's rows: rows are inset 12pt inside the card and the
-        // header carries 4pt internally, so +8 lines the provider name up with the row grip (and the
-        // header grip with the toggles) — the same inset on both edges.
+        // header carries its own internal inset, so +8 lines the provider name up with the row grip —
+        // the same inset on both edges.
         .padding(.horizontal, 8)
         .highPriorityGesture(providerDragGesture(for: group))
     }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -51,6 +51,9 @@ struct DashboardView: View {
     private static let reorderSpace = "popoverReorderSpace"
     /// One width across both densities — switching density shouldn't move the popover's left edge.
     private static let popoverWidth: CGFloat = 320
+    /// Fixed height of the Customize / Settings back nav bar. A constant (not measured) so the popover
+    /// height math stays deterministic — the bar pins itself to exactly this height.
+    private static let topBarHeight: CGFloat = 44
 
     /// Never grow taller than 85% of the *hosting* screen's usable height; scroll beyond that. All
     /// three screens (dashboard, Customize, Settings) share this one cap so they feel consistent —
@@ -59,24 +62,25 @@ struct DashboardView: View {
         floor(usableHeight * 0.85)
     }
 
-    /// The pinned footer lives outside the scroll region, so the scroll area's cap is the popover cap
-    /// minus that fixed chrome.
-    private var chromeHeight: CGFloat {
-        footerHeight
+    /// The pinned chrome that lives outside the scroll region, so the scroll area's cap is the popover
+    /// cap minus that fixed chrome. The footer is on every screen; Customize and Settings add the
+    /// pinned back nav bar on top, so their chrome is taller by exactly that bar.
+    private func chromeHeight(for screen: PopoverScreen) -> CGFloat {
+        footerHeight + (screen == .dashboard ? 0 : Self.topBarHeight)
     }
 
-    private var maxScrollHeight: CGFloat {
-        max(120, maxHeight - chromeHeight)
+    private func maxScrollHeight(for screen: PopoverScreen) -> CGFloat {
+        max(120, maxHeight - chromeHeight(for: screen))
     }
 
     /// The scroll area fits its content exactly until it would exceed the cap, then it scrolls.
     private var dashboardScrollHeight: CGFloat {
-        min(listContentHeight, maxScrollHeight)
+        min(listContentHeight, maxScrollHeight(for: .dashboard))
     }
 
     private var customizeScrollHeight: CGFloat {
         let contentHeight = hasMeasuredCustomizeContent ? customizeContentHeight : estimatedCustomizeContentHeight
-        return min(contentHeight, maxScrollHeight)
+        return min(contentHeight, maxScrollHeight(for: .customize))
     }
 
     /// Settings fits its content exactly, like the dashboard and Customize, up to the global cap.
@@ -84,7 +88,7 @@ struct DashboardView: View {
     /// real measurement only fine-tunes it.
     private var settingsScrollHeight: CGFloat {
         let contentHeight = hasMeasuredSettingsContent ? settingsContentHeight : estimatedSettingsContentHeight
-        return min(contentHeight, maxScrollHeight)
+        return min(contentHeight, maxScrollHeight(for: .settings))
     }
 
     private func scrollHeight(for screen: PopoverScreen) -> CGFloat {
@@ -95,8 +99,13 @@ struct DashboardView: View {
         }
     }
 
+    /// A screen's full popover height: its scroll content plus that screen's pinned chrome.
+    private func screenHeight(for screen: PopoverScreen) -> CGFloat {
+        scrollHeight(for: screen) + chromeHeight(for: screen)
+    }
+
     private var popoverHeight: CGFloat {
-        scrollHeight(for: layout.screen) + chromeHeight
+        screenHeight(for: layout.screen)
     }
 
     /// The popover height to apply while a screen-switch slide is playing: it interpolates from the
@@ -107,7 +116,7 @@ struct DashboardView: View {
     /// pinned offset, so nothing jumps ahead of the slide.
     private var animatedPopoverHeight: CGFloat {
         guard isSliding else { return popoverHeight }
-        let fromHeight = scrollHeight(for: layout.screenSlideFrom) + chromeHeight
+        let fromHeight = screenHeight(for: layout.screenSlideFrom)
         guard animatedSlideID == layout.screenSlideID else { return fromHeight }
         return fromHeight + slideProgress * (popoverHeight - fromHeight)
     }
@@ -156,6 +165,7 @@ struct DashboardView: View {
         modeBody
             .frame(width: Self.popoverWidth)
             .pinnedFooter(spacing: 0) { footerBar }
+            .pinnedTopBar(spacing: 0) { topBar }
             .frame(height: animatedPopoverHeight, alignment: .top)
             // Paint the surface behind the content (and footer) and tell every descendant whether
             // glass is on, so the fallbacks and the meter tints render in step. Both go on the
@@ -350,6 +360,53 @@ struct DashboardView: View {
                 reorderLift: $reorderLift
             )
         }
+    }
+
+    // MARK: - Pinned top nav bar
+
+    /// The back nav bar pinned above Customize and Settings — the macOS-native place for a back
+    /// affordance (top-leading), replacing the old trailing footer "Done" button. Empty on the
+    /// dashboard (which has nowhere to go back to), so it contributes no chrome there. Like the footer
+    /// it pins via `pinnedTopBar`, so content scrolls under it with the native scroll-edge blur.
+    @ViewBuilder
+    private var topBar: some View {
+        if layout.screen != .dashboard {
+            HStack(spacing: 10) {
+                backButton
+                Text(screenTitle)
+                    .font(.headline)
+                Spacer(minLength: 8)
+            }
+            .padding(.horizontal, Self.footerHorizontalPadding)
+            .frame(height: Self.topBarHeight)
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    /// Title for the current non-dashboard screen, shown beside the back button.
+    private var screenTitle: String {
+        switch layout.screen {
+        case .customize: "Customize"
+        case .settings: "Settings"
+        case .dashboard: ""
+        }
+    }
+
+    /// The round glass back button (chevron leading), matching the footer's glass control idiom. Esc
+    /// and the system shortcuts back out too; this is the visible, expected affordance.
+    private var backButton: some View {
+        Button {
+            withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
+        } label: {
+            Label("Back", systemImage: "chevron.backward")
+                .labelStyle(.iconOnly)
+                .frame(width: 16, height: 16)
+        }
+        .glassButtonStyle()
+        .buttonBorderShape(.circle)
+        .controlSize(.large)
+        .hoverTooltip("Back")
+        .accessibilityLabel("Back")
     }
 
     // MARK: - Pinned footer

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -165,7 +165,6 @@ struct DashboardView: View {
         modeBody
             .frame(width: Self.popoverWidth)
             .pinnedFooter(spacing: 0) { footerBar }
-            .pinnedTopBar(spacing: 0) { topBar }
             .frame(height: animatedPopoverHeight, alignment: .top)
             // Paint the surface behind the content (and footer) and tell every descendant whether
             // glass is on, so the fallbacks and the meter tints render in step. Both go on the
@@ -317,11 +316,13 @@ struct DashboardView: View {
                 reorderSpaceName: Self.reorderSpace,
                 reorderLift: $reorderLift
             )
+            .pinnedTopBar(spacing: 0) { navBar(title: "Customize") }
         case .settings:
             SettingsScreen(
                 contentHeight: $settingsContentHeight,
                 hasMeasuredContent: $hasMeasuredSettingsContent
             )
+            .pinnedTopBar(spacing: 0) { navBar(title: "Settings") }
         }
     }
 
@@ -365,31 +366,24 @@ struct DashboardView: View {
     // MARK: - Pinned top nav bar
 
     /// The back nav bar pinned above Customize and Settings — the macOS-native place for a back
-    /// affordance (top-leading), replacing the old trailing footer "Done" button. Empty on the
-    /// dashboard (which has nowhere to go back to), so it contributes no chrome there. Like the footer
-    /// it pins via `pinnedTopBar`, so content scrolls under it with the native scroll-edge blur.
-    @ViewBuilder
-    private var topBar: some View {
-        if layout.screen != .dashboard {
-            HStack(spacing: 10) {
-                backButton
-                Text(screenTitle)
-                    .font(.headline)
-                Spacer(minLength: 8)
-            }
-            .padding(.horizontal, Self.footerHorizontalPadding)
-            .frame(height: Self.topBarHeight)
-            .frame(maxWidth: .infinity)
+    /// affordance (top-leading), replacing the old trailing footer "Done" button. It pins *inside each
+    /// screen's page* (via `pinnedTopBar` in `screenView`) rather than over the whole popover, so it
+    /// slides in and out with its own page during a screen switch and always carries that page's own
+    /// title. Keying it off the shared `layout.screen` instead desynced it from the height: the screen
+    /// flips instantly at slide start while `animatedPopoverHeight` still uses the outgoing screen's
+    /// chrome, so the bar could appear before its 44pt was reserved (or linger after), and
+    /// Settings↔Customize flashed the wrong title mid-slide. Its fixed height is still reserved
+    /// per-screen in `chromeHeight(for:)`. Content scrolls under it with the native scroll-edge blur.
+    private func navBar(title: String) -> some View {
+        HStack(spacing: 10) {
+            backButton
+            Text(title)
+                .font(.headline)
+            Spacer(minLength: 8)
         }
-    }
-
-    /// Title for the current non-dashboard screen, shown beside the back button.
-    private var screenTitle: String {
-        switch layout.screen {
-        case .customize: "Customize"
-        case .settings: "Settings"
-        case .dashboard: ""
-        }
+        .padding(.horizontal, Self.footerHorizontalPadding)
+        .frame(height: Self.topBarHeight)
+        .frame(maxWidth: .infinity)
     }
 
     /// The round glass back button (chevron leading), matching the footer's glass control idiom. Esc

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -20,9 +20,9 @@ struct HeaderView: View {
     }
 
     /// On the dashboard this is the "More" button, opening the pull-down whose "Customize" and "Settings"
-    /// items are the ways into those screens. On any other screen it morphs into the prominent "Done"
-    /// button that returns to the dashboard (clicking it, or pressing ⏎/Esc, which `PopoverKeyReader`
-    /// routes for the whole popover).
+    /// items are the ways into those screens. The Customize and Settings screens carry their own
+    /// top-leading back button (`DashboardView.navBar`) to return home — the macOS-native place for it —
+    /// so the footer control simply drops away there rather than morphing into a trailing "Done".
     @ViewBuilder
     private var leadingControl: some View {
         if layout.screen == .dashboard {
@@ -31,10 +31,6 @@ struct HeaderView: View {
             }
             // The anchor view fills the button's frame so the menu drops from directly under it.
             .background(PopUpMenuAnchorView(anchor: moreMenuAnchor))
-        } else {
-            roundButton("Done", systemImage: "checkmark", prominent: true) {
-                withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
-            }
         }
     }
 
@@ -112,7 +108,8 @@ struct HeaderView: View {
             .glassButtonStyle(prominent: prominent)
             .buttonBorderShape(.circle)
             // The footer's only button: a larger control costs nothing and gives a bigger target.
+            // No hover tooltip — the ellipsis reads as a standard "More" affordance on its own; the
+            // `Label` title still carries the accessible name for VoiceOver.
             .controlSize(.large)
-            .hoverTooltip(title)
     }
 }

--- a/Sources/OpenUsage/Views/ProviderSectionHeader.swift
+++ b/Sources/OpenUsage/Views/ProviderSectionHeader.swift
@@ -50,8 +50,8 @@ struct ProviderSectionHeader<Trailing: View>: View {
                 DragHandleGrip()
                     .padding(.trailing, 4)
             }
-            // Baseline-aligned pair: the plan badge is smaller type, so centering it against
-            // the name leaves it floating high — text sits together only on a shared baseline.
+            // Baseline-aligned pair: the plan badge (and stale tag) are smaller type and sit on the
+            // name's text baseline, so the words line up along the bottom rather than floating centered.
             HStack(alignment: .firstTextBaseline, spacing: 5) {
                 // Name + plan keep their width and stay on one line; under width pressure (a long plan
                 // name like "Super Grok Heavy") the lower-priority stale tag truncates first instead of

--- a/Sources/OpenUsage/Views/ReorderGeometry.swift
+++ b/Sources/OpenUsage/Views/ReorderGeometry.swift
@@ -96,10 +96,8 @@ struct ReorderLiftPreview: View {
         // Same anatomy as the live Customize block (`CustomizeView.providerBlock`): header over the
         // card of metric rows, at the density's header→card spacing.
         VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
-            ProviderSectionHeader(provider: provider) {
-                ReorderGrip()
-            }
-            .padding(.horizontal, 8)
+            ProviderSectionHeader(provider: provider, showsDragHandle: true)
+                .padding(.horizontal, 8)
 
             VStack(spacing: 0) {
                 ForEach(Array(rows.enumerated()), id: \.offset) { _, title in


### PR DESCRIPTION
## What & why

Reworks the popover's Customize/Settings navigation toward the macOS-native pattern and aligns the Customize provider header with the dashboard.

### Back navigation
- The footer control used to **morph into a trailing "Done" checkmark** on Customize/Settings. That control now **disappears** on those screens, replaced by a **pinned top-leading back button** (chevron + screen title) — where users expect a back affordance.
- The dashboard is unchanged: it keeps the "More" (ellipsis) menu that leads into Customize/Settings.
- Added `pinnedTopBar` (`safeAreaBar` on macOS 26, `safeAreaInset` on 15) mirroring the existing `pinnedFooter`, with the native scroll-edge blur as content passes under it.
- Popover height math is now **per-screen chrome**: the back bar's fixed height is folded into `chromeHeight(for:)`/`screenHeight(for:)` so content never clips and the screen-switch slide animation stays in step.

### Customize header unification
- The Customize provider header now uses the **exact dashboard header path** — `ProviderSectionHeader(showsDragHandle: true)`: leading dot-grid drag handle, trailing provider mark — instead of a divergent variant with a trailing `ReorderGrip`. The only differences remain the omitted plan / warning / "Outdated" staleness tag (intentionally not shown in Customize).
- Kept the drag-lift preview (`ReorderGeometry`) in sync so the floating chip matches the live header.

### Minor
- Removed the "More" button's hover tooltip (the ellipsis is self-explanatory; the `Label` title still provides the VoiceOver name).

## Reviewer notes
- Esc and the existing keyboard shortcuts still back out of Customize/Settings — the new button is the visible affordance, not the only path.
- `topBarHeight` is a fixed constant (not measured) to keep the popover height deterministic; the bar pins itself to exactly that height.
- View-only changes; no tests reference these views. Verified with a local dev build + first-run launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SwiftUI-only navigation and layout math; no auth, data, or business-logic changes.
> 
> **Overview**
> Customize and Settings now use a **pinned top bar** (back chevron + title) instead of the footer morphing into a trailing **Done** checkmark; on those screens the footer **More** control is hidden while the dashboard still uses the ellipsis menu.
> 
> Adds **`pinnedTopBar`** (mirroring **`pinnedFooter`**) and folds a fixed **44pt** top bar into **per-screen** **`chromeHeight(for:)`** / **`screenHeight(for:)`** so scroll caps and the screen-switch height animation stay aligned with the bar that slides with each page.
> 
> Customize provider blocks and drag-lift previews now use **`ProviderSectionHeader(showsDragHandle: true)`** (leading dot-grid, trailing mark) like the dashboard, dropping the old trailing **`ReorderGrip`** variant. Minor: **More** loses its hover tooltip; **`.gitignore`** adds **`.agents/scheduled_tasks.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b73410323d90772839c462c3d5b7780303c34f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->