### PR TITLE
[codex] Fix popover height bridge jank

### DIFF
--- a/Sources/OpenUsage/Views/PanelHeightModifier.swift
+++ b/Sources/OpenUsage/Views/PanelHeightModifier.swift
@@ -9,9 +9,10 @@ import os
 /// `animatableData == height` is the per-frame interpolation hook: during a `withAnimation`, the
 /// animation system sets `animatableData` once per display refresh with the interpolated height, and
 /// the setter forwards it (via `PanelHeightBridge`) to the panel — so the window frame and the screen
-/// slide ride the *same* spring. A height of 0 is the "not established yet" sentinel (the panel keeps
-/// the size the controller opened it at) and is skipped, so the first render before measurement lands
-/// never pushes a bogus frame.
+/// slide ride the *same* spring. `effectValue` also forwards the current value so non-animated height
+/// establishments still resize the panel. A height of 0 is the "not established yet" sentinel (the
+/// panel keeps the size the controller opened it at) and is skipped, so the first render before
+/// measurement lands never pushes a bogus frame.
 ///
 /// Built as a `GeometryEffect` (like `DenyShakeEffect`) rather than a plain `ViewModifier`: a custom
 /// `ViewModifier` that implements `body` is inferred `@MainActor` (because `ViewModifier.body` is), which
@@ -31,7 +32,8 @@ struct PanelHeightModifier: GeometryEffect {
     }
 
     func effectValue(size: CGSize) -> ProjectionTransform {
-        ProjectionTransform()
+        PanelHeightBridge.push(height)
+        return ProjectionTransform()
     }
 }
 
@@ -39,26 +41,52 @@ struct PanelHeightModifier: GeometryEffect {
 /// bridge. The hop onto the main queue is MANDATORY and lives here: the setter fires from inside
 /// SwiftUI's update pass, and `applyHeight`'s `setFrame` re-enters AppKit layout on the
 /// constraint-pinned host — running it synchronously would trip `_NSDetectedLayoutRecursion`. The hop
-/// lands it just after the pass unwinds, still within the same display interval. SwiftUI interpolates
-/// on the main thread, so `assumeIsolated` is the right bridge to the `@MainActor` closure.
+/// lands it just after the pass unwinds, still within the same display interval. Bursts are coalesced
+/// to the newest pending height so the panel never replays stale animation frames after SwiftUI has
+/// already moved on. SwiftUI interpolates on the main thread, so `assumeIsolated` is the right bridge
+/// to the `@MainActor` closure.
 enum PanelHeightBridge {
+    private struct State {
+        var generation = 0
+        var pendingHeight: CGFloat?
+        var isScheduled = false
+    }
+
     /// Bumped on every panel open and close. A queued height is applied only if the generation is
     /// unchanged between when it was scheduled and when it runs — so a spring morph in flight when the
     /// panel closes can never resize a hidden, or a freshly reopened, panel with a stale height (the
     /// async hops are otherwise un-cancellable). `OSAllocatedUnfairLock` so the nonisolated `push` and
     /// the main-actor `invalidate` can touch it safely.
-    private static let generation = OSAllocatedUnfairLock(initialState: 0)
+    private static let state = OSAllocatedUnfairLock(initialState: State())
 
     /// Invalidate every in-flight height. Call on panel open and close.
     nonisolated static func invalidate() {
-        generation.withLock { $0 += 1 }
+        state.withLock {
+            $0.generation += 1
+            $0.pendingHeight = nil
+            $0.isScheduled = false
+        }
     }
 
     nonisolated static func push(_ height: CGFloat) {
         guard height > 0 else { return }
-        let scheduled = generation.withLock { $0 }
+        let (scheduled, shouldSchedule) = state.withLock { state in
+            state.pendingHeight = height
+            let scheduled = state.generation
+            guard !state.isScheduled else { return (scheduled, false) }
+            state.isScheduled = true
+            return (scheduled, true)
+        }
+        guard shouldSchedule else { return }
         DispatchQueue.main.async {
-            guard generation.withLock({ $0 }) == scheduled else { return }
+            let height = state.withLock { state -> CGFloat? in
+                guard state.generation == scheduled else { return nil }
+                let height = state.pendingHeight
+                state.pendingHeight = nil
+                state.isScheduled = false
+                return height
+            }
+            guard let height else { return }
             MainActor.assumeIsolated {
                 MenuBarPopover.applyHeight?(height)
             }

--- a/Tests/OpenUsageTests/PanelHeightBridgeTests.swift
+++ b/Tests/OpenUsageTests/PanelHeightBridgeTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class PanelHeightBridgeTests: XCTestCase {
+    func testCoalescesBurstToNewestHeight() async {
+        resetBridge()
+        defer { resetBridge() }
+
+        var applied: [CGFloat] = []
+        let firstApply = expectation(description: "applies coalesced height")
+        let secondApply = expectation(description: "does not replay stale heights")
+        secondApply.isInverted = true
+
+        MenuBarPopover.applyHeight = { height in
+            applied.append(height)
+            if applied.count == 1 {
+                firstApply.fulfill()
+            } else {
+                secondApply.fulfill()
+            }
+        }
+
+        PanelHeightBridge.push(520)
+        PanelHeightBridge.push(560)
+        PanelHeightBridge.push(600)
+
+        await fulfillment(of: [firstApply], timeout: 1)
+        await fulfillment(of: [secondApply], timeout: 0.05)
+        XCTAssertEqual(applied, [600])
+    }
+
+    func testInvalidateDropsQueuedHeight() async {
+        resetBridge()
+        defer { resetBridge() }
+
+        let droppedApply = expectation(description: "drops queued height")
+        droppedApply.isInverted = true
+        MenuBarPopover.applyHeight = { _ in droppedApply.fulfill() }
+
+        PanelHeightBridge.push(600)
+        PanelHeightBridge.invalidate()
+
+        await fulfillment(of: [droppedApply], timeout: 0.05)
+    }
+
+    private func resetBridge() {
+        PanelHeightBridge.invalidate()
+        MenuBarPopover.applyHeight = nil
+    }
+}

--- a/Tests/OpenUsageTests/PanelHeightBridgeTests.swift
+++ b/Tests/OpenUsageTests/PanelHeightBridgeTests.swift
@@ -44,6 +44,23 @@ final class PanelHeightBridgeTests: XCTestCase {
         await fulfillment(of: [droppedApply], timeout: 0.05)
     }
 
+    func testEffectValuePushesEstablishedHeight() async {
+        resetBridge()
+        defer { resetBridge() }
+
+        var applied: [CGFloat] = []
+        let firstApply = expectation(description: "applies established height")
+        MenuBarPopover.applyHeight = { height in
+            applied.append(height)
+            firstApply.fulfill()
+        }
+
+        _ = PanelHeightModifier(height: 640).effectValue(size: CGSize(width: 320, height: 640))
+
+        await fulfillment(of: [firstApply], timeout: 1)
+        XCTAssertEqual(applied, [640])
+    }
+
     private func resetBridge() {
         PanelHeightBridge.invalidate()
         MenuBarPopover.applyHeight = nil


### PR DESCRIPTION
## Summary

Fixes #752 by tightening the SwiftUI-to-AppKit height bridge used by the menu-bar panel during expand/collapse animations.

The panel was receiving every queued intermediate height asynchronously. If the main loop fell behind, AppKit could replay stale panel heights after SwiftUI content had already advanced, which made the card/text and popover frame appear to settle on different frames.

This PR changes the bridge so each main-loop turn applies only the newest pending height. It also forwards the current height from the geometry effect so non-animated height establishment paths, such as first measurement or reopen, still drive the panel frame immediately.

## Validation

- `swift test` passed: 482 tests, 1 skipped
- `./script/build_and_run.sh verify` built, signed, launched, and confirmed the app process
- Manual local test confirmed expand/collapse is smooth on the maintainer system

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI bridge timing for the menu-bar panel; generation invalidation and coalescing reduce stale-frame risk without touching auth or data.
> 
> **Overview**
> Fixes menu-bar popover expand/collapse jank (#752) by changing how SwiftUI forwards height to the AppKit panel.
> 
> **`PanelHeightBridge`** now keeps pending height and a single scheduled main-queue callback: rapid `push` calls in one turn coalesce so only the **newest** height is applied, avoiding stale intermediate frames when the main loop lags behind SwiftUI’s spring.
> 
> **`PanelHeightModifier.effectValue`** also calls `push(height)` so non-animated height establishment (first measurement, reopen) still resizes the panel, not only the `animatableData` animation path. **`invalidate()`** clears pending height and the scheduled flag on open/close, alongside the existing generation guard.
> 
> Adds **`PanelHeightBridgeTests`** for burst coalescing, invalidate dropping queued work, and the `effectValue` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a8dd350e88d3187bc67341f73686c60453674f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Localized change to a single animation bridge utility with no data, auth, or persistence surface; the coalescing logic is correct and the test suite covers all three modified paths.

The lock-based coalescing is implemented correctly: `isScheduled` is only cleared on a successful apply (not on generation mismatch), so a stale in-flight callback can never clobber `isScheduled` after a re-open. `invalidate()` atomically clears all three state fields, and the generation check in the callback guards against any callback that was scheduled before the invalidation. The `effectValue` call is safe from a SwiftUI threading perspective because `GeometryEffect.effectValue` fires on the main thread and `push` is `nonisolated` / lock-protected. All three meaningful scenarios are covered by the new tests.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["test panel height effect bridge"](https://github.com/robinebers/openusage/commit/09a8dd350e88d3187bc67341f73686c60453674f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40112578)</sub>

<!-- /greptile_comment -->