### PR TITLE
Fix Cursor credits and extra usage balances

### DIFF
--- a/Sources/OpenUsage/Models/MenuBarContent.swift
+++ b/Sources/OpenUsage/Models/MenuBarContent.swift
@@ -69,9 +69,8 @@ enum MenuBarContentBuilder {
                 metrics: metrics
             )
         }
-        // Bars show any *bounded* metric (it has a fill), not just percentages — e.g. Cursor "Credits"
-        // is bounded dollars (used/limit) and belongs here. Unbounded values (raw spend/credits, no
-        // limit) have no fill and are dropped.
+        // Bars show any *bounded* metric (it has a fill), not just percentages. Unbounded values (raw
+        // spend/credits, no limit) have no fill and are dropped.
         let bars = resolvedGroups
             .flatMap(\.metrics)
             .filter(\.isBounded)

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -23,10 +23,10 @@ final class CursorProvider: ProviderRuntime {
             .percent(id: "cursor.usage", provider: provider, title: "Total Usage", metricLabel: "Total usage"),
             .percent(id: "cursor.auto", provider: provider, title: "Auto Usage", metricLabel: "Auto usage"),
             .percent(id: "cursor.api", provider: provider, title: "API Usage", metricLabel: "API usage"),
-            .boundedDollars(id: "cursor.onDemand", provider: provider, title: "Extra Usage", metricLabel: "On-demand", limit: 100),
+            .boundedDollars(id: "cursor.onDemand", provider: provider, title: "Extra Usage", metricLabel: "On-demand", limit: 100, valueWord: "spent"),
             .boundedCount(id: "cursor.requests", provider: provider, title: "Requests", limit: 500,
                           suffix: "requests", periodDurationMs: CursorUsageMapper.billingPeriodMs),
-            .boundedDollars(id: "cursor.credits", provider: provider, title: "Credits", limit: 100),
+            .dollarBalance(id: "cursor.credits", provider: provider, title: "Credits", valueWord: "left"),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)
     }

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -123,12 +123,20 @@ enum CursorUsageMapper {
         if let spendLimitUsage {
             let limit = ProviderParse.number(spendLimitUsage["individualLimit"]) ?? ProviderParse.number(spendLimitUsage["pooledLimit"]) ?? 0
             let remaining = ProviderParse.number(spendLimitUsage["individualRemaining"]) ?? ProviderParse.number(spendLimitUsage["pooledRemaining"]) ?? 0
+            let spent = ProviderParse.number(spendLimitUsage["individualUsed"])
+                ?? ProviderParse.number(spendLimitUsage["pooledUsed"])
+                ?? ProviderParse.number(spendLimitUsage["totalSpend"])
             if limit > 0 {
                 lines.append(.progress(
                     label: "On-demand",
-                    used: ProviderParse.centsToDollars(limit - remaining),
+                    used: ProviderParse.centsToDollars(spent ?? (limit - remaining)),
                     limit: ProviderParse.centsToDollars(limit),
                     format: .dollars
+                ))
+            } else if let spent, spent > 0 {
+                lines.append(.values(
+                    label: "On-demand",
+                    values: [MetricValue(number: ProviderParse.centsToDollars(spent), kind: .dollars)]
                 ))
             }
         }
@@ -257,13 +265,12 @@ enum CursorUsageMapper {
         let grantUsedCents = hasCreditGrants ? ProviderParse.number(creditGrants?["usedCents"]) ?? 0 : 0
         let hasValidGrantData = hasCreditGrants && grantTotalCents > 0
         let combinedTotalCents = (hasValidGrantData ? grantTotalCents : 0) + stripeBalanceCents
+        let remainingCents = max(0, combinedTotalCents - (hasValidGrantData ? grantUsedCents : 0))
 
         guard combinedTotalCents > 0 else { return }
-        lines.append(.progress(
+        lines.append(.values(
             label: "Credits",
-            used: ProviderParse.centsToDollars(hasValidGrantData ? grantUsedCents : 0),
-            limit: ProviderParse.centsToDollars(combinedTotalCents),
-            format: .dollars
+            values: [MetricValue(number: ProviderParse.centsToDollars(remainingCents), kind: .dollars)]
         ))
     }
 

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -123,17 +123,15 @@ enum CursorUsageMapper {
         if let spendLimitUsage {
             let limit = ProviderParse.number(spendLimitUsage["individualLimit"]) ?? ProviderParse.number(spendLimitUsage["pooledLimit"]) ?? 0
             let remaining = ProviderParse.number(spendLimitUsage["individualRemaining"]) ?? ProviderParse.number(spendLimitUsage["pooledRemaining"]) ?? 0
-            let spent = ProviderParse.number(spendLimitUsage["individualUsed"])
-                ?? ProviderParse.number(spendLimitUsage["pooledUsed"])
-                ?? ProviderParse.number(spendLimitUsage["totalSpend"])
+            let spent = onDemandSpendCents(from: spendLimitUsage, limit: limit, remaining: remaining)
             if limit > 0 {
                 lines.append(.progress(
                     label: "On-demand",
-                    used: ProviderParse.centsToDollars(spent ?? (limit - remaining)),
+                    used: ProviderParse.centsToDollars(spent),
                     limit: ProviderParse.centsToDollars(limit),
                     format: .dollars
                 ))
-            } else if let spent, spent > 0 {
+            } else if spent > 0 {
                 lines.append(.values(
                     label: "On-demand",
                     values: [MetricValue(number: ProviderParse.centsToDollars(spent), kind: .dollars)]
@@ -142,6 +140,19 @@ enum CursorUsageMapper {
         }
 
         return CursorMappedUsage(plan: planLabel(planName), lines: lines)
+    }
+
+    private static func onDemandSpendCents(from spendLimitUsage: [String: Any], limit: Double, remaining: Double) -> Double {
+        let reported = [
+            ProviderParse.number(spendLimitUsage["individualUsed"]),
+            ProviderParse.number(spendLimitUsage["pooledUsed"]),
+            ProviderParse.number(spendLimitUsage["totalSpend"])
+        ].compactMap { $0 }
+        if let positive = reported.first(where: { $0 > 0 }) {
+            return positive
+        }
+        let inferred = max(0, limit - remaining)
+        return inferred > 0 ? inferred : (reported.first ?? 0)
     }
 
     static func mapRequestBasedUsage(

--- a/Tests/OpenUsageTests/CursorProviderTests.swift
+++ b/Tests/OpenUsageTests/CursorProviderTests.swift
@@ -69,6 +69,31 @@ final class CursorUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "On-demand")?.used, 40)
     }
 
+    func testBoundedOnDemandDoesNotLetZeroSpendMaskPositiveUsage() throws {
+        let mapped = try CursorUsageMapper.mapUsage(
+            usage: [
+                "enabled": true,
+                "billingCycleStart": 1_770_000_000_000,
+                "billingCycleEnd": 1_772_592_000_000,
+                "planUsage": [
+                    "limit": 40_000,
+                    "totalPercentUsed": 20
+                ],
+                "spendLimitUsage": [
+                    "individualLimit": 5_000,
+                    "individualRemaining": 4_500,
+                    "individualUsed": 0,
+                    "totalSpend": 1_200
+                ]
+            ],
+            planName: "Ultra",
+            creditGrants: nil,
+            stripeBalanceCents: 0
+        )
+
+        XCTAssertEqual(progress(mapped.lines, "On-demand")?.used, 12)
+    }
+
     func testMapsSpendOnlyOnDemandAsUnboundedUsage() throws {
         let mapped = try CursorUsageMapper.mapUsage(
             usage: [

--- a/Tests/OpenUsageTests/CursorProviderTests.swift
+++ b/Tests/OpenUsageTests/CursorProviderTests.swift
@@ -62,13 +62,37 @@ final class CursorUsageMapperTests: XCTestCase {
         )
 
         XCTAssertEqual(mapped.plan, "Pro Plan")
-        let credits = try XCTUnwrap(progress(mapped.lines, "Credits"))
-        XCTAssertEqual(credits.used, 2647.29, accuracy: 0.001)
-        XCTAssertEqual(credits.limit, 19915.44, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(dollarValue(mapped.lines, "Credits")), 17268.15, accuracy: 0.001)
         XCTAssertEqual(progress(mapped.lines, "Total usage")?.used, 20)
         XCTAssertEqual(progress(mapped.lines, "Auto usage")?.used, 12.5)
         XCTAssertEqual(progress(mapped.lines, "API usage")?.used, 7.5)
         XCTAssertEqual(progress(mapped.lines, "On-demand")?.used, 40)
+    }
+
+    func testMapsSpendOnlyOnDemandAsUnboundedUsage() throws {
+        let mapped = try CursorUsageMapper.mapUsage(
+            usage: [
+                "enabled": true,
+                "billingCycleStart": 1_781_438_541_000,
+                "billingCycleEnd": 1_784_030_541_000,
+                "planUsage": [
+                    "limit": 40_000,
+                    "totalPercentUsed": 26.346,
+                    "totalSpend": 52_692
+                ],
+                "spendLimitUsage": [
+                    "individualUsed": 16_474,
+                    "limitType": "user",
+                    "totalSpend": 16_474
+                ]
+            ],
+            planName: "Ultra",
+            creditGrants: nil,
+            stripeBalanceCents: 790_964
+        )
+
+        XCTAssertNil(progress(mapped.lines, "On-demand"))
+        XCTAssertEqual(try XCTUnwrap(dollarValue(mapped.lines, "On-demand")), 164.74, accuracy: 0.001)
     }
 
     func testMapsRequestBasedFallback() throws {
@@ -167,7 +191,7 @@ final class CursorProviderTests: XCTestCase {
         let snapshot = await provider.refresh()
 
         XCTAssertEqual(snapshot.plan, "Pro Plan")
-        XCTAssertEqual(progress(snapshot.lines, "Credits")?.limit, 500)
+        XCTAssertEqual(dollarValue(snapshot.lines, "Credits") ?? -1, 500)
         XCTAssertEqual(progress(snapshot.lines, "Total usage")?.used, 20)
         XCTAssertEqual(progress(snapshot.lines, "Auto usage")?.used, 12.5)
         XCTAssertEqual(progress(snapshot.lines, "API usage")?.used, 7.5)
@@ -180,6 +204,13 @@ private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, 
         return nil
     }
     return (used, limit, resetsAt, periodDurationMs)
+}
+
+private func dollarValue(_ lines: [MetricLine], _ label: String) -> Double? {
+    guard case .values(_, let values, _, _) = lines.first(where: { $0.label == label }) else {
+        return nil
+    }
+    return values.first { $0.kind == .dollars }?.number
 }
 
 private func makeCursorJWT(sub: String = "google-oauth2|user", exp: Double = 9_999_999_999) -> String {

--- a/Tests/OpenUsageTests/MenuBarContentTests.swift
+++ b/Tests/OpenUsageTests/MenuBarContentTests.swift
@@ -26,8 +26,8 @@ final class MenuBarContentTests: XCTestCase {
     }
 
     func testBarsIncludeBoundedMetricsAndDropUnbounded() {
-        // A bounded dollar metric (Cursor "Credits": used/limit) has a fill, so it belongs in Bars.
-        // An unbounded value (raw spend, no limit) has no fill and is dropped.
+        // A bounded dollar metric has a fill, so it belongs in Bars. An unbounded value (raw spend,
+        // no limit) has no fill and is dropped.
         let content = MenuBarContentBuilder.build(
             groups: [group("a",
                 percent("a.pct", "Pct", 40),

--- a/Tests/OpenUsageTests/MockData.swift
+++ b/Tests/OpenUsageTests/MockData.swift
@@ -26,9 +26,9 @@ enum MockData {
         countBounded(id: "codex.credits", provider: codex, title: "Extra Usage", used: 320, limit: 1000, suffix: "credits"),
         amount(id: "codex.today", provider: codex, title: "Today", used: 569.09),
 
-        // Cursor — usage % (donut), credits $ with cap (donut), requests count with cap (donut), dollars (number)
+        // Cursor — usage % (donut), credits balance (number), requests count with cap (donut), dollars (number)
         percent(id: "cursor.usage", provider: cursor, title: "Usage", used: 98),
-        dollarsBounded(id: "cursor.credits", provider: cursor, title: "Credits", used: 12.48, limit: 20),
+        amount(id: "cursor.credits", provider: cursor, title: "Credits", used: 12.48),
         countBounded(id: "cursor.requests", provider: cursor, title: "Requests", used: 412, limit: 500, suffix: "requests"),
         amount(id: "cursor.today", provider: cursor, title: "Today", used: 12.48)
     ]
@@ -46,15 +46,6 @@ enum MockData {
             provider,
             title,
             WidgetData(title: title, icon: provider.icon, kind: .percent, used: used, limit: 100)
-        )
-    }
-
-    private static func dollarsBounded(id: String, provider: Provider, title: String, used: Double, limit: Double) -> WidgetDescriptor {
-        descriptor(
-            id,
-            provider,
-            title,
-            WidgetData(title: title, icon: provider.icon, kind: .dollars, used: used, limit: limit)
         )
     }
 

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -230,10 +230,10 @@ final class WidgetDataStoreTests: XCTestCase {
     }
 
     func testBoundedDollarAndCountTrayValuesHonorMeterStyleWithoutPercentConversion() async {
-        let provider = Provider(id: "cursor", displayName: "Cursor", icon: .providerMark("cursor"))
-        let credits = WidgetDescriptor.boundedDollars(id: "cursor.credits", provider: provider, title: "Credits", limit: 100)
+        let provider = Provider(id: "example", displayName: "Example", icon: .providerMark("cursor"))
+        let budget = WidgetDescriptor.boundedDollars(id: "example.budget", provider: provider, title: "Budget", limit: 100)
         let requests = WidgetDescriptor.boundedCount(
-            id: "cursor.requests",
+            id: "example.requests",
             provider: provider,
             title: "Requests",
             limit: 500,
@@ -242,19 +242,19 @@ final class WidgetDataStoreTests: XCTestCase {
         )
         let runtime = TestProviderRuntime(
             provider: provider,
-            descriptors: [credits, requests],
+            descriptors: [budget, requests],
             snapshot: ProviderSnapshot(
                 providerID: provider.id,
                 displayName: provider.displayName,
                 lines: [
-                    .progress(label: "Credits", used: 12.48, limit: 20, format: .dollars),
+                    .progress(label: "Budget", used: 12.48, limit: 20, format: .dollars),
                     .progress(label: "Requests", used: 412, limit: 500, format: .count(suffix: "requests"))
                 ]
             )
         )
         let defaults = makeUserDefaults("cursor-tray-units")
         let store = WidgetDataStore(
-            registry: WidgetRegistry(providers: [provider], descriptors: [credits, requests]),
+            registry: WidgetRegistry(providers: [provider], descriptors: [budget, requests]),
             providers: [runtime],
             cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() }),
             defaults: defaults
@@ -262,12 +262,50 @@ final class WidgetDataStoreTests: XCTestCase {
         await store.refreshAll()
 
         store.meterStyle = .used
-        XCTAssertEqual(store.data(for: credits).menuBarValue, "$12")
+        XCTAssertEqual(store.data(for: budget).menuBarValue, "$12")
         XCTAssertEqual(store.data(for: requests).menuBarValue, "412")
 
         store.meterStyle = .remaining
-        XCTAssertEqual(store.data(for: credits).menuBarValue, "$8")
+        XCTAssertEqual(store.data(for: budget).menuBarValue, "$8")
         XCTAssertEqual(store.data(for: requests).menuBarValue, "88")
+    }
+
+    func testCursorCreditsRenderAsUnboundedBalance() async {
+        let provider = Provider(id: "cursor", displayName: "Cursor", icon: .providerMark("cursor"))
+        let descriptor = WidgetDescriptor.dollarBalance(
+            id: "cursor.credits",
+            provider: provider,
+            title: "Credits",
+            valueWord: "left"
+        )
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.values(label: "Credits", values: [MetricValue(number: 7_909.64, kind: .dollars)])]
+            )
+        )
+        let defaults = makeUserDefaults("cursor-credits-balance")
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() }),
+            defaults: defaults
+        )
+        await store.refreshAll()
+
+        store.meterStyle = .remaining
+        let remaining = store.data(for: descriptor)
+        XCTAssertFalse(remaining.isBounded)
+        XCTAssertEqual(remaining.unboundedDetail, "$7.9K left")
+        XCTAssertEqual(remaining.menuBarValue, "$7.9K")
+
+        store.meterStyle = .used
+        let used = store.data(for: descriptor)
+        XCTAssertEqual(used.unboundedDetail, remaining.unboundedDetail)
+        XCTAssertEqual(used.menuBarValue, remaining.menuBarValue)
     }
 
     func testUncappedExtraUsageRendersCompactAndUnbounded() async {

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -6,12 +6,12 @@ Tracks your Cursor plan usage using the login from the Cursor app.
 
 | Metric | Meaning |
 |---|---|
-| Credits | Credit balance used vs. your grant + prepaid balance |
+| Credits | Credit balance left from grants and prepaid account balance |
 | Total Usage | Plan usage for the billing cycle (percent; dollars on team plans) |
 | Requests | Request count vs. cap (team/enterprise accounts) |
 | Auto Usage | Auto-model usage percent |
 | API Usage | API usage percent |
-| Extra Usage | On-demand spend vs. its limit |
+| Extra Usage | On-demand spend; shown as a meter only when Cursor returns a limit |
 | Today / Yesterday / Last 30 Days | Per-day cost and tokens from Cursor's own usage export |
 | Plan | Your plan name (optional widget) |
 


### PR DESCRIPTION
## Summary
- Render Cursor Credits as an unbounded balance instead of a synthetic used/limit bar.
- Show Cursor Extra Usage as spend-only when Cursor returns usage without a limit.
- Update Cursor docs and regression coverage for the new live API shapes.

## Test plan
- `swift test --filter 'CursorUsageMapperTests|CursorProviderTests/testRefreshFetchesLiveCursorUsage|WidgetDataStoreTests/testCursorCreditsRenderAsUnboundedBalance|WidgetDataStoreTests/testUncappedExtraUsageRendersCompactAndUnbounded|WidgetDataStoreTests/testBoundedDollarAndCountTrayValuesHonorMeterStyleWithoutPercentConversion'`
- `./script/build_and_run.sh verify`


Made with [Cursor](https://cursor.com)