### PR TITLE
[codex] Add provider-aware refresh scheduling

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -57,33 +57,34 @@ final class AppContainer {
 
     deinit { refreshTask.cancel() }
 
-    /// Drives live updates: refresh on launch, then again every refresh interval. Each pass honors the
-    /// cache, so it only hits the network once a snapshot has actually expired. `@Observable` propagates
-    /// the resulting snapshot changes to the menu-bar label and any open widgets, so the UI refreshes on
-    /// its own instead of only when the popover opens.
+    /// Drives live updates: refresh due providers on launch, then wake for the soonest provider-specific
+    /// probe. Each pass honors the cache/backoff, so Codex can be fresh every minute without forcing
+    /// Claude/Grok/Cursor/Devin to poll at the same pace.
     private static func startPeriodicRefresh(dataStore: WidgetDataStore) -> Task<Void, Never> {
         Task {
             while !Task.isCancelled {
-                await dataStore.refreshAll()
-                await waitForNextRefresh()
+                await dataStore.refreshDueProviders()
+                await waitForNextRefresh(dataStore: dataStore)
             }
         }
     }
 
-    /// Sleep for the refresh interval, but wake early when the user enables/disables a provider so a
-    /// newly-enabled provider is fetched promptly instead of waiting out the full interval. Each pass still
-    /// honors the cache (and the per-provider failure backoff), so an early wake only hits the network for
-    /// a provider whose snapshot has actually expired.
+    /// Sleep until the soonest provider is due, but wake early when the user enables/disables a provider
+    /// so a newly-enabled provider is fetched promptly instead of waiting out another provider's cadence.
+    /// Each pass still honors the cache and per-provider backoff.
     ///
     /// Deliberately scoped to `ProviderEnablementStore.didChangeNotification` — NOT the firehose
     /// `UserDefaults.didChangeNotification`, which fires for the app's own snapshot-cache writes, Sparkle's
     /// update bookkeeping, and unrelated global-domain changes from other processes. Waking on that, with
     /// no minimum interval before re-refreshing, collapsed the fixed 5-minute cadence into a refresh storm.
-    private static func waitForNextRefresh() async {
-        let interval = RefreshSetting.interval
+    private static func waitForNextRefresh(dataStore: WidgetDataStore) async {
+        let nextRefreshAt = dataStore.nextScheduledRefreshDate()
         await withTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try? await Task.sleep(for: .seconds(interval))
+            if let nextRefreshAt {
+                group.addTask {
+                    let delay = max(0.25, nextRefreshAt.timeIntervalSinceNow)
+                    try? await Task.sleep(for: .seconds(delay))
+                }
             }
             group.addTask {
                 for await _ in NotificationCenter.default.notifications(named: ProviderEnablementStore.didChangeNotification) {

--- a/Sources/OpenUsage/Models/ProviderSnapshot.swift
+++ b/Sources/OpenUsage/Models/ProviderSnapshot.swift
@@ -7,19 +7,24 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
     var plan: String?
     var lines: [MetricLine]
     var refreshedAt: Date
+    /// Optional provider-supplied deadline for the next live probe, used when an API asks us to slow
+    /// down (for example Claude's `Retry-After` on rate limiting).
+    var retryAfter: Date?
 
     init(
         providerID: String,
         displayName: String,
         plan: String? = nil,
         lines: [MetricLine],
-        refreshedAt: Date = Date()
+        refreshedAt: Date = Date(),
+        retryAfter: Date? = nil
     ) {
         self.providerID = providerID
         self.displayName = displayName
         self.plan = plan
         self.lines = lines
         self.refreshedAt = refreshedAt
+        self.retryAfter = retryAfter
     }
 
     func line(label: String) -> MetricLine? {
@@ -29,13 +34,20 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
     /// The success-path counterpart to `error(provider:message:)`: derives `providerID`/`displayName`
     /// from the provider so every runtime builds its snapshot the same way (`refreshedAt` is required
     /// so each call passes its own `now()`).
-    static func make(provider: Provider, plan: String?, lines: [MetricLine], refreshedAt: Date) -> ProviderSnapshot {
+    static func make(
+        provider: Provider,
+        plan: String?,
+        lines: [MetricLine],
+        refreshedAt: Date,
+        retryAfter: Date? = nil
+    ) -> ProviderSnapshot {
         ProviderSnapshot(
             providerID: provider.id,
             displayName: provider.displayName,
             plan: plan,
             lines: lines,
-            refreshedAt: refreshedAt
+            refreshedAt: refreshedAt,
+            retryAfter: retryAfter
         )
     }
 
@@ -47,4 +59,3 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
         )
     }
 }
-

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -57,7 +57,7 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
         switch self {
         case .sessionExpired, .tokenExpired:
             return true
-        case .notLoggedIn:
+        case .notLoggedIn, .invalidOAuthURL:
             return false
         }
     }
@@ -347,5 +347,4 @@ struct ClaudeAuthStore: Sendable {
         return String(digest.map { String(format: "%02x", $0) }.joined().prefix(8))
     }
 }
-
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -85,7 +85,13 @@ final class ClaudeProvider: ProviderRuntime {
         )
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)
-        return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
+        return ProviderSnapshot.make(
+            provider: provider,
+            plan: mapped.plan,
+            lines: mapped.lines,
+            refreshedAt: now(),
+            retryAfter: mapped.retryAfter
+        )
     }
 
     private func fetchLiveUsage(state: inout ClaudeCredentialState) async throws -> ClaudeMappedUsage {
@@ -115,7 +121,8 @@ final class ClaudeProvider: ProviderRuntime {
             AppLog.info(LogTag.plugin("claude"), "rate-limited")
             return ClaudeUsageMapper.rateLimitedUsage(
                 credentials: working.oauth,
-                retryAfterSeconds: ClaudeUsageMapper.parseRetryAfterSeconds(response, now: now())
+                retryAfterSeconds: ClaudeUsageMapper.parseRetryAfterSeconds(response, now: now()),
+                now: now()
             )
         }
         return try ClaudeUsageMapper.mapUsageResponse(response, credentials: working.oauth, now: now())

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -3,6 +3,7 @@ import Foundation
 struct ClaudeMappedUsage: Equatable, Sendable {
     var plan: String?
     var lines: [MetricLine]
+    var retryAfter: Date?
 }
 
 enum ClaudeUsageMapper {
@@ -28,11 +29,16 @@ enum ClaudeUsageMapper {
 
         return ClaudeMappedUsage(
             plan: formatPlan(subscriptionType: credentials.subscriptionType, rateLimitTier: credentials.rateLimitTier),
-            lines: lines
+            lines: lines,
+            retryAfter: nil
         )
     }
 
-    static func rateLimitedUsage(credentials: ClaudeOAuth, retryAfterSeconds: Int?) -> ClaudeMappedUsage {
+    static func rateLimitedUsage(
+        credentials: ClaudeOAuth,
+        retryAfterSeconds: Int?,
+        now: Date = Date()
+    ) -> ClaudeMappedUsage {
         let retryText = retryAfterSeconds.map(formatRateLimitMinutes)
         let waitText = retryText.map { "Rate limited, retry in ~\($0)" } ?? "Rate limited, try again later"
         let noteText = retryText.map { "Live usage rate limited - retry in ~\($0)" } ?? "Live usage rate limited - data may be stale"
@@ -41,7 +47,8 @@ enum ClaudeUsageMapper {
             lines: [
                 .badge(label: "Status", text: waitText, colorHex: "#F59E0B"),
                 .text(label: "Note", value: noteText)
-            ]
+            ],
+            retryAfter: retryAfterSeconds.map { now.addingTimeInterval(Double($0)) }
         )
     }
 
@@ -144,4 +151,3 @@ private enum HTTPDateFormatter {
         return formatter.date(from: value)
     }
 }
-

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -70,7 +70,7 @@ struct ProviderSnapshotCache {
         return loaded
     }
 
-    func snapshot(providerID: String) -> ProviderSnapshot? {
+    func snapshot(providerID: String, ttl overrideTTL: TimeInterval? = nil) -> ProviderSnapshot? {
         let snapshot = loadPayload().snapshots[providerID]
         guard let snapshot else { return nil }
         // Freshness has two requirements, and disk age alone is not enough: the snapshot must have been
@@ -79,6 +79,7 @@ struct ProviderSnapshotCache {
         // promptly instead of waiting out the previous session's remaining interval (#697).
         let writtenThisSession = sessionWrites.withLock { $0.contains(providerID) }
         let age = now().timeIntervalSince(snapshot.refreshedAt)
+        let ttl = overrideTTL ?? self.ttl
         let fresh = writtenThisSession && age < ttl
         let reason = !writtenThisSession ? "stale (not written this session)"
             : fresh ? "fresh" : "stale"
@@ -94,7 +95,7 @@ struct ProviderSnapshotCache {
         AppLog.debug(.cache, "write \(snapshot.providerID)")
         // Mark this provider as written *this session* so its snapshot now satisfies the freshness gate
         // (a launch-loaded snapshot never does — see `sessionWrites`).
-        sessionWrites.withLock { $0.insert(snapshot.providerID) }
+        _ = sessionWrites.withLock { $0.insert(snapshot.providerID) }
         var payload = loadPayload()
         payload.snapshots[snapshot.providerID] = snapshot
         save(payload)

--- a/Sources/OpenUsage/Stores/RefreshSetting.swift
+++ b/Sources/OpenUsage/Stores/RefreshSetting.swift
@@ -1,12 +1,49 @@
 import Foundation
 
-/// Single source of truth for the background refresh cadence.
-///
-/// The periodic refresh loop and the snapshot-cache TTL both read the cadence through here so they can
-/// never disagree: the cache treats a snapshot as fresh for exactly one refresh interval, and the loop
-/// re-fetches when that window elapses. The cadence is fixed — there's no user-facing control — so the
-/// two always line up.
+/// Legacy fallback refresh cadence for providers without an explicit policy.
 enum RefreshSetting {
     static let defaultMinutes = 5
     static let interval = TimeInterval(defaultMinutes * 60)
+}
+
+/// Internal refresh policy for provider-aware scheduling. These are product defaults, not a user-facing
+/// setting: the app stays simple while provider-specific limits remain easy to tune in code.
+enum ProviderRefreshPolicy {
+    static let codexBaseInterval: TimeInterval = 60
+    static let claudeBaseInterval: TimeInterval = 180
+    static let defaultBaseInterval = RefreshSetting.interval
+    static let maxFailureBackoff: TimeInterval = 15 * 60
+
+    static func baseInterval(for providerID: String) -> TimeInterval {
+        switch providerID {
+        case "codex":
+            codexBaseInterval
+        case "claude":
+            claudeBaseInterval
+        default:
+            defaultBaseInterval
+        }
+    }
+
+    static func failureBackoff(
+        consecutiveFailures: Int,
+        baseInterval: TimeInterval
+    ) -> TimeInterval {
+        guard consecutiveFailures > 0 else { return baseInterval }
+        let step: TimeInterval = switch consecutiveFailures {
+        case 1:
+            2 * 60
+        case 2:
+            5 * 60
+        case 3:
+            10 * 60
+        default:
+            maxFailureBackoff
+        }
+        return min(maxFailureBackoff, max(baseInterval, step))
+    }
+
+    static func stalenessThreshold(effectiveInterval: TimeInterval) -> TimeInterval {
+        effectiveInterval * 2
+    }
 }

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -28,20 +28,16 @@ final class WidgetDataStore {
     private static let meterStyleKey = "meterStyle"
     private static let resetDisplayModeKey = "resetDisplayMode"
     private static let alwaysShowPacingKey = "alwaysShowPacing"
-    /// How long a provider that just failed is skipped before the loop will probe it again. A failed
-    /// refresh isn't cached, so — unlike a success, which the snapshot cache gates for an interval —
-    /// nothing else stops the loop from re-probing a broken provider (logged-out Devin/Grok especially)
-    /// on every wake, spawning subprocesses and network calls in a tight loop. This negative-cache caps a
-    /// failing provider to one probe per window. Shorter than the refresh interval, so the normal
-    /// 5-minute heartbeat always retries; it only suppresses the sub-interval re-probes a wake burst
-    /// would cause. The manual `force` refresh (⌘R) always bypasses it.
-    private static let failureRetryBackoff: TimeInterval = 60
+    /// Providers are considered stale only after a couple of effective refresh windows, so a provider
+    /// that is intentionally backed off after failures does not look stale merely because the app is
+    /// respecting that backoff.
+    private static let stalenessCycleCount: TimeInterval = 2
 
     var snapshots: [String: ProviderSnapshot] = [:]
     var refreshingProviderIDs: Set<String> = []
-    /// Wall-clock time the most recent full refresh pass finished. Together with the chosen refresh
-    /// cadence it drives the dashboard footer's live "Next update in …" countdown, so the footer reflects
-    /// the real schedule instead of a hardcoded value. `nil` until the first pass completes.
+    /// Wall-clock time the most recent refresh batch finished. Kept for logs/tests and older callers; the
+    /// visible countdown now reads `nextScheduledRefreshDate()` because providers can have different
+    /// cadences and failure backoffs.
     var lastRefreshAt: Date?
     /// Latest refresh error per provider (e.g. "Not logged in. Run `codex` to authenticate."). Set when
     /// a refresh comes back as an error snapshot, cleared on the next successful one. The dashboard
@@ -49,9 +45,16 @@ final class WidgetDataStore {
     /// displaying (stale-while-revalidate) instead of being replaced by dead "No data" rows.
     var providerErrors: [String: String] = [:]
 
-    /// Per-provider earliest next-probe time after a failure (see `failureRetryBackoff`). Not part of
-    /// observable UI state, so it's excluded from `@Observable` tracking.
-    @ObservationIgnored private var failureRetryAfter: [String: Date] = [:]
+    /// Earliest next live probe per provider. A missing value means "due now", which gives launch and
+    /// re-enable paths their immediate first fetch.
+    var nextProbeAtByProvider: [String: Date] = [:]
+
+    /// Consecutive failed/rate-limited live probes per provider. A success clears the count.
+    @ObservationIgnored private var consecutiveFailures: [String: Int] = [:]
+
+    /// The latest effective scheduling interval per provider: base cadence on success, current backoff
+    /// after failures. Staleness uses this so intentional backoff does not create a misleading hint.
+    @ObservationIgnored private var effectiveRefreshIntervals: [String: TimeInterval] = [:]
 
     /// Global meter style: whether every bounded tile (and the menu-bar value) renders as "used" or
     /// "left/remaining". Persisted so the choice survives relaunch; defaults to `.remaining`.
@@ -100,12 +103,24 @@ final class WidgetDataStore {
     /// Refresh every enabled provider, concurrently — one slow provider never delays the rest.
     /// Everything stays MainActor-isolated; the overlap happens at the network awaits inside each
     /// provider, and the per-provider in-flight guard in `refresh` still prevents duplicate fetches.
-    /// `force` bypasses the snapshot cache (the manual "refresh now" path); the periodic loop keeps
-    /// honoring it.
+    /// `force` bypasses the snapshot cache and backoff (the manual "refresh now" path).
     func refreshAll(force: Bool = false) async {
+        await refreshBatch(
+            providerIDs: registry.providers.map(\.id).filter { isProviderEnabled($0) },
+            force: force
+        )
+    }
+
+    /// Refresh only providers whose scheduled live probe is due. The background loop uses this so Codex
+    /// can update every minute without dragging more conservative providers along for the ride.
+    func refreshDueProviders() async {
+        await refreshBatch(providerIDs: dueProviderIDs(at: now()), force: false)
+    }
+
+    private func refreshBatch(providerIDs: [String], force: Bool) async {
+        guard !providerIDs.isEmpty else { return }
         // `Task {}` from MainActor context inherits the isolation (a task-group child can't capture
         // the non-Sendable store), so: fire one task per provider, then await them all.
-        let providerIDs = registry.providers.map(\.id).filter { isProviderEnabled($0) }
         let start = Date()
         AppLog.info(.refresh, "batch start (\(providerIDs.count) providers, force=\(force))")
         let tasks = providerIDs.map { providerID in
@@ -130,32 +145,53 @@ final class WidgetDataStore {
         AppLog.info(.refresh, "batch end (\(durationMs)ms, \(refreshed) ok / \(failed) failed / \(cached) cached / \(backedOff) backed off)")
     }
 
+    func dueProviderIDs(at date: Date) -> [String] {
+        registry.providers.map(\.id).filter { providerID in
+            guard isProviderEnabled(providerID) else { return false }
+            guard !refreshingProviderIDs.contains(providerID) else { return false }
+            return (nextProbeAtByProvider[providerID] ?? date) <= date
+        }
+    }
+
+    func nextScheduledRefreshDate(at date: Date? = nil) -> Date? {
+        let reference = date ?? now()
+        return registry.providers.map(\.id)
+            .filter { isProviderEnabled($0) }
+            .map { nextProbeAtByProvider[$0] ?? reference }
+            .min()
+    }
+
     /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch
     /// from real outcomes rather than cumulative error state. `.backedOff` is a probe deliberately skipped
-    /// because the provider failed within the last `failureRetryBackoff` — distinct from `.skipped`
-    /// (disabled / unknown / already in flight) so a wake-burst's suppression is visible in the logs.
+    /// because the provider is waiting out its failure backoff — distinct from `.skipped` (disabled /
+    /// unknown / already in flight) so a wake-burst's suppression is visible in the logs.
     enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
 
     @discardableResult
     func refresh(providerID: String, force: Bool = false) async -> RefreshOutcome {
         guard isProviderEnabled(providerID) else { return .skipped }
-        if !force, let cached = cache.snapshot(providerID: providerID) {
+        let baseInterval = ProviderRefreshPolicy.baseInterval(for: providerID)
+        // A provider that just failed or was rate-limited isn't cached as a healthy success, so hold off
+        // until its scheduled retry. The manual `force` refresh ignores this deadline.
+        if !force,
+           consecutiveFailures[providerID, default: 0] > 0,
+           let retryAfter = nextProbeAtByProvider[providerID],
+           now() < retryAfter {
+            let remaining = Int(ceil(retryAfter.timeIntervalSince(now())))
+            AppLog.debug(.refresh, "backoff skip \(providerID) (\(remaining)s remaining)")
+            return .backedOff
+        }
+        if !force, let cached = cache.snapshot(providerID: providerID, ttl: baseInterval) {
             // Skip the no-op write: `@Observable` doesn't compare values, so unconditionally
             // re-assigning an unchanged snapshot would re-render the menu-bar label every pass.
             AppLog.debug(.refresh, "cache hit \(providerID)")
             if snapshots[providerID] != cached {
                 snapshots[providerID] = cached
             }
+            scheduleSuccess(for: providerID, from: cached.refreshedAt)
             return .cacheHit
         }
         if !force { AppLog.debug(.refresh, "cache miss \(providerID)") }
-
-        // A provider that just failed isn't cached, so nothing else stops the loop from re-probing it on
-        // every wake. Hold off until its backoff expires; the manual `force` refresh ignores the backoff.
-        if !force, let retryAfter = failureRetryAfter[providerID], now() < retryAfter {
-            AppLog.debug(.refresh, "backoff skip \(providerID) (failed <\(Int(Self.failureRetryBackoff))s ago)")
-            return .backedOff
-        }
 
         guard let provider = providersByID[providerID] else { return .skipped }
         // Skip if an in-flight refresh already owns this provider (e.g. the background timer racing the
@@ -173,16 +209,21 @@ final class WidgetDataStore {
             // Failed refresh: surface the error but keep the last good snapshot on screen rather than
             // collapsing every row to "No data". The provider error string is already user-safe.
             providerErrors[providerID] = message
-            // Negative-cache the failure so a wake burst can't re-probe this provider in a tight loop.
-            failureRetryAfter[providerID] = now().addingTimeInterval(Self.failureRetryBackoff)
+            scheduleFailure(for: providerID, retryAfter: snapshot.retryAfter)
             AppLog.warn(.refresh, "\(providerID) failed: \(message)")
+            return .failed
+        }
+        if let retryAfter = snapshot.retryAfter {
+            providerErrors[providerID] = nil
+            scheduleFailure(for: providerID, retryAfter: retryAfter)
+            snapshots[providerID] = snapshot
+            AppLog.warn(.refresh, "\(providerID) asked to retry later")
             return .failed
         }
         if providerErrors[providerID] != nil {
             providerErrors[providerID] = nil
         }
-        // Recovered: drop any backoff so the provider resumes the normal cadence immediately.
-        failureRetryAfter[providerID] = nil
+        scheduleSuccess(for: providerID, from: now())
         snapshots[providerID] = snapshot
         cache.store(snapshot)
         AppLog.info(.refresh, "\(providerID) ok (\(durationMs)ms)")
@@ -194,7 +235,32 @@ final class WidgetDataStore {
     /// failure just before it was turned off must not suppress that fetch (the loop wouldn't otherwise
     /// retry until the 5-minute heartbeat). The periodic loop never calls this — only the user action does.
     func clearFailureBackoff(for providerID: String) {
-        failureRetryAfter[providerID] = nil
+        consecutiveFailures[providerID] = nil
+        effectiveRefreshIntervals[providerID] = ProviderRefreshPolicy.baseInterval(for: providerID)
+        nextProbeAtByProvider[providerID] = nil
+    }
+
+    private func scheduleSuccess(for providerID: String, from date: Date) {
+        let interval = ProviderRefreshPolicy.baseInterval(for: providerID)
+        consecutiveFailures[providerID] = nil
+        effectiveRefreshIntervals[providerID] = interval
+        nextProbeAtByProvider[providerID] = date.addingTimeInterval(interval)
+    }
+
+    private func scheduleFailure(for providerID: String, retryAfter: Date?) {
+        let failureCount = consecutiveFailures[providerID, default: 0] + 1
+        consecutiveFailures[providerID] = failureCount
+
+        let baseInterval = ProviderRefreshPolicy.baseInterval(for: providerID)
+        var delay = ProviderRefreshPolicy.failureBackoff(
+            consecutiveFailures: failureCount,
+            baseInterval: baseInterval
+        )
+        if let retryAfter {
+            delay = max(delay, retryAfter.timeIntervalSince(now()))
+        }
+        effectiveRefreshIntervals[providerID] = delay
+        nextProbeAtByProvider[providerID] = now().addingTimeInterval(delay)
     }
 
     /// The provider's latest refresh error, or `nil` when its last refresh succeeded.
@@ -253,7 +319,13 @@ final class WidgetDataStore {
     /// one, so the threshold sits at two intervals: it fires only when a refresh has actually been missed
     /// — a refresh loop that keeps failing, or a long-suspended background timer — never on the normal
     /// per-cycle aging, which would flicker a hint on healthy providers.
-    static let stalenessThreshold = RefreshSetting.interval * 2
+    static let stalenessThreshold = ProviderRefreshPolicy.defaultBaseInterval * stalenessCycleCount
+
+    func stalenessThreshold(for providerID: String) -> TimeInterval {
+        let effectiveInterval = effectiveRefreshIntervals[providerID]
+            ?? ProviderRefreshPolicy.baseInterval(for: providerID)
+        return ProviderRefreshPolicy.stalenessThreshold(effectiveInterval: effectiveInterval)
+    }
 
     /// A compact "Outdated" hint for the provider's on-screen snapshot, surfaced only once that snapshot
     /// has aged past `stalenessThreshold`; `nil` while the data is still current (the common case), so the
@@ -265,7 +337,8 @@ final class WidgetDataStore {
     func stalenessHint(for providerID: String) -> StalenessHint? {
         guard let refreshedAt = snapshots[providerID]?.refreshedAt else { return nil }
         let age = now().timeIntervalSince(refreshedAt)
-        guard age >= Self.stalenessThreshold, let duration = Formatters.compactDuration(age) else {
+        guard age >= stalenessThreshold(for: providerID),
+              let duration = Formatters.compactDuration(age) else {
             return nil
         }
         return StalenessHint(label: "Outdated", tooltip: "Last updated \(duration) ago")
@@ -426,4 +499,3 @@ final class WidgetDataStore {
         return Double(value[match].replacingOccurrences(of: ",", with: ""))
     }
 }
-

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -585,15 +585,16 @@ struct DashboardView: View {
         !dataStore.refreshingProviderIDs.isEmpty
     }
 
-    /// "Updating…" during an in-flight refresh, otherwise a live countdown to the next scheduled pass
-    /// (last completed pass + the refresh interval). Falls back to a full interval before the first pass.
+    /// "Updating…" during an in-flight refresh, otherwise a live countdown to the soonest provider whose
+    /// scheduled probe is due. Falls back to now before the first pass so launch reads as imminent.
     private func updateStatusText(now: Date) -> String {
         if isUpdating {
             return "Updating…"
         }
-        let interval = RefreshSetting.interval
-        let base = dataStore.lastRefreshAt ?? now
-        let remaining = max(0, base.addingTimeInterval(interval).timeIntervalSince(now))
+        guard let nextRefreshAt = dataStore.nextScheduledRefreshDate(at: now) else {
+            return "No providers enabled"
+        }
+        let remaining = max(0, nextRefreshAt.timeIntervalSince(now))
         let totalSeconds = Int(remaining.rounded(.up))
         if totalSeconds >= 60 {
             let minutes = Int((Double(totalSeconds) / 60).rounded(.up))

--- a/Tests/OpenUsageTests/FailureBackoffTests.swift
+++ b/Tests/OpenUsageTests/FailureBackoffTests.swift
@@ -1,10 +1,9 @@
 import XCTest
 @testable import OpenUsage
 
-/// Covers the per-provider failure backoff: a refresh that fails is negatively cached for a short
-/// window, so an over-eager refresh loop (e.g. a wake burst) can't re-probe a broken provider — the
-/// logged-out Devin/Grok case — in a tight subprocess/network loop. The normal heartbeat and the manual
-/// `force` refresh still retry as expected.
+/// Covers the per-provider failure backoff: a refresh that fails is negatively cached until its next
+/// scheduled retry, so an over-eager wake burst can't re-probe a broken provider in a tight loop. Manual
+/// `force` refresh still retries immediately.
 @MainActor
 final class FailureBackoffTests: XCTestCase {
     func testFailedProviderIsNotReprobedWithinBackoffWindow() async {
@@ -24,8 +23,8 @@ final class FailureBackoffTests: XCTestCase {
         await store.refreshAll()
         XCTAssertEqual(runtime.refreshCount, 1)
 
-        // Once the window elapses, the normal cadence retries.
-        clock = clock.addingTimeInterval(60)
+        // Once Devin's first failure window elapses, the normal cadence retries.
+        clock = clock.addingTimeInterval(300)
         await store.refreshAll()
         XCTAssertEqual(runtime.refreshCount, 2)
     }
@@ -65,7 +64,7 @@ final class FailureBackoffTests: XCTestCase {
         )
         let store = makeStore(provider: provider, descriptor: descriptor, runtime: runtime, clock: { clock })
 
-        await store.refreshAll()                       // pass 1: fails → backoff until +60s
+        await store.refreshAll()                       // pass 1: fails -> backoff until +5m
         XCTAssertEqual(runtime.refreshCount, 1)
 
         clock = clock.addingTimeInterval(1)
@@ -73,7 +72,7 @@ final class FailureBackoffTests: XCTestCase {
         XCTAssertEqual(runtime.refreshCount, 2)
         XCTAssertNil(store.errorMessage(for: provider.id))
 
-        // Pass 3 is still inside the original 60s window: had the success NOT cleared the backoff, this
+        // Pass 3 is still inside the original 5-minute window: had the success NOT cleared the backoff, this
         // would be suppressed (count stays 2). It probes, proving the backoff was cleared on recovery.
         clock = clock.addingTimeInterval(1)
         await store.refreshAll()
@@ -99,12 +98,79 @@ final class FailureBackoffTests: XCTestCase {
         XCTAssertEqual(runtime.refreshCount, 2)
     }
 
+    func testSuccessfulRefreshSchedulesProviderBaseCadence() async {
+        let clock = Date(timeIntervalSince1970: 1_800_000_000)
+        let codex = makeRuntime(providerID: "codex", displayName: "Codex", used: 12, clock: clock)
+        let claude = makeRuntime(providerID: "claude", displayName: "Claude", used: 34, clock: clock)
+        let store = makeStore(runtimes: [codex, claude], clock: { clock })
+
+        await store.refreshAll()
+
+        XCTAssertEqual(store.nextProbeAtByProvider["codex"], clock.addingTimeInterval(60))
+        XCTAssertEqual(store.nextProbeAtByProvider["claude"], clock.addingTimeInterval(180))
+        XCTAssertEqual(store.nextScheduledRefreshDate(at: clock), clock.addingTimeInterval(60))
+    }
+
+    func testCodexFailureBackoffSequenceCapsAtFifteenMinutes() async {
+        var clock = Date(timeIntervalSince1970: 1_800_000_000)
+        let runtime = makeFailingRuntime(providerID: "codex", displayName: "Codex")
+        let store = makeStore(runtime: runtime, clock: { clock })
+
+        await store.refreshAll()
+        XCTAssertEqual(store.nextScheduledRefreshDate(at: clock), clock.addingTimeInterval(120))
+
+        clock = clock.addingTimeInterval(120)
+        await store.refreshAll()
+        XCTAssertEqual(store.nextScheduledRefreshDate(at: clock), clock.addingTimeInterval(300))
+
+        clock = clock.addingTimeInterval(300)
+        await store.refreshAll()
+        XCTAssertEqual(store.nextScheduledRefreshDate(at: clock), clock.addingTimeInterval(600))
+
+        clock = clock.addingTimeInterval(600)
+        await store.refreshAll()
+        XCTAssertEqual(store.nextScheduledRefreshDate(at: clock), clock.addingTimeInterval(900))
+
+        clock = clock.addingTimeInterval(900)
+        await store.refreshAll()
+        XCTAssertEqual(store.nextScheduledRefreshDate(at: clock), clock.addingTimeInterval(900))
+    }
+
+    func testRetryAfterCanExtendFailureBackoff() async {
+        let clock = Date(timeIntervalSince1970: 1_800_000_000)
+        let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let descriptor = WidgetDescriptor(
+            id: "claude.session", providerID: provider.id, metricLabel: "Session",
+            sample: WidgetData(title: "Session", icon: provider.icon, kind: .percent, used: 0, limit: 100)
+        )
+        let retryAfter = clock.addingTimeInterval(10 * 60)
+        let runtime = CountingProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.badge(label: "Status", text: "Rate limited, retry in ~10m")],
+                refreshedAt: clock,
+                retryAfter: retryAfter
+            )
+        )
+        let store = makeStore(provider: provider, descriptor: descriptor, runtime: runtime, clock: { clock })
+
+        await store.refreshAll()
+
+        XCTAssertEqual(store.nextScheduledRefreshDate(at: clock), retryAfter)
+    }
+
     // MARK: - Helpers
 
-    private func makeFailingRuntime() -> CountingProviderRuntime {
-        let provider = Provider(id: "devin", displayName: "Devin", icon: .providerMark("devin"))
+    private func makeFailingRuntime(
+        providerID: String = "devin",
+        displayName: String = "Devin"
+    ) -> CountingProviderRuntime {
+        let provider = Provider(id: providerID, displayName: displayName, icon: .providerMark(providerID))
         let descriptor = WidgetDescriptor(
-            id: "devin.weekly", providerID: provider.id, metricLabel: "Weekly quota",
+            id: "\(providerID).weekly", providerID: provider.id, metricLabel: "Weekly quota",
             sample: WidgetData(title: "Weekly", icon: provider.icon, kind: .percent, used: 0, limit: 100)
         )
         return CountingProviderRuntime(
@@ -134,6 +200,46 @@ final class FailureBackoffTests: XCTestCase {
             cache: ProviderSnapshotCache(userDefaults: suite, storageKey: "snapshots", ttl: 600, now: clock),
             defaults: suite,
             now: clock
+        )
+    }
+
+    private func makeStore(
+        runtimes: [CountingProviderRuntime],
+        clock: @escaping () -> Date
+    ) -> WidgetDataStore {
+        let suite = makeUserDefaults("schedule")
+        return WidgetDataStore(
+            registry: WidgetRegistry(
+                providers: runtimes.map(\.provider),
+                descriptors: runtimes.flatMap(\.widgetDescriptors)
+            ),
+            providers: runtimes.map { $0 as ProviderRuntime },
+            cache: ProviderSnapshotCache(userDefaults: suite, storageKey: "snapshots", ttl: 600, now: clock),
+            defaults: suite,
+            now: clock
+        )
+    }
+
+    private func makeRuntime(
+        providerID: String,
+        displayName: String,
+        used: Double,
+        clock: Date
+    ) -> CountingProviderRuntime {
+        let provider = Provider(id: providerID, displayName: displayName, icon: .providerMark(providerID))
+        let descriptor = WidgetDescriptor(
+            id: "\(providerID).session", providerID: provider.id, metricLabel: "Session",
+            sample: WidgetData(title: "Session", icon: provider.icon, kind: .percent, used: 0, limit: 100)
+        )
+        return CountingProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.progress(label: "Session", used: used, limit: 100, format: .percent)],
+                refreshedAt: clock
+            )
         )
     }
 

--- a/Tests/OpenUsageTests/RefreshSettingTests.swift
+++ b/Tests/OpenUsageTests/RefreshSettingTests.swift
@@ -1,17 +1,32 @@
 import XCTest
 @testable import OpenUsage
 
-/// Covers the refresh cadence as the single source of truth: `RefreshSetting`'s fixed interval, and the
-/// snapshot cache's session-scoped freshness — a snapshot is fresh for one interval only *within the
-/// session that fetched it*, so a relaunch always refetches on the first pass (it still paints the cached
-/// value instantly) while a within-session pass is served from cache until the interval elapses. See #697.
+/// Covers refresh policy and the snapshot cache's session-scoped freshness — a snapshot is fresh for one
+/// provider interval only *within the session that fetched it*, so a relaunch always refetches on the
+/// first pass while a within-session pass is served from cache until that provider's interval elapses.
 @MainActor
 final class RefreshSettingTests: XCTestCase {
-    // MARK: - Fixed cadence
+    // MARK: - Provider cadence
 
-    func testCadenceIsFixedAtFiveMinutes() {
-        XCTAssertEqual(RefreshSetting.defaultMinutes, 5)
-        XCTAssertEqual(RefreshSetting.interval, 300)
+    func testProviderBaseCadences() {
+        XCTAssertEqual(ProviderRefreshPolicy.baseInterval(for: "codex"), 60)
+        XCTAssertEqual(ProviderRefreshPolicy.baseInterval(for: "claude"), 180)
+        XCTAssertEqual(ProviderRefreshPolicy.baseInterval(for: "cursor"), 300)
+        XCTAssertEqual(ProviderRefreshPolicy.baseInterval(for: "grok"), 300)
+        XCTAssertEqual(ProviderRefreshPolicy.baseInterval(for: "devin"), 300)
+    }
+
+    func testFailureBackoffCapsAtFifteenMinutes() {
+        XCTAssertEqual(ProviderRefreshPolicy.failureBackoff(consecutiveFailures: 1, baseInterval: 60), 120)
+        XCTAssertEqual(ProviderRefreshPolicy.failureBackoff(consecutiveFailures: 2, baseInterval: 60), 300)
+        XCTAssertEqual(ProviderRefreshPolicy.failureBackoff(consecutiveFailures: 3, baseInterval: 60), 600)
+        XCTAssertEqual(ProviderRefreshPolicy.failureBackoff(consecutiveFailures: 4, baseInterval: 60), 900)
+        XCTAssertEqual(ProviderRefreshPolicy.failureBackoff(consecutiveFailures: 20, baseInterval: 60), 900)
+    }
+
+    func testFailureBackoffRespectsProviderBase() {
+        XCTAssertEqual(ProviderRefreshPolicy.failureBackoff(consecutiveFailures: 1, baseInterval: 180), 180)
+        XCTAssertEqual(ProviderRefreshPolicy.failureBackoff(consecutiveFailures: 1, baseInterval: 300), 300)
     }
 
     // MARK: - Session-scoped freshness

--- a/Tests/OpenUsageTests/StalenessLabelTests.swift
+++ b/Tests/OpenUsageTests/StalenessLabelTests.swift
@@ -20,8 +20,20 @@ final class StalenessLabelTests: XCTestCase {
         // One refresh interval old is normal right before the next pass — must not flicker a hint on
         // healthy providers, so the threshold sits above a single interval.
         let store = makeStore()
-        store.snapshots["devin"] = snapshot(refreshedAt: now.addingTimeInterval(-RefreshSetting.interval))
+        store.snapshots["devin"] = snapshot(refreshedAt: now.addingTimeInterval(-ProviderRefreshPolicy.defaultBaseInterval))
         XCTAssertNil(store.stalenessHint(for: "devin"))
+    }
+
+    func testCodexUsesShorterStalenessWindow() {
+        let store = makeStore(providerID: "codex", displayName: "Codex")
+        store.snapshots["codex"] = ProviderSnapshot(
+            providerID: "codex", displayName: "Codex", plan: "Plus",
+            lines: [.progress(label: "Session", used: 40, limit: 100, format: .percent)],
+            refreshedAt: now.addingTimeInterval(-2 * 60)
+        )
+
+        XCTAssertEqual(store.stalenessHint(for: "codex"),
+                       StalenessHint(label: "Outdated", tooltip: "Last updated 2m ago"))
     }
 
     func testStaleSnapshotSurfacesOutdatedHint() {
@@ -106,13 +118,24 @@ final class StalenessLabelTests: XCTestCase {
     }
 
     private func makeStore() -> WidgetDataStore {
-        let provider = Provider(id: "devin", displayName: "Devin", icon: .providerMark("devin"))
+        makeStore(providerID: "devin", displayName: "Devin")
+    }
+
+    private func makeStore(providerID: String, displayName: String) -> WidgetDataStore {
+        let provider = Provider(id: providerID, displayName: displayName, icon: .providerMark(providerID))
         let descriptor = WidgetDescriptor(
-            id: "devin.weekly", providerID: provider.id, metricLabel: "Weekly quota",
+            id: "\(providerID).weekly", providerID: provider.id, metricLabel: "Weekly quota",
             sample: WidgetData(title: "Weekly", icon: provider.icon, kind: .percent, used: 0, limit: 100)
         )
-        let runtime = TestProviderRuntime(provider: provider, descriptors: [descriptor],
-                                          snapshot: snapshot(refreshedAt: now))
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id, displayName: provider.displayName, plan: "Team 5x",
+                lines: [.progress(label: "Weekly quota", used: 40, limit: 100, format: .percent)],
+                refreshedAt: now
+            )
+        )
         return makeStore(provider: provider, descriptor: descriptor, runtime: runtime)
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,8 @@ The UI reads from a few observable stores:
   menu bar.
 - `ProviderEnablementStore` — which providers the user has turned on or off.
 
-Refresh runs on a timer in `AppContainer`; each pass respects the cache, so the network is only hit once a
-snapshot has actually expired.
+Refresh runs on a provider-aware timer in `AppContainer`; each pass respects the cache and any failure
+backoff, so the network is only hit when that provider is actually due.
 
 ## The AppKit bridge
 

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -23,6 +23,10 @@ Sign in once with Claude Code; OpenUsage reads the same credentials. It checks e
 
 If one source holds an expired or "locked out" token, OpenUsage falls back to the others — so signing in again with `claude` outside the app is picked up on the next refresh, without restarting OpenUsage. Tokens are refreshed automatically; rotated tokens are written back where they came from.
 
+## Refresh cadence
+
+Claude refreshes about every 3 minutes. If Claude rate-limits the usage API, OpenUsage shows the rate-limit notice, respects the provider's retry timing when available, and backs off before trying again.
+
 ## The spend tiles
 
 Today / Yesterday / Last 30 Days are computed **locally** from your Claude Code logs by running `ccusage` through whichever JavaScript package runner you already have — [Bun](https://bun.sh) (`bunx`) is preferred, otherwise `pnpm dlx`, `yarn dlx`, `npm exec`, or `npx`. Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`); a day with no usage is a real zero and reads `$0.00 · 0 tokens`. The dollars are estimated from token counts (that's the ⓘ); the token counts themselves are measured. No log data leaves your Mac.

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -17,6 +17,10 @@ Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI
 
 Sign in once with the Codex CLI (`codex`); OpenUsage reads the same auth files (`$CODEX_HOME` respected) with a keychain fallback. Tokens refresh automatically and rotate back into the auth file.
 
+## Refresh cadence
+
+Codex refreshes about every minute. If requests fail, OpenUsage backs off automatically and returns to the one-minute cadence after the next successful refresh.
+
 ## The spend tiles
 
 Today / Yesterday / Last 30 Days are computed **locally** from your Codex logs by running `ccusage` through whichever JavaScript package runner you already have — [Bun](https://bun.sh) (`bunx`) is preferred, otherwise `pnpm dlx`, `yarn dlx`, `npm exec`, or `npx`. Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`); a day with no usage is a real zero and reads `$0.00 · 0 tokens`. The dollars are estimated from token counts (that's the ⓘ); the token counts themselves are measured. No log data leaves your Mac.

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -19,6 +19,10 @@ Tracks your Cursor plan usage using the login from the Cursor app.
 
 Just be signed into the Cursor app. OpenUsage reads Cursor's local state database (and its keychain entries) for the session tokens; refreshed tokens are persisted back. Nothing extra to install or configure.
 
+## Refresh cadence
+
+Cursor refreshes about every 5 minutes. If requests fail, OpenUsage backs off automatically before retrying.
+
 ## The spend tiles
 
 Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`), the same as Claude/Codex/Grok; a day with no usage is a real zero and reads `$0.00 · 0 tokens`. The difference is the source: Cursor's Today / Yesterday / Last 30 Days come from Cursor's **server-side usage export** (priced per model with a bundled price list), not a local estimate. Hover the value to see the exact figures and source note. If the export can't be fetched, the tiles show "No data" while everything else keeps working.

--- a/docs/providers/devin.md
+++ b/docs/providers/devin.md
@@ -20,6 +20,10 @@ Checked in this order — whichever works first wins:
 
 If the CLI credentials fail but the app is signed in with a different account, the app's auth is used instead.
 
+## Refresh cadence
+
+Devin refreshes about every 5 minutes. If requests fail, OpenUsage backs off automatically before retrying.
+
 ## Troubleshooting
 
 - **"Not logged in"** — run `devin auth login`, or sign into the Devin app, then refresh.

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -15,6 +15,10 @@ Tracks Grok Build credit usage using the login from the Grok CLI.
 
 Sign in once with the Grok CLI (`grok login`); OpenUsage reads the same `~/.grok/auth.json`. Access tokens refresh automatically before expiry, and rotated tokens are written back to the file.
 
+## Refresh cadence
+
+Grok refreshes about every 5 minutes. If requests fail, OpenUsage backs off automatically before retrying.
+
 ## The spend tiles
 
 Today / Yesterday / Last 30 Days are computed **locally** from the Grok CLI's log (`~/.grok/logs/unified.jsonl`, or `$GROK_HOME/logs/unified.jsonl`). Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`), the same as Claude/Codex/Cursor. Unlike Claude/Codex this needs no package runner — OpenUsage reads the log directly. The dollars are estimated from token counts at public API rates (that's the ⓘ); the token counts themselves are measured, and these estimates are separate from the monthly credits the billing API reports. No log data leaves your Mac. A period with no recorded usage is a real zero and reads `$0.00 · 0 tokens`; "No data" appears only when the log is missing or unreadable.

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -2,22 +2,24 @@
 
 ## When data updates
 
-- All enabled providers refresh together: at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Providers fetch in parallel — one slow provider doesn't delay the others.
-- The popover footer shows `Next update in Nm`. **Clicking it (or ⌘R)** refreshes immediately, skipping the cache.
+- Enabled providers refresh at launch, then on their own cadence: Codex every minute, Claude every 3 minutes, and Cursor, Grok, and Devin every 5 minutes. There is no setting for this; the defaults are chosen to keep data fresh without pushing cautious providers too hard.
+- The popover footer shows the soonest scheduled provider refresh. **Clicking it (or ⌘R)** refreshes immediately, skipping the cache and any retry backoff.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.
 
 ## Caching
 
 Snapshots are cached on disk and load instantly at launch, so you see your last-known values immediately instead of placeholders — even before the first fetch finishes.
 
-A cached value only counts as *fresh* (skip-a-refresh fresh) when it was fetched **during the current running session**. So a value cached in an earlier session always re-fetches on the first pass after launch — you still see it instantly, but the app never waits out the old interval before getting live numbers. This matters after an update: a new app version refreshes right away instead of showing the previous version's data until its interval lapses. Within a session, a freshly fetched value then counts as fresh for one refresh interval before the next pass re-fetches it.
+A cached value only counts as *fresh* (skip-a-refresh fresh) when it was fetched **during the current running session**. So a value cached in an earlier session always re-fetches on the first pass after launch — you still see it instantly, but the app never waits out the old interval before getting live numbers. This matters after an update: a new app version refreshes right away instead of showing the previous version's data until its interval lapses. Within a session, a freshly fetched value then counts as fresh for that provider's refresh interval before the next pass re-fetches it.
 
 ## When a fetch fails
 
 A failed refresh **never wipes your data**: the last good values stay on screen, and a small warning triangle appears next to the provider's name — hover it for the error message (e.g. "Not logged in"). The error clears on the next successful refresh.
 
+Repeated failures back off automatically: the next tries happen after about 2, 5, 10, then 15 minutes. After that, OpenUsage keeps retrying every 15 minutes until the provider works again. A successful refresh resets the provider to its normal cadence. If a provider asks for a longer wait, OpenUsage respects that.
+
 Rows that have never had data show "No data" rather than made-up numbers.
 
 ## Stale data
 
-Because a failed refresh keeps the last good values on screen, those values can persist if refreshes keep failing — so a plan or limit that changed on the provider's side could otherwise keep showing the old figures indefinitely. To make that obvious, a small **"Outdated"** tag appears next to the provider's name once its data is more than a couple of refresh cycles old (about ten minutes); hover it for the precise age ("Last updated 3h ago"). The tag stays short so it never crowds a long plan name. When you see it, the numbers below are from that earlier time, not live — usually because the provider is failing to refresh (check the warning triangle) or the Mac was asleep. A successful refresh clears it.
+Because a failed refresh keeps the last good values on screen, those values can persist if refreshes keep failing — so a plan or limit that changed on the provider's side could otherwise keep showing the old figures indefinitely. To make that obvious, a small **"Outdated"** tag appears next to the provider's name once its data is more than a couple of effective refresh cycles old; hover it for the precise age ("Last updated 3h ago"). The tag stays short so it never crowds a long plan name. When you see it, the numbers below are from that earlier time, not live — usually because the provider is failing to refresh (check the warning triangle) or the Mac was asleep. A successful refresh clears it.


### PR DESCRIPTION
## Draft note

This PR changes the default refresh rates by provider. 

- Codex: 1 min
- Claude: 3 min
- Grok/Devin/Cursor: 5 min

This works, but the problem is that the timer will now always say "next update in one minute" (= Codex). We need a solution for this. 

## Summary

- Adds smarter refresh timing per provider.
- Backs off repeated failures automatically.
- Keeps manual refresh immediate.

Closes #676
Closes #678
Closes #679
Closes #680
Closes #681
