### PR TITLE
feat(popover): coordinated-morph auto-resize for the menu-bar panel

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -393,8 +393,13 @@ final class StatusItemController: NSObject {
     /// adds no second animation to fight SwiftUI's spring.
     private func applyMorphHeight(_ rawHeight: CGFloat) {
         guard rawHeight > 1 else { return }   // 0 = "not established yet"; ignore the sentinel.
+        // Drop heights that arrive after a close. `PanelHeightBridge` hops each frame through
+        // `DispatchQueue.main.async`, so a spring morph in flight when the panel closes leaves queued
+        // callbacks behind; `orderOut` flips `isVisible` synchronously, so they're rejected here while
+        // closed (before any reopen) instead of resizing a hidden — or freshly reopened — panel.
+        guard panel.isVisible else { return }
         guard let anchorTopLeft else {
-            AppLog.error(.statusItem, "Morph height with no anchor; frame not applied")
+            AppLog.error(.statusItem, "Morph height while visible but no anchor; frame not applied")
             return
         }
         let height = min(max(rawHeight, Self.minPanelHeight), maxPanelHeight())

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -305,6 +305,9 @@ final class StatusItemController: NSObject {
             AppLog.error(.statusItem, "Cannot show panel: status item has no button")
             return
         }
+        // Drop any morph heights still queued from a previous session so a quick reopen during an old
+        // spring can't apply a stale height to this fresh open.
+        PanelHeightBridge.invalidate()
         // Lay the content out first so the panel opens at the right size (no first-frame flash).
         hostingController.view.layoutSubtreeIfNeeded()
 
@@ -348,9 +351,12 @@ final class StatusItemController: NSObject {
         statusItem.button?.highlight(false)
         anchorTopLeft = nil
         anchorScreen = nil
-        // Settle any in-flight morph so a reopen doesn't inherit a stale flag.
+        // Settle any in-flight morph so a reopen doesn't inherit a stale flag, and invalidate heights
+        // already queued through PanelHeightBridge so a spring morph caught mid-flight by the close
+        // can't resize the panel after orderOut (or after a quick reopen).
         morphSettleTask?.cancel()
         isMorphing = false
+        PanelHeightBridge.invalidate()
     }
 
     /// Drops keyboard focus inside the panel so a clicked plain-styled control (a metric row's

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -57,9 +57,6 @@ final class StatusItemController: NSObject {
     /// its duration so the panel growing/shrinking under a stationary cursor can't be misread as an
     /// outside click. Cleared by `scheduleMorphSettle` shortly after the per-frame height stream stops.
     private var isMorphing = false
-    /// The last height SwiftUI asked for. A re-render that didn't change the height must not churn the
-    /// main queue with a redundant async `setFrame`, so we drop unchanged requests before the hop.
-    private var lastRequestedHeight: CGFloat = 0
     /// Fires once the per-frame height stream goes quiet: clears `isMorphing` and persists the settled
     /// per-screen height (the next open's flash-free starting guess).
     private var morphSettleTask: Task<Void, Never>?
@@ -346,7 +343,6 @@ final class StatusItemController: NSObject {
         // Settle any in-flight morph so a reopen doesn't inherit a stale flag or a half-applied height.
         morphSettleTask?.cancel()
         isMorphing = false
-        lastRequestedHeight = 0
     }
 
     /// Drops keyboard focus inside the panel so a clicked plain-styled control (a metric row's
@@ -388,15 +384,15 @@ final class StatusItemController: NSObject {
     /// Single clock: only `setFrame(display:false)`, never `animate:true` / `panel.animator()`, so AppKit
     /// adds no second animation to fight SwiftUI's spring.
     private func applyMorphHeight(_ rawHeight: CGFloat) {
-        // Drop unchanged requests so a re-render that didn't move the height doesn't re-`setFrame`.
-        guard rawHeight > 1, abs(rawHeight - lastRequestedHeight) > 0.5 else { return }
-        lastRequestedHeight = rawHeight
+        guard rawHeight > 1 else { return }   // 0 = "not established yet"; ignore the sentinel.
         guard let anchorTopLeft else {
             AppLog.error(.statusItem, "Morph height with no anchor; frame not applied")
             return
         }
         let height = min(max(rawHeight, Self.minPanelHeight), maxPanelHeight())
-        // Break any frame→relayout→frame churn and skip sub-point no-ops.
+        // The live frame is the ground truth: apply only when it would actually move (>1pt). This both
+        // dedupes redundant per-render pushes and guarantees the frame never stops short of the driven
+        // height — there's no separate "last requested" tracking that a skipped apply could desync.
         guard abs(panel.frame.height - height) > 1 else { return }
         let origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - height)
         panel.setFrame(NSRect(origin: origin, size: NSSize(width: Self.panelWidth, height: height)), display: false)

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -335,12 +335,20 @@ final class StatusItemController: NSObject {
         // or reset toggle) stays first responder, so its focus ring would reopen with the popover as a
         // stray blue outline. Drop it on close so every reopen starts unfocused.
         clearStrayFocus()
+        // Persist the closing screen's height NOW, while `container.layout.screen` is still the screen
+        // being shown (the visibility reset that flips it back to dashboard runs later, off the occlusion
+        // notification). `scheduleMorphSettle` only persists after 120ms of quiet and bails once the panel
+        // is hidden, so without this a close right after a resize/screen-switch would never save the new
+        // height and the next open of that screen would use a stale flash-free guess.
+        if panel.isVisible {
+            PanelHeightStore.save(panel.frame.height, for: container.layout.screen)
+        }
         panel.orderOut(nil)
         stopOutsideClickMonitors()
         statusItem.button?.highlight(false)
         anchorTopLeft = nil
         anchorScreen = nil
-        // Settle any in-flight morph so a reopen doesn't inherit a stale flag or a half-applied height.
+        // Settle any in-flight morph so a reopen doesn't inherit a stale flag.
         morphSettleTask?.cancel()
         isMorphing = false
     }

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -53,8 +53,16 @@ final class StatusItemController: NSObject {
     private static let minPanelHeight: CGFloat = 480
     /// Opening height before the user has ever resized the panel.
     private static let defaultPanelHeight: CGFloat = 800
-    /// Panel height at the moment a grip drag began; the live height is this plus the drag distance.
-    private var gripStartHeight: CGFloat = 0
+    /// True while a SwiftUI-driven height morph is in flight. Outside-click dismissal is suspended for
+    /// its duration so the panel growing/shrinking under a stationary cursor can't be misread as an
+    /// outside click. Cleared by `scheduleMorphSettle` shortly after the per-frame height stream stops.
+    private var isMorphing = false
+    /// The last height SwiftUI asked for. A re-render that didn't change the height must not churn the
+    /// main queue with a redundant async `setFrame`, so we drop unchanged requests before the hop.
+    private var lastRequestedHeight: CGFloat = 0
+    /// Fires once the per-frame height stream goes quiet: clears `isMorphing` and persists the settled
+    /// per-screen height (the next open's flash-free starting guess).
+    private var morphSettleTask: Task<Void, Never>?
 
     init(container: AppContainer, updater: UpdaterController) {
         self.container = container
@@ -109,11 +117,14 @@ final class StatusItemController: NSObject {
             self?.hidePanel()
         }
 
-        // The in-page resize grip drives the panel height through these (the panel stays the single
-        // owner of `setFrame`, resizing synchronously so the content never lags the frame).
-        MenuBarPopover.beginResize = { [weak self] in self?.beginGripResize() }
-        MenuBarPopover.resizeBy = { [weak self] distance in self?.updateGripResize(by: distance) }
-        MenuBarPopover.endResize = { [weak self] in self?.endGripResize() }
+        // The panel auto-fits its content: SwiftUI owns one animated height (the single animation
+        // clock) and the panel just follows it. `applyHeight` is the per-frame follower; `clampHeight`
+        // shares the panel's [min, screen-max] clamp so SwiftUI's target matches where the frame lands.
+        MenuBarPopover.applyHeight = { [weak self] height in self?.applyMorphHeight(height) }
+        MenuBarPopover.clampHeight = { [weak self] raw in
+            guard let self else { return raw }
+            return min(max(raw, Self.minPanelHeight), self.maxPanelHeight())
+        }
 
         AppLog.info(.statusItem, "Status item ready (button: \(self.statusItem.button != nil), shortcut: \(KeyboardShortcuts.getShortcut(for: .togglePopover)?.description ?? "none"))")
     }
@@ -332,6 +343,10 @@ final class StatusItemController: NSObject {
         statusItem.button?.highlight(false)
         anchorTopLeft = nil
         anchorScreen = nil
+        // Settle any in-flight morph so a reopen doesn't inherit a stale flag or a half-applied height.
+        morphSettleTask?.cancel()
+        isMorphing = false
+        lastRequestedHeight = 0
     }
 
     /// Drops keyboard focus inside the panel so a clicked plain-styled control (a metric row's
@@ -345,44 +360,61 @@ final class StatusItemController: NSObject {
         panel.makeFirstResponder(nil)
     }
 
-    /// Sizes the panel on show: the user's saved height (or a default), **clamped to fit the current
-    /// screen**, with the top-left pinned under the status item. Width is fixed (single-column list).
+    /// Sizes the panel on show to a **flash-free opening guess** — the last settled height for the
+    /// screen being opened (or a default) — clamped to fit the current screen, top-left pinned under
+    /// the status item. Width is fixed (single-column list).
     ///
-    /// This is the whole cross-display story: we store ONE height. If it doesn't fit the screen the
-    /// panel is opening on (e.g. saved big on a Studio Display, opened on a laptop), we shrink it to fit
-    /// *for this open only* — the saved value is untouched, so it returns to full size back on the big
-    /// screen. The clamp runs before the panel is visible, so it's instant. There's no content-driven
-    /// resize, so switching screens never moves the window — only the user's drag does.
+    /// The panel auto-fits its content via the SwiftUI morph (`applyMorphHeight`), but that measured
+    /// height only lands a runloop turn after the content lays out — too late for the first frame. So
+    /// we open at the persisted per-screen guess (kept current by `scheduleMorphSettle`), and SwiftUI
+    /// snaps to the exact measured height on appear; when the guess is close the snap is invisible.
+    /// Per-screen because `openSettings` opens straight onto Settings, which is a different height than
+    /// the dashboard. The clamp keeps a height saved on a big display from running off a short one.
     private func applyPanelSize() {
         guard let anchorTopLeft else { return }
-        let saved = PanelHeightStore.load() ?? Self.defaultPanelHeight
+        let saved = PanelHeightStore.load(for: container.layout.screen) ?? Self.defaultPanelHeight
         let height = min(max(saved, Self.minPanelHeight), maxPanelHeight())
         let origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - height)
         panel.setFrame(NSRect(origin: origin, size: NSSize(width: Self.panelWidth, height: height)), display: false)
         panel.invalidateShadow()
     }
 
-    // MARK: - Grip resize
+    // MARK: - Content-driven morph
 
-    private func beginGripResize() {
-        gripStartHeight = panel.frame.height
-    }
-
-    /// Live grip drag. `distance` is how far the pointer has moved down from where the drag began (down =
-    /// grow). We set the frame and then lay the content out **synchronously** before it's drawn, so the
-    /// SwiftUI content never lags the window frame — which was the wobble.
-    private func updateGripResize(by distance: CGFloat) {
-        guard let anchorTopLeft else { return }
-        let height = min(max(gripStartHeight + distance, Self.minPanelHeight), maxPanelHeight())
+    /// Per-frame follower for the SwiftUI-driven height morph (the single animation clock). Called once
+    /// per animation frame with the interpolated height — already hopped onto the main queue and out of
+    /// SwiftUI's layout pass by `PanelHeightBridge`, so this runs synchronously and safely (a synchronous
+    /// `setFrame` from inside that pass would re-enter AppKit layout and trip `_NSDetectedLayoutRecursion`).
+    /// Single clock: only `setFrame(display:false)`, never `animate:true` / `panel.animator()`, so AppKit
+    /// adds no second animation to fight SwiftUI's spring.
+    private func applyMorphHeight(_ rawHeight: CGFloat) {
+        // Drop unchanged requests so a re-render that didn't move the height doesn't re-`setFrame`.
+        guard rawHeight > 1, abs(rawHeight - lastRequestedHeight) > 0.5 else { return }
+        lastRequestedHeight = rawHeight
+        guard let anchorTopLeft else {
+            AppLog.error(.statusItem, "Morph height with no anchor; frame not applied")
+            return
+        }
+        let height = min(max(rawHeight, Self.minPanelHeight), maxPanelHeight())
+        // Break any frame→relayout→frame churn and skip sub-point no-ops.
+        guard abs(panel.frame.height - height) > 1 else { return }
         let origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - height)
         panel.setFrame(NSRect(origin: origin, size: NSSize(width: Self.panelWidth, height: height)), display: false)
-        panel.contentView?.layoutSubtreeIfNeeded()
-        panel.displayIfNeeded()
         panel.invalidateShadow()
+        isMorphing = true
+        scheduleMorphSettle()
     }
 
-    private func endGripResize() {
-        PanelHeightStore.save(panel.frame.height)
+    /// Clears `isMorphing` and persists the settled height once the per-frame stream goes quiet (a
+    /// spring keeps changing the height every frame until it settles, so this only fires at rest).
+    private func scheduleMorphSettle() {
+        morphSettleTask?.cancel()
+        morphSettleTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(120))
+            guard !Task.isCancelled, let self, self.panel.isVisible else { return }
+            self.isMorphing = false
+            PanelHeightStore.save(self.panel.frame.height, for: self.container.layout.screen)
+        }
     }
 
     /// The tallest the panel may be on the current screen: the room below its pinned top edge, capped at
@@ -447,6 +479,9 @@ final class StatusItemController: NSObject {
             let screenPoint = NSEvent.mouseLocation
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                // While the panel is morphing its height, its frame is moving under a possibly
+                // stationary cursor — don't let a click land "outside" a frame that's mid-resize.
+                guard !self.isMorphing else { return }
                 // Clicking the status item must NOT dismiss here — its own action toggles the panel.
                 // Dismissing on this click's mouse-down would close the panel, then the button action
                 // would reopen it on mouse-up (the close-then-reopen flicker).
@@ -472,6 +507,8 @@ final class StatusItemController: NSObject {
     /// windows). Status-item clicks can arrive with no window (the menu bar is composited by the Window
     /// Server), so the button is also matched by screen position.
     private func shouldKeepPanelOpen(windowID: ObjectIdentifier?, windowTypeName: String?, screenPoint: NSPoint) -> Bool {
+        // The frame is moving mid-morph; a hit-test against it would be racy, so keep the panel open.
+        if isMorphing { return true }
         if isOnStatusButton(screenPoint: screenPoint) { return true }
         if panel.frame.contains(screenPoint) { return true }
         guard let windowID, let windowTypeName else { return false }
@@ -489,17 +526,26 @@ final class StatusItemController: NSObject {
     }
 }
 
-/// Persists the user's chosen panel height across launches. Width is fixed (single-column list), so
-/// only height is stored; it's clamped to the current screen on each open (see `applyPanelSize`).
+/// Persists the last settled panel height **per screen**, so the next open starts at a flash-free
+/// guess close to what the content will measure (the panel auto-fits, but the measurement lands a tick
+/// after the first frame — see `applyPanelSize`). Width is fixed (single-column list), so only height
+/// is stored; it's clamped to the current screen on each open. Per-screen because the dashboard,
+/// Customize, and Settings are genuinely different heights and `openSettings` opens straight onto one.
 private enum PanelHeightStore {
-    private static let key = "openusage.panel.height"
+    private static func key(for screen: PopoverScreen) -> String {
+        switch screen {
+        case .dashboard: "openusage.panel.height.dashboard"
+        case .customize: "openusage.panel.height.customize"
+        case .settings: "openusage.panel.height.settings"
+        }
+    }
 
-    static func load() -> CGFloat? {
-        let value = UserDefaults.standard.double(forKey: key)
+    static func load(for screen: PopoverScreen) -> CGFloat? {
+        let value = UserDefaults.standard.double(forKey: key(for: screen))
         return value > 0 ? CGFloat(value) : nil
     }
 
-    static func save(_ height: CGFloat) {
-        UserDefaults.standard.set(Double(height), forKey: key)
+    static func save(_ height: CGFloat, for screen: PopoverScreen) {
+        UserDefaults.standard.set(Double(height), forKey: key(for: screen))
     }
 }

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -189,13 +189,15 @@ enum MenuBarPopover {
     /// path as a status-item click.
     static var dismissHandler: (() -> Void)?
 
-    /// Resize bridge: the in-page resize grip (`ResizeGrip`) drives the host panel's height through
-    /// these, so the AppKit panel owner stays the single place that does `setFrame` (synchronously, so
-    /// the content never lags the frame). `beginResize` snapshots the start height; `resizeBy` is the
-    /// cumulative drag distance (down = taller); `endResize` persists.
-    static var beginResize: (() -> Void)?
-    static var resizeBy: ((CGFloat) -> Void)?
-    static var endResize: (() -> Void)?
+    /// Auto-resize bridge — the "single clock". SwiftUI owns the animated height and the AppKit panel
+    /// is a passive follower: `applyHeight` is called once per animation frame from a SwiftUI
+    /// `Animatable` modifier with the interpolated height, and the controller hops it onto the main
+    /// queue (mandatory — it's invoked from inside SwiftUI's layout pass, and `setFrame` re-enters
+    /// AppKit layout on the constraint-pinned host, which would trip `_NSDetectedLayoutRecursion`) and
+    /// `setFrame`s the panel. `clampHeight` lets SwiftUI clamp its target to the same [min, screen-max]
+    /// range the panel will actually sit at, so the spring settles exactly on-frame.
+    static var applyHeight: ((CGFloat) -> Void)?
+    static var clampHeight: ((CGFloat) -> CGFloat)?
 
     /// Closes the popover. Falls back to ordering the given window out if no owner has installed
     /// a handler (which would be a wiring bug, so it's logged loudly by the caller's absence of

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -3,25 +3,38 @@ import AppKit
 
 /// The popover content: the provider/metric list (or the Customize / Settings screen) as a scroll
 /// view between fixed chrome — a top back/title bar on Customize/Settings, and a single bottom footer
-/// (app identity / Customize pin summary + the glass Customize/Settings buttons) with the resize
-/// handle folded into it.
+/// (app identity / Customize pin summary + the glass Customize/Settings buttons).
 ///
 /// The chrome is fixed: it's keyed off `layout.screen` and applied uniformly in `screenView`, so on a
 /// screen switch only the content slides while the footer and top bar stay put. Each screen's scroll
 /// content underlaps the footer with the native soft scroll-edge fade (`softBottomScrollEdge` →
 /// `.scrollEdgeEffectStyle(.soft)`, macOS 26+) — Apple's blurred boundary, not a custom gradient or a
 /// material bar. On macOS 15 the footer/top bar still pin via `safeAreaInset`, just without the blur
-/// (content scrolls flush). The panel is a fixed, user-resizable size (the host window, sized by
-/// `StatusItemController`), so the scroll views inside handle any overflow rather than the popover
-/// growing to fit its content.
+/// (content scrolls flush). The panel **auto-fits its content**: each screen publishes its intrinsic
+/// height (`ScrollContentHeightKey` + the measured footer), and the host window is driven to that on
+/// SwiftUI's animation clock (`drivesPanelHeight` / `PanelHeightModifier`) — so a screen switch morphs
+/// the window height in lockstep with the slide (one spring), and the scroll views only take over once
+/// content exceeds the screen-height cap.
 struct DashboardView: View {
     @Environment(LayoutStore.self) private var layout
     @Environment(WidgetDataStore.self) private var dataStore
     @State private var didInitialRefresh = false
     @State private var reorderLift: ReorderLift?
     @State private var showingResetCustomizationConfirmation = false
-    /// True while the user is dragging the resize grip, so the first drag event begins the resize once.
-    @State private var resizingPanel = false
+    /// The panel height SwiftUI drives — the single animation clock. `PanelHeightModifier` follows it
+    /// frame-by-frame onto the AppKit panel, so the window resize rides the same spring as the screen
+    /// slide (no second AppKit animation to fight). 0 means "not established yet": the panel keeps the
+    /// size the controller opened it at until the first measurement lands, then we snap un-animated.
+    @State private var animatedHeight: CGFloat = 0
+    /// Whether `animatedHeight` has been seeded for this open. Until then the first measurement (or a
+    /// reopen) establishes it without animation; afterwards, changes spring.
+    @State private var didEstablishHeight = false
+    /// Per-screen intrinsic heights, summed into `measuredIdeal`. Written only from geometry/preference
+    /// actions (which run after `body`), so they never trip "Modifying state during view update".
+    @State private var measuredScrollContent: [PopoverScreen: CGFloat] = [:]
+    @State private var measuredFooter: [PopoverScreen: CGFloat] = [:]
+    /// The window height each screen wants — top bar + footer + scroll content. The morph target.
+    @State private var measuredIdeal: [PopoverScreen: CGFloat] = [:]
     /// Horizontal screen-switch slide: 0 shows the outgoing screen, 1 the incoming one. Drives the
     /// page offset so the screens slide between modes on one spring.
     @State private var slideProgress: CGFloat = 1
@@ -49,9 +62,10 @@ struct DashboardView: View {
     var body: some View {
         modeBody
             .frame(width: Self.popoverWidth)
-            // Fill the panel (the host window is the user-set, screen-clamped size); the scroll views
-            // inside handle overflow. The panel no longer sizes to content, so switching screens never
-            // resizes the window — the slide plays over a static frame, with no resize stutter.
+            // Fill the panel. The panel auto-fits its content (the window height is driven to each
+            // screen's measured ideal via `drivesPanelHeight`), so at rest the window is exactly the
+            // content's height and this fill is a no-op; when content exceeds the screen cap the window
+            // clamps and the scroll views inside take the overflow.
             .frame(maxHeight: .infinity, alignment: .top)
             // Paint the opaque tray behind all content (and the footer) so the whole popover reads as
             // one solid panel — the data region never shows the desktop through it. Outermost so the
@@ -59,6 +73,10 @@ struct DashboardView: View {
             // the native soft scroll-edge fade (not a distinct bar). The resize handle is folded into
             // the footer (see `footerBar`), so there's no separate root-level dragger inset anymore.
             .background(PopoverSurface())
+            // Drive the host panel's height on SwiftUI's clock. At the body root, OUTSIDE `modeBody`'s
+            // `.animation(nil, value: layout.screenSlideID)`, so the height rides the active spring (the
+            // slide's, during a switch) instead of being snapped.
+            .drivesPanelHeight(animatedHeight)
             .overlay(alignment: .topLeading) {
                 if let reorderLift {
                     ReorderLiftPreview(lift: reorderLift)
@@ -99,7 +117,17 @@ struct DashboardView: View {
             )
             .background(
                 PopoverVisibilityReader { visible in
-                    if !visible { resetTransientState() }
+                    if visible {
+                        // Reopen: the SwiftUI tree survives a close, so re-seed the height for whatever
+                        // screen we're opening on. Un-animated, and ≈ the controller's opening guess, so
+                        // there's no visible jump. If not yet measured, the measurement onChange seeds it.
+                        if let target = targetHeight() {
+                            didEstablishHeight = true
+                            animatedHeight = target
+                        }
+                    } else {
+                        resetTransientState()
+                    }
                 }
             )
             // A screen switch can tear the list down mid-drag, in which case the gesture's
@@ -118,8 +146,33 @@ struct DashboardView: View {
                 guard id != 0 else { return }
                 slideProgress = 0
                 animatedSlideID = id
+                let destination = layout.screen
                 Task { @MainActor in
-                    withAnimation(Motion.spring) { slideProgress = 1 }
+                    // Co-animate the slide and the height on ONE spring → the coordinated morph: the
+                    // panel grows/shrinks to the destination's size as that screen slides in. The
+                    // destination is mounted (and measured) on the render that set slideProgress=0, so
+                    // its ideal is fresh here; the completion re-syncs in case it wasn't.
+                    didEstablishHeight = true
+                    withAnimation(Motion.spring, completionCriteria: .logicallyComplete) {
+                        slideProgress = 1
+                        animatedHeight = clampedTarget(measuredIdeal[destination] ?? animatedHeight)
+                    } completion: {
+                        if let target = targetHeight(), abs(target - animatedHeight) > 1 {
+                            withAnimation(Motion.spring) { animatedHeight = target }
+                        }
+                    }
+                }
+            }
+            // In-screen growth/shrink (a provider card expands, the footer notice appears, a refresh
+            // loads rows): re-target the height on the same spring. The switch path owns the height
+            // while a slide is in flight, so defer to it then.
+            .onChange(of: measuredIdeal[layout.screen]) { _, _ in
+                guard !isSliding, let target = targetHeight() else { return }
+                if !didEstablishHeight {
+                    didEstablishHeight = true
+                    animatedHeight = target
+                } else if abs(target - animatedHeight) > 1 {
+                    withAnimation(Motion.spring) { animatedHeight = target }
                 }
             }
             .task {
@@ -138,13 +191,11 @@ struct DashboardView: View {
         if layout.screen != .dashboard { layout.screen = .dashboard }
         reorderLift = nil
         layout.cancelDrag()
-        // If the popover closes mid-resize (e.g. the global hotkey fires while dragging), the grip's
-        // `onEnded` never runs — settle it here so the flag can't stay stuck (which would make the next
-        // drag jump from a stale start height), and the dragged height is still persisted.
-        if resizingPanel {
-            resizingPanel = false
-            MenuBarPopover.endResize?()
-        }
+        // Drop the driven height so the next open re-establishes it (un-animated) from the reopened
+        // screen's measurement instead of springing from this session's last value. Until then the
+        // 0 sentinel keeps `PanelHeightModifier` from pushing, so the controller's opening guess stands.
+        animatedHeight = 0
+        didEstablishHeight = false
         dashboardScrollPosition.scrollTo(edge: .top)
     }
 
@@ -214,10 +265,40 @@ struct DashboardView: View {
     @ViewBuilder
     private func screenView(_ screen: PopoverScreen) -> some View {
         scrollBody(for: screen)
+            // Auto-fit: the scroll content publishes its intrinsic height (invariant to the viewport),
+            // which we sum with the chrome into this screen's ideal window height. Keyed by the per-page
+            // `screen`, so during a slide each mounted page measures its own content.
+            .onPreferenceChange(ScrollContentHeightKey.self) { height in
+                measuredScrollContent[screen] = height
+                recomposeIdeal(for: screen)
+            }
             .softTopScrollEdge()
             .softBottomScrollEdge()
             .pinnedTopBar(spacing: 0) { fixedTopBar }
             .pinnedFooter(spacing: 0) { footerBar(for: layout.screen) }
+    }
+
+    // MARK: - Auto-fit height
+
+    /// Sum a screen's measured parts into its ideal window height. Top bar is the fixed `topBarHeight`
+    /// on Customize/Settings and 0 on the dashboard (it pins itself to that exact height); the footer is
+    /// measured because it varies (the Customize pin summary, the denied-pin notice line).
+    private func recomposeIdeal(for screen: PopoverScreen) {
+        guard let content = measuredScrollContent[screen], content > 0 else { return }
+        let topBar: CGFloat = screen == .dashboard ? 0 : Self.topBarHeight
+        let footer = measuredFooter[screen] ?? 0
+        measuredIdeal[screen] = topBar + footer + content
+    }
+
+    /// This screen's ideal height clamped to where the panel can actually sit (the controller owns the
+    /// [min, screen-max] clamp); `nil` until the screen has been measured.
+    private func targetHeight() -> CGFloat? {
+        guard let ideal = measuredIdeal[layout.screen] else { return nil }
+        return clampedTarget(ideal)
+    }
+
+    private func clampedTarget(_ ideal: CGFloat) -> CGFloat {
+        MenuBarPopover.clampHeight?(ideal) ?? ideal
     }
 
     /// The scrolling content for a screen, without chrome — this is the part that slides during a
@@ -250,41 +331,6 @@ struct DashboardView: View {
         case .settings:
             navBar(title: "Settings")
         }
-    }
-
-    /// The resize grabber, folded into the bottom of `footerBar` so it reads as one unit with the
-    /// footer (not a detached strip below it). The drag is measured in `.global` space — pinned to the
-    /// panel's fixed top edge — so the handle moving as the panel grows doesn't feed back into the
-    /// gesture; it drives the host panel through `MenuBarPopover`, which resizes synchronously so the
-    /// content can't lag the frame. The pointer style gives the standard resize cursor.
-    private var resizeDragger: some View {
-        Capsule()
-            .fill(.tertiary)
-            .frame(width: 36, height: 4)
-            .frame(maxWidth: .infinity)
-            // A taller hit area than the 4pt handle, with extra room below so the handle sits up off
-            // the window's rounded bottom edge instead of hugging it. `contentShape` comes after the
-            // padding so the whole padded strip is draggable, not just the visible capsule.
-            .padding(.top, 8)
-            .padding(.bottom, 10)
-            .contentShape(Rectangle())
-            // The grabber sits at the bottom of the footer on every screen, so it reads the same on all
-            // three — the footer (and thus the handle) is the same fixed chrome everywhere now.
-            .pointerStyle(.frameResize(position: .bottom))
-            .gesture(
-                DragGesture(minimumDistance: 0, coordinateSpace: .global)
-                    .onChanged { value in
-                        if !resizingPanel {
-                            resizingPanel = true
-                            MenuBarPopover.beginResize?()
-                        }
-                        MenuBarPopover.resizeBy?(value.translation.height)
-                    }
-                    .onEnded { _ in
-                        resizingPanel = false
-                        MenuBarPopover.endResize?()
-                    }
-            )
     }
 
     /// The widget list as a scroll view that fills the region the footer leaves. The content scrolls
@@ -403,37 +449,38 @@ struct DashboardView: View {
     /// (`HeaderView` only shows them on the dashboard), leaving just the identity line.
     @ViewBuilder
     private func footerBar(for screen: PopoverScreen) -> some View {
-        VStack(spacing: 0) {
-            Group {
-                if screen == .customize {
-                    // Customize summarizes the layout — active (enabled) metrics and how many are pinned —
-                    // centered, using the same middot the metric rows use.
-                    Text(layout.pinLimitNotice ?? "\(activeMetricCount) active · \(layout.pinnedCount) pinned")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(layout.pinLimitNotice == nil ? AnyShapeStyle(.secondary) : Theme.notice)
-                        .denyShake(trigger: layout.pinNoticeShakeTrigger)
-                        .frame(maxWidth: .infinity)
-                        .animation(Motion.spring, value: layout.pinLimitNotice)
-                } else {
-                    HStack(alignment: .center, spacing: 8) {
-                        footerIdentity
-                        Spacer(minLength: 8)
-                        HeaderView(screen: screen)
-                    }
+        Group {
+            if screen == .customize {
+                // Customize summarizes the layout — active (enabled) metrics and how many are pinned —
+                // centered, using the same middot the metric rows use.
+                Text(layout.pinLimitNotice ?? "\(activeMetricCount) active · \(layout.pinnedCount) pinned")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(layout.pinLimitNotice == nil ? AnyShapeStyle(.secondary) : Theme.notice)
+                    .denyShake(trigger: layout.pinNoticeShakeTrigger)
+                    .frame(maxWidth: .infinity)
+                    .animation(Motion.spring, value: layout.pinLimitNotice)
+            } else {
+                HStack(alignment: .center, spacing: 8) {
+                    footerIdentity
+                    Spacer(minLength: 8)
+                    HeaderView(screen: screen)
                 }
             }
-            .padding(.horizontal, Self.footerHorizontalPadding)
-            .padding(.top, 12)
-            // Tight to the resize handle just below, so the footer row and handle read as one cluster.
-            .padding(.bottom, 4)
-            .frame(maxWidth: .infinity)
-
-            resizeDragger
         }
+        .padding(.horizontal, Self.footerHorizontalPadding)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity)
         // Content-aware Liquid Glass: `glassEffect` lenses the in-app data scrolling under the footer
         // (not the desktop), so it stays consistent regardless of what's behind the window. Renders on
         // macOS 26+, including the macOS 27 (Golden Gate) beta; macOS 15 falls back to a frosted material.
         .barGlass()
+        // The footer's height feeds the auto-fit sum (`recomposeIdeal`); it varies — the Customize
+        // summary line vs the dashboard identity row vs the denied-pin notice — so measure it rather
+        // than assume a constant. Keyed by the destination `screen` (footer is keyed off `layout.screen`).
+        .onGeometryChange(for: CGFloat.self) { proxy in proxy.size.height } action: { height in
+            measuredFooter[screen] = height
+            recomposeIdeal(for: screen)
+        }
     }
 
     /// Count of enabled ("active") metrics across providers — the "N active" half of the Customize footer

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -150,28 +150,39 @@ struct DashboardView: View {
                 Task { @MainActor in
                     // Co-animate the slide and the height on ONE spring → the coordinated morph: the
                     // panel grows/shrinks to the destination's size as that screen slides in. The
-                    // destination is mounted (and measured) on the render that set slideProgress=0, so
-                    // its ideal is fresh here; the completion re-syncs in case it wasn't.
-                    didEstablishHeight = true
+                    // destination is usually mounted+measured by now (it mounted on the slideProgress=0
+                    // render), so we morph to its ideal. If it ISN'T measured yet and the height was
+                    // never established (animatedHeight still the 0 sentinel — e.g. opening Settings
+                    // straight from the status-item menu), we must NOT morph to clampedTarget(0), which
+                    // floors to minPanelHeight and wrongly shrinks the panel: leave the height alone and
+                    // let the completion / measurement establish it once a real ideal lands.
+                    let coTarget: CGFloat? = measuredIdeal[destination].map { clampedTarget($0) }
+                        ?? (animatedHeight > 0 ? animatedHeight : nil)
+                    if coTarget != nil { didEstablishHeight = true }
                     withAnimation(Motion.spring, completionCriteria: .logicallyComplete) {
                         slideProgress = 1
-                        animatedHeight = clampedTarget(measuredIdeal[destination] ?? animatedHeight)
+                        if let coTarget { animatedHeight = coTarget }
                     } completion: {
-                        if let target = targetHeight(), abs(target - animatedHeight) > 1 {
+                        guard let target = targetHeight() else { return }
+                        if !didEstablishHeight {
+                            didEstablishHeight = true
+                            animatedHeight = target            // un-animated establish — never grow from 0
+                        } else if abs(target - animatedHeight) > 1 {
                             withAnimation(Motion.spring) { animatedHeight = target }
                         }
                     }
                 }
             }
             // In-screen growth/shrink (a provider card expands, the footer notice appears, a refresh
-            // loads rows): re-target the height on the same spring. The switch path owns the height
-            // while a slide is in flight, so defer to it then.
+            // loads rows): re-target the height on the same spring. Establishment is allowed even mid-
+            // slide (a measurement that lands during a switch must seed the height — there's nothing to
+            // fight yet); the animated *re-target* defers to the switch path while a slide is in flight.
             .onChange(of: measuredIdeal[layout.screen]) { _, _ in
-                guard !isSliding, let target = targetHeight() else { return }
+                guard let target = targetHeight() else { return }
                 if !didEstablishHeight {
                     didEstablishHeight = true
                     animatedHeight = target
-                } else if abs(target - animatedHeight) > 1 {
+                } else if !isSliding, abs(target - animatedHeight) > 1 {
                     withAnimation(Motion.spring) { animatedHeight = target }
                 }
             }

--- a/Sources/OpenUsage/Views/PanelHeightModifier.swift
+++ b/Sources/OpenUsage/Views/PanelHeightModifier.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 
 /// Drives the host panel's height on SwiftUI's animation clock. This is the "single clock" that fixes
 /// the old stutter and the diagonal jank: instead of AppKit running its own `setFrame` animation
@@ -41,9 +42,23 @@ struct PanelHeightModifier: GeometryEffect {
 /// lands it just after the pass unwinds, still within the same display interval. SwiftUI interpolates
 /// on the main thread, so `assumeIsolated` is the right bridge to the `@MainActor` closure.
 enum PanelHeightBridge {
+    /// Bumped on every panel open and close. A queued height is applied only if the generation is
+    /// unchanged between when it was scheduled and when it runs — so a spring morph in flight when the
+    /// panel closes can never resize a hidden, or a freshly reopened, panel with a stale height (the
+    /// async hops are otherwise un-cancellable). `OSAllocatedUnfairLock` so the nonisolated `push` and
+    /// the main-actor `invalidate` can touch it safely.
+    private static let generation = OSAllocatedUnfairLock(initialState: 0)
+
+    /// Invalidate every in-flight height. Call on panel open and close.
+    nonisolated static func invalidate() {
+        generation.withLock { $0 += 1 }
+    }
+
     nonisolated static func push(_ height: CGFloat) {
         guard height > 0 else { return }
+        let scheduled = generation.withLock { $0 }
         DispatchQueue.main.async {
+            guard generation.withLock({ $0 }) == scheduled else { return }
             MainActor.assumeIsolated {
                 MenuBarPopover.applyHeight?(height)
             }

--- a/Sources/OpenUsage/Views/PanelHeightModifier.swift
+++ b/Sources/OpenUsage/Views/PanelHeightModifier.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Drives the host panel's height on SwiftUI's animation clock. This is the "single clock" that fixes
+/// the old stutter and the diagonal jank: instead of AppKit running its own `setFrame` animation
+/// alongside SwiftUI's screen-slide (two clocks fighting), the window is a passive follower of one
+/// SwiftUI-owned, animated value.
+///
+/// `animatableData == height` is the per-frame interpolation hook: during a `withAnimation`, the
+/// animation system sets `animatableData` once per display refresh with the interpolated height, and
+/// the setter forwards it (via `PanelHeightBridge`) to the panel — so the window frame and the screen
+/// slide ride the *same* spring. A height of 0 is the "not established yet" sentinel (the panel keeps
+/// the size the controller opened it at) and is skipped, so the first render before measurement lands
+/// never pushes a bogus frame.
+///
+/// Built as a `GeometryEffect` (like `DenyShakeEffect`) rather than a plain `ViewModifier`: a custom
+/// `ViewModifier` that implements `body` is inferred `@MainActor` (because `ViewModifier.body` is), which
+/// would make `animatableData` `@MainActor` and violate `Animatable`'s `nonisolated` requirement.
+/// `GeometryEffect` supplies its own `body`, so the struct stays nonisolated and the `Animatable`
+/// conformance is clean; the forwarding goes through the `nonisolated` `PanelHeightBridge`. The effect
+/// itself is an identity transform — we only want its per-frame `animatableData` hook, no visual change.
+struct PanelHeightModifier: GeometryEffect {
+    var height: CGFloat
+
+    var animatableData: CGFloat {
+        get { height }
+        set {
+            height = newValue
+            PanelHeightBridge.push(newValue)
+        }
+    }
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        ProjectionTransform()
+    }
+}
+
+/// Forwards interpolated heights from the (nonisolated) `Animatable` setter to the `@MainActor` panel
+/// bridge. The hop onto the main queue is MANDATORY and lives here: the setter fires from inside
+/// SwiftUI's update pass, and `applyHeight`'s `setFrame` re-enters AppKit layout on the
+/// constraint-pinned host — running it synchronously would trip `_NSDetectedLayoutRecursion`. The hop
+/// lands it just after the pass unwinds, still within the same display interval. SwiftUI interpolates
+/// on the main thread, so `assumeIsolated` is the right bridge to the `@MainActor` closure.
+enum PanelHeightBridge {
+    nonisolated static func push(_ height: CGFloat) {
+        guard height > 0 else { return }
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                MenuBarPopover.applyHeight?(height)
+            }
+        }
+    }
+}
+
+extension View {
+    /// Make this view's enclosing menu-bar panel follow `height` on SwiftUI's animation clock. Attach
+    /// at the body root, outside any `.animation(nil, …)` scope, so the height rides the active spring.
+    func drivesPanelHeight(_ height: CGFloat) -> some View {
+        modifier(PanelHeightModifier(height: height))
+    }
+}

--- a/Sources/OpenUsage/Views/PopoverScrollView.swift
+++ b/Sources/OpenUsage/Views/PopoverScrollView.swift
@@ -11,8 +11,12 @@ import SwiftUI
 ///
 /// Screen-specific modifiers — scroll position, edge-effect style, `onAppear`, reorder-frame
 /// preferences — are applied by the caller on the returned view, since those differ per screen.
-/// (Self-measuring was removed when the panel became a fixed, user-resizable size: the screens no
-/// longer report their content height since nothing fits the popover to it anymore.)
+///
+/// It also publishes its inner content's ideal height as a `ScrollContentHeightKey` preference so the
+/// popover can auto-fit the window to its content (see `DashboardView`'s coordinated-morph resize). A
+/// vertical `ScrollView` proposes `nil` height to its children, so the measured value is the content's
+/// intrinsic height — invariant to the window/viewport height, which is what keeps the auto-fit from
+/// feeding back on itself. The preference bubbles up past the `ScrollView` to the per-screen wrapper.
 struct PopoverScrollView<Content: View>: View {
     @ViewBuilder let content: Content
 
@@ -20,7 +24,23 @@ struct PopoverScrollView<Content: View>: View {
         ScrollView(.vertical) {
             content
                 .invisibleOverlayScroller()
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(key: ScrollContentHeightKey.self, value: proxy.size.height)
+                    }
+                )
         }
         .scrollBounceBehavior(.basedOnSize)
+    }
+}
+
+/// The intrinsic height of a popover screen's scroll content, published by `PopoverScrollView` and
+/// read per-screen in `DashboardView` to auto-fit the panel. One emitter per screen subtree, so the
+/// reduce just carries the most recent non-zero measurement.
+struct ScrollContentHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        let next = nextValue()
+        if next > 0 { value = next }
     }
 }

--- a/docs/research/popover-auto-resize-research.md
+++ b/docs/research/popover-auto-resize-research.md
@@ -1,0 +1,237 @@
+# Smooth Content-Driven Auto-Resize for the Custom Menu-Bar Panel
+
+**Research report — 2026-06-25**
+**Question:** How do real macOS apps auto-resize a *custom, keyboard-capable* popover to its content smoothly — without (a) resize lag/stutter and (b) the "diagonal" jank when a screen-slide and a window-resize run at the same time — given OpenUsage must keep its custom `NSPanel` for keyboard shortcuts?
+
+---
+
+## Executive Summary
+
+Both failures you hit have **one root cause: two animation clocks fighting.** Your content/slide is animated by SwiftUI's engine; your window frame was animated by AppKit (`KVO(preferredContentSize) → animated setFrame`). Two independent timelines with different curves, started at slightly different moments, produce stutter (clock A and clock B disagree frame-to-frame) and the "diagonal" (a horizontal SwiftUI curve composited against a vertical AppKit curve).
+
+The fix is not a better AppKit resize animation — it is to **make the window a passive follower of a single SwiftUI-owned height value.** You already have the hard part working: your drag-resize is butter-smooth because it pushes `setFrame(display:false)` synchronously, frame-by-frame, fed by a stream of heights from SwiftUI's `DragGesture`. The recommendation is to **generalize that exact path** so the stream of heights comes from SwiftUI's *animation engine* (an interpolated value) instead of the finger. There is then only one clock, so nothing can fight.
+
+This is genuinely hard and there is **no off-the-shelf API for it** — confirmed by surveying real apps: the polished SwiftUI menu-bar app **FontSwitch** uses the identical `canBecomeKey` panel you do and gives up, shipping a *fixed* size [16]; the competing **Claude-Usage-Tracker** gets smooth auto-resize only by using `NSPopover` (whose `animates` property resizes natively [13]) and pays for it with the exact "not legal to call `-layoutSubtreeIfNeeded` on a view which is already being laid out" recursion warning [9]. `NSPopover` stays off the table for you for the documented reason (its window isn't reliably key in an `LSUIElement` app on macOS 26+, breaking Esc/Return/⌘R and the recorder). So you must build the smooth-resize primitive yourself on the panel — and you've already built it for drag.
+
+**Recommendation:** keep the `MenuBarPanel`; delete the manual drag-resize model users disliked; reinstate auto-fit as a *single-clock follower* — measure the content's ideal height with `onGeometryChange`, push it to the panel through your existing synchronous bridge, and drive screen-switch height changes inside the **same** `withAnimation` that drives the slide (a coordinated "morph"), with sequenced resize via `withAnimation(completionCriteria:completion:)` as the conservative fallback. Both are macOS 15+ APIs, within your floor.
+
+---
+
+## 1. Why this specific combination is hard (the landscape)
+
+There are three viable shapes for a SwiftUI menu-bar surface, and each app picks two of the three properties — *keyboard-key window*, *smooth native content-resize*, *no custom resize code*:
+
+- **`NSPopover`** gives smooth native content-resize for free: "Changes to the content size of the popover will cause the popover to animate while it is shown if the `animates` property is YES" [13][12]. But its window is only key while the whole app is active, and activating an `LSUIElement` app is asynchronous (or denied on macOS 26+), so keystrokes land on the status-item button instead — the documented reason OpenUsage abandoned it. Even apps that accept that tradeoff fight friction: Claude-Usage-Tracker's NSPopover+SwiftUI integration throws layout-recursion warnings caused by creating `NSHostingController` during a layout pass, `withAnimation` mutations mid-layout, `GeometryReader`+`.animation` conflicts, and a fixed `contentSize` conflicting with dynamic SwiftUI content [9].
+
+- **Custom `NSPanel` (`canBecomeKey = true`, `.nonactivatingPanel`)** gives a real key window without activating the app — the keyboard works on the first try. This is your panel, and it's the same one FontSwitch uses ("We become key when using the search bar to receive keyboard input" — `FocusablePanel: NSPanel { override var canBecomeKey: Bool { true } }`, then `panel.makeKey()`) [16]. The cost: you lose `NSPopover.animates`. FontSwitch's answer is a **fixed** panel (`panel.setFrame(frame, display: true)` with a stored `panelSize`) [16] — exactly where OpenUsage landed in PR #717.
+
+- **SwiftUI `Window` / `MenuBarExtra(.window)` scene** can auto-resize to content for free (bind content size to state, wrap in `withAnimation`, SwiftUI's layout engine resizes the window) [6]. But the `.window` style has the same non-key limitation as `NSPopover`, so it's out for the same reason.
+
+**Conclusion:** "custom key-window panel" **and** "smooth content auto-resize" is the one pairing nobody gets for free. You must reimplement the resize. The good news is you already have the smooth primitive (your drag), so this is a generalization, not a from-scratch build.
+
+---
+
+## 2. Root-cause mapping of every prior attempt
+
+Your memory and code record five things that were tried and failed. Each maps cleanly to the two-clocks diagnosis:
+
+1. **`KVO(preferredContentSize) → setFrame`, "stuttered on every screen switch."** `NSHostingController.preferredContentSize` updates at AppKit's cadence (it's a constraint-derived size [2][5]), not on SwiftUI's per-frame animation clock. You then animated the window with a *separate* AppKit animation. Two clocks → stutter. Worse, the measurement and the relayout were happening inside the layout pass — the same recursion trap Claude-Usage-Tracker documented [9].
+
+2. **`animator().setFrame` / `NSAnimationContext` animated resize, "janky."** AppKit's implicit layer-bounds animation stretches the layer's *cached* contents during the animation unless `layerContentsRedrawPolicy` is set correctly, and non-layer-friendly setups are driven by repeated `-setFrame:` on the **main thread**, where "animation performance degrades extremely quickly" [1]. Even done perfectly, it's still a *second* clock fighting the SwiftUI slide.
+
+3. **`setFrame(display:false)`, "instant, no glide."** Correct — a bare `setFrame` has no animation driver. The glide has to come from *something* interpolating the height. You had the right primitive but no interpolated source feeding it. This is the key realization: the primitive isn't broken, it was just being fed a step function instead of a curve.
+
+4. **The "diagonal" on settings open.** The slide is a SwiftUI `.offset` on a spring; the resize was an AppKit `setFrame`. Horizontal-SwiftUI-curve × vertical-AppKit-curve, started a beat apart = a diagonal that arrives crooked. Pure two-clock interference.
+
+5. **Drag-resize: smooth.** The one success. Why? `DragGesture.onChanged` is an *event* callback (not inside a layout pass), and it pushes `setFrame(display:false)` + `layoutSubtreeIfNeeded()` + `displayIfNeeded()` synchronously, one height per tick. The finger is the clock; the window follows exactly. **This is the template for the whole solution.**
+
+---
+
+## 3. The recommended architecture: a single-clock follower
+
+Make the panel height a *pure function of a SwiftUI-owned value*, and let SwiftUI's animation engine be the only thing that ever animates. The window never animates itself; it is repainted at the exact size SwiftUI computed for the current frame.
+
+### 3.1 The primitive (generalize your drag)
+
+Your drag already proves the smooth path:
+
+```swift
+// StatusItemController.updateGripResize(by:) — the proven-smooth path
+panel.setFrame(rect, display: false)
+panel.contentView?.layoutSubtreeIfNeeded()
+panel.displayIfNeeded()
+```
+
+Keep this bridge. Change only *who feeds it heights*: instead of `MenuBarPopover.resizeBy(translation)` from a finger, feed it `applyHeight(_:)` from a SwiftUI-interpolated value.
+
+### 3.2 Measuring the content's ideal height
+
+Measure the **content's natural height**, independent of the window's current height, so there is no feedback loop. The modern, layout-safe API is `onGeometryChange` (macOS 15+, within your floor) [10][17]; it monitors geometry without expanding layout the way a bare `GeometryReader` does:
+
+```swift
+// Measure the SCROLL CONTENT (inner VStack), not the viewport, so the value
+// is the ideal height and does not depend on the window height → no feedback loop.
+scrollContent
+    .onGeometryChange(for: CGFloat.self) { proxy in proxy.size.height }
+        action: { ideal in layout.idealHeight[screen] = ideal }
+```
+
+Because width is fixed at 320 and the cards size to their content, offering the content *more* vertical room never changes this measured value — the loop is broken by construction. (Pre-macOS-15 fallback if ever needed: `.background(GeometryReader { Color.clear.preference(...) })` [17].)
+
+### 3.3 Clamp + scroll fallback (NSPopover's contentSize-as-max, rebuilt)
+
+```
+target = clamp(idealHeight, minHeight, maxPanelHeight())   // you already have maxPanelHeight()
+```
+
+When `ideal ≤ maxScreen`, the window fits the content exactly and the `ScrollView` is inert. When `ideal > maxScreen`, the window caps at `maxPanelHeight()` and the scroll engages — which is precisely how `NSPopover.contentSize` behaves ("if your SwiftUI view requests more space than contentSize allows, the bottom is clipped" [12]), only here it scrolls instead of clipping. Keep `maxPanelHeight()` and top-anchoring exactly as today (origin.y = `anchorTopLeft.y - height`, so the panel grows downward from the status item).
+
+### 3.4 Feeding the follower from SwiftUI's animation clock
+
+This is the crux. To get *interpolated* heights (a curve, not a step) without a second clock, mirror the target height into a zero-cost view whose frame SwiftUI animates, and read the in-flight value:
+
+```swift
+// A 0×target probe. When `target` changes inside withAnimation, SwiftUI
+// interpolates this frame height every render tick and fires the action
+// with the interpolated value — the same clock that drives the slide.
+Color.clear
+    .frame(height: animatedTarget)
+    .onGeometryChange(for: CGFloat.self) { $0.size.height }
+        action: { h in MenuBarPopover.applyHeight?(h) }   // → the synchronous bridge
+```
+
+`applyHeight` pushes to the panel. Because the heights come from SwiftUI's interpolation of `animatedTarget`, the window tracks SwiftUI's curve and clock exactly — identical to how the drag tracks the finger. There is no `NSAnimationContext`, no `animator()`, no AppKit timing to mismatch.
+
+> Equivalent mechanism: a custom `Animatable` modifier whose `animatableData` is the height and whose setter calls `applyHeight` — the classic "drive an NSWindow from a SwiftUI animation" trick. Pick whichever reads cleaner; both put SwiftUI in sole control of the clock.
+
+---
+
+## 4. Solving the "diagonal" — two clean options, both now possible
+
+With the window a passive follower, the slide and the resize are no longer two clocks — the question becomes purely *design*: should they move together or in sequence?
+
+**Option A — Coordinated morph (recommended).** Set the height target to the destination screen's ideal height **inside the same `withAnimation` that drives `slideProgress`.** Both pages are already mounted in the slide `HStack`, so both ideal heights are known. The horizontal offset and the window height then animate on one spring; the panel *morphs* (grows/shrinks) as the new screen slides in — one coherent motion. The old "diagonal" was only ugly because the two axes were on different clocks; on one clock it reads as intentional (this is how system surfaces morph). No extra latency.
+
+```swift
+withAnimation(Motion.spring) {
+    slideProgress = 1
+    animatedTarget = idealHeight[destinationScreen] ?? animatedTarget
+}
+```
+
+**Option B — Sequenced (conservative fallback).** Slide at constant height, then resize — using the native completion API (macOS 14+, within your floor) [14][7][15]:
+
+```swift
+withAnimation(.spring, completionCriteria: .removed) {
+    slideProgress = 1
+} completion: {
+    withAnimation { animatedTarget = idealHeight[destinationScreen] ?? animatedTarget }
+}
+```
+
+To avoid clipping mid-slide, grow *before* the slide when the destination is taller, and shrink *after* when it's shorter. This is more deliberate and slightly slower; choose it if the morph feels too busy with the glass cards.
+
+**In-screen content changes** (a provider loads in, a row expands, spend rows toggle) are the pure case: no slide, just `withAnimation { animatedTarget = newIdeal }`. The follower handles it identically — that's the auto-resize users are actually asking to get back.
+
+---
+
+## 5. Code sketch mapped to your files
+
+| File | Change |
+|---|---|
+| `Support/PopoverDismissReader.swift` | Add `static var applyHeight: ((CGFloat) -> Void)?` to the `MenuBarPopover` bridge (same pattern as `beginResize`/`resizeBy`/`dismissHandler`). |
+| `App/StatusItemController.swift` | Implement `applyHeight` to clamp to `maxPanelHeight()` and call the **existing** synchronous `setFrame(display:false)` path (without forcing `layoutSubtreeIfNeeded` from the callback — see §6). Drop `PanelHeightStore`/drag plumbing once auto-fit ships. |
+| `Views/DashboardView.swift` | Add the `Color.clear.frame(height:).onGeometryChange` probe (or `Animatable` modifier). Measure each screen's ideal height on its scroll content. Set the height target inside the existing slide `withAnimation` (Option A) or sequence it (Option B). Remove `resizeDragger` and the `resizingPanel`/`.frame(maxHeight:.infinity)` fill once auto-fit is proven. |
+| `Stores/LayoutStore.swift` | Hold `idealHeight: [PopoverScreen: CGFloat]` (or two simple `@State`s in `DashboardView`). |
+
+The ~120 lines of dead auto-size machinery already flagged for cleanup (`animatedPopoverHeight`, `ScreenHeightReader`, `contentHeight` bindings) should be deleted, not revived — the new path is smaller and clock-unified.
+
+---
+
+## 6. The one pitfall that will bite you: layout reentrancy
+
+The competitor's recursion warning — *"It's not legal to call `-layoutSubtreeIfNeeded` on a view which is already being laid out"* — was caused by doing layout work *during* a layout pass [9]. `onGeometryChange`'s action (and an `Animatable` setter) can fire *inside* SwiftUI's layout. Your drag is safe because `DragGesture.onChanged` is an event callback, not a layout-time callback — so synchronous `layoutSubtreeIfNeeded()` there is fine. To stay safe when the feed is animation-driven:
+
+- In `applyHeight`, call `panel.setFrame(rect, display: false)` and **do not** force `panel.contentView?.layoutSubtreeIfNeeded()` from inside the callback. With top-anchored content at fixed width, growing the window only *reveals* already-laid-out content — there's nothing to relayout, so the synchronous layout call (the part that risks reentrancy) is unnecessary here. Let `displayIfNeeded()` / the normal CA draw cycle paint it.
+- Set the window bounds *explicitly per frame* (no implicit `animator()` animation), so Core Animation never stretches a stale cached layer [1] — each frame the layer is already the right size with the right content.
+- Never create the `NSHostingController` lazily during a resize/layout (you create it once at startup — keep it that way) [9].
+- Guard `applyHeight` with a re-entrancy flag (`isApplyingHeight`) so a frame change can't recursively trigger another.
+
+---
+
+## 7. Alternatives considered and rejected
+
+- **Go back to `NSPopover` for free smooth resize.** Rejected: its window isn't reliably key in your `LSUIElement` app on macOS 26+ (your documented root cause), which breaks the keyboard — the whole reason `MenuBarPanel` exists. NSPopover+SwiftUI also brings its own layout-recursion friction [9]. No-compromise on keyboard means no NSPopover.
+
+- **AppKit Core-Animation resize (`NSAnimationContext` + `animator().setFrame`, `layerContentsRedrawPolicy = .onSetNeedsDisplay`).** This *can* be made smooth in isolation [1], but it is a second clock — it cannot be curve-matched to SwiftUI's spring, so it reintroduces the diagonal. Only viable if you also drove the slide from AppKit, which you don't want. Rejected in favor of the single SwiftUI clock.
+
+- **Keep the manual drag handle.** Rejected: it's the thing users disliked, and it's redundant once auto-fit returns. (A future "pin a max height" power-user option could reuse the bridge, but it's not needed for the core ask.)
+
+- **`MenuBarExtra(.window)` / SwiftUI `Window` scene** for free auto-resize [6]. Rejected: same non-key keyboard limitation as NSPopover.
+
+---
+
+## 8. Verification plan
+
+The popover can't be auto-opened/screenshotted from here, so this needs your eyes, but make it objective:
+
+1. **In-screen resize** (toggle a provider's spend rows on Dashboard): the panel should grow/shrink in one smooth motion, top edge pinned, no card stretch or one-frame clip.
+2. **Screen switch** (Dashboard → Settings, the tall one): with Option A, slide + grow should read as a single morph; with Option B, a clean two-beat. No diagonal, no wobble.
+3. **Screen-cap case** (very tall content / short display): window caps at `maxPanelHeight()` and the inner `ScrollView` engages with no layout fight.
+4. **Reentrancy:** run from Xcode/Console and confirm **zero** "not legal to call `-layoutSubtreeIfNeeded`…" warnings during rapid screen-switch spamming [9].
+5. **Glass:** confirm no white-flash on the `.quaternary` cards during resize — resize is a pure bounds change (no opacity), so the offset-not-transition rule you already rely on still holds.
+6. Add a regression test where it fits (per AGENTS.md): assert `applyHeight` clamps to `[minHeight, maxPanelHeight()]` and that the height target equals the measured ideal below the cap.
+
+---
+
+## 9. Limitations & caveats
+
+This report is grounded in your actual code (mapped by source exploration) plus authoritative AppKit/SwiftUI documentation, primary-source developer blogs, and two directly-analogous open-source apps. The central claim — that a SwiftUI-interpolated value feeding your synchronous `setFrame` bridge will be as smooth as your drag — is a strong inference from (a) your drag already being smooth via that exact bridge and (b) the single-clock principle, **not** a measured result; it must be verified on-device (§8). The reentrancy mitigation (§6) is the highest-risk detail: if dropping the synchronous `layoutSubtreeIfNeeded` from the callback causes a perceptible one-frame content lag during fast animations, the fallback is to keep it but guard against reentrancy with a flag and/or hop the push out of the layout pass — at the cost of slightly more complexity. `onGeometryChange`'s exact firing cadence during animations isn't formally documented [10][17]; if it proves too coarse, the `Animatable`-modifier mechanism gives frame-locked updates. None of these change the architecture — only which knob you turn.
+
+---
+
+## Bibliography
+
+[1] Jonathan Willing. "A short guide to OS X animations." https://jwilling.com/blog/osx-animations/ — `layerContentsRedrawPolicy` (`NSViewLayerContentsRedrawDuringViewResize` vs `OnSetNeedsDisplay`); main-thread `-setFrame:` degradation; CA-on-background-thread.
+
+[2] Apple. "setFrame(_:display:animate:) — NSWindow." https://developer.apple.com/documentation/appkit/nswindow/1419519-setframe
+
+[3] Jonathan Willing. "JNWAnimatableWindow." https://github.com/jwilling/JNWAnimatableWindow — layer-backed NSWindow animation.
+
+[4] Apple. "sizingOptions — NSHostingController." https://developer.apple.com/documentation/swiftui/nshostingcontroller/sizingoptions
+
+[5] Apple. "preferredContentSize — NSHostingController." https://developer.apple.com/documentation/swiftui/nshostingcontroller/preferredcontentsize
+
+[6] Itsuki. "SwiftUI/MacOS: Auto Window/Panel Resizing Based on Some State." https://medium.com/@itsuki.enjoy/swiftui-macos-auto-window-panel-resizing-based-on-some-state-a8f8ffc4182f
+
+[7] Antoine van der Lee. "withAnimation completion callback with animatable modifiers." https://www.avanderlee.com/swiftui/withanimation-completion-callback/
+
+[8] Michael Tsai (quoting Brian Webster). "How NSHostingView Determines Its Sizing." https://mjtsai.com/blog/2023/08/03/how-nshostingview-determines-its-sizing/
+
+[9] hamed-elfayome / Claude-Usage-Tracker, Discussion #64. "Fix: Layout recursion warning in NSPopover/SwiftUI integration." https://github.com/hamed-elfayome/Claude-Usage-Tracker/discussions/64 — `-layoutSubtreeIfNeeded` reentrancy; NSHostingController-during-layout; `withAnimation` mid-pass; GeometryReader+`.animation`; fixed `contentSize` vs dynamic content.
+
+[10] Fatbobman. "4 Ways to Get View Size in SwiftUI: From GeometryReader to onGeometryChange." https://fatbobman.com/en/snippet/how-to-obtain-view-dimensions-in-swiftui/
+
+[11] Apple. "NSPopover." https://developer.apple.com/documentation/appkit/nspopover
+
+[12] Apple. "contentSize — NSPopover." https://developer.apple.com/documentation/appkit/nspopover/1524677-contentsize
+
+[13] Apple. "animates — NSPopover." https://developer.apple.com/documentation/appkit/nspopover/1526527-animates — content-size changes animate while shown when `animates` is YES.
+
+[14] Apple. "withAnimation(_:completionCriteria:_:completion:)." https://developer.apple.com/documentation/swiftui/withanimation(_:completioncriteria:_:completion:)
+
+[15] Paul Hudson. "How to run a completion callback when an animation finishes." https://www.hackingwithswift.com/quick-start/swiftui/how-to-run-a-completion-callback-when-an-animation-finishes
+
+[16] JPToroDev / FontSwitch. https://github.com/JPToroDev/FontSwitch — `FocusablePanel: NSPanel` with `canBecomeKey = true`, `panel.makeKey()`, fixed `panel.setFrame(frame, display: true)`; an analogous SwiftUI+AppKit key-window menu-bar app that ships a fixed panel size.
+
+[17] Apple. "View.onGeometryChange(for:of:action:)." https://developer.apple.com/documentation/swiftui/view/ongeometrychange(for:of:action:)
+
+[18] Cindori. "Make a floating panel in SwiftUI for macOS." https://cindori.com/developer/floating-panel — `FloatingPanel<Content>: NSPanel`, `.nonactivatingPanel`, `canBecomeKey` override; fixed `contentRect` sizing.
+
+[19] Fazm. "SwiftUI Menu Bar App With a Floating Window: Best Practices." https://fazm.ai/blog/swiftui-menu-bar-app-floating-window-best-practices — NSHostingView relayout-per-frame during live resize; `makeKey()` for text fields; status-item positioning.
+
+[20] Apple Developer Forums, thread 665638. "Animating popover size changes." https://developer.apple.com/forums/thread/665638 — confirmed symptom: popover frame changes instantly while inner controls animate awkwardly; SwiftUI `.popover` does not animate the frame even under `withAnimation`.
+
+[21] dboydor / PopoverResize. https://github.com/dboydor/PopoverResize — resizable NSPopover wrapper (min/max + resize callback).
+
+[22] codestudy.net. "SwiftUI: How to Animate View Frame Resize (Transition Between Known Dimensions)." https://www.codestudy.net/blog/swiftui-animate-resize-of-a-view-frame/


### PR DESCRIPTION
## What

Brings back content-driven auto-fit for the menu-bar popover (dropped in #717 for a manual drag-resize) — **without** the old resize stutter or the diagonal jank when the settings slide and the resize ran at once.

Both old failures had one root cause: **two animation clocks fighting** — SwiftUI animating the screen slide while AppKit separately animated the window frame (`KVO(preferredContentSize) → animated setFrame`). This PR makes it **one clock**: SwiftUI owns an animated height and the AppKit panel is a passive follower, so the window resize rides the *same* spring as the slide and morphs in lockstep with it (the "coordinated morph").

The custom key-capable `NSPanel` is kept — `NSPopover` still can't be a reliable key window in this `LSUIElement` app on macOS 26+, so keyboard shortcuts (Esc/Return/⌘R + the recorder) are unaffected.

## How

- **`PanelHeightModifier`** (new) — drives the panel height once per interpolation frame. Built as a `GeometryEffect` so its `Animatable` conformance stays `nonisolated` (a custom `ViewModifier` that implements `body` is inferred `@MainActor`, which would violate `Animatable`). The **mandatory** main-queue hop lives in the `nonisolated` `PanelHeightBridge`: the setter fires inside SwiftUI's layout pass, and a synchronous `setFrame` on the constraint-pinned host re-enters AppKit layout → `_NSDetectedLayoutRecursion`.
- **`DashboardView`** — measures each screen's intrinsic height (scroll content via a `ScrollContentHeightKey` preference + the footer via `onGeometryChange`, summed with the fixed top-bar height), and sets the height target **inside the slide's `withAnimation(Motion.spring)`**. In-screen content changes (a card expands, the pin-limit notice appears) re-target on the same spring. Drag handle removed.
- **`StatusItemController`** — follows via `applyMorphHeight` (top-anchored, delta-guarded), persists **per-screen** opening guesses (flash-free open), and suspends outside-click dismissal while `isMorphing` so a frame moving under the cursor isn't read as an outside click. Grip-resize bridge and dead fixed-size plumbing removed.
- `docs/research/` captures the investigation (real-app survey, the reentrancy and feedback-loop analysis) behind the approach.

## Verification

- Builds clean (debug + release + tests); release bundle stamped for Liquid Glass controls.
- Launches and runs stable — **no `_NSDetectedLayoutRecursion`, no crash**.
- **437/437 tests pass** (1 skipped, 0 failures).
- Verified live on-device: screen-switch morph, in-screen resize, open paths, outside-click during morph, keyboard intact.

## Known follow-ups (separate issues, not blockers)

- #728 — the Customize screen still feels slightly laggy (reorder-preference / animation churn); profile & optimize.
- #729 — rethink the Customize/Settings header layout (centered-title convention).

## Notes

- Kept the existing `minPanelHeight = 480` floor for v1 (deferred); short/empty content may show some dead space — easy to lower after eyeballing.
- The morph is simultaneous (slide + grow on one spring). A sequenced fallback (`withAnimation(completionCriteria:)`) is available if simultaneous ever feels busy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core panel show/hide, sizing, and dismissal with async height bridging and layout reentrancy guards; keyboard-capable NSPanel path is unchanged but regressions in morph timing or outside-click behavior would be user-visible.
> 
> **Overview**
> Restores **content-driven auto-fit** for the menu-bar popover and removes the manual footer resize grip from #717. SwiftUI owns a single animated height (`PanelHeightModifier` / `drivesPanelHeight`); the AppKit panel follows each interpolated frame via `MenuBarPopover.applyHeight` and synchronous `setFrame(display:false)`—no second AppKit resize animation.
> 
> **`DashboardView`** measures per-screen ideal height (scroll content preference + footer geometry), co-animates height with the screen slide on one spring, and re-targets when in-screen content changes. **`StatusItemController`** adds morph settle persistence **per screen** (dashboard / customize / settings), invalidates stale bridge callbacks on open/close, and pauses outside-click dismissal while `isMorphing`. **`PopoverScrollView`** publishes intrinsic scroll height again for auto-fit.
> 
> Adds `docs/research/popover-auto-resize-research.md` documenting the two-clock root cause and approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e2d5096102a19a9cd56c83abeb1cae21a5c959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->