### PR TITLE
feat(providers): bring back provider quick-link buttons (#596)

### DIFF
--- a/Sources/OpenUsage/Models/Provider.swift
+++ b/Sources/OpenUsage/Models/Provider.swift
@@ -1,6 +1,38 @@
+import Foundation
+
 /// A data source that can register widgets it knows how to feed.
 struct Provider: Identifiable, Hashable {
     let id: String
     let displayName: String
     let icon: IconSource
+    /// Per-provider quick links (e.g. "Status", "Console") shown as buttons in the card's expanded area.
+    /// Declared inline by each provider; mirrors the legacy Tauri `PluginMeta.links`. Empty by default so
+    /// providers without links and the existing `Provider(id:displayName:icon:)` call sites need no change.
+    let links: [ProviderLink]
+
+    init(id: String, displayName: String, icon: IconSource, links: [ProviderLink] = []) {
+        self.id = id
+        self.displayName = displayName
+        self.icon = icon
+        self.links = links
+    }
+
+    /// Links safe to render: trimmed, non-empty label and URL, and an `http(s)` scheme only. Mirrors the
+    /// legacy `visibleLinks` filter so a malformed entry never ships a dead or no-op button.
+    var visibleLinks: [ProviderLink] {
+        links.compactMap { link in
+            let label = link.label.trimmingCharacters(in: .whitespacesAndNewlines)
+            let url = link.url.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !label.isEmpty,
+                  !url.isEmpty,
+                  url.hasPrefix("https://") || url.hasPrefix("http://") else { return nil }
+            return ProviderLink(label: label, url: url)
+        }
+    }
+}
+
+/// One external quick-link button on a provider card: a label and a URL opened in the default browser.
+struct ProviderLink: Hashable {
+    let label: String
+    let url: String
 }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -2,7 +2,15 @@ import Foundation
 
 @MainActor
 final class ClaudeProvider: ProviderRuntime {
-    let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+    let provider = Provider(
+        id: "claude",
+        displayName: "Claude",
+        icon: .providerMark("claude"),
+        links: [
+            .init(label: "Status", url: "https://status.anthropic.com/"),
+            .init(label: "Dashboard", url: "https://claude.ai/settings/usage")
+        ]
+    )
 
     let authStore: ClaudeAuthStore
     let usageClient: ClaudeUsageClient

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -2,7 +2,15 @@ import Foundation
 
 @MainActor
 final class CodexProvider: ProviderRuntime {
-    let provider = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+    let provider = Provider(
+        id: "codex",
+        displayName: "Codex",
+        icon: .providerMark("codex"),
+        links: [
+            .init(label: "Status", url: "https://status.openai.com/"),
+            .init(label: "Dashboard", url: "https://chatgpt.com/codex/settings/usage")
+        ]
+    )
 
     let authStore: CodexAuthStore
     let usageClient: CodexUsageClient

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -2,7 +2,15 @@ import Foundation
 
 @MainActor
 final class CursorProvider: ProviderRuntime {
-    let provider = Provider(id: "cursor", displayName: "Cursor", icon: .providerMark("cursor"))
+    let provider = Provider(
+        id: "cursor",
+        displayName: "Cursor",
+        icon: .providerMark("cursor"),
+        links: [
+            .init(label: "Status", url: "https://status.cursor.com/"),
+            .init(label: "Dashboard", url: "https://www.cursor.com/dashboard")
+        ]
+    )
 
     let authStore: CursorAuthStore
     let usageClient: CursorUsageClient

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -2,7 +2,14 @@ import Foundation
 
 @MainActor
 final class GrokProvider: ProviderRuntime {
-    let provider = Provider(id: "grok", displayName: "Grok", icon: .providerMark("grok"))
+    let provider = Provider(
+        id: "grok",
+        displayName: "Grok",
+        icon: .providerMark("grok"),
+        links: [
+            .init(label: "Usage", url: "https://grok.com/?_s=usage")
+        ]
+    )
 
     let authStore: GrokAuthStore
     let usageClient: GrokUsageClient

--- a/Sources/OpenUsage/Stores/DensitySetting.swift
+++ b/Sources/OpenUsage/Stores/DensitySetting.swift
@@ -91,4 +91,9 @@ enum DensitySetting: String, Hashable, Sendable, CaseIterable {
     /// The Customize "Shown on Expand" divider draws smaller than a metric row, while its invisible
     /// reorder frame stays row-sized so the drag threshold keeps matching normal rows.
     var customizeDividerRowHeight: CGFloat { self == .compact ? 24 : 28 }
+
+    /// Gap between cells in the dashboard's expanded-metrics grid (the area that opens below the
+    /// caret laying secondary metrics up to three across). Kept tight so two or three narrow cells
+    /// still read as one cluster, like the condensed text rows do in the single column above.
+    var expandedGridSpacing: CGFloat { self == .compact ? 4 : 6 }
 }

--- a/Sources/OpenUsage/Views/ProviderLinksView.swift
+++ b/Sources/OpenUsage/Views/ProviderLinksView.swift
@@ -1,0 +1,58 @@
+import AppKit
+import SwiftUI
+
+/// The row of per-provider quick-link buttons (e.g. "Status", "Console") shown in a provider card's
+/// expanded area. Lays out up to three across; extra links wrap to the next row. Each button opens its
+/// URL in the default browser. Mirrors the legacy Tauri `provider-card` quick-links row, adapted to the
+/// native card's expanded area (issue #596 — "bring back provider buttons").
+struct ProviderLinksView: View {
+    let links: [ProviderLink]
+    /// Matches the metric-row inset so the button row lines up with the rows above/below it. The
+    /// expanded-metrics grid passes a tighter value; links keep the full inset since they sit on their
+    /// own line, not inside a narrow cell.
+    var horizontalInset: CGFloat = 14
+
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    /// Hard ceiling from #596: never more than three buttons across, regardless of how many links a
+    /// provider ships. Fewer links use fewer columns so a lone button isn't boxed into a third of the row.
+    private static let maxColumns = 3
+
+    private var columns: [GridItem] {
+        let count = min(Self.maxColumns, max(1, links.count))
+        return Array(repeating: GridItem(.flexible(), spacing: density.expandedGridSpacing, alignment: .top),
+                     count: count)
+    }
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: density.expandedGridSpacing) {
+            ForEach(links, id: \.self) { link in
+                linkButton(link)
+            }
+        }
+        .padding(.horizontal, horizontalInset)
+        .padding(.top, density.textRowPadding)
+        .padding(.bottom, density.textRowPadding)
+    }
+
+    private func linkButton(_ link: ProviderLink) -> some View {
+        Button {
+            if let url = URL(string: link.url) {
+                NSWorkspace.shared.open(url)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(link.label)
+                    .font(.system(size: density.supportingPointSize, weight: .medium))
+                    .lineLimit(1)
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: density.supportingPointSize - 2))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .accessibilityLabel("\(link.label), opens in browser")
+    }
+}

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -85,6 +85,10 @@ struct WidgetGroupedListView: View {
     private enum DashboardMetricCardRow: Identifiable {
         case metric(ResolvedRow)
         case divider
+        /// #596: the provider's quick-link buttons (Status / Console / Dashboard ...), pinned at the
+        /// bottom of the collapsible expanded section. They collapse with the caret — part of the
+        /// expander, not always-visible chrome.
+        case links([ProviderLink])
 
         var id: String {
             switch self {
@@ -92,6 +96,8 @@ struct WidgetGroupedListView: View {
                 "metric:\(row.descriptor.id)"
             case .divider:
                 "expanded-divider"
+            case .links:
+                "provider-links"
             }
         }
     }
@@ -111,7 +117,8 @@ struct WidgetGroupedListView: View {
             alwaysRows: alwaysRows,
             expandedRows: expandedRows,
             hasExpandedMetrics: group.hasExpandedMetrics,
-            isExpanded: isExpanded
+            isExpanded: isExpanded,
+            links: group.provider.visibleLinks
         )
         // Same card builder the lifted preview uses, so the floating chip can't drift from the live card.
         return DashboardMetricCard {
@@ -123,6 +130,8 @@ struct WidgetGroupedListView: View {
                 case .metric(let entry):
                     row(entry.descriptor, data: entry.data, in: providerID,
                         condensedTop: condensedIDs.contains(entry.descriptor.id))
+                case .links(let links):
+                    ProviderLinksView(links: links)
                 case .divider:
                     expandToggle(providerID: providerID, isExpanded: isExpanded)
                 }
@@ -141,11 +150,19 @@ struct WidgetGroupedListView: View {
         alwaysRows: [ResolvedRow],
         expandedRows: [ResolvedRow],
         hasExpandedMetrics: Bool,
-        isExpanded: Bool
+        isExpanded: Bool,
+        links: [ProviderLink]
     ) -> [DashboardMetricCardRow] {
-        alwaysRows.map(DashboardMetricCardRow.metric)
-            + (hasExpandedMetrics ? [.divider] : [])
-            + (isExpanded ? expandedRows.map(DashboardMetricCardRow.metric) : [])
+        // #596: provider quick-link buttons live INSIDE the collapsible expanded section, pinned at its
+        // bottom, so collapsing the caret hides them along with the expanded metrics — they're part of
+        // the expander, not always-visible chrome. The caret shows for any provider with expanded
+        // content (metrics OR links), so a links-only provider still gets a caret to reveal its buttons.
+        let hasLinks = !links.isEmpty
+        let hasExpandedContent = hasExpandedMetrics || hasLinks
+        return alwaysRows.map(DashboardMetricCardRow.metric)
+            + (hasExpandedContent ? [.divider] : [])
+            + (isExpanded && !expandedRows.isEmpty ? expandedRows.map(DashboardMetricCardRow.metric) : [])
+            + (isExpanded && hasLinks ? [.links(links)] : [])
     }
 
     /// The centered caret at the bottom of a provider card that reveals or hides its "Shown on expand"
@@ -190,7 +207,8 @@ struct WidgetGroupedListView: View {
         return ids
     }
 
-    private func row(_ descriptor: WidgetDescriptor, data: WidgetData, in providerID: String, condensedTop: Bool) -> some View {
+    private func row(_ descriptor: WidgetDescriptor, data: WidgetData, in providerID: String,
+                     condensedTop: Bool) -> some View {
         let isActive = activeMetricID == descriptor.id
         return WidgetRowView(
             data: data,

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -297,7 +297,11 @@ struct WidgetGroupedListView: View {
             return []
         }
         let alwaysShown = group.alwaysShownWidgets.compactMap { layout.descriptor(for: $0)?.id }
-        guard group.hasExpandedMetrics, layout.isProviderExpanded(providerID) else { return alwaysShown }
+        // The caret is a drop target whenever the expanded section is open — including a links-only
+        // section (buttons but no expanded metrics), so a metric can be dragged past the caret to tuck
+        // it below the fold even when only buttons are showing there.
+        let hasExpandedContent = group.hasExpandedMetrics || !group.provider.visibleLinks.isEmpty
+        guard hasExpandedContent, layout.isProviderExpanded(providerID) else { return alwaysShown }
         let expanded = group.expandedWidgets.compactMap { layout.descriptor(for: $0)?.id }
         return alwaysShown + [expandedDividerID(for: providerID)] + expanded
     }

--- a/Tests/OpenUsageTests/ProviderLinksTests.swift
+++ b/Tests/OpenUsageTests/ProviderLinksTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import OpenUsage
+
+/// `Provider.visibleLinks` is the boundary that keeps a malformed link entry from shipping a dead or
+/// no-op button on the card. It mirrors the legacy Tauri `visibleLinks` filter: trim, require a
+/// non-empty label and URL, and accept `http(s)` schemes only.
+final class ProviderLinksTests: XCTestCase {
+    private func provider(_ links: [ProviderLink]) -> Provider {
+        Provider(id: "test", displayName: "Test", icon: .providerMark("test"), links: links)
+    }
+
+    func testNoLinksYieldsEmptyVisibleLinks() {
+        XCTAssertTrue(provider([]).visibleLinks.isEmpty)
+        XCTAssertTrue(provider([.init(label: "", url: "")]).visibleLinks.isEmpty)
+    }
+
+    func testKeepsValidHttpsAndHttp() {
+        let links = [
+            ProviderLink(label: "Status", url: "https://status.example.com/"),
+            ProviderLink(label: "HTTP", url: "http://example.com/dashboard")
+        ]
+        let visible = provider(links).visibleLinks
+        XCTAssertEqual(visible.count, 2)
+        XCTAssertEqual(visible[0].label, "Status")
+        XCTAssertEqual(visible[0].url, "https://status.example.com/")
+        XCTAssertEqual(visible[1].url, "http://example.com/dashboard")
+    }
+
+    func testDropsEmptyLabelOrUrl() {
+        let links = [
+            ProviderLink(label: "", url: "https://example.com/"),
+            ProviderLink(label: "No URL", url: ""),
+            ProviderLink(label: "Both", url: "https://example.com/")
+        ]
+        XCTAssertEqual(provider(links).visibleLinks.map(\.label), ["Both"])
+    }
+
+    func testDropsWhitespaceOnlyLabelOrUrl() {
+        let links = [
+            ProviderLink(label: "   ", url: "https://example.com/"),
+            ProviderLink(label: "Spaces", url: "   "),
+            ProviderLink(label: "Kept", url: "https://example.com/")
+        ]
+        XCTAssertEqual(provider(links).visibleLinks.map(\.label), ["Kept"])
+    }
+
+    func testTrimsLabelAndUrl() {
+        let visible = provider([.init(label: "  Status  ", url: "  https://status.example.com/  ")]).visibleLinks
+        XCTAssertEqual(visible.count, 1)
+        XCTAssertEqual(visible[0].label, "Status")
+        XCTAssertEqual(visible[0].url, "https://status.example.com/")
+    }
+
+    func testRejectsNonHttpSchemes() {
+        let links = [
+            ProviderLink(label: "FTP", url: "ftp://example.com/"),
+            ProviderLink(label: "JS", url: "javascript:alert(1)"),
+            ProviderLink(label: "Mail", url: "mailto:a@b.com"),
+            ProviderLink(label: "No scheme", url: "example.com"),
+            ProviderLink(label: "Kept", url: "https://example.com/")
+        ]
+        XCTAssertEqual(provider(links).visibleLinks.map(\.label), ["Kept"])
+    }
+
+    func testMixedSetKeepsOnlyValid() {
+        let links = [
+            ProviderLink(label: "Status", url: "https://status.anthropic.com/"),
+            ProviderLink(label: "", url: "https://console.anthropic.com/"),
+            ProviderLink(label: "Bad", url: "ftp://nope"),
+            ProviderLink(label: "Console", url: "https://console.anthropic.com/")
+        ]
+        XCTAssertEqual(provider(links).visibleLinks.map(\.label), ["Status", "Console"])
+    }
+}

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -60,3 +60,4 @@ factory only when there is no typed error, and never return stale or empty data 
 
 - Validate only at the boundary (the API response); trust the app's internal types.
 - Match the metric labels and units the provider's own dashboard uses, so numbers are recognizable.
+- Declare the provider's **quick links** on its `Provider` value (`links:`). Each link is a `ProviderLink(label:url:)` rendered as a button in the card's expanded area that opens the URL in the default browser. Ship the provider's own Status / Console / Dashboard pages where they exist; leave `links` off (it defaults to empty) for providers without any. Only `http(s)` URLs with a non-empty label render.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -4,6 +4,10 @@ The popover that opens from the menu bar icon. Providers are sections; each sect
 
 Each provider card leads with its **always-shown** metrics. Any metrics you've moved below the **Shown on Expand** line are tucked away behind the in-card caret — click it to reveal them below the caret, click again to collapse. Open cards stay open across popover closes and app restarts. A provider with nothing tucked away shows no caret.
 
+When you expand a card, the tucked-away metrics open below the caret as a single-column list, so each detail row keeps the full card width.
+
+A provider card can also show **quick-link buttons** pinned at the bottom of its expanded section — Status, Console, Dashboard, and the like — that open the provider's own pages in your default browser. They're part of the expander, so collapsing the caret hides them along with the tucked-away metrics. Buttons lay out up to three across, wrapping to a second row when there are more.
+
 ## Rows
 
 **Metrics with a limit** (session, weekly, credits with a cap) show a progress bar with:


### PR DESCRIPTION
## TL;DR
Brings back per-provider quick-link buttons (Status / Dashboard / Usage) in each provider card's expanded section, opening the provider's own pages in the default browser. Closes #596. Supersedes #774.

## What was happening
The native Swift rewrite dropped the legacy Tauri edition's per-provider quick-link buttons (Status / Console / Dashboard / Usage). Issue #596 asked to bring them back. #774 explored a 3-across expanded-metrics grid for #596 but didn't add the links, and that grid overflowed/overlapped text rows (Today / Yesterday / Last 30 Days) at the popover width.

## What this changes
- `Provider` gains a `links: [ProviderLink]` field (default `[]`) and a `visibleLinks` filter (trim, non-empty, `http(s)` only) — mirrors the legacy `visibleLinks` filter.
- Each provider declares its links inline (ported from the legacy `plugins/*/plugin.json`): Claude (Status, Dashboard), Codex (Status, Dashboard), Cursor (Status, Dashboard), Grok (Usage). Devin and Antigravity ship none.
- New `ProviderLinksView` renders the buttons in a `LazyVGrid` up to three across (wrapping when more); each opens its URL in the default browser via `NSWorkspace`.
- `WidgetGroupedListView` pins the button row at the bottom of the collapsible expanded section — collapsing the caret hides the buttons along with the expanded metrics. The caret now appears for any provider with expanded content (metrics **or** links), so a links-only provider still gets a caret.
- `DensitySetting` gains `expandedGridSpacing` for the button grid.
- #774's broken `ExpandedMetricsGrid` (and its test) are removed; expanded metrics stay single-column.

## Heads-up
- Supersedes #774 — its expanded-metrics-grid exploration is removed here. #774 can be closed.
- Links ride the runtime `Provider` value from `WidgetRegistry`; layout persistence is id-based, so no migration.
- The button grid reuses `expandedGridSpacing` (originally added by #774 for the metrics grid) — kept for the button spacing.

## Tests
- `ProviderLinksTests` covers `visibleLinks`: drops empty label/url, whitespace-only, and non-`http(s)` schemes; trims; keeps valid `http(s)`.
- `swift build` clean.

## Screenshots
Attached below — provider card expanded, buttons pinned at the bottom of the expanded section.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — additive feature with no changes to existing data paths, URL validation guarded by both the `visibleLinks` filter and the `if let url = URL(string:)` check in the button action.

The change is purely additive: new fields default to empty so existing providers need no update, URL handling is validated at two layers, the new view is well-isolated, and the test suite covers all edge cases of the filter. No existing functionality is modified in a way that could regress.

No files require special attention.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/OpenUsage/Views/WidgetGroupedListView.swift`, line 168-169 ([link](https://github.com/robinebers/openusage/blob/cbeb8bd060712ff958bc6c335080671d5d07b5cb/Sources/OpenUsage/Views/WidgetGroupedListView.swift#L168-L169)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The docstring still says the toggle is only shown for providers with expanded metrics, but after this change it is also shown for providers that have links and no expanded rows. Any future provider added with links-only would see the correct caret but a misleading doc comment here.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/OpenUsage/Views/WidgetGroupedListView.swift
   Line: 168-169

   Comment:
   The docstring still says the toggle is only shown for providers with expanded metrics, but after this change it is also shown for providers that have links and no expanded rows. Any future provider added with links-only would see the correct caret but a misleading doc comment here.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FOpenUsage%2FViews%2FWidgetGroupedListView.swift%0ALine%3A%20168-169%0A%0AComment%3A%0AThe%20docstring%20still%20says%20the%20toggle%20is%20only%20shown%20for%20providers%20with%20expanded%20metrics%2C%20but%20after%20this%20change%20it%20is%20also%20shown%20for%20providers%20that%20have%20links%20and%20no%20expanded%20rows.%20Any%20future%20provider%20added%20with%20links-only%20would%20see%20the%20correct%20caret%20but%20a%20misleading%20doc%20comment%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20The%20centered%20caret%20at%20the%20bottom%20of%20a%20provider%20card%20that%20reveals%20or%20hides%20its%20%22Shown%20on%20expand%22%0A%20%20%20%20%2F%2F%2F%20metrics.%20Rendered%20for%20any%20provider%20that%20has%20expanded%20content%20%E2%80%94%20expanded%20metrics%2C%20quick-link%20buttons%2C%0A%20%20%20%20%2F%2F%2F%20or%20both.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FOpenUsage%2FViews%2FWidgetGroupedListView.swift%0ALine%3A%20168-169%0A%0AComment%3A%0AThe%20docstring%20still%20says%20the%20toggle%20is%20only%20shown%20for%20providers%20with%20expanded%20metrics%2C%20but%20after%20this%20change%20it%20is%20also%20shown%20for%20providers%20that%20have%20links%20and%20no%20expanded%20rows.%20Any%20future%20provider%20added%20with%20links-only%20would%20see%20the%20correct%20caret%20but%20a%20misleading%20doc%20comment%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20The%20centered%20caret%20at%20the%20bottom%20of%20a%20provider%20card%20that%20reveals%20or%20hides%20its%20%22Shown%20on%20expand%22%0A%20%20%20%20%2F%2F%2F%20metrics.%20Rendered%20for%20any%20provider%20that%20has%20expanded%20content%20%E2%80%94%20expanded%20metrics%2C%20quick-link%20buttons%2C%0A%20%20%20%20%2F%2F%2F%20or%20both.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robinebers%2Fopenusage&pr=779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robinebers%2Fopenusage%22%20on%20the%20existing%20branch%20%22feat%2Fprovider-links%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fprovider-links%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FOpenUsage%2FViews%2FWidgetGroupedListView.swift%0ALine%3A%20168-169%0A%0AComment%3A%0AThe%20docstring%20still%20says%20the%20toggle%20is%20only%20shown%20for%20providers%20with%20expanded%20metrics%2C%20but%20after%20this%20change%20it%20is%20also%20shown%20for%20providers%20that%20have%20links%20and%20no%20expanded%20rows.%20Any%20future%20provider%20added%20with%20links-only%20would%20see%20the%20correct%20caret%20but%20a%20misleading%20doc%20comment%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%2F%20The%20centered%20caret%20at%20the%20bottom%20of%20a%20provider%20card%20that%20reveals%20or%20hides%20its%20%22Shown%20on%20expand%22%0A%20%20%20%20%2F%2F%2F%20metrics.%20Rendered%20for%20any%20provider%20that%20has%20expanded%20content%20%E2%80%94%20expanded%20metrics%2C%20quick-link%20buttons%2C%0A%20%20%20%20%2F%2F%2F%20or%20both.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robinebers%2Fopenusage&pr=779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): allow tucking a metric p..."](https://github.com/robinebers/openusage/commit/b6991bfdb3349559a5ab1adfbc04ee7bfe1d409e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40277007)</sub>

<!-- /greptile_comment -->