### PR TITLE
fix(claude): fail loudly on malformed custom OAuth URL instead of crashing

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -32,6 +32,7 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
     case notLoggedIn
     case sessionExpired
     case tokenExpired
+    case invalidOAuthURL(String)
 
     var errorDescription: String? {
         switch self {
@@ -41,6 +42,8 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
             return "Session expired. Run `claude` to log in again."
         case .tokenExpired:
             return "Token expired. Run `claude` to log in again."
+        case .invalidOAuthURL(let value):
+            return "Invalid Claude OAuth URL: \(value). Check CLAUDE_CODE_CUSTOM_OAUTH_URL / CLAUDE_LOCAL_OAUTH_API_BASE."
         }
     }
 }
@@ -139,7 +142,17 @@ struct ClaudeAuthStore: Sendable {
         envText("CLAUDE_CONFIG_DIR")
     }
 
-    func oauthConfig() -> ClaudeOAuthConfig {
+    // Resolved OAuth endpoint strings before URL validation. The suffix is derived from the same
+    // env-var branching as the URLs but never depends on URL validity, so the (non-throwing) keychain
+    // candidate path can read it without risking a throw.
+    private struct ResolvedOAuthEndpoints {
+        var baseAPI: String
+        var refreshURL: String
+        var clientID: String
+        var suffix: String
+    }
+
+    private func resolveOAuthEndpoints() -> ResolvedOAuthEndpoints {
         var baseAPI = Self.prodBaseAPIURL
         var refreshURL = Self.prodRefreshURL
         var clientID = Self.prodClientID
@@ -169,16 +182,34 @@ struct ClaudeAuthStore: Sendable {
             clientID = override
         }
 
+        return ResolvedOAuthEndpoints(baseAPI: baseAPI, refreshURL: refreshURL, clientID: clientID, suffix: suffix)
+    }
+
+    // baseAPI/refreshURL can derive from user-set env vars (CLAUDE_CODE_CUSTOM_OAUTH_URL,
+    // CLAUDE_LOCAL_OAUTH_API_BASE). A malformed value is a system-boundary input that must fail
+    // loudly — never force-unwrap (crashes the app) and never silently fall back to prod (that hides
+    // the misconfiguration and would send the user's token to production).
+    func oauthConfig() throws -> ClaudeOAuthConfig {
+        let endpoints = resolveOAuthEndpoints()
+        let usageURLString = "\(endpoints.baseAPI)/api/oauth/usage"
+        guard let usageURL = URL(string: usageURLString) else {
+            throw ClaudeAuthError.invalidOAuthURL(usageURLString)
+        }
+        guard let refreshURL = URL(string: endpoints.refreshURL) else {
+            throw ClaudeAuthError.invalidOAuthURL(endpoints.refreshURL)
+        }
         return ClaudeOAuthConfig(
-            usageURL: URL(string: "\(baseAPI)/api/oauth/usage")!,
-            refreshURL: URL(string: refreshURL)!,
-            clientID: clientID,
-            oauthFileSuffix: suffix
+            usageURL: usageURL,
+            refreshURL: refreshURL,
+            clientID: endpoints.clientID,
+            oauthFileSuffix: endpoints.suffix
         )
     }
 
     func keychainServiceCandidates() -> [String] {
-        let base = "\(Self.keychainServicePrefix)\(oauthConfig().oauthFileSuffix)-credentials"
+        // Only needs the file suffix, which never fails — keep this off the throwing URL path so
+        // credential loading stays forgiving even when a custom OAuth URL is malformed.
+        let base = "\(Self.keychainServicePrefix)\(resolveOAuthEndpoints().suffix)-credentials"
         if let configDir = claudeHomeOverride() {
             return ["\(base)-\(hashSuffix(configDir))", base]
         }

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -44,6 +44,26 @@ final class ClaudeAuthStoreTests: XCTestCase {
         XCTAssertEqual(credentials?.oauth.accessToken, "env-token")
         XCTAssertFalse(store.canFetchLiveUsage(credentials!))
     }
+
+    func testMalformedCustomOAuthURLThrowsInsteadOfCrashing() {
+        // A malformed custom OAuth URL is system-boundary input: oauthConfig() must fail loudly
+        // rather than force-unwrap a nil URL (which crashes) or silently fall back to prod.
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CODE_CUSTOM_OAUTH_URL": "http://exa mple.com"]),
+            files: FakeFiles(),
+            keychain: FakeKeychain()
+        )
+
+        XCTAssertThrowsError(try store.oauthConfig()) { error in
+            guard case ClaudeAuthError.invalidOAuthURL = error else {
+                return XCTFail("expected ClaudeAuthError.invalidOAuthURL, got \(error)")
+            }
+        }
+
+        // The forgiving credential-load path only needs the file suffix, so a malformed URL must not
+        // break keychain candidate resolution.
+        XCTAssertEqual(store.keychainServiceCandidates(), ["Claude Code-custom-oauth-credentials"])
+    }
 }
 
 final class ClaudeUsageMapperTests: XCTestCase {


### PR DESCRIPTION
## Description

`ClaudeAuthStore.oauthConfig()` force-unwrapped two `URL(string:)` results built from user-controllable env vars (`CLAUDE_CODE_CUSTOM_OAUTH_URL`, `CLAUDE_LOCAL_OAUTH_API_BASE`):

```swift
usageURL: URL(string: "\(baseAPI)/api/oauth/usage")!,
refreshURL: URL(string: refreshURL)!,
```

A malformed value makes `URL(string:)` return `nil` and the `!` crashes the whole app. This is a system-boundary input that should fail loudly, per AGENTS.md ("Always fail loudly… Only validate at system boundaries").

**What changed:**

- **`oauthConfig()` is now `throws`** and `guard let`s both URL builds, throwing a new `ClaudeAuthError.invalidOAuthURL(String)` — mirroring the existing guard in `DevinUsageClient` (`guard let url = URL(string:) else { throw … }`). No silent fallback to the prod URLs: that would hide the misconfiguration and ship the user's token to production.
- **Endpoint resolution is split from URL construction.** A new non-throwing `resolveOAuthEndpoints()` returns the raw endpoint strings + file suffix. The forgiving credential-load path (`loadCredentials → … → keychainServiceCandidates`) only ever needs the suffix, so it now reads from `resolveOAuthEndpoints()` and never depends on URL validity — keeping credential loading non-throwing.

The two production call sites (`ClaudeProvider.swift:95,119`) and the env-gated live test (`ClaudeProviderTests.swift`) already sit inside `try await` expressions, which cover the now-throwing nested call, so they compile unchanged.

## Related Issue

<!-- none -->

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `swift build` and it succeeded
- [x] I ran `swift test` and all tests pass (361 pass, 1 env-gated `OPENUSAGE_LIVE_CLAUDE` skip)
- [ ] I tested the change locally with `./script/build_and_run.sh`

Added regression test `testMalformedCustomOAuthURLThrowsInsteadOfCrashing`: feeds a malformed `CLAUDE_CODE_CUSTOM_OAUTH_URL`, asserts `oauthConfig()` throws `.invalidOAuthURL`, and asserts `keychainServiceCandidates()` still resolves correctly under the same bad URL (guards the decoupling).

## Screenshots

<!-- not applicable: no UI change -->

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My PR targets the `swift` branch (Swift edition)
- [x] **Behavior change?** No user-visible behavior change beyond replacing a crash with a friendly error; no `docs/` page applies
- [x] I did not introduce new dependencies without justification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow boundary validation on OAuth URL construction; existing provider call sites already propagate errors via `try`, with no silent prod fallback.
> 
> **Overview**
> **Claude OAuth URL building no longer force-unwraps** env-derived strings (`CLAUDE_CODE_CUSTOM_OAUTH_URL`, `CLAUDE_LOCAL_OAUTH_API_BASE`). `oauthConfig()` is now `throws`, validates usage and refresh URLs with `guard let`, and surfaces **`ClaudeAuthError.invalidOAuthURL`** with a message pointing at those env vars—no silent fallback to production endpoints.
> 
> Endpoint string resolution is split into a non-throwing **`resolveOAuthEndpoints()`** so **`keychainServiceCandidates()`** can still derive the OAuth file suffix when URLs are invalid, keeping credential loading from failing on the same misconfiguration.
> 
> A regression test asserts malformed custom OAuth URLs throw from `oauthConfig()` while keychain service names still resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3853e16903a81ed7931a1ddd51d9a1c1544c8676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->