### PR TITLE
feat(popover): System Settings grouped surface + Settings-primary footer

### DIFF
--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -5,9 +5,10 @@ import AppKit
 ///
 /// The popover is always a solid, opaque panel — glass is reserved for the footer chrome (its frosted
 /// bar and the controls on it), never the data region behind it (Apple's guidance: glass for
-/// navigation/controls, content on an opaque surface). So the data surfaces here are plain opaque fills: a light-gray
-/// window "tray" with white grouped cards in light mode, a near-black tray with a step-lighter card
-/// in dark mode — the System Settings grouped-box look.
+/// navigation/controls, content on an opaque surface). The data region mirrors the macOS System
+/// Settings grouped look: a bright page "tray" with borderless grouped cards lifted off it by the
+/// system's own `.fill.quaternary` (the same subtle fill Settings' grouped boxes use — no hand-tuned
+/// values), so it adapts to light/dark like every other Mac app.
 enum Theme {
     /// Hierarchical secondary tint for the provider marks.
     static let iconGray = AnyShapeStyle(.secondary)
@@ -33,42 +34,21 @@ enum Theme {
 
     // MARK: - Surfaces
 
-    /// The popover's opaque backdrop ("tray") behind the grouped cards. Deliberately a touch grayer
-    /// than pure white in light mode so the white cards read as raised boxes on it — the System
-    /// Settings look (`windowBackgroundColor` is too near-white for white cards to separate). A
-    /// near-black in dark mode. Exposed as an `NSColor` so the panel's AppKit backdrop
+    /// The popover's opaque backdrop ("tray") behind the grouped cards — `textBackgroundColor`, the
+    /// bright page surface document/Notes views use (white in light, near-black in dark; it does not
+    /// pick up desktop wallpaper tint). Exposed as an `NSColor` so the panel's AppKit backdrop
     /// (`StatusItemController`) and the SwiftUI surface (`DashboardView.PopoverSurface`) are one color.
-    /// The footer's frosted glass bar samples this opaque tray (in-window), so it reads as glass
-    /// chrome over solid content, never a hole to the desktop.
-    static let trayNSColor = NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            ? NSColor(white: 0.12, alpha: 1)
-            : NSColor(white: 0.93, alpha: 1)
-    }
-    static let traySurface = Color(nsColor: trayNSColor)
+    /// The footer's frosted glass bar samples this opaque tray (in-window), so it reads as glass chrome
+    /// over solid content, never a hole to the desktop. The grouped cards sit on it (see `cardSurface`).
+    static let trayNSColor: NSColor = .textBackgroundColor
+    static var traySurface: Color { Color(nsColor: trayNSColor) }
 
-    /// The opaque grouped-card color, shared by the live card fill and the lifted drag preview so a
-    /// dragged card is the exact same color as the cards it floats over. White over the gray tray in
-    /// light mode, a step lighter than the near-black tray in dark mode (no stock semantic color lifts
-    /// above the window background in dark, so the dark value is set explicitly); the hairline
-    /// `cardBorder` crisps the edge in both modes.
-    static let cardNSColor = NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            ? NSColor(white: 0.19, alpha: 1)
-            : NSColor.white
-    }
-    static let cardFill = AnyShapeStyle(Color(nsColor: cardNSColor))
-
-    /// Backing for lifted drag previews — the SAME opaque color as the live cards, so a dragged card
-    /// matches the cards it floats over (it was a translucent material before, which read as a
-    /// different color). The "lifted" feel comes from `ReorderLiftPreview`'s shadow + scale, not the fill.
-    static let liftedCardFill = AnyShapeStyle(Color(nsColor: cardNSColor))
-
-    /// Hairline outline on cards. The opaque fill separates cards well in light mode but barely in
-    /// dark mode (the card sits only a step above the tray there), so a defined edge carries the
-    /// separation deterministically in both — the way macOS grouped boxes (System Settings) read.
-    /// `.separator` is the semantic hairline, so it tracks light/dark and Increase Contrast.
-    static let cardBorder = AnyShapeStyle(.separator)
+    /// The semantic fill that lifts a grouped card off the `traySurface` page — `.fill.quaternary`, the
+    /// system's own subtle grouped fill (≈ the macOS System Settings grouped box: `#F9F9F9` over white
+    /// in light, a step lighter than the page in dark). No hand-tuned values; it tracks light/dark and
+    /// Increase Contrast. Composited over the opaque page in `cardSurface`, so the card is opaque (a
+    /// lifted drag preview stays solid while it floats).
+    static let cardFill = AnyShapeStyle(.fill.quaternary)
 
     /// The single corner radius for every metric/settings card surface and its lifted twin, so the
     /// floating drag preview always matches the live card's shape.
@@ -81,19 +61,19 @@ enum Theme {
 }
 
 extension View {
-    /// The grouped-card surface used for provider/settings cards, in the shared rounded shape: an
-    /// opaque fill plus a hairline border so each card reads as a distinct raised box on the popover
-    /// tray (the border carries that separation in dark mode). Pass `lifted: true` for the floating
-    /// drag preview, which swaps the fill for the heavier lifted material and skips the border (its
-    /// shadow/`liftedRowSurface` hairline already detaches it). Routing every card site through this
-    /// keeps the live card and its lifted twin one shape.
+    /// The grouped-card surface used for provider/settings cards, in the shared rounded shape: the
+    /// bright page base lifted by the system's `.fill.quaternary` (the System Settings grouped-box
+    /// look), borderless — the subtle fill carries the grouping the way Settings does, in both light
+    /// and dark. Drawing the opaque page base first keeps a lifted drag preview solid while it floats.
+    /// `lifted` is accepted for call-site symmetry; live and lifted cards share one surface (the lift's
+    /// depth comes from `ReorderLiftPreview`'s shadow, not a different fill).
     func cardSurface(lifted: Bool = false) -> some View {
         modifier(CardSurfaceModifier(lifted: lifted))
     }
 
-    /// A single-row lifted preview surface: the card fill plus the thin separator hairline that
-    /// fences a free-floating one-row chip off from the rows beneath it (the multi-row provider
-    /// previews don't take the hairline — the card outline alone reads as detached there).
+    /// A single-row lifted preview surface: the card surface plus a thin separator hairline that fences
+    /// a free-floating one-row chip off from the rows beneath it (the multi-row provider previews don't
+    /// take the hairline — their shadow alone reads as detached).
     func liftedRowSurface() -> some View {
         cardSurface(lifted: true)
             .overlay { Theme.cardShape.strokeBorder(.separator, lineWidth: 0.5) }
@@ -108,20 +88,19 @@ extension View {
     }
 }
 
-/// Backs `cardSurface`. Live cards take the opaque card fill plus the hairline border so they stay
-/// distinct boxes on the opaque popover tray (the border carries the separation in dark mode). The
-/// lifted drag preview always uses its own legible material and no border.
+/// Backs `cardSurface`. The grouped card surface: the opaque page base (`traySurface`) with the
+/// system's `.fill.quaternary` composited on top — borderless, matching the macOS System Settings
+/// grouped box in both light and dark. The opaque base means a lifted drag preview stays solid while
+/// it floats; the page base under a live card is the same color as the tray behind it, so it's
+/// invisible there. `lifted` is unused — both paths share the one surface.
 private struct CardSurfaceModifier: ViewModifier {
     let lifted: Bool
 
-    @ViewBuilder
     func body(content: Content) -> some View {
-        if lifted {
-            content.background(Theme.liftedCardFill, in: Theme.cardShape)
-        } else {
-            content
-                .background(Theme.cardFill, in: Theme.cardShape)
-                .overlay { Theme.cardShape.strokeBorder(Theme.cardBorder, lineWidth: 0.5) }
+        content.background {
+            Theme.cardShape
+                .fill(Theme.traySurface)
+                .overlay { Theme.cardShape.fill(Theme.cardFill) }
         }
     }
 }

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -2,9 +2,11 @@ import AppKit
 import SwiftUI
 
 /// The dashboard footer's trailing control: a **split button** in Liquid Glass — one capsule with
-/// "Customize" on the left and a chevron segment on the right, divided by a hairline (the Export ▾
-/// idiom system apps use). Clicking "Customize" opens the Customize screen; clicking the chevron opens
-/// the overflow menu (Settings / Check for Updates / About / Quit).
+/// "Settings" on the left and a chevron segment on the right, divided by a hairline (the Export ▾
+/// idiom system apps use). Clicking "Settings" opens the Settings screen; clicking the chevron opens
+/// the overflow menu (Customize / Check for Updates / About / Quit). Settings leads because everyday
+/// layout edits (reorder, hide, pin) are already reachable by dragging and right-clicking on the
+/// dashboard itself, so Settings is the more frequent deliberate destination.
 ///
 /// The joined-capsule look comes from one glass surface behind the *whole* control: an `HStack` of two
 /// `.buttonStyle(.plain)` tap targets (a `Button` and a chevron `Menu`) split by a `Divider`, with a
@@ -19,7 +21,7 @@ import SwiftUI
 /// button (`DashboardView.navBar`) to return home — the macOS-native place for it — so the footer
 /// control simply drops away there.
 ///
-/// Shortcuts survive: ⏎ (Customize), ⌘, (Settings) and Esc are handled by the always-on
+/// Shortcuts survive: ⌘, (Settings), ⏎ (Customize) and Esc are handled by the always-on
 /// `PopoverKeyReader` monitor, so they fire from every screen (including Settings, whose footer shows
 /// only the identity line — no buttons). The menu items only carry their ⌘ key-equivalents as labels
 /// and fire while the menu is open, so the monitor and the items never double-fire. ⌘Q (Quit) is
@@ -44,7 +46,7 @@ struct HeaderView: View {
     private var leadingControl: some View {
         if screen == .dashboard {
             HStack(spacing: 0) {
-                customizeHalf
+                settingsHalf
                 Divider()
                     .frame(height: 16)
                 chevronHalf
@@ -54,13 +56,13 @@ struct HeaderView: View {
         }
     }
 
-    /// Left half: opens Customize. `.buttonStyle(.plain)` strips the system chrome so the shared glass
-    /// is the only surface; `contentShape` makes the whole padded half clickable. ⏎ opens Customize
+    /// Left half: opens Settings. `.buttonStyle(.plain)` strips the system chrome so the shared glass
+    /// is the only surface; `contentShape` makes the whole padded half clickable. ⌘, opens Settings
     /// from anywhere via `PopoverKeyReader`, so the shortcut isn't registered here (which would also
     /// flag the button as the window's default and draw a pulsing ring) — the tooltip surfaces it.
-    private var customizeHalf: some View {
-        Button { toggle(.customize) } label: {
-            Text("Customize")
+    private var settingsHalf: some View {
+        Button { toggle(.settings) } label: {
+            Text("Settings")
                 .font(.system(size: 13, weight: .semibold))
                 .padding(.leading, 14)
                 .padding(.trailing, 11)
@@ -68,7 +70,7 @@ struct HeaderView: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .hoverTooltip("Customize (⏎)")
+        .hoverTooltip("Settings (⌘,)")
     }
 
     /// Right half: the chevron pull-down. `.menuStyle(.button)` + `.buttonStyle(.plain)` strip the menu
@@ -94,16 +96,15 @@ struct HeaderView: View {
 
     /// The chevron's overflow items, mirroring their in-popover entry points. `autoenablesItems` has no
     /// SwiftUI equivalent, so the Check for Updates item disables itself when Sparkle can't currently
-    /// check — e.g. dev builds with no feed, or while a check is already in flight. Settings carries ⌘,
-    /// only as a label; the always-on `PopoverKeyReader` monitor actually handles that key while the
-    /// menu is closed (and consumes it, so there's no second registration to fight), and the item fires
-    /// only while the menu is open — so the two never double-toggle.
+    /// check — e.g. dev builds with no feed, or while a check is already in flight. Customize also rides
+    /// ⏎ (and right-clicking the dashboard); the always-on `PopoverKeyReader` monitor handles ⏎ while
+    /// the menu is closed (and consumes it), so it's not registered on this item — the menu entry is the
+    /// discoverable label, the drag/right-click affordances are the everyday path.
     @ViewBuilder
     private var moreMenuItems: some View {
-        Button { toggle(.settings) } label: {
-            Label("Settings", systemImage: "gearshape")
+        Button { toggle(.customize) } label: {
+            Label("Customize", systemImage: "slider.horizontal.3")
         }
-        .keyboardShortcut(",", modifiers: .command)
         Button { updater.checkForUpdates() } label: {
             Label("Check for Updates…", systemImage: "arrow.triangle.2.circlepath")
         }

--- a/Tests/OpenUsageTests/PopoverSurfaceOpacityTests.swift
+++ b/Tests/OpenUsageTests/PopoverSurfaceOpacityTests.swift
@@ -14,9 +14,9 @@ final class PopoverSurfaceOpacityTests: XCTestCase {
         assertOpaque(Theme.trayNSColor, label: "tray")
     }
 
-    func testCardSurfaceIsFullyOpaqueInBothAppearances() {
-        assertOpaque(Theme.cardNSColor, label: "card")
-    }
+    // The grouped card is the opaque tray with a translucent `.fill.quaternary` composited on top (see
+    // `Theme.cardSurface`), so the card surface is opaque by construction as long as the tray is — which
+    // the test above guards. There's no longer a standalone card `NSColor` to assert.
 
     /// Resolves the dynamic (light/dark) color in each appearance and asserts it is fully opaque.
     private func assertOpaque(_ color: NSColor, label: String,

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -34,7 +34,7 @@ The bar pinned to the bottom of the popover. On the left: the app version, and a
 
 ## Customize
 
-The footer's **Customize** button (or pressing **Return**) opens Customize: toggle metrics on/off, add ones that aren't placed yet, pin metrics for the menu bar, and drag to reorder. Drag-reorder also works directly on the dashboard — drag a row within its provider, drag it across the caret boundary while the card is open, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
+Open Customize from the **⌄** menu next to the footer's Settings button (or press **Return**): toggle metrics on/off, add ones that aren't placed yet, pin metrics for the menu bar, and drag to reorder. Drag-reorder also works directly on the dashboard — drag a row within its provider, drag it across the caret boundary while the card is open, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
 
 Each provider card has a dashed **Shown on Expand** line. Metrics above it are always shown; metrics below it hide behind the dashboard caret. Drag a metric onto the dashed line to move it across the fold, or drag it onto a row on the other side — drop a metric under an expanded one and it becomes expanded too. Pinning, hiding, and order all work the same on either side.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-Settings lives inside the popover — there is no separate window. Open it from the **⌄** menu next to the footer's Customize button, with ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen, which carries a back button in its top-left corner. Go back with that button, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
+Settings lives inside the popover — there is no separate window. Open it from the footer's **Settings** button, with ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen, which carries a back button in its top-left corner. Go back with that button, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
 
 ## Startup
 


### PR DESCRIPTION
## What & why

Two popover refinements: make the data region read like a native macOS System Settings grouped pane, and put the more-used destination up front.

### Grouped surface (semantic, no tuned values)
Provider/settings cards now use macOS's own grouped-box treatment — the bright page tray (`textBackgroundColor`) lifted by **`.fill.quaternary`**, the system's subtle grouped fill (≈`#F9F9F9` over white in light; a step lighter than the page in dark), borderless. It tracks light/dark and Increase Contrast automatically, with **no hand-tuned hex values**. Replaces the previous tuned gray-tray/white-card look (and the short-lived Elevated/System toggle, which is dropped).

Why a semantic fill and not a native grouped `List`: the dashboard's drag-to-reorder is a custom local-gesture system *specifically because* the menu-bar panel can't host a system drag session — which native `List`/`Form` reorder relies on. Matching the surface semantically on the existing structure leaves reorder, scroll, and the screen-slide animation untouched.

### Footer: Settings-primary
The footer split button's primary action is now **Settings**; **Customize** moves into the `⌄` overflow menu. Everyday layout edits (reorder, hide, pin) are already reachable by dragging and right-clicking the dashboard, so Settings is the more frequent deliberate destination. `⌘,` and `⏎` shortcuts are unchanged (handled by the always-on key monitor).

## Notes
- Docs (dashboard, settings) and the surface-opacity test updated to match.
- Modern Liquid Glass controls (the SDK-26 linked-SDK stamp, #725) are already on `swift`; this branch inherits them.

## Test plan
- `swift build` + `swift test` — **436 tests pass** (1 skipped).
- Verified the grouped surface in light + dark and the new footer label in a signed SDK-26 dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only theming and footer navigation reordering; no auth, data, or API changes.
> 
> **Overview**
> The popover **data region** no longer uses hand-tuned gray tray / white card colors and card hairlines. The tray is **`textBackgroundColor`**, and grouped cards are a **borderless** stack of opaque tray plus **`.fill.quaternary`** (System Settings–style grouping that follows light/dark and Increase Contrast). Live and lifted drag previews share that one surface; lift depth stays on shadow.
> 
> The dashboard footer **split button** now leads with **Settings**; **Customize** moves into the **⌄** overflow menu. **⌘,** and **⏎** behavior is unchanged via `PopoverKeyReader`. Docs and `PopoverSurfaceOpacityTests` drop the standalone card `NSColor` opacity check in favor of tray-only assertion plus a comment that cards are opaque by construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963730e1e1f9367e6ea1b1431f3673b8f3d774ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->