### PR TITLE
[codex] Fix Codex session usage percent

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -32,19 +32,19 @@ enum CodexUsageMapper {
         let primaryWindow = rateLimit?["primary_window"] as? [String: Any]
         let secondaryWindow = rateLimit?["secondary_window"] as? [String: Any]
 
-        if let headerPrimary = ProviderParse.number(response.header("x-codex-primary-used-percent")) {
+        if let used = ProviderParse.number(primaryWindow?["used_percent"]) {
             lines.append(progress(
                 label: "Session",
-                used: headerPrimary,
+                used: used,
                 resetWindow: primaryWindow,
                 now: now,
                 periodDurationMs: sessionPeriodMs
             ))
         }
-        if let headerSecondary = ProviderParse.number(response.header("x-codex-secondary-used-percent")) {
+        if let used = ProviderParse.number(secondaryWindow?["used_percent"]) {
             lines.append(progress(
                 label: "Weekly",
-                used: headerSecondary,
+                used: used,
                 resetWindow: secondaryWindow,
                 now: now,
                 periodDurationMs: weeklyPeriodMs
@@ -52,7 +52,7 @@ enum CodexUsageMapper {
         }
 
         if !lines.contains(where: { $0.label == "Session" }),
-           let used = ProviderParse.number(primaryWindow?["used_percent"]) {
+           let used = ProviderParse.number(response.header("x-codex-primary-used-percent")) {
             lines.append(progress(
                 label: "Session",
                 used: used,
@@ -62,7 +62,7 @@ enum CodexUsageMapper {
             ))
         }
         if !lines.contains(where: { $0.label == "Weekly" }),
-           let used = ProviderParse.number(secondaryWindow?["used_percent"]) {
+           let used = ProviderParse.number(response.header("x-codex-secondary-used-percent")) {
             lines.append(progress(
                 label: "Weekly",
                 used: used,
@@ -303,4 +303,3 @@ enum CodexUsageError: Error, LocalizedError, Equatable {
         }
     }
 }
-

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -30,7 +30,7 @@ final class CodexAuthStoreTests: XCTestCase {
 }
 
 final class CodexUsageMapperTests: XCTestCase {
-    func testMapsHeadersCreditsAndPlan() throws {
+    func testMapsWindowsCreditsAndPlan() throws {
         let body = Data("""
         {
           "plan_type": "prolite",
@@ -56,14 +56,65 @@ final class CodexUsageMapperTests: XCTestCase {
         )
 
         XCTAssertEqual(mapped.plan, "Pro 5x")
-        XCTAssertEqual(progress(mapped.lines, "Session")?.used, 25)
-        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 50)
+        XCTAssertEqual(progress(mapped.lines, "Session")?.used, 10)
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 20)
         // Credits lead with the dollar value (4¢/credit), then the raw count — no inverted fake cap.
         XCTAssertNil(progress(mapped.lines, "Credits"))
         XCTAssertEqual(values(mapped.lines, "Credits"),
                        [MetricValue(number: 4.0, kind: .dollars), MetricValue(number: 100, kind: .count, label: "credits")])
         XCTAssertNotNil(progress(mapped.lines, "Session")?.resetsAt)
         XCTAssertEqual(progress(mapped.lines, "Session")?.periodDurationMs, CodexUsageMapper.sessionPeriodMs)
+    }
+
+    func testHeadersFillMissingWindows() throws {
+        let body = Data("""
+        {
+          "rate_limit": {}
+        }
+        """.utf8)
+        let response = HTTPResponse(
+            statusCode: 200,
+            headers: [
+                "x-codex-primary-used-percent": "25",
+                "x-codex-secondary-used-percent": "50"
+            ],
+            body: body
+        )
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            response,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertEqual(progress(mapped.lines, "Session")?.used, 25)
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 50)
+    }
+
+    func testSessionWindowBeatsStaleHeader() throws {
+        let body = Data("""
+        {
+          "rate_limit": {
+            "primary_window": { "reset_after_seconds": 60, "used_percent": 0 },
+            "secondary_window": { "reset_after_seconds": 120, "used_percent": 7 }
+          }
+        }
+        """.utf8)
+        let response = HTTPResponse(
+            statusCode: 200,
+            headers: [
+                "x-codex-primary-used-percent": "99",
+                "x-codex-secondary-used-percent": "99"
+            ],
+            body: body
+        )
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            response,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertEqual(progress(mapped.lines, "Session")?.used, 0)
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 7)
     }
 
     func testAppendsTokenUsageLines() {

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -29,6 +29,6 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Codex logs b
 
 ## Under the hood
 
-`GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry.
+`GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry. Session and Weekly are read from the usage window in that response, with the response headers used only when the window fields are missing.
 
 The "Rate Limit Resets" row (placed before Credits) shows the on-demand reset-credit count, e.g. `2 available`. OpenUsage also makes a best-effort `GET https://chatgpt.com/backend-api/wham/rate-limit-reset-credits` call — the dedicated endpoint that lists each credit's expiry — and surfaces those on hover (`Reset expires in 12d 18h`, or a numbered `Resets expire in:` list for several), following the global relative/absolute time setting. A warning triangle appears beside the count when the soonest credit is within 24 hours of expiring. If that call fails, the row falls back to the count embedded in the usage body (`rate_limit_reset_credits.available_count`) with no expiry tooltip. An empty balance reads `0 available`.


### PR DESCRIPTION
## Summary

- Prefer Codex usage-window percentages from the `/wham/usage` response body for Session and Weekly.
- Keep `x-codex-*` percent headers as a fallback when the body window fields are missing.
- Add regression coverage for a stale `99%` header overriding a cold/unused session window.
- Document the body-first mapping behavior.

## Root Cause

OpenUsage trusted the Codex percentage headers before the structured usage window fields. When the header carried a stale `99` but the response body reported the real session window usage, the Session widget could show `99%` before a session had meaningfully started.

Fixes #705

## Verification

- `swift test --filter CodexUsageMapperTests`
- Live sanitized Codex endpoint check on this machine returned body Session `40`, body Weekly `45`, and no percent headers, confirming the body window is the active source for this install.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mapping-order change in Codex usage display with regression tests; no auth or network behavior changes.
> 
> **Overview**
> **Session** and **Weekly** usage percentages now come from `rate_limit` window `used_percent` in the `/wham/usage` JSON first, instead of the `x-codex-*-used-percent` headers.
> 
> The percent headers are only used when a window line was not already added (missing body fields), which fixes stale header values (e.g. 99%) overriding a fresh session at 0%.
> 
> Tests cover body-over-header priority, header fallback, and the stale-header regression; `docs/providers/codex.md` documents body-first mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebbbdf48b70f074fac5e7d0050cc79da322acc93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->