### PR TITLE
Restrict usage trend hover to the mini chart, not the label

### DIFF
--- a/Sources/OpenUsage/Views/UsageSparkline.swift
+++ b/Sources/OpenUsage/Views/UsageSparkline.swift
@@ -34,6 +34,11 @@ struct UsageSparkline: View {
             // Anchor the popover to the bar strip (not the whole row), so its arrow points straight up
             // at the chart rather than at the row's center, off to the left of the bars.
             bars
+                // Only the bar strip is hoverable — hovering the title must not reveal the detail.
+                .contentShape(Rectangle())
+                .onContinuousHover { phase in
+                    if case .active = phase { hover.inlineHover(true) } else { hover.inlineHover(false) }
+                }
                 .popover(isPresented: Binding(get: { hover.isPresented }, set: { hover.isPresented = $0 }),
                          arrowEdge: .top) {
                     UsageTrendDetail(title: data.title, points: points, note: data.chartNote) { inside in
@@ -41,12 +46,8 @@ struct UsageSparkline: View {
                     }
                 }
         }
-        .contentShape(Rectangle())
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
-        .onContinuousHover { phase in
-            if case .active = phase { hover.inlineHover(true) } else { hover.inlineHover(false) }
-        }
         .onDisappear { hover.dismiss() }
     }
 


### PR DESCRIPTION
## What changed

The usage trend detail popover now opens only when hovering the mini bar chart — not when hovering the "Usage Trend" label.

## Why

The hover trigger (`.contentShape(Rectangle())` + `.onContinuousHover`) was attached to the outer `HStack` that wraps both the title `Text` and the bars. As a result, hovering anywhere on the row — including the label — revealed the detail popover. The intended behavior is that only the chart itself is interactive.

## How

Moved `.contentShape` and `.onContinuousHover` off the row's `HStack` and onto the `bars` view in `UsageSparkline.swift`. The popover binding and `TrendHoverState` are unchanged, so dwell/grace timing and the per-bar detail behave exactly as before — just scoped to the chart.

## Testing

- `swift build` passes.
- Launched the app and confirmed hovering the label does nothing while hovering the chart reveals the detail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small SwiftUI hit-target change with no data, auth, or business-logic impact.
> 
> **Overview**
> **Usage trend detail** now opens only when the pointer is over the mini bar chart, not the row title.
> 
> Hover handling (`.contentShape(Rectangle())` and `.onContinuousHover`) moves from the outer `HStack` onto the `bars` view in `UsageSparkline.swift`, matching the existing popover anchor on the chart strip. `TrendHoverState`, dwell/grace behavior, and the popover binding are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c0aae36b1f292dd845d410ad01ad4bb84c2fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->