### PR TITLE
feat(claude): delegate token refresh to the claude CLI when no usable refresh token (#753)

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -195,11 +195,19 @@ struct ClaudeAuthStore: Sendable {
     /// A token-free fingerprint of the credential currently in the preferred source (keychain, else
     /// file), used to detect whether an external `claude` re-login rotated the stored token. Re-reads
     /// the candidates fresh (nothing cached), so it reflects the live on-disk state.
+    ///
+    /// File metadata (mtime/size) is included ONLY when the file is the preferred source. When the
+    /// keychain is preferred, the fingerprint is just the keychain token hash — otherwise a touch that
+    /// only rewrites the file (e.g. `claude --version` updating the file's mtime without rotating the
+    /// keychain token OpenUsage actually reads) would change the fingerprint and yield a false
+    /// "rotated" signal, masking the still-expired keychain token and triggering a 5-min CLI cooldown
+    /// that blocks real recovery.
     func currentFingerprint() -> ClaudeCredentialFingerprint {
-        let oauth = orderedStoredCandidates().first?.oauth
+        let preferred = orderedStoredCandidates().first
+        let filePath = (preferred?.source == .file) ? credentialsPath() : nil
         return ClaudeCredentialFingerprint.make(
-            oauth: oauth,
-            credentialsPath: credentialsPath(),
+            oauth: preferred?.oauth,
+            credentialsPath: filePath,
             files: files
         )
     }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -186,6 +186,24 @@ struct ClaudeAuthStore: Sendable {
         envText("CLAUDE_CONFIG_DIR")
     }
 
+    /// The resolved `~/.claude/.credentials.json` path (honoring `CLAUDE_CONFIG_DIR`). Exposed so the
+    /// delegated-refresh layer can fingerprint the file's mtime/size; the keychain source has no path.
+    func credentialsFilePath() -> String {
+        credentialsPath()
+    }
+
+    /// A token-free fingerprint of the credential currently in the preferred source (keychain, else
+    /// file), used to detect whether an external `claude` re-login rotated the stored token. Re-reads
+    /// the candidates fresh (nothing cached), so it reflects the live on-disk state.
+    func currentFingerprint() -> ClaudeCredentialFingerprint {
+        let oauth = orderedStoredCandidates().first?.oauth
+        return ClaudeCredentialFingerprint.make(
+            oauth: oauth,
+            credentialsPath: credentialsPath(),
+            files: files
+        )
+    }
+
     // Resolved OAuth endpoint strings before URL validation. The suffix is derived from the same
     // env-var branching as the URLs but never depends on URL validity, so the (non-throwing) keychain
     // candidate path can read it without risking a throw.

--- a/Sources/OpenUsage/Providers/Claude/ClaudeCredentialFingerprint.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeCredentialFingerprint.swift
@@ -1,0 +1,70 @@
+import CryptoKit
+import Foundation
+
+/// A `Sendable` wrapper around `UserDefaults` for the delegated-refresh layer's persisted state. The
+/// `Foundation` class is thread-safe but not marked `Sendable`, so it can't be a stored property of a
+/// `Sendable` struct without this shim. The delegated-refresh coordinator genuinely crosses isolation
+/// (its touch runs in a detached `Task`), so the wrapper is the minimal escape hatch.
+struct SendableUserDefaults: @unchecked Sendable {
+    let defaults: UserDefaults
+    init(_ defaults: UserDefaults) { self.defaults = defaults }
+}
+
+/// A token-free, log-safe snapshot of "which credential is currently on disk", used to detect whether
+/// an external `claude` re-login actually rotated the stored credentials. We compare fingerprints
+/// before and after delegating a refresh to the `claude` CLI: an unchanged fingerprint means the CLI
+/// touch did NOT rotate the token (so the attempt failed), a changed one means it did (success).
+///
+/// NEVER carries a token value. `tokenHash` is a SHA256 of `accessToken + ":" + expiresAt`, so it
+/// changes when either the access token or its expiry rotates but can never be reversed to the token.
+/// The file `mtime`/`size` are a cheap secondary signal for the file source (the keychain has no file,
+/// so those stay nil for keychain-sourced credentials and the token hash carries the whole signal).
+struct ClaudeCredentialFingerprint: Codable, Equatable, Sendable {
+    var tokenHash: String?
+    var fileMTimeMs: Int?
+    var fileSize: Int?
+
+    /// Build a fingerprint from the OAuth blob OpenUsage already holds (so this never triggers an extra
+    /// Security.framework keychain prompt) plus optional file metadata for the file-backed source.
+    static func make(
+        oauth: ClaudeOAuth?,
+        credentialsPath: String?,
+        files: TextFileAccessing
+    ) -> ClaudeCredentialFingerprint {
+        ClaudeCredentialFingerprint(
+            tokenHash: tokenHash(for: oauth),
+            fileMTimeMs: nil,
+            fileSize: nil
+        ).withFileMetadata(path: credentialsPath)
+    }
+
+    /// SHA256 of `accessToken + ":" + (expiresAt ?? 0)`. Returns nil when there is no access token. The
+    /// value is a hex digest — never the token itself — so it is safe to persist and (in principle) log.
+    static func tokenHash(for oauth: ClaudeOAuth?) -> String? {
+        guard let accessToken = oauth?.accessToken, !accessToken.isEmpty else { return nil }
+        let expiresAt = oauth?.expiresAt ?? 0
+        // Format the expiry without scientific notation / locale drift so the hash is stable.
+        let material = "\(accessToken):\(Int64(expiresAt.rounded()))"
+        let digest = SHA256.hash(data: Data(material.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Returns a copy with `fileMTimeMs`/`fileSize` filled from the credentials file at `path` (if any).
+    /// Metadata is read via `FileManager` directly — only the real local accessor exposes a filesystem
+    /// path, so test doubles simply leave these nil and rely on the token hash, which is the real signal.
+    private func withFileMetadata(path: String?) -> ClaudeCredentialFingerprint {
+        guard let path, !path.isEmpty else { return self }
+        let expanded = (path as NSString).expandingTildeInPath
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: expanded) else {
+            return self
+        }
+        var copy = self
+        if let modified = attributes[.modificationDate] as? Date {
+            copy.fileMTimeMs = Int(modified.timeIntervalSince1970 * 1000)
+        }
+        if let size = attributes[.size] as? NSNumber {
+            copy.fileSize = size.intValue
+        }
+        return copy
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDelegatedRefreshCoordinator.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDelegatedRefreshCoordinator.swift
@@ -215,14 +215,21 @@ struct ClaudeDelegatedRefreshCoordinator: Sendable {
     }
 
     private func commandExists(_ command: String) -> Bool {
+        // Use `/usr/bin/which` to check PATH presence WITHOUT running `claude` — running
+        // `claude --version` here would be a side-effecting probe that could rotate the credential
+        // BEFORE `runTouchAndVerify` captures its baseline fingerprint, making the probe's rotation
+        // look like the baseline and the second touch look unchanged (bugbot #d30aea11). `which`
+        // only resolves the path; the actual `--version` touch (and its fingerprint verification)
+        // happens in `runTouchAndVerify`.
         do {
             let result = try processRunner.run(
-                executable: command,
-                arguments: ["--version"],
+                executable: "/usr/bin/which",
+                arguments: [command],
                 environment: enrichedPathEnvironment(),
                 timeout: 2
             )
-            return result.succeeded
+            // `which` exits 0 and prints the resolved path when the command is on PATH.
+            return result.succeeded && !result.stdout.isEmpty
         } catch {
             return false
         }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDelegatedRefreshCoordinator.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDelegatedRefreshCoordinator.swift
@@ -1,0 +1,221 @@
+import Foundation
+import os
+
+/// Delegates an OAuth token refresh to the `claude` CLI when OpenUsage's own stored refresh token is
+/// missing or revoked. The CLI owns the refresh token and client credentials OpenUsage never sees, so
+/// touching it can rotate the access token in the keychain/file that OpenUsage reads. This is the
+/// backstop for #738/#753: the credential source OpenUsage reads has no usable refresh token, so it can
+/// never self-heal — but the `claude` CLI can.
+///
+/// The touch is a NON-INTERACTIVE `claude --version` (owner decision). We do not assume `--version`
+/// rotates the token; instead we fingerprint the stored credential before and after and treat the
+/// attempt as successful ONLY when the fingerprint changed. If `--version` proves insufficient in
+/// practice (it doesn't trigger a refresh), the escalation is a PTY-driven `claude /status`.
+//
+// TODO(#753): if a non-interactive `claude --version` does not reliably trigger the CLI's lazy token
+// refresh in the field, escalate to a PTY session running `claude /status` (the CLI refreshes its token
+// on an interactive status check). That requires a pseudo-terminal, which this coordinator deliberately
+// avoids for now — we rely on the fingerprint-changed check to confirm rotation either way.
+struct ClaudeDelegatedRefreshCoordinator: Sendable {
+    enum Outcome: Equatable, Sendable {
+        case skippedByCooldown
+        case cliUnavailable
+        case attemptedSucceeded
+        case attemptedFailed(String)
+    }
+
+    /// Cooldown after a touch that DID rotate the token: a successful delegated refresh is good for a
+    /// while, so don't re-touch the CLI on every refresh.
+    static let successCooldown: TimeInterval = 5 * 60
+    /// Short cooldown reserved under lock the moment an attempt starts (and kept when the touch ran but
+    /// didn't rotate), so concurrent/rapid refreshes don't stampede the CLI.
+    static let shortCooldown: TimeInterval = 20
+    static let touchTimeout: TimeInterval = 8
+    /// Delays (seconds) at which we re-read the credential after the touch to see whether it rotated.
+    static let verifyPollDelays: [TimeInterval] = [0.2, 0.5, 0.8]
+
+    private let processRunner: ProcessRunning
+    private let environment: EnvironmentReading
+    private let homeDirectory: @Sendable () -> URL
+    private let claudeConfigDir: @Sendable () -> String?
+    /// Re-reads the CURRENT on-disk credential fingerprint (baseline before the touch, and again after).
+    private let currentFingerprint: @Sendable () -> ClaudeCredentialFingerprint
+    private let now: @Sendable () -> Date
+    private let sleep: @Sendable (TimeInterval) async -> Void
+    private let isExecutable: @Sendable (String) -> Bool
+
+    private let store: SendableUserDefaults
+    private let lastAttemptKey: String
+    private let cooldownKey: String
+
+    private var defaults: UserDefaults { store.defaults }
+
+    /// Single-flight: a touch already running shares its in-flight `Task` with concurrent callers rather
+    /// than launching the CLI twice. Lock-backed so the value-type coordinator coordinates across calls.
+    private let inFlight = OSAllocatedUnfairLock<Task<Outcome, Never>?>(initialState: nil)
+
+    init(
+        processRunner: ProcessRunning = SystemProcessRunner(),
+        environment: EnvironmentReading = ProcessEnvironmentReader(),
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        claudeConfigDir: @escaping @Sendable () -> String? = { nil },
+        currentFingerprint: @escaping @Sendable () -> ClaudeCredentialFingerprint,
+        now: @escaping @Sendable () -> Date = Date.init,
+        sleep: @escaping @Sendable (TimeInterval) async -> Void = { try? await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) },
+        isExecutable: @escaping @Sendable (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) },
+        defaults: UserDefaults = .standard,
+        lastAttemptKey: String = "claude.delegatedRefresh.lastAttemptAt.v1",
+        cooldownKey: String = "claude.delegatedRefresh.cooldownSeconds.v1"
+    ) {
+        self.processRunner = processRunner
+        self.environment = environment
+        self.homeDirectory = homeDirectory
+        self.claudeConfigDir = claudeConfigDir
+        self.currentFingerprint = currentFingerprint
+        self.now = now
+        self.sleep = sleep
+        self.isExecutable = isExecutable
+        self.store = SendableUserDefaults(defaults)
+        self.lastAttemptKey = lastAttemptKey
+        self.cooldownKey = cooldownKey
+    }
+
+    /// Attempt a delegated refresh. Short-circuits to `.cliUnavailable` (without consuming the cooldown)
+    /// when no `claude` binary resolves; to `.skippedByCooldown` while a prior attempt's cooldown is
+    /// active. Otherwise touches the CLI and reports whether the stored credential actually rotated.
+    func attempt(now currentTime: Date? = nil) async -> Outcome {
+        let moment = currentTime ?? now()
+
+        // Resolve the CLI BEFORE consuming any cooldown — a missing binary isn't a "we tried" event, so
+        // it must not burn the cooldown window (the gate, not the cooldown, decides whether to keep
+        // re-checking for the CLI).
+        guard let cliPath = resolveCLI() else {
+            return .cliUnavailable
+        }
+
+        // Reserve, cooldown-check, and single-flight in ONE locked step so concurrent callers can't race
+        // between "is a launch in flight?" and "create the launch":
+        //   - a launch already in flight → share its Task (single-flight),
+        //   - else inside an active cooldown → skip,
+        //   - else stamp a short cooldown and create the one Task the racers share.
+        enum Reservation { case share(Task<Outcome, Never>); case cooldown }
+        let reservation: Reservation = inFlight.withLock { task in
+            if let task { return .share(task) }
+            if isInCooldown(now: moment) { return .cooldown }
+            stampCooldown(seconds: Self.shortCooldown, now: moment)
+            let created = Task<Outcome, Never> { await self.runTouchAndVerify(cliPath: cliPath, now: moment) }
+            task = created
+            return .share(created)
+        }
+
+        switch reservation {
+        case .cooldown:
+            return .skippedByCooldown
+        case .share(let task):
+            let outcome = await task.value
+            // Only the owner clears the in-flight slot (idempotent: a shared racer clearing it again is
+            // harmless because by then a new attempt would already have created a fresh Task).
+            inFlight.withLock { if $0 == task { $0 = nil } }
+            return outcome
+        }
+    }
+
+    // MARK: - Touch + verify
+
+    private func runTouchAndVerify(cliPath: String, now moment: Date) async -> Outcome {
+        let baseline = currentFingerprint()
+        AppLog.info(LogTag.auth("claude"), "delegated refresh: touching claude CLI")
+
+        var environment = enrichedPathEnvironment()
+        if let configDir = claudeConfigDir(), !configDir.isEmpty {
+            environment["CLAUDE_CONFIG_DIR"] = (configDir as NSString).expandingTildeInPath
+        }
+
+        do {
+            // Output is discarded — we only care whether the touch rotated the credential. `--version`
+            // is non-interactive and side-effect-light; the verify step is what confirms a rotation.
+            _ = try processRunner.run(
+                executable: cliPath,
+                arguments: ["--version"],
+                environment: environment,
+                timeout: Self.touchTimeout
+            )
+        } catch {
+            AppLog.warn(LogTag.auth("claude"), "delegated refresh: claude CLI touch failed: \(LogRedaction.redactLogMessage(error.localizedDescription))")
+            // The touch itself failed (timeout/launch error). Keep the short cooldown already stamped.
+            return .attemptedFailed("touch failed")
+        }
+
+        // Poll the credential a few times — the CLI may write asynchronously just after exit.
+        for delay in Self.verifyPollDelays {
+            await sleep(delay)
+            if currentFingerprint() != baseline {
+                stampCooldown(seconds: Self.successCooldown, now: now())
+                AppLog.info(LogTag.auth("claude"), "delegated refresh: credential rotated (success)")
+                return .attemptedSucceeded
+            }
+        }
+
+        AppLog.info(LogTag.auth("claude"), "delegated refresh: credential unchanged after touch")
+        return .attemptedFailed("credential unchanged")
+    }
+
+    // MARK: - Cooldown
+
+    private func isInCooldown(now moment: Date) -> Bool {
+        guard defaults.object(forKey: lastAttemptKey) != nil else { return false }
+        let last = Date(timeIntervalSince1970: defaults.double(forKey: lastAttemptKey))
+        let cooldown = defaults.double(forKey: cooldownKey)
+        guard cooldown > 0 else { return false }
+        return moment.timeIntervalSince(last) < cooldown
+    }
+
+    private func stampCooldown(seconds: TimeInterval, now moment: Date) {
+        defaults.set(moment.timeIntervalSince1970, forKey: lastAttemptKey)
+        defaults.set(seconds, forKey: cooldownKey)
+    }
+
+    // MARK: - CLI resolution
+
+    /// Resolve the `claude` binary, honoring `CLAUDE_CLI_PATH`, then a fixed set of install locations,
+    /// then a bare `claude` probed against the enriched PATH (a GUI app inherits a stripped PATH).
+    func resolveCLI() -> String? {
+        if let override = environment.value(for: "CLAUDE_CLI_PATH")?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty {
+            let expanded = (override as NSString).expandingTildeInPath
+            return isExecutable(expanded) ? expanded : nil
+        }
+        let home = homeDirectory()
+        let absoluteCandidates = [
+            home.appendingPathComponent(".claude/local/claude").path,
+            home.appendingPathComponent(".local/bin/claude").path,
+            "/opt/homebrew/bin/claude",
+            "/usr/local/bin/claude"
+        ]
+        for candidate in absoluteCandidates where isExecutable(candidate) {
+            return candidate
+        }
+        return commandExists("claude") ? "claude" : nil
+    }
+
+    private func commandExists(_ command: String) -> Bool {
+        do {
+            let result = try processRunner.run(
+                executable: command,
+                arguments: ["--version"],
+                environment: enrichedPathEnvironment(),
+                timeout: 2
+            )
+            return result.succeeded
+        } catch {
+            return false
+        }
+    }
+
+    private func enrichedPathEnvironment() -> [String: String] {
+        ["PATH": CcusageRunner.pathEntries(
+            home: homeDirectory(),
+            existingPath: ProcessInfo.processInfo.environment["PATH"]
+        ).joined(separator: ":")]
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDelegatedRefreshCoordinator.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDelegatedRefreshCoordinator.swift
@@ -150,7 +150,13 @@ struct ClaudeDelegatedRefreshCoordinator: Sendable {
         for delay in Self.verifyPollDelays {
             await sleep(delay)
             if currentFingerprint() != baseline {
-                stampCooldown(seconds: Self.successCooldown, now: now())
+                // Stamp the success cooldown with the same `moment` time source used for the short
+                // cooldown at attempt start, not `now()` — callers that inject time via
+                // `attempt(now:)` would otherwise get mismatched cooldown timestamps (bugbot
+                // #ed400fe6). The verify polls don't advance the injected clock in tests, and in
+                // production `moment == now()` so the ~1.5s of poll delay is negligible vs the 5-min
+                // cooldown.
+                stampCooldown(seconds: Self.successCooldown, now: moment)
                 AppLog.info(LogTag.auth("claude"), "delegated refresh: credential rotated (success)")
                 return .attemptedSucceeded
             }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDelegatedRefreshCoordinator.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDelegatedRefreshCoordinator.swift
@@ -162,6 +162,16 @@ struct ClaudeDelegatedRefreshCoordinator: Sendable {
 
     // MARK: - Cooldown
 
+    /// Whether the coordinator could attempt a delegated refresh right now — the CLI resolves AND
+    /// no cooldown is active. Used by the provider's terminal-block short-circuit to decide whether
+    /// to skip the refresh entirely or let it proceed so the CLI gets a chance to rotate the
+    /// credential (e.g. after the user installed the CLI or the coordinator cooldown expired). Does
+    /// NOT touch the CLI or consume the cooldown — purely a probe.
+    func canAttempt(now: Date) -> Bool {
+        guard resolveCLI() != nil else { return false }
+        return !isInCooldown(now: now)
+    }
+
     private func isInCooldown(now moment: Date) -> Bool {
         guard defaults.object(forKey: lastAttemptKey) != nil else { return false }
         let last = Date(timeIntervalSince1970: defaults.double(forKey: lastAttemptKey))

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -7,6 +7,8 @@ final class ClaudeProvider: ProviderRuntime {
     let authStore: ClaudeAuthStore
     let usageClient: ClaudeUsageClient
     let ccusageRunner: CcusageRunner
+    let coordinator: ClaudeDelegatedRefreshCoordinator
+    let failureGate: ClaudeRefreshFailureGate
     let now: @Sendable () -> Date
 
     /// Last successful live-usage result and a rate-limit cooldown, carried across refreshes (the provider
@@ -22,11 +24,23 @@ final class ClaudeProvider: ProviderRuntime {
         authStore: ClaudeAuthStore = ClaudeAuthStore(),
         usageClient: ClaudeUsageClient = ClaudeUsageClient(),
         ccusageRunner: CcusageRunner = CcusageRunner(),
+        coordinator: ClaudeDelegatedRefreshCoordinator? = nil,
+        failureGate: ClaudeRefreshFailureGate? = nil,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.authStore = authStore
         self.usageClient = usageClient
         self.ccusageRunner = ccusageRunner
+        // The delegated-refresh coordinator and failure gate both need a live, token-free fingerprint of
+        // the stored credential. Default-construct them around the injected auth store (so they observe
+        // the same credential source); tests substitute fakes.
+        let fingerprint: @Sendable () -> ClaudeCredentialFingerprint = { authStore.currentFingerprint() }
+        self.coordinator = coordinator ?? ClaudeDelegatedRefreshCoordinator(
+            claudeConfigDir: { authStore.claudeHomeOverride() },
+            currentFingerprint: fingerprint,
+            now: now
+        )
+        self.failureGate = failureGate ?? ClaudeRefreshFailureGate(currentFingerprint: fingerprint)
         self.now = now
     }
 
@@ -53,6 +67,16 @@ final class ClaudeProvider: ProviderRuntime {
         // e.g. all sources showing `refresh=no` explains why an expiry can never self-heal (issue #738).
         let sources = candidates.map { $0.diagnosticsLabel(now: now()) }.joined(separator: ", ")
         AppLog.info(LogTag.plugin("claude"), "refresh start (\(candidates.count) source\(candidates.count == 1 ? "" : "s"): \(sources))")
+
+        // If a prior refresh left a TERMINAL block (the stored refresh chain is dead) and the credential
+        // hasn't changed since, skip the network entirely — only an external `claude` re-login (which
+        // changes the fingerprint and clears the gate via `shouldAttempt`) can recover. Checked once here,
+        // before the candidate loop, so a fresh re-login is still tried the moment creds change.
+        if case .terminal? = failureGate.currentBlockStatus(now: now()), !failureGate.shouldAttempt(now: now()) {
+            AppLog.info(LogTag.auth("claude"), "refresh blocked (terminal, credentials unchanged); not calling API")
+            return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.tokenExpired)
+        }
+
         let start = Date()
         // Probe each credential source in keychain-before-file order. An auth-expiry failure on one source (a
         // stale/locked-out token that an external `claude` re-login replaced in another source) falls
@@ -89,7 +113,25 @@ final class ClaudeProvider: ProviderRuntime {
         )
 
         if authStore.canFetchLiveUsage(state) {
-            mapped = try await fetchLiveUsage(state: &state)
+            do {
+                mapped = try await fetchLiveUsage(state: &state)
+            } catch let error as ClaudeAuthError where error == .sessionExpired || error == .tokenExpired {
+                // The in-process refresh hit a dead end (revoked refresh token, or none at all). Mark the
+                // gate terminal, then ask the `claude` CLI to refresh; if it rotates the credential,
+                // re-read and retry the live fetch ONCE before falling back to the next source.
+                failureGate.recordTerminalAuthFailure(reason: "\(error)", now: now())
+                if let recovered = try await delegatedRefreshIfPossible(currentSource: state.source) {
+                    state = recovered
+                    mapped = try await fetchLiveUsage(state: &state)
+                } else {
+                    throw error
+                }
+            } catch let error as ClaudeUsageError {
+                // A transport/infra failure during refresh or fetch (connection failed / 5xx) is transient:
+                // the credential may be fine. Back the gate off exponentially rather than marking it dead.
+                if case .connectionFailed = error { failureGate.recordTransientFailure(now: now()) }
+                throw error
+            }
         }
 
         await SpendTileMapper.appendCcusageUsage(
@@ -107,6 +149,18 @@ final class ClaudeProvider: ProviderRuntime {
         if let until = rateLimitedUntil, now() < until {
             AppLog.info(LogTag.plugin("claude"), "rate-limited (cooldown active, serving \(lastGoodUsage == nil ? "badge" : "last-good usage"))")
             return rateLimitedSnapshot(credentials: state.oauth, retryAfterSeconds: Int(until.timeIntervalSince(now()).rounded(.up)))
+        }
+
+        // The #738/#753 dead-end: the token needs refreshing but the source OpenUsage reads has no usable
+        // refresh token, so an in-process refresh is impossible. Go straight to the delegated-CLI path
+        // (gate + coordinator) and, if it rotates the credential, re-read and continue with fresh creds.
+        let hasUsableRefreshToken = (state.oauth.refreshToken?.isEmpty == false)
+        if authStore.needsRefresh(state.oauth), !hasUsableRefreshToken {
+            if let refreshed = try await delegatedRefreshIfPossible(currentSource: state.source) {
+                state = refreshed
+            }
+            // If the delegated refresh didn't yield a usable token, fall through: the fetch below will
+            // 401 and surface a clean auth error (recorded as terminal by the catch in probe()).
         }
 
         if authStore.needsRefresh(state.oauth),
@@ -142,7 +196,39 @@ final class ClaudeProvider: ProviderRuntime {
         let mapped = try ClaudeUsageMapper.mapUsageResponse(response, credentials: working.oauth, now: now())
         lastGoodUsage = mapped
         rateLimitedUntil = nil
+        failureGate.recordSuccess()
         return mapped
+    }
+
+    /// Delegate a refresh to the `claude` CLI when an in-process refresh isn't possible (no usable
+    /// refresh token in the source OpenUsage reads). Gated so a dead credential doesn't launch the CLI on
+    /// every refresh: only attempts when the failure gate allows it, and only treats success as a real
+    /// rotation (verified by the coordinator's fingerprint check). On success, re-reads the credential
+    /// candidates and returns the one matching the source we were probing (else the preferred one).
+    private func delegatedRefreshIfPossible(currentSource: ClaudeCredentialState.Source) async throws -> ClaudeCredentialState? {
+        guard failureGate.shouldAttempt(now: now()) else { return nil }
+
+        let outcome = await coordinator.attempt(now: now())
+        switch outcome {
+        case .attemptedSucceeded:
+            failureGate.recordSuccess()
+            let candidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
+            // Prefer the same source we were probing; otherwise the first (preferred) candidate.
+            let recovered = candidates.first(where: { $0.source == currentSource }) ?? candidates.first
+            if recovered != nil {
+                AppLog.info(LogTag.auth("claude"), "delegated refresh recovered credentials; retrying live fetch")
+            }
+            return recovered
+        case .cliUnavailable:
+            AppLog.info(LogTag.auth("claude"), "delegated refresh unavailable (no claude CLI on PATH)")
+            return nil
+        case .skippedByCooldown:
+            AppLog.info(LogTag.auth("claude"), "delegated refresh skipped (cooldown)")
+            return nil
+        case .attemptedFailed(let reason):
+            AppLog.info(LogTag.auth("claude"), "delegated refresh did not rotate credentials (\(reason))")
+            return nil
+        }
     }
 
     /// Last-good usage with an appended staleness note when we have it; otherwise the plain rate-limited

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -133,7 +133,14 @@ final class ClaudeProvider: ProviderRuntime {
             } catch let error as ClaudeUsageError {
                 // A transport/infra failure during refresh or fetch (connection failed / 5xx) is transient:
                 // the credential may be fine. Back the gate off exponentially rather than marking it dead.
-                if case .connectionFailed = error { failureGate.recordTransientFailure(now: now()) }
+                // 5xx (server unavailable / bad gateway / etc.) is transient too — the server is briefly
+                // broken, not the credential. 4xx other than 401 (e.g. 403, 404) is NOT transient: it
+                // points at a real permission/config problem that re-trying won't fix.
+                if case .connectionFailed = error {
+                    failureGate.recordTransientFailure(now: now())
+                } else if case .requestFailed(let statusCode) = error, (500..<600).contains(statusCode) {
+                    failureGate.recordTransientFailure(now: now())
+                }
                 throw error
             }
         }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -249,17 +249,19 @@ final class ClaudeProvider: ProviderRuntime {
 
     private func delegatedRefreshIfPossible(currentSource: ClaudeCredentialState.Source) async throws -> ClaudeCredentialState? {
         // Allow the attempt when the gate says "go" (no block, transient expired, or fingerprint
-        // changed) OR when a TERMINAL block is active but the coordinator could attempt now (CLI
-        // available and not in cooldown). The terminal-escape hatch lets the CLI retry after the
-        // block was recorded — e.g. the user installed the CLI or the coordinator cooldown expired
-        // — without it, the terminal block would block the delegated attempt forever (bugbot
-        // #bc1ed54a). The coordinator's own cooldown still rate-limits the actual CLI touch.
+        // changed) OR when the coordinator could attempt now (CLI available and not in cooldown),
+        // regardless of the gate's block type. The CLI is the recovery path for auth failures
+        // (sessionExpired/tokenExpired) and for the no-usable-refresh-token path; the gate's
+        // transient block (from a 5xx/connection failure on the usage API) is orthogonal — it backs
+        // off the usage API, not the CLI — so blocking the CLI during a transient block would skip
+        // recovery when the credential is actually dead (bugbot #737e65d5). The terminal-block
+        // escape hatch (bugbot #bc1ed54a) is subsumed by this: any block + canAttempt → try the CLI.
+        // The coordinator's own cooldown still rate-limits the actual CLI touch. `shouldAttempt` is
+        // still called (for its fingerprint-recheck side effect — clears the gate on external
+        // re-login — and to allow when there's no block).
         let gateAllows = failureGate.shouldAttempt(now: now())
-        let terminalEscape: Bool = {
-            guard case .terminal? = failureGate.currentBlockStatus(now: now()) else { return false }
-            return coordinator.canAttempt(now: now())
-        }()
-        guard gateAllows || terminalEscape else { return nil }
+        let escapeHatch = coordinator.canAttempt(now: now())
+        guard gateAllows || escapeHatch else { return nil }
 
         let outcome = await coordinator.attempt(now: now())
         switch outcome {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -361,4 +361,65 @@ final class ClaudeProvider: ProviderRuntime {
         return decoded.accessToken
     }
 
+    // MARK: - Debug (dev builds only; surfaced in Settings → Debug)
+
+    /// Debug: run a delegated CLI refresh attempt in isolation and log the outcome plus the
+    /// fingerprint before/after. Surfaces the coordinator's CLI resolution, `--version` touch, and
+    /// fingerprint-verify logic end-to-end WITHOUT going through the full `refresh()` cycle (no usage
+    /// API call, no candidate loop). Used by the Debug settings section to verify the delegated
+    /// refresh path works against the real `claude` CLI. Set log level to Debug in Advanced to see
+    /// the coordinator's own touch/verify logs.
+    func debugRunDelegatedRefresh() async {
+        let before = await loadOffMainActor { [authStore] in authStore.currentFingerprint() }
+        AppLog.info(LogTag.auth("claude"), "[debug] delegated refresh test — fingerprint before: \(before)")
+        let outcome = await coordinator.attempt(now: now())
+        let after = await loadOffMainActor { [authStore] in authStore.currentFingerprint() }
+        AppLog.info(LogTag.auth("claude"), "[debug] delegated refresh outcome: \(outcome)")
+        AppLog.info(LogTag.auth("claude"), "[debug] fingerprint after: \(after)")
+        AppLog.info(LogTag.auth("claude"), "[debug] fingerprint changed: \(before != after)")
+        if case .attemptedSucceeded = outcome, before != after {
+            AppLog.info(LogTag.auth("claude"), "[debug] ✅ credential rotated — delegated refresh works")
+        } else if case .cliUnavailable = outcome {
+            AppLog.info(LogTag.auth("claude"), "[debug] ⚠️ claude CLI not found — install it or set CLAUDE_CLI_PATH")
+        } else if case .skippedByCooldown = outcome {
+            AppLog.info(LogTag.auth("claude"), "[debug] ⏸️ skipped by cooldown — wait or clear the gate first")
+        } else {
+            AppLog.info(LogTag.auth("claude"), "[debug] ❌ credential unchanged — `claude --version` didn't rotate the token (see TODO(#753) in the coordinator)")
+        }
+    }
+
+    /// Debug: dump the current Claude credential state to the log — every candidate's source, scope
+    /// presence, refresh-token presence, and expiry; the current fingerprint; the failure-gate state;
+    /// and whether `canFetchLiveUsage` would allow the live usage call. Used by the Debug settings
+    /// section to diagnose "No data" issues (e.g. #777's missing `user:profile` scope). Keychain
+    /// reads run off-main to match the production refresh path.
+    func debugDumpCredentialState() async {
+        let candidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
+        let fingerprint = await loadOffMainActor { [authStore] in authStore.currentFingerprint() }
+        AppLog.info(LogTag.auth("claude"), "[debug] credential state dump — \(candidates.count) candidate(s):")
+        for candidate in candidates {
+            AppLog.info(LogTag.auth("claude"), "[debug]   \(candidate.diagnosticsLabel(now: now())) scopes=\(candidate.oauth.scopes ?? [])")
+        }
+        AppLog.info(LogTag.auth("claude"), "[debug] current fingerprint: \(fingerprint)")
+        let gateStatus = failureGate.currentBlockStatus(now: now())
+        AppLog.info(LogTag.auth("claude"), "[debug] failure gate: \(gateStatus.map { "\($0)" } ?? "none (no block)")")
+        if let first = candidates.first {
+            AppLog.info(LogTag.auth("claude"), "[debug] canFetchLiveUsage (preferred source): \(authStore.canFetchLiveUsage(first))")
+            let hasProfile = first.oauth.scopes?.contains("user:profile") ?? false
+            if !hasProfile {
+                AppLog.warn(LogTag.auth("claude"), "[debug] ⚠️ preferred credential is missing user:profile scope — live usage will show 'No data' (see #777/#782); re-login via `claude` subscription flow to fix")
+            }
+        } else {
+            AppLog.warn(LogTag.auth("claude"), "[debug] ⚠️ no credential candidates found — not logged in")
+        }
+    }
+
+    /// Debug: clear the Claude failure gate (terminal/transient block) so the next refresh retries
+    /// immediately instead of waiting for the backoff window. Used by the Debug settings section to
+    /// test recovery without waiting for the 5min→6h exponential backoff.
+    func debugClearFailureGate() {
+        failureGate.recordSuccess()
+        AppLog.info(LogTag.auth("claude"), "[debug] failure gate cleared — next refresh will retry immediately")
+    }
+
 }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -69,11 +69,17 @@ final class ClaudeProvider: ProviderRuntime {
         AppLog.info(LogTag.plugin("claude"), "refresh start (\(candidates.count) source\(candidates.count == 1 ? "" : "s"): \(sources))")
 
         // If a prior refresh left a TERMINAL block (the stored refresh chain is dead) and the credential
-        // hasn't changed since, skip the network entirely — only an external `claude` re-login (which
-        // changes the fingerprint and clears the gate via `shouldAttempt`) can recover. Checked once here,
-        // before the candidate loop, so a fresh re-login is still tried the moment creds change.
-        if case .terminal? = failureGate.currentBlockStatus(now: now()), !failureGate.shouldAttempt(now: now()) {
-            AppLog.info(LogTag.auth("claude"), "refresh blocked (terminal, credentials unchanged); not calling API")
+        // hasn't changed since, skip the network — UNLESS the coordinator could attempt a delegated
+        // refresh right now (CLI available and not in cooldown). In that case, let the refresh proceed
+        // so the CLI gets a chance to rotate the credential (e.g. the user installed the CLI after the
+        // terminal block was recorded, or the coordinator cooldown expired). Without this escape hatch,
+        // a terminal block recorded when the CLI was unavailable or in cooldown would block all future
+        // delegated attempts until the fingerprint changed — so installing the CLI or waiting out the
+        // cooldown never triggered recovery (bugbot #bc1ed54a).
+        if case .terminal? = failureGate.currentBlockStatus(now: now()),
+           !failureGate.shouldAttempt(now: now()),
+           !coordinator.canAttempt(now: now()) {
+            AppLog.info(LogTag.auth("claude"), "refresh blocked (terminal, credentials unchanged, CLI unavailable or in cooldown); not calling API")
             return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.tokenExpired)
         }
 
@@ -215,17 +221,35 @@ final class ClaudeProvider: ProviderRuntime {
     /// refresh token in the source OpenUsage reads). Gated so a dead credential doesn't launch the CLI on
     /// every refresh: only attempts when the failure gate allows it, and only treats success as a real
     /// rotation (verified by the coordinator's fingerprint check). On success, re-reads the credential
-    /// candidates and returns the one matching the source we were probing (else the preferred one).
+    /// candidates and returns the PREFERRED one — the CLI typically rotates the preferred source
+    /// (keychain on macOS), so the same-source candidate we were probing may still be stale. Returning
+    /// the stale same-source candidate caused auth to fail again and record a terminal block with the
+    /// preferred source's (now valid) fingerprint, which then blocked all future refreshes including
+    /// the good keychain (bugbot #8898f938).
     private func delegatedRefreshIfPossible(currentSource: ClaudeCredentialState.Source) async throws -> ClaudeCredentialState? {
-        guard failureGate.shouldAttempt(now: now()) else { return nil }
+        // Allow the attempt when the gate says "go" (no block, transient expired, or fingerprint
+        // changed) OR when a TERMINAL block is active but the coordinator could attempt now (CLI
+        // available and not in cooldown). The terminal-escape hatch lets the CLI retry after the
+        // block was recorded — e.g. the user installed the CLI or the coordinator cooldown expired
+        // — without it, the terminal block would block the delegated attempt forever (bugbot
+        // #bc1ed54a). The coordinator's own cooldown still rate-limits the actual CLI touch.
+        let gateAllows = failureGate.shouldAttempt(now: now())
+        let terminalEscape: Bool = {
+            guard case .terminal? = failureGate.currentBlockStatus(now: now()) else { return false }
+            return coordinator.canAttempt(now: now())
+        }()
+        guard gateAllows || terminalEscape else { return nil }
 
         let outcome = await coordinator.attempt(now: now())
         switch outcome {
         case .attemptedSucceeded:
             failureGate.recordSuccess()
             let candidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
-            // Prefer the same source we were probing; otherwise the first (preferred) candidate.
-            let recovered = candidates.first(where: { $0.source == currentSource }) ?? candidates.first
+            // Use the PREFERRED candidate (first) after recovery. The CLI rotates whichever source it
+            // owns (keychain on macOS, file on Linux) — that's the preferred source in both cases, so
+            // the same-source candidate we were probing (e.g. a fallback file probe after the keychain
+            // failed) may still be stale while the preferred keychain is now fresh.
+            let recovered = candidates.first
             if recovered != nil {
                 AppLog.info(LogTag.auth("claude"), "delegated refresh recovered credentials; retrying live fetch")
             }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -76,8 +76,13 @@ final class ClaudeProvider: ProviderRuntime {
         // a terminal block recorded when the CLI was unavailable or in cooldown would block all future
         // delegated attempts until the fingerprint changed — so installing the CLI or waiting out the
         // cooldown never triggered recovery (bugbot #bc1ed54a).
+        //
+        // The `forceRecheck: true` on `shouldAttempt` bypasses the gate's 15s recheck throttle so an
+        // external re-login (fingerprint change) is detected immediately, not up to 15s late — without
+        // it, the short-circuit would return `tokenExpired` for up to 15s after the user re-logged in,
+        // while the already-loaded fresh candidates go untried (bugbot #f6dcff9f).
         if case .terminal? = failureGate.currentBlockStatus(now: now()),
-           !failureGate.shouldAttempt(now: now()),
+           !failureGate.shouldAttempt(now: now(), forceRecheck: true),
            !coordinator.canAttempt(now: now()) {
             AppLog.info(LogTag.auth("claude"), "refresh blocked (terminal, credentials unchanged, CLI unavailable or in cooldown); not calling API")
             return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.tokenExpired)
@@ -131,22 +136,26 @@ final class ClaudeProvider: ProviderRuntime {
                 // re-read and retry the live fetch ONCE before falling back to the next source.
                 if let recovered = try await delegatedRefreshIfPossible(currentSource: state.source) {
                     state = recovered
-                    mapped = try await fetchLiveUsage(state: &state)
+                    // The retry is wrapped in its own do/catch so its errors route through the same
+                    // gate-update logic as the first attempt — without this, a 5xx on the retry would
+                    // skip recordTransientFailure, and an auth failure after rotation would skip the
+                    // terminal recording (bugbot #88d01254). We do NOT retry delegated refresh again
+                    // (to avoid loops): a second auth failure means the rotation didn't help.
+                    do {
+                        mapped = try await fetchLiveUsage(state: &state)
+                    } catch let retryError as ClaudeAuthError where retryError == .sessionExpired || retryError == .tokenExpired {
+                        failureGate.recordTerminalAuthFailure(reason: "\(retryError)", now: now())
+                        throw retryError
+                    } catch let retryError as ClaudeUsageError {
+                        recordTransientForUsageError(retryError)
+                        throw retryError
+                    }
                 } else {
                     failureGate.recordTerminalAuthFailure(reason: "\(error)", now: now())
                     throw error
                 }
             } catch let error as ClaudeUsageError {
-                // A transport/infra failure during refresh or fetch (connection failed / 5xx) is transient:
-                // the credential may be fine. Back the gate off exponentially rather than marking it dead.
-                // 5xx (server unavailable / bad gateway / etc.) is transient too — the server is briefly
-                // broken, not the credential. 4xx other than 401 (e.g. 403, 404) is NOT transient: it
-                // points at a real permission/config problem that re-trying won't fix.
-                if case .connectionFailed = error {
-                    failureGate.recordTransientFailure(now: now())
-                } else if case .requestFailed(let statusCode) = error, (500..<600).contains(statusCode) {
-                    failureGate.recordTransientFailure(now: now())
-                }
+                recordTransientForUsageError(error)
                 throw error
             }
         }
@@ -226,6 +235,18 @@ final class ClaudeProvider: ProviderRuntime {
     /// the stale same-source candidate caused auth to fail again and record a terminal block with the
     /// preferred source's (now valid) fingerprint, which then blocked all future refreshes including
     /// the good keychain (bugbot #8898f938).
+    /// Record a transient failure gate update for a usage error that's likely transient (connection
+    /// failure or 5xx). 4xx non-auth (e.g. 404) is NOT transient — it's a real problem re-trying won't
+    /// fix. Shared by the first-attempt catch and the retry-after-delegated-refresh catch so both
+    /// route through the same gate-update logic (bugbot #88d01254).
+    private func recordTransientForUsageError(_ error: ClaudeUsageError) {
+        if case .connectionFailed = error {
+            failureGate.recordTransientFailure(now: now())
+        } else if case .requestFailed(let statusCode) = error, (500..<600).contains(statusCode) {
+            failureGate.recordTransientFailure(now: now())
+        }
+    }
+
     private func delegatedRefreshIfPossible(currentSource: ClaudeCredentialState.Source) async throws -> ClaudeCredentialState? {
         // Allow the attempt when the gate says "go" (no block, transient expired, or fingerprint
         // changed) OR when a TERMINAL block is active but the coordinator could attempt now (CLI

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -116,14 +116,18 @@ final class ClaudeProvider: ProviderRuntime {
             do {
                 mapped = try await fetchLiveUsage(state: &state)
             } catch let error as ClaudeAuthError where error == .sessionExpired || error == .tokenExpired {
-                // The in-process refresh hit a dead end (revoked refresh token, or none at all). Mark the
-                // gate terminal, then ask the `claude` CLI to refresh; if it rotates the credential,
+                // The in-process refresh hit a dead end (revoked refresh token, or none at all). Try
+                // delegating to the `claude` CLI FIRST — it owns the refresh token + client credentials
+                // and can rotate the credential where OpenUsage can't. Only if delegation also fails do
+                // we record the terminal block: a terminal block sets `lastRecheckAt = now`, which trips
+                // the gate's 15s recheck throttle and would block the very `shouldAttempt` call the
+                // delegation path needs, so the order matters (this was a bugbot-found bug). On success,
                 // re-read and retry the live fetch ONCE before falling back to the next source.
-                failureGate.recordTerminalAuthFailure(reason: "\(error)", now: now())
                 if let recovered = try await delegatedRefreshIfPossible(currentSource: state.source) {
                     state = recovered
                     mapped = try await fetchLiveUsage(state: &state)
                 } else {
+                    failureGate.recordTerminalAuthFailure(reason: "\(error)", now: now())
                     throw error
                 }
             } catch let error as ClaudeUsageError {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -81,9 +81,17 @@ final class ClaudeProvider: ProviderRuntime {
         // external re-login (fingerprint change) is detected immediately, not up to 15s late — without
         // it, the short-circuit would return `tokenExpired` for up to 15s after the user re-logged in,
         // while the already-loaded fresh candidates go untried (bugbot #f6dcff9f).
-        if case .terminal? = failureGate.currentBlockStatus(now: now()),
-           !failureGate.shouldAttempt(now: now(), forceRecheck: true),
-           !coordinator.canAttempt(now: now()) {
+        //
+        // The whole check runs off-main: `shouldAttempt(forceRecheck:)` re-reads the keychain via
+        // `currentFingerprint()`, and `canAttempt` does filesystem checks for the CLI binary. Both
+        // block the calling thread, so running them on the main actor would freeze the UI on every
+        // refresh tick while a terminal block is active (bugbot #1ba3ab5b).
+        let shouldShortCircuit = await loadOffMainActor { [failureGate, coordinator, now] in
+            guard case .terminal? = failureGate.currentBlockStatus(now: now()) else { return false }
+            return !failureGate.shouldAttempt(now: now(), forceRecheck: true)
+                && !coordinator.canAttempt(now: now())
+        }
+        if shouldShortCircuit {
             AppLog.info(LogTag.auth("claude"), "refresh blocked (terminal, credentials unchanged, CLI unavailable or in cooldown); not calling API")
             return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.tokenExpired)
         }
@@ -193,6 +201,18 @@ final class ClaudeProvider: ProviderRuntime {
            let refreshToken = state.oauth.refreshToken,
            !refreshToken.isEmpty {
             state.oauth.accessToken = try await refreshAccessToken(state: &state, refreshToken: refreshToken)
+        }
+
+        // Transient failure backoff: if the gate has an active transient block (from a recent 5xx /
+        // connection failure on the usage API), skip the live usage call and serve the last-good
+        // usage so a failing endpoint isn't hammered on every periodic refresh (bugbot #bc71842b).
+        // This is checked AFTER the delegated/in-process refresh steps above so credential recovery
+        // still runs during a transient block — only the usage API call is skipped. The block
+        // auto-unblocks by time (exponential backoff) or when the fingerprint changes (external
+        // re-login). Serving the last-good usage mirrors the 429 cooldown path.
+        if case .transient(let until, _)? = failureGate.currentBlockStatus(now: now()), now() < until {
+            AppLog.info(LogTag.plugin("claude"), "transient failure backoff (serving \(lastGoodUsage == nil ? "badge" : "last-good usage"))")
+            return rateLimitedSnapshot(credentials: state.oauth, retryAfterSeconds: Int(until.timeIntervalSince(now()).rounded(.up)))
         }
 
         var working = state

--- a/Sources/OpenUsage/Providers/Claude/ClaudeRefreshFailureGate.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeRefreshFailureGate.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// Throttles how often OpenUsage re-attempts a Claude token refresh after one has failed, so a dead or
+/// revoked credential doesn't spawn a delegated-CLI refresh (or a network round-trip) on every periodic
+/// refresh. Two failure shapes are distinguished:
+///
+/// - **Terminal** (`invalid_grant` / session expired): the stored refresh chain is dead and no amount of
+///   retrying inside OpenUsage will fix it — only an external `claude` re-login can. So a terminal block
+///   has NO time expiry: it stays blocked until the credential fingerprint actually changes (the user
+///   re-logged in elsewhere). It is also monotonic — a later transient failure can't downgrade it back
+///   to a self-clearing transient block.
+/// - **Transient** (network / 5xx / timeout during refresh): the credential may well be fine; the world
+///   was briefly unavailable. These back off exponentially (`5min * 2^(n-1)`, capped at 6h) and
+///   auto-unblock once the window elapses.
+///
+/// Either block also clears early when the on-disk credential fingerprint differs from the one captured
+/// at failure time (an external re-login wrote new creds), rechecked at most once every 15s so the hot
+/// refresh path doesn't re-read the keychain on every tick. State persists to `UserDefaults` so a block
+/// survives an app relaunch (a revoked token is still revoked after a restart).
+struct ClaudeRefreshFailureGate: Sendable {
+    enum BlockStatus: Equatable, Sendable {
+        case terminal(reason: String, failures: Int)
+        case transient(until: Date, failures: Int)
+    }
+
+    /// Persisted state. Serialized as JSON into a single `UserDefaults` key so the whole gate round-trips
+    /// atomically. `nil` means "no active block".
+    private struct State: Codable, Equatable {
+        enum Kind: String, Codable { case terminal, transient }
+        var kind: Kind
+        var reason: String?
+        var failures: Int
+        var until: Date?
+        var fingerprintAtFailure: ClaudeCredentialFingerprint?
+        var lastRecheckAt: Date?
+    }
+
+    static let baseTransientCooldown: TimeInterval = 5 * 60
+    static let maxTransientCooldown: TimeInterval = 6 * 60 * 60
+    static let recheckThrottle: TimeInterval = 15
+
+    private let store: SendableUserDefaults
+    private let storageKey: String
+    /// Re-reads the CURRENT on-disk credential fingerprint so the gate can tell whether an external
+    /// `claude` re-login rotated the creds since the failure. Injectable for tests.
+    private let currentFingerprint: @Sendable () -> ClaudeCredentialFingerprint
+
+    private var defaults: UserDefaults { store.defaults }
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = "claude.refreshGate.state.v1",
+        currentFingerprint: @escaping @Sendable () -> ClaudeCredentialFingerprint
+    ) {
+        self.store = SendableUserDefaults(defaults)
+        self.storageKey = storageKey
+        self.currentFingerprint = currentFingerprint
+    }
+
+    // MARK: - Queries
+
+    /// Whether a refresh should be attempted now. True when there is no active block, when a transient
+    /// block's window has elapsed, or when the credential fingerprint has changed since the failure
+    /// (throttled to one recheck per 15s).
+    func shouldAttempt(now: Date) -> Bool {
+        guard let state = loadState() else { return true }
+
+        if case .transient = state.kind, let until = state.until, until <= now {
+            return true
+        }
+
+        // Fingerprint recheck, throttled. If the creds changed externally, unblock (both kinds).
+        if let last = state.lastRecheckAt, now.timeIntervalSince(last) < Self.recheckThrottle {
+            return false
+        }
+        var refreshed = state
+        refreshed.lastRecheckAt = now
+        let changed = currentFingerprint() != (state.fingerprintAtFailure ?? ClaudeCredentialFingerprint())
+        if changed {
+            clear()
+            return true
+        }
+        saveState(refreshed)
+        return false
+    }
+
+    func currentBlockStatus(now: Date) -> BlockStatus? {
+        guard let state = loadState() else { return nil }
+        switch state.kind {
+        case .terminal:
+            return .terminal(reason: state.reason ?? "session expired", failures: state.failures)
+        case .transient:
+            let until = state.until ?? now
+            if until <= now { return nil }
+            return .transient(until: until, failures: state.failures)
+        }
+    }
+
+    // MARK: - Mutations
+
+    /// Record a terminal auth failure (e.g. `invalid_grant`). Monotonic: once terminal, a later
+    /// transient cannot downgrade it; the failure count only ever climbs. No time expiry — only a
+    /// changed fingerprint (external re-login) clears it.
+    func recordTerminalAuthFailure(reason: String, now: Date) {
+        let previous = loadState()
+        let failures = (previous?.failures ?? 0) + 1
+        saveState(State(
+            kind: .terminal,
+            reason: reason,
+            failures: failures,
+            until: nil,
+            fingerprintAtFailure: currentFingerprint(),
+            lastRecheckAt: now
+        ))
+    }
+
+    /// Record a transient failure (network/5xx/timeout). Backs off `5min * 2^(failures-1)`, capped at 6h.
+    /// If a terminal block is already in place it is NOT downgraded — the credential is still known dead.
+    func recordTransientFailure(now: Date) {
+        let previous = loadState()
+        if previous?.kind == .terminal {
+            // Keep the terminal block, but refresh its fingerprint baseline so a later external re-login
+            // can still clear it. Don't reset the failure count downward.
+            var kept = previous!
+            kept.fingerprintAtFailure = currentFingerprint()
+            kept.lastRecheckAt = now
+            saveState(kept)
+            return
+        }
+        let failures = (previous?.failures ?? 0) + 1
+        let exponent = max(0, failures - 1)
+        let cooldown = min(Self.baseTransientCooldown * pow(2, Double(exponent)), Self.maxTransientCooldown)
+        saveState(State(
+            kind: .transient,
+            reason: nil,
+            failures: failures,
+            until: now.addingTimeInterval(cooldown),
+            fingerprintAtFailure: currentFingerprint(),
+            lastRecheckAt: now
+        ))
+    }
+
+    /// Clear all block state after a refresh succeeds.
+    func recordSuccess() {
+        clear()
+    }
+
+    // MARK: - Persistence
+
+    private func clear() {
+        defaults.removeObject(forKey: storageKey)
+    }
+
+    private func loadState() -> State? {
+        guard let data = defaults.data(forKey: storageKey) else { return nil }
+        return try? JSONDecoder().decode(State.self, from: data)
+    }
+
+    private func saveState(_ state: State) {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeRefreshFailureGate.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeRefreshFailureGate.swift
@@ -61,16 +61,20 @@ struct ClaudeRefreshFailureGate: Sendable {
 
     /// Whether a refresh should be attempted now. True when there is no active block, when a transient
     /// block's window has elapsed, or when the credential fingerprint has changed since the failure
-    /// (throttled to one recheck per 15s).
-    func shouldAttempt(now: Date) -> Bool {
+    /// (throttled to one recheck per 15s, unless `forceRecheck` bypasses the throttle for paths that
+    /// must not miss a fresh credential — e.g. the provider's terminal-block short-circuit, which
+    /// would otherwise return `tokenExpired` for up to 15s after an external re-login changed the
+    /// fingerprint, while the already-loaded fresh candidates go untried).
+    func shouldAttempt(now: Date, forceRecheck: Bool = false) -> Bool {
         guard let state = loadState() else { return true }
 
         if case .transient = state.kind, let until = state.until, until <= now {
             return true
         }
 
-        // Fingerprint recheck, throttled. If the creds changed externally, unblock (both kinds).
-        if let last = state.lastRecheckAt, now.timeIntervalSince(last) < Self.recheckThrottle {
+        // Fingerprint recheck, throttled (unless forceRecheck). If the creds changed externally,
+        // unblock (both kinds).
+        if !forceRecheck, let last = state.lastRecheckAt, now.timeIntervalSince(last) < Self.recheckThrottle {
             return false
         }
         var refreshed = state

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -142,6 +142,14 @@ final class WidgetDataStore {
     /// (disabled / unknown / already in flight) so a wake-burst's suppression is visible in the logs.
     enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
 
+    /// Debug-only accessor for the raw provider runtime. Returns nil for unknown IDs. Used by the
+    /// Debug settings section (dev builds only) to run provider-specific diagnostic methods — e.g.
+    /// Claude's delegated-refresh test and credential-state dump. Not surfaced in release builds;
+    /// harmless in production since the UI never calls it.
+    func debugProvider(_ id: String) -> ProviderRuntime? {
+        providersByID[id]
+    }
+
     @discardableResult
     func refresh(providerID: String, force: Bool = false) async -> RefreshOutcome {
         guard isProviderEnabled(providerID) else { return .skipped }

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -130,6 +130,11 @@ struct SettingsScreen: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             advancedSection
+            // Dev-build only: the signed release ships an SUFeedURL (so `updater.isActive` is true);
+            // dev builds and bare `swift run` don't, so this section is hidden in production.
+            if !updater.isActive {
+                debugSection
+            }
             // Visible whenever the updater is active (only the signed release build ships a feed; the
             // dev build and a bare `swift run`, with no feed, hide this).
             if updater.isActive {
@@ -198,6 +203,53 @@ struct SettingsScreen: View {
                     .padding(.horizontal, 12)
                     .padding(.bottom, 8)
                     .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    // MARK: - Debug (dev builds only)
+
+    /// Diagnostic buttons for the Claude provider's token-refresh path. Each button writes to the
+    /// file log (set Log Level to Debug in Advanced above to see the full trace, including the
+    /// coordinator's touch/verify polls). Hidden in release builds via the `!updater.isActive` gate
+    /// in `content`. The buttons run on the MainActor (the provider is `@MainActor`); keychain reads
+    /// inside the debug methods are offloaded to a background executor to match the production
+    /// refresh path and avoid freezing the popover.
+    private var debugSection: some View {
+        section("Debug") {
+            // Plain-language note so the section isn't a wall of unlabeled buttons.
+            Text("Diagnostic buttons for the Claude token-refresh path. Set Log Level to Debug above, then use Copy Log Path / Reveal in Finder to read the trace.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.top, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            logButton("Refresh Claude (full)") {
+                AppLog.info(.config, "[debug] manual Claude refresh triggered")
+                Task { await container.dataStore.refresh(providerID: "claude", force: true) }
+            }
+            logButton("Test Delegated CLI Refresh") {
+                guard let claude = container.dataStore.debugProvider("claude") as? ClaudeProvider else {
+                    AppLog.warn(.config, "[debug] Claude provider not found")
+                    return
+                }
+                AppLog.info(.config, "[debug] delegated CLI refresh test triggered")
+                Task { await claude.debugRunDelegatedRefresh() }
+            }
+            logButton("Dump Credential State") {
+                guard let claude = container.dataStore.debugProvider("claude") as? ClaudeProvider else {
+                    AppLog.warn(.config, "[debug] Claude provider not found")
+                    return
+                }
+                AppLog.info(.config, "[debug] credential state dump triggered")
+                Task { await claude.debugDumpCredentialState() }
+            }
+            logButton("Clear Failure Gate") {
+                guard let claude = container.dataStore.debugProvider("claude") as? ClaudeProvider else {
+                    AppLog.warn(.config, "[debug] Claude provider not found")
+                    return
+                }
+                claude.debugClearFailureGate()
             }
         }
     }

--- a/Tests/OpenUsageTests/ClaudeDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDelegatedRefreshCoordinatorTests.swift
@@ -48,6 +48,15 @@ final class ClaudeDelegatedRefreshCoordinatorTests: XCTestCase {
             lock.lock()
             launches.append((executable, arguments))
             lock.unlock()
+            // `/usr/bin/which <cmd>` is a non-side-effecting PATH probe (no `--version` touch).
+            // Return success only if the test says the command resolves; never call onTouch for it.
+            if executable == "/usr/bin/which" {
+                let command = arguments.first ?? ""
+                if resolvableExecutables.contains(command) {
+                    return ProcessResult(exitCode: 0, stdout: "/fake/\(command)\n", stderr: "")
+                }
+                return ProcessResult(exitCode: 1, stdout: "", stderr: "not found")
+            }
             // A bare `claude` probe only "succeeds" if the test says it resolves.
             if !executable.hasPrefix("/"), !resolvableExecutables.contains(executable) {
                 return ProcessResult(exitCode: 127, stdout: "", stderr: "not found")
@@ -246,6 +255,34 @@ final class ClaudeDelegatedRefreshCoordinatorTests: XCTestCase {
         let stamped = defaults.double(forKey: "last")
         XCTAssertEqual(stamped, injectedTime.timeIntervalSince1970, accuracy: 0.001,
                        "success cooldown must use the injected `moment` time, not the now() closure")
+    }
+
+    func testPathBasedProbeUsesWhichNotVersion() async {
+        // Bugbot #d30aea11: when the CLI is resolved only via PATH, resolveCLI() used to run
+        // `claude --version` as a probe BEFORE runTouchAndVerify captured its baseline fingerprint.
+        // If that probe rotated the credential, the baseline reflected the post-probe state, the
+        // second touch looked unchanged, and the coordinator returned .attemptedFailed even though
+        // rotation already happened. Fix: commandExists uses `/usr/bin/which` (no side effect)
+        // instead of `claude --version`, so the probe doesn't rotate the credential and the touch's
+        // rotation is detected against the pre-touch baseline.
+        let box = FingerprintBox(.init(tokenHash: "before"))
+        // `resolvableExecutables: ["claude"]` makes the `which claude` probe succeed AND the bare
+        // `claude --version` touch succeed. `onTouch` rotates the credential on every non-`which`
+        // launch — with the fix, only the touch (not the probe) triggers it.
+        let runner = RecordingProcessRunner(resolvableExecutables: ["claude"]) { box.set(.init(tokenHash: "after")) }
+        let coordinator = makeCoordinator(
+            processRunner: runner,
+            executableCLIPaths: [],  // no absolute path → fall back to PATH-based resolution
+            fingerprint: { box.current }
+        )
+
+        let outcome = await coordinator.attempt()
+        XCTAssertEqual(outcome, .attemptedSucceeded,
+                       "PATH-based probe must not rotate the credential before the baseline; the touch's rotation must be detected")
+
+        // The PATH probe should use `/usr/bin/which`, not `claude --version`.
+        let whichLaunches = runner.launches.filter { $0.executable == "/usr/bin/which" }
+        XCTAssertFalse(whichLaunches.isEmpty, "commandExists should use /usr/bin/which for PATH resolution")
     }
 }
 

--- a/Tests/OpenUsageTests/ClaudeDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDelegatedRefreshCoordinatorTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+@testable import OpenUsage
+
+final class ClaudeDelegatedRefreshCoordinatorTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "claude.delegatedRefresh.test.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    /// Records every launch and counts only the non-`--version`-probe ones... but the touch IS
+    /// `--version`, so this counter records ALL launches and we assert on the touch separately. The
+    /// optional `onTouch` hook lets a test mutate state (e.g. rotate the fingerprint) when the CLI runs.
+    private final class RecordingProcessRunner: ProcessRunning, @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var launches: [(executable: String, arguments: [String])] = []
+        var resolvableExecutables: Set<String>
+        let onTouch: (@Sendable () -> Void)?
+
+        init(resolvableExecutables: Set<String>, onTouch: (@Sendable () -> Void)? = nil) {
+            self.resolvableExecutables = resolvableExecutables
+            self.onTouch = onTouch
+        }
+
+        /// The CLI touch always runs an ABSOLUTE resolved path with `--version`; a bare-`claude` PATH
+        /// probe (no leading `/`) also runs `--version` but is resolution, not a touch — so exclude it.
+        var touchCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return launches.filter { $0.arguments == ["--version"] && $0.executable.hasPrefix("/") }.count
+        }
+
+        func run(
+            executable: String,
+            arguments: [String],
+            environment: [String: String],
+            timeout: TimeInterval
+        ) throws -> ProcessResult {
+            lock.lock()
+            launches.append((executable, arguments))
+            lock.unlock()
+            // A bare `claude` probe only "succeeds" if the test says it resolves.
+            if !executable.hasPrefix("/"), !resolvableExecutables.contains(executable) {
+                return ProcessResult(exitCode: 127, stdout: "", stderr: "not found")
+            }
+            onTouch?()
+            return ProcessResult(exitCode: 0, stdout: "1.2.3\n", stderr: "")
+        }
+    }
+
+    private final class FingerprintBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: ClaudeCredentialFingerprint
+        init(_ value: ClaudeCredentialFingerprint) { self.value = value }
+        var current: ClaudeCredentialFingerprint { lock.lock(); defer { lock.unlock() }; return value }
+        func set(_ value: ClaudeCredentialFingerprint) { lock.lock(); defer { lock.unlock() }; self.value = value }
+    }
+
+    private func makeCoordinator(
+        processRunner: ProcessRunning,
+        environment: [String: String] = [:],
+        executableCLIPaths: Set<String> = [],
+        fingerprint: @escaping @Sendable () -> ClaudeCredentialFingerprint,
+        now: @escaping @Sendable () -> Date = { Date(timeIntervalSince1970: 1_000_000) }
+    ) -> ClaudeDelegatedRefreshCoordinator {
+        ClaudeDelegatedRefreshCoordinator(
+            processRunner: processRunner,
+            environment: FakeEnvironment(environment),
+            homeDirectory: { URL(fileURLWithPath: "/Users/test") },
+            currentFingerprint: fingerprint,
+            now: now,
+            sleep: { _ in }, // no real waiting in tests
+            isExecutable: { executableCLIPaths.contains($0) },
+            defaults: defaults,
+            lastAttemptKey: "last",
+            cooldownKey: "cooldown"
+        )
+    }
+
+    func testCLIUnavailableDoesNotConsumeCooldown() async {
+        // No absolute CLI candidate is executable and a bare `claude` probe fails to resolve.
+        let runner = RecordingProcessRunner(resolvableExecutables: [])
+        let box = FingerprintBox(.init(tokenHash: "a"))
+        let coordinator = makeCoordinator(processRunner: runner, fingerprint: { box.current })
+
+        let outcome = await coordinator.attempt()
+        XCTAssertEqual(outcome, .cliUnavailable)
+        // No cooldown was stamped, so the next attempt is NOT skipped by cooldown (it's cliUnavailable again).
+        let second = await coordinator.attempt()
+        XCTAssertEqual(second, .cliUnavailable)
+        XCTAssertEqual(runner.touchCount, 0) // never reached the touch
+    }
+
+    func testSucceedsOnlyWhenFingerprintChanges() async {
+        let box = FingerprintBox(.init(tokenHash: "before"))
+        let cliPath = "/opt/homebrew/bin/claude"
+        // The touch rotates the credential.
+        let runner = RecordingProcessRunner(resolvableExecutables: []) { box.set(.init(tokenHash: "after")) }
+        let coordinator = makeCoordinator(
+            processRunner: runner,
+            executableCLIPaths: [cliPath],
+            fingerprint: { box.current }
+        )
+
+        let outcome = await coordinator.attempt()
+        XCTAssertEqual(outcome, .attemptedSucceeded)
+        XCTAssertEqual(runner.touchCount, 1)
+        XCTAssertEqual(runner.launches.last?.executable, cliPath)
+    }
+
+    func testTouchRanButUnchangedFingerprintFails() async {
+        let box = FingerprintBox(.init(tokenHash: "same"))
+        let cliPath = "/opt/homebrew/bin/claude"
+        // The touch runs but does NOT rotate the credential.
+        let runner = RecordingProcessRunner(resolvableExecutables: [])
+        let coordinator = makeCoordinator(
+            processRunner: runner,
+            executableCLIPaths: [cliPath],
+            fingerprint: { box.current }
+        )
+
+        let outcome = await coordinator.attempt()
+        guard case .attemptedFailed = outcome else {
+            return XCTFail("expected attemptedFailed, got \(outcome)")
+        }
+        XCTAssertEqual(runner.touchCount, 1)
+    }
+
+    func testSkippedByCooldownWithinWindowThenAllowedAfter() async {
+        let box = FingerprintBox(.init(tokenHash: "same"))
+        let cliPath = "/opt/homebrew/bin/claude"
+        let runner = RecordingProcessRunner(resolvableExecutables: [])
+        let clock = ClockBox(Date(timeIntervalSince1970: 1_000_000))
+        let coordinator = makeCoordinator(
+            processRunner: runner,
+            executableCLIPaths: [cliPath],
+            fingerprint: { box.current },
+            now: { clock.now }
+        )
+
+        // First attempt: touch runs, unchanged → attemptedFailed, short cooldown stamped.
+        _ = await coordinator.attempt()
+        XCTAssertEqual(runner.touchCount, 1)
+
+        // Within the short cooldown window: skipped, no new touch.
+        clock.set(Date(timeIntervalSince1970: 1_000_000 + 5))
+        let skipped = await coordinator.attempt()
+        XCTAssertEqual(skipped, .skippedByCooldown)
+        XCTAssertEqual(runner.touchCount, 1)
+
+        // After the 20s short cooldown: allowed again, a second touch runs.
+        clock.set(Date(timeIntervalSince1970: 1_000_000 + 21))
+        _ = await coordinator.attempt()
+        XCTAssertEqual(runner.touchCount, 2)
+    }
+
+    func testSuccessStampsLongerCooldown() async {
+        let box = FingerprintBox(.init(tokenHash: "before"))
+        let cliPath = "/opt/homebrew/bin/claude"
+        let runner = RecordingProcessRunner(resolvableExecutables: []) { box.set(.init(tokenHash: "after")) }
+        let clock = ClockBox(Date(timeIntervalSince1970: 1_000_000))
+        let coordinator = makeCoordinator(
+            processRunner: runner,
+            executableCLIPaths: [cliPath],
+            fingerprint: { box.current },
+            now: { clock.now }
+        )
+
+        let first = await coordinator.attempt()
+        XCTAssertEqual(first, .attemptedSucceeded)
+        // 1 minute later we should still be inside the 5-min success cooldown.
+        clock.set(Date(timeIntervalSince1970: 1_000_000 + 60))
+        let second = await coordinator.attempt()
+        XCTAssertEqual(second, .skippedByCooldown)
+        XCTAssertEqual(runner.touchCount, 1)
+    }
+
+    func testCLIPathEnvOverrideHonored() async {
+        let box = FingerprintBox(.init(tokenHash: "before"))
+        let overridePath = "/custom/bin/claude"
+        let runner = RecordingProcessRunner(resolvableExecutables: []) { box.set(.init(tokenHash: "after")) }
+        let coordinator = makeCoordinator(
+            processRunner: runner,
+            environment: ["CLAUDE_CLI_PATH": overridePath],
+            executableCLIPaths: [overridePath],
+            fingerprint: { box.current }
+        )
+
+        let outcome = await coordinator.attempt()
+        XCTAssertEqual(outcome, .attemptedSucceeded)
+        XCTAssertEqual(runner.launches.last?.executable, overridePath)
+    }
+
+    func testSingleFlightSharesOneLaunch() async {
+        let box = FingerprintBox(.init(tokenHash: "before"))
+        let cliPath = "/opt/homebrew/bin/claude"
+        let runner = RecordingProcessRunner(resolvableExecutables: []) { box.set(.init(tokenHash: "after")) }
+        let coordinator = makeCoordinator(
+            processRunner: runner,
+            executableCLIPaths: [cliPath],
+            fingerprint: { box.current }
+        )
+
+        // Fire several concurrent attempts; they should share one in-flight touch.
+        async let a = coordinator.attempt()
+        async let b = coordinator.attempt()
+        async let c = coordinator.attempt()
+        let outcomes = await [a, b, c]
+
+        XCTAssertTrue(outcomes.allSatisfy { $0 == .attemptedSucceeded })
+        XCTAssertEqual(runner.touchCount, 1, "concurrent attempts must share a single CLI launch")
+    }
+}
+
+/// A mutable clock for coordinator tests (the provider tests have their own private `TestClock`).
+private final class ClockBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+    init(_ value: Date) { self.value = value }
+    var now: Date { lock.lock(); defer { lock.unlock() }; return value }
+    func set(_ value: Date) { lock.lock(); defer { lock.unlock() }; self.value = value }
+}

--- a/Tests/OpenUsageTests/ClaudeDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDelegatedRefreshCoordinatorTests.swift
@@ -219,6 +219,34 @@ final class ClaudeDelegatedRefreshCoordinatorTests: XCTestCase {
         XCTAssertTrue(outcomes.allSatisfy { $0 == .attemptedSucceeded })
         XCTAssertEqual(runner.touchCount, 1, "concurrent attempts must share a single CLI launch")
     }
+
+    func testSuccessCooldownUsesInjectedTimeNotNowClosure() async {
+        // Bugbot #ed400fe6: runTouchAndVerify stamped the success cooldown with now() (the closure)
+        // while the short cooldown at attempt start used the `moment` passed via attempt(now:).
+        // Callers that inject time only via the parameter got mismatched cooldown timestamps. Fix:
+        // stamp the success cooldown with `moment` for consistency.
+        let box = FingerprintBox(.init(tokenHash: "before"))
+        let cliPath = "/opt/homebrew/bin/claude"
+        let runner = RecordingProcessRunner(resolvableExecutables: []) { box.set(.init(tokenHash: "after")) }
+        // makeCoordinator's default `now` closure returns 1_000_000; inject a DIFFERENT time via
+        // attempt(now:) to expose the mismatch.
+        let coordinator = makeCoordinator(
+            processRunner: runner,
+            executableCLIPaths: [cliPath],
+            fingerprint: { box.current }
+        )
+
+        let injectedTime = Date(timeIntervalSince1970: 2_000_000)
+        let outcome = await coordinator.attempt(now: injectedTime)
+        XCTAssertEqual(outcome, .attemptedSucceeded)
+
+        // The success cooldown must be stamped with the injected time (2_000_000), not the closure's
+        // default time (1_000_000). Reading the persisted lastAttempt timestamp verifies which time
+        // source was used.
+        let stamped = defaults.double(forKey: "last")
+        XCTAssertEqual(stamped, injectedTime.timeIntervalSince1970, accuracy: 0.001,
+                       "success cooldown must use the injected `moment` time, not the now() closure")
+    }
 }
 
 /// A mutable clock for coordinator tests (the provider tests have their own private `TestClock`).

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -1414,6 +1414,13 @@ private final class FingerprintRotatingRunner: ProcessRunning, @unchecked Sendab
         guard executable.hasPrefix("/") else {
             return ProcessResult(exitCode: 127, stdout: "", stderr: "not found")
         }
+        // `/usr/bin/which` is a non-side-effecting PATH probe; return FAILURE by default so tests
+        // that inject `isExecutable: { _ in false }` (CLI unavailable) don't accidentally find the
+        // CLI via PATH. Tests that exercise PATH-based resolution use the `RecordingProcessRunner`
+        // with `resolvableExecutables` instead.
+        if executable == "/usr/bin/which" {
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "not found")
+        }
         onTouch()
         return ProcessResult(exitCode: 0, stdout: "1.2.3\n", stderr: "")
     }

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -241,6 +241,21 @@ final class ClaudeUsageMapperTests: XCTestCase {
 
 @MainActor
 final class ClaudeProviderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // Default-constructed providers wire a failure gate + delegated-refresh coordinator backed by
+        // `UserDefaults.standard`. Tests that exercise auth-failure paths would otherwise persist a
+        // terminal block / cooldown into the shared standard domain and poison later tests, so clear
+        // those keys before each test for a clean slate.
+        for key in [
+            "claude.refreshGate.state.v1",
+            "claude.delegatedRefresh.lastAttemptAt.v1",
+            "claude.delegatedRefresh.cooldownSeconds.v1"
+        ] {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
     func testRefreshFetchesLiveUsageAndPassesConfigDirToCcusage() async {
         let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
         let httpClient = FakeHTTPClient(response: HTTPResponse(
@@ -571,6 +586,154 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertNotEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.tokenExpired.localizedDescription)
     }
 
+    // MARK: - Delegated CLI refresh (#753 / #738)
+
+    func testDelegatedRefreshRecoversWhenNoUsableRefreshTokenAndCLISucceeds() async {
+        // #753/#738 regression: the only credential source has an expired access token and NO usable
+        // refresh token, so an in-process refresh is impossible. Delegating to the `claude` CLI rotates
+        // the stored credential (the mock rewrites the file on touch); OpenUsage re-reads it and fetches
+        // live usage instead of dead-ending on "token expired".
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let path = "/tmp/claude/.credentials.json"
+        let files = FakeFiles([
+            path: #"{"claudeAiOauth":{"accessToken":"expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                let authorization = request.headers["Authorization"] ?? ""
+                guard authorization.contains("cli-rotated") else {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":33,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        // The CLI "touch" rewrites the credentials file with a fresh, unexpired token.
+        let runner = FingerprintRotatingRunner {
+            files.files[path] = #"{"claudeAiOauth":{"accessToken":"cli-rotated","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        }
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: runner,
+                environment: FakeEnvironment(["CLAUDE_CLI_PATH": "/fake/claude"]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now },
+                sleep: { _ in },
+                isExecutable: { $0 == "/fake/claude" },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: ClaudeRefreshFailureGate(
+                defaults: Self.isolatedDefaults(),
+                storageKey: "gate",
+                currentFingerprint: { authStore.currentFingerprint() }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(Self.progress(snapshot.lines, "Session")?.used, 33)
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+    }
+
+    func testDelegatedRefreshFailsWhenCLIUnavailableThenTokenExpired() async {
+        // No usable refresh token AND no `claude` CLI to delegate to → the snapshot reports the friendly
+        // token-expired error rather than silently recovering.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: FingerprintRotatingRunner {},
+                environment: FakeEnvironment([:]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now },
+                sleep: { _ in },
+                isExecutable: { _ in false }, // no CLI resolves
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: ClaudeRefreshFailureGate(
+                defaults: Self.isolatedDefaults(), storageKey: "gate",
+                currentFingerprint: { authStore.currentFingerprint() }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.tokenExpired.localizedDescription)
+    }
+
+    func testTerminalBlockWithUnchangedCredsSkipsNetwork() async {
+        // After a terminal failure, while the credential is unchanged the provider must not hit the usage
+        // API at all — it short-circuits to token-expired. Exercised by priming the gate as terminal.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data()))
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let gateDefaults = Self.isolatedDefaults()
+        let gate = ClaudeRefreshFailureGate(
+            defaults: gateDefaults, storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        // Prime a terminal block (as if a prior refresh hit invalid_grant) more than 15s in the past so
+        // the gate's recheck isn't throttled — it rechecks, finds creds unchanged, and stays blocked.
+        gate.recordTerminalAuthFailure(reason: "invalid_grant", now: now.addingTimeInterval(-60))
+
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: FingerprintRotatingRunner {},
+                environment: FakeEnvironment([:]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { _ in false },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.tokenExpired.localizedDescription)
+        // The key assertion: no usage API call was made while terminally blocked with unchanged creds.
+        XCTAssertTrue(httpClient.requests.isEmpty, "terminal-blocked refresh must not call the usage API")
+    }
+
+    private static func isolatedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "claude.provider.test.\(UUID().uuidString)")!
+    }
+
     private func badge(_ lines: [MetricLine], _ label: String) -> String? {
         guard case .badge(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
             return nil
@@ -597,6 +760,28 @@ final class ClaudeProviderTests: XCTestCase {
             return nil
         }
         return (used, limit, resetsAt, periodDurationMs)
+    }
+}
+
+/// A process runner for the delegated-refresh coordinator: every `--version` touch invokes `onTouch`
+/// (a test hook that can rewrite the credentials file to simulate the CLI rotating the token) and
+/// returns success. A bare-command probe (no leading `/`) returns failure so CLI resolution falls to
+/// the `isExecutable` override the test injects.
+private final class FingerprintRotatingRunner: ProcessRunning, @unchecked Sendable {
+    private let onTouch: @Sendable () -> Void
+    init(_ onTouch: @escaping @Sendable () -> Void) { self.onTouch = onTouch }
+
+    func run(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) throws -> ProcessResult {
+        guard executable.hasPrefix("/") else {
+            return ProcessResult(exitCode: 127, stdout: "", stderr: "not found")
+        }
+        onTouch()
+        return ProcessResult(exitCode: 0, stdout: "1.2.3\n", stderr: "")
     }
 }
 

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -1249,6 +1249,71 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertNil(badge(snapshot.lines, "Error"))
     }
 
+    func testTransientBlockDoesNotBlockCLIRecoveryForAuthFailure() async {
+        // Bugbot #737e65d5: while a transient block was active (e.g. after a recent 503), auth
+        // failures skipped the CLI entirely and fell through to recording a terminal failure — even
+        // though the CLI is the intended recovery path when in-process refresh is impossible. The
+        // transient block (from a 5xx on the usage API) is orthogonal to the auth failure; it should
+        // not block the CLI for auth recovery. Fix: delegatedRefreshIfPossible tries the CLI
+        // whenever the coordinator can attempt, regardless of the gate's block type.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let path = "/tmp/claude/.credentials.json"
+        let files = FakeFiles([
+            // Expired access token, no refresh token — the #738/#753 dead-end shape.
+            path: #"{"claudeAiOauth":{"accessToken":"expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                let authorization = request.headers["Authorization"] ?? ""
+                guard authorization.contains("cli-rotated") else {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":66,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let runner = FingerprintRotatingRunner {
+            files.files[path] = #"{"claudeAiOauth":{"accessToken":"cli-rotated","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        }
+        let gate = ClaudeRefreshFailureGate(
+            defaults: Self.isolatedDefaults(), storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        // Prime a TRANSIENT block (as if a prior refresh hit a 503 on the usage API). The block is
+        // active for 5 minutes, so shouldAttempt returns false during that window.
+        gate.recordTransientFailure(now: now.addingTimeInterval(-60))
+
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: runner,
+                environment: FakeEnvironment(["CLAUDE_CLI_PATH": "/fake/claude"]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { $0 == "/fake/claude" },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        // The transient block is active, but the CLI is the recovery path for the auth failure. The
+        // coordinator can attempt (CLI available, not in cooldown), so the CLI is tried, rotates the
+        // credential, and the live fetch succeeds.
+        XCTAssertEqual(Self.progress(snapshot.lines, "Session")?.used, 66)
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+    }
+
     private static func isolatedDefaults() -> UserDefaults {
         UserDefaults(suiteName: "claude.provider.test.\(UUID().uuidString)")!
     }

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -120,6 +120,86 @@ final class ClaudeAuthStoreTests: XCTestCase {
         // break keychain candidate resolution.
         XCTAssertEqual(store.keychainServiceCandidates(), ["Claude Code-custom-oauth-credentials"])
     }
+
+    // MARK: - Fingerprint (bugbot #7c1c8948)
+
+    func testCurrentFingerprintExcludesFileMetadataWhenKeychainPreferred() throws {
+        // Bugbot-found: when the keychain is the preferred source, the fingerprint must NOT include
+        // file metadata — otherwise a touch that only rewrites the file (e.g. `claude --version`
+        // updating the file's mtime without rotating the keychain token OpenUsage actually reads)
+        // would change the fingerprint and yield a false "rotated" signal, masking the still-expired
+        // keychain token and triggering a 5-min CLI cooldown that blocks real recovery.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-fingerprint-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let credPath = dir.appendingPathComponent(".credentials.json").path
+        try #"{"claudeAiOauth":{"accessToken":"file-token","expiresAt":4102444800000,"subscriptionType":"pro"}}"#
+            .write(toFile: credPath, atomically: true, encoding: .utf8)
+
+        let keychain = ServiceKeychain()
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": dir.path]),
+            files: LocalTextFileAccessor(),
+            keychain: keychain,
+            now: { Date(timeIntervalSince1970: 1_000_000) }
+        )
+        let hashedService = store.keychainServiceCandidates().first!
+        keychain.currentUserValues[hashedService] = #"{"claudeAiOauth":{"accessToken":"keychain-token","expiresAt":4070908800000,"subscriptionType":"max"}}"#
+
+        // Keychain is preferred.
+        XCTAssertEqual(store.loadCredentials()?.oauth.accessToken, "keychain-token")
+
+        let before = store.currentFingerprint()
+
+        // Change the file's mtime without touching the keychain.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2_000_000)],
+            ofItemAtPath: credPath
+        )
+
+        let after = store.currentFingerprint()
+
+        // The fingerprint must NOT change when only the non-preferred file's metadata changed.
+        XCTAssertEqual(before, after,
+            "fingerprint must not change when only the non-preferred file source's metadata changes")
+    }
+
+    func testCurrentFingerprintIncludesFileMetadataWhenFilePreferred() throws {
+        // Complement to the above: when the file IS the preferred source (no keychain), the file
+        // metadata IS part of the fingerprint — it's the cheap secondary signal the PR author intended
+        // for detecting a file rewrite that the token hash alone might miss.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-fingerprint-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let credPath = dir.appendingPathComponent(".credentials.json").path
+        try #"{"claudeAiOauth":{"accessToken":"file-token","expiresAt":4102444800000,"subscriptionType":"pro"}}"#
+            .write(toFile: credPath, atomically: true, encoding: .utf8)
+
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": dir.path]),
+            files: LocalTextFileAccessor(),
+            keychain: FakeKeychain(),  // no keychain → file is preferred
+            now: { Date(timeIntervalSince1970: 1_000_000) }
+        )
+
+        XCTAssertEqual(store.loadCredentials()?.oauth.accessToken, "file-token")
+
+        let before = store.currentFingerprint()
+
+        // Change the file's mtime without changing its content (so the token hash stays the same).
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2_000_000)],
+            ofItemAtPath: credPath
+        )
+
+        let after = store.currentFingerprint()
+
+        // The fingerprint MUST change when the preferred file's mtime changed.
+        XCTAssertNotEqual(before, after,
+            "fingerprint must change when the preferred file source's metadata changes")
+    }
 }
 
 final class ClaudeUsageMapperTests: XCTestCase {
@@ -794,6 +874,87 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.tokenExpired.localizedDescription)
         // The key assertion: no usage API call was made while terminally blocked with unchanged creds.
         XCTAssertTrue(httpClient.requests.isEmpty, "terminal-blocked refresh must not call the usage API")
+    }
+
+    // MARK: - 5xx transient failure (bugbot #5afd6cf3)
+
+    func test5xxResponseRecordsTransientFailure() async {
+        // Bugbot-found: a 5xx on the usage API should record a transient failure so the
+        // delegated-refresh gate backs off (the credential is probably fine, the server is briefly
+        // unavailable). The original catch block only recorded transient for `.connectionFailed`, so
+        // 5xx (`requestFailed(503)`) skipped the gate entirely.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"token","refreshToken":"refresh","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = FakeHTTPClient(response: HTTPResponse(statusCode: 503, headers: [:], body: Data()))
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let gate = ClaudeRefreshFailureGate(
+            defaults: Self.isolatedDefaults(), storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: FingerprintRotatingRunner {},
+                environment: FakeEnvironment([:]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { _ in false },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        _ = await provider.refresh()
+
+        guard case .transient? = gate.currentBlockStatus(now: now) else {
+            return XCTFail("expected transient block after 503, got \(String(describing: gate.currentBlockStatus(now: now)))")
+        }
+    }
+
+    func test4xxNonAuthResponseDoesNotRecordTransientFailure() async {
+        // A 4xx that isn't an auth failure (e.g. 404) is NOT transient — it's a real problem that
+        // re-trying won't fix. The gate should not record a transient block. (401/403 are treated as
+        // auth failures by `ProviderAuthRetry.isAuthFailure` and surface as `tokenExpired`, so they
+        // never reach the `ClaudeUsageError` catch block.)
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"token","refreshToken":"refresh","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = FakeHTTPClient(response: HTTPResponse(statusCode: 404, headers: [:], body: Data()))
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let gate = ClaudeRefreshFailureGate(
+            defaults: Self.isolatedDefaults(), storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: FingerprintRotatingRunner {},
+                environment: FakeEnvironment([:]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { _ in false },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        _ = await provider.refresh()
+
+        XCTAssertNil(gate.currentBlockStatus(now: now),
+            "4xx non-auth (404) must not record a transient block")
     }
 
     private static func isolatedDefaults() -> UserDefaults {

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -1062,8 +1062,7 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertTrue(httpClient.requests.isEmpty, "terminal block with CLI unavailable must short-circuit")
     }
 
-    func testDelegatedRefreshUsesPreferredCandidateAfterCLIRotatesKeychain() async {
-        // Bugbot #8898f938: when the CLI rotates the preferred keychain (which was previously empty)
+    func testDelegatedRefreshUsesPreferredCandidateAfterCLIRotatesKeychain() async {        // Bugbot #8898f938: when the CLI rotates the preferred keychain (which was previously empty)
         // while we're probing the fallback file source, recovery must use the preferred (now-fresh)
         // keychain candidate — not the same-source (still-stale) file candidate. The original code
         // preferred the same source, so auth failed again and recorded a terminal block with the
@@ -1123,6 +1122,130 @@ final class ClaudeProviderTests: XCTestCase {
         let snapshot = await provider.refresh()
 
         XCTAssertEqual(Self.progress(snapshot.lines, "Session")?.used, 77)
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+    }
+
+    // MARK: - Retry fetch gate updates + force recheck (bugbot #88d01254, #f6dcff9f)
+
+    func testRetryFetchAfterDelegatedRefreshRecordsTransientFor5xx() async {
+        // Bugbot #88d01254: after a successful delegated CLI recovery, the second `fetchLiveUsage`
+        // call sat inside the auth catch handler, so errors from the retry were not handled by the
+        // surrounding do/catch — a 5xx on the retry never invoked recordTransientFailure. The fix
+        // wraps the retry in its own do/catch that routes through the same gate-update logic.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let path = "/tmp/claude/.credentials.json"
+        let files = FakeFiles([
+            path: #"{"claudeAiOauth":{"accessToken":"expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                let authorization = request.headers["Authorization"] ?? ""
+                if authorization.contains("expired") {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                // The retry after delegated refresh uses the rotated token; return 503 to exercise
+                // the retry-catch path.
+                return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let runner = FingerprintRotatingRunner {
+            files.files[path] = #"{"claudeAiOauth":{"accessToken":"cli-rotated","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        }
+        let gate = ClaudeRefreshFailureGate(
+            defaults: Self.isolatedDefaults(), storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: runner,
+                environment: FakeEnvironment(["CLAUDE_CLI_PATH": "/fake/claude"]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { $0 == "/fake/claude" },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        _ = await provider.refresh()
+
+        // The retry's 503 must have recorded a transient failure — without the fix, the gate would
+        // be empty (the retry's error skipped the catch block).
+        guard case .transient? = gate.currentBlockStatus(now: now) else {
+            return XCTFail("expected transient block after 503 on retry, got \(String(describing: gate.currentBlockStatus(now: now)))")
+        }
+    }
+
+    func testTerminalBlockShortCircuitDetectsFreshCredsImmediatelyWithinThrottle() async {
+        // Bugbot #f6dcff9f: the terminal short-circuit treated `!shouldAttempt` as "credentials
+        // unchanged," but shouldAttempt can be false for up to 15s solely because of the recheck
+        // throttle — even after an external re-login changed the fingerprint. So with the CLI
+        // unavailable, refresh returned tokenExpired for up to 15s after the user re-logged in,
+        // while the already-loaded fresh candidates went untried. The fix force-rechecks the
+        // fingerprint in the short-circuit, bypassing the throttle.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let path = "/tmp/claude/.credentials.json"
+        let files = FakeFiles([
+            path: #"{"claudeAiOauth":{"accessToken":"expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                let authorization = request.headers["Authorization"] ?? ""
+                guard authorization.contains("fresh-after-relogin") else {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":99,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let gate = ClaudeRefreshFailureGate(
+            defaults: Self.isolatedDefaults(), storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        // Prime a terminal block 5s in the past — INSIDE the 15s recheck throttle, so the throttled
+        // shouldAttempt would return false without a fingerprint recheck.
+        gate.recordTerminalAuthFailure(reason: "sessionExpired", now: now.addingTimeInterval(-5))
+
+        // Simulate an external `claude` re-login: rewrite the file with a fresh token. The fingerprint
+        // changes, but the gate's lastRecheckAt is only 5s ago (within the 15s throttle).
+        files.files[path] = #"{"claudeAiOauth":{"accessToken":"fresh-after-relogin","refreshToken":"fresh-refresh","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: FingerprintRotatingRunner {},
+                environment: FakeEnvironment([:]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { _ in false },  // CLI unavailable
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        // The short-circuit must NOT fire: the fingerprint changed (external re-login), and the
+        // force-recheck detects it immediately even within the 15s throttle. The refresh proceeds
+        // with the fresh candidate and fetches live usage.
+        XCTAssertEqual(Self.progress(snapshot.lines, "Session")?.used, 99)
         XCTAssertNil(badge(snapshot.lines, "Error"))
     }
 

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -957,6 +957,175 @@ final class ClaudeProviderTests: XCTestCase {
             "4xx non-auth (404) must not record a transient block")
     }
 
+    // MARK: - Terminal block escape hatch + preferred candidate (bugbot #bc1ed54a, #8898f938)
+
+    func testTerminalBlockAllowsRetryWhenCoordinatorCanAttempt() async {
+        // Bugbot #bc1ed54a: a terminal block recorded when the CLI was unavailable (or in cooldown)
+        // should NOT block the delegated refresh once the coordinator can attempt again (CLI available
+        // and not in cooldown). The short-circuit and delegatedRefreshIfPossible both check
+        // coordinator.canAttempt(now:) as an escape hatch, so the CLI gets a chance to rotate the
+        // credential even while the terminal block is active.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let path = "/tmp/claude/.credentials.json"
+        let files = FakeFiles([
+            path: #"{"claudeAiOauth":{"accessToken":"expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                let authorization = request.headers["Authorization"] ?? ""
+                guard authorization.contains("cli-rotated") else {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":88,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let runner = FingerprintRotatingRunner {
+            files.files[path] = #"{"claudeAiOauth":{"accessToken":"cli-rotated","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        }
+        let gate = ClaudeRefreshFailureGate(
+            defaults: Self.isolatedDefaults(), storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        // Prime a terminal block 60s in the past (as if a prior refresh hit invalid_grant when the
+        // CLI was unavailable). The fingerprint is the expired token's, which is still current.
+        gate.recordTerminalAuthFailure(reason: "sessionExpired", now: now.addingTimeInterval(-60))
+
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: runner,
+                environment: FakeEnvironment(["CLAUDE_CLI_PATH": "/fake/claude"]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { $0 == "/fake/claude" },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        // The terminal block is active, but the coordinator can attempt (CLI available, not in
+        // cooldown), so the refresh proceeds, the CLI rotates the credential, and live usage is fetched.
+        XCTAssertEqual(Self.progress(snapshot.lines, "Session")?.used, 88)
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+    }
+
+    func testTerminalBlockShortCircuitsWhenCoordinatorCannotAttempt() async {
+        // Complement to the above: when the coordinator CANNOT attempt (CLI unavailable), the
+        // terminal block short-circuits the refresh as before — the escape hatch only opens when the
+        // CLI could actually help. This preserves the hammering-prevention behavior for the common
+        // case where the CLI isn't installed.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data()))
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let gate = ClaudeRefreshFailureGate(
+            defaults: Self.isolatedDefaults(), storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        gate.recordTerminalAuthFailure(reason: "sessionExpired", now: now.addingTimeInterval(-60))
+
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: FingerprintRotatingRunner {},
+                environment: FakeEnvironment([:]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { _ in false },  // CLI unavailable
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.tokenExpired.localizedDescription)
+        XCTAssertTrue(httpClient.requests.isEmpty, "terminal block with CLI unavailable must short-circuit")
+    }
+
+    func testDelegatedRefreshUsesPreferredCandidateAfterCLIRotatesKeychain() async {
+        // Bugbot #8898f938: when the CLI rotates the preferred keychain (which was previously empty)
+        // while we're probing the fallback file source, recovery must use the preferred (now-fresh)
+        // keychain candidate — not the same-source (still-stale) file candidate. The original code
+        // preferred the same source, so auth failed again and recorded a terminal block with the
+        // preferred source's (now valid) fingerprint, blocking all future refreshes including the
+        // good keychain.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let path = "/tmp/claude/.credentials.json"
+        let files = FakeFiles([
+            // File: expired access token, no refresh token — the #738/#753 dead-end shape.
+            path: #"{"claudeAiOauth":{"accessToken":"file-expired","expiresAt":1,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let keychain = ServiceKeychain()  // empty keychain → file is the only candidate initially
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: keychain, now: { now }
+        )
+        let hashedService = authStore.keychainServiceCandidates().first!
+
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                let authorization = request.headers["Authorization"] ?? ""
+                guard authorization.contains("keychain-fresh") else {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":77,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+
+        // The CLI touch writes a fresh token to the KEYCHAIN (the preferred source) — simulating the
+        // CLI rotating the keychain while the file is left stale.
+        let runner = FingerprintRotatingRunner {
+            keychain.currentUserValues[hashedService] = #"{"claudeAiOauth":{"accessToken":"keychain-fresh","refreshToken":"keychain-fresh-refresh","expiresAt":4102444800000,"subscriptionType":"max","scopes":["user:profile"]}}"#
+        }
+
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: runner,
+                environment: FakeEnvironment(["CLAUDE_CLI_PATH": "/fake/claude"]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { $0 == "/fake/claude" },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: ClaudeRefreshFailureGate(
+                defaults: Self.isolatedDefaults(), storageKey: "gate",
+                currentFingerprint: { authStore.currentFingerprint() }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(Self.progress(snapshot.lines, "Session")?.used, 77)
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+    }
+
     private static func isolatedDefaults() -> UserDefaults {
         UserDefaults(suiteName: "claude.provider.test.\(UUID().uuidString)")!
     }

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -646,6 +646,72 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertNil(badge(snapshot.lines, "Error"))
     }
 
+    func testDelegatedRefreshRecoversWhenRefreshTokenRevokedAndCLISucceeds() async {
+        // Regression for the bugbot-found bug: when the stored refresh token is present but revoked
+        // (refresh endpoint returns `invalid_grant`), `fetchLiveUsage` throws `sessionExpired` and the
+        // `probe` catch block must STILL get a chance to delegate to the `claude` CLI. The original
+        // implementation recorded the terminal failure BEFORE calling `delegatedRefreshIfPossible`, so
+        // the gate's 15s recheck throttle (set by `recordTerminalAuthFailure`'s `lastRecheckAt = now`)
+        // made `shouldAttempt(now: now)` return false on the immediate next call — the CLI touch never
+        // ran and the provider dead-ended on `sessionExpired` even though the CLI could have rotated
+        // the credential. Fix: try `delegatedRefreshIfPossible` FIRST; only record the terminal block
+        // if delegation also fails.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let path = "/tmp/claude/.credentials.json"
+        let files = FakeFiles([
+            // A still-unexpired access token with a USABLE-LOOKING refresh token — the early
+            // `needsRefresh && !hasUsableRefreshToken` branch in `fetchLiveUsage` is skipped, so
+            // recovery has to come from the `sessionExpired` catch block.
+            path: #"{"claudeAiOauth":{"accessToken":"stale-access","refreshToken":"revoked-refresh","expiresAt":4070908800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        let httpClient = RoutingHTTPClient { request in
+            if request.url.absoluteString.hasSuffix("/api/oauth/usage") {
+                let authorization = request.headers["Authorization"] ?? ""
+                guard authorization.contains("cli-rotated") else {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":55,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            // Refresh endpoint: the stored refresh token is revoked.
+            return HTTPResponse(statusCode: 400, headers: [:], body: Data(#"{"error":"invalid_grant"}"#.utf8))
+        }
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let runner = FingerprintRotatingRunner {
+            files.files[path] = #"{"claudeAiOauth":{"accessToken":"cli-rotated","refreshToken":"fresh-refresh","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        }
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: runner,
+                environment: FakeEnvironment(["CLAUDE_CLI_PATH": "/fake/claude"]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now },
+                sleep: { _ in },
+                isExecutable: { $0 == "/fake/claude" },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: ClaudeRefreshFailureGate(
+                defaults: Self.isolatedDefaults(),
+                storageKey: "gate",
+                currentFingerprint: { authStore.currentFingerprint() }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(Self.progress(snapshot.lines, "Session")?.used, 55)
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+    }
+
     func testDelegatedRefreshFailsWhenCLIUnavailableThenTokenExpired() async {
         // No usable refresh token AND no `claude` CLI to delegate to → the snapshot reports the friendly
         // token-expired error rather than silently recovering.

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -1314,6 +1314,56 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertNil(badge(snapshot.lines, "Error"))
     }
 
+    func testTransientBlockBacksOffUsageAPICall() async {
+        // Bugbot #bc71842b: the gate records exponential backoff on 5xx/connection errors, but
+        // refresh() only short-circuited for terminal blocks — it never consulted the gate before
+        // probe/fetchLiveUsage, so an active transient block still hit /api/oauth/usage on every
+        // periodic refresh and could keep extending backoff while hammering a failing endpoint. Fix:
+        // fetchLiveUsage skips the usage API call when a transient block is active, serving the
+        // last-good usage (or a badge) instead. The delegated/in-process refresh still runs.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"token","refreshToken":"refresh","expiresAt":4102444800000,"subscriptionType":"pro","scopes":["user:profile"]}}"#
+        ])
+        // The HTTP client would return 200, but the transient block should prevent the call.
+        let httpClient = FakeHTTPClient(response: HTTPResponse(
+            statusCode: 200, headers: [:],
+            body: Data(#"{"five_hour":{"utilization":42,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+        ))
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: FakeKeychain(), now: { now }
+        )
+        let gate = ClaudeRefreshFailureGate(
+            defaults: Self.isolatedDefaults(), storageKey: "gate",
+            currentFingerprint: { authStore.currentFingerprint() }
+        )
+        // Prime a TRANSIENT block active for 5 more minutes.
+        gate.recordTransientFailure(now: now.addingTimeInterval(-60))
+
+        let provider = ClaudeProvider(
+            authStore: authStore,
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(processRunner: FakeProcessRunner(), homeDirectory: { URL(fileURLWithPath: "/Users/test") }),
+            coordinator: ClaudeDelegatedRefreshCoordinator(
+                processRunner: FingerprintRotatingRunner {},
+                environment: FakeEnvironment([:]),
+                currentFingerprint: { authStore.currentFingerprint() },
+                now: { now }, sleep: { _ in }, isExecutable: { _ in false },
+                defaults: Self.isolatedDefaults()
+            ),
+            failureGate: gate,
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        // The transient block must skip the usage API call — no requests were made.
+        XCTAssertTrue(httpClient.requests.isEmpty, "transient block must skip the usage API call")
+        // The snapshot serves the rate-limited badge (no last-good usage yet).
+        XCTAssertEqual(badge(snapshot.lines, "Status")?.hasPrefix("Rate limited"), true)
+    }
+
     private static func isolatedDefaults() -> UserDefaults {
         UserDefaults(suiteName: "claude.provider.test.\(UUID().uuidString)")!
     }

--- a/Tests/OpenUsageTests/ClaudeRefreshFailureGateTests.swift
+++ b/Tests/OpenUsageTests/ClaudeRefreshFailureGateTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+@testable import OpenUsage
+
+final class ClaudeRefreshFailureGateTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "claude.refreshGate.test.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    /// A mutable fingerprint box so a test can simulate an external `claude` re-login changing the creds.
+    private final class FingerprintBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: ClaudeCredentialFingerprint
+        init(_ value: ClaudeCredentialFingerprint) { self.value = value }
+        var current: ClaudeCredentialFingerprint {
+            lock.lock(); defer { lock.unlock() }; return value
+        }
+        func set(_ value: ClaudeCredentialFingerprint) {
+            lock.lock(); defer { lock.unlock() }; self.value = value
+        }
+    }
+
+    private func makeGate(_ box: FingerprintBox) -> ClaudeRefreshFailureGate {
+        ClaudeRefreshFailureGate(
+            defaults: defaults,
+            storageKey: "gate.state",
+            currentFingerprint: { box.current }
+        )
+    }
+
+    func testNoBlockAllowsAttempt() {
+        let gate = makeGate(FingerprintBox(.init(tokenHash: "a")))
+        XCTAssertTrue(gate.shouldAttempt(now: Date()))
+        XCTAssertNil(gate.currentBlockStatus(now: Date()))
+    }
+
+    func testTransientExponentialBackoffCappedAtSixHours() {
+        let gate = makeGate(FingerprintBox(.init(tokenHash: "a")))
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+        // 1st failure → 5 min.
+        gate.recordTransientFailure(now: t0)
+        guard case .transient(let until1, let failures1)? = gate.currentBlockStatus(now: t0) else {
+            return XCTFail("expected transient block")
+        }
+        XCTAssertEqual(failures1, 1)
+        XCTAssertEqual(until1.timeIntervalSince(t0), 5 * 60, accuracy: 1)
+
+        // 2nd → 10 min, 3rd → 20 min (after the prior window elapses so the gate allows the attempt).
+        gate.recordTransientFailure(now: until1)
+        guard case .transient(let until2, _)? = gate.currentBlockStatus(now: until1) else {
+            return XCTFail("expected transient block")
+        }
+        XCTAssertEqual(until2.timeIntervalSince(until1), 10 * 60, accuracy: 1)
+
+        // Drive many failures and confirm the cap.
+        var moment = until2
+        for _ in 0..<20 {
+            gate.recordTransientFailure(now: moment)
+            guard case .transient(let until, _)? = gate.currentBlockStatus(now: moment) else {
+                return XCTFail("expected transient block")
+            }
+            moment = until
+        }
+        guard case .transient(let cappedUntil, _)? = gate.currentBlockStatus(now: moment.addingTimeInterval(-1)) else {
+            return XCTFail("expected transient block")
+        }
+        // The last recorded window must be exactly the 6h cap.
+        gate.recordTransientFailure(now: cappedUntil)
+        guard case .transient(let finalUntil, _)? = gate.currentBlockStatus(now: cappedUntil) else {
+            return XCTFail("expected transient block")
+        }
+        XCTAssertEqual(finalUntil.timeIntervalSince(cappedUntil), 6 * 60 * 60, accuracy: 1)
+    }
+
+    func testTransientBlockExpiresByTime() {
+        let gate = makeGate(FingerprintBox(.init(tokenHash: "a")))
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        gate.recordTransientFailure(now: t0)
+
+        XCTAssertFalse(gate.shouldAttempt(now: t0.addingTimeInterval(60)))
+        // After the 5-min window the gate allows an attempt and reports no active block.
+        XCTAssertTrue(gate.shouldAttempt(now: t0.addingTimeInterval(5 * 60 + 1)))
+        XCTAssertNil(gate.currentBlockStatus(now: t0.addingTimeInterval(5 * 60 + 1)))
+    }
+
+    func testTerminalNeverExpiresByTimeAndTransientDoesNotDowngrade() {
+        let box = FingerprintBox(.init(tokenHash: "a"))
+        let gate = makeGate(box)
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        gate.recordTerminalAuthFailure(reason: "invalid_grant", now: t0)
+
+        // Even a year later, terminal stays blocked (creds unchanged).
+        let muchLater = t0.addingTimeInterval(365 * 24 * 60 * 60)
+        guard case .terminal(let reason, _)? = gate.currentBlockStatus(now: muchLater) else {
+            return XCTFail("expected terminal block")
+        }
+        XCTAssertEqual(reason, "invalid_grant")
+        XCTAssertFalse(gate.shouldAttempt(now: muchLater))
+
+        // A later transient failure must NOT downgrade the terminal block to a self-clearing transient.
+        gate.recordTransientFailure(now: muchLater)
+        guard case .terminal? = gate.currentBlockStatus(now: muchLater.addingTimeInterval(10 * 60 * 60)) else {
+            return XCTFail("expected terminal block to survive a transient failure")
+        }
+    }
+
+    func testChangedFingerprintUnblocksTerminal() {
+        let box = FingerprintBox(.init(tokenHash: "a"))
+        let gate = makeGate(box)
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        gate.recordTerminalAuthFailure(reason: "invalid_grant", now: t0)
+        XCTAssertFalse(gate.shouldAttempt(now: t0))
+
+        // External `claude` re-login rotates the credential → fingerprint changes → unblock (after the
+        // 15s recheck throttle elapses).
+        box.set(.init(tokenHash: "b"))
+        XCTAssertTrue(gate.shouldAttempt(now: t0.addingTimeInterval(16)))
+        XCTAssertNil(gate.currentBlockStatus(now: t0.addingTimeInterval(16)))
+    }
+
+    func testChangedFingerprintUnblocksTransient() {
+        let box = FingerprintBox(.init(tokenHash: "a"))
+        let gate = makeGate(box)
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        gate.recordTransientFailure(now: t0)
+        XCTAssertFalse(gate.shouldAttempt(now: t0.addingTimeInterval(16)))
+
+        box.set(.init(tokenHash: "b"))
+        XCTAssertTrue(gate.shouldAttempt(now: t0.addingTimeInterval(32)))
+    }
+
+    func testUnchangedFingerprintStaysBlocked() {
+        let box = FingerprintBox(.init(tokenHash: "a"))
+        let gate = makeGate(box)
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        gate.recordTerminalAuthFailure(reason: "invalid_grant", now: t0)
+
+        // Many rechecks, creds never change → stays blocked.
+        XCTAssertFalse(gate.shouldAttempt(now: t0.addingTimeInterval(20)))
+        XCTAssertFalse(gate.shouldAttempt(now: t0.addingTimeInterval(40)))
+    }
+
+    func testRecheckThrottledToOncePer15Seconds() {
+        let box = FingerprintBox(.init(tokenHash: "a"))
+        let gate = makeGate(box)
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        gate.recordTerminalAuthFailure(reason: "invalid_grant", now: t0)
+
+        // Change the creds, but query within 15s of the failure's recheck stamp → throttled, stays blocked.
+        box.set(.init(tokenHash: "b"))
+        XCTAssertFalse(gate.shouldAttempt(now: t0.addingTimeInterval(5)))
+        XCTAssertFalse(gate.shouldAttempt(now: t0.addingTimeInterval(10)))
+        // Past the throttle window the changed fingerprint is observed → unblocked.
+        XCTAssertTrue(gate.shouldAttempt(now: t0.addingTimeInterval(16)))
+    }
+
+    func testRecordSuccessClearsBlock() {
+        let gate = makeGate(FingerprintBox(.init(tokenHash: "a")))
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        gate.recordTerminalAuthFailure(reason: "invalid_grant", now: t0)
+        XCTAssertNotNil(gate.currentBlockStatus(now: t0))
+
+        gate.recordSuccess()
+        XCTAssertNil(gate.currentBlockStatus(now: t0))
+        XCTAssertTrue(gate.shouldAttempt(now: t0))
+    }
+
+    func testUserDefaultsRoundTripAcrossInstances() {
+        let box = FingerprintBox(.init(tokenHash: "a"))
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+        // First instance records a terminal block.
+        makeGate(box).recordTerminalAuthFailure(reason: "invalid_grant", now: t0)
+
+        // A fresh instance (simulating an app relaunch) reading the same suite still sees the block.
+        let reloaded = makeGate(box)
+        guard case .terminal(let reason, _)? = reloaded.currentBlockStatus(now: t0.addingTimeInterval(1000)) else {
+            return XCTFail("terminal block should survive a fresh gate instance")
+        }
+        XCTAssertEqual(reason, "invalid_grant")
+    }
+}

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -23,6 +23,17 @@ Sign in once with Claude Code; OpenUsage reads the same credentials. It checks e
 
 If one source holds an expired or "locked out" token, OpenUsage falls back to the others — so signing in again with `claude` outside the app is picked up on the next refresh, without restarting OpenUsage. Tokens are refreshed automatically; rotated tokens are written back where they came from.
 
+### When OpenUsage can't refresh on its own
+
+Sometimes the credentials OpenUsage can read don't include everything needed to refresh an expired token — Claude Code keeps that part to itself. When that happens, OpenUsage asks the `claude` command-line tool to refresh for you in the background (it already has what it needs), then re-reads the credentials and carries on. You don't have to do anything, and nothing about your tokens leaves your Mac.
+
+To avoid bothering the `claude` tool too often, this is rate-limited:
+
+- If a refresh genuinely can't succeed (your login has been revoked), OpenUsage stops retrying and shows the "log in again" message — it only tries once more after you actually sign in again with `claude`.
+- If a refresh fails because of a temporary hiccup (no network, a server blip), OpenUsage waits a bit and tries again later, backing off further each time so it never hammers anything.
+
+If the `claude` tool isn't installed where OpenUsage looks, it simply skips this step and shows the usual "log in again" message. You can point OpenUsage at a specific `claude` binary with the `CLAUDE_CLI_PATH` environment variable.
+
 ## The spend tiles
 
 Today / Yesterday / Last 30 Days are computed **locally** from your Claude Code logs by running `ccusage` through whichever JavaScript package runner you already have — [Bun](https://bun.sh) (`bunx`) is preferred, otherwise `pnpm dlx`, `yarn dlx`, `npm exec`, or `npx`. Days are grouped in your Mac's local time zone, so they line up with your own calendar. Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`); a day with no usage is a real zero and reads `$0.00 · 0 tokens`. If `ccusage` hasn't reported a recent day yet — it can briefly lag a Claude Code update — Today / Yesterday read **No data** instead of a misleading `$0.00`; the live Session and Weekly meters are unaffected. The dollars are estimated from token counts (that's the ⓘ); the token counts themselves are measured. No log data leaves your Mac.
@@ -35,6 +46,6 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Claude Code 
 
 ## Under the hood
 
-`GET https://api.anthropic.com/api/oauth/usage` with the Claude Code OAuth token; refresh via `platform.claude.com/v1/oauth/token`. A 401/403 triggers one token refresh and retry. If that still fails because the token is expired or revoked, OpenUsage retries with the next credential source before reporting an error.
+`GET https://api.anthropic.com/api/oauth/usage` with the Claude Code OAuth token; refresh via `platform.claude.com/v1/oauth/token`. A 401/403 triggers one token refresh and retry. If that still fails because the token is expired or revoked, OpenUsage retries with the next credential source before reporting an error. When no source can refresh on its own, OpenUsage delegates the refresh to the `claude` CLI (described above), confirming success only when the stored credential actually changes — gated by a short cooldown and a back-off so a dead login isn't retried in a loop.
 
 When the five-hour session window has no usage yet, the Session row shows **Not started** on the trailing label; hover explains that the session begins after your first message.


### PR DESCRIPTION
## TL;DR

When OpenUsage's stored Claude credential has an expired access token and **no usable refresh token**, it could never recover on its own and dead-ended on "token expired" until the app restarted. This PR adds a backstop: delegate the refresh to the `claude` CLI (which owns the refresh token + client creds), then re-read the keychain/file and verify the credential actually rotated — all gated by a cooldown and a transient-vs-terminal failure gate.

## What was happening

- OpenUsage refreshes Claude tokens in-process using the refresh token it can read. But the source it reads (keychain/file) sometimes carries an access token with **no usable refresh token** (the #738 shape).
- In that case an in-process refresh is impossible, so the provider threw `tokenExpired` and kept doing so on every refresh — it could only self-heal if the user manually re-ran `claude` *and* OpenUsage happened to re-read the new creds.
- There was no mechanism to ask the tool that *does* own the refresh token (the `claude` CLI) to refresh on our behalf.

## What this changes

- **`ClaudeCredentialFingerprint`** — a token-free, log-safe snapshot of the stored credential: `SHA256(accessToken + ":" + expiresAt)` plus the credentials file's mtime/size. Used to detect whether a refresh actually rotated the token. Never logs or stores a token value.
- **`ClaudeDelegatedRefreshCoordinator`** — resolves the `claude` binary (`CLAUDE_CLI_PATH` override, then `~/.claude/local/claude`, `~/.local/bin/claude`, Homebrew/usr-local, then a bare `claude` probed against the enriched PATH a GUI app needs). Runs a **non-interactive `claude --version`** touch, then polls the credential at 0.2/0.5/0.8s and returns `attemptedSucceeded` only when the fingerprint changed. `cliUnavailable` short-circuits *before* consuming the cooldown; a UserDefaults cooldown (20s reserve, 5 min on success) plus single-flight prevents stampedes.
- **`ClaudeRefreshFailureGate`** — distinguishes **terminal** failures (`invalid_grant`: no time expiry, monotonic — a later transient can't downgrade it) from **transient** ones (network/5xx/timeout: exponential back-off `5min·2^(n-1)` capped at 6h). Either block clears when the on-disk fingerprint changes (external re-login), rechecked at most once per 15s; transient also auto-unblocks by time. State persists to UserDefaults so a revoked token stays blocked across relaunches.
- **Wired into `ClaudeProvider`** — a terminal block with unchanged creds short-circuits the whole refresh with `tokenExpired` and **no network call**; the dead-end path and any auth-expiry from the live fetch attempt the delegated refresh and, on success, re-read candidates and retry the fetch once; transient transport errors back the gate off. Coordinator + gate are injectable via `init` (default-constructed around the auth store, like `ccusageRunner`) so tests substitute fakes.
- **Docs** — `docs/providers/claude.md` explains the delegated refresh and its cooldown/back-off in plain language, including the `CLAUDE_CLI_PATH` override.

## Tests

- `ClaudeRefreshFailureGateTests` — exponential back-off capped at 6h; transient expires by time; terminal never expires by time and a later transient doesn't downgrade it; changed fingerprint unblocks both kinds; unchanged stays blocked; 15s recheck throttle; `recordSuccess` clears; UserDefaults round-trip across instances. Suite-isolated `UserDefaults`.
- `ClaudeDelegatedRefreshCoordinatorTests` — `cliUnavailable` when nothing resolves (and does **not** consume cooldown); `skippedByCooldown` within the window then allowed after; `attemptedSucceeded` only when the post-touch fingerprint differs (→ 5-min cooldown); touch ran but unchanged → `attemptedFailed` (short cooldown); `CLAUDE_CLI_PATH` honored; single-flight shares one launch.
- `ClaudeProviderTests` (extended) — expired access token + no refresh token + coordinator succeeds (mock rewrites the file) → live usage fetched (the #753/#738 regression); coordinator fails / CLI unavailable → `tokenExpired`; terminal-blocked + unchanged creds → **no usage API call**. No token is logged on any path.
- `swift build` + full `swift test` green (511 tests, 1 skipped — the opt-in live-network test).

## Heads-up

- **Non-interactive touch chosen** per owner decision: the touch is `claude --version`, and correctness rides on the fingerprint-changed check rather than assuming the command rotates the token. If `--version` proves insufficient in the field (doesn't trigger the CLI's lazy refresh), the documented escalation is a PTY-driven `claude /status` — there's an explicit `// TODO(#753)` marking this. No PTY was built.
- Mirrors CodexBar's coordinator + gate, simplified for OpenUsage.
- Whether `claude --version` reliably triggers a refresh in practice is the open empirical question; the design fails safe either way (unchanged fingerprint → `attemptedFailed`, never a false success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication refresh, keychain/file reads, and subprocess execution of the Claude CLI; logic is complex but heavily tested and fails closed without assuming `--version` always rotates tokens.
> 
> **Overview**
> Adds a **delegated refresh** path for Claude when OpenUsage cannot refresh in-process (missing/revoked refresh token on the keychain/file it reads).
> 
> **New building blocks:** token-free `ClaudeCredentialFingerprint` (hash + optional file mtime/size when file is preferred); `ClaudeDelegatedRefreshCoordinator` runs non-interactive `claude --version`, polls fingerprints, single-flight + UserDefaults cooldowns, resolves CLI via `CLAUDE_CLI_PATH` / common paths / `which`; `ClaudeRefreshFailureGate` persists terminal vs transient blocks (exponential backoff, fingerprint-based unblock).
> 
> **`ClaudeProvider` wiring:** terminal-block short-circuit skips network unless CLI can still attempt; auth failures and no-refresh-token paths try CLI delegation before recording terminal failure; transient blocks skip hammering the usage API while still allowing credential recovery; after CLI success, re-read **preferred** candidate (not same stale source). `ClaudeAuthStore` exposes `currentFingerprint()` / `credentialsFilePath()`.
> 
> **Dev UX:** Settings Debug section (non-release updater builds) for full refresh, delegated CLI test, credential dump, clear gate; `WidgetDataStore.debugProvider`.
> 
> **Docs/tests:** `docs/providers/claude.md` user-facing explanation; extensive unit tests for gate, coordinator, and provider regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c0dd56cbb1e3894d26bda669b79991c01a89d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->