### PR TITLE
fix(cache): scope snapshot freshness to the running session (#697)

### DIFF
--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -14,11 +14,19 @@ struct ProviderSnapshotCache {
     /// safe to share.
     private let memo = OSAllocatedUnfairLock<Payload?>(initialState: nil)
 
+    /// Provider IDs whose snapshot was written by `store` *during this cache instance's lifetime* (i.e.
+    /// this running session). The freshness gate (`snapshot(providerID:)`) trusts a snapshot only when
+    /// its provider is in here — so a snapshot loaded from disk on launch is shown (via `loadSnapshots`)
+    /// but never counts as fresh, forcing one refresh on the first post-launch pass. Lock-backed for the
+    /// same reason as `memo`: the value-type cache shares it across copies and stays safe. See #697.
+    private let sessionWrites = OSAllocatedUnfairLock<Set<String>>(initialState: [])
+
     private let userDefaults: UserDefaults
     private let storageKey: String
-    /// A snapshot stays fresh for exactly one refresh interval, which is what lets cached data survive a
-    /// relaunch without an immediate refetch and expire precisely when the next refresh is due. Tests
-    /// inject a fixed TTL for a deterministic freshness window.
+    /// A snapshot written this session stays fresh for exactly one refresh interval, then expires so the
+    /// periodic loop refetches on schedule. A snapshot loaded from a *previous* session (off disk) is never
+    /// fresh regardless of its `refreshedAt` — see `sessionWrites`. Tests inject a fixed TTL for a
+    /// deterministic freshness window.
     private let ttl: TimeInterval
     private let now: () -> Date
     private let encoder: JSONEncoder
@@ -65,11 +73,16 @@ struct ProviderSnapshotCache {
     func snapshot(providerID: String) -> ProviderSnapshot? {
         let snapshot = loadPayload().snapshots[providerID]
         guard let snapshot else { return nil }
-        // Inlined the freshness check so the staleness can be logged (age vs ttl -> fresh|stale);
-        // behavior is identical to the prior `isValid` helper.
+        // Freshness has two requirements, and disk age alone is not enough: the snapshot must have been
+        // written *this session* AND still be within TTL. A snapshot served from a previous session's
+        // persisted blob is shown for instant paint but never gates a refresh, so every launch refetches
+        // promptly instead of waiting out the previous session's remaining interval (#697).
+        let writtenThisSession = sessionWrites.withLock { $0.contains(providerID) }
         let age = now().timeIntervalSince(snapshot.refreshedAt)
-        let fresh = age < ttl
-        AppLog.debug(.cache, "\(providerID) staleness \(Int(age))s vs ttl \(Int(ttl))s -> \(fresh ? "fresh" : "stale")")
+        let fresh = writtenThisSession && age < ttl
+        let reason = !writtenThisSession ? "stale (not written this session)"
+            : fresh ? "fresh" : "stale"
+        AppLog.debug(.cache, "\(providerID) staleness \(Int(age))s vs ttl \(Int(ttl))s -> \(reason)")
         return fresh ? snapshot : nil
     }
 
@@ -79,6 +92,9 @@ struct ProviderSnapshotCache {
             return
         }
         AppLog.debug(.cache, "write \(snapshot.providerID)")
+        // Mark this provider as written *this session* so its snapshot now satisfies the freshness gate
+        // (a launch-loaded snapshot never does — see `sessionWrites`).
+        sessionWrites.withLock { $0.insert(snapshot.providerID) }
         var payload = loadPayload()
         payload.snapshots[snapshot.providerID] = snapshot
         save(payload)

--- a/Tests/OpenUsageTests/ProviderSnapshotCacheTests.swift
+++ b/Tests/OpenUsageTests/ProviderSnapshotCacheTests.swift
@@ -42,10 +42,60 @@ final class ProviderSnapshotCacheTests: XCTestCase {
         ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 9_999, now: { now })
             .store(snapshot("alpha", used: 42, now: now))
 
-        // A fresh instance starts with an empty mirror, so reading "alpha" proves the write reached
-        // disk — the mirror is a cache over persistence, not a replacement for it.
+        // A fresh instance starts with an empty mirror, so the *display* read (`loadSnapshots`) proves the
+        // write reached disk — the mirror is a cache over persistence, not a replacement for it. (The
+        // freshness gate `snapshot(providerID:)` deliberately treats this disk-loaded value as stale; see
+        // `testRelaunchLoadedSnapshotIsStaleEvenWithinTTL`.)
         let reloaded = ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 9_999, now: { now })
-        XCTAssertEqual(reloaded.snapshot(providerID: "alpha")?.lines.first,
+        XCTAssertEqual(reloaded.loadSnapshots(providerIDs: ["alpha"])["alpha"]?.lines.first,
                        .progress(label: "Session", used: 42, limit: 100, format: .percent))
+    }
+
+    /// #697 core guarantee: a snapshot persisted by a *previous* session and reloaded on launch must not
+    /// satisfy the refresh gate, even when its `refreshedAt` is still well within TTL — otherwise the app
+    /// would wait out the previous session's remaining interval before refetching. It must still *display*
+    /// (instant paint), so `loadSnapshots` returns it.
+    func testRelaunchLoadedSnapshotIsStaleEvenWithinTTL() {
+        let (defaults, suite) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let now = Date()
+        // Session 1 writes a snapshot 1s ago — comfortably inside the 9_999s TTL.
+        ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 9_999, now: { now })
+            .store(snapshot("alpha", used: 42, now: now.addingTimeInterval(-1)))
+
+        // Session 2 (fresh instance = relaunch) reloads it from disk.
+        let relaunched = ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 9_999, now: { now })
+        // Display still paints the last-known value...
+        XCTAssertNotNil(relaunched.loadSnapshots(providerIDs: ["alpha"])["alpha"])
+        // ...but the refresh gate treats it as stale, forcing a refresh on the first post-launch pass.
+        XCTAssertNil(relaunched.snapshot(providerID: "alpha"))
+    }
+
+    /// Acceptance criterion 2: a snapshot written *this* session still short-circuits a redundant refresh
+    /// within that session (no refresh storm) — the gate is "written this session AND within TTL", not
+    /// "written this session" alone.
+    func testSnapshotWrittenThisSessionStaysFreshWithinTTL() {
+        let (defaults, suite) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let now = Date()
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 9_999, now: { now })
+
+        cache.store(snapshot("alpha", used: 42, now: now))
+        XCTAssertEqual(cache.snapshot(providerID: "alpha")?.lines.first,
+                       .progress(label: "Session", used: 42, limit: 100, format: .percent))
+    }
+
+    /// A snapshot written this session still expires once it ages past TTL, so the periodic loop resumes
+    /// refetching on the normal cadence (the session-write flag widens freshness on launch, it doesn't
+    /// pin a snapshot fresh forever).
+    func testSnapshotWrittenThisSessionExpiresAfterTTL() {
+        let (defaults, suite) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+        var now = Date()
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "k", ttl: 100, now: { now })
+
+        cache.store(snapshot("alpha", used: 42, now: now))
+        now = now.addingTimeInterval(101)
+        XCTAssertNil(cache.snapshot(providerID: "alpha"))
     }
 }

--- a/Tests/OpenUsageTests/RefreshSettingTests.swift
+++ b/Tests/OpenUsageTests/RefreshSettingTests.swift
@@ -2,8 +2,9 @@ import XCTest
 @testable import OpenUsage
 
 /// Covers the refresh cadence as the single source of truth: `RefreshSetting`'s fixed interval, and the
-/// snapshot cache treating a snapshot as fresh for exactly one interval (so cached data survives a
-/// relaunch within the interval and is refetched once past it).
+/// snapshot cache's session-scoped freshness — a snapshot is fresh for one interval only *within the
+/// session that fetched it*, so a relaunch always refetches on the first pass (it still paints the cached
+/// value instantly) while a within-session pass is served from cache until the interval elapses. See #697.
 @MainActor
 final class RefreshSettingTests: XCTestCase {
     // MARK: - Fixed cadence
@@ -13,20 +14,53 @@ final class RefreshSettingTests: XCTestCase {
         XCTAssertEqual(RefreshSetting.interval, 300)
     }
 
-    // MARK: - Cache TTL tied to the interval
+    // MARK: - Session-scoped freshness
 
-    func testCacheReusedAcrossRestartWithinInterval() async {
+    func testRelaunchRefetchesEvenWithinIntervalButPaintsCachedValueFirst() async {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let suite = makeDefaults("restart-within")
 
         // A prior session left a snapshot 4 minutes ago — inside the 5-minute interval.
         storeSnapshot(used: 20, age: 240, into: suite, now: now)
 
+        // A fresh store/cache (= relaunch) loads it from disk for instant paint…
         let runtime = makeRuntime(used: 80)
         let store = makeStore(runtime: runtime, suite: suite, now: now)
+        XCTAssertEqual(store.snapshots["test"]?.line(label: "Session"),
+                       .progress(label: "Session", used: 20, limit: 100, format: .percent))
+
+        // …but a disk-loaded snapshot never gates the refresh, so the first pass refetches (#697) even
+        // though the snapshot is still within the interval.
+        await store.refreshAll()
+        XCTAssertEqual(runtime.refreshCount, 1)
+        XCTAssertEqual(store.snapshots["test"]?.line(label: "Session"),
+                       .progress(label: "Session", used: 80, limit: 100, format: .percent))
+    }
+
+    func testWithinSessionPassServedFromCacheUntilInterval() async {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let suite = makeDefaults("within-session")
+
+        // One cache instance shared between the seeding write and the store models a single running
+        // session: the snapshot was fetched 4 minutes ago *this* session, so it short-circuits the pass.
+        let cache = ProviderSnapshotCache(userDefaults: suite, storageKey: "snapshots", now: { now })
+        cache.store(ProviderSnapshot(
+            providerID: "test",
+            displayName: "Test",
+            lines: [.progress(label: "Session", used: 20, limit: 100, format: .percent)],
+            refreshedAt: now.addingTimeInterval(-240)
+        ))
+
+        let runtime = makeRuntime(used: 80)
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [runtime.provider], descriptors: runtime.widgetDescriptors),
+            providers: [runtime],
+            cache: cache,
+            defaults: suite
+        )
         await store.refreshAll()
 
-        XCTAssertEqual(runtime.refreshCount, 0) // within interval => served from cache, no fetch
+        XCTAssertEqual(runtime.refreshCount, 0) // fetched this session, within interval => no refetch
         XCTAssertNotNil(store.snapshots["test"])
     }
 

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -8,7 +8,9 @@
 
 ## Caching
 
-Snapshots are cached on disk and load instantly at launch, so you see your last-known values immediately instead of placeholders — even before the first fetch finishes. A cached value counts as fresh for one refresh interval; after that it still displays, but the next pass re-fetches it.
+Snapshots are cached on disk and load instantly at launch, so you see your last-known values immediately instead of placeholders — even before the first fetch finishes.
+
+A cached value only counts as *fresh* (skip-a-refresh fresh) when it was fetched **during the current running session**. So a value cached in an earlier session always re-fetches on the first pass after launch — you still see it instantly, but the app never waits out the old interval before getting live numbers. This matters after an update: a new app version refreshes right away instead of showing the previous version's data until its interval lapses. Within a session, a freshly fetched value then counts as fresh for one refresh interval before the next pass re-fetches it.
 
 ## When a fetch fails
 


### PR DESCRIPTION
## Description

On launch OpenUsage served the previous session's persisted snapshot **and let it suppress the first refresh** until its TTL lapsed. The result: after a restart/rebuild/update the menu bar could show data up to one refresh interval old, and any ship that changed what a snapshot contains (e.g. the Cursor/Grok Usage Trend rows in #688) showed stale/incomplete data until the cache expired — with no refetch triggered by the launch itself.

This makes snapshot freshness **session-scoped**:

- `ProviderSnapshotCache` now tracks which providers were written via `store` during the current cache instance's lifetime (a lock-backed `sessionWrites` set, mirroring the existing `memo` lock pattern).
- The refresh gate, `snapshot(providerID:)`, trusts a snapshot only when it was **written this session AND is within TTL**. A snapshot loaded from a prior session's disk blob is never in `sessionWrites`, so it never satisfies the gate → the first post-launch pass always refetches.
- The **display** path (`loadSnapshots`) is unchanged, so the popover still paints last-known values instantly (no blank-then-populate flash).
- Within a session, a freshly fetched snapshot still short-circuits redundant refreshes for one interval (no refresh storm).

This also makes the schema-version key bump (`openusage.providerSnapshots.vN`) far less load-bearing: every launch refetches, so a stale-shape payload is replaced immediately rather than misresolved until TTL.

## Related Issue

Fixes #697

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider
- [x] Documentation
- [ ] Performance improvement

## Testing

- [x] I ran `swift build` and it succeeded
- [x] I ran `swift test` and all tests pass

New/updated tests in `ProviderSnapshotCacheTests`:
- `testRelaunchLoadedSnapshotIsStaleEvenWithinTTL` — the issue's required regression: a within-TTL snapshot written by a *previous* instance displays but does **not** suppress the launch refresh.
- `testSnapshotWrittenThisSessionStaysFreshWithinTTL` — in-session hit still short-circuits (acceptance criterion 2).
- `testSnapshotWrittenThisSessionExpiresAfterTTL` — normal cadence still resumes after TTL.
- `testWritesPersistForAFreshInstance` — reframed to prove persistence via the display path (`loadSnapshots`), since the freshness gate now correctly treats disk-loaded data as stale.

Existing same-instance cache-hit and expired-snapshot tests (`StaleWhileRevalidateTests`, `WidgetDataStoreTests`) still pass — they use a single cache instance, which mirrors a real in-session hit.

## Checklist

- [x] My PR targets the `swift` branch
- [x] **Behavior change?** Updated `docs/refreshing.md` (Caching section) to explain session-scoped freshness
- [x] I did not introduce new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core refresh gating used by `WidgetDataStore` on every periodic pass; behavior is well-tested but affects all providers’ fetch cadence at launch.
> 
> **Overview**
> Fixes launch/restart behavior where a **within-TTL disk snapshot could block the first refresh**, so the menu bar could show data up to one interval old until TTL elapsed (notably after app updates or schema changes).
> 
> **`ProviderSnapshotCache`** now tracks provider IDs written via `store` in a lock-backed **`sessionWrites`** set. The refresh gate **`snapshot(providerID:)`** returns a snapshot only when it was **written this session and still within TTL**; disk-loaded snapshots from a prior run never satisfy the gate, so the first post-launch refresh pass always refetches. **`loadSnapshots`** is unchanged so the UI still paints last-known values immediately.
> 
> Within the same session, freshly stored snapshots still skip redundant refreshes until TTL expires. Tests cover relaunch stale-gate vs display paint, in-session cache hits, TTL expiry, and integration via **`RefreshSettingTests`**; **`docs/refreshing.md`** documents session-scoped “skip-a-refresh” freshness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 179de2aa292e393bcbae92c8a1efadfdf66412d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->