### PR TITLE
feat(telemetry): anonymous crash + uncaught-exception reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,29 @@ jobs:
           OPENUSAGE_VERSION: ${{ steps.meta.outputs.version }}
         run: ./script/release.sh
 
+      # Upload the dSYM produced by release.sh so PostHog can symbolicate crash reports (the in-app
+      # crash autocapture is anonymous and honors the Share-Anonymous-Usage opt-out; see docs/privacy.md).
+      # posthog-cli is a CI-only build tool (npm), never shipped in the app bundle. Skips with a loud
+      # warning when POSTHOG_CLI_API_KEY is unset (e.g. forks), so a missing key never blocks a release;
+      # when the key IS set, an upload failure fails the step so we never silently ship unsymbolicated.
+      - name: Upload dSYMs to PostHog
+        env:
+          POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+          POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}
+          # US region, matching TelemetryConfig.host in the app.
+          POSTHOG_CLI_HOST: https://us.i.posthog.com
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          if [ -z "${POSTHOG_CLI_API_KEY}" ]; then
+            echo "::warning::POSTHOG_CLI_API_KEY not set — skipping dSYM upload; crashes for $VERSION will NOT symbolicate."
+            exit 0
+          fi
+          [ -d dist/dSYMs ] || { echo "dist/dSYMs missing — release.sh did not produce a dSYM." >&2; exit 1; }
+          npm install -g @posthog/cli
+          # Symbolication matches a crash report to its symbols by the binary's Mach-O UUID (carried in
+          # the dSYM), so `--directory` is all that's required — no per-release flags to keep in sync.
+          posthog-cli dsym upload --directory dist/dSYMs
+
       - name: Publish DMG to GitHub Releases
         uses: softprops/action-gh-release@v3
         with:

--- a/Sources/OpenUsage/Services/Telemetry.swift
+++ b/Sources/OpenUsage/Services/Telemetry.swift
@@ -42,6 +42,12 @@ protocol TelemetrySink: AnyObject {
 /// sink is inert (the app still builds and the toggle still works), so dev builds never phone home.
 @MainActor
 final class PostHogTelemetrySink: TelemetrySink {
+    /// Crash / uncaught-exception autocapture is gated on the SAME opt-out as usage telemetry, decided
+    /// here so the opt-out contract is unit-testable without touching the `PostHogSDK.shared` singleton.
+    /// Gating *install* (not just sending) on the opt-out means an opted-out launch installs no signal/
+    /// exception handler and writes no crash report to disk — honoring privacy.md's "nothing while off".
+    nonisolated static func errorAutocaptureEnabled(telemetryEnabled: Bool) -> Bool { telemetryEnabled }
+
     private let configured: Bool
 
     init(enabled: Bool, token: String = TelemetryConfig.token, host: String = TelemetryConfig.host) {
@@ -61,9 +67,20 @@ final class PostHogTelemetrySink: TelemetrySink {
         config.captureScreenViews = false
         // Start in the user's chosen state before any event can fire.
         config.optOut = !enabled
-        // NOTE: errorTrackingConfig.autoCapture is left at its default (off) — the app already catches
-        // provider errors and reports them as coarse counts. Never reference sessionReplay / surveys /
-        // captureElementInteractions / tracingHeaders here: they do not exist on a macOS target.
+        // Crash / uncaught-exception autocapture, gated on the SAME opt-out (anonymous `$exception`
+        // events, sent on the NEXT launch after a crash). It captures Mach exceptions, POSIX signals,
+        // and uncaught NSExceptions; Swift traps may surface as a bare `SIGTRAP` without the message —
+        // the symbolicated stack (dSYMs uploaded from release.yml) is what makes them actionable.
+        // Gating install on `enabled` (not relying on `optOut` alone) means an opted-out launch wires
+        // up no handler and writes nothing to disk. A runtime opt-IN therefore activates crash capture
+        // from the next launch; `optOut` (mirrored by `setEnabled`) still hard-stops sending in-session.
+        // NOTE: this local flag is necessary but NOT sufficient — posthog-ios also gates the integration
+        // on a SERVER-side switch (remote config `errorTracking.autocaptureExceptions`). "Exception
+        // autocapture" must be enabled in the PostHog project settings, and because the SDK reads it from
+        // cache at init, capture arms on the *second* launch after enabling (first launch fetches+caches).
+        // Never reference sessionReplay / surveys / captureElementInteractions / tracingHeaders here:
+        // they do not exist on a macOS target.
+        config.errorTrackingConfig.autoCapture = Self.errorAutocaptureEnabled(telemetryEnabled: enabled)
         PostHogSDK.shared.setup(config)
 
         // Super properties ride on every subsequent event (anonymous, non-PII).

--- a/Tests/OpenUsageTests/TelemetrySinkTests.swift
+++ b/Tests/OpenUsageTests/TelemetrySinkTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import OpenUsage
+
+/// Pins the crash-reporting opt-out contract: PostHog error autocapture must be gated on the SAME
+/// `enabled` flag as usage telemetry, so the privacy toggle is the single source of truth and an
+/// opted-out launch installs no crash handler. Tests the pure gating decision so it never touches the
+/// `PostHogSDK.shared` singleton (which would also trip the local Sparkle.framework dlopen issue).
+final class TelemetrySinkTests: XCTestCase {
+    func testErrorAutocaptureFollowsTheOptOut() {
+        XCTAssertTrue(
+            PostHogTelemetrySink.errorAutocaptureEnabled(telemetryEnabled: true),
+            "crash autocapture must be on when telemetry is enabled"
+        )
+        XCTAssertFalse(
+            PostHogTelemetrySink.errorAutocaptureEnabled(telemetryEnabled: false),
+            "crash autocapture must be off when the user has opted out of telemetry"
+        )
+    }
+}

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -9,6 +9,10 @@ When sharing is on, OpenUsage sends two small summaries, **at most once a day ea
 - **App use** — that the app was active today, the app and macOS version, which providers and metrics you have enabled, and which metrics you've pinned to the menu bar or tucked behind the "show more" caret. A random ID (not tied to you or any account) lets us count daily active users without identifying anyone.
 - **Provider refreshes** — per provider, how many refreshes succeeded or failed that day, the **kinds** of errors that happened (for example "not logged in", "network", or an HTTP status group), and how many manual refreshes you triggered.
 
+It also reports **crashes**, so we can find and fix the bugs that make the app quit unexpectedly:
+
+- **Crash reports** — if OpenUsage crashes, it saves a report and sends it the next time you open the app: the technical stack trace (which parts of *OpenUsage's own code* were running when it crashed) plus the app and macOS version. This contains no account details, credentials, or usage values — just where in the app the crash happened.
+
 ## What is never shared
 
 - No account details, names, emails, or credentials.
@@ -19,6 +23,7 @@ When sharing is on, OpenUsage sends two small summaries, **at most once a day ea
 ## How it works
 
 - Data is fully anonymous: OpenUsage never identifies you to the analytics service and creates no user profile.
+- Crash reports use the **same** Share Anonymous Usage switch — turn it off and crash reporting is off too, with no separate setting to find. While it's off, no crash report is recorded or sent.
 - Counts are rolled up locally and sent as a daily summary, so the app's normal 5-minute refresh never turns into a flood of network calls.
 - Your choice and the anonymous ID are stored separately from the rest of the app's settings, so a beta update (which resets other settings) does not re-enable sharing or change your ID.
 

--- a/script/release.sh
+++ b/script/release.sh
@@ -47,6 +47,10 @@ APP_MACOS="$APP_CONTENTS/MacOS"
 APP_RESOURCES="$APP_CONTENTS/Resources"
 APP_BINARY="$APP_MACOS/$APP_NAME"
 DMG_PATH="$DIST_DIR/$DMG_NAME"
+# dSYMs for crash symbolication (uploaded to PostHog by release.yml). A folder, since posthog-cli's
+# `dsym upload --directory` and Sparkle both want a directory of bundles, not a single path.
+DSYM_DIR="$DIST_DIR/dSYMs"
+APP_DSYM="$DSYM_DIR/$APP_NAME.app.dSYM"
 
 # Decide notarization up front. CI always supplies the notarization login; a local dry run can
 # opt out with ALLOW_UNNOTARIZED=1 (the build will then be Gatekeeper-blocked on other Macs). Missing
@@ -71,8 +75,11 @@ echo "==> building $APP_NAME $VERSION ($BUILD) — universal (arm64 + x86_64)"
 # Build both arch slices and let SwiftPM lipo-merge them into one universal binary. With multiple
 # --arch, --show-bin-path resolves to the merged products dir (.build/apple/Products/Release), which
 # also holds the *.bundle resources, so the staging loop below is unchanged.
-swift build -c release --arch arm64 --arch x86_64
-BUILD_DIR="$(swift build -c release --arch arm64 --arch x86_64 --show-bin-path)"
+# `-Xswiftc -g` emits DWARF so `dsymutil` can build a real (line-level) dSYM for crash symbolication.
+# This does NOT grow the shipped binary: Mach-O keeps DWARF in the .o files (referenced by the binary's
+# debug map) and dsymutil extracts it into the .dSYM — the executable only carries the symbol table.
+swift build -c release --arch arm64 --arch x86_64 -Xswiftc -g
+BUILD_DIR="$(swift build -c release --arch arm64 --arch x86_64 -Xswiftc -g --show-bin-path)"
 BUILD_BINARY="$BUILD_DIR/$APP_NAME"
 [ -x "$BUILD_BINARY" ] || { echo "missing built binary: $BUILD_BINARY" >&2; exit 1; }
 
@@ -100,6 +107,24 @@ if vtool -show-build "$APP_BINARY" | grep -q "sdk 15.0"; then
   echo "SDK restamp failed: $APP_BINARY still reports sdk 15.0" >&2
   exit 1
 fi
+
+# Generate the dSYM for crash symbolication AFTER the vtool restamp, from the exact binary we ship, so
+# the dSYM's Mach-O UUID matches the shipped one. (Verified: `vtool -set-build-version` rewrites only
+# the build-version load command and preserves LC_UUID, so the restamp does not break symbol upload.)
+# dsymutil follows the binary's debug map to the .build/*.o files (still present in this same build) to
+# pull DWARF; signing happens later and never touches the UUID, so dSYM↔binary stay matched.
+echo "==> generating dSYM (crash symbolication)"
+rm -rf "$DSYM_DIR"
+mkdir -p "$DSYM_DIR"
+dsymutil "$APP_BINARY" -o "$APP_DSYM"
+# Guard the symbolication contract: every arch UUID in the shipped binary must be present in the dSYM,
+# else uploaded symbols would never match a crash report (a silent miss that looks like "no symbols").
+for uuid in $(dwarfdump --uuid "$APP_BINARY" | awk '{print $2}'); do
+  dwarfdump --uuid "$APP_DSYM" | grep -q "$uuid" \
+    || { echo "dSYM UUID mismatch: $uuid (binary) absent from $APP_DSYM — symbolication would fail." >&2; exit 1; }
+done
+echo "    dSYM: $APP_DSYM"
+
 shopt -s nullglob
 for bundle in "$BUILD_DIR"/*.bundle; do
   cp -R "$bundle" "$APP_RESOURCES/$(basename "$bundle")"
@@ -187,5 +212,6 @@ if [ "$NOTARIZE" = "1" ]; then
 fi
 
 echo "==> done"
-echo "    DMG: $DMG_PATH"
+echo "    DMG:  $DMG_PATH"
+echo "    dSYM: $APP_DSYM (uploaded to PostHog for crash symbolication by release.yml)."
 echo "    The appcast is generated from this DMG by generate_appcast (see release.yml)."


### PR DESCRIPTION
## What & why

Telemetry (PR #735) reported only coarse provider-refresh error *counts* — app crashes and uncaught exceptions went unreported. This captures them, anonymously, gated by the **same** Settings → Privacy → *Share Anonymous Usage* opt-out.

**Backend decision:** PostHog Error Tracking, not Sentry (owner call). It reuses the existing posthog-ios SDK/token/dashboard and the opt-out plumbing, so it adds **no new shipped dependency**. Trade-off accepted: PostHog labels Swift traps as bare `SIGTRAP` and lacks Sentry's crash-triage tooling; in exchange we keep one vendor and one toggle. (The engine underneath is vendored PLCrashReporter — Mach + uncaught-exception handlers — so native capture itself is mature.)

## Changes
- **`Telemetry.swift`** — `config.errorTrackingConfig.autoCapture = enabled`. Gating *install* (not just sending) on the opt-out means an opted-out launch installs no handler and writes nothing to disk; `optOut()` (mirrored by `setEnabled`) also uninstalls the integration and ignores captures at runtime. Anonymous: no `identify`, `personProfiles = .never`.
- **`release.sh`** — build with `-Xswiftc -g` (DWARF; **zero** binary-size cost — DWARF stays in `.o`, extracted into the dSYM), then `dsymutil` **after** the vtool SDK restamp, with a guard that every shipped-binary UUID is present in the dSYM.
- **`release.yml`** — upload the dSYM via `posthog-cli dsym upload --directory dist/dSYMs`. Skips with a loud warning if `POSTHOG_CLI_API_KEY` is unset, so a missing key never blocks a release.
- **`docs/privacy.md`** — crash reporting honors the same toggle; no PII (stack traces of our own code only).
- **`TelemetrySinkTests.swift`** — regression test pinning *opt-out ⇒ no crash autocapture*.

## Dependency justification (per AGENTS.md)
No new **shipped** dependency — PostHog is already in `Package.swift`. The only addition is `@posthog/cli`, a **CI-only** npm tool used in the release workflow to upload dSYMs; it is never embedded in the app bundle.

## Verification
- Full suite: **444 pass, 0 fail** (incl. the new opt-out test).
- On the real app binary: `vtool` restamp **preserves `LC_UUID`** (identical before → after → in the dSYM), and `-g`+`dsymutil` yields **61,944 DWARF line-table rows** — so the Liquid Glass restamp does **not** break symbol upload.
- Inert/no-token path confirmed to make **zero** PostHog network calls.
- SDK source confirms opt-out uninstalls the crash integration + ignores captures.

## Action items before crashes symbolicate
- [x] "Exception autocapture" enabled in the PostHog project (already on; it's a server-side gate the SDK reads from cache, so capture arms on the *second* launch after enabling).
- [ ] Add GitHub secrets **`POSTHOG_CLI_API_KEY`** (scopes: error-tracking write + org read) and **`POSTHOG_CLI_PROJECT_ID`**. Without them, the upload step skips (warns) and crashes won't symbolicate.

## Note
Dev builds (`com.robinebers.openusage.dev`) use the same baked token, so dev crashes also report — tagged `app_version = 0.7.0-dev`, unsymbolicated. Consistent with the existing usage-telemetry posture; excluding dev would be a uniform follow-up across all telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes privacy-sensitive telemetry behavior and the release workflow; mitigated by explicit opt-out gating, docs, and CI guards on dSYM presence and upload failures when secrets are set.
> 
> **Overview**
> Adds **anonymous crash and uncaught-exception reporting** through the existing PostHog SDK, using the same **Share Anonymous Usage** opt-out as daily usage telemetry. `PostHogTelemetrySink` turns on `errorTrackingConfig.autoCapture` only when telemetry is enabled at init (via a testable `errorAutocaptureEnabled` helper), so an opted-out launch does not install crash handlers or write reports locally.
> 
> The **release pipeline** now emits symbol-friendly builds and uploads matching debug symbols: `release.sh` builds with `-Xswiftc -g`, runs `dsymutil` on the post-`vtool` shipped binary, and fails if any Mach-O UUID is missing from the dSYM. **release.yml** adds a PostHog dSYM upload step (`posthog-cli`); it warns and skips when `POSTHOG_CLI_API_KEY` is unset but fails the release if upload fails when the key is present.
> 
> **docs/privacy.md** documents crash reports under the same toggle, and **TelemetrySinkTests** locks the opt-out contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 284fa8472745901af9850cc13f8250f34158f4d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->