### PR TITLE
feat(popover): make the menu-bar panel user-resizable

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -30,9 +30,9 @@ final class StatusItemController: NSObject {
     private let statusItem: NSStatusItem
     private let panel: MenuBarPanel
     private let hostingController: NSHostingController<AnyView>
-    /// Tracks the SwiftUI content's ideal size so the panel resizes to it (the dashboard animates its
-    /// own height on mode switches). Replaces the `NSPopover` `preferredContentSize` auto-tracking.
-    private var contentSizeObservation: NSKeyValueObservation?
+    /// The screen the status-item button is on, captured on show — used to clamp the saved panel size
+    /// to whatever display the panel is currently opening on.
+    private var anchorScreen: NSScreen?
     /// Closes the panel on clicks outside it (the panel is non-activating and dismissal is ours to
     /// implement, the same model the old `.applicationDefined` popover used).
     private var outsideClickMonitors: [Any] = []
@@ -45,16 +45,23 @@ final class StatusItemController: NSObject {
     /// Reduce Transparency is on. Exactly one is visible (see `applyReduceTransparency`).
     private var glassBackdrop: NSVisualEffectView?
     private var solidBackdrop: NSBox?
-    /// Panel top-left in screen coords, captured on show. The panel grows downward from here as the
-    /// content animates its height, so the top edge stays pinned just under the status-item button.
+    /// Panel top-left in screen coords, captured on show. The panel grows downward from here, so the
+    /// top edge stays pinned just under the status-item button as the user resizes it.
     private var anchorTopLeft: NSPoint?
 
-    /// One width across both densities (matches `DashboardView.popoverWidth`).
+    /// One width across both densities (matches `DashboardView.popoverWidth`). The panel is a single
+    /// column of metrics, so width is fixed; only height is user-resizable.
     private static let panelWidth: CGFloat = 320
     /// Gap between the menu bar and the panel's top edge.
     private static let topGap: CGFloat = 4
     /// Corner radius of the panel surface; tuned to read like a system menu-bar popover.
     private static let cornerRadius: CGFloat = 13
+    /// Smallest the panel can be dragged — room for the footer plus a couple of rows.
+    private static let minPanelHeight: CGFloat = 240
+    /// Opening height before the user has ever resized the panel.
+    private static let defaultPanelHeight: CGFloat = 800
+    /// Panel height at the moment a grip drag began; the live height is this plus the drag distance.
+    private var gripStartHeight: CGFloat = 0
 
     init(container: AppContainer, updater: UpdaterController) {
         self.container = container
@@ -70,13 +77,13 @@ final class StatusItemController: NSObject {
                     .environment(updater)
             )
         )
-        // The panel tracks SwiftUI's preferred size, so the dashboard's animated height changes
-        // (mode switches, content growth) resize the panel instead of clipping.
-        hosting.sizingOptions = .preferredContentSize
+        // The panel is a fixed, user-resizable size — NOT content-sized. The host view fills the
+        // window (its autoresizing mask) and the content scrolls, so switching screens never resizes
+        // the window. That's what removes the resize stutter: the only resize is the user's own drag.
         self.hostingController = hosting
 
         self.panel = MenuBarPanel(
-            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: 400),
+            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.defaultPanelHeight),
             styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -123,6 +130,12 @@ final class StatusItemController: NSObject {
         MenuBarPopover.dismissHandler = { [weak self] in
             self?.hidePanel()
         }
+
+        // The in-page resize grip drives the panel height through these (the panel stays the single
+        // owner of `setFrame`, resizing synchronously so the content never lags the frame).
+        MenuBarPopover.beginResize = { [weak self] in self?.beginGripResize() }
+        MenuBarPopover.resizeBy = { [weak self] distance in self?.updateGripResize(by: distance) }
+        MenuBarPopover.endResize = { [weak self] in self?.endGripResize() }
 
         AppLog.info(.statusItem, "Status item ready (button: \(self.statusItem.button != nil), shortcut: \(KeyboardShortcuts.getShortcut(for: .togglePopover)?.description ?? "none"))")
     }
@@ -174,6 +187,10 @@ final class StatusItemController: NSObject {
         host.frame = container.bounds
         host.autoresizingMask = [.width, .height]
         host.wantsLayer = true
+        // Redraw the SwiftUI content on every step of a live resize instead of stretching the layer's
+        // cached contents (the default `.onSetNeedsDisplay`), which is what made the cards jitter while
+        // dragging the bottom edge.
+        host.layerContentsRedrawPolicy = .duringViewResize
         host.layer?.cornerRadius = Self.cornerRadius
         host.layer?.cornerCurve = .continuous
         host.layer?.masksToBounds = true
@@ -185,15 +202,11 @@ final class StatusItemController: NSObject {
         solidBackdrop = solid
 
         // A plain container VC owns the backdrop; the hosting controller is its child so SwiftUI gets
-        // a proper view-controller hierarchy. The panel itself is sized by `resizePanelToContent`.
+        // a proper view-controller hierarchy. The panel itself is sized by `applyPanelSize`.
         let rootVC = NSViewController()
         rootVC.view = container
         rootVC.addChild(hostingController)
         panel.contentViewController = rootVC
-
-        contentSizeObservation = hostingController.observe(\.preferredContentSize, options: [.new]) { [weak self] _, _ in
-            MainActor.assumeIsolated { self?.resizePanelToContent() }
-        }
 
         applyReduceTransparency()
     }
@@ -338,8 +351,9 @@ final class StatusItemController: NSObject {
         hostingController.view.layoutSubtreeIfNeeded()
 
         let buttonRectOnScreen = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
+        anchorScreen = NSScreen.screens.first { $0.frame.intersects(buttonRectOnScreen) } ?? NSScreen.main
         anchorTopLeft = clampedTopLeft(below: buttonRectOnScreen, width: Self.panelWidth)
-        resizePanelToContent()
+        applyPanelSize()
 
         // `canBecomeKey` + `.nonactivatingPanel` makes this key without activating the app — no
         // activation race, so the dashboard receives keys on the first try.
@@ -367,6 +381,7 @@ final class StatusItemController: NSObject {
         stopOutsideClickMonitors()
         statusItem.button?.highlight(false)
         anchorTopLeft = nil
+        anchorScreen = nil
     }
 
     /// Drops keyboard focus inside the panel so a clicked plain-styled control (a metric row's
@@ -380,19 +395,55 @@ final class StatusItemController: NSObject {
         panel.makeFirstResponder(nil)
     }
 
-    /// Resizes the panel to the SwiftUI content's ideal size, keeping the top edge pinned under the
-    /// status-item button (macOS window origins are bottom-left, so the origin drops as height grows).
-    private func resizePanelToContent() {
-        let size = hostingController.preferredContentSize
-        guard size.width > 0, size.height > 0 else { return }
-        let origin: NSPoint
-        if let anchorTopLeft {
-            origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - size.height)
-        } else {
-            origin = panel.frame.origin
-        }
-        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+    /// Sizes the panel on show: the user's saved height (or a default), **clamped to fit the current
+    /// screen**, with the top-left pinned under the status item. Width is fixed (single-column list).
+    ///
+    /// This is the whole cross-display story: we store ONE height. If it doesn't fit the screen the
+    /// panel is opening on (e.g. saved big on a Studio Display, opened on a laptop), we shrink it to fit
+    /// *for this open only* — the saved value is untouched, so it returns to full size back on the big
+    /// screen. The clamp runs before the panel is visible, so it's instant. There's no content-driven
+    /// resize, so switching screens never moves the window — only the user's drag does.
+    private func applyPanelSize() {
+        guard let anchorTopLeft else { return }
+        let saved = PanelHeightStore.load() ?? Self.defaultPanelHeight
+        let height = min(max(saved, Self.minPanelHeight), maxPanelHeight())
+        let origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - height)
+        panel.setFrame(NSRect(origin: origin, size: NSSize(width: Self.panelWidth, height: height)), display: false)
         panel.invalidateShadow()
+    }
+
+    // MARK: - Grip resize
+
+    private func beginGripResize() {
+        gripStartHeight = panel.frame.height
+    }
+
+    /// Live grip drag. `distance` is how far the pointer has moved down from where the drag began (down =
+    /// grow). We set the frame and then lay the content out **synchronously** before it's drawn, so the
+    /// SwiftUI content never lags the window frame — which was the wobble.
+    private func updateGripResize(by distance: CGFloat) {
+        guard let anchorTopLeft else { return }
+        let height = min(max(gripStartHeight + distance, Self.minPanelHeight), maxPanelHeight())
+        let origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - height)
+        panel.setFrame(NSRect(origin: origin, size: NSSize(width: Self.panelWidth, height: height)), display: false)
+        panel.contentView?.layoutSubtreeIfNeeded()
+        panel.displayIfNeeded()
+        panel.invalidateShadow()
+    }
+
+    private func endGripResize() {
+        PanelHeightStore.save(panel.frame.height)
+    }
+
+    /// The tallest the panel may be on the current screen: the room below its pinned top edge, capped at
+    /// 85% of the screen's usable height so it never dominates a large display.
+    private func maxPanelHeight() -> CGFloat {
+        guard let anchorTopLeft, let visible = (anchorScreen ?? NSScreen.main)?.visibleFrame else {
+            return Self.defaultPanelHeight
+        }
+        let roomBelowAnchor = anchorTopLeft.y - visible.minY - 8
+        let aestheticCap = floor(visible.height * 0.85)
+        return max(Self.minPanelHeight, min(roomBelowAnchor, aestheticCap))
     }
 
     /// Places the panel's top-left just below the button, clamped to the button's screen.
@@ -481,5 +532,20 @@ final class StatusItemController: NSObject {
         guard let button = statusItem.button, let buttonWindow = button.window else { return false }
         let buttonFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
         return buttonFrame.contains(screenPoint)
+    }
+}
+
+/// Persists the user's chosen panel height across launches. Width is fixed (single-column list), so
+/// only height is stored; it's clamped to the current screen on each open (see `applyPanelSize`).
+private enum PanelHeightStore {
+    private static let key = "openusage.panel.height"
+
+    static func load() -> CGFloat? {
+        let value = UserDefaults.standard.double(forKey: key)
+        return value > 0 ? CGFloat(value) : nil
+    }
+
+    static func save(_ height: CGFloat) {
+        UserDefaults.standard.set(Double(height), forKey: key)
     }
 }

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -443,7 +443,11 @@ final class StatusItemController: NSObject {
         }
         let roomBelowAnchor = anchorTopLeft.y - visible.minY - 8
         let aestheticCap = floor(visible.height * 0.85)
-        return max(Self.minPanelHeight, min(roomBelowAnchor, aestheticCap))
+        // The ceiling is the room below the pinned top edge (capped at 85% for aesthetics). It is NOT
+        // floored at `minPanelHeight`: on a screen too short for the minimum, fitting on-screen wins —
+        // the panel becomes smaller than the min rather than running off the bottom edge. `max(1, …)`
+        // only guards a degenerate non-positive frame.
+        return max(1, min(roomBelowAnchor, aestheticCap))
     }
 
     /// Places the panel's top-left just below the button, clamped to the button's screen.

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -168,6 +168,14 @@ enum MenuBarPopover {
     /// path as a status-item click.
     static var dismissHandler: (() -> Void)?
 
+    /// Resize bridge: the in-page resize grip (`ResizeGrip`) drives the host panel's height through
+    /// these, so the AppKit panel owner stays the single place that does `setFrame` (synchronously, so
+    /// the content never lags the frame). `beginResize` snapshots the start height; `resizeBy` is the
+    /// cumulative drag distance (down = taller); `endResize` persists.
+    static var beginResize: (() -> Void)?
+    static var resizeBy: ((CGFloat) -> Void)?
+    static var endResize: (() -> Void)?
+
     /// Closes the popover. Falls back to ordering the given window out if no owner has installed
     /// a handler (which would be a wiring bug, so it's logged loudly by the caller's absence of
     /// effect rather than silently swallowed here).

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -254,6 +254,13 @@ struct DashboardView: View {
         if layout.screen != .dashboard { layout.screen = .dashboard }
         reorderLift = nil
         layout.cancelDrag()
+        // If the popover closes mid-resize (e.g. the global hotkey fires while dragging), the grip's
+        // `onEnded` never runs — settle it here so the flag can't stay stuck (which would make the next
+        // drag jump from a stale start height), and the dragged height is still persisted.
+        if resizingPanel {
+            resizingPanel = false
+            MenuBarPopover.endResize?()
+        }
         dashboardScrollPosition.scrollTo(edge: .top)
     }
 

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -26,6 +26,8 @@ struct DashboardView: View {
     @State private var hasMeasuredSettingsContent = false
     @State private var reorderLift: ReorderLift?
     @State private var showingResetCustomizationConfirmation = false
+    /// True while the user is dragging the resize grip, so the first drag event begins the resize once.
+    @State private var resizingPanel = false
     /// Horizontal screen-switch slide: 0 shows the outgoing screen, 1 the incoming one. Drives both the
     /// page offset and the interpolated popover height, so the slide and the resize share one spring.
     @State private var slideProgress: CGFloat = 1
@@ -165,8 +167,13 @@ struct DashboardView: View {
     var body: some View {
         modeBody
             .frame(width: Self.popoverWidth)
-            .pinnedFooter(spacing: 0) { footerBar }
-            .frame(height: animatedPopoverHeight, alignment: .top)
+            // Fill the panel (the host window is the user-set, screen-clamped size); the scroll views
+            // inside handle overflow. The panel no longer sizes to content, so switching screens never
+            // resizes the window — the slide plays over a static frame, with no resize stutter.
+            .frame(maxHeight: .infinity, alignment: .top)
+            // The resize dragger is a persistent bar at the very bottom — on every screen, including
+            // Settings — separate from the footer above it. It never slides; the pages slide above it.
+            .safeAreaInset(edge: .bottom, spacing: 0) { resizeDragger }
             // Paint the surface behind the content (and footer) and tell every descendant whether
             // glass is on, so the fallbacks and the meter tints render in step. Both go on the
             // outermost level of the chain so the footer, header buttons, and scroll content inherit.
@@ -310,6 +317,7 @@ struct DashboardView: View {
         switch screen {
         case .dashboard:
             scrollingDashboard
+                .pinnedFooter(spacing: 0) { footerBar(for: .dashboard) }
         case .customize:
             CustomizeView(
                 contentHeight: $customizeContentHeight,
@@ -318,13 +326,53 @@ struct DashboardView: View {
                 reorderLift: $reorderLift
             )
             .pinnedTopBar(spacing: 0) { navBar(title: "Customize", showsReset: true) }
+            .pinnedFooter(spacing: 0) { footerBar(for: .customize) }
         case .settings:
+            // No footer — Settings shows only its content (with the top nav bar) above the persistent
+            // dragger. The dragger lives at the root, so it's still there.
             SettingsScreen(
                 contentHeight: $settingsContentHeight,
                 hasMeasuredContent: $hasMeasuredSettingsContent
             )
             .pinnedTopBar(spacing: 0) { navBar(title: "Settings") }
         }
+    }
+
+    /// The resize dragger: a persistent grabber at the very bottom of the popover, present on every
+    /// screen and separate from the footer above it (it never slides). The drag is measured in `.global`
+    /// space — pinned to the panel's fixed top edge — so the bar moving as the panel grows doesn't feed
+    /// back into the gesture; it drives the host panel through `MenuBarPopover`, which resizes
+    /// synchronously so the content can't lag the frame. The pointer style gives the standard resize cursor.
+    private var resizeDragger: some View {
+        Capsule()
+            .fill(.tertiary)
+            .frame(width: 36, height: 4)
+            .frame(maxWidth: .infinity)
+            .frame(height: 10)
+            .contentShape(Rectangle())
+            // Settings has no footer above the dragger, so the grabber would float on bare glass and be
+            // hard to spot — give it a faint bar of its own there. The other screens have the footer right
+            // above it for context, so it stays backgroundless.
+            .background {
+                if layout.screen == .settings {
+                    Rectangle().fill(.bar)
+                }
+            }
+            .pointerStyle(.frameResize(position: .bottom))
+            .gesture(
+                DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                    .onChanged { value in
+                        if !resizingPanel {
+                            resizingPanel = true
+                            MenuBarPopover.beginResize?()
+                        }
+                        MenuBarPopover.resizeBy?(value.translation.height)
+                    }
+                    .onEnded { _ in
+                        resizingPanel = false
+                        MenuBarPopover.endResize?()
+                    }
+            )
     }
 
     /// The widget list as a scroll view that fills the region the footer leaves. The content scrolls
@@ -439,19 +487,38 @@ struct DashboardView: View {
     /// trailing edge. Pinned via `pinnedFooter` so the content scrolls under it with the native scroll
     /// edge effect (`safeAreaBar` on macOS 26; `safeAreaInset` on macOS 15, where the footer still
     /// pins but the scroll-edge blur is absent).
-    private var footerBar: some View {
-        HStack(alignment: .center, spacing: 8) {
-            footerIdentity
-            Spacer(minLength: 8)
-            HeaderView()
+    @ViewBuilder
+    private func footerBar(for screen: PopoverScreen) -> some View {
+        Group {
+            if screen == .customize {
+                // Customize summarizes the layout — active (enabled) metrics and how many are pinned —
+                // centered, using the same middot the metric rows use.
+                Text(layout.pinLimitNotice ?? "\(activeMetricCount) active · \(layout.pinnedCount) pinned")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(layout.pinLimitNotice == nil ? AnyShapeStyle(.secondary) : Theme.notice)
+                    .denyShake(trigger: layout.pinNoticeShakeTrigger)
+                    .frame(maxWidth: .infinity)
+                    .animation(Motion.spring, value: layout.pinLimitNotice)
+            } else {
+                HStack(alignment: .center, spacing: 8) {
+                    footerIdentity
+                    Spacer(minLength: 8)
+                    HeaderView(screen: screen)
+                }
+            }
         }
         .padding(.horizontal, Self.footerHorizontalPadding)
-        // Balanced vertical padding so the footer content sits evenly between the bar's edges. The
-        // scroll edge blur spans the bar's full height regardless, so the transition stays smooth.
-        .padding(.vertical, 12)
+        .padding(.top, 12)
+        // Tight to the resize dragger just below, so the footer and handle read as one bottom cluster.
+        .padding(.bottom, 4)
         .frame(maxWidth: .infinity)
-        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { newValue in
-            if newValue > 0 { footerHeight = newValue }
+    }
+
+    /// Count of enabled ("active") metrics across providers — the "N active" half of the Customize footer
+    /// summary. Pinned metrics are a subset of these.
+    private var activeMetricCount: Int {
+        layout.customizeGroups.reduce(0) { count, group in
+            count + group.metrics.filter { layout.isMetricEnabled($0.id) }.count
         }
     }
 
@@ -462,29 +529,21 @@ struct DashboardView: View {
     /// deny shake — the wrong-password idiom — on every blocked click.
     @ViewBuilder
     private var footerIdentity: some View {
-        if layout.isEditing {
-            Text(layout.pinLimitNotice ?? "\(layout.pinnedCount) pinned")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(layout.pinLimitNotice == nil ? AnyShapeStyle(.secondary) : Theme.notice)
-                .denyShake(trigger: layout.pinNoticeShakeTrigger)
-                .animation(Motion.spring, value: layout.pinLimitNotice)
-        } else {
-            // Both lines share the same font and muted style so the footer reads as one block.
-            VStack(alignment: .leading, spacing: 0) {
-                Text("OpenUsage \(AppInfo.version)")
-                if let notice = layout.pinLimitNotice {
-                    Text(notice)
-                        .foregroundStyle(Theme.notice)
-                        // This label is inserted by the denial itself, so it must shake on mount.
-                        .denyShake(trigger: layout.pinNoticeShakeTrigger, shakeOnAppear: true)
-                } else {
-                    nextUpdateButton
-                }
+        // Both lines share the same font and muted style so the footer reads as one block.
+        VStack(alignment: .leading, spacing: 0) {
+            Text("OpenUsage \(AppInfo.version)")
+            if let notice = layout.pinLimitNotice {
+                Text(notice)
+                    .foregroundStyle(Theme.notice)
+                    // This label is inserted by the denial itself, so it must shake on mount.
+                    .denyShake(trigger: layout.pinNoticeShakeTrigger, shakeOnAppear: true)
+            } else {
+                nextUpdateButton
             }
-            .font(.caption2)
-            .foregroundStyle(.secondary)
-            .animation(Motion.spring, value: layout.pinLimitNotice)
         }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .animation(Motion.spring, value: layout.pinLimitNotice)
     }
 
     /// Ticks once a second so the "Next update in …" copy counts down live, and doubles as the manual

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -14,6 +14,10 @@ import SwiftUI
 struct HeaderView: View {
     @Environment(LayoutStore.self) private var layout
     @Environment(UpdaterController.self) private var updater
+    /// The screen this footer belongs to. Footers are per-page now (they slide with their page), so the
+    /// "More" button keys off the page it's drawn in — not the global current screen, which flips at the
+    /// start of a slide and would otherwise pop the button off the outgoing page mid-transition.
+    let screen: PopoverScreen
 
     var body: some View {
         leadingControl
@@ -27,7 +31,7 @@ struct HeaderView: View {
     /// on the footer's Liquid Glass (bordered on macOS 15).
     @ViewBuilder
     private var leadingControl: some View {
-        if layout.screen == .dashboard {
+        if screen == .dashboard {
             Menu {
                 moreMenuItems
             } label: {

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -42,13 +42,6 @@ struct SettingsScreen: View {
         }) {
             content
         }
-        .onAppear {
-            // The menu-bar panel never activates the app on its own, and an inactive accessory
-            // app receives no text input — the shortcut recorder field would silently ignore
-            // clicks. Activating on entry gives the screen's only text control a working focus
-            // path; the panel itself is already the key window.
-            NSApp.activate()
-        }
     }
 
     private var content: some View {


### PR DESCRIPTION
## What

Makes the menu-bar popover a **user-resizable** panel instead of auto-sizing to its content.

## Why

The panel sized itself to its content, so every screen switch and content change resized the window — which stuttered badly on a content-sized `NSPanel`. (An `NSPopover` resizes smoothly, but we deliberately use a key-capable `NSPanel` so the keyboard / shortcut-recorder works.) Letting the user set a fixed height removes the per-frame resizing entirely.

## How

- **Fixed, user-resizable height**, persisted and clamped to the current screen on each open — so a tall size set on a big display opens clamped on a laptop without losing the saved size. Width stays 320 (single-column list).
- **Persistent resize dragger** at the very bottom on every screen, with the standard resize cursor. It drives the panel through a small `MenuBarPopover` bridge so the panel resizes **synchronously** (content never lags the frame — no wobble).
- **Footer is per page** (Dashboard, Customize) and slides with it; **Settings has no footer** — just its content and the dragger.
- **Customize footer**: centered `N active · N pinned`.
- Dropped a redundant `NSApp.activate()` on Settings that glitched the footer glass once the panel stopped resizing per screen-switch.

## Test plan

- Drag the bottom handle — smooth resize, top stays pinned, height persists across open/close and app restart.
- Switch Dashboard ↔ Customize ↔ Settings — no window resize; the slide is smooth.
- Settings shows only its content + the dragger (no footer); the dragger has a faint background there so it's visible.
- Open on a smaller display — clamps to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core menu-bar window framing and Settings keyboard focus behavior (removed `NSApp.activate()`), but changes are localized to popover UI with no auth or data-path impact.
> 
> **Overview**
> Replaces **content-driven panel sizing** with a **fixed 320pt-wide height** the user sets via a bottom resize grip. `StatusItemController` drops `preferredContentSize` observation, applies saved height from `PanelHeightStore` on open (clamped per display without overwriting the saved value), and owns all `setFrame` updates through synchronous grip-drag layout so SwiftUI does not lag the frame.
> 
> Adds a **persistent bottom dragger** on every screen (via `MenuBarPopover` resize hooks), **per-page footers** that slide with Dashboard/Customize (Customize shows centered **N active · N pinned**), and **no footer on Settings**—only content plus the grip. `HeaderView` takes a `screen` parameter so the More menu stays on the correct page during transitions. Removes `NSApp.activate()` on Settings entry and handles **mid-resize dismiss** by persisting height when the popover closes during a drag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9251865b2b866e7d2ac09cebc6fd10855080569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->