### PR TITLE
feat(telemetry): anonymous opt-out PostHog usage analytics

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4b4208cc6b66e4d67f41cea4f49a97ebfcd34ff72df211453cb16820565e606a",
+  "originHash" : "d6ab79cc97b8f7cbcc3ed979a86ab577b61a7583e177eaa7c3aec62d26d4ca03",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios.git",
+      "state" : {
+        "revision" : "9fcdb83e79b155c0dae104eadf5c269079dcbddb",
+        "version" : "3.62.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,14 +13,17 @@ let package = Package(
         // The de-facto standard recorder + global hotkey for Mac apps (System Settings-style field).
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.4.0"),
         // In-app auto-updates (appcast + EdDSA-signed downloads). 2.8+ adds macOS 26 Tahoe support.
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.3")
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.3"),
+        // Anonymous, opt-out product analytics (official, MIT-licensed, first-party Swift SDK).
+        .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.62.0")
     ],
     targets: [
         .executableTarget(
             name: "OpenUsage",
             dependencies: [
                 .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
-                .product(name: "Sparkle", package: "Sparkle")
+                .product(name: "Sparkle", package: "Sparkle"),
+                .product(name: "PostHog", package: "posthog-ios")
             ],
             path: "Sources/OpenUsage",
             resources: [

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -60,11 +60,18 @@ final class AppContainer {
             sink: PostHogTelemetrySink(enabled: telemetryStore.enabled),
             store: telemetryStore,
             snapshot: { [registry, enablement, layout] in
-                TelemetryConfigSnapshot(
+                // Report the *active* configuration: a metric whose provider is turned off is hidden
+                // from the dashboard and menu bar, so exclude it here too — keeping the metric arrays
+                // consistent with `enabledProviders` (which is also enablement-filtered).
+                let providerOn: (String) -> Bool = { metricID in
+                    guard let providerID = registry.descriptor(id: metricID)?.providerID else { return false }
+                    return enablement.isEnabled(providerID)
+                }
+                return TelemetryConfigSnapshot(
                     enabledProviders: registry.providers.map(\.id).filter { enablement.isEnabled($0) },
-                    enabledMetricIDs: layout.placed.map(\.descriptorID),
-                    pinnedMetricIDs: Array(layout.pinnedMetricIDs),
-                    expandedMetricIDs: Array(layout.expandedMetricIDs),
+                    enabledMetricIDs: layout.placed.map(\.descriptorID).filter(providerOn),
+                    pinnedMetricIDs: layout.pinnedMetricIDs.filter(providerOn),
+                    expandedMetricIDs: layout.expandedMetricIDs.filter(providerOn),
                     menuBarStyle: layout.menuBarStyle.rawValue
                 )
             }

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -12,6 +12,9 @@ final class AppContainer {
     /// Single source of truth for which providers the user has turned off. Both stores consult it (via
     /// injected closures) and the Providers settings tab drives it.
     let enablement: ProviderEnablementStore
+    /// Anonymous, opt-out usage telemetry (daily rollups). Exposed so Settings can toggle it and the
+    /// app-termination hook can flush any queued events.
+    let telemetry: TelemetryRecorder
     /// Read-only usage API on 127.0.0.1:6736 for other local apps (silently off when the port is taken).
     private let localAPI: LocalUsageServer
     // A `let` of a `Sendable` `Task` is implicitly nonisolated, so the nonisolated `deinit` can cancel it.
@@ -47,6 +50,29 @@ final class AppContainer {
         self.enablement = enablement
         self.layout = layout
         self.dataStore = dataStore
+
+        // Anonymous, opt-out usage telemetry (two daily-rollup events). Its state lives in a dedicated
+        // UserDefaults suite so the user's opt-out choice and the install id survive BetaSettingsReset's
+        // standard-domain wipe on every beta bump. The snapshot closure reads the live layout/enablement
+        // so `app_daily_active` always reflects the current configuration.
+        let telemetryStore = TelemetryStore()
+        let telemetry = TelemetryRecorder(
+            sink: PostHogTelemetrySink(enabled: telemetryStore.enabled),
+            store: telemetryStore,
+            snapshot: { [registry, enablement, layout] in
+                TelemetryConfigSnapshot(
+                    enabledProviders: registry.providers.map(\.id).filter { enablement.isEnabled($0) },
+                    enabledMetricIDs: layout.placed.map(\.descriptorID),
+                    pinnedMetricIDs: Array(layout.pinnedMetricIDs),
+                    expandedMetricIDs: Array(layout.expandedMetricIDs),
+                    menuBarStyle: layout.menuBarStyle.rawValue
+                )
+            }
+        )
+        dataStore.onRefreshOutcome = { [weak telemetry] providerID, outcome, category, manual in
+            telemetry?.record(providerID: providerID, outcome: outcome, category: category, manual: manual)
+        }
+        self.telemetry = telemetry
         self.localAPI = LocalUsageServer(state: { [layout, enablement, dataStore] in
             LocalUsageAPI.State(
                 enabledOrderedIDs: layout.providerOrder.filter { enablement.isEnabled($0) },
@@ -54,7 +80,7 @@ final class AppContainer {
                 snapshots: dataStore.snapshots
             )
         })
-        self.refreshTask = Self.startPeriodicRefresh(dataStore: dataStore)
+        self.refreshTask = Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry)
         localAPI.start()
     }
 
@@ -64,10 +90,14 @@ final class AppContainer {
     /// cache, so it only hits the network once a snapshot has actually expired. `@Observable` propagates
     /// the resulting snapshot changes to the menu-bar label and any open widgets, so the UI refreshes on
     /// its own instead of only when the popover opens.
-    private static func startPeriodicRefresh(dataStore: WidgetDataStore) -> Task<Void, Never> {
+    private static func startPeriodicRefresh(dataStore: WidgetDataStore, telemetry: TelemetryRecorder) -> Task<Void, Never> {
         Task {
             while !Task.isCancelled {
                 await dataStore.refreshAll()
+                // Day-rollover beat: emits `app_daily_active` once per local day and flushes any
+                // prior-day provider rollups. Runs on launch and every interval, so always-running
+                // instances still produce a daily-active signal.
+                telemetry.tick()
                 await waitForNextRefresh()
             }
         }

--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -54,4 +54,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Starts background update checks (release build only; dormant under preview/`swift run`).
         updater.start()
     }
+
+    /// Flush queued telemetry on quit. The SDK's lifecycle autocapture is off (we emit our own daily
+    /// rollups), so it won't auto-flush on termination — this explicit flush keeps low-frequency events
+    /// from being stranded across a clean quit.
+    func applicationWillTerminate(_ notification: Notification) {
+        container?.telemetry.flush()
+    }
 }

--- a/Sources/OpenUsage/Models/ProviderSnapshot.swift
+++ b/Sources/OpenUsage/Models/ProviderSnapshot.swift
@@ -7,19 +7,24 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
     var plan: String?
     var lines: [MetricLine]
     var refreshedAt: Date
+    /// Set only on error snapshots: a stable, non-PII bucket for the failure, read by telemetry on the
+    /// failure path. Always `nil` on success (and error snapshots aren't cached), so it never persists.
+    var errorCategory: ErrorCategory?
 
     init(
         providerID: String,
         displayName: String,
         plan: String? = nil,
         lines: [MetricLine],
-        refreshedAt: Date = Date()
+        refreshedAt: Date = Date(),
+        errorCategory: ErrorCategory? = nil
     ) {
         self.providerID = providerID
         self.displayName = displayName
         self.plan = plan
         self.lines = lines
         self.refreshedAt = refreshedAt
+        self.errorCategory = errorCategory
     }
 
     func line(label: String) -> MetricLine? {
@@ -39,11 +44,24 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
         )
     }
 
-    static func error(provider: Provider, message: String) -> ProviderSnapshot {
+    /// Build an error snapshot straight from a caught error: the badge text stays the error's
+    /// user-facing `localizedDescription` (UI copy is unchanged), and the telemetry category is derived
+    /// from the error's `CategorizedError` conformance (falling back to `.other` for anything that
+    /// doesn't classify itself). Preferred over `error(provider:message:)` wherever an `Error` is in hand.
+    static func error(provider: Provider, error: Error) -> ProviderSnapshot {
+        Self.error(
+            provider: provider,
+            message: error.localizedDescription,
+            category: (error as? CategorizedError)?.errorCategory ?? .other
+        )
+    }
+
+    static func error(provider: Provider, message: String, category: ErrorCategory? = nil) -> ProviderSnapshot {
         ProviderSnapshot(
             providerID: provider.id,
             displayName: provider.displayName,
-            lines: [.badge(label: MetricLine.errorBadgeLabel, text: message, colorHex: "#EF4444")]
+            lines: [.badge(label: MetricLine.errorBadgeLabel, text: message, colorHex: "#EF4444")],
+            errorCategory: category
         )
     }
 }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -36,7 +36,7 @@ final class ClaudeProvider: ProviderRuntime {
             .filter { $0.oauth.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
         guard !candidates.isEmpty else {
             AppLog.info(LogTag.auth("claude"), "no access token, not logged in")
-            return ProviderSnapshot.error(provider: provider, message: ClaudeAuthError.notLoggedIn.localizedDescription)
+            return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.notLoggedIn)
         }
 
         AppLog.info(LogTag.plugin("claude"), "refresh start (\(candidates.count) credential source\(candidates.count == 1 ? "" : "s"))")
@@ -56,12 +56,12 @@ final class ClaudeProvider: ProviderRuntime {
                 lastFallbackError = error
                 continue
             } catch {
-                return ProviderSnapshot.error(provider: provider, message: error.localizedDescription)
+                return ProviderSnapshot.error(provider: provider, error: error)
             }
         }
         return ProviderSnapshot.error(
             provider: provider,
-            message: (lastFallbackError ?? ClaudeAuthError.notLoggedIn).localizedDescription
+            error: lastFallbackError ?? ClaudeAuthError.notLoggedIn
         )
     }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -42,7 +42,7 @@ final class CodexProvider: ProviderRuntime {
                 lastFallbackError = error
                 continue
             } catch {
-                return ProviderSnapshot.error(provider: provider, message: error.localizedDescription)
+                return ProviderSnapshot.error(provider: provider, error: error)
             }
         }
 
@@ -50,14 +50,14 @@ final class CodexProvider: ProviderRuntime {
             do {
                 return try await probe(authState: keychainCandidate)
             } catch {
-                return ProviderSnapshot.error(provider: provider, message: error.localizedDescription)
+                return ProviderSnapshot.error(provider: provider, error: error)
             }
         }
 
         if let lastFallbackError {
-            return ProviderSnapshot.error(provider: provider, message: lastFallbackError.localizedDescription)
+            return ProviderSnapshot.error(provider: provider, error: lastFallbackError)
         }
-        return ProviderSnapshot.error(provider: provider, message: CodexAuthError.notLoggedIn.localizedDescription)
+        return ProviderSnapshot.error(provider: provider, error: CodexAuthError.notLoggedIn)
     }
 
     private func probe(authState initialState: CodexAuthState) async throws -> ProviderSnapshot {

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -33,13 +33,13 @@ final class CursorProvider: ProviderRuntime {
 
     func refresh() async -> ProviderSnapshot {
         guard let state = await loadOffMainActor({ [authStore] in authStore.loadAuthState() }) else {
-            return ProviderSnapshot.error(provider: provider, message: CursorAuthError.notLoggedIn.localizedDescription)
+            return ProviderSnapshot.error(provider: provider, error: CursorAuthError.notLoggedIn)
         }
 
         do {
             return try await probe(authState: state)
         } catch {
-            return ProviderSnapshot.error(provider: provider, message: error.localizedDescription)
+            return ProviderSnapshot.error(provider: provider, error: error)
         }
     }
 

--- a/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
@@ -63,7 +63,7 @@ final class DevinProvider: ProviderRuntime {
         if sawAPIKey {
             return ProviderSnapshot.error(provider: provider, error: DevinUsageError.quotaUnavailable)
         }
-        return ProviderSnapshot.error(provider: provider, message: DevinAuthError.notLoggedIn.localizedDescription)
+        return ProviderSnapshot.error(provider: provider, error: DevinAuthError.notLoggedIn)
     }
 
     private func attempt(auth: DevinAuth) async -> DevinAuthAttempt {

--- a/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
@@ -58,10 +58,10 @@ final class DevinProvider: ProviderRuntime {
         }
 
         if sawAuthFailure {
-            return ProviderSnapshot.error(provider: provider, message: DevinAuthError.notLoggedIn.localizedDescription)
+            return ProviderSnapshot.error(provider: provider, error: DevinAuthError.notLoggedIn)
         }
         if sawAPIKey {
-            return ProviderSnapshot.error(provider: provider, message: DevinUsageError.quotaUnavailable.localizedDescription)
+            return ProviderSnapshot.error(provider: provider, error: DevinUsageError.quotaUnavailable)
         }
         return ProviderSnapshot.error(provider: provider, message: DevinAuthError.notLoggedIn.localizedDescription)
     }

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// A stable, machine-readable bucket for a refresh failure, so telemetry can group "what kind of
+/// errors happen" without sending the free-form (localized, user-facing) error message — which is not
+/// groupable and risks leaking detail. Every provider error enum maps its cases to one of these via
+/// `CategorizedError`; the raw values are the strings reported to telemetry, so keep them stable.
+///
+/// `notLoggedIn` is split out deliberately: a large share of refresh "failures" are simply providers
+/// the user has not authenticated, which is expected noise rather than a bug — keeping it as its own
+/// category lets analysis filter it out.
+enum ErrorCategory: String, Sendable, CaseIterable, Codable {
+    case notLoggedIn = "not_logged_in"
+    /// A previously-valid credential went bad (expired / revoked / conflicting session).
+    case authExpired = "auth_expired"
+    /// Auth is structurally wrong rather than stale (bad payload, misconfigured OAuth URL, unsupported key).
+    case authInvalid = "auth_invalid"
+    /// The request never completed (transport / connection failure).
+    case network = "network"
+    /// A response came back but could not be parsed / a required field was missing.
+    case decoding = "decoding"
+    case http4xx = "http_4xx"
+    case http5xx = "http_5xx"
+    case rateLimited = "rate_limited"
+    /// Usage data is legitimately unavailable for this account/plan (no subscription, API-key-only, quota
+    /// endpoint absent) — not a malfunction.
+    case notAvailable = "not_available"
+    case other = "other"
+
+    /// Classify a non-2xx HTTP status. 429 is called out as rate limiting; everything else splits on the
+    /// 4xx/5xx boundary.
+    static func http(_ statusCode: Int) -> ErrorCategory {
+        switch statusCode {
+        case 429: return .rateLimited
+        case 400..<500: return .http4xx
+        case 500..<600: return .http5xx
+        default: return .other
+        }
+    }
+}
+
+/// An error that knows its own telemetry bucket. Conformed by every provider error enum below so the
+/// classification lives next to the cases it describes and stays exhaustive as cases are added.
+protocol CategorizedError: Error {
+    var errorCategory: ErrorCategory { get }
+}
+
+// MARK: - Provider conformances
+//
+// Retroactive conformances kept in one file so the full mapping is reviewable at a glance and a new
+// error case forces a compile error here (exhaustive switches) rather than silently falling to `.other`.
+
+extension ClaudeAuthError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .notLoggedIn: .notLoggedIn
+        case .sessionExpired, .tokenExpired: .authExpired
+        case .invalidOAuthURL: .authInvalid
+        }
+    }
+}
+
+extension ClaudeUsageError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .connectionFailed: .network
+        case .invalidResponse: .decoding
+        case .requestFailed(let status): ErrorCategory.http(status)
+        }
+    }
+}
+
+extension CodexAuthError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .notLoggedIn: .notLoggedIn
+        case .sessionExpired, .tokenConflict, .tokenRevoked, .tokenExpired: .authExpired
+        case .usageAPIKey: .notAvailable
+        case .invalidAuthPayload: .authInvalid
+        }
+    }
+}
+
+extension CodexUsageError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .connectionFailed: .network
+        case .invalidResponse: .decoding
+        case .requestFailed(let status): ErrorCategory.http(status)
+        }
+    }
+}
+
+extension CursorAuthError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .notLoggedIn: .notLoggedIn
+        case .sessionExpired, .tokenExpired: .authExpired
+        }
+    }
+}
+
+extension CursorUsageError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .connectionFailed: .network
+        case .invalidResponse, .totalUsageLimitMissing: .decoding
+        case .requestFailed(let status): ErrorCategory.http(status)
+        case .requestBasedUnavailable, .noActiveSubscription: .notAvailable
+        case .usageAfterRefreshFailed: .other
+        }
+    }
+}
+
+extension GrokAuthError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .notLoggedIn: .notLoggedIn
+        case .invalidAuth: .authInvalid
+        case .expired: .authExpired
+        }
+    }
+}
+
+extension GrokUsageError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .connectionFailed: .network
+        case .invalidResponse: .decoding
+        case .requestFailed(let status): ErrorCategory.http(status)
+        }
+    }
+}
+
+extension DevinAuthError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .notLoggedIn: .notLoggedIn
+        }
+    }
+}
+
+extension DevinUsageError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .invalidResponse: .decoding
+        case .quotaUnavailable: .notAvailable
+        }
+    }
+}
+
+extension HTTPClientError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .invalidResponse: .decoding
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -34,7 +34,7 @@ final class GrokProvider: ProviderRuntime {
         do {
             return try await loadAndProbe()
         } catch {
-            return ProviderSnapshot.error(provider: provider, message: error.localizedDescription)
+            return ProviderSnapshot.error(provider: provider, error: error)
         }
     }
 

--- a/Sources/OpenUsage/Services/Telemetry.swift
+++ b/Sources/OpenUsage/Services/Telemetry.swift
@@ -1,0 +1,91 @@
+import Foundation
+import PostHog
+
+/// Build-time configuration for the PostHog project. The project token is a client-side, write-only
+/// key (it ships in every distributed binary, like any analytics SDK key), so it is safe to commit;
+/// an `OPENUSAGE_POSTHOG_TOKEN` environment override is supported for local testing without editing
+/// source. The host is region-bound — a US token will not ingest against the EU host.
+enum TelemetryConfig {
+    /// Sentinel meaning "no real token configured" — the sink stays inert (no setup, no network) while
+    /// the resolved token equals this. Do NOT change this value.
+    static let placeholderToken = "phc_REPLACE_ME"
+
+    /// The project token baked into the build. Replace `phc_REPLACE_ME` with the real US-region
+    /// `phc_…` key (safe to commit — it's a client write-only key), or leave it and set
+    /// `OPENUSAGE_POSTHOG_TOKEN` at runtime for local testing.
+    private static let bakedToken = "phc_vGEqXEpQNwViyKnMNWvmKWpv8XxMT3yaeYi6gfidr4nf"
+
+    static var token: String {
+        let env = ProcessInfo.processInfo.environment["OPENUSAGE_POSTHOG_TOKEN"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let env, !env.isEmpty { return env }
+        return bakedToken
+    }
+
+    /// US cloud. Switch to "https://eu.i.posthog.com" only with an EU-region project token.
+    static let host = "https://us.i.posthog.com"
+}
+
+/// The transport seam telemetry is emitted through. Abstracted from PostHog so the recorder's
+/// daily-rollup/dedup logic can be unit-tested against a fake sink.
+@MainActor
+protocol TelemetrySink: AnyObject {
+    func capture(_ event: String, _ properties: [String: Any])
+    /// Mirror the user's opt-out choice onto the underlying SDK at runtime.
+    func setEnabled(_ enabled: Bool)
+    func flush()
+}
+
+/// Anonymous, opt-out PostHog sink. No `identify()`/`group()`/`alias()`, `personProfiles = .never`,
+/// and only IDs/counts/enums are ever sent — never the free-form error message (the file log's
+/// `LogRedaction` does not cover a network transport). When no real project token is configured the
+/// sink is inert (the app still builds and the toggle still works), so dev builds never phone home.
+@MainActor
+final class PostHogTelemetrySink: TelemetrySink {
+    private let configured: Bool
+
+    init(enabled: Bool, token: String = TelemetryConfig.token, host: String = TelemetryConfig.host) {
+        guard token.hasPrefix("phc_"), token != TelemetryConfig.placeholderToken else {
+            configured = false
+            AppLog.info(.config, "telemetry inert: no PostHog project token configured")
+            return
+        }
+        configured = true
+
+        let config = PostHogConfig(projectToken: token, host: host)
+        // Fully anonymous: no person profiles, no anonymous->identified merge.
+        config.personProfiles = .never
+        // We use no feature flags and emit our own daily rollups, so skip both startup fetches/autocapture.
+        config.preloadFeatureFlags = false
+        config.captureApplicationLifecycleEvents = false
+        config.captureScreenViews = false
+        // Start in the user's chosen state before any event can fire.
+        config.optOut = !enabled
+        // NOTE: errorTrackingConfig.autoCapture is left at its default (off) — the app already catches
+        // provider errors and reports them as coarse counts. Never reference sessionReplay / surveys /
+        // captureElementInteractions / tracingHeaders here: they do not exist on a macOS target.
+        PostHogSDK.shared.setup(config)
+
+        // Super properties ride on every subsequent event (anonymous, non-PII).
+        PostHogSDK.shared.register([
+            "app_version": AppInfo.version,
+            "os_version": ProcessInfo.processInfo.operatingSystemVersionString
+        ])
+        AppLog.info(.config, "telemetry initialized (enabled=\(enabled))")
+    }
+
+    func capture(_ event: String, _ properties: [String: Any]) {
+        guard configured else { return }
+        PostHogSDK.shared.capture(event, properties: properties)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        guard configured else { return }
+        if enabled { PostHogSDK.shared.optIn() } else { PostHogSDK.shared.optOut() }
+    }
+
+    func flush() {
+        guard configured else { return }
+        PostHogSDK.shared.flush()
+    }
+}

--- a/Sources/OpenUsage/Stores/TelemetryRecorder.swift
+++ b/Sources/OpenUsage/Stores/TelemetryRecorder.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// The once-a-day configuration snapshot that rides on `app_daily_active` (answers "which providers /
+/// metrics are enabled" and "which are primary vs secondary"). All values are stable IDs/enums.
+struct TelemetryConfigSnapshot: Sendable {
+    let enabledProviders: [String]
+    let enabledMetricIDs: [String]
+    let pinnedMetricIDs: [String]
+    let expandedMetricIDs: [String]
+    let menuBarStyle: String
+}
+
+/// Turns raw refresh outcomes into the two daily-rollup events, enforcing "at most one event per day"
+/// without flooding the pipeline from the 5-minute refresh timer (~1,440 outcomes/user/day).
+///
+/// - `app_daily_active`: emitted once per local day (DAU + the config snapshot), driven by `tick()`.
+/// - `provider_refresh_daily`: one per provider per day, accumulated in the persisted store and emitted
+///   when the day rolls over (so counts are complete and survive app restarts within a day).
+///
+/// All work is skipped while telemetry is disabled, so opting out is a hard stop, not just a no-op sink.
+@MainActor
+final class TelemetryRecorder {
+    private let sink: TelemetrySink
+    private let store: TelemetryStore
+    private let snapshot: @MainActor () -> TelemetryConfigSnapshot
+    private let now: () -> Date
+
+    init(
+        sink: TelemetrySink,
+        store: TelemetryStore,
+        snapshot: @escaping @MainActor () -> TelemetryConfigSnapshot,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.sink = sink
+        self.store = store
+        self.snapshot = snapshot
+        self.now = now
+    }
+
+    var isEnabled: Bool { store.enabled }
+
+    /// Toggle the user's opt-out choice: persist it (in the beta-wipe-proof store) and mirror it onto
+    /// the SDK. A no-op when unchanged.
+    func setEnabled(_ enabled: Bool) {
+        guard store.enabled != enabled else { return }
+        store.enabled = enabled
+        sink.setEnabled(enabled)
+        AppLog.info(.config, "telemetry \(enabled ? "enabled" : "disabled") by user")
+    }
+
+    /// Run on every refresh pass (launch + each interval): flush any provider counters left over from a
+    /// previous day, then emit `app_daily_active` once per local day.
+    func tick() {
+        guard store.enabled else { return }
+        let today = Self.dayString(now())
+        flushStaleCounters(today: today)
+        if store.activeDay != today {
+            store.activeDay = today
+            emitDailyActive()
+        }
+    }
+
+    /// Record one provider refresh outcome. Only `.refreshed` / `.failed` count — cache hits, skips, and
+    /// backoffs are timer noise, not usage, and are dropped.
+    func record(providerID: String, outcome: WidgetDataStore.RefreshOutcome, category: ErrorCategory?, manual: Bool) {
+        guard store.enabled else { return }
+        guard outcome == .refreshed || outcome == .failed else { return }
+
+        let today = Self.dayString(now())
+        var counters = store.providerCounters()
+        // Roll a stale prior-day counter over to its own event before accumulating today's.
+        if let existing = counters[providerID], existing.day != today {
+            emitProviderRollup(providerID: providerID, counter: existing)
+            counters[providerID] = nil
+        }
+        var counter = counters[providerID] ?? ProviderDailyCounter(day: today)
+        switch outcome {
+        case .refreshed:
+            counter.success += 1
+        case .failed:
+            counter.failure += 1
+            counter.errors[(category ?? .other).rawValue, default: 0] += 1
+        default:
+            break
+        }
+        if manual { counter.manual += 1 }
+        counters[providerID] = counter
+        store.setProviderCounters(counters)
+    }
+
+    func flush() {
+        guard store.enabled else { return }
+        sink.flush()
+    }
+
+    // MARK: - Internals
+
+    /// Emit (and clear) every provider counter that belongs to a day other than `today`.
+    private func flushStaleCounters(today: String) {
+        var counters = store.providerCounters()
+        var changed = false
+        for (providerID, counter) in counters where counter.day != today {
+            emitProviderRollup(providerID: providerID, counter: counter)
+            counters[providerID] = nil
+            changed = true
+        }
+        if changed { store.setProviderCounters(counters) }
+    }
+
+    private func emitDailyActive() {
+        let config = snapshot()
+        sink.capture("app_daily_active", [
+            "install_id": store.installID,
+            "app_version": AppInfo.version,
+            "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
+            "enabled_providers": config.enabledProviders,
+            "enabled_metric_ids": config.enabledMetricIDs,
+            "pinned_metric_ids": config.pinnedMetricIDs,
+            "expanded_metric_ids": config.expandedMetricIDs,
+            "menu_bar_style": config.menuBarStyle
+        ])
+        sink.flush()
+    }
+
+    private func emitProviderRollup(providerID: String, counter: ProviderDailyCounter) {
+        sink.capture("provider_refresh_daily", [
+            "provider_id": providerID,
+            "success_count": counter.success,
+            "failure_count": counter.failure,
+            "error_categories": counter.errors,
+            "manual_refresh_count": counter.manual
+        ])
+        sink.flush()
+    }
+
+    /// Local-calendar `yyyy-MM-dd`. Local (not UTC) so "every day" matches the user's perception; the
+    /// calendar is injectable for tests.
+    static func dayString(_ date: Date, calendar: Calendar = .current) -> String {
+        let parts = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", parts.year ?? 0, parts.month ?? 0, parts.day ?? 0)
+    }
+}

--- a/Sources/OpenUsage/Stores/TelemetryStore.swift
+++ b/Sources/OpenUsage/Stores/TelemetryStore.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Per-provider running tally for one local calendar day. Persisted so counts survive app restarts
+/// within a day, then emitted as a single `provider_refresh_daily` event once the day rolls over.
+struct ProviderDailyCounter: Codable, Sendable, Equatable {
+    var day: String
+    var success = 0
+    var failure = 0
+    var manual = 0
+    /// Stable `ErrorCategory` raw value -> count. No messages, no PII.
+    var errors: [String: Int] = [:]
+}
+
+/// Telemetry bookkeeping that MUST outlive `BetaSettingsReset` — which wipes the app's *standard*
+/// `UserDefaults` domain on every beta version bump. This store lives in a dedicated suite domain
+/// (`<bundle id>.telemetry`), a separate plist that the standard-domain wipe does not touch, so the
+/// anonymous install id, the user's opt-out choice, and the daily-dedup state are NOT reset on each
+/// beta update (which would otherwise re-enable telemetry the user turned off and inflate DAU /
+/// new-install counts).
+@MainActor
+final class TelemetryStore {
+    private let defaults: UserDefaults
+
+    private static let installIDKey = "installID"
+    private static let enabledKey = "enabled"
+    private static let activeDayKey = "activeDay"
+    private static let providerDaysKey = "providerDays"
+
+    static var suiteName: String { (Bundle.main.bundleIdentifier ?? "com.openusage.app") + ".telemetry" }
+
+    /// `defaults` is injectable for tests; production uses the dedicated suite (falling back to standard
+    /// only if the suite can't be opened, which would be unusual).
+    init(defaults: UserDefaults? = nil) {
+        self.defaults = defaults ?? UserDefaults(suiteName: Self.suiteName) ?? .standard
+    }
+
+    /// Stable anonymous install id (random UUID), minted once on first read and reused thereafter.
+    var installID: String {
+        if let existing = defaults.string(forKey: Self.installIDKey) { return existing }
+        let minted = UUID().uuidString
+        defaults.set(minted, forKey: Self.installIDKey)
+        return minted
+    }
+
+    /// Whether telemetry is enabled. Opt-out design: defaults to `true` when the user has never chosen.
+    var enabled: Bool {
+        get { defaults.object(forKey: Self.enabledKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: Self.enabledKey) }
+    }
+
+    /// The last local day on which `app_daily_active` was emitted (`yyyy-MM-dd`), or nil if never.
+    var activeDay: String? {
+        get { defaults.string(forKey: Self.activeDayKey) }
+        set { defaults.set(newValue, forKey: Self.activeDayKey) }
+    }
+
+    func providerCounters() -> [String: ProviderDailyCounter] {
+        guard let data = defaults.data(forKey: Self.providerDaysKey) else { return [:] }
+        return (try? JSONDecoder().decode([String: ProviderDailyCounter].self, from: data)) ?? [:]
+    }
+
+    func setProviderCounters(_ counters: [String: ProviderDailyCounter]) {
+        guard let data = try? JSONEncoder().encode(counters) else {
+            AppLog.warn(.config, "failed to persist telemetry counters")
+            return
+        }
+        defaults.set(data, forKey: Self.providerDaysKey)
+    }
+}

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -53,6 +53,12 @@ final class WidgetDataStore {
     /// observable UI state, so it's excluded from `@Observable` tracking.
     @ObservationIgnored private var failureRetryAfter: [String: Date] = [:]
 
+    /// Telemetry hook wired by `AppContainer`. Invoked once per *real* provider fetch — `.refreshed` or
+    /// `.failed` only, never the cache-hit/skip/backoff outcomes that the 5-minute timer produces in
+    /// bulk — so the recorder can roll daily usage and error counts up into one event per provider per
+    /// day. `nil` (and so a no-op) in tests and previews. Not observable UI state.
+    @ObservationIgnored var onRefreshOutcome: (@MainActor (String, RefreshOutcome, ErrorCategory?, Bool) -> Void)?
+
     /// Global meter style: whether every bounded tile (and the menu-bar value) renders as "used" or
     /// "left/remaining". Persisted so the choice survives relaunch; defaults to `.remaining`.
     var meterStyle: WidgetDisplayMode {
@@ -176,6 +182,7 @@ final class WidgetDataStore {
             // Negative-cache the failure so a wake burst can't re-probe this provider in a tight loop.
             failureRetryAfter[providerID] = now().addingTimeInterval(Self.failureRetryBackoff)
             AppLog.warn(.refresh, "\(providerID) failed: \(message)")
+            onRefreshOutcome?(providerID, .failed, snapshot.errorCategory, force)
             return .failed
         }
         if providerErrors[providerID] != nil {
@@ -186,6 +193,7 @@ final class WidgetDataStore {
         snapshots[providerID] = snapshot
         cache.store(snapshot)
         AppLog.info(.refresh, "\(providerID) ok (\(durationMs)ms)")
+        onRefreshOutcome?(providerID, .refreshed, nil, force)
         return .refreshed
     }
 

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -112,6 +112,23 @@ struct SettingsScreen: View {
                     providerRow(provider)
                 }
             }
+            section("Privacy") {
+                row("Share Anonymous Usage") {
+                    Toggle("", isOn: Binding(
+                        get: { container.telemetry.isEnabled },
+                        set: { container.telemetry.setEnabled($0) }
+                    ))
+                    .settingsSwitchStyle()
+                }
+                // Plain-language disclosure of exactly what leaves the machine — coarse counts and
+                // error types only, never account details or usage values.
+                Text("Shares anonymous usage counts and error types to help improve OpenUsage. No account details, credentials, or usage values are sent.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
             advancedSection
             // Visible whenever the updater is active (only the signed release build ships a feed; the
             // dev build and a bare `swift run`, with no feed, hide this).

--- a/Tests/OpenUsageTests/DevinProviderTests.swift
+++ b/Tests/OpenUsageTests/DevinProviderTests.swift
@@ -193,6 +193,9 @@ final class DevinProviderTests: XCTestCase {
 
         XCTAssertEqual(snapshot.lines.first?.label, "Error")
         XCTAssertEqual(errorText(snapshot.lines), DevinAuthError.notLoggedIn.localizedDescription)
+        // The final fallback must carry a real telemetry category (regression: it once used the
+        // message-only factory, leaving errorCategory nil so failures bucketed as `other`).
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
     }
 
     private func errorText(_ lines: [MetricLine]) -> String? {

--- a/Tests/OpenUsageTests/TelemetryRecorderTests.swift
+++ b/Tests/OpenUsageTests/TelemetryRecorderTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the daily-rollup/dedup contract of `TelemetryRecorder`: the 5-minute refresh timer produces
+/// ~1,440 outcomes/user/day, so the recorder must collapse them into at most one event per provider
+/// per day (and one `app_daily_active` per day), drop cache/skip/backoff noise, classify errors, and
+/// stop entirely when the user opts out.
+@MainActor
+final class TelemetryRecorderTests: XCTestCase {
+    /// Records captured events without touching PostHog.
+    private final class FakeSink: TelemetrySink {
+        var events: [(name: String, properties: [String: Any])] = []
+        var enabledCalls: [Bool] = []
+        var flushCount = 0
+        func capture(_ event: String, _ properties: [String: Any]) { events.append((event, properties)) }
+        func setEnabled(_ enabled: Bool) { enabledCalls.append(enabled) }
+        func flush() { flushCount += 1 }
+        func events(named name: String) -> [[String: Any]] {
+            events.filter { $0.name == name }.map(\.properties)
+        }
+    }
+
+    private let snapshot = TelemetryConfigSnapshot(
+        enabledProviders: ["claude", "codex"],
+        enabledMetricIDs: ["claude.session", "codex.weekly"],
+        pinnedMetricIDs: ["claude.session"],
+        expandedMetricIDs: ["codex.weekly"],
+        menuBarStyle: "text"
+    )
+
+    func testOnlyRefreshedAndFailedCount_andRollOverEmitsCompleteDailyCounts() {
+        let sink = FakeSink()
+        let store = makeStore("rollover")
+        var clock = day(25)
+        let recorder = TelemetryRecorder(sink: sink, store: store, snapshot: { self.snapshot }, now: { clock })
+
+        // Day 25: real fetches plus timer noise that must be ignored.
+        recorder.record(providerID: "claude", outcome: .refreshed, category: nil, manual: false)
+        recorder.record(providerID: "claude", outcome: .refreshed, category: nil, manual: true)
+        recorder.record(providerID: "claude", outcome: .failed, category: .network, manual: false)
+        recorder.record(providerID: "claude", outcome: .failed, category: .notLoggedIn, manual: false)
+        recorder.record(providerID: "claude", outcome: .cacheHit, category: nil, manual: false)
+        recorder.record(providerID: "claude", outcome: .skipped, category: nil, manual: false)
+        recorder.record(providerID: "claude", outcome: .backedOff, category: nil, manual: false)
+
+        // Same day → nothing emitted yet (it's still accumulating).
+        XCTAssertTrue(sink.events(named: "provider_refresh_daily").isEmpty)
+
+        // New day → the first record rolls day 25's complete totals into one event.
+        clock = day(26)
+        recorder.record(providerID: "claude", outcome: .refreshed, category: nil, manual: false)
+
+        let rollups = sink.events(named: "provider_refresh_daily")
+        XCTAssertEqual(rollups.count, 1)
+        let props = rollups[0]
+        XCTAssertEqual(props["provider_id"] as? String, "claude")
+        XCTAssertEqual(props["success_count"] as? Int, 2)
+        XCTAssertEqual(props["failure_count"] as? Int, 2)
+        XCTAssertEqual(props["manual_refresh_count"] as? Int, 1)
+        XCTAssertEqual(props["error_categories"] as? [String: Int], ["network": 1, "not_logged_in": 1])
+    }
+
+    func testTickEmitsDailyActiveOncePerDayWithConfigSnapshot() {
+        let sink = FakeSink()
+        let store = makeStore("daily-active")
+        var clock = day(25)
+        let recorder = TelemetryRecorder(sink: sink, store: store, snapshot: { self.snapshot }, now: { clock })
+
+        recorder.tick()
+        recorder.tick() // same day → must not emit twice
+
+        let active = sink.events(named: "app_daily_active")
+        XCTAssertEqual(active.count, 1)
+        XCTAssertEqual(active[0]["install_id"] as? String, store.installID)
+        XCTAssertEqual(active[0]["enabled_providers"] as? [String], ["claude", "codex"])
+        XCTAssertEqual(active[0]["pinned_metric_ids"] as? [String], ["claude.session"])
+        XCTAssertEqual(active[0]["expanded_metric_ids"] as? [String], ["codex.weekly"])
+        XCTAssertEqual(active[0]["menu_bar_style"] as? String, "text")
+
+        clock = day(26)
+        recorder.tick() // new day → emit again
+        XCTAssertEqual(sink.events(named: "app_daily_active").count, 2)
+    }
+
+    func testTickFlushesStalePriorDayCounterEvenWithoutNewOutcomes() {
+        let sink = FakeSink()
+        let store = makeStore("sweep")
+        var clock = day(25)
+        let recorder = TelemetryRecorder(sink: sink, store: store, snapshot: { self.snapshot }, now: { clock })
+
+        recorder.record(providerID: "grok", outcome: .refreshed, category: nil, manual: false)
+
+        // A new day with no further grok outcomes: the tick sweep must still emit day 25's rollup.
+        clock = day(26)
+        recorder.tick()
+
+        let rollups = sink.events(named: "provider_refresh_daily")
+        XCTAssertEqual(rollups.count, 1)
+        XCTAssertEqual(rollups[0]["provider_id"] as? String, "grok")
+        XCTAssertEqual(rollups[0]["success_count"] as? Int, 1)
+    }
+
+    func testOptingOutStopsAllEmissionAndPersists() {
+        let sink = FakeSink()
+        let store = makeStore("opt-out")
+        var clock = day(25)
+        let recorder = TelemetryRecorder(sink: sink, store: store, snapshot: { self.snapshot }, now: { clock })
+
+        recorder.setEnabled(false)
+        XCTAssertEqual(sink.enabledCalls, [false])
+
+        recorder.tick()
+        recorder.record(providerID: "claude", outcome: .refreshed, category: nil, manual: false)
+        clock = day(26)
+        recorder.record(providerID: "claude", outcome: .failed, category: .network, manual: false)
+        recorder.tick()
+
+        XCTAssertTrue(sink.events.isEmpty, "no events should be captured while opted out")
+        XCTAssertFalse(store.enabled, "opt-out must persist")
+    }
+
+    func testInstallIDIsStableAcrossStoreInstances() {
+        let defaults = makeDefaults("install-id")
+        let first = TelemetryStore(defaults: defaults).installID
+        let second = TelemetryStore(defaults: defaults).installID
+        XCTAssertFalse(first.isEmpty)
+        XCTAssertEqual(first, second)
+    }
+
+    // MARK: - Helpers
+
+    /// Local noon on 2026-06-`d`, matching the recorder's local-calendar day boundary.
+    private func day(_ d: Int) -> Date {
+        var c = DateComponents()
+        c.year = 2026; c.month = 6; c.day = d; c.hour = 12
+        return Calendar.current.date(from: c)!
+    }
+
+    private func makeStore(_ name: String) -> TelemetryStore {
+        TelemetryStore(defaults: makeDefaults(name))
+    }
+
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.Telemetry.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ What the app does and how it behaves. These pages describe **behavior, not visua
 - [Settings](settings.md) — every option, what it changes
 - [Refreshing & caching](refreshing.md) — when data updates and what happens when a fetch fails
 - [Updates](updates.md) — automatic updates, manual checks, and the early access channel
+- [Privacy & usage data](privacy.md) — what anonymous data is shared, and how to turn it off
 
 ## Integrations
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,27 @@
+# Privacy & Usage Data
+
+OpenUsage can share **anonymous** usage data to help us understand how the app is used and catch problems. It is on by default and you can turn it off any time in **Settings → Privacy → Share Anonymous Usage**.
+
+## What is shared
+
+When sharing is on, OpenUsage sends two small summaries, **at most once a day each**:
+
+- **App use** — that the app was active today, the app and macOS version, which providers and metrics you have enabled, and which metrics you've pinned to the menu bar or tucked behind the "show more" caret. A random ID (not tied to you or any account) lets us count daily active users without identifying anyone.
+- **Provider refreshes** — per provider, how many refreshes succeeded or failed that day, the **kinds** of errors that happened (for example "not logged in", "network", or an HTTP status group), and how many manual refreshes you triggered.
+
+## What is never shared
+
+- No account details, names, emails, or credentials.
+- No actual usage **values** (no spend amounts, token counts, or limits).
+- No error **messages** or file paths — only coarse error categories as counts.
+- Nothing while the toggle is off.
+
+## How it works
+
+- Data is fully anonymous: OpenUsage never identifies you to the analytics service and creates no user profile.
+- Counts are rolled up locally and sent as a daily summary, so the app's normal 5-minute refresh never turns into a flood of network calls.
+- Your choice and the anonymous ID are stored separately from the rest of the app's settings, so a beta update (which resets other settings) does not re-enable sharing or change your ID.
+
+## Turning it off
+
+Open **Settings → Privacy** and switch **Share Anonymous Usage** off. Sharing stops immediately and nothing further is sent.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -30,6 +30,12 @@ Settings lives inside the popover — there is no separate window. Open it from 
 
 One switch per provider. Turning a provider **off** hides it everywhere (dashboard, Customize, menu bar, the collection endpoint of the [local HTTP API](local-http-api.md)) and pauses its updates. Nothing is deleted — turning it back on restores its metrics and order.
 
+## Privacy
+
+| Setting | Options | What it does |
+|---|---|---|
+| Share Anonymous Usage | On / Off | On (default) shares anonymous, daily usage summaries — no account details, credentials, or usage values. Off stops all sharing immediately. See [Privacy & Usage Data](privacy.md) for exactly what is and isn't sent. |
+
 ## Advanced
 
 | Setting | Options | What it does |


### PR DESCRIPTION
## What & why

Adds **anonymous, opt-out** usage telemetry (PostHog) so we can answer five concrete questions about the Swift edition over time:

| Question | Answered by |
|---|---|
| How often is each provider used, per day? | `provider_refresh_daily.success_count` |
| Are there errors, and what kind? | `provider_refresh_daily.failure_count` + `error_categories` |
| How many daily active users? | distinct `app_daily_active.install_id` |
| Which metrics are enabled? | `app_daily_active.enabled_providers` + `enabled_metric_ids` |
| Which metrics are primary vs secondary? | `pinned_metric_ids` + `expanded_metric_ids` |

## Design

The app refreshes every enabled provider every 5 minutes regardless of viewing (~1,440 outcomes/user/day), so emitting per-refresh would flood the pipeline. Instead, **two daily-rollup events, at most once per day each**, driven off the existing refresh cycle:

- **`app_daily_active`** — once per local day; carries `install_id`, app/OS version, and the config snapshot (enabled providers/metrics, pins, expanded, menu-bar style).
- **`provider_refresh_daily`** — one per provider per day; success/failure counts, a stable `error_categories` map, and manual-refresh count. Counts accumulate locally and emit on day-rollover.

## Privacy posture

- Fully anonymous: `personProfiles = .never`, no `identify`/`group`/`alias`. `install_id` is a random per-install UUID (not a hardware/machine id).
- Only IDs / counts / enums are ever sent — never error messages, credentials, or usage values.
- **Opt-out** (default ON) via **Settings → Privacy → "Share Anonymous Usage"**.
- Install id + opt-out choice + dedup state live in a **dedicated UserDefaults suite** so they survive `BetaSettingsReset`'s standard-domain wipe (otherwise every beta update would re-enable telemetry and inflate DAU).
- `ErrorCategory` classifies every provider error enum into a stable, non-PII bucket; crash autocapture is intentionally left off (no dSYM pipeline work).

## Notable

- New dependency: `posthog-ios` 3.62.0 (official, MIT, first-party Swift SDK) — justified per AGENTS.md.
- The PostHog **project token is baked in** (`TelemetryConfig`). It's a client-side, write-only key (ships in every client like any analytics SDK key), so committing it is safe; `OPENUSAGE_POSTHOG_TOKEN` overrides it at runtime.
- Docs: new `docs/privacy.md`, plus a Privacy row in `docs/settings.md` and README.

## Verification

- `swift build` clean; **443 existing tests + new `TelemetryRecorderTests` pass** (rollover, dedup, error classification, opt-out, install-id stability).
- **Live delivery confirmed**: PostHog returned `{"status":"Ok"}` to a direct capture probe, and the running app's SDK logged `Queued event 'app_daily_active'` → `Sending batch of 1 records` → `batch sent successfully`.

## Reviewer notes

- Targets `swift` (the active Swift line); base is ~2 commits behind tip, rebase if the merge view prefers it.
- `app_daily_active` emits on the first refresh tick of each local day; `provider_refresh_daily` emits at day-rollover, so a single session shows usage as "successes today" rather than per-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds outbound analytics and a baked-in PostHog token, but limits payload to anonymous IDs/counts with explicit opt-out and no credentials or usage values in events.
> 
> **Overview**
> Introduces **anonymous, opt-out** product analytics via the PostHog iOS SDK (`posthog-ios` 3.62.0), wired through `AppContainer` and a new **Settings → Privacy** toggle (on by default).
> 
> Instead of per-refresh events (~1,440/day), the app emits **two daily rollups**: `app_daily_active` (install UUID, app/OS version, enabled providers/metrics, pins, menu bar style) and `provider_refresh_daily` (per-provider success/failure/manual counts and `error_categories`). Counters accumulate locally and flush on **local day rollover**; `telemetry.tick()` runs after each refresh pass and `applicationWillTerminate` flushes the queue.
> 
> **`ErrorCategory`** plus `CategorizedError` on provider errors classify failures without sending messages; error snapshots gain optional `errorCategory`, and providers use `ProviderSnapshot.error(provider:error:)`. **`WidgetDataStore`** calls `onRefreshOutcome` only for real `.refreshed`/`.failed` fetches (not cache hits/backoff).
> 
> Opt-out, install ID, and dedup state live in a **dedicated UserDefaults suite** so they survive beta settings resets. PostHog is configured with `personProfiles = .never`, no lifecycle/screen autocapture, and coarse properties only.
> 
> Docs: new `docs/privacy.md` and Settings/README updates; **`TelemetryRecorderTests`** cover rollup, dedup, and opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb53001a18f74be3a07e21840ff8f5132406021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->