### PR TITLE
docs: document PostHog CLI secrets for dSYM symbolication

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,12 @@ The release workflow needs these repository secrets (Settings → Secrets and va
 | `APPLE_TEAM_ID` | your Apple Developer team ID |
 | `SPARKLE_PUBLIC_KEY` | base64 EdDSA public key, baked into the build as `SUPublicEDKey` |
 | `SPARKLE_PRIVATE_KEY` | base64 EdDSA private key used to sign the DMG |
+| `POSTHOG_CLI_API_KEY` | PostHog personal API key used to upload dSYMs for crash symbolication |
+| `POSTHOG_CLI_PROJECT_ID` | numeric PostHog project ID the dSYMs upload to |
 
 Export the Developer ID Application cert (with its private key) from Keychain Access as a `.p12`, then `base64 -i DeveloperID.p12 | pbcopy`. App-specific passwords come from appleid.apple.com → Sign-In and Security → App-Specific Passwords. Generate the Sparkle EdDSA key pair once with Sparkle's `generate_keys` tool; the public and private values must be a matching pair or signing is silently skipped.
+
+The two `POSTHOG_CLI_*` secrets are only used to upload debug symbols (dSYMs) so PostHog can symbolicate crash reports: `POSTHOG_CLI_API_KEY` is a PostHog personal API key (PostHog → Settings → Personal API keys) and `POSTHOG_CLI_PROJECT_ID` is the numeric ID from your project URL. The upload host is hardcoded in the workflow (`https://us.i.posthog.com`), so there is no `POSTHOG_CLI_HOST` secret. Unlike the secrets above these don't block a release — if `POSTHOG_CLI_API_KEY` is unset the workflow skips the upload with a warning and the release still ships, but crash reports for that version show raw addresses instead of symbolicated stack traces.
 
 The repository must be public (Sparkle fetches the DMG and appcast anonymously), and the appcast is served from GitHub Pages — confirm Settings → Pages points at the `gh-pages` branch after the first release.
 


### PR DESCRIPTION
## Problem

The release workflow's **Upload dSYMs to PostHog** step in [.github/workflows/release.yml](.github/workflows/release.yml) is being **skipped** on releases because the `POSTHOG_CLI_API_KEY` repo secret isn't set. CI emits:

> `POSTHOG_CLI_API_KEY not set — skipping dSYM upload; crashes for <version> will NOT symbolicate.`

This started mattering at **v0.7.0-beta.16**, the first release shipping crash reporting ([#739](https://github.com/robinebers/openusage/pull/739)). Crash capture works on users' machines, but without the uploaded dSYMs PostHog renders stack traces as raw addresses.

Root cause for the gap: the README's **Release setup (one-time)** secrets table documented only the Apple and Sparkle secrets — the `POSTHOG_CLI_*` requirement was undiscoverable, so the secret was never added in repo Settings.

## Change

Docs-only. In the README secrets table:

- Add `POSTHOG_CLI_API_KEY` (PostHog **personal** API key) and `POSTHOG_CLI_PROJECT_ID` (numeric project ID).
- Add a note that `POSTHOG_CLI_HOST` is **hardcoded** in the workflow (`https://us.i.posthog.com`), so it is **not** a secret.
- Clarify that, unlike the Apple/Sparkle secrets, a missing `POSTHOG_CLI_API_KEY` does **not** block a release — the upload is skipped with a warning and only symbolication is lost.

## Workflow wiring verified

The dSYM step reads exactly these env vars (release.yml:123-139):

| env var | source |
| --- | --- |
| `POSTHOG_CLI_API_KEY` | `secrets.POSTHOG_CLI_API_KEY` |
| `POSTHOG_CLI_PROJECT_ID` | `secrets.POSTHOG_CLI_PROJECT_ID` |
| `POSTHOG_CLI_HOST` | hardcoded `https://us.i.posthog.com` (not a secret) |

PostHog key semantics confirmed against the [PostHog CLI docs](https://posthog.com/docs/cli) (`POSTHOG_CLI_API_KEY` = personal API key; `POSTHOG_CLI_PROJECT_ID` = numeric project ID).

## Owner action required (out of scope for this PR)

Setting the actual secret values in **Settings → Secrets and variables → Actions** is the maintainer's action — `POSTHOG_CLI_API_KEY` is a private key not included here. This PR only makes the requirement discoverable. Once the secret is set, the next release will upload dSYMs and crashes will symbolicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to README; no code or workflow behavior is modified.
> 
> **Overview**
> Documents the **PostHog CLI** repository secrets needed for the release workflow’s dSYM upload so crash reports can symbolicate in PostHog.
> 
> The **Release setup** secrets table now lists `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID`, with a short paragraph explaining where to get each value, that the upload host is **hardcoded** in `.github/workflows/release.yml` (no `POSTHOG_CLI_HOST` secret), and that a missing API key **does not block** a release—the step is skipped with a warning and only symbolication is lost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35f138aaa52c4393047a6f0f6d999945819c0226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no code paths are affected.

Every factual claim in the added text — secret names, hardcoded host URL, and the skip-on-missing-key behavior — was verified directly against the workflow file. There is nothing here that could break a build or change runtime behavior.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["docs: document PostHog CLI secrets for d..."](https://github.com/robinebers/openusage/commit/35f138aaa52c4393047a6f0f6d999945819c0226) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40055965)</sub>

<!-- /greptile_comment -->