### PR TITLE
Centered Customize/Settings header + per-provider reset menu (#729)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,4 @@ Always fail loudly into error logging and show friendly errors to the user. Do n
 
 - Use title case for any hardcoded copy used as a title.
 - Match the existing design language; OpenUsage has a specific look and feel.
+- Only add tooltips (`hoverTooltip`) when explicitly asked to. Don't add them proactively to new controls.

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -18,12 +18,15 @@ final class AppContainer {
     private let refreshTask: Task<Void, Never>
 
     init() {
+        // Alphabetical by display name — this registry order is the default provider order
+        // (`LayoutStore.orderedProviderIDs` falls back to it, and `resetToDefault` seeds it), so the
+        // dashboard, Customize sections, and the per-provider reset menu all read alphabetically.
         let providers: [ProviderRuntime] = [
             ClaudeProvider(),
             CodexProvider(),
+            CursorProvider(),
             DevinProvider(),
-            GrokProvider(),
-            CursorProvider()
+            GrokProvider()
         ]
         let registry = WidgetRegistry.from(providers)
         let enablement = ProviderEnablementStore()

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -13,13 +13,13 @@ enum DefaultLayout {
         "codex.session", "codex.weekly", "codex.trend",
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
 
+        "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend",
+        "cursor.onDemand", "cursor.today", "cursor.yesterday", "cursor.last30",
+
         "devin.daily", "devin.weekly", "devin.extra",
 
         "grok.creditsUsed", "grok.trend",
-        "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30",
-
-        "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend",
-        "cursor.onDemand", "cursor.today", "cursor.yesterday", "cursor.last30"
+        "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30"
     ]
 
     /// Frozen snapshot of the default-on metrics from the release that introduced default seeding.
@@ -59,9 +59,9 @@ enum DefaultLayout {
     static let expandedMetricIDs: [String] = [
         "claude.sonnet", "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
-        "devin.extra",
-        "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30",
         "cursor.onDemand", "cursor.requests", "cursor.credits",
-        "cursor.today", "cursor.yesterday", "cursor.last30"
+        "cursor.today", "cursor.yesterday", "cursor.last30",
+        "devin.extra",
+        "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30"
     ]
 }

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -666,6 +666,50 @@ final class LayoutStore {
         persist()
     }
 
+    /// Reset a single provider's customization to default — its enabled metrics, metric order, pins,
+    /// and expanded (caret) membership — while leaving every other provider, and the overall provider
+    /// order, untouched. The per-provider counterpart to `resetToDefault` ("Reset all providers"): same
+    /// per-provider effect, scoped to one `providerID` instead of the whole layout. No-op for an
+    /// unknown provider.
+    func resetProvider(_ providerID: String) {
+        guard registry.provider(id: providerID) != nil else { return }
+        cancelDrag()
+
+        // This provider's descriptor universe — the membership sets below are all scoped to it.
+        let owned = Set(registry.descriptors(for: providerID).map(\.id))
+        func defaults(_ ids: [String]) -> [String] {
+            ids.filter { owned.contains($0) && registry.descriptor(id: $0) != nil }
+        }
+
+        // Enabled metrics: drop this provider's placed widgets, re-seed its default-on set. Other
+        // providers' widgets keep their identity and position; `syncPlacedOrder` re-sorts the whole
+        // list by provider + metric order at the end.
+        placed = placed.filter { !owned.contains($0.descriptorID) }
+            + defaults(defaultMetricIDs).map { PlacedWidget(descriptorID: $0) }
+
+        // Metric order back to registry order for this provider only.
+        metricOrderByProvider[providerID] = registry.descriptors(for: providerID).map(\.id)
+        persistMetricOrder()
+
+        // Pins, expanded membership, and the default-expanded-on-enable carry: swap this provider's
+        // entries for its defaults, leaving the rest of each set intact.
+        pinnedMetricIDs.subtract(owned)
+        pinnedMetricIDs.formUnion(defaults(defaultPinnedMetricIDs))
+        persistPins()
+
+        expandedMetricIDs.subtract(owned)
+        expandedMetricIDs.formUnion(defaults(defaultExpandedMetricIDs))
+        defaultExpandedOnEnableIDs.subtract(owned)
+        persistExpanded()
+
+        // Default is a collapsed card.
+        if expandedProviderIDs.remove(providerID) != nil {
+            persistExpandedProviders()
+        }
+
+        syncPlacedOrder() // persists `placed`
+    }
+
     func cancelDrag() {
         draggingID = nil
     }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -20,7 +20,6 @@ struct DashboardView: View {
     @Environment(WidgetDataStore.self) private var dataStore
     @State private var didInitialRefresh = false
     @State private var reorderLift: ReorderLift?
-    @State private var showingResetCustomizationConfirmation = false
     /// The panel height SwiftUI drives — the single animation clock. `PanelHeightModifier` follows it
     /// frame-by-frame onto the AppKit panel, so the window resize rides the same spring as the screen
     /// slide (no second AppKit animation to fight). 0 means "not established yet": the panel keeps the
@@ -387,13 +386,23 @@ struct DashboardView: View {
     /// `barGlass()` (Liquid Glass) background lenses the content scrolling under it — the same
     /// content-aware glass as the footer.
     private func navBar(title: String, showsReset: Bool = false) -> some View {
-        HStack(spacing: 10) {
-            backButton
+        // Centered title with the back control floating leading and the reset menu trailing — the macOS
+        // toolbar convention (leading navigation · centered title · trailing actions). The title is
+        // centered against the *full* bar width (a ZStack layer, not an HStack slot) so it stays
+        // optically centered regardless of the leading/trailing control widths, and both flanks are
+        // matching circular glass controls.
+        ZStack {
             Text(title)
                 .font(.headline)
-            Spacer(minLength: 8)
-            if showsReset {
-                resetCustomizationButton
+                .lineLimit(1)
+                .frame(maxWidth: .infinity)
+
+            HStack(spacing: 0) {
+                backButton
+                Spacer(minLength: 8)
+                if showsReset {
+                    resetMenu
+                }
             }
         }
         .padding(.horizontal, Self.footerHorizontalPadding)
@@ -401,18 +410,6 @@ struct DashboardView: View {
         .frame(maxWidth: .infinity)
         // Same content-aware Liquid Glass as the footer (`barGlass`) — the matching top/bottom chrome.
         .barGlass()
-        .confirmationDialog(
-            "Reset Customization?",
-            isPresented: $showingResetCustomizationConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button("Reset", role: .destructive) {
-                layout.resetToDefault()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This restores the default metrics, order, and menu-bar pins. Provider settings are unchanged.")
-        }
     }
 
     /// The round glass back button (chevron leading), matching the footer's glass control idiom. Esc
@@ -432,17 +429,48 @@ struct DashboardView: View {
         .accessibilityLabel("Back")
     }
 
-    private var resetCustomizationButton: some View {
-        Button {
-            showingResetCustomizationConfirmation = true
+    /// The trailing "More" pull-down on the Customize header: a circular glass control mirroring the
+    /// leading back chevron, holding a per-provider reset for each provider plus "Reset all providers".
+    /// Resets are secondary, occasional actions — the macOS toolbar convention routes those into a More
+    /// menu rather than giving each a prominent bar button. Glass goes on the container via
+    /// `interactiveGlass(in: Circle())` with a `.plain`/`.menuStyle(.button)` menu: the system
+    /// `.buttonStyle(.glass)` renders flat on a `Menu` (its own chrome wins), so this matches the
+    /// footer's split-button idiom (`HeaderView`).
+    private var resetMenu: some View {
+        Menu {
+            resetMenuItems
         } label: {
-            Label("Reset", systemImage: "arrow.counterclockwise")
-                .labelStyle(.titleAndIcon)
+            Image(systemName: "ellipsis")
+                .font(.system(size: 13, weight: .semibold))
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
         }
-        .glassButtonStyle()
-        .controlSize(.small)
-        .hoverTooltip("Reset Customization")
-        .accessibilityLabel("Reset Customization")
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .interactiveGlass(in: Circle())
+        .accessibilityLabel("Reset")
+    }
+
+    /// One "Reset <Provider>" per provider currently shown in Customize (so the list tracks the enabled
+    /// providers and stays in the alphabetical registry order), then "Reset all providers" below a
+    /// divider. Per-provider items reset that provider's contents only; "Reset all" (destructive) is the
+    /// full `resetToDefault`, including provider order. No confirmation — a menu pick isn't a misfire,
+    /// and the destructive role flags the all-providers item.
+    @ViewBuilder
+    private var resetMenuItems: some View {
+        ForEach(layout.customizeGroups, id: \.provider.id) { group in
+            Button("Reset \(group.provider.displayName)") {
+                withAnimation(Motion.spring) { layout.resetProvider(group.provider.id) }
+            }
+        }
+
+        Divider()
+
+        Button("Reset all providers", role: .destructive) {
+            withAnimation(Motion.spring) { layout.resetToDefault() }
+        }
     }
 
     // MARK: - Pinned footer

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -96,15 +96,16 @@ struct HeaderView: View {
 
     /// The chevron's overflow items, mirroring their in-popover entry points. `autoenablesItems` has no
     /// SwiftUI equivalent, so the Check for Updates item disables itself when Sparkle can't currently
-    /// check — e.g. dev builds with no feed, or while a check is already in flight. Customize also rides
-    /// ⏎ (and right-clicking the dashboard); the always-on `PopoverKeyReader` monitor handles ⏎ while
-    /// the menu is closed (and consumes it), so it's not registered on this item — the menu entry is the
-    /// discoverable label, the drag/right-click affordances are the everyday path.
+    /// check — e.g. dev builds with no feed, or while a check is already in flight. Customize carries its
+    /// bare-⏎ key equivalent so the menu shows the shortcut: when the menu is open the item handles ⏎;
+    /// when it's closed the `PopoverDismissReader` monitor handles (and consumes) ⏎ first, so the item's
+    /// equivalent can't double-fire. Same split as the old Settings ⌘, item / the Quit ⌘Q item below.
     @ViewBuilder
     private var moreMenuItems: some View {
         Button { toggle(.customize) } label: {
             Label("Customize", systemImage: "slider.horizontal.3")
         }
+        .keyboardShortcut(.return, modifiers: [])
         Button { updater.checkForUpdates() } label: {
             Label("Check for Updates…", systemImage: "arrow.triangle.2.circlepath")
         }

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -700,6 +700,60 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertFalse(store.isProviderExpanded("codex"))
     }
 
+    func testResetProviderRestoresOneProviderAndLeavesOthersAndOrderUntouched() {
+        let defaults = makeDefaults("ResetOneProvider")
+        let store = LayoutStore(
+            registry: .mock,
+            defaults: defaults,
+            storageKey: "layout",
+            defaultMetricIDs: ["claude.session", "codex.session"],
+            migrationBaselineMetricIDs: [],
+            defaultPinnedMetricIDs: ["claude.session", "codex.session"],
+            defaultExpandedMetricIDs: []
+        )
+
+        // Reorder providers first, so we can prove a per-provider reset leaves provider order alone.
+        store.reorderProvider(dragged: "cursor", target: "claude")
+        let orderBefore = store.customizeGroups.map(\.provider.id)
+
+        // Diverge Claude from its defaults in every dimension a reset should restore.
+        store.setMetricEnabled("claude.weekly", true)
+        store.setPinned(true, for: "claude.weekly")
+        store.setProviderExpanded(true, for: "claude")
+        store.reorderMetric(dragged: "claude.extra", target: "claude.session", in: "claude")
+
+        // Diverge Codex too — a Claude reset must not touch it.
+        store.setMetricEnabled("codex.weekly", true)
+        store.setPinned(true, for: "codex.weekly")
+
+        store.resetProvider("claude")
+
+        // Claude restored: enabled set, metric order, pins, and expanded state back to default.
+        XCTAssertTrue(store.isMetricEnabled("claude.session"))
+        XCTAssertFalse(store.isMetricEnabled("claude.weekly"))
+        XCTAssertTrue(store.isPinned("claude.session"))
+        XCTAssertFalse(store.isPinned("claude.weekly"))
+        XCTAssertFalse(store.isProviderExpanded("claude"))
+        XCTAssertEqual(
+            store.orderedSupportedMetrics(for: "claude").map(\.id),
+            MockData.descriptors(for: "claude").map(\.id)
+        )
+
+        // Codex untouched by a Claude-only reset.
+        XCTAssertTrue(store.isMetricEnabled("codex.weekly"))
+        XCTAssertTrue(store.isPinned("codex.weekly"))
+
+        // Provider order untouched — contents-only reset.
+        XCTAssertEqual(store.customizeGroups.map(\.provider.id), orderBefore)
+    }
+
+    func testResetProviderIsNoOpForUnknownProvider() {
+        let store = makeStore("ResetUnknownProvider")
+        let before = store.placed.map(\.descriptorID)
+        store.resetProvider("nope")
+        XCTAssertEqual(store.placed.map(\.descriptorID), before)
+    }
+
     private func makeStore(_ name: String) -> LayoutStore {
         LayoutStore(registry: .mock, defaults: makeDefaults(name), storageKey: "layout")
     }


### PR DESCRIPTION
Closes #729.

Reworks the Customize/Settings top bar to the macOS toolbar convention and rethinks the reset affordance, per the issue's ask and the Apple HIG (Toolbars/Buttons, Liquid Glass guidance).

<img width="371" height="63" alt="image" src="https://github.com/user-attachments/assets/ba3c4821-307d-4ec2-b301-574afc4b1b8a" />

<img width="488" height="224" alt="image" src="https://github.com/user-attachments/assets/fb56ef30-a87e-4754-9c0c-e211837b4171" />

## Header
- **Centered title** with the back chevron floating leading and a trailing actions menu — the title is centered against the full bar width (a `ZStack` layer, not an `HStack` slot), so it stays optically centered regardless of the leading/trailing control widths. Both flanks are matching **circular glass** controls.
- Height stays a fixed **44pt**, so the auto-fit measurement (`recomposeIdeal`) is untouched.
- Back affordance stays the chevron symbol (HIG: use the standard Back symbol, not a "Back"/"Done" text label). Esc + ⌘ shortcuts unchanged.

## Reset → trailing "…" glass menu
Reset moves out of a prominent labeled button into a trailing **`…` glass menu** — the HIG routes secondary/occasional and destructive actions into a More menu rather than giving each a prominent bar button. Built with the codebase's canonical glass-`Menu` pattern (`interactiveGlass(in: Circle())` + `.plain`/`.menuStyle(.button)`, since `.buttonStyle(.glass)` flattens menus).

Items (generated from the registry, so the list tracks providers and stays alphabetical — no hardcoded list):

```
Reset Claude
Reset Codex
Reset Cursor
Reset Devin
Reset Grok
──────────────
Reset all providers   (destructive)
```

- New `LayoutStore.resetProvider(_:)` — a **contents-only** reset (enabled metrics, metric order, pins, expanded state) that leaves other providers **and the overall provider order** untouched.
- **Reset all providers** remains the full `resetToDefault` (including provider order).
- **No confirmation dialogs** (per owner decision); the destructive role flags the all-providers item.

## Alphabetical provider order
The default provider order is now **Claude, Codex, Cursor, Devin, Grok** in the registry (`AppContainer`) and `DefaultLayout`, so the dashboard, Customize sections, and the reset menu all read alphabetically. `migrationBaselineMetricIDs` left frozen (it's a Set comparison baseline).

## Customize shortcut regression (separate commit)
#726 moved Customize into the footer More menu but dropped its key equivalent, so the menu stopped showing the shortcut. Re-registers the bare-`⏎` equivalent on the item — safe against double-fire because of the existing menu-open/closed split the `PopoverDismissReader` monitor relies on (monitor handles ⏎ when the menu is closed and consumes it first; the item handles it when the menu is open). Same pattern as the Quit `⌘Q` item.

## Tests
- `testResetProviderRestoresOneProviderAndLeavesOthersAndOrderUntouched`
- `testResetProviderIsNoOpForUnknownProvider`
- Full suite green: **438 tests, 0 failures** (1 pre-existing skip).

## Verification note
Code builds and runs (signed dev build). I could not screenshot the popover myself — driving a menu-bar status item needs Accessibility permission the headless terminal lacks. Worth an eyeball before merge:
- the `…` circle visually matches the back-chevron diameter (sized at 28pt; tunable);
- the Customize menu item shows the `↩` glyph and Return still toggles once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Layout resets change persisted user customization (now without confirmation), and default provider ordering shifts for fresh installs and full resets—behavior users may notice, though migration baseline is unchanged.
> 
> **Overview**
> Reworks the **Customize** top bar to a macOS-style toolbar: **centered title** in a `ZStack`, circular glass **back** control on the leading edge, and a trailing **`…` menu** instead of a labeled Reset button and confirmation dialog.
> 
> The menu lists **Reset &lt;Provider&gt;** for each enabled Customize group (registry order) plus a destructive **Reset all providers**. **`LayoutStore.resetProvider(_:)`** restores one provider’s enabled metrics, metric order, pins, expanded/caret membership, and collapsed card state without changing other providers or **provider order**; **Reset all** still calls **`resetToDefault`**.
> 
> **Default provider order** is now alphabetical (**Claude, Codex, Cursor, Devin, Grok**) in **`AppContainer`** and **`DefaultLayout`** so dashboard, Customize, and the reset menu stay consistent. **`AGENTS.md`** adds a rule to avoid proactive **`hoverTooltip`** on new controls.
> 
> **`HeaderView`** restores the bare **Return** key equivalent on the footer **Customize** menu item so the shortcut shows in the menu without double-firing when the menu is closed. Regression tests cover **`resetProvider`** scoping and no-ops for unknown IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f66be7895a3d948f3aac0af92f97272c3fba45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->