### PR TITLE
feat(popover): Liquid Glass split button in the footer

### DIFF
--- a/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
+++ b/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
@@ -39,25 +39,14 @@ extension View {
         }
     }
 
-    /// Groups adjacent glass buttons in a `GlassEffectContainer` on macOS 26 so the system samples
-    /// their glass coherently. On macOS 15 there is no glass to coordinate, so the container is
-    /// dropped and the content is returned unchanged.
-    @ViewBuilder
-    func glassButtonGroup(spacing: CGFloat) -> some View {
-        if #available(macOS 26, *) {
-            GlassEffectContainer(spacing: spacing) { self }
-        } else {
-            self
-        }
-    }
-
-    /// A custom interactive Liquid Glass surface (in the given shape) for a *control label* — the
-    /// footer "More" pull-down passes `Circle()`. Apply it to a `Menu`/`Button` label together with
-    /// `.buttonStyle(.plain)`: the system `.buttonStyle(.glass)` does **not** render glass on a `Menu` —
-    /// the menu's own button chrome wins and falls back to a flat bordered look (the "looks like macOS
-    /// 15" bug) — so we draw the glass ourselves on the label instead. `.interactive()` adds the
-    /// hover/press shimmer + scale that reads as Liquid Glass even on a static opaque surface. macOS 15
-    /// gets a frosted material shape with a hairline border (no glass to draw there).
+    /// A single interactive Liquid Glass surface (in the given shape) drawn behind a *whole control* —
+    /// the footer's split button wraps its `HStack` (Customize + divider + chevron) in one
+    /// `interactiveGlass(in: Capsule())` so the two plain-styled tap targets sit on one continuous
+    /// capsule rather than two separate pills. Apply it to the container, never to each segment, and
+    /// keep the segments `.buttonStyle(.plain)` so this glass is the only surface — the system
+    /// `.buttonStyle(.glass)` renders flat on a `Menu` (its own button chrome wins), and per-segment
+    /// glass would split the capsule. `.interactive()` adds the hover/press shimmer + scale that reads
+    /// as Liquid Glass. macOS 15 gets a frosted material shape with a hairline border (no glass there).
     @ViewBuilder
     func interactiveGlass(in shape: some InsettableShape) -> some View {
         if #available(macOS 26, *) {

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -68,8 +68,8 @@ struct PopoverVisibilityReader: NSViewRepresentable {
 ///   popover is dismissed through `MenuBarPopover.dismiss`, the same path a status-item click takes
 ///   — so it stays in sync, reopens in one click, and trips the visibility reset (cancelling edit
 ///   mode + the jiggle).
-/// - **Return**: `onReturn` opens/closes Customize (the affordance the standalone Customize button
-///   carried before it folded into the More menu). Consuming the key here is also what stops a bare
+/// - **Return**: `onReturn` opens/closes Customize (the same affordance the footer's Customize
+///   button carries). Consuming the key here is also what stops a bare
 ///   Return from falling through and dismissing the popover.
 struct PopoverKeyReader: NSViewRepresentable {
     /// Called first on Esc. Return `true` when the press was handled in-popover (Esc then does

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -175,8 +175,8 @@ struct DashboardView: View {
             .background(ScreenHeightReader(usableHeight: $usableHeight))
             .background(
                 // Esc backs out of Customize / Settings first; only from the dashboard does it close
-                // the popover. Return opens Customize from the dashboard (the affordance the standalone
-                // Customize button carried before it folded into the More menu) and returns to the
+                // the popover. Return opens Customize from the dashboard (the same affordance the
+                // footer's Customize button carries) and returns to the
                 // dashboard from Customize or Settings — matching Esc and the prominent "Done" control,
                 // never jumping Settings → Customize. Always consumed, so a bare Return can't fall
                 // through and dismiss the popover.

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -1,74 +1,110 @@
 import AppKit
 import SwiftUI
 
-/// The footer's lone glass control: a "More" pull-down button (Customize / Settings / Check for Updates /
-/// About / Quit). On the dashboard it shows; the Customize and Settings screens carry their own
-/// top-leading back button (`DashboardView.navBar`) to return home — the macOS-native place for it — so
-/// the footer control simply drops away there rather than morphing into a trailing "Done".
+/// The dashboard footer's trailing control: a **split button** in Liquid Glass — one capsule with
+/// "Customize" on the left and a chevron segment on the right, divided by a hairline (the Export ▾
+/// idiom system apps use). Clicking "Customize" opens the Customize screen; clicking the chevron opens
+/// the overflow menu (Settings / Check for Updates / About / Quit).
 ///
-/// It's a SwiftUI `Menu` presenting a custom round Liquid Glass button: `.menuStyle(.button)` makes the
-/// menu present from a button, `.buttonStyle(.plain)` strips the system button chrome so our
-/// `interactiveGlass(in:)` is the only surface, drawing the interactive glass — the system
-/// `.buttonStyle(.glass)` renders flat on a `Menu`, which is why this draws the glass itself. The menu
-/// renders in its own `NSMenu`-backed window, which `StatusItemController.shouldKeepPanelOpen` already
-/// keeps the popover open for (same rule that covers the Settings pickers' popups). The ⌘, / ⏎ key
-/// equivalents on the menu items render as shortcut labels and fire while the menu is open; the
-/// always-on `PopoverKeyReader` monitor handles those keys the rest of the time (and from screens with
-/// no footer, like Settings), so no separate SwiftUI shortcut button is needed.
+/// The joined-capsule look comes from one glass surface behind the *whole* control: an `HStack` of two
+/// `.buttonStyle(.plain)` tap targets (a `Button` and a chevron `Menu`) split by a `Divider`, with a
+/// single `interactiveGlass(in: Capsule())` drawn behind all of it. Glass goes on the container, not
+/// each segment — per-segment glass would split it into two pills, and the system `.buttonStyle(.glass)`
+/// renders flat on a `Menu` (its own button chrome wins). This is the canonical macOS 26 pattern
+/// (custom `glassEffect` surface behind grouped controls); it falls back to a frosted material capsule
+/// on macOS 15. The menu renders in its own `NSMenu`-backed window, which
+/// `StatusItemController.shouldKeepPanelOpen` keeps the popover open for.
+///
+/// Only the dashboard shows this; the Customize and Settings screens carry their own top-leading back
+/// button (`DashboardView.navBar`) to return home — the macOS-native place for it — so the footer
+/// control simply drops away there.
+///
+/// Shortcuts survive: ⏎ (Customize), ⌘, (Settings) and Esc are handled by the always-on
+/// `PopoverKeyReader` monitor, so they fire from every screen (including Settings, which has no
+/// footer). The menu items only carry their ⌘ key-equivalents as labels and fire while the menu is
+/// open, so the monitor and the items never double-fire. ⌘Q (Quit) is unowned elsewhere, so it rides
+/// its menu item directly.
 struct HeaderView: View {
     @Environment(LayoutStore.self) private var layout
     @Environment(UpdaterController.self) private var updater
     /// The screen this footer belongs to. Footers are per-page now (they slide with their page), so the
-    /// "More" button keys off the page it's drawn in — not the global current screen, which flips at the
-    /// start of a slide and would otherwise pop the button off the outgoing page mid-transition.
+    /// control keys off the page it's drawn in — not the global current screen, which flips at the start
+    /// of a slide and would otherwise pop the control off the outgoing page mid-transition.
     let screen: PopoverScreen
+
+    /// Shared height for both halves, so the capsule reads as one control.
+    private static let controlHeight: CGFloat = 28
 
     var body: some View {
         leadingControl
-            .glassButtonGroup(spacing: 4)
     }
 
-    /// On the dashboard this is the "More" pull-down: an ellipsis on a custom interactive Liquid Glass
-    /// round button. `.buttonStyle(.plain)` strips the system button chrome so `interactiveGlass(in:)`
-    /// is the only surface (the system glass button style renders flat on a `Menu`);
-    /// `.menuIndicator(.hidden)` drops the chevron — the ellipsis already reads as "more". The `Label`
-    /// title carries the accessible name for VoiceOver.
+    /// On the dashboard, the split button: the two halves laid out edge to edge (spacing 0) with a
+    /// hairline `Divider` between, all on one glass capsule.
     @ViewBuilder
     private var leadingControl: some View {
         if screen == .dashboard {
-            Menu {
-                moreMenuItems
-            } label: {
-                Label("More", systemImage: "ellipsis")
-                    .labelStyle(.iconOnly)
-                    .font(.system(size: 14, weight: .semibold))
-                    .frame(width: 28, height: 28)
-                    .interactiveGlass(in: Circle())
-                    .contentShape(Circle())
+            HStack(spacing: 0) {
+                customizeHalf
+                Divider()
+                    .frame(height: 16)
+                chevronHalf
             }
-            .menuStyle(.button)
-            .buttonStyle(.plain)
-            .menuIndicator(.hidden)
+            .fixedSize()
+            .interactiveGlass(in: Capsule())
         }
     }
 
-    /// The "More" menu items, mirroring their in-popover entry points. `autoenablesItems` has no SwiftUI
-    /// equivalent, so the Check for Updates item disables itself when Sparkle can't currently check — e.g.
-    /// dev builds with no feed, or while a check is already in flight. Settings (⌘,) and Customize (⏎)
-    /// carry their key equivalents so the menu shows the shortcut labels; the always-on `PopoverKeyReader`
-    /// monitor actually handles those keys while the menu is closed (and consumes them, so there's no
-    /// second registration to fight), and the menu item only fires while the menu is open — so the two
-    /// never double-toggle.
+    /// Left half: opens Customize. `.buttonStyle(.plain)` strips the system chrome so the shared glass
+    /// is the only surface; `contentShape` makes the whole padded half clickable. ⏎ opens Customize
+    /// from anywhere via `PopoverKeyReader`, so the shortcut isn't registered here (which would also
+    /// flag the button as the window's default and draw a pulsing ring) — the tooltip surfaces it.
+    private var customizeHalf: some View {
+        Button { toggle(.customize) } label: {
+            Text("Customize")
+                .font(.system(size: 13, weight: .semibold))
+                .padding(.leading, 14)
+                .padding(.trailing, 11)
+                .frame(height: Self.controlHeight)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .hoverTooltip("Customize (⏎)")
+    }
+
+    /// Right half: the chevron pull-down. `.menuStyle(.button)` + `.buttonStyle(.plain)` strip the menu
+    /// chrome to just the glyph; `.menuIndicator(.hidden)` drops the built-in arrow (the chevron already
+    /// reads as "more"). `.fixedSize` keeps the glyph from stretching the half.
+    private var chevronHalf: some View {
+        Menu {
+            moreMenuItems
+        } label: {
+            Image(systemName: "chevron.down")
+                .font(.system(size: 11, weight: .semibold))
+                .padding(.leading, 9)
+                .padding(.trailing, 12)
+                .frame(height: Self.controlHeight)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel("More")
+    }
+
+    /// The chevron's overflow items, mirroring their in-popover entry points. `autoenablesItems` has no
+    /// SwiftUI equivalent, so the Check for Updates item disables itself when Sparkle can't currently
+    /// check — e.g. dev builds with no feed, or while a check is already in flight. Settings carries ⌘,
+    /// only as a label; the always-on `PopoverKeyReader` monitor actually handles that key while the
+    /// menu is closed (and consumes it, so there's no second registration to fight), and the item fires
+    /// only while the menu is open — so the two never double-toggle.
     @ViewBuilder
     private var moreMenuItems: some View {
         Button { toggle(.settings) } label: {
             Label("Settings", systemImage: "gearshape")
         }
         .keyboardShortcut(",", modifiers: .command)
-        Button { toggle(.customize) } label: {
-            Label("Customize", systemImage: "slider.horizontal.3")
-        }
-        .keyboardShortcut(.return, modifiers: [])
         Button { updater.checkForUpdates() } label: {
             Label("Check for Updates…", systemImage: "arrow.triangle.2.circlepath")
         }

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -26,9 +26,13 @@ Rows with a reset date tick every 30 seconds, so countdowns and pace stay live b
 Every row: **Hide · Pin to menu bar / Unpin · Refresh \<provider\> · Customize…**
 Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on under Settings ▸ Providers.)
 
+## Footer
+
+The bar pinned to the bottom of the popover. On the left: the app version, and a live "Next update in …" countdown you can click (or press **⌘R**) to refresh right away. On the right: a **Customize** button paired with a **⌄** menu. The menu holds the app-level actions — **Settings**, **Check for Updates…**, **About OpenUsage**, and **Quit OpenUsage**.
+
 ## Customize
 
-The More button's **Customize Metrics** item (or pressing **Return**) opens Customize: toggle metrics on/off, add ones that aren't placed yet, pin metrics for the menu bar, and drag to reorder. Drag-reorder also works directly on the dashboard — drag a row within its provider, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
+The footer's **Customize** button (or pressing **Return**) opens Customize: toggle metrics on/off, add ones that aren't placed yet, pin metrics for the menu bar, and drag to reorder. Drag-reorder also works directly on the dashboard — drag a row within its provider, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
 
 When OpenUsage ships a new default metric, existing layouts get it once. If you turn it off, it stays off. The **Reset** button in Customize restores the default metrics, order, and menu-bar pins, but leaves provider settings and other preferences unchanged.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-Settings lives inside the popover — there is no separate window. Open it with the gear button in the popover footer, ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen; the gear becomes a checkmark while you're there. Go back with the checkmark, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
+Settings lives inside the popover — there is no separate window. Open it from the **⌄** menu next to the footer's Customize button, with ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen, which carries a back button in its top-left corner. Go back with that button, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
 
 ## Startup
 


### PR DESCRIPTION
## Summary
- Replaces the footer's ellipsis "More" pull-down with a native-style **Liquid Glass split button**: **Customize** is the primary action, joined to a chevron segment that opens the overflow menu — **Settings**, **Check for Updates…**, separator, **About OpenUsage**, **Quit OpenUsage**.
- The joined capsule is one `interactiveGlass(in: Capsule())` surface behind an `HStack` of two `.buttonStyle(.plain)` tap targets split by a hairline `Divider` — glass on the container, **not** per segment. Per-segment glass splits it into two pills, and `.buttonStyle(.glass)` renders flat on a `Menu`, so neither matches the system split-button look. This is the canonical macOS 26 pattern (custom `glassEffect` surface behind grouped controls); it falls back to a frosted material capsule on macOS 15.
- Keyboard shortcuts are unchanged: ⏎ (Customize), ⌘, (Settings) and Esc ride the always-on `PopoverKeyReader` monitor; ⌘Q stays on the Quit item.
- Drops the now-unused `glassButtonGroup` helper and updates the dashboard/settings docs.

## Test plan
- [ ] Open the popover; the footer shows one joined glass capsule (`Customize | ⌄`), not two separate pills or a flat system divider.
- [ ] Click **Customize** → opens the Customize screen.
- [ ] Click the **⌄** → menu shows Settings, Check for Updates…, separator, About, Quit.
- [ ] ⏎ opens/closes Customize; ⌘, opens/closes Settings; ⌘Q quits.
- [ ] Right-click status item still shows Settings + Quit (unchanged).
- [ ] Sanity-check the macOS 15 fallback renders a frosted material capsule.

Made with [Cursor](https://cursor.com)