### PR TITLE
feat(share): branded 16:9 PNG share card per provider (#762)

### DIFF
--- a/Sources/OpenUsage/Support/ShareCardRenderer.swift
+++ b/Sources/OpenUsage/Support/ShareCardRenderer.swift
@@ -1,0 +1,115 @@
+import AppKit
+import SwiftUI
+
+/// Renders a `ShareCardView` into a PNG and hands it to the clipboard or a Save panel. Mirrors
+/// `MenuBarStripRenderer`'s `ImageRenderer` → `cgImage` → `NSImage` path (scale 2 for a crisp
+/// export), then adds the PNG encode and the two destinations.
+@MainActor
+enum ShareCardRenderer {
+    /// What the Share action should do with the rendered card.
+    enum Action {
+        case copy
+        case save
+    }
+
+    /// Off-screen render scale. ×2 matches the menu-bar strip renderer, so the exported PNG is crisp
+    /// on Retina displays: a 1200×675 card ships as a 2400×1350 image.
+    static let scale: CGFloat = 2
+
+    /// The card rendered to an `NSImage`, or `nil` if `ImageRenderer` produces no CGImage. The
+    /// image's point size is the card's authored size; its pixel size is that times `scale`.
+    static func image(for view: ShareCardView) -> NSImage? {
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = scale
+        guard let cgImage = renderer.cgImage else { return nil }
+        return NSImage(
+            cgImage: cgImage,
+            size: NSSize(width: CGFloat(cgImage.width) / scale, height: CGFloat(cgImage.height) / scale)
+        )
+    }
+
+    /// PNG-encodes an `NSImage`, or `nil` if the bitmap can't be formed.
+    static func pngData(from image: NSImage) -> Data? {
+        guard
+            let tiff = image.tiffRepresentation,
+            let rep = NSBitmapImageRep(data: tiff)
+        else { return nil }
+        return rep.representation(using: .png, properties: [:])
+    }
+
+    /// Writes the card's PNG onto the general pasteboard (replacing its contents). No-op if the PNG
+    /// can't be encoded.
+    static func copyToPasteboard(_ image: NSImage) {
+        guard let png = pngData(from: image) else {
+            AppLog.error(.lifecycle, "share card: failed to encode PNG for clipboard")
+            return
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setData(png, forType: .png)
+    }
+
+    /// Presents a Save panel (PNG only) and writes the card on confirm. No-op if the PNG can't be
+    /// encoded or the user cancels.
+    static func save(_ image: NSImage, suggestedName: String) {
+        guard let png = pngData(from: image) else {
+            AppLog.error(.lifecycle, "share card: failed to encode PNG for save")
+            return
+        }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.png]
+        panel.nameFieldStringValue = suggestedName
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try png.write(to: url)
+        } catch {
+            AppLog.error(.lifecycle, "share card: failed to write PNG: \(error.localizedDescription)")
+        }
+    }
+
+    /// Orchestrates a Share action end to end: resolve the provider's visible rows from the data
+    /// store, build the card with the effective appearance, render it, and dispatch to the clipboard
+    /// or Save panel. The rows mirror what the dashboard shows — always-shown plus expanded only when
+    /// the provider's caret is open — so the export matches what the user sees.
+    static func share(
+        group: ProviderGroup,
+        dataStore: WidgetDataStore,
+        layout: LayoutStore,
+        appearance: ColorScheme,
+        action: Action
+    ) {
+        let visibleWidgets = layout.isProviderExpanded(group.provider.id) ? group.widgets : group.alwaysShownWidgets
+        let rows = visibleWidgets.compactMap { widget -> WidgetData? in
+            guard let descriptor = layout.descriptor(for: widget) else { return nil }
+            return dataStore.data(for: descriptor)
+        }
+        let view = ShareCardView(
+            provider: group.provider,
+            plan: dataStore.plan(for: group.provider.id),
+            rows: rows,
+            appearance: appearance
+        )
+        guard let image = image(for: view) else {
+            AppLog.error(.lifecycle, "share card: ImageRenderer produced no image for \(group.provider.id)")
+            return
+        }
+        switch action {
+        case .copy:
+            copyToPasteboard(image)
+        case .save:
+            save(image, suggestedName: suggestedFileName(for: group.provider))
+        }
+    }
+
+    /// Default export filename, e.g. `OpenUsage-Claude-2026-06-27.png`. Spaces in a display name are
+    /// stripped so the suggested name is filesystem-friendly.
+    static func suggestedFileName(for provider: Provider) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let date = formatter.string(from: Date())
+        let safeName = provider.displayName.replacingOccurrences(of: " ", with: "")
+        return "OpenUsage-\(safeName)-\(date).png"
+    }
+}

--- a/Sources/OpenUsage/Views/ShareCardView.swift
+++ b/Sources/OpenUsage/Views/ShareCardView.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+/// An off-screen, branded 16:9 card of one provider's usage, rendered to a PNG for the right-click
+/// "Share" action. It is a static snapshot — no drag grips, spinners, staleness tags, or refresh
+/// warnings — so the exported image reads as a clean, shareable summary rather than a screenshot of
+/// the live, interactive dashboard.
+///
+/// The view takes already-resolved `[WidgetData]` (not a store), so it has no environment dependency
+/// and is rendered the same way in the app and in tests. It paints an explicit opaque
+/// `Theme.traySurface` background because an `ImageRenderer` has no window backdrop behind it, and it
+/// forces the effective light/dark appearance via `.environment(\.colorScheme, …)` (the rows resolve
+/// their colors from the environment, not locally), so a Light-mode user gets a light card even when
+/// the OS is in dark mode.
+struct ShareCardView: View {
+    let provider: Provider
+    var plan: String?
+    let rows: [WidgetData]
+    let appearance: ColorScheme
+
+    /// Fixed 16:9 canvas. The renderer scales this up (×2) for a crisp PNG; the layout itself is
+    /// authored at these point dimensions.
+    static let width: CGFloat = 1200
+    static let height: CGFloat = 675
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 28) {
+            headerRow
+            metricsCard
+            Spacer(minLength: 0)
+            footer
+        }
+        .padding(48)
+        .frame(width: Self.width, height: Self.height, alignment: .topLeading)
+        .background(Theme.traySurface)
+        .environment(\.colorScheme, appearance)
+    }
+
+    // MARK: - Header
+
+    /// Provider mark + name (+ optional plan), mirroring the dashboard header but static: no drag
+    /// grip, spinner, staleness tag, or warning triangle.
+    private var headerRow: some View {
+        HStack(spacing: 16) {
+            ProviderIcon(source: provider.icon, inset: 0.04)
+                .frame(width: 44, height: 44)
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(provider.displayName)
+                    .font(.system(size: 34, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                if let plan, !plan.isEmpty {
+                    Text(plan)
+                        .font(.system(size: 20))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Body
+
+    /// The provider's visible metric rows in the shared card surface, reusing `WidgetRowView` so the
+    /// exported card matches the live dashboard exactly. Toggles are nil (static render). An empty
+    /// provider falls back to a quiet placeholder so the card never renders blank.
+    @ViewBuilder
+    private var metricsCard: some View {
+        if rows.isEmpty {
+            DashboardMetricCard {
+                Text("No metrics to show")
+                    .font(.system(size: 18))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+            }
+        } else {
+            DashboardMetricCard {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, data in
+                    WidgetRowView(data: data)
+                }
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    /// The brand mark + wordmark, anchored bottom-leading. Quiet (secondary) so it reads as a
+    /// watermark, not a headline.
+    private var footer: some View {
+        HStack(spacing: 8) {
+            ProviderIcon(source: .providerMark("openusage"), inset: 0)
+                .frame(width: 22, height: 22)
+            Text("OpenUsage")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// The dashboard display: one inset group per provider (System Settings style). A provider's icon + name
@@ -69,7 +70,26 @@ struct WidgetGroupedListView: View {
             Button("Customize…") {
                 withAnimation(Motion.modeSwitch) { layout.isEditing = true }
             }
+            Divider()
+            Menu("Share \(group.provider.displayName)…") {
+                Button("Copy Image") { shareCard(group, action: .copy) }
+                Button("Save Image…") { shareCard(group, action: .save) }
+            }
         }
+    }
+
+    /// Renders the provider's branded 16:9 card and copies it to the clipboard or saves it to disk.
+    /// The effective light/dark appearance is resolved from `NSApp` so the card matches what the user
+    /// sees (the popover follows the menu bar, which follows the app/OS appearance).
+    private func shareCard(_ group: ProviderGroup, action: ShareCardRenderer.Action) {
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        ShareCardRenderer.share(
+            group: group,
+            dataStore: dataStore,
+            layout: layout,
+            appearance: isDark ? .dark : .light,
+            action: action
+        )
     }
 
     /// A row's placed widget paired with its resolved descriptor + data, so each `dataStore.data(for:)`

--- a/Tests/OpenUsageTests/ShareCardRendererTests.swift
+++ b/Tests/OpenUsageTests/ShareCardRendererTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import SwiftUI
+@testable import OpenUsage
+
+/// Covers the Share card export pipeline: `image(for:)` rasterizes the fixed 16:9 card at ×2, and
+/// `pngData(from:)` round-trips to a valid PNG. `ImageRenderer` is MainActor-only, so the whole case
+/// runs on the main actor.
+@MainActor
+final class ShareCardRendererTests: XCTestCase {
+    private func sampleCard() -> ShareCardView {
+        let provider = MockData.claude
+        let rows = MockData.descriptors(for: provider.id).map { $0.sample }
+        return ShareCardView(provider: provider, plan: "Max", rows: rows, appearance: .light)
+    }
+
+    func testImageRendersAtFixedPixelDimensions() throws {
+        let image = try XCTUnwrap(ShareCardRenderer.image(for: sampleCard()))
+
+        // Point size is the authored 16:9 card; the bitmap is that times the render scale.
+        let rep = try XCTUnwrap(image.representations.first)
+        XCTAssertEqual(rep.pixelsWide, Int(ShareCardView.width * ShareCardRenderer.scale))
+        XCTAssertEqual(rep.pixelsHigh, Int(ShareCardView.height * ShareCardRenderer.scale))
+    }
+
+    func testPNGDataRoundTripsToValidPNG() throws {
+        let image = try XCTUnwrap(ShareCardRenderer.image(for: sampleCard()))
+        let png = try XCTUnwrap(ShareCardRenderer.pngData(from: image))
+
+        XCTAssertFalse(png.isEmpty)
+        // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A.
+        let magic: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+        XCTAssertEqual(Array(png.prefix(magic.count)), magic)
+        // The PNG must decode back into an image (a non-empty Data alone isn't proof it's valid).
+        XCTAssertNotNil(NSImage(data: png))
+    }
+
+    func testRendersEmptyProviderWithoutCrashing() throws {
+        let card = ShareCardView(provider: MockData.cursor, plan: nil, rows: [], appearance: .dark)
+        let image = try XCTUnwrap(ShareCardRenderer.image(for: card))
+        let rep = try XCTUnwrap(image.representations.first)
+        XCTAssertEqual(rep.pixelsWide, Int(ShareCardView.width * ShareCardRenderer.scale))
+    }
+
+    func testSuggestedFileNameStripsSpacesAndCarriesDate() {
+        let provider = Provider(id: "super", displayName: "Super Grok", icon: .symbol("bolt"))
+        let name = ShareCardRenderer.suggestedFileName(for: provider)
+        XCTAssertTrue(name.hasPrefix("OpenUsage-SuperGrok-"))
+        XCTAssertTrue(name.hasSuffix(".png"))
+    }
+}

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -26,7 +26,16 @@ Rows with a reset date tick every 30 seconds, so countdowns and pace stay live b
 ## Right-click menus
 
 Every row: **Hide · Pin to menu bar / Unpin · Refresh \<provider\> · Customize…**
-Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on under Settings ▸ Providers.)
+Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on under Settings ▸ Providers.) plus **Share \<provider\>…** (see below).
+
+## Share
+
+Right-click a provider header and choose **Share \<provider\>…** to turn that provider's usage into a clean, branded image you can drop into a chat, a tweet, or a doc. The submenu has two choices:
+
+- **Copy Image** — puts the image on the clipboard, ready to paste.
+- **Save Image…** — opens a save dialog (default name like `OpenUsage-Claude-2026-06-27.png`).
+
+The image is a fixed 16:9 PNG using the app's look — the provider's mark and name up top, the metric rows you currently see for that provider, and a small OpenUsage mark in the corner. It follows your Light/Dark appearance and shows everything on the card as-is (nothing is hidden or blurred).
 
 ## Footer
 


### PR DESCRIPTION
**TL;DR** — Adds a right-click **Share \<provider\>…** action on a provider header that renders a clean, branded 16:9 PNG of that provider's usage and lets you copy it to the clipboard or save it to disk. Closes #762 (MVP).

**What was happening**
- There was no way to get a shareable image of a provider's usage out of OpenUsage. You could only screenshot the popover, which captures interactive chrome (drag grips, spinners, staleness tags) and whatever window/desktop is behind it.

**What this changes**
- New `ShareCardView` (`Sources/OpenUsage/Views/ShareCardView.swift`): an off-screen, fixed **1200×675** (16:9) card painted on an opaque `Theme.traySurface`, with the appearance forced via `.environment(\.colorScheme, …)` so it renders correctly off-screen. Top: provider mark + name + plan (static — no drag grip, spinner, or warning). Body: that provider's visible metric rows via the shared `WidgetRowView`. Footer: a small "OpenUsage" wordmark + `openusage.svg` mark. Takes already-resolved `[WidgetData]`, so it has no store dependency (keeps it testable).
- New `ShareCardRenderer` (`Sources/OpenUsage/Support/ShareCardRenderer.swift`): mirrors `MenuBarStripRenderer` — `ImageRenderer` at `scale = 2` → `cgImage` → `NSImage`; PNG encode via `tiffRepresentation` → `NSBitmapImageRep`; `copyToPasteboard`, `save` (NSSavePanel, PNG only), and a `share(group:dataStore:layout:appearance:action:)` orchestration entry that resolves the provider's visible rows (always-shown + expanded only when the caret is open, matching the dashboard) and dispatches `.copy` / `.save`.
- `WidgetGroupedListView`: the provider-header context menu gains a **Share \<provider\>…** submenu with **Copy Image** and **Save Image…**. The effective light/dark appearance is resolved from `NSApp.effectiveAppearance`.
- Docs: a short Share behavior note in `docs/dashboard.md`.
- Default filename: `OpenUsage-<Provider>-<yyyy-MM-dd>.png`.

**Tests**
- `Tests/OpenUsageTests/ShareCardRendererTests.swift` (MainActor): `image(for:)` renders at `1200×675 × scale` pixels; `pngData(from:)` round-trips to a valid PNG (non-empty, correct magic bytes, re-decodes); an empty provider renders without crashing; the suggested filename strips spaces and carries the date.
- `swift build` clean; full `swift test` green (495 XCTest + the Swift Testing suite, 0 failures). Sparkle dlopen workaround was needed locally (`ln -sfn ../Sparkle.framework .build/out/Products/Debug/PackageFrameworks/Sparkle.framework`).

**Heads-up**
- This is the owner-scoped **MVP**: a single 16:9 format, **no redaction** (per owner — the card shows everything as-is), copy **and** save. No native macOS share sheet yet (could be a follow-up).
- **Visual change — screenshot needed before un-drafting.** The exported card can't be rendered headlessly in this environment, so no screenshot is attached yet. Run the app, right-click a provider header ▸ **Share ▸ Save Image…**, and attach the generated PNG (ideally one light + one dark) before marking ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)