### PR TITLE
fix(metrics): clamp quota percent meters to 0–100 (#703)

### DIFF
--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -195,7 +195,11 @@ struct WidgetData: Hashable {
     var menuBarValue: String {
         guard hasData else { return valueText }
         if let limit, limit > 0 {
-            let percent = max(0, Int((displayedValue / limit * 100).rounded()))
+            // The tray glance is always 0...100%: clamp both ends so neither a negative sample nor an
+            // over-limit one (e.g. a dollar meter past its cap, rendered here as a percentage) ever
+            // reads "-5%" or "105%" beside the icon. Over-limit is shown by the meter's color/spent
+            // state in the popover, not by the tray number.
+            let percent = min(100, max(0, Int((displayedValue / limit * 100).rounded())))
             return "\(percent)%"
         }
         if let first = selectedValues.first {

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -281,11 +281,19 @@ final class WidgetDataStore {
     private func resolve(_ line: MetricLine, descriptor: WidgetDescriptor) -> WidgetData? {
         switch line {
         case .progress(_, let used, let limit, let format, let resetsAt, let periodDurationMs, _):
+            // A percent meter is a bounded 0...100 domain; sanitize an out-of-range sample (a provider
+            // reporting a negative or >100 utilization) here, at the single construction choke point
+            // every provider funnels through, so no surface — headline, flip tooltip, menu bar — can
+            // render "-5%" or "105%". For percent the limit is always 100, so clamping `used` also
+            // keeps the meter's spent verdict intact (>=100 still reads "Limit reached"). Non-percent
+            // meters keep their raw `used`: a dollar/count overage (used > limit) is real and is
+            // conveyed by the meter's spent state rather than hidden.
+            let normalizedUsed = format == .percent ? ProviderParse.clampPercent(used) : used
             return WidgetData(
                 title: descriptor.sample.title,
                 icon: descriptor.sample.icon,
                 kind: format.metricKind,
-                used: used,
+                used: normalizedUsed,
                 limit: limit,
                 countSuffix: format.countSuffix,
                 valuePrefix: descriptor.sample.valuePrefix,
@@ -356,8 +364,10 @@ final class WidgetDataStore {
         case .percent:
             guard let percent = Self.firstNumber(in: value) else { return sample }
             // Percent rows are always 0–100, so a missing sample limit defaults to a full 100 scale,
-            // and they carry no `unboundedValueWord` (they're never an unbounded balance).
-            return textData(sample, kind: .percent, used: percent, limit: sample.limit ?? 100)
+            // and they carry no `unboundedValueWord` (they're never an unbounded balance). `firstNumber`
+            // accepts a leading sign, so clamp the parsed value to the same 0...100 domain the
+            // `.progress` percent path guarantees, keeping a stray "-5%" out of every surface.
+            return textData(sample, kind: .percent, used: ProviderParse.clampPercent(percent), limit: sample.limit ?? 100)
         }
     }
 

--- a/Sources/OpenUsage/Support/MetricFormatter.swift
+++ b/Sources/OpenUsage/Support/MetricFormatter.swift
@@ -25,7 +25,11 @@ enum MetricFormatter {
     static func number(_ value: Double, kind: MetricKind, style: Style) -> String {
         switch kind {
         case .percent:
-            return "\(Int(value.rounded()))%"
+            // Percent is a bounded 0...100 domain, so clamp defensively: a bad sample (a provider
+            // reporting a negative or >100 utilization) can never print "-5%" or "105%" on any
+            // surface that formats through here. Over-limit is conveyed by the meter's spent state
+            // and color (see `WidgetData.meterState`), not by an out-of-range headline number.
+            return "\(Int(ProviderParse.clampPercent(value).rounded()))%"
         case .dollars:
             // Tray and row abbreviate four figures and up ("$1.2M", "$2.1K") so neither carries
             // "$2,059.07"; the full form (tooltips/headlines) always keeps grouped cents.

--- a/Tests/OpenUsageTests/MetricFormatterTests.swift
+++ b/Tests/OpenUsageTests/MetricFormatterTests.swift
@@ -30,6 +30,15 @@ final class MetricFormatterTests: XCTestCase {
         XCTAssertEqual(MetricFormatter.number(95.4, kind: .percent, style: .tray), "95%")
     }
 
+    func testPercentClampsOutOfRangeSamples() {
+        // Percent is a bounded 0...100 domain: a bad sample (a provider reporting a negative or >100
+        // utilization) must never print "-5%" or "130%" — it clamps to the nearest bound. (#703)
+        XCTAssertEqual(MetricFormatter.number(-5, kind: .percent, style: .full), "0%")
+        XCTAssertEqual(MetricFormatter.number(-5, kind: .percent, style: .tray), "0%")
+        XCTAssertEqual(MetricFormatter.number(130, kind: .percent, style: .full), "100%")
+        XCTAssertEqual(MetricFormatter.number(100.6, kind: .percent, style: .row), "100%")
+    }
+
     func testValueStringAppendsUnitLabelWhenPresent() {
         let credits = MetricValue(number: 772, kind: .count, label: "credits")
         XCTAssertEqual(MetricFormatter.string(for: credits, style: .row), "772 credits")

--- a/Tests/OpenUsageTests/WidgetPercentClampTests.swift
+++ b/Tests/OpenUsageTests/WidgetPercentClampTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import OpenUsage
+
+/// Regression for #703: a percent meter fed an out-of-range sample (a provider reporting a negative or
+/// >100 utilization) must never surface "-5%" or "105%" on any rendering path — the tile headline, the
+/// Used/Left flip tooltip, or the menu-bar value — in either meter style. The sample is sanitized at the
+/// construction choke point (`WidgetDataStore.resolve`), with a defensive clamp in `MetricFormatter`.
+@MainActor
+final class WidgetPercentClampTests: XCTestCase {
+    func testNegativePercentSampleNeverRendersNegative() async {
+        let (store, descriptor) = await makePercentStore(used: -5, suite: "negative")
+
+        // Default (remaining) mode: clamped used = 0 reads as a clean "0% used" / "100% left" meter.
+        store.meterStyle = .remaining
+        let remaining = store.data(for: descriptor)
+        XCTAssertEqual(remaining.used, 0) // sanitized at construction
+        XCTAssertEqual(remaining.valueText, "100%")
+        XCTAssertEqual(remaining.boundedHeadline, "100% left")
+        XCTAssertEqual(remaining.menuBarValue, "100%")
+        // The flip tooltip was the path that leaked "-5% used" even in the default mode.
+        XCTAssertEqual(remaining.meterStyleTooltip, "0% used")
+
+        // Used mode: the headline itself was the visible "-5% used" bug.
+        store.meterStyle = .used
+        let used = store.data(for: descriptor)
+        XCTAssertEqual(used.valueText, "0%")
+        XCTAssertEqual(used.boundedHeadline, "0% used")
+        XCTAssertEqual(used.menuBarValue, "0%")
+        XCTAssertEqual(used.meterStyleTooltip, "100% left")
+    }
+
+    func testOverHundredPercentSampleNeverRendersOverHundred() async {
+        let (store, descriptor) = await makePercentStore(used: 130, suite: "over")
+
+        store.meterStyle = .used
+        let used = store.data(for: descriptor)
+        XCTAssertEqual(used.used, 100) // sanitized at construction
+        XCTAssertEqual(used.valueText, "100%")
+        XCTAssertEqual(used.boundedHeadline, "100% used")
+        XCTAssertEqual(used.menuBarValue, "100%")
+        // Overage still reads as spent — it's conveyed by the meter state, not an out-of-range number.
+        XCTAssertEqual(used.meterState(), .spent)
+
+        store.meterStyle = .remaining
+        let remaining = store.data(for: descriptor)
+        XCTAssertEqual(remaining.valueText, "0%")
+        XCTAssertEqual(remaining.boundedHeadline, "0% left")
+        XCTAssertEqual(remaining.menuBarValue, "0%")
+    }
+
+    // MARK: - Helper
+
+    /// A refreshed store whose single provider emits one `.progress(format: .percent)` line with the
+    /// given `used` against a limit of 100 — i.e. the real resolve path every provider funnels through.
+    private func makePercentStore(used: Double, suite: String) async -> (WidgetDataStore, WidgetDescriptor) {
+        let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("codex"))
+        let descriptor = WidgetDescriptor(
+            id: "test.metric",
+            providerID: provider.id,
+            metricLabel: "Metric",
+            sample: WidgetData(title: "Metric", icon: provider.icon, kind: .percent, used: 0, limit: 100)
+        )
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.progress(label: "Metric", used: used, limit: 100, format: .percent)]
+            )
+        )
+        let suiteName = "OpenUsageTests.PercentClamp.\(suite).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() })
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: cache,
+            defaults: defaults
+        )
+        await store.refreshAll()
+        return (store, descriptor)
+    }
+}


### PR DESCRIPTION
Closes #703.

## Problem

A quota **percent** meter fed an out-of-range sample could render outside `[0, 100]`:

- **Tile headline (Used mode)** — `valueText` → `boundedHeadline` formatted `used` with no clamp → `-5% used`.
- **Used/Left flip tooltip (even in the default Left mode)** — `meterStyleTooltip` passed `used` straight through → headline `105% left` with a hover reading `-5% used`.
- **Menu-bar strip** — `menuBarValue` clamped the low end but had no upper bound → `105%`.

Root cause: only **Grok** and **Devin** sanitized via `ProviderParse.clampPercent`. **Codex** / **Claude** / **Cursor** fed raw `used_percent` / `utilization` / `totalPercentUsed` — plus Cursor's computed `planUsedCents / limit * 100`, which goes negative when `remaining > limit` (credit/refund/pooled mismatch) — straight into `.progress(format: .percent)`. `MetricFormatter.number(.percent)` then printed whatever it was handed.

## Fix

- Clamp percent `used` to `0…100` centrally in `WidgetDataStore.resolve` (and the `.percent` branch of `resolveText`) — one choke point every provider funnels through.
- Defensive clamp in `MetricFormatter.number` for `.percent`.
- Cap `menuBarValue`'s bounded-percent tray glance at `100`.

Overage semantics are unchanged: `meterState` still reads the raw pace inputs, so over-limit surfaces through the existing **spent / running-out** state and color — never a `105%` number.

## Tests

- `WidgetPercentClampTests` — `used = -5` and `used = 130` across both meter styles, asserting in-range `valueText`, `boundedHeadline`, `menuBarValue`, and `meterStyleTooltip` (and that `130` still reads `.spent`).
- `MetricFormatterTests` — `.percent` clamps `-5 → 0%` and `130 → 100%`.

Full suite: 369 tests, 0 failures.

## Note on #682

This is the split-out, genuinely-reachable half of #682. That issue's attached screenshot — a horizontal `49% · -5%` menu-bar strip — was checked across every released version of **both** editions and is **not** produced by our code (the Swift strip stacks vertically and clamps; Tauri shows a single clamped percent), so #682 was closed as not-ours. This PR fixes the in-app surfaces that *can* go out of range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-layer sanitization with targeted tests; non-percent meters and spent/overage semantics are unchanged.
> 
> **Overview**
> Fixes **#703** by keeping percent quota meters on a **0…100** domain everywhere users see them, so bad provider samples never show **-5%** or **105%** on tiles, Used/Left tooltips, or the menu bar.
> 
> **`WidgetDataStore`** now runs `ProviderParse.clampPercent` on percent `.progress` lines and on percent values parsed from `.text` rows—the single construction path for widget data. **`MetricFormatter`** applies the same clamp for `.percent` as a backstop. **`WidgetData.menuBarValue`** caps bounded tray percentages at **100%** (it already floored at 0). Dollar/count meters still pass through raw overages; only percent utilization is normalized.
> 
> Regression coverage: **`WidgetPercentClampTests`** for negative and >100 samples across meter styles and surfaces, plus **`MetricFormatterTests`** for out-of-range percent formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ab43d38056981954581cb144faa001575f46d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->