### PR TITLE
[codex] Add provider telemetry reason rollups

### DIFF
--- a/Sources/OpenUsage/Providers/ProviderRuntime.swift
+++ b/Sources/OpenUsage/Providers/ProviderRuntime.swift
@@ -14,8 +14,9 @@ import Foundation
 /// - `.badge` — a short status pill (e.g. "Disabled", or a pay-as-you-go cap). Use for state, not a number
 ///   to fill a bar with.
 ///
-/// On failure, return `ProviderSnapshot.error(provider:message:)` so the error surfaces loudly in the UI
-/// rather than showing stale or empty data.
+/// On failure, return `ProviderSnapshot.error(provider:error:)` with a typed provider error so the error
+/// surfaces loudly in the UI and telemetry can report a stable, non-PII category. Use the message-only
+/// factory only when no typed error exists.
 @MainActor
 protocol ProviderRuntime: AnyObject {
     var provider: Provider { get }
@@ -35,4 +36,3 @@ protocol ProviderRuntime: AnyObject {
 func loadOffMainActor<T: Sendable>(_ load: @escaping @Sendable () -> T) async -> T {
     await Task.detached(priority: .utility, operation: load).value
 }
-

--- a/Sources/OpenUsage/Stores/TelemetryRecorder.swift
+++ b/Sources/OpenUsage/Stores/TelemetryRecorder.swift
@@ -123,14 +123,29 @@ final class TelemetryRecorder {
     }
 
     private func emitProviderRollup(providerID: String, counter: ProviderDailyCounter) {
-        sink.capture("provider_refresh_daily", [
+        sink.capture("provider_refresh_daily", Self.providerRollupProperties(providerID: providerID, counter: counter))
+        sink.flush()
+    }
+
+    private static func providerRollupProperties(providerID: String, counter: ProviderDailyCounter) -> [String: Any] {
+        var properties: [String: Any] = [
             "provider_id": providerID,
             "success_count": counter.success,
             "failure_count": counter.failure,
             "error_categories": counter.errors,
             "manual_refresh_count": counter.manual
-        ])
-        sink.flush()
+        ]
+
+        for category in ErrorCategory.allCases {
+            properties["\(category.rawValue)_failure_count"] = counter.errors[category.rawValue] ?? 0
+        }
+
+        let expectedFailureCount = [ErrorCategory.notLoggedIn, .notAvailable].reduce(0) { total, category in
+            total + (counter.errors[category.rawValue] ?? 0)
+        }
+        properties["expected_failure_count"] = expectedFailureCount
+        properties["unexpected_failure_count"] = max(0, counter.failure - expectedFailureCount)
+        return properties
     }
 
     /// Local-calendar `yyyy-MM-dd`. Local (not UTC) so "every day" matches the user's perception; the

--- a/Tests/OpenUsageTests/TelemetryRecorderTests.swift
+++ b/Tests/OpenUsageTests/TelemetryRecorderTests.swift
@@ -39,6 +39,7 @@ final class TelemetryRecorderTests: XCTestCase {
         recorder.record(providerID: "claude", outcome: .refreshed, category: nil, manual: true)
         recorder.record(providerID: "claude", outcome: .failed, category: .network, manual: false)
         recorder.record(providerID: "claude", outcome: .failed, category: .notLoggedIn, manual: false)
+        recorder.record(providerID: "claude", outcome: .failed, category: .notAvailable, manual: false)
         recorder.record(providerID: "claude", outcome: .cacheHit, category: nil, manual: false)
         recorder.record(providerID: "claude", outcome: .skipped, category: nil, manual: false)
         recorder.record(providerID: "claude", outcome: .backedOff, category: nil, manual: false)
@@ -55,9 +56,18 @@ final class TelemetryRecorderTests: XCTestCase {
         let props = rollups[0]
         XCTAssertEqual(props["provider_id"] as? String, "claude")
         XCTAssertEqual(props["success_count"] as? Int, 2)
-        XCTAssertEqual(props["failure_count"] as? Int, 2)
+        XCTAssertEqual(props["failure_count"] as? Int, 3)
         XCTAssertEqual(props["manual_refresh_count"] as? Int, 1)
-        XCTAssertEqual(props["error_categories"] as? [String: Int], ["network": 1, "not_logged_in": 1])
+        XCTAssertEqual(
+            props["error_categories"] as? [String: Int],
+            ["network": 1, "not_available": 1, "not_logged_in": 1]
+        )
+        XCTAssertEqual(props["network_failure_count"] as? Int, 1)
+        XCTAssertEqual(props["not_logged_in_failure_count"] as? Int, 1)
+        XCTAssertEqual(props["not_available_failure_count"] as? Int, 1)
+        XCTAssertEqual(props["auth_expired_failure_count"] as? Int, 0)
+        XCTAssertEqual(props["expected_failure_count"] as? Int, 2)
+        XCTAssertEqual(props["unexpected_failure_count"] as? Int, 1)
     }
 
     func testTickEmitsDailyActiveOncePerDayWithConfigSnapshot() {

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -36,8 +36,9 @@ of the number, not by the provider:
   a fillable number.
 
 Set the snapshot's `plan` when the provider exposes a plan name. On failure, return
-`ProviderSnapshot.error(provider:message:)` with a friendly message — never return stale or empty data
-silently.
+`ProviderSnapshot.error(provider:error:)` with a typed provider error when possible, so telemetry can group
+the failure by a stable, non-private reason such as "not logged in" or "network". Use the message-only
+factory only when there is no typed error, and never return stale or empty data silently.
 
 ## Steps
 


### PR DESCRIPTION
## Summary

- Keep the existing `provider_refresh_daily` event and legacy rollup fields intact.
- Add per-category scalar failure counts such as `not_logged_in_failure_count` and `network_failure_count` for easier PostHog dashboarding.
- Add `expected_failure_count` and `unexpected_failure_count` so dashboards can separate expected auth/setup noise from more actionable provider failures.
- Update provider guidance to prefer typed errors so future failures keep stable, non-PII categories.

## Impact

Existing dashboards that use `failure_count`, `success_count`, `manual_refresh_count`, or `error_categories` should continue to work. New dashboards can chart the additive scalar fields without unpacking the nested `error_categories` dictionary.

## Validation

- `swift build` passes.
- `swift test --filter TelemetryRecorderTests` builds, but cannot execute in this environment because `Sparkle.framework` is missing from the test runtime path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry properties and documentation only; existing `provider_refresh_daily` fields are unchanged.
> 
> **Overview**
> **`provider_refresh_daily`** still sends the same legacy fields (`failure_count`, `error_categories`, etc.). Each daily rollup now also includes **per-category scalar counts** (`network_failure_count`, `not_logged_in_failure_count`, …) for every `ErrorCategory`, so dashboards can chart failures without unpacking the nested dictionary.
> 
> Rollup payload construction is centralized in **`providerRollupProperties`**. Two additive metrics split noise from actionable failures: **`expected_failure_count`** sums `not_logged_in` and `not_available`, and **`unexpected_failure_count`** is the remainder of `failure_count`.
> 
> Provider guidance (`ProviderRuntime`, **`docs/adding-a-provider.md`**) now tells implementers to return **`ProviderSnapshot.error(provider:error:)`** with typed errors when possible, so future failures stay in stable telemetry categories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288eac81610b48b3ff6e7767ae607fd82b799f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive, all legacy fields are preserved, and the new aggregate logic is straightforward and well-tested.

The property-generation loop zero-fills every ErrorCategory case and the two aggregate fields are computed consistently from the same counters that drive the existing failure_count. Backward compatibility is intact. Tests are updated with concrete assertions for the new scalars and the aggregate split. No unsafe paths are introduced.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/provider-..."](https://github.com/robinebers/openusage/commit/288eac81610b48b3ff6e7767ae607fd82b799f46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40243333)</sub>

<!-- /greptile_comment -->