### PR TITLE
Fix the pace marker — and what it actually is

### DIFF
--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -130,10 +130,10 @@ struct WidgetData: Hashable {
         case closeToLimit(spare: String, tick: Double, projectedFraction: Double)
         /// On course to finish with ≥10% to spare. Blue. By default it carries no decoration; when
         /// "always show pacing" is on it surfaces the projection copy ("~N% left at reset") and
-        /// `evenPaceTick` is set — the even-pace line, anchored to the side the fill leaves open (out
-        /// in the gray ahead of the fill in Left view, inside the fill in Used view), so the row reads
-        /// "you're ahead of pace" at a glance. `nil` when the setting is off. `projectedFraction` backs
-        /// the tooltip's "% left at reset" cushion copy.
+        /// `evenPaceTick` is set — the even-pace line, framed like the fill (in the gray ahead of the
+        /// fill in Used view, inside the fill in Left view), so the gap to the fill edge shows how far
+        /// ahead of pace you are. `nil` when the setting is off. `projectedFraction` backs the tooltip's
+        /// "% left at reset" cushion copy.
         case healthy(projectedFraction: Double, evenPaceTick: Double?)
         /// No pace signal to project (no reset window, or <5% of it elapsed): color from the
         /// absolute level bands on the share used, no copy.
@@ -464,17 +464,17 @@ extension WidgetData {
         if let ctx = paceContext,
            let result = Pace.evaluate(used: used, limit: ctx.limit, resetsAt: ctx.resetsAt,
                                       periodDuration: ctx.period, now: now) {
-            // The even-pace line: where a perfectly steady user would sit right now — the elapsed
-            // fraction of the period, recovered as used ÷ projected-usage (projected = used ÷ elapsed,
-            // so the dates cancel). Placed to read as "ahead" against the bar's framing: in Left
-            // (remaining) view — the common one — it sits out in the gray ahead of the fill; in Used
-            // view it sits inside the fill. (These are mirror positions; we anchor to whichever side
-            // the fill leaves open so a healthy bar's tick never buries itself in the fill in Left
-            // view.) Only surfaced when "always show pacing" is on; otherwise `nil` leaves every row as it was.
+            // The even-pace notch: where a steady user would sit right now — the elapsed fraction of the
+            // window (used ÷ projected-usage, since projected = used ÷ elapsed, so the dates cancel).
+            // Framed like the fill, so it mirrors by mode: Used view plots the used share → `elapsed`
+            // (out in the gray ahead of the fill); Left view plots the remaining share → `1 - elapsed`
+            // (inside the fill). Same point either way, always on the bar — when you're ahead the lead
+            // shows as the gap between the notch and the fill edge. Surfaced only when "always show
+            // pacing" is on; otherwise `nil` leaves every row unchanged.
             let evenPaceTick: Double? = {
                 guard alwaysShowPacing, result.projectedUsage > 0 else { return nil }
                 let elapsed = min(max(used / result.projectedUsage, 0), 1)
-                return displayMode == .remaining ? elapsed : 1 - elapsed
+                return displayMode == .remaining ? 1 - elapsed : elapsed
             }()
             switch result.status {
             case .ahead:

--- a/Tests/OpenUsageTests/PaceTests.swift
+++ b/Tests/OpenUsageTests/PaceTests.swift
@@ -223,14 +223,26 @@ final class PaceTests: XCTestCase {
     }
 
     func testAlwaysShowPacingAddsEvenPaceTickToHealthyBar() {
-        // On: the blue bar gains the even-pace line (elapsed fraction = used ÷ projected = 30/75 = 0.4).
-        // It's anchored to the side the fill leaves open: Left/remaining view puts it ahead in the gray
-        // at the elapsed fraction (0.4); Used view mirrors it to 1 − 0.4 = 0.6, inside the fill.
+        // On: the blue bar gains the even-pace line — a steady user's fill edge (elapsed fraction =
+        // used ÷ projected = 30/75 = 0.4). It's plotted in the bar's own coordinates (position from the
+        // left = shown value ÷ limit), so it tracks the fill's framing. Used view plots the used share,
+        // so the line is the elapsed fraction (0.4), landing in the gray just ahead of the small fill
+        // (0.30) → "ahead". Left view plots the remaining share, so it mirrors to 1 − 0.4 = 0.6, landing
+        // inside the large fill (0.70) just short of its edge → also "ahead".
+        XCTAssertEqual(healthyTick(pacedData(used: 30, elapsed: 0.4, alwaysShowPacing: true)) ?? -1,
+                       0.4, accuracy: 0.001)
         XCTAssertEqual(healthyTick(pacedData(used: 30, elapsed: 0.4, displayMode: .remaining,
                                              alwaysShowPacing: true)) ?? -1,
-                       0.4, accuracy: 0.001)
-        XCTAssertEqual(healthyTick(pacedData(used: 30, elapsed: 0.4, alwaysShowPacing: true)) ?? -1,
                        0.6, accuracy: 0.001)
+    }
+
+    func testEvenPaceNotchInLeftViewSitsInsideTheFill() {
+        // Devin Weekly regression: a near-full Left bar early in its window. used 2 with ~30% of the
+        // week gone → even-pace = 1 − 0.30 = 0.70, which sits inside the blue (the fill edge is 0.98);
+        // the 0.70→0.98 gap is how far ahead you are. Always on the bar — no overshoot, no clamp.
+        XCTAssertEqual(healthyTick(pacedData(used: 2, elapsed: 0.30, displayMode: .remaining,
+                                             alwaysShowPacing: true)) ?? -1,
+                       0.70, accuracy: 0.001)
     }
 
     func testAlwaysShowPacingSwitchesAmberTickToTheEvenPaceLine() {
@@ -241,6 +253,19 @@ final class PaceTests: XCTestCase {
         XCTAssertEqual(tick(pacedData(used: 46, elapsed: 0.5, alwaysShowPacing: true)) ?? -1,
                        0.5, accuracy: 0.001)
         XCTAssertEqual(spare(pacedData(used: 46, elapsed: 0.5, alwaysShowPacing: true)), "~8% spare")
+    }
+
+    func testAlwaysShowPacingAmberEvenPaceTickTracksTheFillFraming() {
+        // Asymmetric elapsed so the even-pace line isn't its own mirror (which 0.5 is, hiding a swap).
+        // used 76 with 80% of the window gone → projected 95 (onTrack, 5% spare); even-pace line =
+        // used ÷ projected = 0.8. Used view plots used, so the tick is the elapsed fraction 0.8 (just
+        // inside the slack edge at 0.76 + 0.05 = 0.81); Left view plots remaining, so it mirrors to
+        // 1 − 0.8 = 0.2 (just inside the fill edge at 0.24).
+        XCTAssertEqual(tick(pacedData(used: 76, elapsed: 0.8, alwaysShowPacing: true)) ?? -1,
+                       0.8, accuracy: 0.001)
+        XCTAssertEqual(tick(pacedData(used: 76, elapsed: 0.8, displayMode: .remaining,
+                                      alwaysShowPacing: true)) ?? -1,
+                       0.2, accuracy: 0.001)
     }
 
     func testAlwaysShowPacingNeverPutsATickOnARedBar() {


### PR DESCRIPTION
## In one line

The little vertical line on each usage bar is the **pace mark**. It shows where you'd be *right now* if you used your allowance evenly across the whole window. This PR fixes where it's drawn — and this description explains, in plain words, what it actually is, so we can link people here later instead of re-explaining it.

## What is the pace mark? (the candy jar)

Imagine you get a jar of 100 candies on Monday and it has to last all week. If you ate the same number every day, by Wednesday you'd have a certain amount left. **The pace mark is that "even eating" spot** — where you'd be if you spread it out perfectly from the start to the reset.

Every bar resets on some window, and the mark works the same for all of them:

- a **5-hour** Claude session
- a **weekly** limit
- a **monthly** limit

Same idea each time: "where would I be right now if I used this at a steady, even pace?"

## How to read it

- Your colored bar reaches **past** the mark → you've used **less** than an even pace → you're **ahead** (plenty in the tank).
- Your colored bar **falls short** of the mark → you're going through it **faster** than even → you're **behind**, and could run out before it resets.

One glance answers: *am I going faster or slower than I can afford?* The gap between the end of your bar and the mark is your cushion.

## Why we changed it

The mark was being drawn in the wrong spot. On a nearly-full bar it ended up buried deep in the colored part, or pinned to the far edge — so it looked disconnected from your actual usage (e.g. Devin showing the mark jammed to the right while you still had 98% left). Now it sits where it belongs.

## Where the confusion came from (what we tried, what didn't work)

This took a few tries. Writing it down so we don't repeat the loop:

1. **"The mark should always sit in the empty/gray part of the bar."** It feels right, but it only works in **Used** mode. There, the colored part is what you've *used* (small when you're ahead), so there's lots of empty room on the right for the mark. In **Left** mode the colored part is what's *left* (big when you're ahead), so there's barely any room on the right — the mark has nowhere to go and shoots off the end. Used and Left are mirror opposites; you can't force the same look onto both.

2. **"Mirror the mark so Left mode also shows it in the gray."** This caused the worst version of the bug: when you were far ahead, the mark overshot and pinned itself to the far-right edge — which looked nonsensical ("I have 98% left, why is the mark at the very end?").

3. **The fix: stop fighting it.** The mark is one single point — *where an even pace would put you.* In Used mode that naturally lands in the gray ahead of your fill; in Left mode it naturally lands inside the colored part. Both are correct. The "lead" is just the gap between the mark and the end of your bar — no special cases, no clamping, it always lands on the bar.

## Why not "where you'll run out"?

We also considered pointing the mark at your **projected** finish (the "~49% left at reset" forecast). But that number is **already written next to the bar in words** — making the mark repeat it adds nothing. The even-pace mark tells you a *second*, different thing: your steady-pace line. So together the bar tells you both *where you'll land* (the text) and *what an even pace looks like* (the mark).

## What actually changed in the code

One line: the mark now uses the true even-pace position (`1 − elapsed` in Left view, `elapsed` in Used view) instead of a mirrored version that could fly off the end. Tests updated to lock the positions in both views, including the near-full-bar case that started all this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line display math and test/doc updates for meter pacing ticks; no API, persistence, or security impact.
> 
> **Overview**
> Fixes where the **even-pace mark** (vertical tick when “always show pacing” is on) is drawn on usage meter bars.
> 
> **`meterState(now:)`** now maps the steady-pace position to each view’s bar coordinates: **Used** mode uses the elapsed fraction (`used ÷ projected`), so the mark sits in the gray ahead of a small fill when you’re ahead; **Left** mode uses `1 − elapsed`, so the mark sits inside the large remaining fill instead of mirroring into the empty track or clamping to the far edge (the near-full-bar case).
> 
> Comments describing healthy/amber tick behavior were updated to match. **Pace tests** lock Used vs Left tick values, add the near-full Left regression, and cover amber bars with asymmetric elapsed fractions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b90f9445da1ac69fd65214b436596a024fc913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->