### PR TITLE
fix(claude): restore the weekly Sonnet limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ OpenUsage shows how much of your AI coding plans you've used: session and weekly
 ## Supported Providers
 
 - [**Antigravity**](docs/providers/antigravity.md) — Gemini Pro/Flash and Claude model quotas
-- [**Claude**](docs/providers/claude.md) — session, weekly, extra usage, local daily spend (ccusage)
+- [**Claude**](docs/providers/claude.md) — session, weekly, Sonnet, extra usage, local daily spend (ccusage)
 - [**Codex**](docs/providers/codex.md) — session, weekly, credits, local daily spend (ccusage)
 - [**Cursor**](docs/providers/cursor.md) — credits, total/auto/API usage, requests, on-demand, per-day spend
 - [**Devin**](docs/providers/devin.md) — weekly and daily quota, extra usage balance

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -25,6 +25,7 @@ final class ClaudeProvider: ProviderRuntime {
         [
             .percent(id: "claude.session", provider: provider, title: "Session"),
             .percent(id: "claude.weekly", provider: provider, title: "Weekly"),
+            .percent(id: "claude.sonnet", provider: provider, title: "Sonnet"),
             .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent"),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -23,6 +23,7 @@ enum ClaudeUsageMapper {
         var lines: [MetricLine] = []
         appendUsageWindow(body["five_hour"], label: "Session", periodDurationMs: sessionPeriodMs, to: &lines)
         appendUsageWindow(body["seven_day"], label: "Weekly", periodDurationMs: weeklyPeriodMs, to: &lines)
+        appendUsageWindow(body["seven_day_sonnet"], label: "Sonnet", periodDurationMs: weeklyPeriodMs, to: &lines)
         appendExtraUsage(body["extra_usage"], to: &lines)
 
         return ClaudeMappedUsage(

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -55,7 +55,7 @@ enum DefaultLayout {
     ]
 
     /// Metrics tucked below the per-provider "Shown on expand" divider on a fresh install. This is
-    /// membership, not enablement: optional disabled rows like Cursor Requests/Credits are
+    /// membership, not enablement: optional disabled rows like Sonnet or Cursor Requests/Credits are
     /// listed here so if the user enables them later they appear below the caret by default.
     /// Filtered to the active registry by `LayoutStore`, and only seeded on a genuinely fresh launch
     /// (existing layouts keep everything always-shown unless they reset customization).
@@ -67,7 +67,7 @@ enum DefaultLayout {
         // are marked secondary), so leaving Session primary is what makes the caret appear at all.
         // See AGENTS.md "## Providers".
         "claude.weekly", "claude.trend",
-        "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
+        "claude.sonnet", "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
         "cursor.onDemand", "cursor.requests", "cursor.credits",
         "cursor.today", "cursor.yesterday", "cursor.last30",

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -97,6 +97,7 @@ final class ClaudeUsageMapperTests: XCTestCase {
             {
               "five_hour": { "utilization": 10, "resets_at": "2099-01-01T00:00:00.000Z" },
               "seven_day": { "utilization": 20, "resets_at": "2099-01-01T00:00:00.000Z" },
+              "seven_day_sonnet": { "utilization": 5, "resets_at": "2099-01-01T00:00:00.000Z" },
               "extra_usage": { "is_enabled": true, "used_credits": 500, "monthly_limit": 1000 }
             }
             """.utf8)
@@ -110,6 +111,7 @@ final class ClaudeUsageMapperTests: XCTestCase {
         XCTAssertEqual(mapped.plan, "Max 20x")
         XCTAssertEqual(progress(mapped.lines, "Session")?.used, 10)
         XCTAssertEqual(progress(mapped.lines, "Weekly")?.periodDurationMs, ClaudeUsageMapper.weeklyPeriodMs)
+        XCTAssertEqual(progress(mapped.lines, "Sonnet")?.used, 5)
         XCTAssertEqual(progress(mapped.lines, "Extra usage spent")?.used, 5)
         XCTAssertEqual(progress(mapped.lines, "Extra usage spent")?.limit, 10)
     }
@@ -258,7 +260,7 @@ final class ClaudeProviderTests: XCTestCase {
         print("LIVE response reset headers:", resetHeaders)
 
         let body = try XCTUnwrap(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
-        for key in ["five_hour", "seven_day"] {
+        for key in ["five_hour", "seven_day", "seven_day_sonnet"] {
             guard let window = body[key] as? [String: Any] else { continue }
             print("LIVE \(key)=", window)
         }
@@ -267,7 +269,7 @@ final class ClaudeProviderTests: XCTestCase {
             response,
             credentials: state.oauth
         )
-        for label in ["Session", "Weekly"] {
+        for label in ["Session", "Weekly", "Sonnet"] {
             let resetsAt = Self.progress(mapped.lines, label)?.resetsAt
             print("LIVE mapped \(label) resetsAt=", resetsAt as Any)
         }

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -257,7 +257,7 @@ final class LayoutStoreTests: XCTestCase {
         let store = LayoutStore(registry: registry, defaults: makeDefaults("FreshCustomizeOrder"), storageKey: "layout")
 
         XCTAssertEqual(store.orderedSupportedMetrics(for: "claude").map(\.id), [
-            "claude.session", "claude.weekly", "claude.extra",
+            "claude.session", "claude.weekly", "claude.sonnet", "claude.extra",
             "claude.trend", "claude.today", "claude.yesterday", "claude.last30"
         ])
         XCTAssertEqual(store.orderedSupportedMetrics(for: "codex").map(\.id), [
@@ -298,6 +298,7 @@ final class LayoutStoreTests: XCTestCase {
             "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend",
             "cursor.onDemand", "cursor.today", "cursor.yesterday", "cursor.last30"
         ]))
+        XCTAssertFalse(store.isMetricEnabled("claude.sonnet"))
         XCTAssertFalse(store.isMetricEnabled("cursor.requests"))
         XCTAssertFalse(store.isMetricEnabled("cursor.credits"))
 
@@ -312,7 +313,7 @@ final class LayoutStoreTests: XCTestCase {
         // always keeps ≥1 primary row) — see AGENTS.md "## Providers".
         XCTAssertEqual(primaryByProvider["claude"], ["claude.session"])
         XCTAssertEqual(expandedByProvider["claude"], [
-            "claude.weekly", "claude.extra", "claude.trend",
+            "claude.weekly", "claude.sonnet", "claude.extra", "claude.trend",
             "claude.today", "claude.yesterday", "claude.last30"
         ])
         XCTAssertEqual(primaryByProvider["codex"], ["codex.session", "codex.weekly", "codex.trend"])

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -38,7 +38,7 @@ Open Customize from the **⌄** menu next to the footer's Settings button (or pr
 
 Each provider card has a dashed **Shown on Expand** line. Metrics above it are always shown; metrics below it hide behind the dashboard caret. Drag a metric onto the dashed line to move it across the fold, or drag it onto a row on the other side — drop a metric under an expanded one and it becomes expanded too. Pinning, hiding, and order all work the same on either side.
 
-The default reset layout keeps each provider's core quota meters and Usage Trend always shown, then tucks balances, reset details, and spend-history rows behind the caret. Optional detail rows like Cursor Requests/Credits stay off by default, but start below the divider if you enable them.
+The default reset layout keeps each provider's core quota meters and Usage Trend always shown, then tucks balances, reset details, and spend-history rows behind the caret. Optional detail rows like Claude Sonnet and Cursor Requests/Credits stay off by default, but start below the divider if you enable them.
 
 When OpenUsage ships a new default metric, existing layouts get it once. If you turn it off, it stays off. The **Reset** button in Customize restores the default metrics, order, menu-bar pins, and which metrics start behind the expand caret, but leaves provider settings and other preferences unchanged.
 

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -8,6 +8,7 @@ Tracks your Claude subscription limits using the login you already have from Cla
 |---|---|
 | Session | 5-hour rolling window usage |
 | Weekly | 7-day window usage |
+| Sonnet | Separate weekly Sonnet limit (plan-dependent) |
 | Extra Usage | Extra-usage credits spent against your monthly cap |
 | Today / Yesterday / Last 30 Days | Local spend, as cost, tokens, or both (see below) |
 | Plan | Your plan name (optional widget) |


### PR DESCRIPTION
## What

Re-adds the separate weekly **Sonnet** limit to the Claude provider. Anthropic has brought the limit back upstream — the `seven_day_sonnet` field is present in the usage API response again (the Anthropic console once more shows distinct "All models" and "Sonnet" weekly meters), so the metric should reappear.

This reverses #744, which dropped the metric when the field disappeared.

## Changes

Restored end to end, matching the metric's original defaults:

- **Widget descriptor** (`ClaudeProvider`) — `claude.sonnet`, ordered after Weekly.
- **Mapper** (`ClaudeUsageMapper`) — reads `seven_day_sonnet` as a weekly-period window.
- **Default layout** (`DefaultLayout`) — off by default, member of `expandedMetricIDs` so it sits below the per-provider caret if a user enables it.
- **Tests** — `ClaudeUsageMapperTests` and `LayoutStoreTests` assertions for the Sonnet row.
- **Docs** — provider reference, dashboard guide, README.

## Notes

The mapper reads each usage window behind a presence guard (`guard let object = value as? [String: Any]`), so responses that omit `seven_day_sonnet` simply skip the row rather than showing an empty meter. This keeps the change backward-compatible with any account/plan that doesn't expose a separate Sonnet limit.

## Verification

- `swift build` — succeeds (pre-existing unrelated warnings only).
- `swift test --filter 'ClaudeUsageMapperTests|LayoutStoreTests'` — 45 tests pass, including the restored Sonnet assertions.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a clean, contained restoration of a single optional metric with full backward compatibility.

The mapper uses an existing, well-tested presence guard so missing API fields are silently skipped. The metric is off by default on fresh installs and is placed correctly below the fold when enabled. Tests cover the mapper value, the disabled-by-default state, and the expanded-section ordering. Docs, README, and all five change sites are consistent with each other.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(claude): restore the weekly Sonnet l..."](https://github.com/robinebers/openusage/commit/3e07332538adf7b3dcc4581b26628a0a02fad4a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40074622)</sub>

<!-- /greptile_comment -->