### PR TITLE
fix(antigravity): show "Not started" for unused 5-hour quota pools

### DIFF
--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -516,8 +516,9 @@ extension WidgetData {
     /// read — the `resetsAt - now ≈ full period` test is only valid the instant the snapshot is captured,
     /// then drifts every second until the next refresh, which split the headline from the label (headline
     /// "100% left" while the label fell back to "Resets in 5h"). Usage is the stable, snapshot-consistent
-    /// signal: Codex's whole-percent floor is normalized to 0 at a fresh window in its mapper, while Claude
-    /// and Antigravity report 0 utilization directly, so zero means the same for all — the window is unused.
+    /// signal: Codex's whole-percent floor is normalized to 0 at a fresh window in its mapper, Claude
+    /// reports 0 utilization directly, and Antigravity's mapper rounds its fraction-derived percent (so a
+    /// pool under ~0.5% used also reads 0). In each case zero means the window is effectively unused.
     /// Still gated on `now < resetsAt`: once the reset has passed the snapshot is stale, so we drop the
     /// "Not started" claim and let the row fall back to the normal "Resets soon"/countdown formatting.
     func isFreshSessionWindow(now: Date = Date()) -> Bool {

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -497,7 +497,8 @@ extension WidgetData {
 
     /// Trailing text on the bounded primary row, reset-display-mode aware. Priority mirrors
     /// `boundedSubtitle`, but a concrete reset honors `resetDisplayMode` (relative ⟷ absolute).
-    /// Codex and Claude session rows show "Not started" while the rolling window has not begun.
+    /// Codex, Claude, and Antigravity session rows show "Not started" while the rolling window has
+    /// not begun.
     func boundedTrailingText(now: Date = Date()) -> String? {
         guard hasData else { return Self.noDataSubtitle }
         if let subtitleOverride { return subtitleOverride }
@@ -510,13 +511,13 @@ extension WidgetData {
         return boundedSubtitle // period cadence / dollar limit / count suffix — nothing to flip
     }
 
-    /// Codex and Claude session meters only: a "Not started" state for the current window when nothing
-    /// has been spent in it yet. Driven by frozen usage (`used == 0`), not a window-timing read — the
-    /// `resetsAt - now ≈ full period` test is only valid the instant the snapshot is captured, then
-    /// drifts every second until the next refresh, which split the headline from the label (headline
+    /// Codex, Claude, and Antigravity session meters only: a "Not started" state for the current window
+    /// when nothing has been spent in it yet. Driven by frozen usage (`used == 0`), not a window-timing
+    /// read — the `resetsAt - now ≈ full period` test is only valid the instant the snapshot is captured,
+    /// then drifts every second until the next refresh, which split the headline from the label (headline
     /// "100% left" while the label fell back to "Resets in 5h"). Usage is the stable, snapshot-consistent
-    /// signal: Codex's whole-percent floor is normalized to 0 at a fresh window in its mapper, and Claude
-    /// reports 0 utilization directly, so zero means the same for both — the current window is unused.
+    /// signal: Codex's whole-percent floor is normalized to 0 at a fresh window in its mapper, while Claude
+    /// and Antigravity report 0 utilization directly, so zero means the same for all — the window is unused.
     /// Still gated on `now < resetsAt`: once the reset has passed the snapshot is stale, so we drop the
     /// "Not started" claim and let the row fall back to the normal "Resets soon"/countdown formatting.
     func isFreshSessionWindow(now: Date = Date()) -> Bool {
@@ -525,7 +526,12 @@ extension WidgetData {
         return now < resetsAt
     }
 
-    private static let sessionWindowWidgetIDs: Set<String> = ["codex.session", "claude.session"]
+    private static let sessionWindowWidgetIDs: Set<String> = [
+        "codex.session", "claude.session",
+        // Antigravity's three quota pools are rolling 5-hour windows too: an unused pool reports
+        // `used == 0` with a reset a full period out, so it gets the same "Not started" treatment.
+        "antigravity.geminiPro", "antigravity.geminiFlash", "antigravity.claude"
+    ]
 
     /// True when the bounded primary row's trailing text is a concrete reset countdown (so the row makes
     /// it the clickable toggle). False for limit/suffix context, fresh session windows, or no reset date.

--- a/Tests/OpenUsageTests/ResetDisplayTests.swift
+++ b/Tests/OpenUsageTests/ResetDisplayTests.swift
@@ -49,10 +49,11 @@ final class ResetDisplayTests: XCTestCase {
         XCTAssertEqual(data.resetTooltip()?.hasPrefix("Resets in "), true)      // opposite = relative
     }
 
-    func testFreshSessionWindowShowsNotStartedForCodexAndClaude() {
+    func testFreshSessionWindowShowsNotStartedForCodexClaudeAndAntigravity() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let period: TimeInterval = 5 * 3600
-        for id in ["codex.session", "claude.session"] {
+        for id in ["codex.session", "claude.session",
+                   "antigravity.geminiPro", "antigravity.geminiFlash", "antigravity.claude"] {
             var data = WidgetData(title: "Session", icon: .symbol("clock"), kind: .percent, used: 0, limit: 100)
             data.widgetID = id
             data.periodDurationMs = Int(period * 1000)

--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -15,6 +15,8 @@ Antigravity exposes a separate quota for each model, which OpenUsage groups into
 
 Each meter shows how much of the rolling 5-hour window you've used, and when it resets. Quotas are reported as a fraction (full = 0% used), so there are no token or dollar spend tiles. The model lineup is read live from Antigravity, so new models appear on their own.
 
+While a pool's rolling 5-hour window has no usage yet, that meter reads **Not started** on the trailing label instead of a reset countdown; hover explains that the window begins after your first message to that model.
+
 ## Where credentials come from
 
 OpenUsage never asks for a token — it reads what Antigravity already has:


### PR DESCRIPTION
**TL;DR** — Antigravity's quota meters now read **"Not started"** while a pool's rolling 5-hour window is unused, instead of a misleading "Resets in 5h" countdown — the same treatment Claude and Codex already get.

## What was happening
- Antigravity's three quota pools (Gemini Pro, Gemini Flash, Claude) are rolling 5-hour windows, just like Claude's Session and Codex's session/weekly meters.
- When a pool has no usage yet, the API reports `used: 0` with `resetsAt` exactly one full period (5h) out.
- The UI rendered this as **"Resets in 5h"**, implying the window was already counting down when nothing had been spent. Verified against the live API on a machine running Antigravity: all three pools showed `used: 0`, `resetsAt = fetchedAt + 5h`, `periodDurationMs: 18000000`.

## What this changes
- The "Not started" machinery built for Claude/Codex in #719 already keys off `used == 0` while `now < resetsAt` for any widget ID in `sessionWindowWidgetIDs`. Antigravity simply wasn't registered.
- Antigravity reports `used: 0` directly (no whole-percent floor like Codex), so **no mapper change is needed** — registering the three widget IDs (`antigravity.geminiPro`, `antigravity.geminiFlash`, `antigravity.claude`) is enough.
- Unused pools now show **"Not started"** on the trailing label, a calm level bar with no pace tick, and the shared hover copy ("Sessions start after you send your first message."). Once a model is used, that pool's row returns to its normal reset countdown.
- Updated the two doc-comments that said "Codex and Claude only" and documented the behavior in `docs/providers/antigravity.md`.

## Heads-up
- Each pool is evaluated independently, so a used pool still shows its live countdown while unused pools read "Not started" — which is correct.
- The shared tooltip says "Sessions start after your first message"; generically fine for Antigravity's per-pool windows, but a pool-specific copy tweak could follow later if desired.

## Tests
- `swift build` — clean.
- `swift test --filter ResetDisplayTests` — 10/10 pass, including the regression test extended to cover all three Antigravity IDs.
- Built and launched the dev app against live Antigravity data to confirm the rows flip to "Not started".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only allow-list extension reusing existing session-window logic; widget IDs match `AntigravityProvider` descriptors.
> 
> **Overview**
> Antigravity’s **Gemini Pro**, **Gemini Flash**, and **Claude** quota meters now use the same **Not started** trailing label as Codex and Claude when `used == 0` and the rolling 5-hour window hasn’t been consumed yet, instead of a misleading **Resets in …** countdown.
> 
> The change registers `antigravity.geminiPro`, `antigravity.geminiFlash`, and `antigravity.claude` in `sessionWindowWidgetIDs` so existing `isFreshSessionWindow` / `boundedTrailingText` behavior applies with no mapper changes. Docs and `ResetDisplayTests` are updated to cover all three IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419eb6db22bda7b1849917f48559edd0a371d86f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure additive registration of three IDs to an existing set; all shared logic and its guards remain unmodified.

The addition is a one-directional widening of a constant set. The underlying isFreshSessionWindow guard already has test coverage for the Codex and Claude cases, and the PR extends that same test loop to all three Antigravity IDs with identical assertions. There are no new code paths, no changed guards, and no mapper modifications. The previous review thread's doc-comment inaccuracy was addressed in the prior commit.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/antigravity..."](https://github.com/robinebers/openusage/commit/419eb6db22bda7b1849917f48559edd0a371d86f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40249999)</sub>

<!-- /greptile_comment -->