### PR TITLE
fix(claude): keychain-first creds, 429 resilience, and auth diagnostics (#738)

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -20,12 +20,39 @@ struct ClaudeCredentialState: Hashable, Sendable {
         case keychainCurrentUser(service: String)
         case keychainLegacy(service: String)
         case environment
+
+        /// Log-safe source kind — NEVER the keychain service name or any token.
+        var label: String {
+            switch self {
+            case .file: "file"
+            case .keychainCurrentUser: "keychainCurrentUser"
+            case .keychainLegacy: "keychainLegacy"
+            case .environment: "environment"
+            }
+        }
     }
 
     var oauth: ClaudeOAuth
     var source: Source
     var fullData: ClaudeCredentialsFile?
     var inferenceOnly: Bool
+
+    /// A token-free, log-safe one-line descriptor for diagnosing auth failures from a default-level
+    /// (info) log: the source kind plus booleans for whether this candidate carries a refresh token and
+    /// whether its access token is already expired (`expiresAt`, epoch ms, vs `now`). NEVER includes any
+    /// token value or the credential blob — only the source kind and the two booleans. Why these two
+    /// booleans: a candidate with `refresh=no` can never self-heal an expiry (the #738 root cause), and
+    /// `expired=yes` explains why a refresh was needed at all.
+    func diagnosticsLabel(now: Date) -> String {
+        let refresh = (oauth.refreshToken?.isEmpty == false) ? "yes" : "no"
+        let expired: String
+        if let expiresAt = oauth.expiresAt {
+            expired = expiresAt <= now.timeIntervalSince1970 * 1000 ? "yes" : "no"
+        } else {
+            expired = "unknown"
+        }
+        return "\(source.label) refresh=\(refresh) expired=\(expired)"
+    }
 }
 
 enum ClaudeAuthError: Error, LocalizedError, Equatable {
@@ -96,11 +123,11 @@ struct ClaudeAuthStore: Sendable {
         self.now = now
     }
 
-    /// All credential sources currently on disk/keychain, freshest first, for the refresh loop to try in
-    /// order. The provider probes each and — on an auth-expiry error (`ClaudeAuthError.allowsAuthFallback`)
-    /// — falls through to the next, so an external `claude` re-login is picked up no matter which source
-    /// it lands in, even when a stale/locked-out token still sits in another. Re-read on every refresh;
-    /// nothing is cached in memory.
+    /// All credential sources currently on disk/keychain, in fixed keychain-before-file order, for the
+    /// refresh loop to try in order. The provider probes each and — on an auth-expiry error
+    /// (`ClaudeAuthError.allowsAuthFallback`) — falls through to the next, so an external `claude`
+    /// re-login is picked up no matter which source it lands in, even when a stale/locked-out token still
+    /// sits in another. Re-read on every refresh; nothing is cached in memory.
     func loadCredentialCandidates() -> [ClaudeCredentialState] {
         // An explicit env token overrides everything and is inference-only (no live usage call), so there
         // is no auth failure to fall back from — return the single env-wrapped candidate.
@@ -118,7 +145,8 @@ struct ClaudeAuthStore: Sendable {
         return orderedStoredCandidates()
     }
 
-    /// The first (freshest) credential candidate. Kept for callers that only need a single source.
+    /// The first (preferred) credential candidate — the keychain when present, else the file. Kept for
+    /// callers that only need a single source.
     func loadCredentials() -> ClaudeCredentialState? {
         loadCredentialCandidates().first
     }
@@ -145,16 +173,7 @@ struct ClaudeAuthStore: Sendable {
             return
         }
         // NEVER log the credential blob/tokens — only that a rotation was persisted, and to where.
-        AppLog.debug(LogTag.auth("claude"), "persisted rotated credentials (source=\(sourceLabel(state.source)))")
-    }
-
-    private func sourceLabel(_ source: ClaudeCredentialState.Source) -> String {
-        switch source {
-        case .file: "file"
-        case .keychainCurrentUser: "keychainCurrentUser"
-        case .keychainLegacy: "keychainLegacy"
-        case .environment: "environment"
-        }
+        AppLog.debug(LogTag.auth("claude"), "persisted rotated credentials (source=\(state.source.label))")
     }
 
     func canFetchLiveUsage(_ state: ClaudeCredentialState) -> Bool {
@@ -245,30 +264,26 @@ struct ClaudeAuthStore: Sendable {
         ProviderParse.decodeJSONWithHexFallback(text, as: ClaudeCredentialsFile.self)
     }
 
-    /// Keychain and file credentials, ordered freshest-first by access-token expiry. A later expiry means
-    /// a more recent login, so a fresh external re-login is preferred over a stale token still sitting in
-    /// another source. The sort is stable, so when expiries tie — or are both absent — keychain stays
-    /// ahead of file, preserving the historical precedence. The source kind (never the token) is logged
-    /// so a "locked out" report can be diagnosed from which source was chosen.
+    /// Keychain and file credentials in fixed keychain-before-file order. The keychain is Claude Code's
+    /// source of truth on macOS — recent versions keep the current session there and can leave a stale
+    /// `~/.claude/.credentials.json` behind — so it must win when valid; the file is only a fallback
+    /// (older installs / Linux-style layouts). The refresh loop still falls through to the file on an
+    /// auth-expiry error, so a fresh external `claude` re-login that landed in the other source is picked
+    /// up (#687) WITHOUT letting a stale file outrank the live keychain just because its token carries a
+    /// later expiry (the #738 regression from ranking purely by expiry). The source kind (never the
+    /// token) is logged so a "locked out" report can be diagnosed from which source was chosen.
     private func orderedStoredCandidates() -> [ClaudeCredentialState] {
         var candidates: [ClaudeCredentialState] = []
         if let keychain = loadKeychainCredentials() { candidates.append(keychain) }
         if let file = loadFileCredentials() { candidates.append(file) }
 
-        let ordered = candidates.enumerated().sorted { lhs, rhs in
-            let lhsExpiry = lhs.element.oauth.expiresAt ?? -.greatestFiniteMagnitude
-            let rhsExpiry = rhs.element.oauth.expiresAt ?? -.greatestFiniteMagnitude
-            if lhsExpiry == rhsExpiry { return lhs.offset < rhs.offset }
-            return lhsExpiry > rhsExpiry
-        }.map(\.element)
-
-        if ordered.count > 1 {
-            let labels = ordered.map { sourceLabel($0.source) }.joined(separator: ", ")
-            AppLog.debug(LogTag.auth("claude"), "credential candidates (freshest first): \(labels)")
-        } else if let only = ordered.first {
-            AppLog.debug(LogTag.auth("claude"), "credential source: \(sourceLabel(only.source))")
+        if candidates.count > 1 {
+            let labels = candidates.map(\.source.label).joined(separator: ", ")
+            AppLog.debug(LogTag.auth("claude"), "credential candidates (keychain first): \(labels)")
+        } else if let only = candidates.first {
+            AppLog.debug(LogTag.auth("claude"), "credential source: \(only.source.label)")
         }
-        return ordered
+        return candidates
     }
 
     private func loadFileCredentials() -> ClaudeCredentialState? {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -9,6 +9,15 @@ final class ClaudeProvider: ProviderRuntime {
     let ccusageRunner: CcusageRunner
     let now: @Sendable () -> Date
 
+    /// Last successful live-usage result and a rate-limit cooldown, carried across refreshes (the provider
+    /// is a long-lived singleton). `/api/oauth/usage` rate-limits aggressively, so on a 429 we serve the
+    /// last-good bars with a staleness note instead of blanking the dashboard, and skip the live call
+    /// entirely until the cooldown expires so we don't keep hammering an endpoint that's already limiting
+    /// us. Mirrors the legacy plugin's `cachedUsageData` + `rateLimitedUntilMs`.
+    private var lastGoodUsage: ClaudeMappedUsage?
+    private var rateLimitedUntil: Date?
+    private static let rateLimitCooldown: TimeInterval = 5 * 60
+
     init(
         authStore: ClaudeAuthStore = ClaudeAuthStore(),
         usageClient: ClaudeUsageClient = ClaudeUsageClient(),
@@ -39,7 +48,11 @@ final class ClaudeProvider: ProviderRuntime {
             return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.notLoggedIn)
         }
 
-        AppLog.info(LogTag.plugin("claude"), "refresh start (\(candidates.count) credential source\(candidates.count == 1 ? "" : "s"))")
+        // Per-source diagnostics at info level (token-free: source kind + refresh-token-present + expired
+        // booleans) so a "token expired" report is diagnosable from a default log without a debug build —
+        // e.g. all sources showing `refresh=no` explains why an expiry can never self-heal (issue #738).
+        let sources = candidates.map { $0.diagnosticsLabel(now: now()) }.joined(separator: ", ")
+        AppLog.info(LogTag.plugin("claude"), "refresh start (\(candidates.count) source\(candidates.count == 1 ? "" : "s"): \(sources))")
         let start = Date()
         // Probe each credential source in freshest-first order. An auth-expiry failure on one source (a
         // stale/locked-out token that an external `claude` re-login replaced in another source) falls
@@ -52,7 +65,7 @@ final class ClaudeProvider: ProviderRuntime {
                 AppLog.info(LogTag.plugin("claude"), "refresh end (\(Int(Date().timeIntervalSince(start) * 1000))ms)")
                 return snapshot
             } catch let error as ClaudeAuthError where error.allowsAuthFallback {
-                AppLog.warn(LogTag.auth("claude"), "credential source failed (\(error)); falling back to next source if any")
+                AppLog.warn(LogTag.auth("claude"), "\(state.source.label) failed (\(error)); falling back to next source if any")
                 lastFallbackError = error
                 continue
             } catch {
@@ -89,6 +102,13 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     private func fetchLiveUsage(state: inout ClaudeCredentialState) async throws -> ClaudeMappedUsage {
+        // Inside an active rate-limit cooldown, skip the live call and serve the last-good usage so a
+        // constantly-limited endpoint doesn't blank the dashboard (and we don't pile on more 429s).
+        if let until = rateLimitedUntil, now() < until {
+            AppLog.info(LogTag.plugin("claude"), "rate-limited (cooldown active, serving \(lastGoodUsage == nil ? "badge" : "last-good usage"))")
+            return rateLimitedSnapshot(credentials: state.oauth, retryAfterSeconds: Int(until.timeIntervalSince(now()).rounded(.up)))
+        }
+
         if authStore.needsRefresh(state.oauth),
            let refreshToken = state.oauth.refreshToken,
            !refreshToken.isEmpty {
@@ -110,15 +130,31 @@ final class ClaudeProvider: ProviderRuntime {
             authExpired: ClaudeAuthError.tokenExpired
         )
 
-        // 429 can come back from either attempt; the helper hands both through unchanged.
+        // 429 can come back from either attempt; the helper hands both through unchanged. Start a cooldown
+        // (respecting Retry-After) and serve the last-good usage rather than a bare badge.
         if response.statusCode == 429 {
-            AppLog.info(LogTag.plugin("claude"), "rate-limited")
-            return ClaudeUsageMapper.rateLimitedUsage(
-                credentials: working.oauth,
-                retryAfterSeconds: ClaudeUsageMapper.parseRetryAfterSeconds(response, now: now())
-            )
+            let retryAfterSeconds = ClaudeUsageMapper.parseRetryAfterSeconds(response, now: now())
+            rateLimitedUntil = now().addingTimeInterval(TimeInterval(retryAfterSeconds ?? Int(Self.rateLimitCooldown)))
+            AppLog.info(LogTag.plugin("claude"), "rate-limited (serving \(lastGoodUsage == nil ? "badge" : "last-good usage"))")
+            return rateLimitedSnapshot(credentials: working.oauth, retryAfterSeconds: retryAfterSeconds)
         }
-        return try ClaudeUsageMapper.mapUsageResponse(response, credentials: working.oauth, now: now())
+
+        let mapped = try ClaudeUsageMapper.mapUsageResponse(response, credentials: working.oauth, now: now())
+        lastGoodUsage = mapped
+        rateLimitedUntil = nil
+        return mapped
+    }
+
+    /// Last-good usage with an appended staleness note when we have it; otherwise the plain rate-limited
+    /// badge (no successful fetch yet this run). `lastGoodUsage` only ever holds a clean `mapUsageResponse`
+    /// result (never a rate-limited snapshot), so the note is never duplicated and no stale ccusage tiles
+    /// ride along — `probe` appends those fresh after this returns.
+    private func rateLimitedSnapshot(credentials: ClaudeOAuth, retryAfterSeconds: Int?) -> ClaudeMappedUsage {
+        guard var mapped = lastGoodUsage else {
+            return ClaudeUsageMapper.rateLimitedUsage(credentials: credentials, retryAfterSeconds: retryAfterSeconds)
+        }
+        mapped.lines.append(ClaudeUsageMapper.rateLimitedNote(retryAfterSeconds: retryAfterSeconds))
+        return mapped
     }
 
     private func refreshAccessToken(state: inout ClaudeCredentialState, refreshToken: String) async throws -> String {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -54,7 +54,7 @@ final class ClaudeProvider: ProviderRuntime {
         let sources = candidates.map { $0.diagnosticsLabel(now: now()) }.joined(separator: ", ")
         AppLog.info(LogTag.plugin("claude"), "refresh start (\(candidates.count) source\(candidates.count == 1 ? "" : "s"): \(sources))")
         let start = Date()
-        // Probe each credential source in freshest-first order. An auth-expiry failure on one source (a
+        // Probe each credential source in keychain-before-file order. An auth-expiry failure on one source (a
         // stale/locked-out token that an external `claude` re-login replaced in another source) falls
         // through to the next rather than failing the whole refresh; any non-auth error (rate limit,
         // request/transport failure) surfaces immediately so a real outage is never masked as a retry.

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -32,17 +32,26 @@ enum ClaudeUsageMapper {
         )
     }
 
+    /// Snapshot shown when the usage endpoint rate-limits us and there is no last-good usage to fall back
+    /// on (e.g. the first fetch after launch): a status badge plus the staleness note, no live bars.
     static func rateLimitedUsage(credentials: ClaudeOAuth, retryAfterSeconds: Int?) -> ClaudeMappedUsage {
         let retryText = retryAfterSeconds.map(formatRateLimitMinutes)
         let waitText = retryText.map { "Rate limited, retry in ~\($0)" } ?? "Rate limited, try again later"
-        let noteText = retryText.map { "Live usage rate limited - retry in ~\($0)" } ?? "Live usage rate limited - data may be stale"
         return ClaudeMappedUsage(
             plan: formatPlan(subscriptionType: credentials.subscriptionType, rateLimitTier: credentials.rateLimitTier),
             lines: [
                 .badge(label: "Status", text: waitText, colorHex: "#F59E0B"),
-                .text(label: "Note", value: noteText)
+                rateLimitedNote(retryAfterSeconds: retryAfterSeconds)
             ]
         )
+    }
+
+    /// The "live usage is rate limited" note appended to a last-good snapshot so the still-shown bars are
+    /// flagged as possibly stale. Shared with `rateLimitedUsage` so the wording stays in one place.
+    static func rateLimitedNote(retryAfterSeconds: Int?) -> MetricLine {
+        let retryText = retryAfterSeconds.map(formatRateLimitMinutes)
+        let noteText = retryText.map { "Live usage rate limited - retry in ~\($0)" } ?? "Live usage rate limited - data may be stale"
+        return .text(label: "Note", value: noteText)
     }
 
     static func parseRetryAfterSeconds(_ response: HTTPResponse, now: Date = Date()) -> Int? {

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -12,6 +12,39 @@ final class ClaudeAuthStoreTests: XCTestCase {
         XCTAssertEqual(credentials?.claudeAiOauth?.subscriptionType, "pro")
     }
 
+    func testCredentialDiagnosticsLabelIsTokenFreeWithSourceRefreshAndExpiredFlags() {
+        // The info-level "refresh start" / fallback diagnostics must name the source kind and whether each
+        // candidate carries a refresh token + is already expired — never any token value (#738 diagnosis).
+        let now = Date(timeIntervalSince1970: 1_000_000) // 1_000_000_000 ms
+
+        let fresh = ClaudeCredentialState(
+            oauth: ClaudeOAuth(accessToken: "ACCESS_SECRET", refreshToken: "REFRESH_SECRET", expiresAt: 2_000_000_000_000),
+            source: .keychainCurrentUser(service: "Claude Code-credentials"),
+            fullData: nil,
+            inferenceOnly: false
+        )
+        XCTAssertEqual(fresh.diagnosticsLabel(now: now), "keychainCurrentUser refresh=yes expired=no")
+        XCTAssertFalse(fresh.diagnosticsLabel(now: now).contains("SECRET")) // never leaks token values
+
+        // No refresh token + an already-expired access token: the #738 shape that can never self-heal.
+        let lockedOut = ClaudeCredentialState(
+            oauth: ClaudeOAuth(accessToken: "a", refreshToken: nil, expiresAt: 1),
+            source: .file,
+            fullData: nil,
+            inferenceOnly: false
+        )
+        XCTAssertEqual(lockedOut.diagnosticsLabel(now: now), "file refresh=no expired=yes")
+
+        // Empty refresh token counts as absent; missing expiry is reported as unknown, not assumed fresh.
+        let unknownExpiry = ClaudeCredentialState(
+            oauth: ClaudeOAuth(accessToken: "a", refreshToken: "", expiresAt: nil),
+            source: .keychainLegacy(service: "svc"),
+            fullData: nil,
+            inferenceOnly: false
+        )
+        XCTAssertEqual(unknownExpiry.diagnosticsLabel(now: now), "keychainLegacy refresh=no expired=unknown")
+    }
+
     func testPrefersCurrentUserKeychainCredentialsBeforeFile() {
         let files = FakeFiles([
             "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"file-token","subscriptionType":"pro"}}"#
@@ -32,10 +65,11 @@ final class ClaudeAuthStoreTests: XCTestCase {
         XCTAssertEqual(credentials?.oauth.subscriptionType, "max")
     }
 
-    func testPrefersFresherFileTokenOverStaleKeychain() {
-        // #687: keychain is the historical default source, but when the file holds a token with a later
-        // expiry (a more recent external `claude` login), it must be tried first so a stale keychain
-        // entry can no longer shadow the fresh login. Ordering still keeps both candidates available.
+    func testPrefersKeychainOverFileEvenWhenFileTokenExpiresLater() {
+        // #738 regression: the keychain is Claude Code's live source of truth, so it must win even when a
+        // stale `~/.claude/.credentials.json` carries a *later* expiry. Ranking purely by expiry (the old
+        // #694 behavior) let that stale file outrank the live keychain and starved token refresh. Both
+        // candidates stay available so the refresh loop can still fall back keychain → file on auth expiry.
         let files = FakeFiles([
             "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"file-token","expiresAt":4102444800000,"subscriptionType":"pro"}}"#
         ])
@@ -50,8 +84,8 @@ final class ClaudeAuthStoreTests: XCTestCase {
 
         let candidates = store.loadCredentialCandidates()
 
-        XCTAssertEqual(candidates.map(\.oauth.accessToken), ["file-token", "keychain-token"])
-        XCTAssertEqual(store.loadCredentials()?.oauth.accessToken, "file-token")
+        XCTAssertEqual(candidates.map(\.oauth.accessToken), ["keychain-token", "file-token"])
+        XCTAssertEqual(store.loadCredentials()?.oauth.accessToken, "keychain-token")
     }
 
     func testEnvironmentTokenIsInferenceOnly() {
@@ -339,9 +373,9 @@ final class ClaudeProviderTests: XCTestCase {
             keychain: keychain,
             now: { now }
         )
-        // The stale keychain token even has a *later* expiry than the file token, so freshest-first
-        // ordering still probes it first — proving the recovery comes from the auth-failure fallback,
-        // not just from reordering.
+        // The keychain is always probed first (it's the source of truth), so this exercises the
+        // auth-failure fallback: the stale keychain token's refresh is revoked, and recovery comes from
+        // falling through to the fresh file token — not from any expiry-based reordering.
         let hashedService = authStore.keychainServiceCandidates().first!
         keychain.currentUserValues[hashedService] = #"{"claudeAiOauth":{"accessToken":"stale-access","refreshToken":"stale-refresh","expiresAt":4102444800000,"subscriptionType":"max","scopes":["user:profile"]}}"#
 
@@ -448,6 +482,60 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertEqual(badge(snapshot.lines, "Status")?.hasPrefix("Rate limited"), true)
     }
 
+    func testRateLimitServesLastGoodUsageThenBacksOff() async {
+        // Tier 2: once a live fetch succeeds, a subsequent 429 keeps showing the cached bars (with a
+        // staleness note) instead of a bare badge, and the cooldown then skips the live call entirely so
+        // a constantly-limited endpoint isn't hammered. Mirrors the legacy plugin's cache + 429 backoff.
+        let t0 = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let clock = TestClock(t0)
+        let usageCalls = CallCounter()
+        let httpClient = RoutingHTTPClient { request in
+            guard request.url.absoluteString.hasSuffix("/api/oauth/usage") else {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+            }
+            if usageCalls.next() == 1 {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":25,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 429, headers: ["retry-after": "600"], body: Data())
+        }
+        let provider = ClaudeProvider(
+            authStore: ClaudeAuthStore(
+                environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+                files: FakeFiles([
+                    "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"token","subscriptionType":"pro","scopes":["user:profile"]}}"#
+                ]),
+                keychain: FakeKeychain(),
+                now: { clock.now }
+            ),
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(
+                processRunner: FakeProcessRunner(),
+                homeDirectory: { URL(fileURLWithPath: "/Users/test") }
+            ),
+            now: { clock.now }
+        )
+
+        // 1) Live fetch succeeds and is cached.
+        let first = await provider.refresh()
+        XCTAssertEqual(Self.progress(first.lines, "Session")?.used, 25)
+
+        // 2) 429: still shows the cached Session bar plus the staleness note, not a bare "Status" badge.
+        let second = await provider.refresh()
+        XCTAssertEqual(Self.progress(second.lines, "Session")?.used, 25)
+        XCTAssertEqual(text(second.lines, "Note")?.contains("rate limited"), true)
+        XCTAssertNil(badge(second.lines, "Status"))
+
+        // 3) Within the cooldown the live call is skipped entirely; the cached bar is still shown.
+        clock.set(t0.addingTimeInterval(60))
+        let third = await provider.refresh()
+        XCTAssertEqual(Self.progress(third.lines, "Session")?.used, 25)
+        XCTAssertEqual(httpClient.requests.filter { $0.url.absoluteString.hasSuffix("/api/oauth/usage") }.count, 2)
+    }
+
     func testRefreshSurfacesRequestFailureForNonOAuthRefreshErrorBody() async {
         // The usage call 401s (forcing a refresh); the refresh endpoint then returns a non-OAuth 400
         // (an HTML proxy/WAF page). The snapshot must report a request failure, NOT "token expired" —
@@ -497,10 +585,43 @@ final class ClaudeProviderTests: XCTestCase {
         return values
     }
 
+    private func text(_ lines: [MetricLine], _ label: String) -> String? {
+        guard case .text(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return value
+    }
+
     private static func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
         guard case .progress(_, let used, let limit, _, let resetsAt, let periodDurationMs, _) = lines.first(where: { $0.label == label }) else {
             return nil
         }
         return (used, limit, resetsAt, periodDurationMs)
+    }
+}
+
+/// A monotonic call counter for stateful `RoutingHTTPClient` handlers (e.g. "succeed once, then 429").
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    func next() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        value += 1
+        return value
+    }
+}
+
+/// A mutable clock so a test can advance `now` between refreshes to exercise time-based gates.
+private final class TestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+    init(_ value: Date) { self.value = value }
+    var now: Date {
+        lock.lock(); defer { lock.unlock() }
+        return value
+    }
+    func set(_ value: Date) {
+        lock.lock(); defer { lock.unlock() }
+        self.value = value
     }
 }

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -15,7 +15,7 @@ Tracks your Claude subscription limits using the login you already have from Cla
 
 ## Where credentials come from
 
-Sign in once with Claude Code; OpenUsage reads the same credentials. It checks every place Claude Code can store them and prefers the most recent login:
+Sign in once with Claude Code; OpenUsage reads the same credentials. It checks every place Claude Code can store them, in priority order — the keychain is Claude Code's source of truth on macOS, so it wins over a leftover credentials file:
 
 1. `CLAUDE_CODE_OAUTH_TOKEN` environment variable
 2. The macOS keychain entry Claude Code maintains


### PR DESCRIPTION
## Summary

Fixes the Claude usage flapping reported in #738 ("Claude - token expired"), where the menu bar alternated between a hard "Token expired" error and a bare "Rate limited" badge while the legacy edition kept working. Diagnosed from the reporter's log (172 ok / 69 failed over 22h, **zero** token-refresh attempts, 172/172 "ok" cycles were HTTP 429). Three changes, anchored to the behavior of the most-trusted monitors (CodexBar 15.4k★, plus the 0-open-issue ones) and the still-working legacy plugin:

### 1. Source selection — the regression (Tier 1)
#694 replaced fixed **keychain-first** selection with ranking by token `expiresAt`. That let a stale `~/.claude/.credentials.json` outrank the live keychain (Claude Code's source of truth on macOS), so OpenUsage rode a refresh-token-less blob and could never self-heal an expiry.

- Restore fixed **keychain-before-file** order in `orderedStoredCandidates`.
- **Keep** #694's auth-failure fallback loop, so a fresh external `claude` re-login that landed in the other source is still picked up (#687) — that fix only needed the fallback, not the reordering.

### 2. Rate-limit resilience (Tier 2)
`/api/oauth/usage` rate-limits aggressively (every "ok" cycle in the report was a 429). Now, on a 429 the provider:
- serves the **last-good usage bars + a staleness note** instead of a bare badge, and
- **skips the live call during a short cooldown** (respects `Retry-After`) so it stops hammering an endpoint that's already limiting it.

Mirrors the legacy plugin's `cachedUsageData` + `rateLimitedUntilMs`; complements the store's error-only stale-while-revalidate (a 429 returns a success snapshot it doesn't catch).

### 3. Auth diagnostics (Tier 0)
The default-level (info) log gave no way to tell *which* source failed or whether it carried a refresh token. Now:
- info "refresh start" lists token-free per-source metadata: `refresh start (2 sources: keychainCurrentUser refresh=no expired=yes, file refresh=no expired=yes)`,
- the fallback WARN names the source: `[auth:claude] keychainCurrentUser failed (tokenExpired); ...`.

No token values are ever logged — only the source kind and two booleans.

## Verification
- `swift build` clean; **full `swift test` green (481 tests, 0 failures)**, including new regression tests for keychain-first ordering, 429-serves-last-good + cooldown, and the token-free diagnostics label.
- Ran the app: confirmed `refresh start (1 source: keychainCurrentUser refresh=yes expired=no)` in a real log, with no token leakage.

## Follow-up
- #753 — CLI-delegated token refresh (CodexBar / opencode pattern) for the case where the stored refresh token is genuinely missing/revoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth credential selection and live usage fetch behavior on a long-lived provider singleton; changes are scoped to Claude with regression tests, but wrong ordering or stale cache could still mislead users briefly during rate limits.
> 
> **Overview**
> Fixes Claude menu-bar flapping between **token expired** and bare **rate limited** (#738) by changing how credentials are chosen, how 429s are handled, and what gets logged at info level.
> 
> **Credential order** reverts expiry-based ranking to fixed **keychain → file**. A stale `~/.claude/.credentials.json` with a later `expiresAt` no longer beats the live keychain (the #738 regression); auth-failure fallback across sources is unchanged (#687).
> 
> **Rate limits**: on HTTP 429 the provider keeps **last-good usage bars** and appends a staleness note instead of only a status badge; it sets a cooldown from `Retry-After` (or ~5m) and **skips** live `/api/oauth/usage` calls until it expires so the dashboard does not blank and the endpoint is not hammered.
> 
> **Diagnostics**: token-free info logs list each source as `source refresh=yes|no expired=yes|no|unknown`; fallback warnings name the failing `source.label`. `Source.label` centralizes log-safe source names.
> 
> Docs and tests updated for keychain-first ordering, 429 cache/backoff, and diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98b900abab4c6446ecd68ef9c7ab47c883756be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The change is safe to merge: all mutable state is confined to the @MainActor-isolated ClaudeProvider singleton, the credential ordering fix is mechanically simple, and every new behavior path is covered by targeted regression tests.

The three-part fix is well-scoped — credential ordering is a two-line structural change, the 429 cache introduces only two new fields on the existing singleton with no shared-state hazards, and diagnostics are additive. The full 481-test suite passes, including new tests specifically targeting keychain-before-file ordering, last-good-usage serving on 429, cooldown skip, and token-free label content. No auth contract changes or schema migrations involved.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["docs(claude): fix stale &quot;freshest-first&quot;..."](https://github.com/robinebers/openusage/commit/e98b900abab4c6446ecd68ef9c7ab47c883756be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40113707)</sub>

<!-- /greptile_comment -->