### PR TITLE
feat(share): per-provider Copy as Image card (#762)

### DIFF
--- a/Sources/OpenUsage/Support/ShareCardRenderer.swift
+++ b/Sources/OpenUsage/Support/ShareCardRenderer.swift
@@ -31,22 +31,27 @@ enum ShareCardRenderer {
         return rep.representation(using: .png, properties: [:])
     }
 
-    /// Writes the card's PNG onto the general pasteboard (replacing its contents). No-op if the PNG
-    /// can't be encoded.
+    /// Writes the card's PNG onto the general pasteboard (replacing its contents). Beeps and logs if the
+    /// PNG can't be encoded or the pasteboard rejects it, so a failed copy isn't silently swallowed.
     static func copyToPasteboard(_ image: NSImage) {
         guard let png = pngData(from: image) else {
             AppLog.error(.lifecycle, "share card: failed to encode PNG for clipboard")
+            NSSound.beep()
             return
         }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setData(png, forType: .png)
+        guard pasteboard.setData(png, forType: .png) else {
+            AppLog.error(.lifecycle, "share card: pasteboard rejected the PNG")
+            NSSound.beep()
+            return
+        }
     }
 
-    /// Orchestrates a Copy as Image action end to end: resolve the provider's visible rows from the data store,
-    /// build the card with the effective appearance, render it, and copy the PNG to the clipboard. The
-    /// rows mirror what the dashboard shows — always-shown plus expanded only when the provider's caret
-    /// is open — so the export matches what the user sees.
+    /// Orchestrates a Copy as Image action end to end: resolve the provider's visible rows from the data
+    /// store, build the card with the effective appearance, render it, and copy the PNG to the clipboard.
+    /// The rows mirror what the dashboard shows — always-shown plus expanded only when the provider's
+    /// caret is open — so the export matches what the user sees.
     ///
     /// The render is pinned to the regular density regardless of the user's popover density slider: the
     /// rows read density via `@AppStorage`, so the saved value is swapped to `.regular` for the duration
@@ -58,16 +63,22 @@ enum ShareCardRenderer {
         layout: LayoutStore,
         appearance: ColorScheme
     ) {
-        let visibleWidgets = layout.isProviderExpanded(group.provider.id) ? group.widgets : group.alwaysShownWidgets
-        let rows = visibleWidgets.compactMap { widget -> WidgetData? in
+        let isExpanded = layout.isProviderExpanded(group.provider.id)
+        let alwaysRows = group.alwaysShownWidgets.compactMap { widget -> WidgetData? in
             guard let descriptor = layout.descriptor(for: widget) else { return nil }
             return dataStore.data(for: descriptor)
         }
+        let expandedRows = group.expandedWidgets.compactMap { widget -> WidgetData? in
+            guard let descriptor = layout.descriptor(for: widget) else { return nil }
+            return dataStore.data(for: descriptor)
+        }
+        let rows = isExpanded ? alwaysRows + expandedRows : alwaysRows
         let view = ShareCardView(
             provider: group.provider,
             plan: dataStore.plan(for: group.provider.id),
             rows: rows,
-            appearance: appearance
+            appearance: appearance,
+            expandBoundaryIndex: isExpanded ? alwaysRows.count : nil
         )
         let densityKey = DensitySetting.key
         let savedDensity = UserDefaults.standard.string(forKey: densityKey)

--- a/Sources/OpenUsage/Support/ShareCardRenderer.swift
+++ b/Sources/OpenUsage/Support/ShareCardRenderer.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SwiftUI
+
+/// Renders a `ShareCardView` into a PNG and copies it to the clipboard. Mirrors `MenuBarStripRenderer`'s
+/// `ImageRenderer` → `cgImage` → `NSImage` path (×4 for a crisp, large export), then PNG-encodes it and
+/// writes it to the pasteboard.
+@MainActor
+enum ShareCardRenderer {
+    /// Off-screen render scale. ×4 turns the popover-scale card into a crisp, large PNG — a 360pt card
+    /// ships as a 1440px image — without authoring a separate large-format layout.
+    static let scale: CGFloat = 4
+
+    /// The card rendered to an `NSImage`, or `nil` if `ImageRenderer` produces no CGImage. The image's
+    /// point size is the card's natural (flexible) size; its pixel size is that times `scale`.
+    static func image(for view: ShareCardView) -> NSImage? {
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = scale
+        guard let cgImage = renderer.cgImage else { return nil }
+        return NSImage(
+            cgImage: cgImage,
+            size: NSSize(width: CGFloat(cgImage.width) / scale, height: CGFloat(cgImage.height) / scale)
+        )
+    }
+
+    /// PNG-encodes an `NSImage`, or `nil` if the bitmap can't be formed.
+    static func pngData(from image: NSImage) -> Data? {
+        guard
+            let tiff = image.tiffRepresentation,
+            let rep = NSBitmapImageRep(data: tiff)
+        else { return nil }
+        return rep.representation(using: .png, properties: [:])
+    }
+
+    /// Writes the card's PNG onto the general pasteboard (replacing its contents). No-op if the PNG
+    /// can't be encoded.
+    static func copyToPasteboard(_ image: NSImage) {
+        guard let png = pngData(from: image) else {
+            AppLog.error(.lifecycle, "share card: failed to encode PNG for clipboard")
+            return
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setData(png, forType: .png)
+    }
+
+    /// Orchestrates a Copy as Image action end to end: resolve the provider's visible rows from the data store,
+    /// build the card with the effective appearance, render it, and copy the PNG to the clipboard. The
+    /// rows mirror what the dashboard shows — always-shown plus expanded only when the provider's caret
+    /// is open — so the export matches what the user sees.
+    ///
+    /// The render is pinned to the regular density regardless of the user's popover density slider: the
+    /// rows read density via `@AppStorage`, so the saved value is swapped to `.regular` for the duration
+    /// of the render and restored on exit (synchronously), keeping the exported card consistent without
+    /// disturbing the live popover.
+    static func share(
+        group: ProviderGroup,
+        dataStore: WidgetDataStore,
+        layout: LayoutStore,
+        appearance: ColorScheme
+    ) {
+        let visibleWidgets = layout.isProviderExpanded(group.provider.id) ? group.widgets : group.alwaysShownWidgets
+        let rows = visibleWidgets.compactMap { widget -> WidgetData? in
+            guard let descriptor = layout.descriptor(for: widget) else { return nil }
+            return dataStore.data(for: descriptor)
+        }
+        let view = ShareCardView(
+            provider: group.provider,
+            plan: dataStore.plan(for: group.provider.id),
+            rows: rows,
+            appearance: appearance
+        )
+        let densityKey = DensitySetting.key
+        let savedDensity = UserDefaults.standard.string(forKey: densityKey)
+        UserDefaults.standard.set(DensitySetting.regular.rawValue, forKey: densityKey)
+        defer {
+            if let savedDensity {
+                UserDefaults.standard.set(savedDensity, forKey: densityKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: densityKey)
+            }
+        }
+        guard let image = image(for: view) else {
+            AppLog.error(.lifecycle, "share card: ImageRenderer produced no image for \(group.provider.id)")
+            return
+        }
+        copyToPasteboard(image)
+    }
+}

--- a/Sources/OpenUsage/Support/ShareCardRenderer.swift
+++ b/Sources/OpenUsage/Support/ShareCardRenderer.swift
@@ -92,6 +92,7 @@ enum ShareCardRenderer {
         }
         guard let image = image(for: view) else {
             AppLog.error(.lifecycle, "share card: ImageRenderer produced no image for \(group.provider.id)")
+            NSSound.beep()
             return
         }
         copyToPasteboard(image)

--- a/Sources/OpenUsage/Views/ShareCardView.swift
+++ b/Sources/OpenUsage/Views/ShareCardView.swift
@@ -76,15 +76,26 @@ struct ShareCardView: View {
             }
         } else {
             DashboardMetricCard {
-                ForEach(Array(rows.enumerated()), id: \.offset) { _, data in
-                    WidgetRowView(data: data)
+                let condensed = Self.condensedTextRowIndices(rows)
+                ForEach(Array(rows.enumerated()), id: \.offset) { index, data in
+                    WidgetRowView(data: data, condensedTop: condensed.contains(index))
                 }
             }
         }
     }
 
-    // MARK: - Footer
+    /// Indices of text-only rows that sit directly under another text-only row — the neighbor-aware
+    /// condensing rule the live dashboard applies, so a run of one-liners (Today / Yesterday /
+    /// Last 30 Days) pulls into one cluster in the export the same way it does in the popover.
+    static func condensedTextRowIndices(_ rows: [WidgetData]) -> Set<Int> {
+        var indices = Set<Int>()
+        for i in 1..<rows.count where !rows[i - 1].isBounded && !rows[i].isBounded {
+            indices.insert(i)
+        }
+        return indices
+    }
 
+    // MARK: - Footer
     /// The brand mark + tagline, centered at the bottom of the card. Quiet (secondary) so it reads as
     /// a watermark, not a headline.
     private var footer: some View {

--- a/Sources/OpenUsage/Views/ShareCardView.swift
+++ b/Sources/OpenUsage/Views/ShareCardView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// An off-screen, branded PNG of one provider's usage, rendered for the right-click "Share" action.
+/// It is a static snapshot — no drag grips, spinners, staleness tags, or refresh warnings — that mirrors
+/// what the provider's card currently shows in the popover (respecting whether the caret is expanded),
+/// drawn at the popover's own scale and rasterized at ×4 for a crisp, large share image.
+///
+/// The layout is intentionally not a fixed canvas: the card height grows with its rows, so a collapsed
+/// provider exports a short card and an expanded one a tall one, with little wasted whitespace. The view
+/// takes already-resolved `[WidgetData]` (not a store), so it has no environment dependency and renders
+/// the same way in the app and in tests. It paints an opaque `Theme.traySurface` background (an
+/// `ImageRenderer` has no window backdrop) and forces the appearance via `.environment(\.colorScheme, …)`
+/// so a Light-mode user gets a light card even when the OS is in dark mode.
+struct ShareCardView: View {
+    let provider: Provider
+    var plan: String?
+    let rows: [WidgetData]
+    let appearance: ColorScheme
+
+    /// Authored card width in points. The renderer multiplies this by `ShareCardRenderer.scale` for the
+    /// PNG's pixel width; the height is whatever the rows add up to (flexible).
+    static let width: CGFloat = 360
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            headerRow
+            metricsCard
+            footer
+        }
+        .padding(16)
+        .frame(width: Self.width, alignment: .topLeading)
+        .background(Theme.traySurface)
+        .environment(\.colorScheme, appearance)
+    }
+
+    // MARK: - Header
+
+    /// Provider mark + name (+ optional plan), leading — logo, then name, then plan — at the popover's
+    /// type scale so it sits in proportion to the rows. Static: no drag grip, spinner, staleness tag, or
+    /// warning triangle.
+    private var headerRow: some View {
+        HStack(spacing: 10) {
+            ProviderIcon(source: provider.icon, inset: 0.04)
+                .frame(width: 22, height: 22)
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(provider.displayName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                if let plan, !plan.isEmpty {
+                    Text(plan)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Body
+
+    /// The provider's visible metric rows in the shared card surface, reusing `WidgetRowView` so the
+    /// exported card matches the live dashboard exactly. Toggles are nil (static render). An empty
+    /// provider falls back to a quiet placeholder so the card never renders blank.
+    @ViewBuilder
+    private var metricsCard: some View {
+        if rows.isEmpty {
+            DashboardMetricCard {
+                Text("No metrics to show")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+            }
+        } else {
+            DashboardMetricCard {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, data in
+                    WidgetRowView(data: data)
+                }
+            }
+        }
+    }
+
+    // MARK: - Footer
+
+    /// The brand mark + tagline, centered at the bottom of the card. Quiet (secondary) so it reads as
+    /// a watermark, not a headline.
+    private var footer: some View {
+        HStack(spacing: 6) {
+            ProviderIcon(source: .providerMark("openusage"), inset: 0)
+                .frame(width: 14, height: 14)
+            Text("Monitor Your AI Subscriptions with OpenUsage")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Sources/OpenUsage/Views/ShareCardView.swift
+++ b/Sources/OpenUsage/Views/ShareCardView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-/// An off-screen, branded PNG of one provider's usage, rendered for the right-click "Share" action.
-/// It is a static snapshot — no drag grips, spinners, staleness tags, or refresh warnings — that mirrors
-/// what the provider's card currently shows in the popover (respecting whether the caret is expanded),
-/// drawn at the popover's own scale and rasterized at ×4 for a crisp, large share image.
+/// An off-screen, branded PNG of one provider's usage, rendered for the right-click "Copy as Image"
+/// action. It is a static snapshot — no drag grips, spinners, staleness tags, or refresh warnings — that
+/// mirrors what the provider's card currently shows in the popover (respecting whether the caret is
+/// expanded), drawn at the popover's own scale and rasterized at ×4 for a crisp, large share image.
 ///
 /// The layout is intentionally not a fixed canvas: the card height grows with its rows, so a collapsed
 /// provider exports a short card and an expanded one a tall one, with little wasted whitespace. The view
@@ -16,6 +16,10 @@ struct ShareCardView: View {
     var plan: String?
     let rows: [WidgetData]
     let appearance: ColorScheme
+    /// Index in `rows` where the "shown on expand" rows begin (the always-shown count), so the
+    /// neighbor-aware condensing treats the expand caret as a hard boundary the way the live dashboard
+    /// does. `nil` when the provider is collapsed (no expanded section).
+    var expandBoundaryIndex: Int? = nil
 
     /// Authored card width in points. The renderer multiplies this by `ShareCardRenderer.scale` for the
     /// PNG's pixel width; the height is whatever the rows add up to (flexible).
@@ -76,7 +80,7 @@ struct ShareCardView: View {
             }
         } else {
             DashboardMetricCard {
-                let condensed = Self.condensedTextRowIndices(rows)
+                let condensed = Self.condensedTextRowIndices(rows, boundary: expandBoundaryIndex)
                 ForEach(Array(rows.enumerated()), id: \.offset) { index, data in
                     WidgetRowView(data: data, condensedTop: condensed.contains(index))
                 }
@@ -86,16 +90,23 @@ struct ShareCardView: View {
 
     /// Indices of text-only rows that sit directly under another text-only row — the neighbor-aware
     /// condensing rule the live dashboard applies, so a run of one-liners (Today / Yesterday /
-    /// Last 30 Days) pulls into one cluster in the export the same way it does in the popover.
-    static func condensedTextRowIndices(_ rows: [WidgetData]) -> Set<Int> {
+    /// Last 30 Days) pulls into one cluster in the export the same way it does in the popover. The
+    /// expand caret is a hard boundary: condensing runs within the always-shown rows and within the
+    /// expanded rows separately, never across, so the export's spacing matches the popover.
+    static func condensedTextRowIndices(_ rows: [WidgetData], boundary: Int? = nil) -> Set<Int> {
         var indices = Set<Int>()
-        for i in 1..<rows.count where !rows[i - 1].isBounded && !rows[i].isBounded {
-            indices.insert(i)
+        let end = rows.count
+        let edges = boundary.map { [0, $0, end] } ?? [0, end]
+        for (lower, upper) in zip(edges, edges.dropFirst()) {
+            for i in (lower + 1)..<upper where !rows[i - 1].isBounded && !rows[i].isBounded {
+                indices.insert(i)
+            }
         }
         return indices
     }
 
     // MARK: - Footer
+
     /// The brand mark + tagline, centered at the bottom of the card. Quiet (secondary) so it reads as
     /// a watermark, not a headline.
     private var footer: some View {

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 /// The dashboard display: one inset group per provider (System Settings style). A provider's icon + name
@@ -14,6 +13,7 @@ struct WidgetGroupedListView: View {
     @Environment(AppContainer.self) private var container
     @Environment(LayoutStore.self) private var layout
     @Environment(WidgetDataStore.self) private var dataStore
+    @Environment(\.colorScheme) private var colorScheme
     let reorderSpaceName: String
     @Binding var reorderLift: ReorderLift?
 
@@ -75,16 +75,16 @@ struct WidgetGroupedListView: View {
         }
     }
 
-    /// Renders the provider's branded share card and copies the PNG to the clipboard. The effective
-    /// light/dark appearance is resolved from `NSApp` so the card matches what the user sees (the
-    /// popover follows the menu bar, which follows the app/OS appearance).
+    /// Renders the provider's branded share card and copies the PNG to the clipboard. The appearance is
+    /// taken from the popover's own `colorScheme` — this view is hosted in the popover panel, whose
+    /// appearance is `AppearanceSetting.current` (explicit for Light/Dark, the menu bar for System) — so
+    /// the export matches the card on screen instead of guessing from `NSApp.effectiveAppearance`.
     private func shareCard(_ group: ProviderGroup) {
-        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
         ShareCardRenderer.share(
             group: group,
             dataStore: dataStore,
             layout: layout,
-            appearance: isDark ? .dark : .light
+            appearance: colorScheme
         )
     }
 

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// The dashboard display: one inset group per provider (System Settings style). A provider's icon + name
@@ -69,7 +70,22 @@ struct WidgetGroupedListView: View {
             Button("Customize…") {
                 withAnimation(Motion.modeSwitch) { layout.isEditing = true }
             }
+            Divider()
+            Button("Copy as Image") { shareCard(group) }
         }
+    }
+
+    /// Renders the provider's branded share card and copies the PNG to the clipboard. The effective
+    /// light/dark appearance is resolved from `NSApp` so the card matches what the user sees (the
+    /// popover follows the menu bar, which follows the app/OS appearance).
+    private func shareCard(_ group: ProviderGroup) {
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        ShareCardRenderer.share(
+            group: group,
+            dataStore: dataStore,
+            layout: layout,
+            appearance: isDark ? .dark : .light
+        )
     }
 
     /// A row's placed widget paired with its resolved descriptor + data, so each `dataStore.data(for:)`

--- a/Tests/OpenUsageTests/ShareCardRendererTests.swift
+++ b/Tests/OpenUsageTests/ShareCardRendererTests.swift
@@ -59,4 +59,18 @@ final class ShareCardRendererTests: XCTestCase {
                            "row \(i) condensing should match the neighbor-aware text-only rule")
         }
     }
+
+    func testCondensedTextRowIndicesRespectExpandBoundary() {
+        let rows = MockData.descriptors(for: MockData.claude.id).map { $0.sample }
+        XCTAssertGreaterThan(rows.count, 1, "sample fixture should have multiple rows")
+        let boundary = rows.count / 2
+        let condensed = ShareCardView.condensedTextRowIndices(rows, boundary: boundary)
+        XCTAssertFalse(condensed.contains(boundary), "the first expanded row (at the boundary) is never condensed")
+        for i in 1..<rows.count {
+            let sameSide = (i < boundary) == (i - 1 < boundary)
+            let expected = sameSide && !rows[i - 1].isBounded && !rows[i].isBounded
+            XCTAssertEqual(condensed.contains(i), expected,
+                           "row \(i) condensing should not bridge the expand caret boundary")
+        }
+    }
 }

--- a/Tests/OpenUsageTests/ShareCardRendererTests.swift
+++ b/Tests/OpenUsageTests/ShareCardRendererTests.swift
@@ -47,4 +47,16 @@ final class ShareCardRendererTests: XCTestCase {
         XCTAssertEqual(rep.pixelsWide % Int(ShareCardView.width), 0)
         XCTAssertGreaterThan(rep.pixelsHigh, 0)
     }
+
+    func testCondensedTextRowIndicesFollowsNeighborRule() {
+        let rows = MockData.descriptors(for: MockData.claude.id).map { $0.sample }
+        XCTAssertGreaterThan(rows.count, 1, "sample fixture should have multiple rows")
+        let condensed = ShareCardView.condensedTextRowIndices(rows)
+        XCTAssertFalse(condensed.contains(0), "the first row is never condensed")
+        for i in 1..<rows.count {
+            let expected = !rows[i - 1].isBounded && !rows[i].isBounded
+            XCTAssertEqual(condensed.contains(i), expected,
+                           "row \(i) condensing should match the neighbor-aware text-only rule")
+        }
+    }
 }

--- a/Tests/OpenUsageTests/ShareCardRendererTests.swift
+++ b/Tests/OpenUsageTests/ShareCardRendererTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import SwiftUI
+@testable import OpenUsage
+
+/// Covers the Share card export pipeline: `image(for:)` rasterizes the flexible-height card, and
+/// `pngData(from:)` round-trips to a valid PNG. `ImageRenderer` is MainActor-only, so the whole case
+/// runs on the main actor. Pixel dimensions are checked scale-agnostically (the bitmap width is a
+/// multiple of the authored card width) because `ImageRenderer.scale` is not honored in headless CI.
+@MainActor
+final class ShareCardRendererTests: XCTestCase {
+    private func sampleCard() -> ShareCardView {
+        let provider = MockData.claude
+        let rows = MockData.descriptors(for: provider.id).map { $0.sample }
+        return ShareCardView(provider: provider, plan: "Max", rows: rows, appearance: .light)
+    }
+
+    func testImageRasterizesAtAuthoredWidthMultiple() throws {
+        let image = try XCTUnwrap(ShareCardRenderer.image(for: sampleCard()))
+
+        // The bitmap width is the authored card width times the render scale. `ImageRenderer.scale` is
+        // not honored in headless CI (it rasterizes at ×1), so assert a scale-agnostic multiple rather
+        // than an exact `width * scale` — it holds at ×1 in CI and ×4 locally.
+        let rep = try XCTUnwrap(image.representations.first)
+        let width = Int(ShareCardView.width)
+        XCTAssertGreaterThan(rep.pixelsWide, 0)
+        XCTAssertEqual(rep.pixelsWide % width, 0, "bitmap width should be a whole multiple of the authored card width")
+        XCTAssertGreaterThan(rep.pixelsHigh, 0, "flexible-height card should rasterize with a positive height")
+    }
+
+    func testPNGDataRoundTripsToValidPNG() throws {
+        let image = try XCTUnwrap(ShareCardRenderer.image(for: sampleCard()))
+        let png = try XCTUnwrap(ShareCardRenderer.pngData(from: image))
+
+        XCTAssertFalse(png.isEmpty)
+        // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A.
+        let magic: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+        XCTAssertEqual(Array(png.prefix(magic.count)), magic)
+        // The PNG must decode back into an image (a non-empty Data alone isn't proof it's valid).
+        XCTAssertNotNil(NSImage(data: png))
+    }
+
+    func testRendersEmptyProviderWithoutCrashing() throws {
+        let card = ShareCardView(provider: MockData.cursor, plan: nil, rows: [], appearance: .dark)
+        let image = try XCTUnwrap(ShareCardRenderer.image(for: card))
+        let rep = try XCTUnwrap(image.representations.first)
+        // Same scale-agnostic width check; the point is it doesn't crash on an empty provider.
+        XCTAssertEqual(rep.pixelsWide % Int(ShareCardView.width), 0)
+        XCTAssertGreaterThan(rep.pixelsHigh, 0)
+    }
+}

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -26,7 +26,13 @@ Rows with a reset date tick every 30 seconds, so countdowns and pace stay live b
 ## Right-click menus
 
 Every row: **Hide · Pin to menu bar / Unpin · Refresh \<provider\> · Customize…**
-Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on under Settings ▸ Providers.)
+Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on under Settings ▸ Providers.) plus **Copy as Image** (see below).
+
+## Share
+
+Right-click a provider header and choose **Copy as Image** to copy a clean, branded PNG of that provider's usage to your clipboard, ready to paste into a chat, a tweet, or a doc.
+
+The image is a flexible-height PNG using the app's look — the provider's mark and name up top, the metric rows you currently see for that provider, and a small OpenUsage mark in the corner. It follows your Light/Dark appearance and shows everything on the card as-is (nothing is hidden or blurred).
 
 ## Footer
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -32,7 +32,7 @@ Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** 
 
 Right-click a provider header and choose **Copy as Image** to copy a clean, branded PNG of that provider's usage to your clipboard, ready to paste into a chat, a tweet, or a doc.
 
-The image is a flexible-height PNG using the app's look — the provider's mark and name up top, the metric rows you currently see for that provider, and a small OpenUsage mark in the corner. It follows your Light/Dark appearance and shows everything on the card as-is (nothing is hidden or blurred).
+The image is a flexible-height PNG using the app's look — the provider's mark and name up top, the metric rows you currently see for that provider, and a small OpenUsage mark centered at the bottom. It follows your Light/Dark appearance and shows everything on the card as-is (nothing is hidden or blurred).
 
 ## Footer
 


### PR DESCRIPTION
## TL;DR
Right-click a provider header and choose **Copy as Image** to copy a clean, branded PNG of that provider's usage to the clipboard. The card mirrors what the popover shows, drawn bigger, with flexible height and a centered OpenUsage tagline. Supersedes #772. Closes #762.

## What was happening
- #772 shipped a fixed 1200×675 (16:9) share card with a Copy/Save submenu. The authored canvas was large but the rows rendered at popover scale, so the card was ~60% whitespace with tiny text/bars, and the export changed with the popover density slider.
- The submenu offered Save-to-disk, which we don't want for the MVP.

## What this changes
- **Flexible height** — the card grows with its rows (no fixed canvas): collapsed providers export short, expanded ones tall, with little whitespace.
- **Much bigger** — authored at popover scale and rasterized at ×4, so fonts/bars are ~2× the prior export and the PNG is ~1440px wide.
- **Mirrors the popover** — always-shown rows, or all rows when the provider's caret is expanded.
- **Copy as Image** — single menu item, clipboard only. The save path, `NSSavePanel`, the `Action` enum, and the suggested-filename helper are removed.
- **Density-pinned** — the render always uses regular density (rows read density via `@AppStorage`; the saved value is swapped to `.regular` for the synchronous render and restored), so the export is consistent regardless of the popover density slider.
- **Footer** — a centered `(icon) Monitor Your AI Subscriptions with OpenUsage` tagline at the bottom. Header unchanged (provider mark + name + plan, leading).

## Heads-up
- `ImageRenderer.scale` isn't honored in headless CI (it rasterizes at ×1), so the tests assert scale-agnostic properties (bitmap width is a multiple of the authored card width) rather than `width × scale`. This fixes the CI failures #772 had.
- Supersedes #772 — close it on merge.

## Tests
`ShareCardRendererTests` (3, green locally): rasterize at authored-width multiple; PNG round-trips (magic bytes + re-decodes); empty provider doesn't crash. `swift build` clean.

## Screenshots
Pending — owner has light + dark PNGs (via Copy as Image ▸ paste into Preview) to attach before merge.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive (new files + one small hook in WidgetGroupedListView), all failure paths beep and log without crashing, and the synchronous UserDefaults density swap is correctly scoped with defer.

Both new files are standalone and additive. The density swap is synchronous on the main actor so the defer-based restore runs before any queued SwiftUI redraws. The condensing logic and its boundary handling are correct and covered by the new tests. Previous review threads have been addressed.

No files require special attention.

<sub>Reviews (5): Last reviewed commit: ["fix(share): match the popover&#39;s colorSch..."](https://github.com/robinebers/openusage/commit/80c1ae3d4058c90e340d35987d2fce74fad4bc6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40275818)</sub>

<!-- /greptile_comment -->