### PR TITLE
fix(claude): remove discontinued Sonnet weekly limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ OpenUsage shows how much of your AI coding plans you've used: session and weekly
 ## Supported Providers
 
 - [**Antigravity**](docs/providers/antigravity.md) — Gemini Pro/Flash and Claude model quotas
-- [**Claude**](docs/providers/claude.md) — session, weekly, Sonnet, extra usage, local daily spend (ccusage)
+- [**Claude**](docs/providers/claude.md) — session, weekly, extra usage, local daily spend (ccusage)
 - [**Codex**](docs/providers/codex.md) — session, weekly, credits, local daily spend (ccusage)
 - [**Cursor**](docs/providers/cursor.md) — credits, total/auto/API usage, requests, on-demand, per-day spend
 - [**Devin**](docs/providers/devin.md) — weekly and daily quota, extra usage balance

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -25,7 +25,6 @@ final class ClaudeProvider: ProviderRuntime {
         [
             .percent(id: "claude.session", provider: provider, title: "Session"),
             .percent(id: "claude.weekly", provider: provider, title: "Weekly"),
-            .percent(id: "claude.sonnet", provider: provider, title: "Sonnet"),
             .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent"),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -23,7 +23,6 @@ enum ClaudeUsageMapper {
         var lines: [MetricLine] = []
         appendUsageWindow(body["five_hour"], label: "Session", periodDurationMs: sessionPeriodMs, to: &lines)
         appendUsageWindow(body["seven_day"], label: "Weekly", periodDurationMs: weeklyPeriodMs, to: &lines)
-        appendUsageWindow(body["seven_day_sonnet"], label: "Sonnet", periodDurationMs: weeklyPeriodMs, to: &lines)
         appendExtraUsage(body["extra_usage"], to: &lines)
 
         return ClaudeMappedUsage(

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -55,7 +55,7 @@ enum DefaultLayout {
     ]
 
     /// Metrics tucked below the per-provider "Shown on expand" divider on a fresh install. This is
-    /// membership, not enablement: optional disabled rows like Sonnet or Cursor Requests/Credits are
+    /// membership, not enablement: optional disabled rows like Cursor Requests/Credits are
     /// listed here so if the user enables them later they appear below the caret by default.
     /// Filtered to the active registry by `LayoutStore`, and only seeded on a genuinely fresh launch
     /// (existing layouts keep everything always-shown unless they reset customization).
@@ -67,7 +67,7 @@ enum DefaultLayout {
         // are marked secondary), so leaving Session primary is what makes the caret appear at all.
         // See AGENTS.md "## Providers".
         "claude.weekly", "claude.trend",
-        "claude.sonnet", "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
+        "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
         "cursor.onDemand", "cursor.requests", "cursor.credits",
         "cursor.today", "cursor.yesterday", "cursor.last30",

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -97,7 +97,6 @@ final class ClaudeUsageMapperTests: XCTestCase {
             {
               "five_hour": { "utilization": 10, "resets_at": "2099-01-01T00:00:00.000Z" },
               "seven_day": { "utilization": 20, "resets_at": "2099-01-01T00:00:00.000Z" },
-              "seven_day_sonnet": { "utilization": 5, "resets_at": "2099-01-01T00:00:00.000Z" },
               "extra_usage": { "is_enabled": true, "used_credits": 500, "monthly_limit": 1000 }
             }
             """.utf8)
@@ -111,7 +110,6 @@ final class ClaudeUsageMapperTests: XCTestCase {
         XCTAssertEqual(mapped.plan, "Max 20x")
         XCTAssertEqual(progress(mapped.lines, "Session")?.used, 10)
         XCTAssertEqual(progress(mapped.lines, "Weekly")?.periodDurationMs, ClaudeUsageMapper.weeklyPeriodMs)
-        XCTAssertEqual(progress(mapped.lines, "Sonnet")?.used, 5)
         XCTAssertEqual(progress(mapped.lines, "Extra usage spent")?.used, 5)
         XCTAssertEqual(progress(mapped.lines, "Extra usage spent")?.limit, 10)
     }
@@ -260,7 +258,7 @@ final class ClaudeProviderTests: XCTestCase {
         print("LIVE response reset headers:", resetHeaders)
 
         let body = try XCTUnwrap(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
-        for key in ["five_hour", "seven_day", "seven_day_sonnet"] {
+        for key in ["five_hour", "seven_day"] {
             guard let window = body[key] as? [String: Any] else { continue }
             print("LIVE \(key)=", window)
         }
@@ -269,7 +267,7 @@ final class ClaudeProviderTests: XCTestCase {
             response,
             credentials: state.oauth
         )
-        for label in ["Session", "Weekly", "Sonnet"] {
+        for label in ["Session", "Weekly"] {
             let resetsAt = Self.progress(mapped.lines, label)?.resetsAt
             print("LIVE mapped \(label) resetsAt=", resetsAt as Any)
         }

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -257,7 +257,7 @@ final class LayoutStoreTests: XCTestCase {
         let store = LayoutStore(registry: registry, defaults: makeDefaults("FreshCustomizeOrder"), storageKey: "layout")
 
         XCTAssertEqual(store.orderedSupportedMetrics(for: "claude").map(\.id), [
-            "claude.session", "claude.weekly", "claude.sonnet", "claude.extra",
+            "claude.session", "claude.weekly", "claude.extra",
             "claude.trend", "claude.today", "claude.yesterday", "claude.last30"
         ])
         XCTAssertEqual(store.orderedSupportedMetrics(for: "codex").map(\.id), [
@@ -298,7 +298,6 @@ final class LayoutStoreTests: XCTestCase {
             "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend",
             "cursor.onDemand", "cursor.today", "cursor.yesterday", "cursor.last30"
         ]))
-        XCTAssertFalse(store.isMetricEnabled("claude.sonnet"))
         XCTAssertFalse(store.isMetricEnabled("cursor.requests"))
         XCTAssertFalse(store.isMetricEnabled("cursor.credits"))
 
@@ -313,7 +312,7 @@ final class LayoutStoreTests: XCTestCase {
         // always keeps ≥1 primary row) — see AGENTS.md "## Providers".
         XCTAssertEqual(primaryByProvider["claude"], ["claude.session"])
         XCTAssertEqual(expandedByProvider["claude"], [
-            "claude.weekly", "claude.sonnet", "claude.extra", "claude.trend",
+            "claude.weekly", "claude.extra", "claude.trend",
             "claude.today", "claude.yesterday", "claude.last30"
         ])
         XCTAssertEqual(primaryByProvider["codex"], ["codex.session", "codex.weekly", "codex.trend"])

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -38,7 +38,7 @@ Open Customize from the **⌄** menu next to the footer's Settings button (or pr
 
 Each provider card has a dashed **Shown on Expand** line. Metrics above it are always shown; metrics below it hide behind the dashboard caret. Drag a metric onto the dashed line to move it across the fold, or drag it onto a row on the other side — drop a metric under an expanded one and it becomes expanded too. Pinning, hiding, and order all work the same on either side.
 
-The default reset layout keeps each provider's core quota meters and Usage Trend always shown, then tucks balances, reset details, and spend-history rows behind the caret. Optional detail rows like Claude Sonnet and Cursor Requests/Credits stay off by default, but start below the divider if you enable them.
+The default reset layout keeps each provider's core quota meters and Usage Trend always shown, then tucks balances, reset details, and spend-history rows behind the caret. Optional detail rows like Cursor Requests/Credits stay off by default, but start below the divider if you enable them.
 
 When OpenUsage ships a new default metric, existing layouts get it once. If you turn it off, it stays off. The **Reset** button in Customize restores the default metrics, order, menu-bar pins, and which metrics start behind the expand caret, but leaves provider settings and other preferences unchanged.
 

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -8,7 +8,6 @@ Tracks your Claude subscription limits using the login you already have from Cla
 |---|---|
 | Session | 5-hour rolling window usage |
 | Weekly | 7-day window usage |
-| Sonnet | Separate weekly Sonnet limit (plan-dependent) |
 | Extra Usage | Extra-usage credits spent against your monthly cap |
 | Today / Yesterday / Last 30 Days | Local spend, as cost, tokens, or both (see below) |
 | Plan | Your plan name (optional widget) |


### PR DESCRIPTION
## What

Anthropic removed the separate weekly Sonnet limit, so the `seven_day_sonnet` field is gone from the Claude usage API response. This removes the now-dead metric end to end.

## Changes

- **`ClaudeProvider.swift`** — drop the `claude.sonnet` percent widget descriptor.
- **`ClaudeUsageMapper.swift`** — stop reading `body["seven_day_sonnet"]`.
- **`DefaultLayout.swift`** — remove `claude.sonnet` from the expanded-metrics membership list (and the comment that named it).
- **Tests** (`ClaudeProviderTests`, `LayoutStoreTests`) — drop the `seven_day_sonnet` fixture, the Sonnet assertion/label loops, and the layout ordering/expanded/enablement expectations.
- **Docs** (`docs/providers/claude.md`, `docs/dashboard.md`, `README.md`) — remove the Sonnet row and mentions.

## Notes for reviewers

- Claude *model* names (e.g. `claude-4.5-sonnet`) in `model_manifest.json` and `CursorSpendTests.swift` are product/pricing references, not the removed limit, and were intentionally left intact.
- No `MetricLine`/`MetricValue` schema change, so the snapshot cache version was not bumped — a stale cached Sonnet line simply stops rendering and is replaced on the next refresh.
- `swift build` is clean (only pre-existing warnings) and the Claude + Layout test suites pass (47 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow removal of a dead API field and UI metric; no auth, schema, or refresh-path changes beyond dropping one mapper line.
> 
> **Overview**
> Removes the **Claude Sonnet** weekly limit metric end to end because Anthropic dropped `seven_day_sonnet` from the OAuth usage API.
> 
> The **`claude.sonnet`** widget is gone from `ClaudeProvider`, and **`ClaudeUsageMapper`** no longer maps that field. Default layout seeding and expanded-metric lists no longer mention it; tests and docs (`README`, `docs/providers/claude.md`, `docs/dashboard.md`) are updated to match. No snapshot cache version bump — cached Sonnet lines simply stop appearing after refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4342387a58db63bce75b0fa7415e29839ec6b94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes a metric that no longer exists in the upstream API, with no impact on remaining Claude quota tracking.

Every reference to the discontinued seven_day_sonnet field is cleanly excised from the mapper, provider descriptor, default layout, tests, and docs. The migrationBaselineMetricIDs snapshot never included claude.sonnet (it was always disabled by default), so there is no migration gap. Existing users with a stale cached Sonnet line will simply stop seeing it on the next refresh — no data loss and no UI breakage.

No files require special attention — all changes are consistent across the mapper, provider, layout defaults, tests, and documentation.

<sub>Reviews (1): Last reviewed commit: ["fix(claude): remove discontinued Sonnet ..."](https://github.com/robinebers/openusage/commit/4342387a58db63bce75b0fa7415e29839ec6b94e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40037552)</sub>

<!-- /greptile_comment -->