### PR TITLE
fix(settings): rename Startup→General, Menu Style→Icon Style

### DIFF
--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -40,7 +40,7 @@ struct SettingsScreen: View {
         @Bindable var updater = updater
         // Same section rhythm as the dashboard and Customize (all read the density setting).
         return VStack(alignment: .leading, spacing: density.sectionSpacing) {
-            section("Startup") {
+            section("General") {
                 row("Launch at Login") {
                     Toggle("", isOn: $launchAtLogin)
                         .settingsSwitchStyle()
@@ -75,7 +75,7 @@ struct SettingsScreen: View {
                 }
             }
             section("Appearance") {
-                row("Menu Style") {
+                row("Icon Style") {
                     picker($layout.menuBarStyle, options: MenuBarStyle.allCases, label: \.label)
                 }
                 row("Theme") {
@@ -174,7 +174,7 @@ struct SettingsScreen: View {
                 logActionError = nil
             }
             if let logActionError {
-                // Same orange inline-notice idiom as the Startup section's error line.
+                // Same orange inline-notice idiom as the General section's error line.
                 Text(logActionError)
                     .font(.caption)
                     .foregroundStyle(Theme.notice)


### PR DESCRIPTION
Tweaks settings copy:

- **Startup → General** — renamed the section (now covers Launch at Login + Global Shortcut).
- **Menu Style → Icon Style** — clearer label for the menu-bar icon picker.

Launch at Login and Global Shortcut copy left unchanged. Default log level confirmed as Info (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible label and comment changes only; no logic or persistence changes.
> 
> **Overview**
> Renames two settings labels in the in-popover **Settings** screen for clearer copy.
> 
> The first section header changes from **Startup** to **General** (still groups Launch at Login and Global Shortcut). Under **Appearance**, the row label **Menu Style** becomes **Icon Style** for the menu-bar icon picker. A comment in the Advanced logging block is updated to refer to the General section instead of Startup.
> 
> No behavior, bindings, or layout changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d27c477782774d661812fcbaf291c208488e9f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->