### PR TITLE
docs: require a structured PR description in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,17 @@ Conventions for the per-provider modules under `Sources/OpenUsage/Providers/<Nam
 
 - There is no hot reload. The app is a long-lived menu-bar process, so **every code change requires a full rebuild and restart of the running app** to take effect — kill the running instance, rebuild, and relaunch before testing.
 
+## Pull Requests
+
+Every PR description must follow this structure so reviewers can skim it quickly:
+
+- **TL;DR** — open with a one- or two-sentence plain-English summary of the change.
+- **What was happening** — plain-English bullet points describing the prior behavior, bug, or gap that motivated the change.
+- **What this changes** — bullet points describing what the PR actually changes.
+- **Heads-up** (optional) — noteworthy things a reviewer or future maintainer should consider (risks, follow-ups, trade-offs).
+- **Tests** (optional) — how the change was verified.
+- **Screenshots** (optional in general, but **required for any PR that makes a visual change**) — images of the affected UI after the change.
+
 ## Documentation
 
 - Logic changes must update any docs in `docs/` that describe the affected behavior.


### PR DESCRIPTION
**TL;DR** — Adds a "## Pull Requests" section to AGENTS.md that defines a standard PR description structure so reviewers can skim PRs quickly.

## What was happening

- AGENTS.md documented engineering conventions but said nothing about how PR descriptions should be written.
- PR bodies had no agreed structure, so the level of plain-English context varied from PR to PR.

## What this changes

- Adds a new **## Pull Requests** section (after "Running / Testing Changes") requiring every PR description to include:
  - **TL;DR** — a one/two-sentence plain-English summary.
  - **What was happening** — plain-English bullets on the prior behavior/gap.
  - **What this changes** — bullets on what the PR actually changes.
  - **Heads-up** (optional) — noteworthy considerations.
  - **Tests** (optional) — how the change was verified.
  - **Screenshots** — optional in general, but required for any PR with a visual change (after-the-change images).

## Heads-up

- Docs-only change; no code or behavior is affected.
- This PR description itself follows the new structure as a working example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to agent/contributor guidelines; no runtime code or app behavior changes.
> 
> **Overview**
> Adds a new **## Pull Requests** section to `AGENTS.md` (placed after **Running / Testing Changes**) that defines a required PR description layout for agents and contributors.
> 
> The section mandates **TL;DR**, **What was happening**, and **What this changes**, plus optional **Heads-up** and **Tests**, and **Screenshots** that become mandatory for any visually changing PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6635418c07d6bb708623fc03483ecd4e74efe6fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Docs-only change that adds a single new section to AGENTS.md with no impact on code, tests, or runtime behavior.

The change is a straightforward documentation addition. The wording is clear, the section is appropriately placed, and the required vs. optional fields are well-labelled. No code paths are touched.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["docs: require a structured PR descriptio..."](https://github.com/robinebers/openusage/commit/6635418c07d6bb708623fc03483ecd4e74efe6fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40245570)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/robinebers/github/robinebers/openusage/-/custom-context?memory=b3b750b7-f3db-4400-9aee-7c016c5aa0c8))

<!-- /greptile_comment -->