### PR TITLE
fix(build): stamp linked SDK 26 so macOS renders modern Liquid Glass controls

### DIFF
--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -53,6 +53,16 @@ rm -rf "$APP_BUNDLE"
 mkdir -p "$APP_MACOS" "$APP_RESOURCES"
 cp "$BUILD_BINARY" "$APP_BINARY"
 chmod +x "$APP_BINARY"
+
+# SwiftPM stamps LC_BUILD_VERSION's `sdk` field with the deployment target (macOS 15), not the real
+# SDK it compiled against. macOS gates the modern Liquid Glass control appearance (pop-up buttons,
+# pickers, etc.) on the linked SDK — a "15.0" stamp makes AppKit fall back to legacy Aqua controls.
+# Restamp the sdk to 26.0 (Tahoe, where Liquid Glass landed) while keeping minos at MIN_SYSTEM_VERSION
+# so the app still runs on macOS 15 but gets the modern controls. Re-signed below.
+echo "==> stamping linked SDK 26.0 for Liquid Glass controls (minos stays $MIN_SYSTEM_VERSION)"
+vtool -set-build-version macos "$MIN_SYSTEM_VERSION" 26.0 -replace -output "$APP_BINARY.tmp" "$APP_BINARY"
+mv "$APP_BINARY.tmp" "$APP_BINARY"
+chmod +x "$APP_BINARY"
 # Stage every SwiftPM resource bundle produced by the build (the app's own
 # OpenUsage_OpenUsage.bundle, which carries the provider SVGs + model manifest)
 # into Contents/Resources, the standard app layout. Bundle.openUsageResources

--- a/script/release.sh
+++ b/script/release.sh
@@ -85,6 +85,21 @@ chmod +x "$APP_BINARY"
 # fat binary is the whole point, and generate_appcast derives Sparkle's hardwareRequirements from it.
 lipo -archs "$APP_BINARY" | grep -q "x86_64" && lipo -archs "$APP_BINARY" | grep -q "arm64" \
   || { echo "Expected a universal (arm64 + x86_64) binary, got: $(lipo -archs "$APP_BINARY")" >&2; exit 1; }
+
+# SwiftPM stamps LC_BUILD_VERSION's `sdk` field with the deployment target (macOS 15), not the real
+# SDK it compiled against. macOS gates the modern Liquid Glass control appearance (pop-up buttons,
+# pickers, etc.) on the linked SDK — a "15.0" stamp makes AppKit fall back to legacy Aqua controls.
+# Restamp the sdk to 26.0 (Tahoe) while keeping minos at MIN_SYSTEM_VERSION so the app still runs on
+# macOS 15 but gets the modern controls. Stamps every slice of the universal binary; re-signed below.
+echo "==> stamping linked SDK 26.0 for Liquid Glass controls (minos stays $MIN_SYSTEM_VERSION)"
+vtool -set-build-version macos "$MIN_SYSTEM_VERSION" 26.0 -replace -output "$APP_BINARY.tmp" "$APP_BINARY"
+mv "$APP_BINARY.tmp" "$APP_BINARY"
+chmod +x "$APP_BINARY"
+# Fail loudly if any slice still reports the old SDK (a silent vtool no-op would ship legacy controls).
+if vtool -show-build "$APP_BINARY" | grep -q "sdk 15.0"; then
+  echo "SDK restamp failed: $APP_BINARY still reports sdk 15.0" >&2
+  exit 1
+fi
 shopt -s nullglob
 for bundle in "$BUILD_DIR"/*.bundle; do
   cp -R "$bundle" "$APP_RESOURCES/$(basename "$bundle")"


### PR DESCRIPTION
## What & why

Settings pop-up buttons / pickers were rendering in the **legacy Aqua style** (old blue-square chevrons) instead of the macOS 26 (Tahoe) Liquid Glass controls.

Root cause (measured, not guessed): the app binary's `LC_BUILD_VERSION` recorded **`sdk 15.0`**. macOS uses the executable's *linked SDK* version — a "linked-on-or-after" check — to decide modern vs legacy control rendering, so it treated the app as pre-Tahoe and drew legacy controls. SwiftPM stamps that `sdk` field with the **deployment target** (`.macOS(.v15)`), not the real SDK it compiled against, so every `swift build` produced a "15.0" binary. This regressed when the floor dropped to macOS 15 (#623); earlier macOS-26-targeted builds stamped `sdk 26` and looked modern (the "production" that still looks right).

`glassEffect` was unaffected — it's an explicit runtime call gated by `#available`. Only the *automatic* control modernization is SDK-gated, which is why the glass footer/header worked but the pickers didn't.

## Fix

After staging the binary and before code-signing, `vtool` restamps the binary to **`sdk 26.0`** while keeping **`minos 15.0`** — so it still runs on macOS 15 but AppKit gives it the modern controls. Applied in both build scripts:
- `build_and_run.sh` (dev)
- `release.sh` (shipped) — stamps the universal binary and **fails loudly** if any slice still reports `sdk 15.0`.

The binary is re-signed after the restamp (the existing `codesign` step).

## Verification

Dev build: the binary now reports `minos 15.0 / sdk 26.0`, signature valid, and the Settings pop-up controls render in the modern Liquid Glass style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Post-build binary mutation before signing could break notarization or App Store review if Apple rejects altered `LC_BUILD_VERSION`, but scope is limited to build scripts and existing re-sign flow.
> 
> **Overview**
> **Dev and release staging** now run `vtool` on the copied app executable after SwiftPM build, **before** the existing `codesign` step, to rewrite `LC_BUILD_VERSION` so **`sdk` is 26.0** while **`minos` stays 15.0**. That works around SwiftPM stamping `sdk` with the deployment target (15.0), which made AppKit treat pickers/pop-up buttons as legacy Aqua instead of Tahoe Liquid Glass.
> 
> `script/build_and_run.sh` applies the restamp only. **`script/release.sh`** adds a **`vtool -show-build` guard** that aborts if any slice still shows `sdk 15.0`, so a failed restamp cannot ship in the universal binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07bfcf10e6e2708c1c295827c4827c6205197052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->