### PR TITLE
feat(cursor): price GLM 5.2 (high/max variants) in the spend manifest

### DIFF
--- a/Sources/OpenUsage/Resources/model_manifest.json
+++ b/Sources/OpenUsage/Resources/model_manifest.json
@@ -588,6 +588,17 @@
       "cache_read_per_million": 0.1,
       "output_per_million": 3.0,
       "apply_max_mode_uplift": true
+    },
+    "glm-5.2": {
+      "display_name": "GLM 5.2",
+      "provider": "zai",
+      "family_id": "glm-5.2",
+      "family_display_name": "GLM 5.2",
+      "input_per_million": 1.4,
+      "cache_write_per_million": 1.4,
+      "cache_read_per_million": 0.26,
+      "output_per_million": 4.4,
+      "apply_max_mode_uplift": true
     }
   },
   "alias_rules": [
@@ -651,6 +662,7 @@
     { "pattern": "^gpt-5\\.5(?:-(?:low|medium|high|xhigh|extra-high))?$", "canonical": "gpt-5.5" },
     { "pattern": "^kimi-k2\\.5$", "canonical": "kimi-k2.5" },
     { "pattern": "^kimi-k2p5$", "canonical": "kimi-k2.5" },
+    { "pattern": "^glm-5\\.2(?:-(?:high|max))?$", "canonical": "glm-5.2" },
     { "pattern": "^[Pp]remium \\((?:[Gg][Pp][Tt]-5\\.3-[Cc]odex|[Cc]odex 5\\.3)\\)$", "canonical": "gpt-5.3-codex" }
   ]
 }

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -82,6 +82,29 @@ final class CursorPricingTests: XCTestCase {
         XCTAssertEqual(fable.outputPerMillion, opus48.outputPerMillion * 2)
     }
 
+    /// GLM 5.2 (Z.ai) was added to Cursor's pricing page after the 2026-06-09 manifest sync. It ships
+    /// as two reasoning-effort variants — `glm-5.2-high` and `glm-5.2-max` — which both resolve to the
+    /// one canonical `glm-5.2` entry. The pricing page lists no separate cache-write price, so cache
+    /// write is billed at the input rate ($1.4), matching how the Gemini/GPT entries are filled.
+    func testGLM52PricingAndAliases() throws {
+        XCTAssertEqual(CursorPricing.canonicalModel(for: "glm-5.2"), "glm-5.2")
+        XCTAssertEqual(CursorPricing.canonicalModel(for: "glm-5.2-high"), "glm-5.2")
+        XCTAssertEqual(CursorPricing.canonicalModel(for: "glm-5.2-max"), "glm-5.2")
+
+        let glm = try XCTUnwrap(CursorPricing.pricingEntry(for: "glm-5.2-max"))
+        XCTAssertEqual(glm.familyDisplayName, "GLM 5.2")
+        XCTAssertEqual(glm.inputPerMillion, 1.4)
+        XCTAssertEqual(glm.cacheWritePerMillion, 1.4)
+        XCTAssertEqual(glm.cacheReadPerMillion, 0.26)
+        XCTAssertEqual(glm.outputPerMillion, 4.4)
+
+        // 1M output at $4.4/M → $4.40; a slug outside the high/max allowlist stays unpriced ($0).
+        let outputOnly = CursorTokenUsage(inputCacheWrite: 0, inputNoCacheWrite: 0, cacheRead: 0, output: 1_000_000)
+        XCTAssertEqual(CursorPricing.estimatedCostDollars(model: "glm-5.2-high", maxMode: false, tokens: outputOnly), 4.4, accuracy: 1e-9)
+        XCTAssertNil(CursorPricing.canonicalModel(for: "glm-5.2-bogus"))
+        XCTAssertEqual(CursorPricing.estimatedCostDollars(model: "glm-5.2-bogus", maxMode: false, tokens: outputOnly), 0, accuracy: 1e-9)
+    }
+
     func testCostSumsAllFourBucketsAndUnpricedIsZero() {
         let entry = try! XCTUnwrap(CursorPricing.pricingEntry(for: "composer-1"))
         let tokens = CursorTokenUsage(


### PR DESCRIPTION
## TL;DR
Adds GLM 5.2 (Z.ai) to Cursor's bundled pricing manifest so its `glm-5.2-high` and `glm-5.2-max` variants price correctly instead of imputing $0.

## What was happening
- GLM 5.2 is listed on Cursor's pricing page ($1.4 in / $0.26 cache read / $4.4 out) but had no entry in `model_manifest.json` and no alias rule.
- Both variants Cursor ships (`glm-5.2-high`, `glm-5.2-max`) therefore resolved to "unknown" and priced at $0 in the spend imputation path (`CursorPricing.estimatedCostDollars` returns 0 for unknown models).

## What this changes
- Adds a `glm-5.2` pricing entry: input $1.4, cache write $1.4 (billed at the input rate — the pricing page lists no separate cache-write price, same convention as the Gemini/GPT entries), cache read $0.26, output $4.4, provider `zai`, `apply_max_mode_uplift: true`.
- Adds an alias rule `^glm-5\.2(?:-(?:high|max))?$` → `glm-5.2`, so bare `glm-5.2`, `glm-5.2-high`, and `glm-5.2-max` all resolve to the one canonical entry. Slugs outside that allowlist (e.g. `glm-5.2-bogus`) stay unpriced.
- Adds `testGLM52PricingAndAliases` covering all three IDs, the four price fields, a 1M-output = $4.40 cost check, and the negative (non-variant) case.

## Heads-up
- `apply_max_mode_uplift` is metadata-only here — the cost model bills at the base rate regardless (see `CursorModelManifest.swift`), so it doesn't affect spend math. Set to `true` to match the majority pattern; the pricing page has no Max Mode note for GLM 5.2.
- `retrieved_at` left at `2026-06-09` — this is a targeted patch, not a full re-sync.
- No visual change: Cursor spend tiles are still disabled per #758/#760, so GLM pricing won't render in the app until that flag flips back. The manifest + test are ready for when it does.

## Tests
`swift test --filter Cursor` → 25 passed, 0 failures, including the new `testGLM52PricingAndAliases`. Manifest JSON validated as well-formed.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure data addition with no changes to pricing logic or application code paths.

Both changed files are additive only: a new JSON object in the manifest and a new test function. The alias regex correctly anchors with ^ and $, escapes the literal dot, and the optional suffix group covers exactly the two known Cursor slugs. Price values match the source and the test exercises the full round-trip from alias resolution through cost calculation.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["feat(cursor): price GLM 5.2 in the spend..."](https://github.com/robinebers/openusage/commit/84cf46f808a2f498aee63e355771d25d5aec6a73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40281359)</sub>

<!-- /greptile_comment -->