### PR TITLE
feat(notifications): macOS alerts when quota pace worsens (#633)

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -12,6 +12,9 @@ final class AppContainer {
     /// Single source of truth for which providers the user has turned off. Both stores consult it (via
     /// injected closures) and the Providers settings tab drives it.
     let enablement: ProviderEnablementStore
+    /// Quota pace notification preferences (master + three triggers). Drives the Settings section and is
+    /// read by `WidgetDataStore.evaluateNotifications`.
+    let notificationSettings: NotificationSettingsStore
     /// Anonymous, opt-out usage telemetry (daily rollups). Exposed so Settings can toggle it and the
     /// app-termination hook can flush any queued events.
     let telemetry: TelemetryRecorder
@@ -36,6 +39,7 @@ final class AppContainer {
         ]
         let registry = WidgetRegistry.from(providers)
         let enablement = ProviderEnablementStore()
+        let notificationSettings = NotificationSettingsStore()
         let layout = LayoutStore(
             registry: registry,
             isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
@@ -44,13 +48,15 @@ final class AppContainer {
             registry: registry,
             providers: providers,
             isProviderEnabled: { [enablement] in enablement.isEnabled($0) },
-            orderedDescriptors: { [layout] in layout.visiblePlaced.compactMap { layout.descriptor(for: $0) } }
+            orderedDescriptors: { [layout] in layout.visiblePlaced.compactMap { layout.descriptor(for: $0) } },
+            notificationSettings: { notificationSettings }
         )
         // Re-enabling a provider should fetch it promptly, so clear any leftover failure backoff before
         // the enablement wake refreshes. `weak` breaks the cycle (dataStore already captures enablement).
         enablement.onProviderEnabled = { [weak dataStore] id in dataStore?.clearFailureBackoff(for: id) }
         self.registry = registry
         self.enablement = enablement
+        self.notificationSettings = notificationSettings
         self.layout = layout
         self.dataStore = dataStore
 
@@ -92,6 +98,11 @@ final class AppContainer {
         })
         self.refreshTask = Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry)
         localAPI.start()
+        // Quota notifications default ON, so request authorization once at launch (the prompt is
+        // expected) and become the notification-center delegate so banners show while frontmost — a
+        // menu-bar accessory effectively always is. No-op under tests.
+        AppNotifications.shared.registerAsDelegate()
+        AppNotifications.shared.requestAuthorizationOnStartup()
     }
 
     deinit { refreshTask.cancel() }
@@ -104,6 +115,10 @@ final class AppContainer {
         Task {
             while !Task.isCancelled {
                 await dataStore.refreshAll()
+                // Re-evaluate quota pace milestones every tick — after the refresh so it sees fresh data,
+                // and on every loop (not just on a fetch) so pace worsening from elapsed time alone still
+                // alerts even with the popover closed.
+                dataStore.evaluateNotifications()
                 // Day-rollover beat: emits `app_daily_active` once per local day and flushes any
                 // prior-day provider rollups. Runs on launch and every interval, so always-running
                 // instances still produce a daily-active signal.

--- a/Sources/OpenUsage/Stores/NotificationSettingsStore.swift
+++ b/Sources/OpenUsage/Stores/NotificationSettingsStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Observation
+
+/// User preferences for quota pace notifications: a master switch and the three per-milestone
+/// triggers. All default ON (owner decision) — a fresh install starts alerting, and the app requests
+/// notification authorization on first launch because of that.
+///
+/// Persisted in `UserDefaults` (each key independently, so an unset key reads its `true` default and a
+/// future-added trigger defaults on without migration). `@Observable` so the Settings toggles and the
+/// evaluation in `WidgetDataStore` read live values.
+@MainActor
+@Observable
+final class NotificationSettingsStore {
+    private let defaults: UserDefaults
+
+    private static let masterKey = "openusage.notifications.enabled"
+    private static let underTenKey = "openusage.notifications.underTenPercent"
+    private static let healthyToCloseKey = "openusage.notifications.healthyToClose"
+    private static let closeToRunningOutKey = "openusage.notifications.closeToRunningOut"
+
+    /// Master switch. When off, no quota notification fires regardless of the per-trigger toggles.
+    var enabled: Bool {
+        didSet { defaults.set(enabled, forKey: Self.masterKey) }
+    }
+
+    /// Alert the first time a metric drops under 10% remaining for the period.
+    var underTenPercent: Bool {
+        didSet { defaults.set(underTenPercent, forKey: Self.underTenKey) }
+    }
+
+    /// Alert when pace worsens from healthy (blue) to close-to-limit (yellow).
+    var healthyToClose: Bool {
+        didSet { defaults.set(healthyToClose, forKey: Self.healthyToCloseKey) }
+    }
+
+    /// Alert when pace worsens from close-to-limit (yellow) to running-out (red).
+    var closeToRunningOut: Bool {
+        didSet { defaults.set(closeToRunningOut, forKey: Self.closeToRunningOutKey) }
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.enabled = defaults.boolWithDefault(Self.masterKey, default: true)
+        self.underTenPercent = defaults.boolWithDefault(Self.underTenKey, default: true)
+        self.healthyToClose = defaults.boolWithDefault(Self.healthyToCloseKey, default: true)
+        self.closeToRunningOut = defaults.boolWithDefault(Self.closeToRunningOutKey, default: true)
+    }
+
+    /// The per-milestone toggles as the pure logic consumes them. The master switch is applied
+    /// separately by the caller (it gates the whole evaluation, not one milestone).
+    var toggles: PaceNotificationToggles {
+        PaceNotificationToggles(
+            underTenPercent: underTenPercent,
+            healthyToClose: healthyToClose,
+            closeToRunningOut: closeToRunningOut
+        )
+    }
+}
+
+private extension UserDefaults {
+    /// `bool(forKey:)` returns `false` for an unset key, which can't express an opt-out default. This
+    /// reads the stored bool when present and falls back to `default` only when the key is genuinely
+    /// unset — so a default-on toggle starts on yet still honors a user's explicit off.
+    func boolWithDefault(_ key: String, default fallback: Bool) -> Bool {
+        object(forKey: key) as? Bool ?? fallback
+    }
+}

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -24,6 +24,12 @@ final class WidgetDataStore {
     private let orderedDescriptors: @MainActor () -> [WidgetDescriptor]
     /// Clock for the failure-backoff window. Injected so tests can advance time deterministically.
     private let now: () -> Date
+    /// Quota-notification preferences (master + per-trigger). Injected; `nil` disables notifications
+    /// entirely (tests and previews that don't wire it).
+    private let notificationSettings: (@MainActor () -> NotificationSettingsStore)?
+    /// Where a fired milestone is delivered: `(idPrefix, title, body)`. Injected so tests can record the
+    /// posts without a live notification center; defaults to the shared `AppNotifications`.
+    private let postNotification: @MainActor (String, String, String) -> Void
 
     private static let meterStyleKey = "meterStyle"
     private static let resetDisplayModeKey = "resetDisplayMode"
@@ -52,6 +58,10 @@ final class WidgetDataStore {
     /// Per-provider earliest next-probe time after a failure (see `failureRetryBackoff`). Not part of
     /// observable UI state, so it's excluded from `@Observable` tracking.
     @ObservationIgnored private var failureRetryAfter: [String: Date] = [:]
+
+    /// Per-metric dedup state for quota notifications, keyed by `providerID + "." + descriptorID`.
+    /// Not observable UI state. Dropped for a provider when it's disabled, so re-enabling starts fresh.
+    @ObservationIgnored private var notificationState: [String: NotificationState] = [:]
 
     /// Telemetry hook wired by `AppContainer`. Invoked once per *real* provider fetch — `.refreshed` or
     /// `.failed` only, never the cache-hit/skip/backoff outcomes that the 5-minute timer produces in
@@ -85,7 +95,9 @@ final class WidgetDataStore {
         defaults: UserDefaults = .standard,
         isProviderEnabled: @escaping @MainActor (String) -> Bool = { _ in true },
         orderedDescriptors: (@MainActor () -> [WidgetDescriptor])? = nil,
-        now: @escaping () -> Date = Date.init
+        now: @escaping () -> Date = Date.init,
+        notificationSettings: (@MainActor () -> NotificationSettingsStore)? = nil,
+        postNotification: (@MainActor (String, String, String) -> Void)? = nil
     ) {
         self.registry = registry
         self.providersByID = Dictionary(uniqueKeysWithValues: providers.map { ($0.provider.id, $0) })
@@ -94,6 +106,9 @@ final class WidgetDataStore {
         self.isProviderEnabled = isProviderEnabled
         self.orderedDescriptors = orderedDescriptors ?? { registry.descriptors }
         self.now = now
+        self.notificationSettings = notificationSettings
+        self.postNotification = postNotification
+            ?? { idPrefix, title, body in AppNotifications.shared.post(idPrefix: idPrefix, title: title, body: body) }
         self.meterStyle = defaults.enumValue(forKey: Self.meterStyleKey, default: .remaining)
         self.resetDisplayMode = defaults.enumValue(forKey: Self.resetDisplayModeKey, default: .relative)
         self.alwaysShowPacing = defaults.bool(forKey: Self.alwaysShowPacingKey)
@@ -134,6 +149,69 @@ final class WidgetDataStore {
         let cached = outcomes.count { $0 == .cacheHit }
         let backedOff = outcomes.count { $0 == .backedOff }
         AppLog.info(.refresh, "batch end (\(durationMs)ms, \(refreshed) ok / \(failed) failed / \(cached) cached / \(backedOff) backed off)")
+    }
+
+    /// Evaluate every visible, enabled metric for a quota pace milestone and post a notification for any
+    /// that just crossed one. Driven from the periodic loop *after* `refreshAll`, so it catches pace
+    /// worsening from time passing (not only from a fresh fetch). Deduped per metric per reset window via
+    /// `notificationState`; the no-trustworthy-pace states (no data, fresh session, level bands) never
+    /// fire. A no-op when notifications are unconfigured (tests/previews) or the master toggle is off.
+    ///
+    /// State for metrics not visited this pass (e.g. a provider the user just disabled, or a metric
+    /// removed from the layout) is pruned, so re-enabling/re-adding starts fresh rather than carrying a
+    /// stale "already fired" flag.
+    func evaluateNotifications(now: Date = Date()) {
+        guard let settingsProvider = notificationSettings else { return }
+        let settings = settingsProvider()
+        // The master switch is off: don't fire, and don't accumulate state (so turning it back on starts
+        // clean and the next worsening fires).
+        guard settings.enabled else {
+            if !notificationState.isEmpty { notificationState = [:] }
+            return
+        }
+        let toggles = settings.toggles
+        var nextState: [String: NotificationState] = [:]
+        for descriptor in orderedDescriptors() where isProviderEnabled(descriptor.providerID) {
+            let key = "\(descriptor.providerID).\(descriptor.id)"
+            let data = data(for: descriptor)
+            // Unbounded rows (no limit) and charts have no pace story — skip them outright so they never
+            // occupy state. `meterState` returns `.level`/`.noData` for them anyway, which wouldn't fire,
+            // but skipping keeps the state map to genuine meters.
+            guard data.isBounded else { continue }
+            let state = data.meterState(now: now)
+            let result = PaceNotificationLogic.transitions(
+                state: state,
+                fraction: data.fraction,
+                resetsAt: data.resetsAt,
+                previous: notificationState[key] ?? NotificationState(),
+                toggles: toggles
+            )
+            nextState[key] = result.newState
+            for milestone in result.fire {
+                post(milestone: milestone, data: data, providerID: descriptor.providerID)
+            }
+        }
+        notificationState = nextState
+    }
+
+    /// Build and post one milestone notification. Title/body are Title Case per AGENTS.md; the body names
+    /// the metric so the user knows which quota worsened without opening the popover.
+    private func post(milestone: PaceMilestone, data: WidgetData, providerID: String) {
+        let metricName = data.title
+        let title: String
+        let body: String
+        switch milestone {
+        case .underTenPercent:
+            title = "Quota Almost Gone"
+            body = "\(metricName) is under 10% remaining for this period."
+        case .healthyToClose:
+            title = "Pace Warning"
+            body = "\(metricName) is on track to run close to its limit."
+        case .closeToRunningOut:
+            title = "Pace Critical"
+            body = "\(metricName) is projected to run out before it resets."
+        }
+        postNotification("\(providerID).\(milestone.rawValue)", title, body)
     }
 
     /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch

--- a/Sources/OpenUsage/Support/AppLog.swift
+++ b/Sources/OpenUsage/Support/AppLog.swift
@@ -16,6 +16,7 @@ enum LogTag: String, Sendable {
     case localAPI = "localapi"
     case subprocess
     case lifecycle
+    case notifications
 
     /// Compound `[plugin:<id>]` / `[auth:<id>]` tags for per-provider lines.
     static func plugin(_ id: String) -> String { "plugin:\(id)" }

--- a/Sources/OpenUsage/Support/AppNotifications.swift
+++ b/Sources/OpenUsage/Support/AppNotifications.swift
@@ -1,0 +1,124 @@
+import Foundation
+import UserNotifications
+
+/// The single entry point for posting macOS user notifications. Quota pace alerts go through `post`;
+/// authorization is requested once at launch (the master toggle defaults ON, so the prompt is expected).
+///
+/// Authorization is memoized in one `Task<Bool, Never>`: the first caller reads the current settings,
+/// short-circuits an already-authorized or already-denied state, and otherwise requests it; every later
+/// caller awaits the same task rather than re-prompting. The class is the notification-center delegate so
+/// banners still show while the app is frontmost (a menu-bar accessory usually is).
+@MainActor
+final class AppNotifications: NSObject, UNUserNotificationCenterDelegate {
+    static let shared = AppNotifications()
+
+    /// Injectable so tests can supply a fake center and assert what got scheduled. Production returns
+    /// the system `current()` center.
+    private let centerProvider: @Sendable () -> UNUserNotificationCenter
+
+    /// Memoized authorization request — created on first use, awaited by everyone after.
+    private var authorizationTask: Task<Bool, Never>?
+
+    init(centerProvider: @escaping @Sendable () -> UNUserNotificationCenter = { UNUserNotificationCenter.current() }) {
+        self.centerProvider = centerProvider
+        super.init()
+    }
+
+    /// True while running inside the XCTest harness, so a unit test never actually schedules a system
+    /// notification or trips the authorization prompt. (No XCTest symbol is linked into the app target,
+    /// so this is a runtime class lookup.)
+    static var isRunningUnderTests: Bool {
+        NSClassFromString("XCTestCase") != nil
+    }
+
+    /// Make this object the delegate and kick off the authorization request once at launch. Safe to call
+    /// from app launch; a no-op under tests.
+    func registerAsDelegate() {
+        guard !Self.isRunningUnderTests else { return }
+        centerProvider().delegate = self
+    }
+
+    /// Request notification authorization once at startup. Because the master toggle defaults ON, the
+    /// permission prompt is expected on first launch. Memoized, so repeated calls don't re-prompt.
+    @discardableResult
+    func requestAuthorizationOnStartup() -> Task<Bool, Never> {
+        ensureAuthorization()
+    }
+
+    /// Post one immediate notification. `idPrefix` names the source (e.g. a metric key) for the log line;
+    /// the actual identifier is made unique so repeated alerts on the same metric don't coalesce. No-op
+    /// under tests, when authorization is denied, or when notifications can't be authorized.
+    func post(idPrefix: String, title: String, body: String, soundEnabled: Bool = true) {
+        guard !Self.isRunningUnderTests else { return }
+        Task {
+            let authorized = await ensureAuthorization().value
+            guard authorized else {
+                AppLog.debug(.notifications, "skip \(idPrefix): not authorized")
+                return
+            }
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            if soundEnabled { content.sound = .default }
+            let id = "openusage-\(idPrefix)-\(UUID().uuidString)"
+            let request = UNNotificationRequest(identifier: id, content: content, trigger: nil)
+            do {
+                try await centerProvider().add(request)
+                AppLog.info(.notifications, "posted \(idPrefix)")
+            } catch {
+                AppLog.error(.notifications, "post \(idPrefix) failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Authorization
+
+    /// The shared authorization task, created on first call. Reads current settings, short-circuits a
+    /// resolved (authorized/denied) state, and otherwise requests alert + sound permission.
+    private func ensureAuthorization() -> Task<Bool, Never> {
+        if let authorizationTask { return authorizationTask }
+        let center = centerProvider()
+        let task = Task<Bool, Never> {
+            let settings = await center.notificationSettings()
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                return true
+            case .denied:
+                AppLog.info(.notifications, "authorization denied")
+                return false
+            case .notDetermined:
+                do {
+                    let granted = try await center.requestAuthorization(options: [.alert, .sound])
+                    AppLog.info(.notifications, "authorization \(granted ? "granted" : "refused")")
+                    return granted
+                } catch {
+                    AppLog.error(.notifications, "authorization request failed: \(error.localizedDescription)")
+                    return false
+                }
+            @unknown default:
+                return false
+            }
+        }
+        authorizationTask = task
+        return task
+    }
+
+    /// Current authorization status, for the Settings screen's denied-permission notice. Returns
+    /// `.notDetermined` under tests.
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        guard !Self.isRunningUnderTests else { return .notDetermined }
+        return await centerProvider().notificationSettings().authorizationStatus
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    /// Show the banner (and play sound) even when the app is frontmost — a menu-bar accessory is
+    /// effectively always frontmost, so without this the user would never see the alert.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+}

--- a/Sources/OpenUsage/Support/PaceNotificationLogic.swift
+++ b/Sources/OpenUsage/Support/PaceNotificationLogic.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+/// One of the three quota milestones a user can be alerted about. Each maps to a single per-trigger
+/// toggle in Settings and is deduped independently within a reset window.
+enum PaceMilestone: String, CaseIterable, Hashable, Sendable {
+    /// First time the remaining share of the quota drops under 10% for the period.
+    case underTenPercent
+    /// Pace verdict worsened from healthy (blue) to close-to-limit (yellow).
+    case healthyToClose
+    /// Pace verdict worsened from close-to-limit (yellow) to running-out (red).
+    case closeToRunningOut
+}
+
+/// The pace-severity bucket a metric is in, derived from its `MeterState`. Only the three live-pace
+/// verdicts (and the terminal `spent`) carry a comparable severity; states with no trustworthy pace
+/// (`noData`, absolute-band `level`, and a fresh session window) are `untracked` — they neither fire a
+/// milestone nor count as an improvement, so they can't reset a fired flag either.
+enum PaceBucket: Hashable, Sendable {
+    /// No pace story to act on (no data, plain level band, or a not-yet-started session window).
+    case untracked
+    /// Blue: on course to finish with ≥10% to spare.
+    case healthy
+    /// Yellow: projected inside the last 10%, cutting it close.
+    case close
+    /// Red: projected to run out before the reset, or already spent to nothing.
+    case runningOut
+}
+
+/// Deduplication state for one metric (provider + descriptor), persisted across refresh passes so a
+/// milestone fires once per reset window rather than on every tick. Lives in `WidgetDataStore`.
+struct NotificationState: Equatable, Sendable {
+    /// The reset instant of the window the fired flags belong to. When this advances (a new window),
+    /// the fired set clears so the same milestones can fire again next period.
+    var resetsAt: Date?
+    /// Milestones already alerted in the current window.
+    var firedMilestones: Set<PaceMilestone> = []
+    /// The bucket observed on the previous evaluation, so a worsening transition can be detected.
+    var previousBucket: PaceBucket = .untracked
+    /// Whether the metric was under 10% remaining on the previous evaluation, so the crossing into
+    /// under-10% is an edge (and a recovery above 10% re-arms it).
+    var wasUnderTenPercent: Bool = false
+}
+
+/// Which per-milestone toggles are currently on. The master toggle is applied by the caller before
+/// this runs; this struct only carries the three individual switches.
+struct PaceNotificationToggles: Sendable {
+    var underTenPercent: Bool
+    var healthyToClose: Bool
+    var closeToRunningOut: Bool
+
+    static let allOn = PaceNotificationToggles(underTenPercent: true, healthyToClose: true, closeToRunningOut: true)
+
+    func isOn(_ milestone: PaceMilestone) -> Bool {
+        switch milestone {
+        case .underTenPercent: return underTenPercent
+        case .healthyToClose: return healthyToClose
+        case .closeToRunningOut: return closeToRunningOut
+        }
+    }
+}
+
+/// Pure milestone logic — no SwiftUI, no UserNotifications — so the firing rules stay unit-testable.
+/// `WidgetDataStore.evaluateNotifications` feeds it the current `MeterState` + `fraction` + `resetsAt`
+/// for each metric and posts a notification for every returned milestone.
+enum PaceNotificationLogic {
+    /// Result of one evaluation: the milestones to fire now, and the state to persist for next time.
+    struct Transition: Equatable {
+        var fire: [PaceMilestone]
+        var newState: NotificationState
+    }
+
+    /// Maps a meter state to its pace bucket. The "no trustworthy pace" states (no data, fresh
+    /// session, absolute level bands) are `untracked` — they never fire and never reset flags.
+    static func bucket(for state: WidgetData.MeterState) -> PaceBucket {
+        switch state {
+        case .noData, .level: return .untracked
+        case .healthy: return .healthy
+        case .closeToLimit: return .close
+        case .runningOut, .spent: return .runningOut
+        }
+    }
+
+    /// Decide which milestones to fire for one metric this pass, and the state to persist.
+    ///
+    /// Rules:
+    /// - A new reset window (a later `resetsAt`) clears the fired set so milestones can fire again.
+    /// - `healthyToClose` / `closeToRunningOut` fire only on a worsening *edge* between adjacent
+    ///   buckets, only if not already fired this window, and only if their toggle is on.
+    /// - `underTenPercent` fires the first time remaining crosses under 10% this window; recovering
+    ///   above 10% re-arms it so a later dip re-fires.
+    /// - `untracked` states (no data, fresh session, level bands) suppress everything — they carry no
+    ///   trustworthy pace — and don't disturb the recorded "previous" signals, so a momentary gap
+    ///   (e.g. a failed refresh) doesn't spuriously re-fire when real data returns.
+    /// - Improving pace clears the relevant fired flags so a later worsening re-fires.
+    static func transitions(
+        state: WidgetData.MeterState,
+        fraction: Double,
+        resetsAt: Date?,
+        previous: NotificationState,
+        toggles: PaceNotificationToggles
+    ) -> Transition {
+        var next = previous
+
+        // New window: reset dedup. A nil-or-equal reset keeps the window; a strictly later reset (or a
+        // reset appearing where there was none) starts fresh.
+        if let resetsAt, previous.resetsAt == nil || resetsAt > (previous.resetsAt ?? .distantPast) {
+            next.firedMilestones = []
+            next.wasUnderTenPercent = false
+            next.previousBucket = .untracked
+        }
+        next.resetsAt = resetsAt ?? previous.resetsAt
+
+        let currentBucket = bucket(for: state)
+
+        // Untracked: no trustworthy pace. Don't fire, and don't overwrite the previous signals — a
+        // transient no-data tick shouldn't look like an "improvement" that re-arms milestones, nor a
+        // worsening that fires them. Leave state as-is (window reset above still applies).
+        guard currentBucket != .untracked else {
+            return Transition(fire: [], newState: next)
+        }
+
+        var fire: [PaceMilestone] = []
+
+        // Pace-verdict edges. Severity order: untracked(-1) < healthy(0) < close(1) < runningOut(2).
+        // A milestone fires when the metric reaches (or passes) its threshold bucket having been below
+        // it before. Comparing severities — rather than naming exact buckets — makes two cases fall out:
+        //   • a jump straight from blue to red still crosses the yellow boundary, so it fires both;
+        //   • a *cold start* already in a bad bucket (previous == untracked, severity -1) fires too, so
+        //     a user who launches the app already over-pace is alerted on the first evaluation.
+        let previousSeverity = severity(next.previousBucket)
+        let currentSeverity = severity(currentBucket)
+        // "Pace Warning" is the yellow state itself: fire only when the metric is *currently* yellow and
+        // was below it before. If pace has already blown through to red, the user gets the single, more
+        // urgent "Pace Critical" instead — never both at once.
+        if currentBucket == .close, previousSeverity < severity(.close) {
+            maybeFire(.healthyToClose, into: &fire, state: &next, toggles: toggles)
+        }
+        if currentSeverity >= severity(.runningOut), previousSeverity < severity(.runningOut) {
+            maybeFire(.closeToRunningOut, into: &fire, state: &next, toggles: toggles)
+        }
+        // Improving pace clears the now-irrelevant fired flags so a later worsening re-fires them.
+        if currentSeverity < previousSeverity {
+            if currentSeverity <= severity(.healthy) { next.firedMilestones.remove(.healthyToClose) }
+            if currentSeverity <= severity(.close) { next.firedMilestones.remove(.closeToRunningOut) }
+        }
+        next.previousBucket = currentBucket
+
+        // Under-10%-remaining edge, tracked independently of the pace verdict.
+        let underNow = fraction < 0.10
+        if underNow, !next.wasUnderTenPercent {
+            maybeFire(.underTenPercent, into: &fire, state: &next, toggles: toggles)
+        }
+        if !underNow {
+            // Recovered above 10% — re-arm so a later dip fires again.
+            next.firedMilestones.remove(.underTenPercent)
+        }
+        next.wasUnderTenPercent = underNow
+
+        return Transition(fire: fire, newState: next)
+    }
+
+    /// Fires a milestone if its toggle is on and it hasn't already fired this window, recording it.
+    private static func maybeFire(
+        _ milestone: PaceMilestone,
+        into fire: inout [PaceMilestone],
+        state: inout NotificationState,
+        toggles: PaceNotificationToggles
+    ) {
+        guard toggles.isOn(milestone), !state.firedMilestones.contains(milestone) else { return }
+        fire.append(milestone)
+        state.firedMilestones.insert(milestone)
+    }
+
+    /// Ordinal pace severity so transitions can be compared (`untracked` sorts below `healthy`).
+    private static func severity(_ bucket: PaceBucket) -> Int {
+        switch bucket {
+        case .untracked: return -1
+        case .healthy: return 0
+        case .close: return 1
+        case .runningOut: return 2
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -2,6 +2,7 @@ import AppKit
 import KeyboardShortcuts
 import ServiceManagement
 import SwiftUI
+import UserNotifications
 
 /// The in-popover Settings screen — the popover's third mode alongside the dashboard and
 /// Customize. It replaces the old separate Settings window, which forced the popover closed every
@@ -25,6 +26,10 @@ struct SettingsScreen: View {
     @AppStorage(LogLevelSetting.key) private var logLevel = LogLevelSetting.fallback
     /// Surfaced under the Advanced rows when copying the path or revealing the file fails.
     @State private var logActionError: String?
+    /// True when notifications are enabled but macOS has denied authorization, so the Notifications
+    /// section shows an inline notice pointing the user to System Settings. Refreshed on appear and
+    /// whenever the master toggle flips on.
+    @State private var notificationsDenied = false
 
     /// Fills the region the dashboard's pinned footer leaves. Same scroller treatment as Customize:
     /// the overlay scroller stays (the scroll edge effect needs it) but is invisible.
@@ -38,6 +43,7 @@ struct SettingsScreen: View {
         @Bindable var store = container.dataStore
         @Bindable var layout = container.layout
         @Bindable var updater = updater
+        @Bindable var notifications = container.notificationSettings
         // Same section rhythm as the dashboard and Customize (all read the density setting).
         return VStack(alignment: .leading, spacing: density.sectionSpacing) {
             section("General") {
@@ -107,6 +113,7 @@ struct SettingsScreen: View {
                         .hoverTooltip("Show how you're pacing on every metric, not just ones near their limit")
                 }
             }
+            notificationsSection
             section("Providers") {
                 ForEach(container.registry.providers) { provider in
                     providerRow(provider)
@@ -159,6 +166,63 @@ struct SettingsScreen: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
+        .task { await refreshNotificationsDenied() }
+    }
+
+    // MARK: - Notifications
+
+    /// Quota pace notifications: a master switch, the three per-trigger rows (shown only when the master
+    /// is on), and an inline notice when macOS has denied permission. Defaults are all-on (owner
+    /// decision); the app requests authorization at first launch.
+    private var notificationsSection: some View {
+        @Bindable var notifications = container.notificationSettings
+        return section("Notifications") {
+            row("Quota Notifications") {
+                Toggle("", isOn: $notifications.enabled)
+                    .settingsSwitchStyle()
+                    .onChange(of: notifications.enabled) { _, enabled in
+                        if enabled {
+                            // Turning it back on may need a fresh prompt (or surface a prior denial).
+                            AppNotifications.shared.requestAuthorizationOnStartup()
+                            Task { await refreshNotificationsDenied() }
+                        }
+                    }
+            }
+            if notifications.enabled {
+                if notificationsDenied {
+                    // Same orange inline-notice idiom as the Launch-at-Login error line.
+                    Text("Notifications Are Turned Off for OpenUsage. Enable Them in System Settings → Notifications.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.notice)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                row("Low Remaining") {
+                    Toggle("", isOn: $notifications.underTenPercent)
+                        .settingsSwitchStyle()
+                }
+                row("Pace Warning") {
+                    Toggle("", isOn: $notifications.healthyToClose)
+                        .settingsSwitchStyle()
+                }
+                row("Pace Critical") {
+                    Toggle("", isOn: $notifications.closeToRunningOut)
+                        .settingsSwitchStyle()
+                }
+            }
+        }
+    }
+
+    /// Refresh `notificationsDenied` from the live authorization status — but only flag it when the user
+    /// actually wants notifications, so a denied notice never shows while the master switch is off.
+    private func refreshNotificationsDenied() async {
+        guard container.notificationSettings.enabled else {
+            notificationsDenied = false
+            return
+        }
+        let status = await AppNotifications.shared.authorizationStatus()
+        notificationsDenied = status == .denied
     }
 
     // MARK: - Advanced (logging)

--- a/Tests/OpenUsageTests/AppNotificationsTests.swift
+++ b/Tests/OpenUsageTests/AppNotificationsTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import UserNotifications
+@testable import OpenUsage
+
+/// `AppNotifications` wraps `UNUserNotificationCenter`, which can't be instantiated or subclassed in a
+/// unit test. The behavior we can pin without a live center is the test short-circuit: under XCTest,
+/// `post` / `registerAsDelegate` must never touch the center (no prompt, no scheduled notification), so
+/// the injected center provider is never invoked. The end-to-end "one post per fired milestone" check
+/// lives in `WidgetDataStoreNotificationTests`, which injects a recording sink into the store.
+@MainActor
+final class AppNotificationsTests: XCTestCase {
+    func testIsRunningUnderTestsIsTrueInTheHarness() {
+        XCTAssertTrue(AppNotifications.isRunningUnderTests)
+    }
+
+    func testPostIsANoOpUnderTestsAndNeverTouchesTheCenter() {
+        let probe = CenterProbe()
+        let notifications = AppNotifications(centerProvider: {
+            probe.touched = true
+            return UNUserNotificationCenter.current()
+        })
+        notifications.post(idPrefix: "claude.session.healthyToClose", title: "Pace Warning", body: "x")
+        notifications.registerAsDelegate()
+        XCTAssertFalse(probe.touched, "Under tests, no notification path should reach the center provider")
+    }
+
+    /// A tiny reference box so the `@Sendable` provider closure can record whether it ran.
+    private final class CenterProbe: @unchecked Sendable {
+        var touched = false
+    }
+}

--- a/Tests/OpenUsageTests/PaceNotificationLogicTests.swift
+++ b/Tests/OpenUsageTests/PaceNotificationLogicTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the pure milestone logic that decides when a quota notification fires: worsening pace edges
+/// (blue→yellow, yellow→red), the under-10%-remaining crossing, per-window dedup, reset rollover,
+/// recovery re-arming, the no-trustworthy-pace suppression, and the toggle gates. Mirrors CodexBar's
+/// QuotaWarningNotificationLogicTests.
+final class PaceNotificationLogicTests: XCTestCase {
+    private let reset = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // Meter states with a comfortable fraction so the under-10% rule doesn't co-fire unless intended.
+    private let healthy = WidgetData.MeterState.healthy(projectedFraction: 0.5)
+    private let close = WidgetData.MeterState.closeToLimit(spare: "~5% spare", projectedFraction: 0.95)
+    private let running = WidgetData.MeterState.runningOut(eta: nil, projectedFraction: 1.2)
+
+    /// Run one evaluation from a prior state with all toggles on.
+    private func step(
+        _ state: WidgetData.MeterState,
+        fraction: Double = 0.5,
+        resetsAt: Date? = nil,
+        from previous: NotificationState = NotificationState(),
+        toggles: PaceNotificationToggles = .allOn
+    ) -> PaceNotificationLogic.Transition {
+        PaceNotificationLogic.transitions(
+            state: state, fraction: fraction, resetsAt: resetsAt ?? reset,
+            previous: previous, toggles: toggles
+        )
+    }
+
+    // MARK: - Pace-verdict edges
+
+    func testHealthyToCloseFiresOnce() {
+        let first = step(healthy)
+        XCTAssertTrue(first.fire.isEmpty)
+        let second = step(close, from: first.newState)
+        XCTAssertEqual(second.fire, [.healthyToClose])
+    }
+
+    func testStayingYellowDoesNotRefire() {
+        var state = step(healthy).newState
+        state = step(close, from: state).newState   // fires
+        let again = step(close, from: state)        // still yellow
+        XCTAssertTrue(again.fire.isEmpty)
+    }
+
+    func testCloseToRunningOutFires() {
+        var state = step(healthy).newState
+        state = step(close, from: state).newState
+        let red = step(running, from: state)
+        XCTAssertEqual(red.fire, [.closeToRunningOut])
+    }
+
+    func testJumpStraightFromHealthyToRedFiresCritical() {
+        let state = step(healthy).newState
+        let red = step(running, from: state)
+        XCTAssertEqual(red.fire, [.closeToRunningOut])
+    }
+
+    // MARK: - Under 10% remaining
+
+    func testUnderTenPercentFiresOncePerWindow() {
+        let first = step(close, fraction: 0.08)
+        XCTAssertTrue(first.fire.contains(.underTenPercent))
+        let again = step(close, fraction: 0.05, from: first.newState)
+        XCTAssertFalse(again.fire.contains(.underTenPercent))
+    }
+
+    // MARK: - Cold start with already-bad state
+
+    func testColdStartAlreadyRedFiresCritical() {
+        // No prior observation (previousBucket == .untracked). Entering red from cold still fires the
+        // yellow-boundary crossing.
+        let red = step(running, fraction: 0.02)
+        XCTAssertTrue(red.fire.contains(.closeToRunningOut))
+        XCTAssertTrue(red.fire.contains(.underTenPercent))
+    }
+
+    // MARK: - Reset rollover
+
+    func testResetRolloverClearsFiredSetSoItCanFireAgain() {
+        var state = step(healthy).newState
+        state = step(close, from: state).newState   // fires healthyToClose this window
+        XCTAssertTrue(step(close, from: state).fire.isEmpty)   // deduped within the window
+        // A later reset window: same worsening should fire again. Re-enter healthy then close in the
+        // new window so the edge is present.
+        let newReset = reset.addingTimeInterval(3600)
+        let rolled = step(healthy, resetsAt: newReset, from: state).newState
+        let refired = step(close, resetsAt: newReset, from: rolled)
+        XCTAssertEqual(refired.fire, [.healthyToClose])
+    }
+
+    // MARK: - Recovery re-arms
+
+    func testRecoveryThenReworseningRefires() {
+        var state = step(healthy).newState
+        state = step(close, from: state).newState   // fired
+        state = step(running, from: state).newState // fired closeToRunningOut
+        // Recover all the way back to blue — clears the fired flags.
+        state = step(healthy, from: state).newState
+        // Worsen again: both edges should be available to fire once more.
+        let close2 = step(close, from: state)
+        XCTAssertEqual(close2.fire, [.healthyToClose])
+        let red2 = step(running, from: close2.newState)
+        XCTAssertEqual(red2.fire, [.closeToRunningOut])
+    }
+
+    func testUnderTenPercentReArmsAfterRecoveryAboveTen() {
+        let first = step(close, fraction: 0.05)
+        XCTAssertTrue(first.fire.contains(.underTenPercent))
+        let recovered = step(close, fraction: 0.50, from: first.newState)  // back above 10%
+        XCTAssertFalse(recovered.fire.contains(.underTenPercent))
+        let dipsAgain = step(close, fraction: 0.05, from: recovered.newState)
+        XCTAssertTrue(dipsAgain.fire.contains(.underTenPercent))
+    }
+
+    // MARK: - No trustworthy pace never fires
+
+    func testNoDataNeverFires() {
+        let result = step(.noData, fraction: 0.01)
+        XCTAssertTrue(result.fire.isEmpty)
+    }
+
+    func testLevelNeverFires() {
+        let result = step(.level(.critical), fraction: 0.01)
+        XCTAssertTrue(result.fire.isEmpty)
+    }
+
+    func testUntrackedDoesNotDisturbPreviousSignals() {
+        // healthy, then an untracked gap (e.g. a failed refresh → no data), then close. The gap must
+        // not look like an improvement that re-arms, nor swallow the edge: close should still fire.
+        var state = step(healthy).newState
+        state = step(.noData, fraction: 0.5, from: state).newState
+        let close = step(self.close, from: state)
+        XCTAssertEqual(close.fire, [.healthyToClose])
+    }
+
+    // MARK: - Toggle gates
+
+    func testMasterOffSuppressionIsCallerSide() {
+        // The pure logic has no master flag; the caller gates it. With all per-triggers off, nothing
+        // fires even on a clear worsening — this stands in for the per-trigger-off path.
+        let off = PaceNotificationToggles(underTenPercent: false, healthyToClose: false, closeToRunningOut: false)
+        let state = step(healthy, toggles: off).newState
+        let close = step(self.close, fraction: 0.05, from: state, toggles: off)
+        XCTAssertTrue(close.fire.isEmpty)
+    }
+
+    func testPerTriggerOffSuppressesOnlyThatMilestone() {
+        // Only the yellow→red trigger is off; blue→yellow still fires.
+        let toggles = PaceNotificationToggles(underTenPercent: false, healthyToClose: true, closeToRunningOut: false)
+        let state = step(healthy, toggles: toggles).newState
+        let close = step(self.close, fraction: 0.05, from: state, toggles: toggles)
+        XCTAssertEqual(close.fire, [.healthyToClose])
+        let red = step(running, fraction: 0.02, from: close.newState, toggles: toggles)
+        XCTAssertTrue(red.fire.isEmpty)
+    }
+
+    // MARK: - Fresh session window (treated as untracked by the caller via .level/.noData)
+
+    func testFreshSessionStyleStateNeverFires() {
+        // A fresh session window resolves to an absolute-level state (`.level`), which is untracked.
+        let result = step(.level(.normal), fraction: 0.99)
+        XCTAssertTrue(result.fire.isEmpty)
+    }
+}

--- a/Tests/OpenUsageTests/WidgetDataStoreNotificationTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreNotificationTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import OpenUsage
+
+/// End-to-end coverage of `WidgetDataStore.evaluateNotifications`: it resolves each enabled, visible
+/// bounded metric, runs the pure milestone logic, gates on the master + per-trigger settings, dedups
+/// per metric per window, and posts one notification per fired milestone. A recording sink stands in
+/// for `AppNotifications`; pace worsens by raising the metric's `used` between refreshes (real-world
+/// consumption), with `now` pinned so the projection stays deterministic.
+@MainActor
+final class WidgetDataStoreNotificationTests: XCTestCase {
+    private let week: TimeInterval = 7 * 24 * 60 * 60
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+    /// Reset window with ~90% of the week already elapsed at `base`, so `used%` ≈ the projected end %.
+    private var resetsAt: Date { base.addingTimeInterval(week * 0.10) }
+
+    /// A recording sink for posted notifications: each entry is `(idPrefix, title, body)`.
+    private final class Recorder {
+        var posts: [(String, String, String)] = []
+    }
+
+    /// A mutable enablement flag the store reads through its injected closure (so a test can flip it
+    /// without a "mutated after capture" warning on a captured local var).
+    private final class EnabledFlag {
+        var value: Bool
+        init(_ value: Bool) { self.value = value }
+    }
+
+    /// A provider whose snapshot can be swapped between refreshes to simulate rising usage.
+    private final class MutableRuntime: ProviderRuntime {
+        let provider: Provider
+        let widgetDescriptors: [WidgetDescriptor]
+        var snapshot: ProviderSnapshot
+        init(provider: Provider, descriptors: [WidgetDescriptor], snapshot: ProviderSnapshot) {
+            self.provider = provider
+            self.widgetDescriptors = descriptors
+            self.snapshot = snapshot
+        }
+        func refresh() async -> ProviderSnapshot { snapshot }
+    }
+
+    private func makeUserDefaults(_ name: String) -> UserDefaults {
+        let suite = "WidgetDataStoreNotificationTests.\(name)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private static let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("cursor"))
+
+    private static func descriptor() -> WidgetDescriptor {
+        WidgetDescriptor(
+            id: "test.session",
+            providerID: provider.id,
+            metricLabel: "Session",
+            sample: WidgetData(title: "Session", icon: provider.icon, kind: .percent, used: 10, limit: 100)
+        )
+    }
+
+    private func snapshot(used: Double) -> ProviderSnapshot {
+        ProviderSnapshot(
+            providerID: Self.provider.id,
+            displayName: Self.provider.displayName,
+            lines: [.progress(label: "Session", used: used, limit: 100, format: .percent,
+                              resetsAt: resetsAt, periodDurationMs: Int(week * 1000))]
+        )
+    }
+
+    private func makeStore(
+        used: Double,
+        settings: NotificationSettingsStore,
+        recorder: Recorder,
+        defaultsName: String,
+        isEnabled: @escaping @MainActor (String) -> Bool = { _ in true }
+    ) -> (WidgetDataStore, MutableRuntime, WidgetDescriptor) {
+        let descriptor = Self.descriptor()
+        let runtime = MutableRuntime(provider: Self.provider, descriptors: [descriptor], snapshot: snapshot(used: used))
+        let defaults = makeUserDefaults(defaultsName)
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [Self.provider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() }),
+            defaults: defaults,
+            isProviderEnabled: isEnabled,
+            orderedDescriptors: { [descriptor] },
+            notificationSettings: { settings },
+            postNotification: { idPrefix, title, body in recorder.posts.append((idPrefix, title, body)) }
+        )
+        return (store, runtime, descriptor)
+    }
+
+    func testHealthyToCloseFiresOnceThroughTheStore() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("h2c-settings"))
+        let recorder = Recorder()
+        // 80% used at ~90% elapsed → projected ~89% → healthy.
+        let (store, runtime, _) = makeStore(used: 80, settings: settings, recorder: recorder, defaultsName: "h2c")
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        XCTAssertTrue(recorder.posts.isEmpty, "healthy should not fire")
+
+        // Usage rises to 87% → projected ~96.7% → close.
+        runtime.snapshot = snapshot(used: 87)
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        XCTAssertEqual(recorder.posts.count, 1)
+        XCTAssertEqual(recorder.posts.first?.0, "test.healthyToClose")
+        XCTAssertEqual(recorder.posts.first?.1, "Pace Warning")
+
+        // Staying yellow doesn't re-fire.
+        store.evaluateNotifications(now: base)
+        XCTAssertEqual(recorder.posts.count, 1)
+    }
+
+    func testCloseToRunningOutFiresThroughTheStore() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("c2r-settings"))
+        let recorder = Recorder()
+        let (store, runtime, _) = makeStore(used: 87, settings: settings, recorder: recorder, defaultsName: "c2r")
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)   // close → fires healthyToClose (cold→close)
+        XCTAssertTrue(recorder.posts.contains { $0.0 == "test.healthyToClose" })
+
+        // Usage rises to 95% → projected ~105% → red.
+        runtime.snapshot = snapshot(used: 95)
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        XCTAssertTrue(recorder.posts.contains { $0.0 == "test.closeToRunningOut" })
+        XCTAssertTrue(recorder.posts.contains { $0.2 == "Session is projected to run out before it resets." })
+    }
+
+    func testMasterOffSuppressesAllPosts() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("master-off-settings"))
+        settings.enabled = false
+        let recorder = Recorder()
+        let (store, runtime, _) = makeStore(used: 80, settings: settings, recorder: recorder, defaultsName: "master-off")
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        runtime.snapshot = snapshot(used: 95)
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        XCTAssertTrue(recorder.posts.isEmpty)
+    }
+
+    func testPerTriggerOffSuppressesThatMilestoneOnly() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("per-trigger-settings"))
+        settings.healthyToClose = false   // turn off "Pace Warning" only
+        let recorder = Recorder()
+        let (store, runtime, _) = makeStore(used: 80, settings: settings, recorder: recorder, defaultsName: "per-trigger")
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        runtime.snapshot = snapshot(used: 87)
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        XCTAssertFalse(recorder.posts.contains { $0.0 == "test.healthyToClose" })
+        // The critical trigger is still on: pushing to red fires it.
+        runtime.snapshot = snapshot(used: 95)
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        XCTAssertTrue(recorder.posts.contains { $0.0 == "test.closeToRunningOut" })
+    }
+
+    func testDisablingProviderDropsItsNotificationState() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("disable-settings"))
+        let recorder = Recorder()
+        let enabled = EnabledFlag(true)
+        // 95% used → red immediately, so a milestone fires on the first evaluation.
+        let (store, _, _) = makeStore(used: 95, settings: settings, recorder: recorder,
+                                      defaultsName: "disable", isEnabled: { _ in enabled.value })
+        await store.refreshAll(force: true)
+        store.evaluateNotifications(now: base)
+        let firstCount = recorder.posts.count
+        XCTAssertGreaterThan(firstCount, 0)
+
+        // Disable the provider: evaluation skips it (and prunes its state), so nothing new fires.
+        enabled.value = false
+        store.evaluateNotifications(now: base)
+        XCTAssertEqual(recorder.posts.count, firstCount)
+    }
+}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -26,6 +26,21 @@ Settings lives inside the popover — there is no separate window. Open it from 
 | Reset Times | Countdown / Exact time | "Resets in 3h 25m" vs "Resets today at 6:38 PM" — same toggle as clicking a reset label. |
 | Always Show Pacing | Off / On | Off (default) shows pacing only when a metric is close to or over its limit. On surfaces it on every metric with a reset window: on-track rows gain their projection ("~33% left at reset") and an even-pace tick marking where steady use would put you right now. Metrics without a reset window have no pace to show. |
 
+## Notifications
+
+OpenUsage can alert you with a macOS notification when a metric's pace gets worse, so you don't have to keep the popover open to catch a quota creeping toward its limit. Alerts work while the app runs in the menu bar, even with the popover closed.
+
+| Setting | Options | What it does |
+|---|---|---|
+| Quota Notifications | On / Off | The master switch. On (default) lets the three alerts below fire; off silences all of them. |
+| Low Remaining | On / Off | Alerts the first time a metric drops under 10% remaining for the period. |
+| Pace Warning | On / Off | Alerts when a metric's pace shifts from comfortable (blue) to close-to-limit (yellow) — on track to run near its limit before the reset. |
+| Pace Critical | On / Off | Alerts when a metric's pace worsens to running out (red) — projected to run out before the reset. |
+
+Each alert fires **once per metric per reset period**, so you get a heads-up without repeats on every refresh. If a metric recovers (its pace eases back) and later worsens again, it can alert again. When a new period begins, the slate is wiped clean. Metrics without a reset window, or while their data can't be read, don't pace and never alert.
+
+Because the master switch is on by default, OpenUsage asks for notification permission the first time it launches. If you decline (or turn notifications off for OpenUsage in System Settings), this section shows a reminder with a link to re-enable them in System Settings → Notifications.
+
 ## Providers
 
 One switch per provider. Turning a provider **off** hides it everywhere (dashboard, Customize, menu bar, the collection endpoint of the [local HTTP API](local-http-api.md)) and pauses its updates. Nothing is deleted — turning it back on restores its metrics and order.


### PR DESCRIPTION
## TL;DR
Adds opt-out macOS notifications that alert you when a quota's pace worsens, at three milestones, deduped once per metric per reset period — so you catch a quota creeping toward its limit without keeping the popover open. Closes #633.

## What was happening
- OpenUsage surfaced pace visually (blue/yellow/red bars, "~N% spare", run-out times), but only while the popover was open.
- A quota could drift from healthy to nearly exhausted with no signal unless you looked. There was no notification path in the app at all.

## What this changes
- **Three milestones**, fired once per metric per reset window:
  - **Low Remaining** — first time under 10% remaining for the period.
  - **Pace Warning** — pace `.healthy` (blue) → `.closeToLimit` (yellow).
  - **Pace Critical** — pace `.closeToLimit` (yellow) → `.runningOut` (red).
- **Always-on, popover-closed:** evaluation runs every refresh tick in the periodic loop (`AppContainer.startPeriodicRefresh`), so worsening from elapsed time alone still alerts.
- **Dedup** keyed by `providerID + descriptorID + reset period`. A new window clears the fired set; a recovery re-arms a milestone so a later worsening re-fires. No spam on every refresh.
- **Suppressed where there's no trustworthy pace:** fresh-session windows, absolute-level bands, and no-data states never fire.
- **Settings → Notifications** section: master "Quota Notifications" toggle (default on) plus "Low Remaining" / "Pace Warning" / "Pace Critical" rows (shown when the master is on). An inline orange notice appears when macOS authorization is denied, linking to System Settings (reusing the Launch-at-Login notice idiom).
- **Owner decisions honored:** master + all three triggers default **on**; authorization is requested once at first launch (because it's on by default).
- New 3-layer design mirroring CodexBar: pure `PaceNotificationLogic` (no SwiftUI/UN), `AppNotifications` (the single UN entry point + delegate), and a small `@Observable` `NotificationSettingsStore`. New `AppLog` `.notifications` category. `docs/settings.md` documents the section and what fires when.

## Tests
- `PaceNotificationLogicTests` (15): blue→yellow fires once; staying yellow doesn't re-fire; yellow→red fires; jump straight to red fires critical only; under-10% fires once per window and re-arms after recovery; cold start already-bad fires; reset rollover clears the fired set; recovery then re-worsening re-fires; no-data / level / fresh-session never fire; master-off and per-trigger-off suppress.
- `WidgetDataStoreNotificationTests` (5): end-to-end through the store with a recording sink — healthy→close fires once, close→running-out fires, master-off and per-trigger-off suppress, disabling a provider prunes its state.
- `AppNotificationsTests` (2): `isRunningUnderTests` short-circuit — no UN center is touched under XCTest.
- Full suite: **513 tests pass** (1 pre-existing live-Claude skip). `swift build` clean.

## Heads-up
- **On by default (owner decision)** → the app prompts for notification permission on first launch. Authorization is memoized in a single task; if denied, posts are silent no-ops and Settings shows the re-enable notice.
- Dedup is keyed by provider + descriptor + reset period; per-metric state is pruned each pass for metrics no longer visible/enabled, so re-enabling starts fresh.
- `AppNotifications` is the **single UN entry point** for the app, ready for any future notification needs (there is no prior #607 background-activity alert in the tree to coordinate with).
- Copy chosen (Title Case per AGENTS.md): titles "Quota Almost Gone" / "Pace Warning" / "Pace Critical"; settings rows "Low Remaining" / "Pace Warning" / "Pace Critical" as specified. Happy to adjust wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)