### PR TITLE
feat(dashboard): add "Always Show Pacing" setting for on-track meters (#685)

### DIFF
--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -23,6 +23,12 @@ struct WidgetData: Hashable {
     var displayMode: WidgetDisplayMode = .used
     /// Global relative/absolute reset display, stamped by `WidgetDataStore` (like `displayMode`).
     var resetDisplayMode: ResetDisplayMode = .relative
+    /// Global "always show pacing" opt-in, stamped by `WidgetDataStore` (like `displayMode`). When on,
+    /// `meterState(now:)` surfaces pacing on the otherwise-silent on-track rows: the blue/healthy row
+    /// gains its projection copy + an even-pace tick, and the amber tick switches from the slack edge to
+    /// the same even-pace line. Off (default) leaves every row exactly as it was. The red run-out states
+    /// never gain a tick either way — the flame + run-out time already carry the message there.
+    var alwaysShowPacing: Bool = false
     var resetsAt: Date?
     /// Zero or more future expiry instants surfaced in the row's hover tooltip (Codex rate-limit-reset
     /// credits — one entry per still-available credit). Empty for every other row. Kept as raw `Date`s so
@@ -87,10 +93,12 @@ struct WidgetData: Hashable {
     }
 
     /// The meter's full visual state, derived once (`meterState(now:)`) so the bar color, the
-    /// amber tick, and the label-line warning copy can never contradict each other. Precedence,
+    /// tick, and the label-line warning copy can never contradict each other. Precedence,
     /// highest first: no data → spent → live pace verdict → absolute level bands. Each case owns
     /// exactly the data its rendering needs, so impossible combinations (a tick on a red bar, a
-    /// run-out time with no flame) can't be expressed.
+    /// run-out time with no flame) can't be expressed. A tick lives only on the on-track cases
+    /// (`closeToLimit` always; `healthy` only when "always show pacing" is on) — the red run-out
+    /// states carry the flame instead, so a tick never sits on a red bar.
     enum MeterState: Hashable {
         /// No real metric backs the tile — gray, empty track, no copy.
         case noData
@@ -104,7 +112,8 @@ struct WidgetData: Hashable {
         /// rounds to 0%
         /// (≤ limit, so there's no run-out time) — in both cases the flame shows alone rather than a
         /// misleading "0s" or a "~0% spare" amber bar. `projectedFraction` (projected end-of-period
-        /// usage ÷ limit) backs the tooltip's overage / "lands at the limit" copy.
+        /// usage ÷ limit) backs the tooltip's overage / "lands at the limit" copy. Carries no tick —
+        /// a behind bar is the flame's job, never a notch.
         case runningOut(eta: String?, projectedFraction: Double)
         /// Projected to land inside the last 10% — cutting it close — but still with a cushion of at
         /// least 1%. (A cushion that rounds to 0% promotes to `runningOut` instead, so amber never
@@ -114,9 +123,13 @@ struct WidgetData: Hashable {
         /// remaining − spare in Left view, so it's the last slice of the fill — see
         /// `WidgetRowView.meter`). `projectedFraction` backs the tooltip's "% used at reset" copy.
         case closeToLimit(spare: String, tick: Double, projectedFraction: Double)
-        /// On course to finish with ≥10% to spare. Blue, no decoration. `projectedFraction` backs the
-        /// tooltip's "% left at reset" cushion copy.
-        case healthy(projectedFraction: Double)
+        /// On course to finish with ≥10% to spare. Blue. By default it carries no decoration; when
+        /// "always show pacing" is on it surfaces the projection copy ("~N% left at reset") and
+        /// `evenPaceTick` is set — the even-pace line, anchored to the side the fill leaves open (out
+        /// in the gray ahead of the fill in Left view, inside the fill in Used view), so the row reads
+        /// "you're ahead of pace" at a glance. `nil` when the setting is off. `projectedFraction` backs
+        /// the tooltip's "% left at reset" cushion copy.
+        case healthy(projectedFraction: Double, evenPaceTick: Double?)
         /// No pace signal to project (no reset window, or <5% of it elapsed): color from the
         /// absolute level bands on the share used, no copy.
         case level(MeterSeverity)
@@ -143,7 +156,7 @@ struct WidgetData: Hashable {
             switch self {
             case .noData, .level: return nil
             case .spent: return "Limit reached"
-            case .healthy(let projectedFraction):
+            case .healthy(let projectedFraction, _):
                 let left = Int(((1 - projectedFraction) * 100).rounded())
                 return "~\(left)% left at reset"
             case .closeToLimit(_, _, let projectedFraction):
@@ -154,6 +167,18 @@ struct WidgetData: Hashable {
                 // Floored to 1% so a bar projected even slightly over never reads "~0% over limit".
                 let over = max(1, Int(((projectedFraction - 1) * 100).rounded()))
                 return "~\(over)% over limit at reset"
+            }
+        }
+
+        /// The tick position on the bar (0...1), or `nil` when the bar carries no tick. Lives on the
+        /// on-track cases only — `closeToLimit` always, `healthy` when "always show pacing" set its
+        /// `evenPaceTick`. The red run-out states and the plain level/no-data states never have one, so
+        /// a tick can never appear on a red bar.
+        var tick: Double? {
+            switch self {
+            case .closeToLimit(_, let tick, _): return tick
+            case .healthy(_, let evenPaceTick): return evenPaceTick
+            case .noData, .spent, .runningOut, .level: return nil
             }
         }
     }
@@ -422,9 +447,22 @@ extension WidgetData {
         if let ctx = paceContext,
            let result = Pace.evaluate(used: used, limit: ctx.limit, resetsAt: ctx.resetsAt,
                                       periodDuration: ctx.period, now: now) {
+            // The even-pace line: where a perfectly steady user would sit right now — the elapsed
+            // fraction of the period, recovered as used ÷ projected-usage (projected = used ÷ elapsed,
+            // so the dates cancel). Placed to read as "ahead" against the bar's framing: in Left
+            // (remaining) view — the common one — it sits out in the gray ahead of the fill; in Used
+            // view it sits inside the fill. (These are mirror positions; we anchor to whichever side
+            // the fill leaves open so a healthy bar's tick never buries itself in the fill in Left
+            // view.) Only surfaced when "always show pacing" is on; otherwise `nil` leaves every row as it was.
+            let evenPaceTick: Double? = {
+                guard alwaysShowPacing, result.projectedUsage > 0 else { return nil }
+                let elapsed = min(max(used / result.projectedUsage, 0), 1)
+                return displayMode == .remaining ? elapsed : 1 - elapsed
+            }()
             switch result.status {
             case .ahead:
-                return .healthy(projectedFraction: result.projectedUsage / ctx.limit)
+                return .healthy(projectedFraction: result.projectedUsage / ctx.limit,
+                                evenPaceTick: evenPaceTick)
             case .onTrack:
                 let projected = result.projectedUsage / ctx.limit
                 let spare = Int(((1 - projected) * 100).rounded())
@@ -435,8 +473,11 @@ extension WidgetData {
                 // tooltip reads "~100% used at reset", exactly `runningOut`'s documented float-edge meaning.
                 guard spare >= 1 else { return .runningOut(eta: nil, projectedFraction: projected) }
                 let usedShare = used / ctx.limit
-                let tick = displayMode == .remaining ? projected - usedShare
-                                                     : usedShare + (1 - projected)
+                // Default: the slack-edge tick (used + spare). When "always show pacing" is on, switch
+                // to the even-pace line so the tick means the same thing on every on-track bar.
+                let slackTick = displayMode == .remaining ? projected - usedShare
+                                                          : usedShare + (1 - projected)
+                let tick = evenPaceTick ?? slackTick
                 return .closeToLimit(spare: "~\(spare)% spare", tick: tick, projectedFraction: projected)
             case .behind:
                 let eta = Pace.secondsToRunOut(used: used, limit: ctx.limit, resetsAt: ctx.resetsAt,

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -27,6 +27,7 @@ final class WidgetDataStore {
 
     private static let meterStyleKey = "meterStyle"
     private static let resetDisplayModeKey = "resetDisplayMode"
+    private static let alwaysShowPacingKey = "alwaysShowPacing"
     /// How long a provider that just failed is skipped before the loop will probe it again. A failed
     /// refresh isn't cached, so — unlike a success, which the snapshot cache gates for an interval —
     /// nothing else stops the loop from re-probing a broken provider (logged-out Devin/Grok especially)
@@ -64,6 +65,13 @@ final class WidgetDataStore {
         didSet { defaults.set(resetDisplayMode.rawValue, forKey: Self.resetDisplayModeKey) }
     }
 
+    /// Global "always show pacing" opt-in: when on, on-track rows surface their pace projection (the
+    /// blue/healthy row gains its "~N% left at reset" copy + an even-pace tick, the amber tick switches
+    /// to the same even-pace line). Persisted across relaunch; defaults to `false` (every row unchanged).
+    var alwaysShowPacing: Bool {
+        didSet { defaults.set(alwaysShowPacing, forKey: Self.alwaysShowPacingKey) }
+    }
+
     init(
         registry: WidgetRegistry,
         providers: [ProviderRuntime],
@@ -82,6 +90,7 @@ final class WidgetDataStore {
         self.now = now
         self.meterStyle = defaults.enumValue(forKey: Self.meterStyleKey, default: .remaining)
         self.resetDisplayMode = defaults.enumValue(forKey: Self.resetDisplayModeKey, default: .relative)
+        self.alwaysShowPacing = defaults.bool(forKey: Self.alwaysShowPacingKey)
         // Stale-while-revalidate: load whatever was cached (expired included) so the menu bar and
         // dashboard show last-known values immediately at launch instead of "—"; the refresh loop
         // replaces them as soon as fresh data lands.
@@ -229,6 +238,7 @@ final class WidgetDataStore {
         // unbounded tiles (limit == nil), whose displayed value ignores displayMode.
         result.displayMode = meterStyle
         result.resetDisplayMode = resetDisplayMode
+        result.alwaysShowPacing = alwaysShowPacing
         return result
     }
 

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -127,6 +127,14 @@ struct SettingsScreen: View {
                 row("Reset Times") {
                     picker($store.resetDisplayMode, options: ResetDisplayMode.allCases, label: \.label)
                 }
+                // Off (default) leaves every row as it is — pacing shows only when a metric is close to
+                // or over its limit. On surfaces it everywhere it can: on-track rows gain their pace
+                // projection and an even-pace tick. Rows with no reset window have no pace to show.
+                row("Always Show Pacing") {
+                    Toggle("", isOn: $store.alwaysShowPacing)
+                        .settingsSwitchStyle()
+                        .hoverTooltip("Show how you're pacing on every metric, not just ones near their limit")
+                }
             }
             section("Providers") {
                 ForEach(container.registry.providers) { provider in

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -121,7 +121,8 @@ struct WidgetRowView: View {
     }
 
     /// The single escalating warning slot, switching exhaustively over the state so the copy can
-    /// never contradict the bar. The flame cases share one builder; the amber case is plain text.
+    /// never contradict the bar. The flame cases share one builder; the amber and (always-show-pacing)
+    /// blue cases are plain text.
     @ViewBuilder
     private func warning(_ state: WidgetData.MeterState) -> some View {
         switch state {
@@ -144,6 +145,19 @@ struct WidgetRowView: View {
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
                 .hoverTooltip(state.tooltip)
+        case .healthy where data.alwaysShowPacing:
+            // "Always show pacing" surfaces the projection on the otherwise-silent on-track row: the
+            // same quiet secondary note as the amber case, but the cushion ("~33% left at reset")
+            // rather than the spare. No flame (blue isn't a warning) and no hover tooltip — the copy
+            // already *is* the projection the amber case hides in its tooltip.
+            if let projection = state.tooltip {
+                Spacer(minLength: 8)
+                Text(projection)
+                    .font(supportingFont)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
         case .noData, .healthy, .level:
             EmptyView()
         }
@@ -323,20 +337,22 @@ struct WidgetRowView: View {
     /// `MeterState.severity`), softened for the popover glass via `Theme.glassTint` — explicit
     /// colors get no vibrancy adaptation there; the earlier provider-brand gradient was removed
     /// deliberately so the bar's color always reads as state.
-    /// Empty + colorless without data. In the `closeToLimit` (amber) state a thin tick fences the
-    /// spare-width sliver off **at the fill's edge** — a glanceable "this sliver is all the slack
-    /// you've got", pinned to current usage rather than to either end of the track: in Used view
-    /// the sliver is the empty slice between the fill's edge and the tick (used + spare); in Left
-    /// view it's the last slice of the fill, between the tick and the edge (remaining − spare).
-    /// (Tried and rejected: an even-pace tick on every bar, read as "where I'll end up"; the tick
-    /// at the projected landing point, which hugged a track end far from the fill where it read
-    /// as an artifact; and right-anchoring the Left fill, which read as an RTL glitch.) Drawing
-    /// the tick from the `closeToLimit` case means a red or blue bar structurally cannot carry
-    /// it. Hovering shows the pace projection (`MeterState.tooltip`). Hidden from accessibility — the
-    /// headline text carries the exact value, and the label line's warning copy carries the amber
-    /// and red cases.
+    /// Empty + colorless without data. By default a thin tick appears only in the `closeToLimit`
+    /// (amber) state, fencing the spare-width sliver off **at the fill's edge** — a glanceable "this
+    /// sliver is all the slack you've got", pinned to current usage rather than to either end of the
+    /// track: in Used view the sliver is the empty slice between the fill's edge and the tick (used +
+    /// spare); in Left view it's the last slice of the fill, between the tick and the edge (remaining −
+    /// spare). With "always show pacing" on, the tick instead marks the **even-pace line** (where a
+    /// steady user would be right now) and also appears on the blue `healthy` bar. The red run-out
+    /// states carry no tick — the flame + run-out time is the message there. The tick rides in an
+    /// overlay (see below) so it pokes out top and bottom without changing the bar's height. Hovering
+    /// shows the pace projection (`MeterState.tooltip`). Hidden from accessibility — the headline text
+    /// carries the exact value, and the label line's warning copy carries the amber and red cases.
     private func meter(_ state: WidgetData.MeterState) -> some View {
         GeometryReader { proxy in
+            // Track + fill define the bar's height; the tick rides in an `.overlay` so its taller frame
+            // pokes out top and bottom without stretching the capsules. (As a ZStack sibling it grew the
+            // stack and the flexible capsules stretched with it, so a tick'd bar read as a thicker bar.)
             ZStack(alignment: .leading) {
                 // Semantic quaternary fill (not an opacity-faded color) so the track stays vibrant
                 // on glass and adapts to Increase Contrast / Reduce Transparency.
@@ -344,10 +360,12 @@ struct WidgetRowView: View {
                 Capsule()
                     .fill(severityColor(state.severity))
                     .frame(width: fillWidth(track: proxy.size.width))
-                if case .closeToLimit(_, let tick, _) = state {
+            }
+            .overlay(alignment: .leading) {
+                if let tick = state.tick {
                     RoundedRectangle(cornerRadius: 1)
                         .fill(Color.primary.opacity(0.55))
-                        .frame(width: Self.paceTickWidth, height: density.meterHeight + 3)
+                        .frame(width: Self.paceTickWidth, height: density.meterHeight + Self.paceTickOverhang)
                         .offset(x: paceTickOffset(track: proxy.size.width, fraction: tick))
                 }
             }
@@ -359,6 +377,9 @@ struct WidgetRowView: View {
     }
 
     private static let paceTickWidth: CGFloat = 2
+    /// How much taller than the bar the tick is, so it pokes out slightly above and below (half each
+    /// end). The bar itself stays at `meterHeight` regardless — the tick lives in an overlay.
+    private static let paceTickOverhang: CGFloat = 4
 
     /// Leading offset that centers the tick on its fraction, clamped so the tick never pokes past
     /// either rounded end of the track.

--- a/Tests/OpenUsageTests/PaceTests.swift
+++ b/Tests/OpenUsageTests/PaceTests.swift
@@ -196,4 +196,66 @@ final class PaceTests: XCTestCase {
         XCTAssertEqual(eta ?? 0, 0.33 * week, accuracy: week * 0.01) // projected exhaustion ≈ ⅓ of a week out
         XCTAssertNil(Pace.secondsToRunOut(used: 30, limit: 100, resetsAt: reset, periodDuration: week, now: now)) // ahead → nil
     }
+
+    // MARK: Always Show Pacing (the opt-in even-pace tick + healthy copy)
+
+    /// `used` percent of 100 with `elapsed` of the window gone (projected = used / elapsed),
+    /// optionally opting into "always show pacing".
+    private func pacedData(used: Double, elapsed: Double, displayMode: WidgetDisplayMode = .used,
+                           alwaysShowPacing: Bool = false) -> WidgetData {
+        var data = WidgetData(title: "Weekly", icon: .symbol("clock"), kind: .percent,
+                              used: used, limit: 100, displayMode: displayMode)
+        data.resetsAt = resetsAt(elapsed: elapsed, period: week)
+        data.periodDurationMs = Int(week * 1000)
+        data.alwaysShowPacing = alwaysShowPacing
+        return data
+    }
+
+    /// The even-pace tick fraction carried by the blue `healthy` bar (nil unless always-show is on).
+    private func healthyTick(_ data: WidgetData) -> Double? {
+        if case .healthy(_, let tick) = data.meterState(now: now) { return tick }
+        return nil
+    }
+
+    func testHealthyBarHasNoTickByDefault() {
+        // Off (default): the blue/healthy bar carries no even-pace tick (projected 75% → ahead).
+        XCTAssertNil(healthyTick(pacedData(used: 30, elapsed: 0.4)))
+    }
+
+    func testAlwaysShowPacingAddsEvenPaceTickToHealthyBar() {
+        // On: the blue bar gains the even-pace line (elapsed fraction = used ÷ projected = 30/75 = 0.4).
+        // It's anchored to the side the fill leaves open: Left/remaining view puts it ahead in the gray
+        // at the elapsed fraction (0.4); Used view mirrors it to 1 − 0.4 = 0.6, inside the fill.
+        XCTAssertEqual(healthyTick(pacedData(used: 30, elapsed: 0.4, displayMode: .remaining,
+                                             alwaysShowPacing: true)) ?? -1,
+                       0.4, accuracy: 0.001)
+        XCTAssertEqual(healthyTick(pacedData(used: 30, elapsed: 0.4, alwaysShowPacing: true)) ?? -1,
+                       0.6, accuracy: 0.001)
+    }
+
+    func testAlwaysShowPacingSwitchesAmberTickToTheEvenPaceLine() {
+        // Amber (used 46, half the window gone → projected 92%). Default tick is the slack edge
+        // (0.46 + 0.08 spare = 0.54); with always-show on it becomes the even-pace line
+        // (used ÷ projected = 46/92 = 0.5). The "~N% spare" copy is unaffected either way.
+        XCTAssertEqual(tick(pacedData(used: 46, elapsed: 0.5)) ?? -1, 0.54, accuracy: 0.001)
+        XCTAssertEqual(tick(pacedData(used: 46, elapsed: 0.5, alwaysShowPacing: true)) ?? -1,
+                       0.5, accuracy: 0.001)
+        XCTAssertEqual(spare(pacedData(used: 46, elapsed: 0.5, alwaysShowPacing: true)), "~8% spare")
+    }
+
+    func testAlwaysShowPacingNeverPutsATickOnARedBar() {
+        // Behind (projected 120%) and spent both stay tick-free even with the setting on — the flame
+        // and "Limit reached" / run-out time carry the message on a red bar, never a notch.
+        XCTAssertNil(pacedData(used: 60, elapsed: 0.5, alwaysShowPacing: true).meterState(now: now).tick)
+        XCTAssertNil(pacedData(used: 100, elapsed: 0.5, alwaysShowPacing: true).meterState(now: now).tick)
+    }
+
+    func testAlwaysShowPacingLeavesRowsWithoutPaceSignalPlain() {
+        // No reset window → no pace signal → nothing to project, so no tick even with the setting on.
+        var data = WidgetData(title: "Credits", icon: .symbol("creditcard"), kind: .dollars,
+                              used: 12, limit: 20)
+        data.alwaysShowPacing = true
+        XCTAssertNil(data.meterState(now: now).tick)
+        XCTAssertNil(data.meterState(now: now).tooltip)
+    }
 }

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -25,6 +25,7 @@ Settings lives inside the popover — there is no separate window. Open it with 
 |---|---|---|
 | Show Usage As | Used / Left | Whether bounded metrics read "48% used" or "52% left" — same toggle as clicking a headline. |
 | Reset Times | Countdown / Exact time | "Resets in 3h 25m" vs "Resets today at 6:38 PM" — same toggle as clicking a reset label. |
+| Always Show Pacing | Off / On | Off (default) shows pacing only when a metric is close to or over its limit. On surfaces it on every metric with a reset window: on-track rows gain their projection ("~33% left at reset") and an even-pace tick marking where steady use would put you right now. Metrics without a reset window have no pace to show. |
 
 ## Providers
 


### PR DESCRIPTION
Closes #685.

## What

Adds a global **Always Show Pacing** toggle (Settings → Usage Display, **off by default**). Today the pacing indicators — flame + run-out time, "~N% spare", and the meter tick — only appear once a metric is close to or over its limit. When the toggle is on, pacing is surfaced on the calm/on-track rows too.

| State | Off (default) | On |
|---|---|---|
| Blue / on track | silent | `~33% left at reset` copy + even-pace tick |
| Amber / close | slack-edge tick + `~N% spare` | even-pace tick + `~N% spare` |
| Red / running out | flame + `Limit in 3h 45m` | unchanged (flame; no tick) |
| Spent | `Limit reached` | unchanged |
| Level (no pace signal) | plain | plain (nothing to project) |

The **even-pace tick** marks where a perfectly steady user would sit right now. It's anchored to the side the fill leaves open — out in the gray ahead of the fill in the default **Left** view, inside the fill in **Used** view — so a healthy bar reads "ahead of pace" at a glance. Red run-out bars never get a tick (the flame carries the message); `level` rows have no projection so they stay plain.

The tick rides in an `.overlay` so it pokes out above/below the bar without changing the bar's height (previously it was a ZStack sibling and stretched the flexible capsules, making a ticked bar read as thicker).

## How

- New `alwaysShowPacing` flag persisted on `WidgetDataStore` (same pattern as `meterStyle`/`resetDisplayMode`), stamped onto `WidgetData` at the single `data(for:)` choke point so toggling re-renders live.
- `WidgetData.meterState(...)` attaches the even-pace tick to `healthy`/`closeToLimit` only when the flag is on; a `MeterState.tick` accessor centralizes "does this bar carry a tick".
- `WidgetRowView`: `warning(_:)` prints the healthy projection copy; `meter(_:)` draws the tick via overlay.
- Settings row added under "Usage Display"; documented in `docs/settings.md`.

## Tests

`swift build` + `swift test` green (371 tests, 5 new in `PaceTests`): default-off, even-pace tick on healthy (both display modes), amber tick switch, never-on-red, and no-pace-signal-stays-plain.

## Known follow-up (not in this PR)

A bar in the first <5% of its window is a `level` state with no pace projection (deliberate guard — early projections swing wildly), so it shows nothing even with the toggle on. Whether to relax that guard for the always-show case is an open product question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only preference defaulting off; pacing logic is extended with tests and does not touch auth, providers, or data refresh.
> 
> **Overview**
> Adds a global **Always Show Pacing** toggle (Settings → Usage Display, **off by default**). When enabled, on-track meter rows show pace cues that today only appear near the limit.
> 
> **Blue / healthy** rows gain secondary projection copy (e.g. `~33% left at reset`) and an **even-pace tick** on the bar. **Amber / close** rows keep `~N% spare` but the tick switches from the slack-edge marker to the same even-pace line. **Red** run-out and **spent** states are unchanged (no tick; flame/copy only). Metrics without a reset window stay plain.
> 
> The preference is persisted on `WidgetDataStore` and stamped onto each `WidgetData` in `data(for:)`, like `meterStyle`. `meterState(now:)` attaches optional `evenPaceTick` to `healthy` and prefers it over the amber slack tick when the flag is on; `MeterState.tick` centralizes drawing. `WidgetRowView` renders healthy projection text and draws ticks in a bar **overlay** so tick height no longer stretches the capsule track.
> 
> `docs/settings.md` documents the option; `PaceTests` adds coverage for default-off, display modes, amber tick switch, and no tick on red / no-pace rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f707a68cc009d17f4d507a14e194e9f3a0d208c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->