### PR TITLE
[codex] Fix menu bar metric units

### DIFF
--- a/Sources/OpenUsage/Models/MenuBarContent.swift
+++ b/Sources/OpenUsage/Models/MenuBarContent.swift
@@ -35,7 +35,7 @@ struct MenuBarContent: Equatable {
     var isEmpty: Bool { groups.isEmpty }
 
     /// VoiceOver summary for the rendered strip image, e.g.
-    /// "Claude Session 41%, Weekly 12%; Cursor Credits 67%".
+    /// "Claude Session 41%, Weekly 12%; Cursor Credits $12".
     var accessibilityText: String {
         groups.map { group in
             let metrics = group.metrics.map { "\($0.label) \($0.value)" }.joined(separator: ", ")

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -213,21 +213,26 @@ struct WidgetData: Hashable {
         return (valuePrefix ?? "") + format(displayedValue)
     }
 
-    /// The menu-bar (tray) reading: a bounded metric glances as a percentage (regardless of unit, so
-    /// Cursor Credits reads "67%", not "$12,923"); an unbounded one shows its selected value compacted
-    /// (1.2M tokens / $3.4K) through the same formatter the popover uses. A status badge with no number
-    /// (e.g. Grok "Disabled") shows its text rather than a misleading "0".
+    /// The menu-bar (tray) reading: bounded metrics stay unit-aware (percent meters as %, dollar meters
+    /// as compact dollars, count meters as compact counts) while still honoring the global Used/Left
+    /// mode through `displayedValue`. Unbounded rows show their selected value compacted through the same
+    /// formatter the popover uses. A status badge with no number (e.g. Grok "Disabled") shows its text
+    /// rather than a misleading "0".
     var menuBarValue: String {
         guard hasData else { return valueText }
         if let limit, limit > 0 {
-            // The tray glance is always 0...100%: clamp both ends so neither a negative sample nor an
-            // over-limit one (e.g. a dollar meter past its cap, rendered here as a percentage) ever
-            // reads "-5%" or "105%" beside the icon. Over-limit is shown by the meter's color/spent
-            // state in the popover, not by the tray number.
-            let percent = min(100, max(0, Int((displayedValue / limit * 100).rounded())))
-            return "\(percent)%"
+            if kind == .percent {
+                // Percent is the only bounded unit that should collapse to a tray percentage. Clamp both
+                // ends so a provider sample can never print "-5%" or "105%" beside the icon.
+                let percent = min(100, max(0, Int((displayedValue / limit * 100).rounded())))
+                return "\(percent)%"
+            }
+            return MetricFormatter.number(displayedValue, kind: kind, style: .tray)
         }
         if let first = selectedValues.first {
+            if title == "Rate Limit Resets", first.kind == .count {
+                return "\(MetricFormatter.number(first.number, kind: .count, style: .tray)) resets"
+            }
             return MetricFormatter.string(for: first, style: .tray)
         }
         if let valueTextOverride { return valueTextOverride }

--- a/Tests/OpenUsageTests/MenuBarContentTests.swift
+++ b/Tests/OpenUsageTests/MenuBarContentTests.swift
@@ -95,15 +95,16 @@ final class MenuBarContentTests: XCTestCase {
         XCTAssertEqual(content.groups[0].metrics.map(\.label), ["T", "M"])
     }
 
-    func testBoundedReadsAsPercentUnboundedStaysAValue() {
-        // "Everything with a bar" → a percentage for a quick glance (Cursor Credits: 12000/18000 ≈ 67%);
-        // unbounded values stay a real (compacted) number, never a percentage.
+    func testBoundedTrayValuesStayUnitAware() {
+        // Percent meters still read as percentages, while bounded dollars/counts keep their natural
+        // unit in the strip instead of collapsing to "used / limit" percentages.
+        let usage = percent("a.usage", "Usage", 67)
         let credits = boundedDollars("a.credits", "Credits", used: 12000, limit: 18000)
+        let requests = boundedCount("a.requests", "Requests", used: 412, limit: 500)
         let spend = unbounded("a.spend", "Spend")   // unbounded $42
-        let content = MenuBarContentBuilder.build(groups: [group("a", credits, spend)], data: { $0.sample })
+        let content = MenuBarContentBuilder.build(groups: [group("a", usage, credits, requests, spend)], data: { $0.sample })
 
-        XCTAssertEqual(content.groups[0].metrics[0].value, "67%")
-        XCTAssertEqual(content.groups[0].metrics[1].value, "$42")
+        XCTAssertEqual(content.groups[0].metrics.map(\.value), ["67%", "$12K", "412", "$42"])
     }
 
     func testUnboundedNumbersAreCompacted() {
@@ -138,6 +139,10 @@ final class MenuBarContentTests: XCTestCase {
 
     private func boundedDollars(_ id: String, _ label: String, used: Double, limit: Double) -> WidgetDescriptor {
         descriptor(id, label, WidgetData(title: label, icon: .symbol("gauge"), kind: .dollars, used: used, limit: limit))
+    }
+
+    private func boundedCount(_ id: String, _ label: String, used: Double, limit: Double) -> WidgetDescriptor {
+        descriptor(id, label, WidgetData(title: label, icon: .symbol("gauge"), kind: .count, used: used, limit: limit))
     }
 
     private func unbounded(_ id: String, _ label: String, _ used: Double = 42) -> WidgetDescriptor {

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -194,7 +194,8 @@ final class WidgetDataStoreTests: XCTestCase {
 
     func testRateLimitResetsTileShowsCountInTrayAndPopover() async {
         // Regression (#641): the menu-bar tile and the popover row resolve from one raw number, so a
-        // pinned tile can't read "0" while the popover reads "1". The count is carried raw.
+        // pinned tile can't read "0" while the popover reads "1". The popover keeps Codex's "available"
+        // wording, while the tighter tray reads "resets".
         let provider = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
         let descriptor = WidgetDescriptor.values(
             id: "codex.rateLimitResets",
@@ -209,7 +210,7 @@ final class WidgetDataStoreTests: XCTestCase {
                 providerID: provider.id,
                 displayName: provider.displayName,
                 lines: [.values(label: "Rate Limit Resets",
-                                values: [MetricValue(number: 1, kind: .count)])]
+                                values: [MetricValue(number: 1, kind: .count, label: "available")])]
             )
         )
         let defaults = makeUserDefaults("codex-resets")
@@ -224,8 +225,49 @@ final class WidgetDataStoreTests: XCTestCase {
         let data = store.data(for: descriptor)
         XCTAssertTrue(data.hasData)
         XCTAssertFalse(data.isBounded)
-        XCTAssertEqual(data.unboundedDetail, "1")   // popover row — bare count, no unit label
-        XCTAssertEqual(data.menuBarValue, "1")      // tray — the real count, never "0"
+        XCTAssertEqual(data.unboundedDetail, "1 available")
+        XCTAssertEqual(data.menuBarValue, "1 resets")
+    }
+
+    func testBoundedDollarAndCountTrayValuesHonorMeterStyleWithoutPercentConversion() async {
+        let provider = Provider(id: "cursor", displayName: "Cursor", icon: .providerMark("cursor"))
+        let credits = WidgetDescriptor.boundedDollars(id: "cursor.credits", provider: provider, title: "Credits", limit: 100)
+        let requests = WidgetDescriptor.boundedCount(
+            id: "cursor.requests",
+            provider: provider,
+            title: "Requests",
+            limit: 500,
+            suffix: "requests",
+            periodDurationMs: CursorUsageMapper.billingPeriodMs
+        )
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [credits, requests],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [
+                    .progress(label: "Credits", used: 12.48, limit: 20, format: .dollars),
+                    .progress(label: "Requests", used: 412, limit: 500, format: .count(suffix: "requests"))
+                ]
+            )
+        )
+        let defaults = makeUserDefaults("cursor-tray-units")
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [credits, requests]),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() }),
+            defaults: defaults
+        )
+        await store.refreshAll()
+
+        store.meterStyle = .used
+        XCTAssertEqual(store.data(for: credits).menuBarValue, "$12")
+        XCTAssertEqual(store.data(for: requests).menuBarValue, "412")
+
+        store.meterStyle = .remaining
+        XCTAssertEqual(store.data(for: credits).menuBarValue, "$8")
+        XCTAssertEqual(store.data(for: requests).menuBarValue, "88")
     }
 
     func testUncappedExtraUsageRendersCompactAndUnbounded() async {


### PR DESCRIPTION
## Summary

- Keep menu-bar values unit-aware for bounded metrics: percent meters still show `%`, while bounded dollar and count meters show compact dollars/counts.
- Show Codex rate-limit reset credits as `N resets` in the menu bar while preserving `N available` in the popover.
- Preserve the global Used/Left mode for bounded dollar/count tray values so the strip matches the dashboard mode.

## Why

The menu-bar strip previously converted every bounded metric into a percentage. That made Cursor Credits, Requests, and On-demand usage less useful because they lost their natural units.

## Validation

- `swift test`
- Built and launched `dist/OpenUsage.app` with `script/build_and_run.sh run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting in `menuBarValue` with expanded unit tests; no auth, persistence, or provider API changes.
> 
> **Overview**
> The menu bar strip no longer turns every bounded metric into a percentage. **Percent** meters still show a clamped `%` glance; **bounded dollars and counts** now use compact tray formatting (`$12K`, `412`, etc.) and still follow the global **Used/Left** mode via `displayedValue`.
> 
> **Codex Rate Limit Resets** uses tighter tray copy: `N resets` in the menu bar while the popover row keeps provider wording (`N available`). VoiceOver example text was updated to match dollar tray readings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb1f0c78b1099bf1a051d1d5ac9a500941b684e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->