### PR TITLE
feat(appearance): Increase Transparency toggle + secret-code Party/Drunk easter egg

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -22,6 +22,10 @@ final class AppContainer {
     /// Anonymous, opt-out usage telemetry (daily rollups). Exposed so Settings can toggle it and the
     /// app-termination hook can flush any queued events.
     let telemetry: TelemetryRecorder
+    /// Source of truth for the popover's transparency: the persisted Increase Transparency toggle, the
+    /// ephemeral secret-code easter-egg state, and the system accessibility flags it yields to. Read by both
+    /// the SwiftUI surface and the AppKit panel (`StatusItemController`).
+    let transparency: PopoverTransparencyStore
     /// Read-only usage API on 127.0.0.1:6736 for other local apps (silently off when the port is taken).
     private let localAPI: LocalUsageServer
     // A `let` of a `Sendable` `Task` is implicitly nonisolated, so the nonisolated `deinit` can cancel it.
@@ -103,6 +107,7 @@ final class AppContainer {
             telemetry?.record(providerID: providerID, outcome: outcome, category: category, manual: manual)
         }
         self.telemetry = telemetry
+        self.transparency = PopoverTransparencyStore()
         self.localAPI = LocalUsageServer(state: { [layout, enablement, dataStore] in
             LocalUsageAPI.State(
                 enabledOrderedIDs: layout.providerOrder.filter { enablement.isEnabled($0) },

--- a/Sources/OpenUsage/App/PopoverBackdropView.swift
+++ b/Sources/OpenUsage/App/PopoverBackdropView.swift
@@ -1,0 +1,81 @@
+import AppKit
+
+/// The popover panel's backdrop: two full-frame layers built once and switched by visibility.
+///
+/// `.opaque` shows a solid `NSBox` (the `Theme.trayNSColor` tray) so the data region never reveals the
+/// desktop — the app's default look. `.translucent` shows a behind-window `NSVisualEffectView` that
+/// samples the desktop with vibrancy, which is the HIG-correct way to "increase transparency" (SwiftUI
+/// `glassEffect`/`Material` only sample in-app content, so they can't show the desktop).
+///
+/// Both children are permanent and pinned to the full frame: rebuilding on toggle would race the
+/// observer that drives `mode`, and a partial frame could reveal a transparent strip during the panel's
+/// height morph. The vibrancy view carries a stretchable rounded `maskImage` because behind-window blur
+/// is composited by the window server and doesn't reliably honor a parent layer's corner masking.
+final class PopoverBackdropView: NSView {
+    enum Mode { case opaque, translucent }
+
+    private let opaqueBox = NSBox()
+    private let vibrancy = NSVisualEffectView()
+
+    init(cornerRadius: CGFloat) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        opaqueBox.boxType = .custom
+        opaqueBox.titlePosition = .noTitle
+        opaqueBox.borderWidth = 0
+        opaqueBox.cornerRadius = cornerRadius
+        opaqueBox.contentViewMargins = .zero
+        opaqueBox.fillColor = Theme.trayNSColor
+        opaqueBox.translatesAutoresizingMaskIntoConstraints = false
+
+        vibrancy.material = .popover
+        vibrancy.blendingMode = .behindWindow
+        vibrancy.state = .active
+        vibrancy.maskImage = Self.roundedMaskImage(cornerRadius: cornerRadius)
+        vibrancy.isHidden = true
+        vibrancy.translatesAutoresizingMaskIntoConstraints = false
+
+        // The opaque box sits above the vibrancy view so the default look fully covers it; only one is
+        // ever visible at a time, so the order is just defensive.
+        addSubview(vibrancy)
+        addSubview(opaqueBox, positioned: .above, relativeTo: vibrancy)
+        NSLayoutConstraint.activate([
+            vibrancy.leadingAnchor.constraint(equalTo: leadingAnchor),
+            vibrancy.trailingAnchor.constraint(equalTo: trailingAnchor),
+            vibrancy.topAnchor.constraint(equalTo: topAnchor),
+            vibrancy.bottomAnchor.constraint(equalTo: bottomAnchor),
+            opaqueBox.leadingAnchor.constraint(equalTo: leadingAnchor),
+            opaqueBox.trailingAnchor.constraint(equalTo: trailingAnchor),
+            opaqueBox.topAnchor.constraint(equalTo: topAnchor),
+            opaqueBox.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Which backdrop layer is showing. Driven by `StatusItemController` from the transparency style.
+    var mode: Mode = .opaque {
+        didSet {
+            guard mode != oldValue else { return }
+            opaqueBox.isHidden = (mode != .opaque)
+            vibrancy.isHidden = (mode == .opaque)
+        }
+    }
+
+    /// A stretchable rounded-rectangle mask: a small rounded square whose cap insets equal the corner
+    /// radius, so AppKit tiles the flat center and keeps crisp corners at any size.
+    private static func roundedMaskImage(cornerRadius: CGFloat) -> NSImage {
+        let side = cornerRadius * 2 + 1
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            NSColor.black.setFill()
+            NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius).fill()
+            return true
+        }
+        image.capInsets = NSEdgeInsets(top: cornerRadius, left: cornerRadius,
+                                       bottom: cornerRadius, right: cornerRadius)
+        image.resizingMode = .stretch
+        return image
+    }
+}

--- a/Sources/OpenUsage/App/PopoverBackdropView.swift
+++ b/Sources/OpenUsage/App/PopoverBackdropView.swift
@@ -8,14 +8,17 @@ import AppKit
 /// `glassEffect`/`Material` only sample in-app content, so they can't show the desktop).
 ///
 /// Both children are permanent and pinned to the full frame: rebuilding on toggle would race the
-/// observer that drives `mode`, and a partial frame could reveal a transparent strip during the panel's
-/// height morph. The vibrancy view carries a stretchable rounded `maskImage` because behind-window blur
-/// is composited by the window server and doesn't reliably honor a parent layer's corner masking.
+/// observer that drives the mode, and a partial frame could reveal a transparent strip during the
+/// panel's height morph. The mode switch is an **alpha crossfade** (both layers stay mounted, one fades
+/// out as the other fades in) so enabling/disabling the egg eases rather than snaps. The vibrancy view
+/// carries a stretchable rounded `maskImage` because behind-window blur is composited by the window
+/// server and doesn't reliably honor a parent layer's corner masking.
 final class PopoverBackdropView: NSView {
     enum Mode { case opaque, translucent }
 
     private let opaqueBox = NSBox()
     private let vibrancy = NSVisualEffectView()
+    private var currentMode: Mode = .opaque
 
     init(cornerRadius: CGFloat) {
         super.init(frame: .zero)
@@ -27,13 +30,15 @@ final class PopoverBackdropView: NSView {
         opaqueBox.cornerRadius = cornerRadius
         opaqueBox.contentViewMargins = .zero
         opaqueBox.fillColor = Theme.trayNSColor
+        opaqueBox.wantsLayer = true                 // layer-backed so alphaValue animates
         opaqueBox.translatesAutoresizingMaskIntoConstraints = false
 
         vibrancy.material = .popover
         vibrancy.blendingMode = .behindWindow
         vibrancy.state = .active
         vibrancy.maskImage = Self.roundedMaskImage(cornerRadius: cornerRadius)
-        vibrancy.isHidden = true
+        vibrancy.wantsLayer = true
+        vibrancy.alphaValue = 0                      // starts hidden; opaque tray is the default look
         vibrancy.translatesAutoresizingMaskIntoConstraints = false
 
         // The opaque box sits above the vibrancy view so the default look fully covers it; only one is
@@ -55,12 +60,21 @@ final class PopoverBackdropView: NSView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-    /// Which backdrop layer is showing. Driven by `StatusItemController` from the transparency style.
-    var mode: Mode = .opaque {
-        didSet {
-            guard mode != oldValue else { return }
-            opaqueBox.isHidden = (mode != .opaque)
-            vibrancy.isHidden = (mode == .opaque)
+    /// Crossfades to the given backdrop layer. Driven by `StatusItemController` from the transparency
+    /// style; pass `animated: false` for the initial state so launch doesn't fade in. When `animated`,
+    /// the caller wraps this in the same `NSAnimationContext` group as the window-alpha change so they
+    /// ease together.
+    func setMode(_ mode: Mode, animated: Bool) {
+        guard mode != currentMode else { return }
+        currentMode = mode
+        let opaqueAlpha: CGFloat = mode == .opaque ? 1 : 0
+        let vibrancyAlpha: CGFloat = mode == .opaque ? 0 : 1
+        if animated {
+            opaqueBox.animator().alphaValue = opaqueAlpha
+            vibrancy.animator().alphaValue = vibrancyAlpha
+        } else {
+            opaqueBox.alphaValue = opaqueAlpha
+            vibrancy.alphaValue = vibrancyAlpha
         }
     }
 

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -245,11 +245,19 @@ final class StatusItemController: NSObject {
 
     // MARK: - Transparency
 
+    /// True once the launch application has run, so subsequent style changes animate (the first one
+    /// shouldn't fade in from nothing).
+    private var hasAppliedTransparency = false
+
     /// Applies the resolved transparency style to the panel and re-arms on the next change. Mirrors
     /// `updateButtonImage`'s `withObservationTracking` re-arm (its `onChange` is one-shot). Reads the
     /// store's `effectiveStyle`, which folds in the persisted toggle, the egg state, and the system
     /// accessibility flags — so this fires whenever any of them changes. Backdrop already exists (it's a
     /// stored property), so the first call from `init` safely sets the initial look.
+    ///
+    /// On every change after launch the window alpha and the backdrop crossfade ease together in one
+    /// ~0.55s group, matching the SwiftUI side (`tooMuchTransparency`'s `.animation`), so toggling the
+    /// egg or Increase Transparency fades in and out instead of snapping.
     private func applyTransparency() {
         let style = withObservationTracking {
             container.transparency.effectiveStyle
@@ -258,8 +266,20 @@ final class StatusItemController: NSObject {
                 self?.applyTransparency()
             }
         }
-        backdrop.mode = style.surfaceTreatment == .opaque ? .opaque : .translucent
-        panel.alphaValue = style.windowAlpha
+        let mode: PopoverBackdropView.Mode = style.surfaceTreatment == .opaque ? .opaque : .translucent
+        if hasAppliedTransparency {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.55
+                context.allowsImplicitAnimation = true
+                panel.animator().alphaValue = style.windowAlpha
+                backdrop.setMode(mode, animated: true)
+            }
+        } else {
+            hasAppliedTransparency = true
+            panel.alphaValue = style.windowAlpha
+            backdrop.setMode(mode, animated: false)
+        }
+        // Shadow isn't animatable; set it directly (the crossfade masks the change).
         panel.hasShadow = style.wantsShadow
         panel.invalidateShadow()
     }

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -154,7 +154,7 @@ final class StatusItemController: NSObject {
         // Backdrop: by default an opaque tray so the data region never shows the desktop through it
         // (Liquid Glass stays reserved for the footer chrome, rendered in-window over this backing). The
         // `PopoverBackdropView` also holds a behind-window vibrancy layer that the transparency style
-        // swaps in for Increase Transparency / the ghost egg. It fills the whole window, so a
+        // swaps in for Increase Transparency / the secret-code egg. It fills the whole window, so a
         // screen-switch resize can't reveal a transparent strip, and any region SwiftUI leaves unpainted
         // shows the backdrop, not a raw hole. Its opaque tray is `Theme.trayNSColor` (tracks light/dark
         // and the forced appearance override) matching the SwiftUI tray (`DashboardView.PopoverSurface`),

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -343,6 +343,11 @@ final class StatusItemController: NSObject {
             AppLog.error(.statusItem, "Cannot show panel: status item has no button")
             return
         }
+        // Mark the popover on-screen before laying out, so the egg's animation loops mount their
+        // `TimelineView` clocks in time for the first displayed frame. Read by the SwiftUI egg via
+        // `\.popoverIsVisible`; a closed popover keeps the loops unmounted, so a left-on egg costs no CPU.
+        container.transparency.setPopoverShown(true)
+
         // Drop any morph heights still queued from a previous session so a quick reopen during an old
         // spring can't apply a stale height to this fresh open.
         PanelHeightBridge.invalidate()
@@ -384,6 +389,10 @@ final class StatusItemController: NSObject {
         if panel.isVisible {
             PanelHeightStore.save(panel.frame.height, for: container.layout.screen)
         }
+        // Closing: drop the on-screen flag so the egg's animation loops unmount their `TimelineView`
+        // clocks and stop ticking — the whole point of the gate (no CPU while the egg is left on but the
+        // popover is hidden). This is the authoritative hide signal, flipped synchronously with `orderOut`.
+        container.transparency.setPopoverShown(false)
         panel.orderOut(nil)
         stopOutsideClickMonitors()
         statusItem.button?.highlight(false)

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -30,6 +30,9 @@ final class StatusItemController: NSObject {
     private let statusItem: NSStatusItem
     private let panel: MenuBarPanel
     private let hostingController: NSHostingController<AnyView>
+    /// The panel's backdrop: an opaque tray by default, swapped to a behind-window vibrancy view when
+    /// the transparency style is non-opaque. Built once and toggled, so it can't race the style observer.
+    private let backdrop = PopoverBackdropView(cornerRadius: StatusItemController.cornerRadius)
     /// The screen the status-item button is on, captured on show — used to clamp the saved panel size
     /// to whatever display the panel is currently opening on.
     private var anchorScreen: NSScreen?
@@ -74,6 +77,7 @@ final class StatusItemController: NSObject {
                     .environment(container)
                     .environment(container.layout)
                     .environment(container.dataStore)
+                    .environment(container.transparency)
                     .environment(updater)
             )
         )
@@ -94,6 +98,7 @@ final class StatusItemController: NSObject {
         configurePanel()
         configureStatusItem()
         updateButtonImage()
+        applyTransparency()
 
         appearanceObserver = NotificationCenter.default.addObserver(
             forName: AppearanceSetting.didChangeNotification,
@@ -146,24 +151,14 @@ final class StatusItemController: NSObject {
 
         let container = NSView()
 
-        // Opaque backdrop: the popover is a solid panel — the data region never shows the desktop
-        // through it. Liquid Glass is reserved for the footer chrome (its frosted bar + controls),
-        // rendered in-window over this opaque backing, never behind the data. The box fills the whole
-        // window, so a screen-switch resize can't briefly reveal a transparent strip beneath the
-        // content-sized SwiftUI surface, and any region SwiftUI leaves unpainted shows this opaque
-        // tray, not a hole to the desktop. `Theme.trayNSColor` tracks light/dark (and the forced
-        // appearance override) and matches the SwiftUI tray (`DashboardView.PopoverSurface`); rounded
-        // via `cornerRadius` so it follows the panel's shape. `panel.appearance` (tracked by
-        // `appearanceObserver`) pins the light/dark mode.
-        let backdrop = NSBox()
-        backdrop.boxType = .custom
-        backdrop.titlePosition = .noTitle
-        backdrop.borderWidth = 0
-        backdrop.cornerRadius = Self.cornerRadius
-        backdrop.contentViewMargins = .zero
-        backdrop.fillColor = Theme.trayNSColor
-        backdrop.translatesAutoresizingMaskIntoConstraints = false
-
+        // Backdrop: by default an opaque tray so the data region never shows the desktop through it
+        // (Liquid Glass stays reserved for the footer chrome, rendered in-window over this backing). The
+        // `PopoverBackdropView` also holds a behind-window vibrancy layer that the transparency style
+        // swaps in for Increase Transparency / the ghost egg. It fills the whole window, so a
+        // screen-switch resize can't reveal a transparent strip, and any region SwiftUI leaves unpainted
+        // shows the backdrop, not a raw hole. Its opaque tray is `Theme.trayNSColor` (tracks light/dark
+        // and the forced appearance override) matching the SwiftUI tray (`DashboardView.PopoverSurface`),
+        // rounded via `cornerRadius`. `panel.appearance` (tracked by `appearanceObserver`) pins the mode.
         let host = hostingController.view
         host.translatesAutoresizingMaskIntoConstraints = false
         host.wantsLayer = true
@@ -246,6 +241,27 @@ final class StatusItemController: NSObject {
         return MenuBarStripRenderer.image(for: content, style: container.layout.menuBarStyle)
             ?? MenuBarIcon.image
             ?? MenuBarStripRenderer.fallbackIcon
+    }
+
+    // MARK: - Transparency
+
+    /// Applies the resolved transparency style to the panel and re-arms on the next change. Mirrors
+    /// `updateButtonImage`'s `withObservationTracking` re-arm (its `onChange` is one-shot). Reads the
+    /// store's `effectiveStyle`, which folds in the persisted toggle, the egg state, and the system
+    /// accessibility flags — so this fires whenever any of them changes. Backdrop already exists (it's a
+    /// stored property), so the first call from `init` safely sets the initial look.
+    private func applyTransparency() {
+        let style = withObservationTracking {
+            container.transparency.effectiveStyle
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.applyTransparency()
+            }
+        }
+        backdrop.mode = style.surfaceTreatment == .opaque ? .opaque : .translucent
+        panel.alphaValue = style.windowAlpha
+        panel.hasShadow = style.wantsShadow
+        panel.invalidateShadow()
     }
 
     // MARK: - Show / hide

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
@@ -2,8 +2,8 @@ import AppKit
 import Observation
 
 /// Single source of truth for the popover's transparency: the persisted "Increase Transparency"
-/// preference, the ephemeral secret-code easter-egg state, and the live macOS accessibility flags the proper
-/// toggle must yield to. Both SwiftUI (via `surfaceTreatment`) and the AppKit panel
+/// preference, the ephemeral secret-code easter-egg state, and the live macOS accessibility flags that
+/// both the proper toggle and the egg must yield to. Both SwiftUI (via `surfaceTreatment`) and the AppKit panel
 /// (`StatusItemController`, via `effectiveStyle`) read this one store, so the SwiftUI surface and the
 /// window can't drift apart.
 @MainActor
@@ -35,12 +35,17 @@ final class PopoverTransparencyStore {
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private var accessibilityObservation: Task<Void, Never>?
 
-    init(defaults: UserDefaults = .standard) {
+    init(
+        defaults: UserDefaults = .standard,
+        reduceTransparency: Bool = NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency,
+        increaseContrast: Bool = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
+    ) {
         self.defaults = defaults
         self.increaseTransparency = defaults.bool(forKey: Self.key)
-        let workspace = NSWorkspace.shared
-        self.reduceTransparency = workspace.accessibilityDisplayShouldReduceTransparency
-        self.increaseContrast = workspace.accessibilityDisplayShouldIncreaseContrast
+        // The flags default to the live `NSWorkspace` values (production) but are injectable so tests can
+        // pin them and exercise the accessibility clamp deterministically, independent of the test host.
+        self.reduceTransparency = reduceTransparency
+        self.increaseContrast = increaseContrast
         startObservingAccessibility()
     }
 
@@ -91,6 +96,13 @@ final class PopoverTransparencyStore {
     /// — so Settings can show a friendly "paused" note instead of silently doing nothing.
     var isPaused: Bool {
         increaseTransparency && (reduceTransparency || increaseContrast)
+    }
+
+    /// True when the egg is active but a system accessibility setting (Reduce Transparency / Increase
+    /// Contrast) is clamping the panel back to opaque — so Settings can explain why the party looks
+    /// normal rather than leaving the user puzzled that the code "did nothing".
+    var partyPaused: Bool {
+        secretCodeActive && (reduceTransparency || increaseContrast)
     }
 
     /// Accessibility display options post to `NSWorkspace`'s OWN notification center (never `.default`).

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
@@ -1,0 +1,94 @@
+import AppKit
+import Observation
+
+/// Single source of truth for the popover's transparency: the persisted "Increase Transparency"
+/// preference, the ephemeral secret-code easter-egg state, and the live macOS accessibility flags the proper
+/// toggle must yield to. Both SwiftUI (via `surfaceTreatment`) and the AppKit panel
+/// (`StatusItemController`, via `effectiveStyle`) read this one store, so the SwiftUI surface and the
+/// window can't drift apart.
+@MainActor
+@Observable
+final class PopoverTransparencyStore {
+    static let key = "increaseTransparency"
+
+    /// The persisted preference (default off). Stored here rather than as a view-local `@AppStorage` so
+    /// the AppKit panel honors exactly the value the Settings toggle writes. The no-op guard avoids a
+    /// redundant defaults write (and the firehose `UserDefaults.didChangeNotification` it would emit).
+    var increaseTransparency: Bool {
+        didSet {
+            guard increaseTransparency != oldValue else { return }
+            defaults.set(increaseTransparency, forKey: Self.key)
+        }
+    }
+
+    /// Ephemeral easter-egg state. Never persisted: it clears on quit, but survives panel open/close
+    /// within a run, so the only way out is re-typing the code.
+    private(set) var secretCodeActive = false
+    /// "Even More" — only meaningful while `secretCodeActive`. Cleared whenever the egg turns off.
+    var evenMore = false
+
+    /// Live system accessibility flags. Read from `NSWorkspace` and refreshed on the change notification.
+    private(set) var reduceTransparency: Bool
+    private(set) var increaseContrast: Bool
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private var accessibilityObservation: Task<Void, Never>?
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.increaseTransparency = defaults.bool(forKey: Self.key)
+        let workspace = NSWorkspace.shared
+        self.reduceTransparency = workspace.accessibilityDisplayShouldReduceTransparency
+        self.increaseContrast = workspace.accessibilityDisplayShouldIncreaseContrast
+        startObservingAccessibility()
+    }
+
+    deinit { accessibilityObservation?.cancel() }
+
+    /// Toggled by `TooMuchTransparencyKeyReader` when the full code is entered — so a second entry turns
+    /// the egg off.
+    func toggleSecretCode() {
+        secretCodeActive.toggle()
+        if !secretCodeActive { evenMore = false }
+        AppLog.info(.statusItem, "Too-much-transparency egg \(secretCodeActive ? "enabled" : "disabled")")
+    }
+
+    /// The resolved level both the panel and the SwiftUI surface render.
+    var effectiveStyle: PopoverTransparencyStyle {
+        PopoverTransparencyStyle.resolve(
+            increaseTransparency: increaseTransparency,
+            secretCodeActive: secretCodeActive,
+            evenMore: evenMore,
+            reduceTransparency: reduceTransparency,
+            increaseContrast: increaseContrast
+        )
+    }
+
+    /// SwiftUI surface treatment derived from the resolved style.
+    var surfaceTreatment: PopoverSurfaceTreatment { effectiveStyle.surfaceTreatment }
+
+    /// True when the user turned the proper toggle on but a system accessibility setting is overriding it
+    /// — so Settings can show a friendly "paused" note instead of silently doing nothing.
+    var isPaused: Bool {
+        increaseTransparency && (reduceTransparency || increaseContrast)
+    }
+
+    /// Accessibility display options post to `NSWorkspace`'s OWN notification center (never `.default`).
+    /// The notification carries no payload, so we ignore it and re-read the flags on the main actor —
+    /// which also sidesteps the non-`Sendable` `Notification` under Swift 6 strict concurrency.
+    private func startObservingAccessibility() {
+        let center = NSWorkspace.shared.notificationCenter
+        let name = NSWorkspace.accessibilityDisplayOptionsDidChangeNotification
+        accessibilityObservation = Task { [weak self] in
+            for await _ in center.notifications(named: name) {
+                self?.refreshAccessibilityFlags()
+            }
+        }
+    }
+
+    private func refreshAccessibilityFlags() {
+        let workspace = NSWorkspace.shared
+        reduceTransparency = workspace.accessibilityDisplayShouldReduceTransparency
+        increaseContrast = workspace.accessibilityDisplayShouldIncreaseContrast
+    }
+}

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
@@ -47,11 +47,30 @@ final class PopoverTransparencyStore {
     deinit { accessibilityObservation?.cancel() }
 
     /// Toggled by `TooMuchTransparencyKeyReader` when the full code is entered — so a second entry turns
-    /// the egg off.
+    /// the egg off. Exiting drops back to the base state (Normal / Increase Transparency): the persisted
+    /// `increaseTransparency` is preserved untouched (its Settings toggle is disabled while the egg runs),
+    /// so the resolver returns to whichever base the user was in before.
     func toggleSecretCode() {
-        secretCodeActive.toggle()
-        if !secretCodeActive { drunkMode = false }
-        AppLog.info(.statusItem, "Too-much-transparency egg \(secretCodeActive ? "enabled" : "disabled")")
+        setSecretCode(!secretCodeActive)
+    }
+
+    /// The Settings "Party Mode" toggle (shown only while the egg is active). Reading mirrors the egg
+    /// state; setting it `false` exits the egg entirely — the only way *in* is the secret code, so the
+    /// toggle is never rendered while off and `set(true)` can't be reached from the UI. Turning it off
+    /// from "Party Mode + Drunk Mode" also clears Drunk Mode (you can't be drunk without the party), so
+    /// both rows disappear together.
+    var partyModeActive: Bool {
+        get { secretCodeActive }
+        set { setSecretCode(newValue) }
+    }
+
+    /// Single point that flips the egg, so the cheat code and the Party Mode toggle share one exit path:
+    /// leaving the egg always clears Drunk Mode (state 4 → base, never a dangling drunk-without-party).
+    private func setSecretCode(_ active: Bool) {
+        guard active != secretCodeActive else { return }
+        secretCodeActive = active
+        if !active { drunkMode = false }
+        AppLog.info(.statusItem, "Too-much-transparency egg \(active ? "enabled" : "disabled")")
     }
 
     /// The resolved level both the panel and the SwiftUI surface render.

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
@@ -28,6 +28,16 @@ final class PopoverTransparencyStore {
     /// `secretCodeActive`; cleared whenever the egg turns off.
     var drunkMode = false
 
+    /// Whether the popover is currently on-screen (ordered-on). Runtime-transient like `secretCodeActive`
+    /// — never persisted. Set by `StatusItemController` at its `showPanel`/`hidePanel` chokepoints (the
+    /// authoritative on-screen state, flipped synchronously with `makeKeyAndOrderFront`/`orderOut`) and
+    /// read by the SwiftUI egg via `\.popoverIsVisible` to **mount** its animation loops only while
+    /// visible — so a closed popover with the egg still active spends no CPU animating. Deliberately NOT
+    /// derived from occlusion or window key state: a `.canJoinAllSpaces` panel is briefly fully occluded
+    /// mid Space-switch while still following the user on-screen, so an occlusion gate would freeze the
+    /// animation on the very panel the user is now looking at.
+    private(set) var popoverShown = false
+
     /// Live system accessibility flags. Read from `NSWorkspace` and refreshed on the change notification.
     private(set) var reduceTransparency: Bool
     private(set) var increaseContrast: Bool
@@ -78,6 +88,14 @@ final class PopoverTransparencyStore {
         AppLog.info(.statusItem, "Too-much-transparency egg \(active ? "enabled" : "disabled")")
     }
 
+    /// Flips the on-screen flag from `StatusItemController`'s show/hide chokepoints. Guards on change so a
+    /// redundant set doesn't churn observers. Orthogonal to `effectiveStyle` (it never enters `resolve`),
+    /// so toggling it re-renders only the SwiftUI egg's mount gate, never the AppKit backdrop crossfade.
+    func setPopoverShown(_ shown: Bool) {
+        guard shown != popoverShown else { return }
+        popoverShown = shown
+    }
+
     /// The resolved level both the panel and the SwiftUI surface render.
     var effectiveStyle: PopoverTransparencyStyle {
         PopoverTransparencyStyle.resolve(
@@ -91,6 +109,15 @@ final class PopoverTransparencyStore {
 
     /// SwiftUI surface treatment derived from the resolved style.
     var surfaceTreatment: PopoverSurfaceTreatment { effectiveStyle.surfaceTreatment }
+
+    /// True exactly when an egg animation loop should be mounted and ticking: the popover is on-screen
+    /// AND the resolved style is one of the animated egg states. The headless test seam for "no animation
+    /// work while the popover is hidden" — the SwiftUI loops gate on the same two inputs
+    /// (`\.popoverIsVisible` plus the party/drunk style). Reads `effectiveStyle`, so the accessibility
+    /// clamp (which resolves the egg to `.opaque`) correctly reports no animation even with the code on.
+    var eggAnimationsActive: Bool {
+        popoverShown && (effectiveStyle == .party || effectiveStyle == .drunk)
+    }
 
     /// True when the user turned the proper toggle on but a system accessibility setting is overriding it
     /// — so Settings can show a friendly "paused" note instead of silently doing nothing.

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
@@ -24,8 +24,9 @@ final class PopoverTransparencyStore {
     /// Ephemeral easter-egg state. Never persisted: it clears on quit, but survives panel open/close
     /// within a run, so the only way out is re-typing the code.
     private(set) var secretCodeActive = false
-    /// "Even More" — only meaningful while `secretCodeActive`. Cleared whenever the egg turns off.
-    var evenMore = false
+    /// "Drunk Mode" — escalates the party into the woozy, barely-readable state. Only meaningful while
+    /// `secretCodeActive`; cleared whenever the egg turns off.
+    var drunkMode = false
 
     /// Live system accessibility flags. Read from `NSWorkspace` and refreshed on the change notification.
     private(set) var reduceTransparency: Bool
@@ -49,7 +50,7 @@ final class PopoverTransparencyStore {
     /// the egg off.
     func toggleSecretCode() {
         secretCodeActive.toggle()
-        if !secretCodeActive { evenMore = false }
+        if !secretCodeActive { drunkMode = false }
         AppLog.info(.statusItem, "Too-much-transparency egg \(secretCodeActive ? "enabled" : "disabled")")
     }
 
@@ -58,7 +59,7 @@ final class PopoverTransparencyStore {
         PopoverTransparencyStyle.resolve(
             increaseTransparency: increaseTransparency,
             secretCodeActive: secretCodeActive,
-            evenMore: evenMore,
+            drunkMode: drunkMode,
             reduceTransparency: reduceTransparency,
             increaseContrast: increaseContrast
         )

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
@@ -2,46 +2,49 @@ import CoreGraphics
 
 /// The popover's resolved transparency level. Deliberately discrete (not a continuous slider) so the
 /// precedence rules, the accessibility clamp, and the visual-regression tests stay tractable; a future
-/// level is one more case here. Cases are ordered by increasing transparency.
+/// level is one more case here.
 enum PopoverTransparencyStyle: Equatable, Sendable {
     /// Today's solid, opaque panel.
     case opaque
     /// The proper "Increase Transparency": the desktop shows through with system vibrancy, text legible.
     case increased
-    /// Secret-code easter egg: a barely-readable ghost.
+    /// Secret-code easter egg: a loud but **readable** party — animated gradient backdrop, glowing rim,
+    /// disco meters, all behind crisp text on frosted cards.
+    case disco
+    /// Secret-code egg + "Even More": the deliberately barely-readable pink-glass chaos.
     case ghost
-    /// Secret-code easter egg + "Even More": ghostier still.
-    case ghostMore
 
-    /// Whether the page tray and cards should clear their opaque base so the behind-window vibrancy
-    /// backdrop (the desktop) shows through.
+    /// How the page tray and cards paint their base.
     var surfaceTreatment: PopoverSurfaceTreatment {
-        self == .opaque ? .opaque : .translucent
+        switch self {
+        case .opaque: return .opaque
+        case .increased, .ghost: return .translucent   // clear, so the desktop/chaos shows through
+        case .disco: return .scrim                      // frosted cards keep text readable over the party
+        }
     }
 
-    /// Window-level alpha. The proper modes keep full opacity so text stays legible. The egg modes stay
-    /// only partly transparent on purpose: the "barely readable" look comes from the animated pink-glass
-    /// chaos (`tooMuchTransparency`), not from fading the window to nothing — too low an alpha would dim
-    /// the pink along with everything else. (Tunable; verified live since there's no preview.)
+    /// Window-level alpha. The proper and disco modes stay (near) solid so text is crisp; only the ghost
+    /// fades the whole window — text and all — into a see-through gimmick. (Tunable; verified live.)
     var windowAlpha: CGFloat {
         switch self {
         case .opaque, .increased: return 1
-        case .ghost: return 0.8
-        case .ghostMore: return 0.65
+        case .disco: return 0.94
+        case .ghost: return 0.62
         }
     }
 
     /// The window shadow reads as a hard rectangle once the surface is a faint ghost, so drop it there.
     var wantsShadow: Bool {
         switch self {
-        case .opaque, .increased: return true
-        case .ghost, .ghostMore: return false
+        case .opaque, .increased, .disco: return true
+        case .ghost: return false
         }
     }
 
     /// The single home for the precedence rules. The egg wins regardless of the system accessibility
-    /// flags (it's an opt-in cheat code the user explicitly invoked); the proper "Increase Transparency"
-    /// toggle yields to the system's Reduce Transparency / Increase Contrast settings.
+    /// flags (it's an opt-in cheat code the user explicitly invoked): the secret code turns on the
+    /// readable disco, and "Even More" pushes it to the unreadable ghost. The proper "Increase
+    /// Transparency" toggle yields to the system's Reduce Transparency / Increase Contrast settings.
     static func resolve(
         increaseTransparency: Bool,
         secretCodeActive: Bool,
@@ -50,7 +53,7 @@ enum PopoverTransparencyStyle: Equatable, Sendable {
         increaseContrast: Bool
     ) -> PopoverTransparencyStyle {
         if secretCodeActive {
-            return evenMore ? .ghostMore : .ghost
+            return evenMore ? .ghost : .disco
         }
         if increaseTransparency, !reduceTransparency, !increaseContrast {
             return .increased

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
@@ -44,10 +44,13 @@ enum PopoverTransparencyStyle: Equatable, Sendable {
         }
     }
 
-    /// The single home for the precedence rules. The egg wins regardless of the system accessibility
-    /// flags (it's an opt-in cheat code the user explicitly invoked): the secret code turns on the
-    /// readable party, and "Drunk Mode" pushes it to the woozy, barely-readable drunk. The proper
-    /// "Increase Transparency" toggle yields to the system's Reduce Transparency / Increase Contrast.
+    /// The single home for the precedence rules. Reduce Transparency and Increase Contrast are
+    /// accessibility *needs*, not preferences, so they clamp everything to opaque first — neither the
+    /// opt-in "Increase Transparency" toggle nor the secret-code egg may turn the panel translucent or
+    /// fade the window while either is on. The egg being a hidden, user-invoked cheat code doesn't make
+    /// overriding an accessibility setting safe, so it yields too. With the flags off the egg wins (the
+    /// secret code is the readable party, "Drunk Mode" the woozy barely-readable drunk), then the proper
+    /// toggle, then opaque.
     static func resolve(
         increaseTransparency: Bool,
         secretCodeActive: Bool,
@@ -55,10 +58,14 @@ enum PopoverTransparencyStyle: Equatable, Sendable {
         reduceTransparency: Bool,
         increaseContrast: Bool
     ) -> PopoverTransparencyStyle {
+        // Accessibility wins over every translucent treatment, the egg included.
+        if reduceTransparency || increaseContrast {
+            return .opaque
+        }
         if secretCodeActive {
             return drunkMode ? .drunk : .party
         }
-        if increaseTransparency, !reduceTransparency, !increaseContrast {
+        if increaseTransparency {
             return .increased
         }
         return .opaque

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
@@ -9,51 +9,51 @@ enum PopoverTransparencyStyle: Equatable, Sendable {
     /// The proper "Increase Transparency": the desktop shows through with system vibrancy, text legible.
     case increased
     /// Secret-code easter egg: a loud but **readable** party — animated gradient backdrop, glowing rim,
-    /// disco meters, all behind crisp text on frosted cards.
-    case disco
-    /// Secret-code egg + "Even More": the deliberately barely-readable pink-glass chaos.
-    case ghost
+    /// party meters, all behind crisp text on frosted cards.
+    case party
+    /// Party + "Drunk Mode": woozy and deliberately barely-readable — blur, pink haze, a spinning sway.
+    case drunk
 
     /// How the page tray and cards paint their base.
     var surfaceTreatment: PopoverSurfaceTreatment {
         switch self {
         case .opaque: return .opaque
-        case .increased, .ghost: return .translucent   // clear, so the desktop/chaos shows through
-        case .disco: return .scrim                      // frosted cards keep text readable over the party
+        case .increased, .drunk: return .translucent   // clear, so the desktop/haze shows through
+        case .party: return .scrim                      // frosted cards keep text readable over the party
         }
     }
 
-    /// Window-level alpha. The proper and disco modes stay (near) solid so text is crisp; only the ghost
-    /// fades the whole window — text and all — into a see-through gimmick. (Tunable; verified live.)
+    /// Window-level alpha. The proper and party modes stay (near) solid so text is crisp; only drunk
+    /// fades the whole window — text and all — into a see-through haze. (Tunable; verified live.)
     var windowAlpha: CGFloat {
         switch self {
         case .opaque, .increased: return 1
-        case .disco: return 0.94
-        case .ghost: return 0.62
+        case .party: return 0.94
+        case .drunk: return 0.62
         }
     }
 
-    /// The window shadow reads as a hard rectangle once the surface is a faint ghost, so drop it there.
+    /// The window shadow reads as a hard rectangle once the surface is a faint haze, so drop it there.
     var wantsShadow: Bool {
         switch self {
-        case .opaque, .increased, .disco: return true
-        case .ghost: return false
+        case .opaque, .increased, .party: return true
+        case .drunk: return false
         }
     }
 
     /// The single home for the precedence rules. The egg wins regardless of the system accessibility
     /// flags (it's an opt-in cheat code the user explicitly invoked): the secret code turns on the
-    /// readable disco, and "Even More" pushes it to the unreadable ghost. The proper "Increase
-    /// Transparency" toggle yields to the system's Reduce Transparency / Increase Contrast settings.
+    /// readable party, and "Drunk Mode" pushes it to the woozy, barely-readable drunk. The proper
+    /// "Increase Transparency" toggle yields to the system's Reduce Transparency / Increase Contrast.
     static func resolve(
         increaseTransparency: Bool,
         secretCodeActive: Bool,
-        evenMore: Bool,
+        drunkMode: Bool,
         reduceTransparency: Bool,
         increaseContrast: Bool
     ) -> PopoverTransparencyStyle {
         if secretCodeActive {
-            return evenMore ? .ghost : .disco
+            return drunkMode ? .drunk : .party
         }
         if increaseTransparency, !reduceTransparency, !increaseContrast {
             return .increased

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
@@ -8,8 +8,9 @@ enum PopoverTransparencyStyle: Equatable, Sendable {
     case opaque
     /// The proper "Increase Transparency": the desktop shows through with system vibrancy, text legible.
     case increased
-    /// Secret-code easter egg: a loud but **readable** party — animated gradient backdrop, glowing rim,
-    /// party meters, all behind crisp text on frosted cards.
+    /// Secret-code easter egg: a loud but **readable** party built on the same translucent foundation as
+    /// `increased` — the blurred desktop shows through, tinted by an animated party gradient, with a
+    /// glowing rim, party meters, and crisp text on frosted cards on top.
     case party
     /// Party + "Drunk Mode": woozy and deliberately barely-readable — blur, pink haze, a spinning sway.
     case drunk
@@ -18,17 +19,19 @@ enum PopoverTransparencyStyle: Equatable, Sendable {
     var surfaceTreatment: PopoverSurfaceTreatment {
         switch self {
         case .opaque: return .opaque
-        case .increased, .drunk: return .translucent   // clear, so the desktop/haze shows through
-        case .party: return .scrim                      // frosted cards keep text readable over the party
+        // All three translucent modes clear the page so the behind-window vibrancy backdrop (the
+        // blurred desktop) shows through; party tints that same backdrop rather than replacing it.
+        case .increased, .party, .drunk: return .translucent
         }
     }
 
-    /// Window-level alpha. The proper and party modes stay (near) solid so text is crisp; only drunk
-    /// fades the whole window — text and all — into a see-through haze. (Tunable; verified live.)
+    /// Window-level alpha. Opaque, increased, and party all keep the window fully opaque — the desktop
+    /// shows through via the translucent backdrop, never by fading the window (fading would dim the text
+    /// too). Only drunk deliberately fades the whole window — text and all — into a see-through haze.
+    /// (Tunable; verified live.)
     var windowAlpha: CGFloat {
         switch self {
-        case .opaque, .increased: return 1
-        case .party: return 0.94
+        case .opaque, .increased, .party: return 1
         case .drunk: return 0.62
         }
     }

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStyle.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+
+/// The popover's resolved transparency level. Deliberately discrete (not a continuous slider) so the
+/// precedence rules, the accessibility clamp, and the visual-regression tests stay tractable; a future
+/// level is one more case here. Cases are ordered by increasing transparency.
+enum PopoverTransparencyStyle: Equatable, Sendable {
+    /// Today's solid, opaque panel.
+    case opaque
+    /// The proper "Increase Transparency": the desktop shows through with system vibrancy, text legible.
+    case increased
+    /// Secret-code easter egg: a barely-readable ghost.
+    case ghost
+    /// Secret-code easter egg + "Even More": ghostier still.
+    case ghostMore
+
+    /// Whether the page tray and cards should clear their opaque base so the behind-window vibrancy
+    /// backdrop (the desktop) shows through.
+    var surfaceTreatment: PopoverSurfaceTreatment {
+        self == .opaque ? .opaque : .translucent
+    }
+
+    /// Window-level alpha. The proper modes keep full opacity so text stays legible. The egg modes stay
+    /// only partly transparent on purpose: the "barely readable" look comes from the animated pink-glass
+    /// chaos (`tooMuchTransparency`), not from fading the window to nothing — too low an alpha would dim
+    /// the pink along with everything else. (Tunable; verified live since there's no preview.)
+    var windowAlpha: CGFloat {
+        switch self {
+        case .opaque, .increased: return 1
+        case .ghost: return 0.8
+        case .ghostMore: return 0.65
+        }
+    }
+
+    /// The window shadow reads as a hard rectangle once the surface is a faint ghost, so drop it there.
+    var wantsShadow: Bool {
+        switch self {
+        case .opaque, .increased: return true
+        case .ghost, .ghostMore: return false
+        }
+    }
+
+    /// The single home for the precedence rules. The egg wins regardless of the system accessibility
+    /// flags (it's an opt-in cheat code the user explicitly invoked); the proper "Increase Transparency"
+    /// toggle yields to the system's Reduce Transparency / Increase Contrast settings.
+    static func resolve(
+        increaseTransparency: Bool,
+        secretCodeActive: Bool,
+        evenMore: Bool,
+        reduceTransparency: Bool,
+        increaseContrast: Bool
+    ) -> PopoverTransparencyStyle {
+        if secretCodeActive {
+            return evenMore ? .ghostMore : .ghost
+        }
+        if increaseTransparency, !reduceTransparency, !increaseContrast {
+            return .increased
+        }
+        return .opaque
+    }
+}

--- a/Sources/OpenUsage/Stores/SecretCodeMatcher.swift
+++ b/Sources/OpenUsage/Stores/SecretCodeMatcher.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// One recognized key in the secret transparency code. A pure token so the matcher carries no AppKit
+/// dependency and stays unit-testable by feeding tokens directly (the `NSEvent` → token mapping lives in
+/// `TooMuchTransparencyKeyReader`, the event-source layer).
+enum SecretCodeKey: Equatable, Sendable {
+    case up, down, left, right, a, b
+}
+
+/// Matches the secret transparency code (↑ ↑ ↓ ↓ ← → ← → B A) from a stream of key tokens. Pure value
+/// type, no UI.
+///
+/// Uses an overlapping sliding window: it keeps only the last N tokens and checks them against the
+/// target, so a run of extra keys before a clean entry still matches and the user never has to "start
+/// from empty". `accept` returns `true` exactly on the keystroke that completes the full sequence, then
+/// clears its buffer so the next full entry matches again — which is what lets re-typing the code toggle
+/// the easter egg back off.
+struct SecretCodeMatcher {
+    /// The canonical secret code.
+    static let sequence: [SecretCodeKey] = [.up, .up, .down, .down, .left, .right, .left, .right, .b, .a]
+
+    private let target: [SecretCodeKey]
+    private var buffer: [SecretCodeKey] = []
+
+    init(target: [SecretCodeKey] = SecretCodeMatcher.sequence) {
+        self.target = target
+    }
+
+    /// Feed one token. Returns `true` when this token completes the full sequence.
+    mutating func accept(_ token: SecretCodeKey) -> Bool {
+        buffer.append(token)
+        if buffer.count > target.count {
+            buffer.removeFirst(buffer.count - target.count)
+        }
+        guard buffer == target else { return false }
+        buffer.removeAll(keepingCapacity: true)
+        return true
+    }
+
+    /// Drop any partial progress (e.g. when a non-sequence key breaks the run).
+    mutating func reset() {
+        buffer.removeAll(keepingCapacity: true)
+    }
+}

--- a/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
+++ b/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
@@ -10,8 +10,8 @@ import SwiftUI
 /// distinction, the scroll view still scrolls. Nothing here hides a runtime error — each branch is a
 /// compile-time `#available` check, which is the intended way to back-deploy newer-SDK APIs.
 ///
-/// These gate purely on OS version. The popover backdrop is opaque by default (`StatusItemController`'s
-/// `NSBox`, matching `Theme.traySurface`); the opt-in Increase Transparency mode crossfades it to a
+/// These gate purely on OS version. The popover backdrop is opaque by default (`PopoverBackdropView`'s
+/// opaque tray, matching `Theme.traySurface`); the opt-in Increase Transparency mode crossfades it to a
 /// behind-window vibrancy view so the desktop shows through, and the cards swap to a frosted standard
 /// material. Either way glass stays reserved for the footer chrome — its `.bar`/glass bar plus the
 /// interactive glass controls — never the content cards.

--- a/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
+++ b/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
@@ -10,10 +10,11 @@ import SwiftUI
 /// distinction, the scroll view still scrolls. Nothing here hides a runtime error — each branch is a
 /// compile-time `#available` check, which is the intended way to back-deploy newer-SDK APIs.
 ///
-/// These gate purely on OS version. The popover backdrop is always opaque (`StatusItemController`'s
-/// `NSBox`, matching `Theme.traySurface`), with opaque grouped cards on it; glass is reserved for the
-/// footer chrome — its frosted `.bar` material bar plus the interactive glass controls on it —
-/// rendered in-window over that opaque backing.
+/// These gate purely on OS version. The popover backdrop is opaque by default (`StatusItemController`'s
+/// `NSBox`, matching `Theme.traySurface`); the opt-in Increase Transparency mode crossfades it to a
+/// behind-window vibrancy view so the desktop shows through, and the cards swap to a frosted standard
+/// material. Either way glass stays reserved for the footer chrome — its `.bar`/glass bar plus the
+/// interactive glass controls — never the content cards.
 ///
 /// Keeping every `#available(macOS 26, *)` check in this one file means the views (`HeaderView`,
 /// `SettingsScreen`, `DashboardView`) stay free of inline availability branches.

--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -15,6 +15,22 @@ extension EnvironmentValues {
     }
 }
 
+/// Whether the popover is currently on-screen. The easter-egg animations pause their `TimelineView`
+/// clocks when this is `false`, so a closed (but still-egg-active) popover spends no CPU animating — the
+/// SwiftUI tree survives `orderOut`, so without this the loops would keep ticking while hidden. Driven
+/// from `DashboardView`'s `PopoverVisibilityReader`. Defaults to `false` (paused) so nothing animates
+/// until the popover reports itself visible.
+private struct PopoverIsVisibleKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var popoverIsVisible: Bool {
+        get { self[PopoverIsVisibleKey.self] }
+        set { self[PopoverIsVisibleKey.self] = newValue }
+    }
+}
+
 enum PartyMode {
     /// Vivid gradient fill for meter bars in party mode. The bar still shows its fraction by width, so
     /// it stays readable — it just trades the solid severity color for party colors.
@@ -45,8 +61,12 @@ extension View {
 }
 
 private struct PartyPulseModifier: ViewModifier {
+    @Environment(\.popoverIsVisible) private var isVisible
+
     func body(content: Content) -> some View {
-        TimelineView(.animation) { timeline in
+        // Runs at the display's native rate (matching the user's refresh, including ProMotion) while the
+        // popover is on-screen, and pauses entirely when it isn't — so a hidden popover spends no energy.
+        TimelineView(.animation(paused: !isVisible)) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             content
                 .scaleEffect(1 + sin(t * 3.2) * 0.12)

--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// True inside the readable "disco" easter-egg mode, so leaf views (meter bars, provider marks) can
+/// join the party while staying legible. Default `false` everywhere — the windowless ShareCard export
+/// and every normal surface never opt in.
+private struct PopoverPartyModeKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var popoverPartyMode: Bool {
+        get { self[PopoverPartyModeKey.self] }
+        set { self[PopoverPartyModeKey.self] = newValue }
+    }
+}
+
+enum PartyMode {
+    /// Vivid gradient fill for meter bars in disco mode. The bar still shows its fraction by width, so
+    /// it stays readable — it just trades the solid severity color for party colors.
+    static let meterFill = AnyShapeStyle(
+        LinearGradient(
+            colors: [
+                Color(red: 1.00, green: 0.35, blue: 0.78),
+                Color(red: 0.60, green: 0.42, blue: 1.00),
+                Color(red: 0.30, green: 0.85, blue: 1.00),
+            ],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    )
+}
+
+extension View {
+    /// A gentle pulse + color shimmer for the provider marks while disco mode is on; identity otherwise
+    /// (no `TimelineView` mounted when the party is off).
+    @ViewBuilder
+    func partyPulse(_ active: Bool) -> some View {
+        if active {
+            modifier(PartyPulseModifier())
+        } else {
+            self
+        }
+    }
+}
+
+private struct PartyPulseModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        TimelineView(.animation) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            content
+                .scaleEffect(1 + sin(t * 3.2) * 0.12)
+                .hueRotation(.degrees(sin(t * 2.0) * 28))
+        }
+    }
+}

--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -15,22 +15,6 @@ extension EnvironmentValues {
     }
 }
 
-/// Whether the popover is currently on-screen. The easter-egg animations pause their `TimelineView`
-/// clocks when this is `false`, so a closed (but still-egg-active) popover spends no CPU animating — the
-/// SwiftUI tree survives `orderOut`, so without this the loops would keep ticking while hidden. Driven
-/// from `DashboardView`'s `PopoverVisibilityReader`. Defaults to `false` (paused) so nothing animates
-/// until the popover reports itself visible.
-private struct PopoverIsVisibleKey: EnvironmentKey {
-    static let defaultValue = false
-}
-
-extension EnvironmentValues {
-    var popoverIsVisible: Bool {
-        get { self[PopoverIsVisibleKey.self] }
-        set { self[PopoverIsVisibleKey.self] = newValue }
-    }
-}
-
 enum PartyMode {
     /// Vivid gradient fill for meter bars in party mode. The bar still shows its fraction by width, so
     /// it stays readable — it just trades the solid severity color for party colors.
@@ -61,12 +45,11 @@ extension View {
 }
 
 private struct PartyPulseModifier: ViewModifier {
-    @Environment(\.popoverIsVisible) private var isVisible
-
     func body(content: Content) -> some View {
-        // Runs at the display's native rate (matching the user's refresh, including ProMotion) while the
-        // popover is on-screen, and pauses entirely when it isn't — so a hidden popover spends no energy.
-        TimelineView(.animation(paused: !isVisible)) { timeline in
+        // Plain `.animation` (not the `paused:` overload), so it starts immediately when party is switched
+        // on with the popover already open — the visibility-coupled overload only attached on a window
+        // show, which froze in-place activation until a close→reopen.
+        TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             content
                 .scaleEffect(1 + sin(t * 3.2) * 0.12)

--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -31,6 +31,22 @@ extension EnvironmentValues {
     }
 }
 
+/// Whether the popover is the key (focused) window. The translucent keepalive — which re-rasters static
+/// content so the compositor can't cull it on a non-key window — runs only when this is `false`. While
+/// the popover is focused there is no cull to fight, so the keepalive stays off and the content renders
+/// perfectly crisp; only the unfocused, floating popover pays the (sub-pixel) keepalive cost. Defaults to
+/// `true` (assume focused → no keepalive), so the windowless ShareCard export and previews never blur.
+private struct PopoverIsKeyKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+extension EnvironmentValues {
+    var popoverIsKey: Bool {
+        get { self[PopoverIsKeyKey.self] }
+        set { self[PopoverIsKeyKey.self] = newValue }
+    }
+}
+
 enum PartyMode {
     /// Vivid gradient fill for meter bars in party mode. The bar still shows its fraction by width, so
     /// it stays readable — it just trades the solid severity color for party colors.

--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -15,6 +15,30 @@ extension EnvironmentValues {
     }
 }
 
+/// Whether the hosting popover is currently on-screen. The easter-egg animation loops read this to
+/// **mount** their `TimelineView(.animation)` clocks only while the popover is visible and drop to a
+/// static frame when it isn't, so a closed popover with the egg still active runs no display link and
+/// spends no CPU. Default `false`, so the windowless ShareCard export and any non-popover host never
+/// mount the loops. Seeded from `PopoverTransparencyStore.popoverShown`, which `StatusItemController`
+/// flips at its `showPanel`/`hidePanel` chokepoints.
+///
+/// This is a STRUCTURAL mount gate (`if shown { TimelineView } else { static }`), deliberately NOT the
+/// reverted `TimelineView(.animation(paused: !shown))` overload (commit 1ef9c4e): that overload froze
+/// in-place activation because its schedule only re-primes on a window-lifecycle event, never on an
+/// in-place `paused` flip. Mounting a fresh `TimelineView` always attaches its display link, so the egg
+/// starts the instant it's switched on with the popover already open. Do not collapse this back to the
+/// paused overload.
+private struct PopoverIsVisibleKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var popoverIsVisible: Bool {
+        get { self[PopoverIsVisibleKey.self] }
+        set { self[PopoverIsVisibleKey.self] = newValue }
+    }
+}
+
 enum PartyMode {
     /// Vivid gradient fill for meter bars in party mode. The bar still shows its fraction by width, so
     /// it stays readable — it just trades the solid severity color for party colors.
@@ -45,15 +69,29 @@ extension View {
 }
 
 private struct PartyPulseModifier: ViewModifier {
+    @Environment(\.popoverIsVisible) private var shown
+
+    @ViewBuilder
     func body(content: Content) -> some View {
-        // Plain `.animation` (not the `paused:` overload), so it starts immediately when party is switched
-        // on with the popover already open — the visibility-coupled overload only attached on a window
-        // show, which froze in-place activation until a close→reopen.
-        TimelineView(.animation) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
-            content
-                .scaleEffect(1 + sin(t * 3.2) * 0.12)
-                .hueRotation(.degrees(sin(t * 2.0) * 28))
+        // Mount the pulse clock only while the popover is on-screen; a closed popover with the egg still
+        // active drops to a static frame (no `TimelineView`, no display link, no CPU). A fresh mount on
+        // reopen / in-place activation always attaches its display link, so the pulse starts immediately —
+        // unlike the reverted `.animation(paused:)` overload (see `\.popoverIsVisible`).
+        if shown {
+            TimelineView(.animation) { timeline in
+                pulse(content, at: timeline.date.timeIntervalSinceReferenceDate)
+            }
+            .transition(.identity)
+        } else {
+            // Frozen at the current instant so it matches the live clock's first frame (no scale pop).
+            pulse(content, at: Date().timeIntervalSinceReferenceDate)
+                .transition(.identity)
         }
+    }
+
+    private func pulse(_ content: Content, at t: TimeInterval) -> some View {
+        content
+            .scaleEffect(1 + sin(t * 3.2) * 0.12)
+            .hueRotation(.degrees(sin(t * 2.0) * 28))
     }
 }

--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
-/// True inside the readable "disco" easter-egg mode, so leaf views (meter bars, provider marks) can
+/// True inside the readable "party" easter-egg mode, so leaf views (meter bars, provider marks) can
 /// join the party while staying legible. Default `false` everywhere — the windowless ShareCard export
-/// and every normal surface never opt in.
+/// and every normal surface never opt in. (The unreadable "drunk" escalation does not set this; it just
+/// blurs everything.)
 private struct PopoverPartyModeKey: EnvironmentKey {
     static let defaultValue = false
 }
@@ -15,7 +16,7 @@ extension EnvironmentValues {
 }
 
 enum PartyMode {
-    /// Vivid gradient fill for meter bars in disco mode. The bar still shows its fraction by width, so
+    /// Vivid gradient fill for meter bars in party mode. The bar still shows its fraction by width, so
     /// it stays readable — it just trades the solid severity color for party colors.
     static let meterFill = AnyShapeStyle(
         LinearGradient(
@@ -31,7 +32,7 @@ enum PartyMode {
 }
 
 extension View {
-    /// A gentle pulse + color shimmer for the provider marks while disco mode is on; identity otherwise
+    /// A gentle pulse + color shimmer for the provider marks while party mode is on; identity otherwise
     /// (no `TimelineView` mounted when the party is off).
     @ViewBuilder
     func partyPulse(_ active: Bool) -> some View {

--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -31,22 +31,6 @@ extension EnvironmentValues {
     }
 }
 
-/// Whether the popover is the key (focused) window. The translucent keepalive — which re-rasters static
-/// content so the compositor can't cull it on a non-key window — runs only when this is `false`. While
-/// the popover is focused there is no cull to fight, so the keepalive stays off and the content renders
-/// perfectly crisp; only the unfocused, floating popover pays the (sub-pixel) keepalive cost. Defaults to
-/// `true` (assume focused → no keepalive), so the windowless ShareCard export and previews never blur.
-private struct PopoverIsKeyKey: EnvironmentKey {
-    static let defaultValue = true
-}
-
-extension EnvironmentValues {
-    var popoverIsKey: Bool {
-        get { self[PopoverIsKeyKey.self] }
-        set { self[PopoverIsKeyKey.self] = newValue }
-    }
-}
-
 enum PartyMode {
     /// Vivid gradient fill for meter bars in party mode. The bar still shows its fraction by width, so
     /// it stays readable — it just trades the solid severity color for party colors.

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -34,6 +34,23 @@ struct PopoverVisibilityReader: NSViewRepresentable {
         NSWindow.didBecomeKeyNotification
     ]
 
+    /// Whether a visibility report should be delivered to `onChange`, given the value being reported and
+    /// the last delivered value. A `false` before any `true` (`lastVisible == nil`) is **not** a dismissal
+    /// — the popover was never shown, so there is nothing transient to reset — and is suppressed: the
+    /// reader mounts into the not-yet-ordered-front panel during `showPanel`'s pre-show layout, where
+    /// `isVisible` is still false, and delivering it would run the consumer's `resetTransientState` and
+    /// clobber a screen `openSettings` pre-set before showing. A real `orderOut` always arrives as a
+    /// `false` *after* a `true` (via the occlusion notification while the view is still in its window), so
+    /// genuine dismissals are unaffected. This suppression is deliberate — do not "fix" it to deliver the
+    /// initial `false`.
+    ///
+    /// `nonisolated static` so tests exercise it without a window or a MainActor hop (cf. the sibling
+    /// `PopoverKeyReader.keyTargetsPopover`).
+    nonisolated static func shouldDeliver(_ visible: Bool, lastVisible: Bool?) -> Bool {
+        guard let lastVisible else { return visible }   // first report: deliver only a `true`
+        return lastVisible != visible                   // otherwise deliver real changes
+    }
+
     func makeNSView(context: Context) -> NSView {
         let view = VisibilityView()
         view.onChange = onChange
@@ -54,7 +71,11 @@ struct PopoverVisibilityReader: NSViewRepresentable {
             observers.forEach(NotificationCenter.default.removeObserver)
             observers.removeAll()
             guard let window else {
-                report(false)
+                // Detaching from the window is not a dismissal: the panel is retained on close
+                // (`isReleasedWhenClosed = false`) and this reader is a permanent root-level `.background`,
+                // so this fires only on real teardown, never on a popover close. A genuine `orderOut` is
+                // already caught by the occlusion observer while the view is still in its window, so don't
+                // report `false` here — doing so could reset a still-on-screen popover.
                 return
             }
             // Two triggers, because neither alone catches every transition. The value reported is always
@@ -87,9 +108,11 @@ struct PopoverVisibilityReader: NSViewRepresentable {
         }
 
         private func report(_ visible: Bool) {
-            guard lastVisible != visible else { return }
+            // Compute from the prior value, then seed, then deliver — so a suppressed first `false`
+            // still updates `lastVisible` (next real change is detected) without firing `onChange`.
+            let deliver = PopoverVisibilityReader.shouldDeliver(visible, lastVisible: lastVisible)
             lastVisible = visible
-            onChange?(visible)
+            if deliver { onChange?(visible) }
         }
     }
 }

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -17,98 +17,78 @@ import AppKit
 /// — which blanked the scroll content (the reset scrolls to top, drops the driven height, and resets the
 /// screen) while the pinned chrome and the egg's gradient, living outside that subtree, kept rendering.
 /// `isVisible` is true the whole time the panel is ordered-on (across Space switches and partial
-/// occlusion) and flips to false only on a real `orderOut`, which is exactly the reset moment. Three
-/// notifications wake the reads — occlusion (open, close, Space switches) plus become/resign-key — but
-/// the *value* the dismiss/pause consumers use is always `isVisible`, so a Space switch or a focus change
-/// never reads as "gone". Become-key also catches the very first show that occlusion misses, and the
-/// become/resign-key pair feeds a separate `isKeyWindow` signal (`onKeyChange`) that the translucent
-/// keepalive uses to run only while the popover is unfocused. See `VisibilityView`.
+/// occlusion) and flips to false only on a real `orderOut`, which is exactly the reset moment. Two
+/// notifications wake the read — occlusion (open, close, Space switches) and the window becoming key
+/// (every `makeKeyAndOrderFront`, which is the one that catches the *first* show; see `VisibilityView`)
+/// — but the *value* reported is always `isVisible`, so a Space switch never reads as "gone".
 struct PopoverVisibilityReader: NSViewRepresentable {
-    /// Reports `window.isVisible` (ordered-on): false drives the dismiss reset and pauses the egg loops.
     var onChange: (Bool) -> Void
-    /// Reports `window.isKeyWindow` (focused). Optional — only the translucent keepalive needs it, to run
-    /// solely while the popover is *not* the key window (the cull only hits non-key windows), so a focused
-    /// popover keeps crisp content.
-    var onKeyChange: ((Bool) -> Void)?
 
-    /// What wakes the reads. Occlusion alone misses the first show (a freshly-created panel's
+    /// What wakes the `isVisible` read. Occlusion alone misses the first show (a freshly-created panel's
     /// `occlusionState` already contains `.visible`, so the first `makeKeyAndOrderFront` posts no change),
-    /// so the key transitions are observed too: become-key catches that first show, and the
-    /// become/resign-key pair tracks focus for the keepalive. All must stay present (guarded by a test).
-    static let windowStateTriggers: [NSNotification.Name] = [
+    /// so becoming key — which every open fires — is observed too. Both must stay present, or the egg
+    /// animations freeze on first activation until a close-and-reopen (guarded by a test).
+    static let visibilityTriggers: [NSNotification.Name] = [
         NSWindow.didChangeOcclusionStateNotification,
-        NSWindow.didBecomeKeyNotification,
-        NSWindow.didResignKeyNotification
+        NSWindow.didBecomeKeyNotification
     ]
 
     func makeNSView(context: Context) -> NSView {
         let view = VisibilityView()
         view.onChange = onChange
-        view.onKeyChange = onKeyChange
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        guard let view = nsView as? VisibilityView else { return }
-        view.onChange = onChange
-        view.onKeyChange = onKeyChange
+        (nsView as? VisibilityView)?.onChange = onChange
     }
 
     final class VisibilityView: NSView {
-        var onChange: ((Bool) -> Void)?            // window.isVisible (ordered-on)
-        var onKeyChange: ((Bool) -> Void)?         // window.isKeyWindow (focused)
+        var onChange: ((Bool) -> Void)?
         private var observers: [NSObjectProtocol] = []
         private var lastVisible: Bool?
-        private var lastKey: Bool?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             observers.forEach(NotificationCenter.default.removeObserver)
             observers.removeAll()
             guard let window else {
-                report(visible: false, key: false)
+                report(false)
                 return
             }
-            // Three triggers, because no single one catches every transition. Both reported values come
-            // straight from the window (`isVisible`, `isKeyWindow`) — neither is KVO-compliant, so these
-            // notifications are the wake-up; the dedup in `report` ignores the redundant fires.
+            // Two triggers, because neither alone catches every transition. The value reported is always
+            // `window.isVisible` (true whenever the panel is ordered-on, false only on a real `orderOut`);
+            // `isVisible` itself isn't KVO-compliant, so these notifications are the wake-up.
             //
             // - Occlusion fires on close, Space switches, and being covered — but NOT on the very first
             //   show: a freshly-created panel's `occlusionState` already contains `.visible`, so the first
             //   `makeKeyAndOrderFront` posts no *change*. Relying on it alone left the popover reporting
             //   its launch-time `isVisible == false` until a close-and-reopen finally toggled occlusion —
             //   which froze the easter-egg animations (paused via `\.popoverIsVisible`) on first activation.
-            // - Become-key fires on every `makeKeyAndOrderFront` (every open), so it reliably catches that
-            //   first show, and with resign-key it tracks focus for the keepalive.
-            //
-            // The dismiss reset and the egg pause both ride the `isVisible` value, NOT the key state: a
-            // panel that resigns key (a click in another app, a tracking menu) is still ordered-on, so
-            // `isVisible` stays true and resign-key can't misfire a dismissal — it only flips the
-            // separate `isKeyWindow` signal the keepalive reads.
-            for name in PopoverVisibilityReader.windowStateTriggers {
+            // - Becoming key fires on every `makeKeyAndOrderFront`, and every open goes through one, so it
+            //   reliably catches that first show. We observe become-key but deliberately NOT resign-key: a
+            //   panel that resigns key (a click in another app, a tracking menu) is still ordered-on and
+            //   visible, and resign-key also fires on in-popover control clicks — the exact reason this
+            //   reader avoids key/focus for its value. Reporting only `true` here can't misfire a
+            //   dismissal (that rides a `false` from `orderOut`); it just fills the gap occlusion leaves.
+            for name in PopoverVisibilityReader.visibilityTriggers {
                 observers.append(NotificationCenter.default.addObserver(
                     forName: name,
                     object: window,
                     queue: .main
                 ) { [weak self, weak window] _ in
                     MainActor.assumeIsolated {
-                        self?.report(visible: window?.isVisible ?? false,
-                                     key: window?.isKeyWindow ?? false)
+                        self?.report(window?.isVisible ?? false)
                     }
                 })
             }
-            report(visible: window.isVisible, key: window.isKeyWindow)
+            report(window.isVisible)
         }
 
-        private func report(visible: Bool, key: Bool) {
-            if lastVisible != visible {
-                lastVisible = visible
-                onChange?(visible)
-            }
-            if lastKey != key {
-                lastKey = key
-                onKeyChange?(key)
-            }
+        private func report(_ visible: Bool) {
+            guard lastVisible != visible else { return }
+            lastVisible = visible
+            onChange?(visible)
         }
     }
 }

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -17,11 +17,21 @@ import AppKit
 /// — which blanked the scroll content (the reset scrolls to top, drops the driven height, and resets the
 /// screen) while the pinned chrome and the egg's gradient, living outside that subtree, kept rendering.
 /// `isVisible` is true the whole time the panel is ordered-on (across Space switches and partial
-/// occlusion) and flips to false only on a real `orderOut`, which is exactly the reset moment. The
-/// occlusion notification is still the cheap *trigger* — it fires on open, close, and Space switches —
-/// but the *value* we report is `isVisible`, so a Space switch no longer reads as "gone".
+/// occlusion) and flips to false only on a real `orderOut`, which is exactly the reset moment. Two
+/// notifications wake the read — occlusion (open, close, Space switches) and the window becoming key
+/// (every `makeKeyAndOrderFront`, which is the one that catches the *first* show; see `VisibilityView`)
+/// — but the *value* reported is always `isVisible`, so a Space switch never reads as "gone".
 struct PopoverVisibilityReader: NSViewRepresentable {
     var onChange: (Bool) -> Void
+
+    /// What wakes the `isVisible` read. Occlusion alone misses the first show (a freshly-created panel's
+    /// `occlusionState` already contains `.visible`, so the first `makeKeyAndOrderFront` posts no change),
+    /// so becoming key — which every open fires — is observed too. Both must stay present, or the egg
+    /// animations freeze on first activation until a close-and-reopen (guarded by a test).
+    static let visibilityTriggers: [NSNotification.Name] = [
+        NSWindow.didChangeOcclusionStateNotification,
+        NSWindow.didBecomeKeyNotification
+    ]
 
     func makeNSView(context: Context) -> NSView {
         let view = VisibilityView()
@@ -35,33 +45,42 @@ struct PopoverVisibilityReader: NSViewRepresentable {
 
     final class VisibilityView: NSView {
         var onChange: ((Bool) -> Void)?
-        private var observer: NSObjectProtocol?
+        private var observers: [NSObjectProtocol] = []
         private var lastVisible: Bool?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
-            if let observer {
-                NotificationCenter.default.removeObserver(observer)
-                self.observer = nil
-            }
+            observers.forEach(NotificationCenter.default.removeObserver)
+            observers.removeAll()
             guard let window else {
                 report(false)
                 return
             }
-            // Occlusion is only the trigger (it fires on open, close, Space switches, and being covered);
-            // the value we report is `isVisible`, which is true whenever the panel is ordered-on — so a
-            // Space switch or a covering window no longer reads as a dismissal. `isVisible` is already
-            // false by the time this fires for a real `orderOut`, which is the genuine reset moment.
-            // (`isVisible` itself isn't KVO-compliant, so it can't be observed directly — hence the
-            // occlusion notification as the wake-up.)
-            observer = NotificationCenter.default.addObserver(
-                forName: NSWindow.didChangeOcclusionStateNotification,
-                object: window,
-                queue: .main
-            ) { [weak self, weak window] _ in
-                MainActor.assumeIsolated {
-                    self?.report(window?.isVisible ?? false)
-                }
+            // Two triggers, because neither alone catches every transition. The value reported is always
+            // `window.isVisible` (true whenever the panel is ordered-on, false only on a real `orderOut`);
+            // `isVisible` itself isn't KVO-compliant, so these notifications are the wake-up.
+            //
+            // - Occlusion fires on close, Space switches, and being covered — but NOT on the very first
+            //   show: a freshly-created panel's `occlusionState` already contains `.visible`, so the first
+            //   `makeKeyAndOrderFront` posts no *change*. Relying on it alone left the popover reporting
+            //   its launch-time `isVisible == false` until a close-and-reopen finally toggled occlusion —
+            //   which froze the easter-egg animations (paused via `\.popoverIsVisible`) on first activation.
+            // - Becoming key fires on every `makeKeyAndOrderFront`, and every open goes through one, so it
+            //   reliably catches that first show. We observe become-key but deliberately NOT resign-key: a
+            //   panel that resigns key (a click in another app, a tracking menu) is still ordered-on and
+            //   visible, and resign-key also fires on in-popover control clicks — the exact reason this
+            //   reader avoids key/focus for its value. Reporting only `true` here can't misfire a
+            //   dismissal (that rides a `false` from `orderOut`); it just fills the gap occlusion leaves.
+            for name in PopoverVisibilityReader.visibilityTriggers {
+                observers.append(NotificationCenter.default.addObserver(
+                    forName: name,
+                    object: window,
+                    queue: .main
+                ) { [weak self, weak window] _ in
+                    MainActor.assumeIsolated {
+                        self?.report(window?.isVisible ?? false)
+                    }
+                })
             }
             report(window.isVisible)
         }

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -1,15 +1,25 @@
 import SwiftUI
 import AppKit
 
-/// Reports whether the hosting menu-bar popover is actually on-screen, via the window's occlusion
-/// state.
+/// Reports whether the hosting menu-bar popover is actually present (ordered-on), so the dashboard can
+/// reset its transient UI state when the popover genuinely goes away.
 ///
-/// Why occlusion and not key/focus: the popover keeps its SwiftUI view tree alive across
-/// open/close, so transient UI state (edit mode, the add-widget gallery) would otherwise
-/// persist and reopen "stuck". We need a signal for "the popover went away" — but it must NOT fire
-/// when the user merely clicks a control inside the popover. Key/resign-key fires on those clicks
-/// (breaking buttons); occlusion does not. Occlusion flips to not-`visible` when the popover is
-/// dismissed (its window orders out), which is exactly the moment we want to reset.
+/// Why this signal and not key/focus: the popover keeps its SwiftUI view tree alive across open/close,
+/// so transient UI state (edit mode, the add-widget gallery, scroll position) would otherwise persist
+/// and reopen "stuck". We need a signal for "the popover went away" that does NOT fire when the user
+/// merely clicks a control inside it. Key/resign-key fires on those clicks (breaking buttons), so it's
+/// out.
+///
+/// Why it reports `window.isVisible` rather than the occlusion state: a `.canJoinAllSpaces` panel that
+/// is open while the user switches macOS Spaces stays ordered-on (it follows them), but it is fully
+/// *occluded* during the Space transition, so `occlusionState` drops `.visible` and then regains it.
+/// Reporting occlusion directly mistook that for a dismissal and reset the still-open popover mid-switch
+/// — which blanked the scroll content (the reset scrolls to top, drops the driven height, and resets the
+/// screen) while the pinned chrome and the egg's gradient, living outside that subtree, kept rendering.
+/// `isVisible` is true the whole time the panel is ordered-on (across Space switches and partial
+/// occlusion) and flips to false only on a real `orderOut`, which is exactly the reset moment. The
+/// occlusion notification is still the cheap *trigger* — it fires on open, close, and Space switches —
+/// but the *value* we report is `isVisible`, so a Space switch no longer reads as "gone".
 struct PopoverVisibilityReader: NSViewRepresentable {
     var onChange: (Bool) -> Void
 
@@ -38,16 +48,22 @@ struct PopoverVisibilityReader: NSViewRepresentable {
                 report(false)
                 return
             }
+            // Occlusion is only the trigger (it fires on open, close, Space switches, and being covered);
+            // the value we report is `isVisible`, which is true whenever the panel is ordered-on — so a
+            // Space switch or a covering window no longer reads as a dismissal. `isVisible` is already
+            // false by the time this fires for a real `orderOut`, which is the genuine reset moment.
+            // (`isVisible` itself isn't KVO-compliant, so it can't be observed directly — hence the
+            // occlusion notification as the wake-up.)
             observer = NotificationCenter.default.addObserver(
                 forName: NSWindow.didChangeOcclusionStateNotification,
                 object: window,
                 queue: .main
             ) { [weak self, weak window] _ in
                 MainActor.assumeIsolated {
-                    self?.report(window?.occlusionState.contains(.visible) ?? false)
+                    self?.report(window?.isVisible ?? false)
                 }
             }
-            report(window.occlusionState.contains(.visible))
+            report(window.isVisible)
         }
 
         private func report(_ visible: Bool) {

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -17,78 +17,98 @@ import AppKit
 /// — which blanked the scroll content (the reset scrolls to top, drops the driven height, and resets the
 /// screen) while the pinned chrome and the egg's gradient, living outside that subtree, kept rendering.
 /// `isVisible` is true the whole time the panel is ordered-on (across Space switches and partial
-/// occlusion) and flips to false only on a real `orderOut`, which is exactly the reset moment. Two
-/// notifications wake the read — occlusion (open, close, Space switches) and the window becoming key
-/// (every `makeKeyAndOrderFront`, which is the one that catches the *first* show; see `VisibilityView`)
-/// — but the *value* reported is always `isVisible`, so a Space switch never reads as "gone".
+/// occlusion) and flips to false only on a real `orderOut`, which is exactly the reset moment. Three
+/// notifications wake the reads — occlusion (open, close, Space switches) plus become/resign-key — but
+/// the *value* the dismiss/pause consumers use is always `isVisible`, so a Space switch or a focus change
+/// never reads as "gone". Become-key also catches the very first show that occlusion misses, and the
+/// become/resign-key pair feeds a separate `isKeyWindow` signal (`onKeyChange`) that the translucent
+/// keepalive uses to run only while the popover is unfocused. See `VisibilityView`.
 struct PopoverVisibilityReader: NSViewRepresentable {
+    /// Reports `window.isVisible` (ordered-on): false drives the dismiss reset and pauses the egg loops.
     var onChange: (Bool) -> Void
+    /// Reports `window.isKeyWindow` (focused). Optional — only the translucent keepalive needs it, to run
+    /// solely while the popover is *not* the key window (the cull only hits non-key windows), so a focused
+    /// popover keeps crisp content.
+    var onKeyChange: ((Bool) -> Void)?
 
-    /// What wakes the `isVisible` read. Occlusion alone misses the first show (a freshly-created panel's
+    /// What wakes the reads. Occlusion alone misses the first show (a freshly-created panel's
     /// `occlusionState` already contains `.visible`, so the first `makeKeyAndOrderFront` posts no change),
-    /// so becoming key — which every open fires — is observed too. Both must stay present, or the egg
-    /// animations freeze on first activation until a close-and-reopen (guarded by a test).
-    static let visibilityTriggers: [NSNotification.Name] = [
+    /// so the key transitions are observed too: become-key catches that first show, and the
+    /// become/resign-key pair tracks focus for the keepalive. All must stay present (guarded by a test).
+    static let windowStateTriggers: [NSNotification.Name] = [
         NSWindow.didChangeOcclusionStateNotification,
-        NSWindow.didBecomeKeyNotification
+        NSWindow.didBecomeKeyNotification,
+        NSWindow.didResignKeyNotification
     ]
 
     func makeNSView(context: Context) -> NSView {
         let view = VisibilityView()
         view.onChange = onChange
+        view.onKeyChange = onKeyChange
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        (nsView as? VisibilityView)?.onChange = onChange
+        guard let view = nsView as? VisibilityView else { return }
+        view.onChange = onChange
+        view.onKeyChange = onKeyChange
     }
 
     final class VisibilityView: NSView {
-        var onChange: ((Bool) -> Void)?
+        var onChange: ((Bool) -> Void)?            // window.isVisible (ordered-on)
+        var onKeyChange: ((Bool) -> Void)?         // window.isKeyWindow (focused)
         private var observers: [NSObjectProtocol] = []
         private var lastVisible: Bool?
+        private var lastKey: Bool?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             observers.forEach(NotificationCenter.default.removeObserver)
             observers.removeAll()
             guard let window else {
-                report(false)
+                report(visible: false, key: false)
                 return
             }
-            // Two triggers, because neither alone catches every transition. The value reported is always
-            // `window.isVisible` (true whenever the panel is ordered-on, false only on a real `orderOut`);
-            // `isVisible` itself isn't KVO-compliant, so these notifications are the wake-up.
+            // Three triggers, because no single one catches every transition. Both reported values come
+            // straight from the window (`isVisible`, `isKeyWindow`) — neither is KVO-compliant, so these
+            // notifications are the wake-up; the dedup in `report` ignores the redundant fires.
             //
             // - Occlusion fires on close, Space switches, and being covered — but NOT on the very first
             //   show: a freshly-created panel's `occlusionState` already contains `.visible`, so the first
             //   `makeKeyAndOrderFront` posts no *change*. Relying on it alone left the popover reporting
             //   its launch-time `isVisible == false` until a close-and-reopen finally toggled occlusion —
             //   which froze the easter-egg animations (paused via `\.popoverIsVisible`) on first activation.
-            // - Becoming key fires on every `makeKeyAndOrderFront`, and every open goes through one, so it
-            //   reliably catches that first show. We observe become-key but deliberately NOT resign-key: a
-            //   panel that resigns key (a click in another app, a tracking menu) is still ordered-on and
-            //   visible, and resign-key also fires on in-popover control clicks — the exact reason this
-            //   reader avoids key/focus for its value. Reporting only `true` here can't misfire a
-            //   dismissal (that rides a `false` from `orderOut`); it just fills the gap occlusion leaves.
-            for name in PopoverVisibilityReader.visibilityTriggers {
+            // - Become-key fires on every `makeKeyAndOrderFront` (every open), so it reliably catches that
+            //   first show, and with resign-key it tracks focus for the keepalive.
+            //
+            // The dismiss reset and the egg pause both ride the `isVisible` value, NOT the key state: a
+            // panel that resigns key (a click in another app, a tracking menu) is still ordered-on, so
+            // `isVisible` stays true and resign-key can't misfire a dismissal — it only flips the
+            // separate `isKeyWindow` signal the keepalive reads.
+            for name in PopoverVisibilityReader.windowStateTriggers {
                 observers.append(NotificationCenter.default.addObserver(
                     forName: name,
                     object: window,
                     queue: .main
                 ) { [weak self, weak window] _ in
                     MainActor.assumeIsolated {
-                        self?.report(window?.isVisible ?? false)
+                        self?.report(visible: window?.isVisible ?? false,
+                                     key: window?.isKeyWindow ?? false)
                     }
                 })
             }
-            report(window.isVisible)
+            report(visible: window.isVisible, key: window.isKeyWindow)
         }
 
-        private func report(_ visible: Bool) {
-            guard lastVisible != visible else { return }
-            lastVisible = visible
-            onChange?(visible)
+        private func report(visible: Bool, key: Bool) {
+            if lastVisible != visible {
+                lastVisible = visible
+                onChange?(visible)
+            }
+            if lastKey != key {
+                lastKey = key
+                onKeyChange?(key)
+            }
         }
     }
 }

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -26,8 +26,9 @@ struct PopoverVisibilityReader: NSViewRepresentable {
 
     /// What wakes the `isVisible` read. Occlusion alone misses the first show (a freshly-created panel's
     /// `occlusionState` already contains `.visible`, so the first `makeKeyAndOrderFront` posts no change),
-    /// so becoming key — which every open fires — is observed too. Both must stay present, or the egg
-    /// animations freeze on first activation until a close-and-reopen (guarded by a test).
+    /// so becoming key — which every open fires — is observed too. Both stay present so the first show is
+    /// reported like any other open (it drives the transient-state reset on close and the reopen height
+    /// re-seed); a test guards that both triggers remain wired.
     static let visibilityTriggers: [NSNotification.Name] = [
         NSWindow.didChangeOcclusionStateNotification,
         NSWindow.didBecomeKeyNotification
@@ -62,9 +63,9 @@ struct PopoverVisibilityReader: NSViewRepresentable {
             //
             // - Occlusion fires on close, Space switches, and being covered — but NOT on the very first
             //   show: a freshly-created panel's `occlusionState` already contains `.visible`, so the first
-            //   `makeKeyAndOrderFront` posts no *change*. Relying on it alone left the popover reporting
-            //   its launch-time `isVisible == false` until a close-and-reopen finally toggled occlusion —
-            //   which froze the easter-egg animations (paused via `\.popoverIsVisible`) on first activation.
+            //   `makeKeyAndOrderFront` posts no *change*. Relying on it alone would leave the first show
+            //   unreported (the popover stuck at its launch-time `isVisible == false`), so the open-side
+            //   height re-seed wouldn't run on the very first open.
             // - Becoming key fires on every `makeKeyAndOrderFront`, and every open goes through one, so it
             //   reliably catches that first show. We observe become-key but deliberately NOT resign-key: a
             //   panel that resigns key (a click in another app, a tracking menu) is still ordered-on and

--- a/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
+++ b/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
@@ -8,8 +8,14 @@ import SwiftUI
 /// driven from `PopoverTransparencyStore.surfaceTreatment` and read by `PopoverSurface` (the tray) and
 /// `CardSurfaceModifier` (the grouped cards).
 enum PopoverSurfaceTreatment: Equatable, Sendable {
+    /// Today's solid panel: opaque tray, opaque card base.
     case opaque
+    /// The page clears to whatever is behind the window (vibrancy desktop, or the ghost chaos); cards
+    /// clear their opaque base too.
     case translucent
+    /// Disco: the page clears so the animated party backdrop shows, but cards keep a frosted material
+    /// base so the text on them stays readable over the moving colors.
+    case scrim
 }
 
 private struct PopoverSurfaceTreatmentKey: EnvironmentKey {

--- a/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
+++ b/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// How the popover's page tray and grouped cards paint their base.
+///
+/// `.opaque` is the default and keeps today's solid panel (and the windowless `ShareCardView`
+/// `ImageRenderer` export, which never injects a non-default value). `.translucent` clears the opaque
+/// page base so the AppKit behind-window vibrancy backdrop — the desktop — shows through. The value is
+/// driven from `PopoverTransparencyStore.surfaceTreatment` and read by `PopoverSurface` (the tray) and
+/// `CardSurfaceModifier` (the grouped cards).
+enum PopoverSurfaceTreatment: Equatable, Sendable {
+    case opaque
+    case translucent
+}
+
+private struct PopoverSurfaceTreatmentKey: EnvironmentKey {
+    static let defaultValue: PopoverSurfaceTreatment = .opaque
+}
+
+extension EnvironmentValues {
+    var popoverSurfaceTreatment: PopoverSurfaceTreatment {
+        get { self[PopoverSurfaceTreatmentKey.self] }
+        set { self[PopoverSurfaceTreatmentKey.self] = newValue }
+    }
+}

--- a/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
+++ b/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
@@ -10,8 +10,9 @@ import SwiftUI
 enum PopoverSurfaceTreatment: Equatable, Sendable {
     /// Today's solid panel: opaque tray, opaque card base.
     case opaque
-    /// The page clears to whatever is behind the window (vibrancy desktop, or the ghost chaos); cards
-    /// clear their opaque base too.
+    /// The page clears to whatever is behind the window (the behind-window vibrancy desktop, or the
+    /// drunk haze); cards drop their opaque base for a frosted `.regularMaterial` so text stays legible
+    /// over it — the HIG-correct "translucent but legible" content material, not a bare fill.
     case translucent
     /// Party: the page clears so the animated party backdrop shows, but cards keep a frosted material
     /// base so the text on them stays readable over the moving colors.

--- a/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
+++ b/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
@@ -10,13 +10,11 @@ import SwiftUI
 enum PopoverSurfaceTreatment: Equatable, Sendable {
     /// Today's solid panel: opaque tray, opaque card base.
     case opaque
-    /// The page clears to whatever is behind the window (the behind-window vibrancy desktop, or the
-    /// drunk haze); cards drop their opaque base for a frosted `.regularMaterial` so text stays legible
-    /// over it — the HIG-correct "translucent but legible" content material, not a bare fill.
+    /// The page clears to whatever is behind the window (the behind-window vibrancy desktop, the party
+    /// tint over it, or the drunk haze); cards drop their opaque base for a frosted `.regularMaterial`
+    /// so text stays legible over it — the HIG-correct "translucent but legible" content material, not a
+    /// bare fill. Shared by Increase Transparency, party, and drunk.
     case translucent
-    /// Party: the page clears so the animated party backdrop shows, but cards keep a frosted material
-    /// base so the text on them stays readable over the moving colors.
-    case scrim
 }
 
 private struct PopoverSurfaceTreatmentKey: EnvironmentKey {

--- a/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
+++ b/Sources/OpenUsage/Support/PopoverSurfaceTreatment.swift
@@ -13,7 +13,7 @@ enum PopoverSurfaceTreatment: Equatable, Sendable {
     /// The page clears to whatever is behind the window (vibrancy desktop, or the ghost chaos); cards
     /// clear their opaque base too.
     case translucent
-    /// Disco: the page clears so the animated party backdrop shows, but cards keep a frosted material
+    /// Party: the page clears so the animated party backdrop shows, but cards keep a frosted material
     /// base so the text on them stays readable over the moving colors.
     case scrim
 }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -114,6 +114,11 @@ private struct CardSurfaceModifier: ViewModifier {
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }
             case .translucent:
                 Theme.cardShape.fill(Theme.cardFill)
+            case .scrim:
+                // Frosted material over the animated disco backdrop so the metric text stays readable.
+                Theme.cardShape
+                    .fill(.regularMaterial)
+                    .overlay { Theme.cardShape.fill(Theme.cardFill) }
             }
         }
     }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -115,7 +115,7 @@ private struct CardSurfaceModifier: ViewModifier {
             case .translucent:
                 Theme.cardShape.fill(Theme.cardFill)
             case .scrim:
-                // Frosted material over the animated disco backdrop so the metric text stays readable.
+                // Frosted material over the animated party backdrop so the metric text stays readable.
                 Theme.cardShape
                     .fill(.regularMaterial)
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -115,18 +115,13 @@ private struct CardSurfaceModifier: ViewModifier {
                     .fill(Theme.traySurface)
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }
             case .translucent:
-                // Increase Transparency (and drunk): the card carries its own frosted `.regularMaterial`
-                // so metric text stays legible over whatever desktop shows through the behind-window
-                // backdrop, with `.fill.quaternary` on top preserving the grouped-card hierarchy. HIG:
-                // back content-layer surfaces with a standard material — a bare low-opacity fill over the
-                // desktop is the "washed out" anti-pattern. This is a standard material, not `glassEffect`:
-                // Liquid Glass stays in the chrome layer, not the content cards.
-                Theme.cardShape
-                    .fill(.regularMaterial)
-                    .overlay { Theme.cardShape.fill(Theme.cardFill) }
-            case .scrim:
-                // Same frosted recipe as `.translucent`, kept a distinct case for the party backdrop
-                // (it sits over the animated gradient rather than the desktop) in case the two diverge.
+                // Increase Transparency, party, and drunk: the card carries its own frosted
+                // `.regularMaterial` so metric text stays legible over whatever shows through the
+                // behind-window backdrop (the desktop, or the party tint over it), with `.fill.quaternary`
+                // on top preserving the grouped-card hierarchy. HIG: back content-layer surfaces with a
+                // standard material — a bare low-opacity fill over the desktop is the "washed out"
+                // anti-pattern. This is a standard material, not `glassEffect`: Liquid Glass stays in the
+                // chrome layer, not the content cards.
                 Theme.cardShape
                     .fill(.regularMaterial)
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -3,12 +3,14 @@ import AppKit
 
 /// Central palette + surface styles. Surfaces stay adaptive (light/dark).
 ///
-/// The popover is always a solid, opaque panel — glass is reserved for the footer chrome (its frosted
-/// bar and the controls on it), never the data region behind it (Apple's guidance: glass for
-/// navigation/controls, content on an opaque surface). The data region mirrors the macOS System
-/// Settings grouped look: a bright page "tray" with borderless grouped cards lifted off it by the
-/// system's own `.fill.quaternary` (the same subtle fill Settings' grouped boxes use — no hand-tuned
-/// values), so it adapts to light/dark like every other Mac app.
+/// By default the popover is a solid, opaque panel; the opt-in Increase Transparency mode (and the
+/// secret-code egg) make it translucent. Either way, Liquid Glass is reserved for the footer/top-bar
+/// chrome — the controls/navigation layer — and never the data cards: Apple's guidance is to keep
+/// Liquid Glass out of the content layer and back content with standard materials instead. The data
+/// region mirrors the macOS System Settings grouped look: a page "tray" with borderless grouped cards
+/// lifted off it by the system's own `.fill.quaternary` (no hand-tuned values), so it adapts to
+/// light/dark like every other Mac app. Under the translucent treatment the cards swap their opaque
+/// base for a frosted standard material so text stays legible (see `cardSurface`).
 enum Theme {
     /// Hierarchical secondary tint for the provider marks.
     static let iconGray = AnyShapeStyle(.secondary)
@@ -115,10 +117,10 @@ private struct CardSurfaceModifier: ViewModifier {
             case .translucent:
                 // Increase Transparency (and drunk): the card carries its own frosted `.regularMaterial`
                 // so metric text stays legible over whatever desktop shows through the behind-window
-                // backdrop, with `.fill.quaternary` on top preserving the grouped-card hierarchy. HIG
-                // names the regular material as the choice for text-dense popovers; a bare low-opacity
-                // fill over the desktop is the "washed out" anti-pattern. Glass stays out of the content
-                // layer — this is a standard material, not `glassEffect`.
+                // backdrop, with `.fill.quaternary` on top preserving the grouped-card hierarchy. HIG:
+                // back content-layer surfaces with a standard material — a bare low-opacity fill over the
+                // desktop is the "washed out" anti-pattern. This is a standard material, not `glassEffect`:
+                // Liquid Glass stays in the chrome layer, not the content cards.
                 Theme.cardShape
                     .fill(.regularMaterial)
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -113,9 +113,18 @@ private struct CardSurfaceModifier: ViewModifier {
                     .fill(Theme.traySurface)
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }
             case .translucent:
-                Theme.cardShape.fill(Theme.cardFill)
+                // Increase Transparency (and drunk): the card carries its own frosted `.regularMaterial`
+                // so metric text stays legible over whatever desktop shows through the behind-window
+                // backdrop, with `.fill.quaternary` on top preserving the grouped-card hierarchy. HIG
+                // names the regular material as the choice for text-dense popovers; a bare low-opacity
+                // fill over the desktop is the "washed out" anti-pattern. Glass stays out of the content
+                // layer — this is a standard material, not `glassEffect`.
+                Theme.cardShape
+                    .fill(.regularMaterial)
+                    .overlay { Theme.cardShape.fill(Theme.cardFill) }
             case .scrim:
-                // Frosted material over the animated party backdrop so the metric text stays readable.
+                // Same frosted recipe as `.translucent`, kept a distinct case for the party backdrop
+                // (it sits over the animated gradient rather than the desktop) in case the two diverge.
                 Theme.cardShape
                     .fill(.regularMaterial)
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -100,7 +100,7 @@ extension View {
 /// it floats; the page base under a live card is the same color as the tray behind it, so it's
 /// invisible there. `lifted` is unused — both paths share the one surface.
 ///
-/// Under the translucent surface treatment (Increase Transparency / the ghost egg) the opaque page base
+/// Under the translucent surface treatment (Increase Transparency / the secret-code egg) the opaque page base
 /// is dropped so the behind-window vibrancy backdrop shows through, while the system grouped fill stays
 /// so cards still read as grouped boxes over the desktop.
 private struct CardSurfaceModifier: ViewModifier {

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -97,14 +97,24 @@ extension View {
 /// grouped box in both light and dark. The opaque base means a lifted drag preview stays solid while
 /// it floats; the page base under a live card is the same color as the tray behind it, so it's
 /// invisible there. `lifted` is unused — both paths share the one surface.
+///
+/// Under the translucent surface treatment (Increase Transparency / the ghost egg) the opaque page base
+/// is dropped so the behind-window vibrancy backdrop shows through, while the system grouped fill stays
+/// so cards still read as grouped boxes over the desktop.
 private struct CardSurfaceModifier: ViewModifier {
     let lifted: Bool
+    @Environment(\.popoverSurfaceTreatment) private var treatment
 
     func body(content: Content) -> some View {
         content.background {
-            Theme.cardShape
-                .fill(Theme.traySurface)
-                .overlay { Theme.cardShape.fill(Theme.cardFill) }
+            switch treatment {
+            case .opaque:
+                Theme.cardShape
+                    .fill(Theme.traySurface)
+                    .overlay { Theme.cardShape.fill(Theme.cardFill) }
+            case .translucent:
+                Theme.cardShape.fill(Theme.cardFill)
+            }
         }
     }
 }

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -61,77 +61,125 @@ private struct TooMuchTransparencyModifier: ViewModifier {
 /// composite against the AppKit vibrancy view behind the host, so the desktop only blends through via
 /// alpha — hence the reduced opacity rather than a blend mode.)
 private struct PartyBackdrop: View {
+    @Environment(\.popoverIsVisible) private var shown
+
     var body: some View {
-        TimelineView(.animation) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
-            ZStack {
-                AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 28))
-                    .opacity(0.5)   // translucent tint, so the blurred desktop blends through the colors
-                RadialGradient(
-                    colors: [Color.white.opacity(0.15), .clear],
-                    center: UnitPoint(x: 0.5 + cos(t * 0.5) * 0.3, y: 0.5 + sin(t * 0.6) * 0.3),
-                    startRadius: 0,
-                    endRadius: 240
-                )
-                .blendMode(.plusLighter)
+        // The churning clock is mounted only while the popover is on-screen; closed, it drops to a static
+        // frame so no display link ticks (see `\.popoverIsVisible`).
+        if shown {
+            TimelineView(.animation) { timeline in
+                gradient(at: timeline.date.timeIntervalSinceReferenceDate)
             }
+            .transition(.identity)
+        } else {
+            // Static frame at the current instant: matches the live clock's first frame, so the (at most
+            // one-frame) static render during a show is indistinguishable from the running animation.
+            gradient(at: Date().timeIntervalSinceReferenceDate)
+                .transition(.identity)
+        }
+    }
+
+    private func gradient(at t: TimeInterval) -> some View {
+        ZStack {
+            AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 28))
+                .opacity(0.5)   // translucent tint, so the blurred desktop blends through the colors
+            RadialGradient(
+                colors: [Color.white.opacity(0.15), .clear],
+                center: UnitPoint(x: 0.5 + cos(t * 0.5) * 0.3, y: 0.5 + sin(t * 0.6) * 0.3),
+                startRadius: 0,
+                endRadius: 240
+            )
+            .blendMode(.plusLighter)
         }
     }
 }
 
 /// A glowing rim that rotates around the popover edge — pure party, never over the text.
 private struct PartyRim: View {
+    @Environment(\.popoverIsVisible) private var shown
+
     var body: some View {
-        TimelineView(.animation) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
-            RoundedRectangle(cornerRadius: 13, style: .continuous)
-                .strokeBorder(
-                    AngularGradient(colors: partyColors, center: .center, angle: .degrees(-t * 36)),
-                    lineWidth: 2.5
-                )
-                .shadow(color: Color(red: 1, green: 0.4, blue: 0.85).opacity(0.7), radius: 7)
+        if shown {
+            TimelineView(.animation) { timeline in
+                rim(at: timeline.date.timeIntervalSinceReferenceDate)
+            }
+            .transition(.identity)
+        } else {
+            rim(at: Date().timeIntervalSinceReferenceDate)
+                .transition(.identity)
         }
+    }
+
+    private func rim(at t: TimeInterval) -> some View {
+        RoundedRectangle(cornerRadius: 13, style: .continuous)
+            .strokeBorder(
+                AngularGradient(colors: partyColors, center: .center, angle: .degrees(-t * 36)),
+                lineWidth: 2.5
+            )
+            .shadow(color: Color(red: 1, green: 0.4, blue: 0.85).opacity(0.7), radius: 7)
     }
 }
 
 // MARK: - Drunk (the woozy, barely-readable escalation)
 
 /// Blurs, hue-wobbles, and woozily sways the content — the "had one too many" part. Identity when
-/// inactive (no `TimelineView` mounted), so it costs nothing outside the egg. Plain `.animation` (not the
-/// `paused:` overload), so the sway starts immediately when Drunk Mode is switched on with the popover
-/// already open — the visibility-coupled overload only attached on a window show, freezing in-place toggles.
+/// inactive (no `TimelineView`, no effect), so it costs nothing outside the egg. While Drunk is active the
+/// sway clock is mounted only with the popover on-screen (a fresh mount on in-place activation starts it
+/// immediately, unlike the reverted `.animation(paused:)` overload); when Drunk is active but the popover
+/// is hidden it freezes the distortion at a static frame rather than dropping it, so the look doesn't snap
+/// off on close. The three branches are deliberate — collapsing active-but-hidden into the inactive branch
+/// would visibly remove the blur the instant the popover closes.
 private struct DrunkDistortion: ViewModifier {
     let active: Bool
+    @Environment(\.popoverIsVisible) private var shown
 
     @ViewBuilder
     func body(content: Content) -> some View {
-        if active {
+        if active && shown {
             TimelineView(.animation) { timeline in
-                let t = timeline.date.timeIntervalSinceReferenceDate
-                content
-                    .saturation(1.55)
-                    .blur(radius: 3.6)
-                    .hueRotation(.degrees(sin(t * 1.1) * 16))
-                    .scaleEffect(1.05 * (1 + sin(t * 1.2) * 0.018))   // over-scale hides sway gaps
-                    .rotationEffect(.degrees(sin(t * 1.5) * 1.1))     // the room is spinning
+                distort(content, at: timeline.date.timeIntervalSinceReferenceDate)
             }
+            .transition(.identity)
+        } else if active {
+            distort(content, at: Date().timeIntervalSinceReferenceDate)
+                .transition(.identity)
         } else {
             content
         }
+    }
+
+    private func distort(_ content: Content, at t: TimeInterval) -> some View {
+        content
+            .saturation(1.55)
+            .blur(radius: 3.6)
+            .hueRotation(.degrees(sin(t * 1.1) * 16))
+            .scaleEffect(1.05 * (1 + sin(t * 1.2) * 0.018))   // over-scale hides sway gaps
+            .rotationEffect(.degrees(sin(t * 1.5) * 1.1))     // the room is spinning
     }
 }
 
 /// The pink-glass haze layered over the content: a clear-glass lens (the deliberate Liquid Glass abuse)
 /// and a slowly churning pink wash — double-vision territory.
 private struct DrunkOverlays: View {
+    @Environment(\.popoverIsVisible) private var shown
+
     var body: some View {
-        TimelineView(.animation) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
-            ZStack {
-                glassLens()
-                AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 26))
-                    .opacity(0.5)
+        if shown {
+            TimelineView(.animation) { timeline in
+                haze(at: timeline.date.timeIntervalSinceReferenceDate)
             }
+            .transition(.identity)
+        } else {
+            haze(at: Date().timeIntervalSinceReferenceDate)
+                .transition(.identity)
+        }
+    }
+
+    private func haze(at t: TimeInterval) -> some View {
+        ZStack {
+            glassLens()
+            AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 26))
+                .opacity(0.5)
         }
     }
 

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -122,15 +122,21 @@ private struct PartyRim: View {
 /// switching Spaces), an animated layer stays but the static cards/text blank out, and why drunk mode
 /// (whose whole content is animated by `DrunkDistortion`) never blanks. This forces a re-raster each
 /// frame with a *varying* sub-pixel blur — a transform/scale wouldn't, since those reuse the cached
-/// bitmap, whereas a changing blur re-renders the content. The radius peaks under a point, so it reads as
-/// crisp. Identity when inactive (no `TimelineView` mounted), so it costs nothing on the opaque surface.
+/// bitmap, whereas a changing blur re-renders the content.
+///
+/// Crucially it runs ONLY while the popover is NOT the key window (`!isKey`): a focused popover isn't
+/// culled, so there's nothing to fight and the content must stay perfectly crisp — running the blur then
+/// is the visible "pulsing" regression. So while focused this is identity (plain content); it engages
+/// only once focus leaves, where the sub-pixel blur on the now-background popover is unnoticeable. Also
+/// identity when inactive or hidden, so it costs nothing on the opaque surface or a closed popover.
 private struct TranslucentKeepAlive: ViewModifier {
     let active: Bool
     @Environment(\.popoverIsVisible) private var isVisible
+    @Environment(\.popoverIsKey) private var isKey
 
     @ViewBuilder
     func body(content: Content) -> some View {
-        if active {
+        if active && !isKey {
             // Low cadence (the blur is sub-pixel, so it's invisible) and paused while the popover is
             // hidden — when it's not on-screen the layer can't be culled, so the keepalive isn't needed.
             TimelineView(.animation(minimumInterval: keepAliveFrameInterval, paused: !isVisible)) { timeline in

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -26,13 +26,6 @@ private let partyColors: [Color] = [
     Color(red: 1.00, green: 0.32, blue: 0.74),
 ]
 
-/// The keepalive runs far below the display's refresh: its only job is to out-pace the compositor's idle
-/// layer-cull (~1s of no repaint), and its blur is sub-pixel so the low cadence is invisible. The visible
-/// party animations, by contrast, run at the display's native rate (matching the user's refresh, ProMotion
-/// included) so they look exactly as designed — the energy win comes from pausing when the popover is
-/// hidden (see `\.popoverIsVisible`), not from capping the frame rate.
-private let keepAliveFrameInterval: Double = 1.0 / 10.0
-
 /// One stable modifier whose layers come and go by `style`. The `.animation(value:)` plus per-layer
 /// `.transition(.opacity)` is what makes toggling the egg fade in and out (the AppKit window alpha and
 /// backdrop crossfade on the same ~0.55s ease, driven by `StatusItemController`).
@@ -45,11 +38,6 @@ private struct TooMuchTransparencyModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .modifier(DrunkDistortion(active: isDrunk))
-            // Party's cards are static behind its animated gradient/rim; keep them re-rasterizing so they
-            // survive losing key focus, the same way drunk's `DrunkDistortion` animation does. Scoped to
-            // party ONLY: the plain Increase Transparency surface does not blank, and the keepalive's
-            // sub-pixel blur — invisible amid party — would read as a visible "pulse" on its crisp text.
-            .modifier(PartyKeepAlive(active: isParty))
             .background {
                 if isParty { PartyBackdrop().transition(.opacity) }
             }
@@ -106,37 +94,6 @@ private struct PartyRim: View {
                     lineWidth: 2.5
                 )
                 .shadow(color: Color(red: 1, green: 0.4, blue: 0.85).opacity(0.7), radius: 7)
-        }
-    }
-}
-
-/// Keeps party's static content re-rasterizing so it survives losing key focus.
-///
-/// In party mode the cards/text are static behind the animated gradient and rim. When focus left the
-/// popover (Cmd-Tab, clicking another app) those static cards were observed to blank while the animated
-/// layers kept rendering, so this forces a re-raster each frame with a *varying* sub-pixel blur — a
-/// transform/scale wouldn't, since those reuse the cached bitmap, whereas a changing blur re-renders the
-/// content. The radius peaks under a point, invisible amid the party visuals. Paused while the popover is
-/// hidden (nothing on-screen to keep alive), and identity when inactive, so it costs nothing off party.
-///
-/// Deliberately party-only. The plain Increase Transparency surface does NOT mount this: there the
-/// oscillating blur reads as a visible "pulse" on otherwise-crisp text, and — unlike the party visuals —
-/// that surface does not blank (the earlier belief that it shared party's failure was a wrong inference).
-private struct PartyKeepAlive: ViewModifier {
-    let active: Bool
-    @Environment(\.popoverIsVisible) private var isVisible
-
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if active {
-            // Low cadence (the blur is sub-pixel, so it's invisible) and paused while the popover is
-            // hidden — when it's not on-screen the layer can't be culled, so the keepalive isn't needed.
-            TimelineView(.animation(minimumInterval: keepAliveFrameInterval, paused: !isVisible)) { timeline in
-                let t = timeline.date.timeIntervalSinceReferenceDate
-                content.blur(radius: (1 + sin(t * 1.8)) * 0.3)   // 0–0.6pt, oscillating; forces a re-raster
-            }
-        } else {
-            content
         }
     }
 }

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -41,19 +41,15 @@ private struct TooMuchTransparencyModifier: ViewModifier {
 
     private var isParty: Bool { style == .party }
     private var isDrunk: Bool { style == .drunk }
-    /// Increase Transparency (`.increased`) and party both show *static* content on the translucent,
-    /// non-key panel, which the compositor culls unless it keeps repainting; drunk is exempt because
-    /// `DrunkDistortion` already repaints it every frame.
-    private var needsKeepAlive: Bool { style.surfaceTreatment == .translucent && !isDrunk }
 
     func body(content: Content) -> some View {
         content
             .modifier(DrunkDistortion(active: isDrunk))
-            // Keep translucent static content continuously re-rasterizing so it survives losing key
-            // focus, the same way drunk's `DrunkDistortion` animation does (drunk never blanks for
-            // exactly this reason). Covers the plain Increase Transparency surface too, not only party —
-            // both blank otherwise on a Space switch or Cmd-Tab.
-            .modifier(TranslucentKeepAlive(active: needsKeepAlive))
+            // Party's cards are static behind its animated gradient/rim; keep them re-rasterizing so they
+            // survive losing key focus, the same way drunk's `DrunkDistortion` animation does. Scoped to
+            // party ONLY: the plain Increase Transparency surface does not blank, and the keepalive's
+            // sub-pixel blur — invisible amid party — would read as a visible "pulse" on its crisp text.
+            .modifier(PartyKeepAlive(active: isParty))
             .background {
                 if isParty { PartyBackdrop().transition(.opacity) }
             }
@@ -114,29 +110,25 @@ private struct PartyRim: View {
     }
 }
 
-/// Keeps a translucent content layer resident while the panel isn't the key window — for both the plain
-/// Increase Transparency surface and party.
+/// Keeps party's static content re-rasterizing so it survives losing key focus.
 ///
-/// On a non-opaque, non-key window the compositor drops *static* SwiftUI content — only views that
-/// repaint every frame survive. That's why, with focus elsewhere (Cmd-Tab, clicking another app,
-/// switching Spaces), an animated layer stays but the static cards/text blank out, and why drunk mode
-/// (whose whole content is animated by `DrunkDistortion`) never blanks. This forces a re-raster each
-/// frame with a *varying* sub-pixel blur — a transform/scale wouldn't, since those reuse the cached
-/// bitmap, whereas a changing blur re-renders the content.
+/// In party mode the cards/text are static behind the animated gradient and rim. When focus left the
+/// popover (Cmd-Tab, clicking another app) those static cards were observed to blank while the animated
+/// layers kept rendering, so this forces a re-raster each frame with a *varying* sub-pixel blur — a
+/// transform/scale wouldn't, since those reuse the cached bitmap, whereas a changing blur re-renders the
+/// content. The radius peaks under a point, invisible amid the party visuals. Paused while the popover is
+/// hidden (nothing on-screen to keep alive), and identity when inactive, so it costs nothing off party.
 ///
-/// Crucially it runs ONLY while the popover is NOT the key window (`!isKey`): a focused popover isn't
-/// culled, so there's nothing to fight and the content must stay perfectly crisp — running the blur then
-/// is the visible "pulsing" regression. So while focused this is identity (plain content); it engages
-/// only once focus leaves, where the sub-pixel blur on the now-background popover is unnoticeable. Also
-/// identity when inactive or hidden, so it costs nothing on the opaque surface or a closed popover.
-private struct TranslucentKeepAlive: ViewModifier {
+/// Deliberately party-only. The plain Increase Transparency surface does NOT mount this: there the
+/// oscillating blur reads as a visible "pulse" on otherwise-crisp text, and — unlike the party visuals —
+/// that surface does not blank (the earlier belief that it shared party's failure was a wrong inference).
+private struct PartyKeepAlive: ViewModifier {
     let active: Bool
     @Environment(\.popoverIsVisible) private var isVisible
-    @Environment(\.popoverIsKey) private var isKey
 
     @ViewBuilder
     func body(content: Content) -> some View {
-        if active && !isKey {
+        if active {
             // Low cadence (the blur is sub-pixel, so it's invisible) and paused while the popover is
             // hidden — when it's not on-screen the layer can't be culled, so the keepalive isn't needed.
             TimelineView(.animation(minimumInterval: keepAliveFrameInterval, paused: !isVisible)) { timeline in

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -41,13 +41,19 @@ private struct TooMuchTransparencyModifier: ViewModifier {
 
     private var isParty: Bool { style == .party }
     private var isDrunk: Bool { style == .drunk }
+    /// Increase Transparency (`.increased`) and party both show *static* content on the translucent,
+    /// non-key panel, which the compositor culls unless it keeps repainting; drunk is exempt because
+    /// `DrunkDistortion` already repaints it every frame.
+    private var needsKeepAlive: Bool { style.surfaceTreatment == .translucent && !isDrunk }
 
     func body(content: Content) -> some View {
         content
             .modifier(DrunkDistortion(active: isDrunk))
-            // Keep party's content continuously re-rasterizing so it survives losing key focus, the same
-            // way drunk's `DrunkDistortion` animation does (drunk never blanks for exactly this reason).
-            .modifier(PartyKeepAlive(active: isParty))
+            // Keep translucent static content continuously re-rasterizing so it survives losing key
+            // focus, the same way drunk's `DrunkDistortion` animation does (drunk never blanks for
+            // exactly this reason). Covers the plain Increase Transparency surface too, not only party —
+            // both blank otherwise on a Space switch or Cmd-Tab.
+            .modifier(TranslucentKeepAlive(active: needsKeepAlive))
             .background {
                 if isParty { PartyBackdrop().transition(.opacity) }
             }
@@ -108,16 +114,17 @@ private struct PartyRim: View {
     }
 }
 
-/// Keeps the party content layer resident while the panel isn't the key window.
+/// Keeps a translucent content layer resident while the panel isn't the key window — for both the plain
+/// Increase Transparency surface and party.
 ///
 /// On a non-opaque, non-key window the compositor drops *static* SwiftUI content — only views that
 /// repaint every frame survive. That's why, with focus elsewhere (Cmd-Tab, clicking another app,
-/// switching Spaces), the animated party gradient stays but the static cards/text blank out, and why
-/// drunk mode (whose whole content is animated by `DrunkDistortion`) never blanks. This forces a re-raster
-/// each frame with a *varying* sub-pixel blur — a transform/scale wouldn't, since those reuse the cached
+/// switching Spaces), an animated layer stays but the static cards/text blank out, and why drunk mode
+/// (whose whole content is animated by `DrunkDistortion`) never blanks. This forces a re-raster each
+/// frame with a *varying* sub-pixel blur — a transform/scale wouldn't, since those reuse the cached
 /// bitmap, whereas a changing blur re-renders the content. The radius peaks under a point, so it reads as
-/// crisp. Identity when inactive (no `TimelineView` mounted), and it only runs while party is on.
-private struct PartyKeepAlive: ViewModifier {
+/// crisp. Identity when inactive (no `TimelineView` mounted), so it costs nothing on the opaque surface.
+private struct TranslucentKeepAlive: ViewModifier {
     let active: Bool
     @Environment(\.popoverIsVisible) private var isVisible
 

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -61,10 +61,8 @@ private struct TooMuchTransparencyModifier: ViewModifier {
 /// composite against the AppKit vibrancy view behind the host, so the desktop only blends through via
 /// alpha — hence the reduced opacity rather than a blend mode.)
 private struct PartyBackdrop: View {
-    @Environment(\.popoverIsVisible) private var isVisible
-
     var body: some View {
-        TimelineView(.animation(paused: !isVisible)) { timeline in
+        TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             ZStack {
                 AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 28))
@@ -83,10 +81,8 @@ private struct PartyBackdrop: View {
 
 /// A glowing rim that rotates around the popover edge — pure party, never over the text.
 private struct PartyRim: View {
-    @Environment(\.popoverIsVisible) private var isVisible
-
     var body: some View {
-        TimelineView(.animation(paused: !isVisible)) { timeline in
+        TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             RoundedRectangle(cornerRadius: 13, style: .continuous)
                 .strokeBorder(
@@ -101,15 +97,16 @@ private struct PartyRim: View {
 // MARK: - Drunk (the woozy, barely-readable escalation)
 
 /// Blurs, hue-wobbles, and woozily sways the content — the "had one too many" part. Identity when
-/// inactive (no `TimelineView` mounted), so it costs nothing outside the egg.
+/// inactive (no `TimelineView` mounted), so it costs nothing outside the egg. Plain `.animation` (not the
+/// `paused:` overload), so the sway starts immediately when Drunk Mode is switched on with the popover
+/// already open — the visibility-coupled overload only attached on a window show, freezing in-place toggles.
 private struct DrunkDistortion: ViewModifier {
     let active: Bool
-    @Environment(\.popoverIsVisible) private var isVisible
 
     @ViewBuilder
     func body(content: Content) -> some View {
         if active {
-            TimelineView(.animation(paused: !isVisible)) { timeline in
+            TimelineView(.animation) { timeline in
                 let t = timeline.date.timeIntervalSinceReferenceDate
                 content
                     .saturation(1.55)
@@ -124,25 +121,16 @@ private struct DrunkDistortion: ViewModifier {
     }
 }
 
-/// The pink-glass haze layered over the content: a clear-glass lens (the deliberate Liquid Glass abuse),
-/// a pink wash, and a drifting specular shimmer — double-vision territory.
+/// The pink-glass haze layered over the content: a clear-glass lens (the deliberate Liquid Glass abuse)
+/// and a slowly churning pink wash — double-vision territory.
 private struct DrunkOverlays: View {
-    @Environment(\.popoverIsVisible) private var isVisible
-
     var body: some View {
-        TimelineView(.animation(paused: !isVisible)) { timeline in
+        TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             ZStack {
                 glassLens()
                 AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 26))
                     .opacity(0.5)
-                RadialGradient(
-                    colors: [Color.white.opacity(0.55), .clear],
-                    center: UnitPoint(x: 0.5 + cos(t * 0.8) * 0.32, y: 0.5 + sin(t * 0.9) * 0.32),
-                    startRadius: 0,
-                    endRadius: 130
-                )
-                .blendMode(.plusLighter)
             }
         }
     }

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -26,6 +26,13 @@ private let partyColors: [Color] = [
     Color(red: 1.00, green: 0.32, blue: 0.74),
 ]
 
+/// The keepalive runs far below the display's refresh: its only job is to out-pace the compositor's idle
+/// layer-cull (~1s of no repaint), and its blur is sub-pixel so the low cadence is invisible. The visible
+/// party animations, by contrast, run at the display's native rate (matching the user's refresh, ProMotion
+/// included) so they look exactly as designed — the energy win comes from pausing when the popover is
+/// hidden (see `\.popoverIsVisible`), not from capping the frame rate.
+private let keepAliveFrameInterval: Double = 1.0 / 10.0
+
 /// One stable modifier whose layers come and go by `style`. The `.animation(value:)` plus per-layer
 /// `.transition(.opacity)` is what makes toggling the egg fade in and out (the AppKit window alpha and
 /// backdrop crossfade on the same ~0.55s ease, driven by `StatusItemController`).
@@ -38,6 +45,9 @@ private struct TooMuchTransparencyModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .modifier(DrunkDistortion(active: isDrunk))
+            // Keep party's content continuously re-rasterizing so it survives losing key focus, the same
+            // way drunk's `DrunkDistortion` animation does (drunk never blanks for exactly this reason).
+            .modifier(PartyKeepAlive(active: isParty))
             .background {
                 if isParty { PartyBackdrop().transition(.opacity) }
             }
@@ -61,8 +71,10 @@ private struct TooMuchTransparencyModifier: ViewModifier {
 /// composite against the AppKit vibrancy view behind the host, so the desktop only blends through via
 /// alpha — hence the reduced opacity rather than a blend mode.)
 private struct PartyBackdrop: View {
+    @Environment(\.popoverIsVisible) private var isVisible
+
     var body: some View {
-        TimelineView(.animation) { timeline in
+        TimelineView(.animation(paused: !isVisible)) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             ZStack {
                 AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 28))
@@ -81,8 +93,10 @@ private struct PartyBackdrop: View {
 
 /// A glowing rim that rotates around the popover edge — pure party, never over the text.
 private struct PartyRim: View {
+    @Environment(\.popoverIsVisible) private var isVisible
+
     var body: some View {
-        TimelineView(.animation) { timeline in
+        TimelineView(.animation(paused: !isVisible)) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             RoundedRectangle(cornerRadius: 13, style: .continuous)
                 .strokeBorder(
@@ -94,17 +108,46 @@ private struct PartyRim: View {
     }
 }
 
+/// Keeps the party content layer resident while the panel isn't the key window.
+///
+/// On a non-opaque, non-key window the compositor drops *static* SwiftUI content — only views that
+/// repaint every frame survive. That's why, with focus elsewhere (Cmd-Tab, clicking another app,
+/// switching Spaces), the animated party gradient stays but the static cards/text blank out, and why
+/// drunk mode (whose whole content is animated by `DrunkDistortion`) never blanks. This forces a re-raster
+/// each frame with a *varying* sub-pixel blur — a transform/scale wouldn't, since those reuse the cached
+/// bitmap, whereas a changing blur re-renders the content. The radius peaks under a point, so it reads as
+/// crisp. Identity when inactive (no `TimelineView` mounted), and it only runs while party is on.
+private struct PartyKeepAlive: ViewModifier {
+    let active: Bool
+    @Environment(\.popoverIsVisible) private var isVisible
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if active {
+            // Low cadence (the blur is sub-pixel, so it's invisible) and paused while the popover is
+            // hidden — when it's not on-screen the layer can't be culled, so the keepalive isn't needed.
+            TimelineView(.animation(minimumInterval: keepAliveFrameInterval, paused: !isVisible)) { timeline in
+                let t = timeline.date.timeIntervalSinceReferenceDate
+                content.blur(radius: (1 + sin(t * 1.8)) * 0.3)   // 0–0.6pt, oscillating; forces a re-raster
+            }
+        } else {
+            content
+        }
+    }
+}
+
 // MARK: - Drunk (the woozy, barely-readable escalation)
 
 /// Blurs, hue-wobbles, and woozily sways the content — the "had one too many" part. Identity when
 /// inactive (no `TimelineView` mounted), so it costs nothing outside the egg.
 private struct DrunkDistortion: ViewModifier {
     let active: Bool
+    @Environment(\.popoverIsVisible) private var isVisible
 
     @ViewBuilder
     func body(content: Content) -> some View {
         if active {
-            TimelineView(.animation) { timeline in
+            TimelineView(.animation(paused: !isVisible)) { timeline in
                 let t = timeline.date.timeIntervalSinceReferenceDate
                 content
                     .saturation(1.55)
@@ -122,8 +165,10 @@ private struct DrunkDistortion: ViewModifier {
 /// The pink-glass haze layered over the content: a clear-glass lens (the deliberate Liquid Glass abuse),
 /// a pink wash, and a drifting specular shimmer — double-vision territory.
 private struct DrunkOverlays: View {
+    @Environment(\.popoverIsVisible) private var isVisible
+
     var body: some View {
-        TimelineView(.animation) { timeline in
+        TimelineView(.animation(paused: !isVisible)) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             ZStack {
                 glassLens()

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -1,25 +1,18 @@
 import SwiftUI
 
 extension View {
-    /// The "too much transparency" easter-egg treatment.
+    /// The "too much transparency" easter-egg treatment, applied as one stable modifier so enabling and
+    /// disabling **crossfade** (a ~0.55s ease) instead of snapping.
     ///
     /// - `.disco`: the secret code's main state — a loud but **readable** party. A vivid churning
     ///   gradient fills the popover behind the content and a glowing rim rotates around the edge, while
-    ///   the content stays crisp on frosted cards (no blur over text, the window stays solid). Meter bars
-    ///   and provider marks join in via the `popoverPartyMode` environment flag.
-    /// - `.ghost`: the "Even More" extreme — the deliberately barely-readable pink-glass chaos, where the
-    ///   abuse is layered *over* the content (blur, pink wash, sway) and the window goes see-through.
-    /// A no-op for the normal and increased styles.
-    @ViewBuilder
+    ///   the content stays crisp on frosted cards (no blur over text). Meter bars and provider marks join
+    ///   in via the `popoverPartyMode` environment flag.
+    /// - `.ghost`: the "Even More" extreme — the deliberately barely-readable pink-glass chaos, layered
+    ///   *over* the content (blur, pink wash, sway) with the window going see-through.
+    /// - `.opaque` / `.increased`: nothing — just the normal look.
     func tooMuchTransparency(_ style: PopoverTransparencyStyle) -> some View {
-        switch style {
-        case .disco:
-            modifier(DiscoModifier())
-        case .ghost:
-            modifier(GhostModifier())
-        case .opaque, .increased:
-            self
-        }
+        modifier(TooMuchTransparencyModifier(style: style))
     }
 }
 
@@ -32,19 +25,33 @@ private let discoColors: [Color] = [
     Color(red: 1.00, green: 0.32, blue: 0.74),
 ]
 
-// MARK: - Disco (loud but readable)
+/// One stable modifier whose layers come and go by `style`. The `.animation(value:)` plus per-layer
+/// `.transition(.opacity)` is what makes toggling the egg fade in and out (the AppKit window alpha and
+/// backdrop crossfade on the same ~0.55s ease, driven by `StatusItemController`).
+private struct TooMuchTransparencyModifier: ViewModifier {
+    let style: PopoverTransparencyStyle
 
-private struct DiscoModifier: ViewModifier {
+    private var isDisco: Bool { style == .disco }
+    private var isGhost: Bool { style == .ghost }
+
     func body(content: Content) -> some View {
         content
-            // Leaf views (meters, provider marks) read this to join the party.
-            .environment(\.popoverPartyMode, true)
-            // The gradient lives BEHIND the content (which sits on frosted scrim cards), so text never
-            // gets washed or blurred — that's what keeps it readable.
-            .background { DiscoBackdrop() }
-            .overlay { DiscoRim().allowsHitTesting(false) }
+            .modifier(GhostDistortion(active: isGhost))
+            .background {
+                if isDisco { DiscoBackdrop().transition(.opacity) }
+            }
+            .overlay {
+                if isDisco { DiscoRim().transition(.opacity).allowsHitTesting(false) }
+            }
+            .overlay {
+                if isGhost { GhostOverlays().transition(.opacity).allowsHitTesting(false) }
+            }
+            .environment(\.popoverPartyMode, isDisco)
+            .animation(.easeInOut(duration: 0.55), value: style)
     }
 }
+
+// MARK: - Disco (loud but readable)
 
 /// A vivid, slowly churning gradient that fills the popover behind the (frosted, readable) content.
 private struct DiscoBackdrop: View {
@@ -82,33 +89,50 @@ private struct DiscoRim: View {
 
 // MARK: - Ghost (the unreadable "Even More" extreme)
 
-/// The deliberately barely-readable chaos: pink iridescence and a clear-glass lens layered *over* the
-/// content, which is blurred, hue-wobbled, and gently swaying. The joke leans into abusing Liquid Glass.
-private struct GhostModifier: ViewModifier {
+/// Blurs, hue-wobbles, and gently sways the content — the unreadable part. Identity when inactive (no
+/// `TimelineView` mounted), so it costs nothing outside the egg.
+private struct GhostDistortion: ViewModifier {
+    let active: Bool
+
+    @ViewBuilder
     func body(content: Content) -> some View {
+        if active {
+            TimelineView(.animation) { timeline in
+                let t = timeline.date.timeIntervalSinceReferenceDate
+                content
+                    .saturation(1.55)
+                    .blur(radius: 3.6)
+                    .hueRotation(.degrees(sin(t * 1.1) * 16))
+                    .scaleEffect(1.05 * (1 + sin(t * 1.2) * 0.018))   // over-scale hides sway gaps
+                    .rotationEffect(.degrees(sin(t * 1.5) * 1.1))
+            }
+        } else {
+            content
+        }
+    }
+}
+
+/// The pink-glass chaos layered over the content: a clear-glass lens (the deliberate Liquid Glass
+/// abuse), a pink wash, and a drifting specular shimmer.
+private struct GhostOverlays: View {
+    var body: some View {
         TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
-            let spin = t * 26
-            let hueWobble = sin(t * 1.1) * 16
-            let sway = sin(t * 1.5) * 1.1
-            let breathe = 1 + sin(t * 1.2) * 0.018
-            let driftX = cos(t * 0.8) * 0.32
-            let driftY = sin(t * 0.9) * 0.32
-
-            content
-                .saturation(1.55)
-                .blur(radius: 3.6)
-                .hueRotation(.degrees(hueWobble))
-                .scaleEffect(1.05 * breathe)        // over-scale hides sway gaps at the rounded corners
-                .rotationEffect(.degrees(sway))
-                .overlay { glassLens().allowsHitTesting(false) }
-                .overlay { pinkWash(angle: spin).allowsHitTesting(false) }
-                .overlay { shimmer(driftX: driftX, driftY: driftY).allowsHitTesting(false) }
+            ZStack {
+                glassLens()
+                AngularGradient(colors: discoColors, center: .center, angle: .degrees(t * 26))
+                    .opacity(0.5)
+                RadialGradient(
+                    colors: [Color.white.opacity(0.55), .clear],
+                    center: UnitPoint(x: 0.5 + cos(t * 0.8) * 0.32, y: 0.5 + sin(t * 0.9) * 0.32),
+                    startRadius: 0,
+                    endRadius: 130
+                )
+                .blendMode(.plusLighter)
+            }
         }
     }
 
-    /// The deliberate Liquid Glass abuse: a full-cover clear-glass lens (macOS 26) or frosted material
-    /// (macOS 15) that refracts the whole popover.
     @ViewBuilder
     private func glassLens() -> some View {
         if #available(macOS 26, *) {
@@ -116,23 +140,5 @@ private struct GhostModifier: ViewModifier {
         } else {
             Rectangle().fill(.ultraThinMaterial)
         }
-    }
-
-    /// Rotating pink iridescence, blended so it tints and washes the content rather than hiding it flat.
-    private func pinkWash(angle: Double) -> some View {
-        AngularGradient(colors: discoColors, center: .center, angle: .degrees(angle))
-            .blendMode(.overlay)
-            .opacity(0.95)
-    }
-
-    /// A soft white specular highlight that drifts around — the "liquid" shimmer of the glass.
-    private func shimmer(driftX: Double, driftY: Double) -> some View {
-        RadialGradient(
-            colors: [Color.white.opacity(0.55), .clear],
-            center: UnitPoint(x: 0.5 + driftX, y: 0.5 + driftY),
-            startRadius: 0,
-            endRadius: 130
-        )
-        .blendMode(.plusLighter)
     }
 }

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -1,46 +1,105 @@
 import SwiftUI
 
 extension View {
-    /// The "too much transparency" easter-egg treatment for the ghost styles: an animated pink/rose
-    /// iridescence that slowly rotates over a clear Liquid Glass lens, a soft specular shimmer that
-    /// drifts around, and the content gently blurred, breathing, and swaying. The result is barely
-    /// readable, but on purpose and in a pretty, chaotic-but-elegant way — the joke leans into abusing
-    /// Liquid Glass, not just cranking the window alpha. A no-op for the non-egg styles.
+    /// The "too much transparency" easter-egg treatment.
+    ///
+    /// - `.disco`: the secret code's main state — a loud but **readable** party. A vivid churning
+    ///   gradient fills the popover behind the content and a glowing rim rotates around the edge, while
+    ///   the content stays crisp on frosted cards (no blur over text, the window stays solid). Meter bars
+    ///   and provider marks join in via the `popoverPartyMode` environment flag.
+    /// - `.ghost`: the "Even More" extreme — the deliberately barely-readable pink-glass chaos, where the
+    ///   abuse is layered *over* the content (blur, pink wash, sway) and the window goes see-through.
+    /// A no-op for the normal and increased styles.
     @ViewBuilder
     func tooMuchTransparency(_ style: PopoverTransparencyStyle) -> some View {
         switch style {
+        case .disco:
+            modifier(DiscoModifier())
         case .ghost:
-            modifier(TooMuchTransparencyModifier(intense: false))
-        case .ghostMore:
-            modifier(TooMuchTransparencyModifier(intense: true))
+            modifier(GhostModifier())
         case .opaque, .increased:
             self
         }
     }
 }
 
-/// Drives every animated value off one continuous clock (`TimelineView(.animation)`) so the motion is
-/// smooth and self-contained — the modifier is only mounted while the egg is on, so there's no cost
-/// otherwise. `intense` is the "Even More" gear: faster, blurrier, more saturated, more pink.
-private struct TooMuchTransparencyModifier: ViewModifier {
-    let intense: Bool
+/// Shared party palette — pink, violet, cyan, rose.
+private let discoColors: [Color] = [
+    Color(red: 1.00, green: 0.32, blue: 0.74),
+    Color(red: 0.62, green: 0.40, blue: 1.00),
+    Color(red: 0.30, green: 0.85, blue: 1.00),
+    Color(red: 1.00, green: 0.55, blue: 0.86),
+    Color(red: 1.00, green: 0.32, blue: 0.74),
+]
 
+// MARK: - Disco (loud but readable)
+
+private struct DiscoModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            // Leaf views (meters, provider marks) read this to join the party.
+            .environment(\.popoverPartyMode, true)
+            // The gradient lives BEHIND the content (which sits on frosted scrim cards), so text never
+            // gets washed or blurred — that's what keeps it readable.
+            .background { DiscoBackdrop() }
+            .overlay { DiscoRim().allowsHitTesting(false) }
+    }
+}
+
+/// A vivid, slowly churning gradient that fills the popover behind the (frosted, readable) content.
+private struct DiscoBackdrop: View {
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            ZStack {
+                AngularGradient(colors: discoColors, center: .center, angle: .degrees(t * 28))
+                RadialGradient(
+                    colors: [Color.white.opacity(0.22), .clear],
+                    center: UnitPoint(x: 0.5 + cos(t * 0.5) * 0.3, y: 0.5 + sin(t * 0.6) * 0.3),
+                    startRadius: 0,
+                    endRadius: 240
+                )
+                .blendMode(.plusLighter)
+            }
+        }
+    }
+}
+
+/// A glowing rim that rotates around the popover edge — pure party, never over the text.
+private struct DiscoRim: View {
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .strokeBorder(
+                    AngularGradient(colors: discoColors, center: .center, angle: .degrees(-t * 36)),
+                    lineWidth: 2.5
+                )
+                .shadow(color: Color(red: 1, green: 0.4, blue: 0.85).opacity(0.7), radius: 7)
+        }
+    }
+}
+
+// MARK: - Ghost (the unreadable "Even More" extreme)
+
+/// The deliberately barely-readable chaos: pink iridescence and a clear-glass lens layered *over* the
+/// content, which is blurred, hue-wobbled, and gently swaying. The joke leans into abusing Liquid Glass.
+private struct GhostModifier: ViewModifier {
     func body(content: Content) -> some View {
         TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
-            let spin = t * (intense ? 26 : 14)                       // gradient rotation, degrees/sec
-            let hueWobble = sin(t * (intense ? 1.1 : 0.7)) * (intense ? 16 : 9)
-            let sway = sin(t * (intense ? 1.5 : 0.9)) * (intense ? 1.1 : 0.6)   // degrees
-            let breathe = 1 + sin(t * (intense ? 1.2 : 0.8)) * (intense ? 0.018 : 0.01)
-            let driftX = cos(t * (intense ? 0.8 : 0.5)) * 0.32       // shimmer drift, unit-point offset
-            let driftY = sin(t * (intense ? 0.9 : 0.6)) * 0.32
+            let spin = t * 26
+            let hueWobble = sin(t * 1.1) * 16
+            let sway = sin(t * 1.5) * 1.1
+            let breathe = 1 + sin(t * 1.2) * 0.018
+            let driftX = cos(t * 0.8) * 0.32
+            let driftY = sin(t * 0.9) * 0.32
 
             content
-                .saturation(intense ? 1.55 : 1.2)
-                .blur(radius: intense ? 3.6 : 2.2)
+                .saturation(1.55)
+                .blur(radius: 3.6)
                 .hueRotation(.degrees(hueWobble))
-                // Over-scale so the sway never opens a gap at the rounded corners; the host clips it.
-                .scaleEffect((intense ? 1.05 : 1.035) * breathe)
+                .scaleEffect(1.05 * breathe)        // over-scale hides sway gaps at the rounded corners
                 .rotationEffect(.degrees(sway))
                 .overlay { glassLens().allowsHitTesting(false) }
                 .overlay { pinkWash(angle: spin).allowsHitTesting(false) }
@@ -48,8 +107,8 @@ private struct TooMuchTransparencyModifier: ViewModifier {
         }
     }
 
-    /// The deliberate Liquid Glass abuse: a full-cover clear-glass lens that refracts and frosts the
-    /// whole popover (macOS 26), or a frosted material on macOS 15.
+    /// The deliberate Liquid Glass abuse: a full-cover clear-glass lens (macOS 26) or frosted material
+    /// (macOS 15) that refracts the whole popover.
     @ViewBuilder
     private func glassLens() -> some View {
         if #available(macOS 26, *) {
@@ -59,30 +118,20 @@ private struct TooMuchTransparencyModifier: ViewModifier {
         }
     }
 
-    /// The rotating pink iridescence, blended so it tints and washes the content rather than hiding it.
+    /// Rotating pink iridescence, blended so it tints and washes the content rather than hiding it flat.
     private func pinkWash(angle: Double) -> some View {
-        AngularGradient(
-            colors: [
-                Color(red: 1.00, green: 0.42, blue: 0.78),
-                Color(red: 0.96, green: 0.28, blue: 0.62),
-                Color(red: 0.80, green: 0.40, blue: 0.96),
-                Color(red: 1.00, green: 0.58, blue: 0.86),
-                Color(red: 1.00, green: 0.42, blue: 0.78),
-            ],
-            center: .center,
-            angle: .degrees(angle)
-        )
-        .blendMode(.overlay)
-        .opacity(intense ? 0.95 : 0.72)
+        AngularGradient(colors: discoColors, center: .center, angle: .degrees(angle))
+            .blendMode(.overlay)
+            .opacity(0.95)
     }
 
     /// A soft white specular highlight that drifts around — the "liquid" shimmer of the glass.
     private func shimmer(driftX: Double, driftY: Double) -> some View {
         RadialGradient(
-            colors: [Color.white.opacity(intense ? 0.55 : 0.4), .clear],
+            colors: [Color.white.opacity(0.55), .clear],
             center: UnitPoint(x: 0.5 + driftX, y: 0.5 + driftY),
             startRadius: 0,
-            endRadius: intense ? 130 : 170
+            endRadius: 130
         )
         .blendMode(.plusLighter)
     }

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -4,24 +4,25 @@ extension View {
     /// The "too much transparency" easter-egg treatment, applied as one stable modifier so enabling and
     /// disabling **crossfade** (a ~0.55s ease) instead of snapping.
     ///
-    /// - `.disco`: the secret code's main state — a loud but **readable** party. A vivid churning
+    /// - `.party`: the secret code's main state — a loud but **readable** party. A vivid churning
     ///   gradient fills the popover behind the content and a glowing rim rotates around the edge, while
     ///   the content stays crisp on frosted cards (no blur over text). Meter bars and provider marks join
     ///   in via the `popoverPartyMode` environment flag.
-    /// - `.ghost`: the "Even More" extreme — the deliberately barely-readable pink-glass chaos, layered
-    ///   *over* the content (blur, pink wash, sway) with the window going see-through.
+    /// - `.drunk`: the "Drunk Mode" escalation — properly tipsy: the deliberately barely-readable
+    ///   pink-glass chaos layered *over* the content (blur, pink wash, a woozy sway) with the window
+    ///   going see-through.
     /// - `.opaque` / `.increased`: nothing — just the normal look.
     func tooMuchTransparency(_ style: PopoverTransparencyStyle) -> some View {
         modifier(TooMuchTransparencyModifier(style: style))
     }
 }
 
-/// Shared party palette — pink, violet, cyan, rose.
-private let discoColors: [Color] = [
+/// Shared party palette — a cocktail of hot pink, violet, teal, and amber.
+private let partyColors: [Color] = [
     Color(red: 1.00, green: 0.32, blue: 0.74),
     Color(red: 0.62, green: 0.40, blue: 1.00),
-    Color(red: 0.30, green: 0.85, blue: 1.00),
-    Color(red: 1.00, green: 0.55, blue: 0.86),
+    Color(red: 0.30, green: 0.85, blue: 0.95),
+    Color(red: 1.00, green: 0.72, blue: 0.30),
     Color(red: 1.00, green: 0.32, blue: 0.74),
 ]
 
@@ -31,35 +32,35 @@ private let discoColors: [Color] = [
 private struct TooMuchTransparencyModifier: ViewModifier {
     let style: PopoverTransparencyStyle
 
-    private var isDisco: Bool { style == .disco }
-    private var isGhost: Bool { style == .ghost }
+    private var isParty: Bool { style == .party }
+    private var isDrunk: Bool { style == .drunk }
 
     func body(content: Content) -> some View {
         content
-            .modifier(GhostDistortion(active: isGhost))
+            .modifier(DrunkDistortion(active: isDrunk))
             .background {
-                if isDisco { DiscoBackdrop().transition(.opacity) }
+                if isParty { PartyBackdrop().transition(.opacity) }
             }
             .overlay {
-                if isDisco { DiscoRim().transition(.opacity).allowsHitTesting(false) }
+                if isParty { PartyRim().transition(.opacity).allowsHitTesting(false) }
             }
             .overlay {
-                if isGhost { GhostOverlays().transition(.opacity).allowsHitTesting(false) }
+                if isDrunk { DrunkOverlays().transition(.opacity).allowsHitTesting(false) }
             }
-            .environment(\.popoverPartyMode, isDisco)
+            .environment(\.popoverPartyMode, isParty)
             .animation(.easeInOut(duration: 0.55), value: style)
     }
 }
 
-// MARK: - Disco (loud but readable)
+// MARK: - Party (loud but readable)
 
 /// A vivid, slowly churning gradient that fills the popover behind the (frosted, readable) content.
-private struct DiscoBackdrop: View {
+private struct PartyBackdrop: View {
     var body: some View {
         TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             ZStack {
-                AngularGradient(colors: discoColors, center: .center, angle: .degrees(t * 28))
+                AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 28))
                 RadialGradient(
                     colors: [Color.white.opacity(0.22), .clear],
                     center: UnitPoint(x: 0.5 + cos(t * 0.5) * 0.3, y: 0.5 + sin(t * 0.6) * 0.3),
@@ -73,13 +74,13 @@ private struct DiscoBackdrop: View {
 }
 
 /// A glowing rim that rotates around the popover edge — pure party, never over the text.
-private struct DiscoRim: View {
+private struct PartyRim: View {
     var body: some View {
         TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             RoundedRectangle(cornerRadius: 13, style: .continuous)
                 .strokeBorder(
-                    AngularGradient(colors: discoColors, center: .center, angle: .degrees(-t * 36)),
+                    AngularGradient(colors: partyColors, center: .center, angle: .degrees(-t * 36)),
                     lineWidth: 2.5
                 )
                 .shadow(color: Color(red: 1, green: 0.4, blue: 0.85).opacity(0.7), radius: 7)
@@ -87,11 +88,11 @@ private struct DiscoRim: View {
     }
 }
 
-// MARK: - Ghost (the unreadable "Even More" extreme)
+// MARK: - Drunk (the woozy, barely-readable escalation)
 
-/// Blurs, hue-wobbles, and gently sways the content — the unreadable part. Identity when inactive (no
-/// `TimelineView` mounted), so it costs nothing outside the egg.
-private struct GhostDistortion: ViewModifier {
+/// Blurs, hue-wobbles, and woozily sways the content — the "had one too many" part. Identity when
+/// inactive (no `TimelineView` mounted), so it costs nothing outside the egg.
+private struct DrunkDistortion: ViewModifier {
     let active: Bool
 
     @ViewBuilder
@@ -104,7 +105,7 @@ private struct GhostDistortion: ViewModifier {
                     .blur(radius: 3.6)
                     .hueRotation(.degrees(sin(t * 1.1) * 16))
                     .scaleEffect(1.05 * (1 + sin(t * 1.2) * 0.018))   // over-scale hides sway gaps
-                    .rotationEffect(.degrees(sin(t * 1.5) * 1.1))
+                    .rotationEffect(.degrees(sin(t * 1.5) * 1.1))     // the room is spinning
             }
         } else {
             content
@@ -112,15 +113,15 @@ private struct GhostDistortion: ViewModifier {
     }
 }
 
-/// The pink-glass chaos layered over the content: a clear-glass lens (the deliberate Liquid Glass
-/// abuse), a pink wash, and a drifting specular shimmer.
-private struct GhostOverlays: View {
+/// The pink-glass haze layered over the content: a clear-glass lens (the deliberate Liquid Glass abuse),
+/// a pink wash, and a drifting specular shimmer — double-vision territory.
+private struct DrunkOverlays: View {
     var body: some View {
         TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             ZStack {
                 glassLens()
-                AngularGradient(colors: discoColors, center: .center, angle: .degrees(t * 26))
+                AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 26))
                     .opacity(0.5)
                 RadialGradient(
                     colors: [Color.white.opacity(0.55), .clear],

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+extension View {
+    /// The "too much transparency" easter-egg treatment for the ghost styles: an animated pink/rose
+    /// iridescence that slowly rotates over a clear Liquid Glass lens, a soft specular shimmer that
+    /// drifts around, and the content gently blurred, breathing, and swaying. The result is barely
+    /// readable, but on purpose and in a pretty, chaotic-but-elegant way — the joke leans into abusing
+    /// Liquid Glass, not just cranking the window alpha. A no-op for the non-egg styles.
+    @ViewBuilder
+    func tooMuchTransparency(_ style: PopoverTransparencyStyle) -> some View {
+        switch style {
+        case .ghost:
+            modifier(TooMuchTransparencyModifier(intense: false))
+        case .ghostMore:
+            modifier(TooMuchTransparencyModifier(intense: true))
+        case .opaque, .increased:
+            self
+        }
+    }
+}
+
+/// Drives every animated value off one continuous clock (`TimelineView(.animation)`) so the motion is
+/// smooth and self-contained — the modifier is only mounted while the egg is on, so there's no cost
+/// otherwise. `intense` is the "Even More" gear: faster, blurrier, more saturated, more pink.
+private struct TooMuchTransparencyModifier: ViewModifier {
+    let intense: Bool
+
+    func body(content: Content) -> some View {
+        TimelineView(.animation) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            let spin = t * (intense ? 26 : 14)                       // gradient rotation, degrees/sec
+            let hueWobble = sin(t * (intense ? 1.1 : 0.7)) * (intense ? 16 : 9)
+            let sway = sin(t * (intense ? 1.5 : 0.9)) * (intense ? 1.1 : 0.6)   // degrees
+            let breathe = 1 + sin(t * (intense ? 1.2 : 0.8)) * (intense ? 0.018 : 0.01)
+            let driftX = cos(t * (intense ? 0.8 : 0.5)) * 0.32       // shimmer drift, unit-point offset
+            let driftY = sin(t * (intense ? 0.9 : 0.6)) * 0.32
+
+            content
+                .saturation(intense ? 1.55 : 1.2)
+                .blur(radius: intense ? 3.6 : 2.2)
+                .hueRotation(.degrees(hueWobble))
+                // Over-scale so the sway never opens a gap at the rounded corners; the host clips it.
+                .scaleEffect((intense ? 1.05 : 1.035) * breathe)
+                .rotationEffect(.degrees(sway))
+                .overlay { glassLens().allowsHitTesting(false) }
+                .overlay { pinkWash(angle: spin).allowsHitTesting(false) }
+                .overlay { shimmer(driftX: driftX, driftY: driftY).allowsHitTesting(false) }
+        }
+    }
+
+    /// The deliberate Liquid Glass abuse: a full-cover clear-glass lens that refracts and frosts the
+    /// whole popover (macOS 26), or a frosted material on macOS 15.
+    @ViewBuilder
+    private func glassLens() -> some View {
+        if #available(macOS 26, *) {
+            Color.clear.glassEffect(.clear, in: Rectangle())
+        } else {
+            Rectangle().fill(.ultraThinMaterial)
+        }
+    }
+
+    /// The rotating pink iridescence, blended so it tints and washes the content rather than hiding it.
+    private func pinkWash(angle: Double) -> some View {
+        AngularGradient(
+            colors: [
+                Color(red: 1.00, green: 0.42, blue: 0.78),
+                Color(red: 0.96, green: 0.28, blue: 0.62),
+                Color(red: 0.80, green: 0.40, blue: 0.96),
+                Color(red: 1.00, green: 0.58, blue: 0.86),
+                Color(red: 1.00, green: 0.42, blue: 0.78),
+            ],
+            center: .center,
+            angle: .degrees(angle)
+        )
+        .blendMode(.overlay)
+        .opacity(intense ? 0.95 : 0.72)
+    }
+
+    /// A soft white specular highlight that drifts around — the "liquid" shimmer of the glass.
+    private func shimmer(driftX: Double, driftY: Double) -> some View {
+        RadialGradient(
+            colors: [Color.white.opacity(intense ? 0.55 : 0.4), .clear],
+            center: UnitPoint(x: 0.5 + driftX, y: 0.5 + driftY),
+            startRadius: 0,
+            endRadius: intense ? 130 : 170
+        )
+        .blendMode(.plusLighter)
+    }
+}

--- a/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyEffect.swift
@@ -54,15 +54,21 @@ private struct TooMuchTransparencyModifier: ViewModifier {
 
 // MARK: - Party (loud but readable)
 
-/// A vivid, slowly churning gradient that fills the popover behind the (frosted, readable) content.
+/// A vivid, slowly churning gradient that **tints** the popover, sitting behind the (frosted, readable)
+/// content. Built on the same translucent foundation as Increase Transparency: it's deliberately
+/// semi-transparent so the behind-window vibrancy backdrop — the blurred desktop — shows through and
+/// blends with the party colors, rather than an opaque wall that hides it. (A SwiftUI `blendMode` can't
+/// composite against the AppKit vibrancy view behind the host, so the desktop only blends through via
+/// alpha — hence the reduced opacity rather than a blend mode.)
 private struct PartyBackdrop: View {
     var body: some View {
         TimelineView(.animation) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             ZStack {
                 AngularGradient(colors: partyColors, center: .center, angle: .degrees(t * 28))
+                    .opacity(0.5)   // translucent tint, so the blurred desktop blends through the colors
                 RadialGradient(
-                    colors: [Color.white.opacity(0.22), .clear],
+                    colors: [Color.white.opacity(0.15), .clear],
                     center: UnitPoint(x: 0.5 + cos(t * 0.5) * 0.3, y: 0.5 + sin(t * 0.6) * 0.3),
                     startRadius: 0,
                     endRadius: 240

--- a/Sources/OpenUsage/Support/TooMuchTransparencyKeyReader.swift
+++ b/Sources/OpenUsage/Support/TooMuchTransparencyKeyReader.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import AppKit
+
+/// Detects the secret transparency code (↑ ↑ ↓ ↓ ← → ← → B A) while the popover panel is the key window
+/// and calls `onMatched` (which toggles the "too much transparency" easter egg). A deliberate sibling of
+/// `PopoverKeyReader` rather than an extra hook on it: the navigation monitor is carefully tuned and
+/// shouldn't carry the egg's concerns. Like that reader it installs one local `keyDown` monitor, but it
+/// **never consumes** keys — it only observes, so normal typing and navigation are untouched.
+struct TooMuchTransparencyKeyReader: NSViewRepresentable {
+    /// Called on a completed sequence. A second completion fires it again (re-type to toggle off).
+    var onMatched: @MainActor () -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = MonitorView()
+        view.onMatched = onMatched
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        (nsView as? MonitorView)?.onMatched = onMatched
+    }
+
+    final class MonitorView: NSView {
+        var onMatched: (@MainActor () -> Void)?
+        private var monitor: Any?
+        private var matcher = SecretCodeMatcher()
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+                self.monitor = nil
+            }
+            matcher.reset()
+            guard window != nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                // The code is bare key presses: ignore auto-repeat and any ⌘/⌃/⌥ chord (Shift is
+                // allowed so a capital A/B still counts — `charactersIgnoringModifiers` normalizes case).
+                guard !event.isARepeat,
+                      event.modifierFlags.intersection([.command, .control, .option]).isEmpty else {
+                    return event
+                }
+                let keyCode = event.keyCode
+                let characters = event.charactersIgnoringModifiers
+                let eventWindowID = event.window.map(ObjectIdentifier.init)
+                MainActor.assumeIsolated {
+                    guard let self, let window = self.window, window.isVisible else { return }
+                    // Only while the popover owns the keystroke (its key window is the panel), and not
+                    // while a text field / shortcut recorder is capturing — that input is the user's.
+                    guard PopoverKeyReader.keyTargetsPopover(
+                        eventWindowID: eventWindowID,
+                        popoverWindowID: ObjectIdentifier(window)
+                    ), !(window.firstResponder is NSText), !ShortcutRecorderField.isRecordingActive else {
+                        return
+                    }
+                    guard let token = Self.token(keyCode: keyCode, characters: characters) else {
+                        // A real key that isn't part of the code breaks the run.
+                        self.matcher.reset()
+                        return
+                    }
+                    if self.matcher.accept(token) {
+                        self.onMatched?()
+                    }
+                }
+                // Never consume — the egg observes, it doesn't steal keys.
+                return event
+            }
+        }
+
+        // Cleanup rides `viewDidMoveToWindow(nil)` (fired when the representable is torn down or moves
+        // off-window), matching `PopoverKeyReader` — so there's no `deinit` reaching the non-Sendable
+        // monitor token from a nonisolated context under Swift 6.
+
+        /// Arrows by virtual key code (layout-stable); A/B by character. Matching A/B by `keyCode` would
+        /// be wrong on non-QWERTY layouts (the ANSI "A" key code is `0`, i.e. a different physical key).
+        private static func token(keyCode: UInt16, characters: String?) -> SecretCodeKey? {
+            switch keyCode {
+            case 126: return .up
+            case 125: return .down
+            case 123: return .left
+            case 124: return .right
+            default: break
+            }
+            switch characters?.lowercased() {
+            case "a": return .a
+            case "b": return .b
+            default: return nil
+            }
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -42,10 +42,6 @@ struct DashboardView: View {
     /// id, a freshly-started transition pins to the outgoing screen so the first frame never flashes
     /// the destination.
     @State private var animatedSlideID = 0
-    /// Whether the popover is on-screen. Drives `\.popoverIsVisible` so the easter-egg animation loops
-    /// pause while the popover is hidden (the SwiftUI tree survives a close, so they'd otherwise keep
-    /// ticking and burn CPU). Updated by the `PopoverVisibilityReader` below.
-    @State private var popoverVisible = false
     /// Reset to the top whenever the popover closes, so it never reopens mid-scroll.
     @State private var dashboardScrollPosition = ScrollPosition(edge: .top)
     /// Row rhythm tracks the global density setting live.
@@ -145,7 +141,6 @@ struct DashboardView: View {
             )
             .background(
                 PopoverVisibilityReader { visible in
-                    popoverVisible = visible    // pauses the egg animation loops while the popover is hidden
                     if visible {
                         // Reopen: the SwiftUI tree survives a close, so re-seed the height for whatever
                         // screen we're opening on. Un-animated, and ≈ the controller's opening guess, so
@@ -232,10 +227,6 @@ struct DashboardView: View {
             // for "Drunk Mode". No-op for the normal/increased styles. Controls stay clickable (overlays
             // don't hit-test), so the Settings "Drunk Mode" toggle is reachable while it's running.
             .tooMuchTransparency(transparency.effectiveStyle)
-            // Lets the egg animations (gradient, rim, drunk distortion, provider pulses) pause
-            // their clocks while the popover is hidden — outermost so it reaches the `.background`/`.overlay`
-            // egg layers added by `tooMuchTransparency` as well as the in-content pulses.
-            .environment(\.popoverIsVisible, popoverVisible)
     }
 
     private func resetTransientState() {

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -18,6 +18,7 @@ import AppKit
 struct DashboardView: View {
     @Environment(LayoutStore.self) private var layout
     @Environment(WidgetDataStore.self) private var dataStore
+    @Environment(PopoverTransparencyStore.self) private var transparency
     @State private var didInitialRefresh = false
     @State private var reorderLift: ReorderLift?
     /// The panel height SwiftUI drives — the single animation clock. `PanelHeightModifier` follows it
@@ -213,6 +214,17 @@ struct DashboardView: View {
                 didInitialRefresh = true
                 await dataStore.refreshAll()
             }
+            // Watches for the secret transparency code while the panel is key and toggles the egg. A
+            // sibling of `PopoverKeyReader` that only observes (never consumes), so it can't disturb
+            // navigation or typing.
+            .background(TooMuchTransparencyKeyReader { transparency.toggleSecretCode() })
+            // Reaches `modeBody`, the `PopoverSurface` background, and every card: drives whether surfaces
+            // paint their opaque base or clear to the behind-window vibrancy backdrop.
+            .environment(\.popoverSurfaceTreatment, transparency.surfaceTreatment)
+            // The ghost easter egg's animated pink-glass chaos, layered over the whole popover. No-op for
+            // the normal/increased styles. Controls stay clickable (overlays don't hit-test), so the
+            // Settings "Even More" toggle is still reachable while it's running.
+            .tooMuchTransparency(transparency.effectiveStyle)
     }
 
     private func resetTransientState() {
@@ -664,8 +676,18 @@ struct DashboardView: View {
 /// glass bar on top of this (in-window), so glass stays chrome over solid content. Never hit-tests,
 /// so it can't steal clicks from the content above it.
 private struct PopoverSurface: View {
+    @Environment(\.popoverSurfaceTreatment) private var treatment
+
     var body: some View {
-        Theme.traySurface
-            .allowsHitTesting(false)
+        Group {
+            switch treatment {
+            case .opaque:
+                Theme.traySurface
+            case .translucent:
+                // Clear so the panel's behind-window vibrancy backdrop (the desktop) shows through.
+                Color.clear
+            }
+        }
+        .allowsHitTesting(false)
     }
 }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -42,6 +42,10 @@ struct DashboardView: View {
     /// id, a freshly-started transition pins to the outgoing screen so the first frame never flashes
     /// the destination.
     @State private var animatedSlideID = 0
+    /// Whether the popover is on-screen. Drives `\.popoverIsVisible` so the easter-egg animation loops
+    /// pause while the popover is hidden (the SwiftUI tree survives a close, so they'd otherwise keep
+    /// ticking and burn CPU). Updated by the `PopoverVisibilityReader` below.
+    @State private var popoverVisible = false
     /// Reset to the top whenever the popover closes, so it never reopens mid-scroll.
     @State private var dashboardScrollPosition = ScrollPosition(edge: .top)
     /// Row rhythm tracks the global density setting live.
@@ -141,6 +145,7 @@ struct DashboardView: View {
             )
             .background(
                 PopoverVisibilityReader { visible in
+                    popoverVisible = visible    // pauses the egg animation loops while the popover is hidden
                     if visible {
                         // Reopen: the SwiftUI tree survives a close, so re-seed the height for whatever
                         // screen we're opening on. Un-animated, and ≈ the controller's opening guess, so
@@ -227,6 +232,10 @@ struct DashboardView: View {
             // for "Drunk Mode". No-op for the normal/increased styles. Controls stay clickable (overlays
             // don't hit-test), so the Settings "Drunk Mode" toggle is reachable while it's running.
             .tooMuchTransparency(transparency.effectiveStyle)
+            // Lets the egg animations (gradient, rim, keepalive, drunk distortion, provider pulses) pause
+            // their clocks while the popover is hidden — outermost so it reaches the `.background`/`.overlay`
+            // egg layers added by `tooMuchTransparency` as well as the in-content pulses.
+            .environment(\.popoverIsVisible, popoverVisible)
     }
 
     private func resetTransientState() {

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -232,7 +232,7 @@ struct DashboardView: View {
             // for "Drunk Mode". No-op for the normal/increased styles. Controls stay clickable (overlays
             // don't hit-test), so the Settings "Drunk Mode" toggle is reachable while it's running.
             .tooMuchTransparency(transparency.effectiveStyle)
-            // Lets the egg animations (gradient, rim, keepalive, drunk distortion, provider pulses) pause
+            // Lets the egg animations (gradient, rim, drunk distortion, provider pulses) pause
             // their clocks while the popover is hidden — outermost so it reaches the `.background`/`.overlay`
             // egg layers added by `tooMuchTransparency` as well as the in-content pulses.
             .environment(\.popoverIsVisible, popoverVisible)

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -46,6 +46,10 @@ struct DashboardView: View {
     /// pause while the popover is hidden (the SwiftUI tree survives a close, so they'd otherwise keep
     /// ticking and burn CPU). Updated by the `PopoverVisibilityReader` below.
     @State private var popoverVisible = false
+    /// Whether the popover is the key (focused) window. Drives `\.popoverIsKey` so the translucent
+    /// keepalive runs only while the popover is unfocused — focused content stays crisp (no sub-pixel
+    /// re-raster blur). Defaults to focused. Updated by the `PopoverVisibilityReader` below.
+    @State private var popoverKey = true
     /// Reset to the top whenever the popover closes, so it never reopens mid-scroll.
     @State private var dashboardScrollPosition = ScrollPosition(edge: .top)
     /// Row rhythm tracks the global density setting live.
@@ -144,20 +148,23 @@ struct DashboardView: View {
                 )
             )
             .background(
-                PopoverVisibilityReader { visible in
-                    popoverVisible = visible    // pauses the egg animation loops while the popover is hidden
-                    if visible {
-                        // Reopen: the SwiftUI tree survives a close, so re-seed the height for whatever
-                        // screen we're opening on. Un-animated, and ≈ the controller's opening guess, so
-                        // there's no visible jump. If not yet measured, the measurement onChange seeds it.
-                        if let target = targetHeight() {
-                            didEstablishHeight = true
-                            animatedHeight = target
+                PopoverVisibilityReader(
+                    onChange: { visible in
+                        popoverVisible = visible    // pauses the egg animation loops while the popover is hidden
+                        if visible {
+                            // Reopen: the SwiftUI tree survives a close, so re-seed the height for whatever
+                            // screen we're opening on. Un-animated, and ≈ the controller's opening guess, so
+                            // there's no visible jump. If not yet measured, the measurement onChange seeds it.
+                            if let target = targetHeight() {
+                                didEstablishHeight = true
+                                animatedHeight = target
+                            }
+                        } else {
+                            resetTransientState()
                         }
-                    } else {
-                        resetTransientState()
-                    }
-                }
+                    },
+                    onKeyChange: { key in popoverKey = key }   // keepalive runs only while unfocused
+                )
             )
             // A screen switch can tear the list down mid-drag, in which case the gesture's
             // `onEnded` never fires — clear the lift here or its overlay survives onto the new
@@ -236,6 +243,9 @@ struct DashboardView: View {
             // their clocks while the popover is hidden — outermost so it reaches the `.background`/`.overlay`
             // egg layers added by `tooMuchTransparency` as well as the in-content pulses.
             .environment(\.popoverIsVisible, popoverVisible)
+            // Gates the translucent keepalive: it re-rasters static content only while the popover is
+            // unfocused (the compositor cull hits non-key windows), so a focused popover stays crisp.
+            .environment(\.popoverIsKey, popoverKey)
     }
 
     private func resetTransientState() {

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -221,10 +221,10 @@ struct DashboardView: View {
             // Reaches `modeBody`, the `PopoverSurface` background, and every card: drives whether surfaces
             // paint their opaque base or clear to the behind-window vibrancy backdrop.
             .environment(\.popoverSurfaceTreatment, transparency.surfaceTreatment)
-            // The easter egg's visuals: the readable disco party (gradient backdrop + glowing rim, text
-            // crisp on frosted cards) for the secret code, or the unreadable pink-glass ghost for "Even
-            // More". No-op for the normal/increased styles. Controls stay clickable (overlays don't
-            // hit-test), so the Settings "Even More" toggle is reachable while it's running.
+            // The easter egg's visuals: the readable party (gradient backdrop + glowing rim, text crisp
+            // on frosted cards) for the secret code, or the woozy, barely-readable pink-glass drunk mode
+            // for "Drunk Mode". No-op for the normal/increased styles. Controls stay clickable (overlays
+            // don't hit-test), so the Settings "Drunk Mode" toggle is reachable while it's running.
             .tooMuchTransparency(transparency.effectiveStyle)
     }
 
@@ -686,7 +686,7 @@ private struct PopoverSurface: View {
                 Theme.traySurface
             case .translucent, .scrim:
                 // Clear so what's behind the page shows through: the behind-window vibrancy backdrop
-                // (the desktop) for increased/ghost, or the animated party gradient for disco.
+                // (the desktop) for increased/drunk, or the animated party gradient for party mode.
                 Color.clear
             }
         }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -685,9 +685,10 @@ private struct PopoverSurface: View {
             switch treatment {
             case .opaque:
                 Theme.traySurface
-            case .translucent, .scrim:
-                // Clear so what's behind the page shows through: the behind-window vibrancy backdrop
-                // (the desktop) for increased/drunk, or the animated party gradient for party mode.
+            case .translucent:
+                // Clear so what's behind the page shows through: the behind-window vibrancy backdrop —
+                // the blurred desktop for increased/drunk, and the same desktop tinted by the party
+                // gradient for party mode.
                 Color.clear
             }
         }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -221,9 +221,10 @@ struct DashboardView: View {
             // Reaches `modeBody`, the `PopoverSurface` background, and every card: drives whether surfaces
             // paint their opaque base or clear to the behind-window vibrancy backdrop.
             .environment(\.popoverSurfaceTreatment, transparency.surfaceTreatment)
-            // The ghost easter egg's animated pink-glass chaos, layered over the whole popover. No-op for
-            // the normal/increased styles. Controls stay clickable (overlays don't hit-test), so the
-            // Settings "Even More" toggle is still reachable while it's running.
+            // The easter egg's visuals: the readable disco party (gradient backdrop + glowing rim, text
+            // crisp on frosted cards) for the secret code, or the unreadable pink-glass ghost for "Even
+            // More". No-op for the normal/increased styles. Controls stay clickable (overlays don't
+            // hit-test), so the Settings "Even More" toggle is reachable while it's running.
             .tooMuchTransparency(transparency.effectiveStyle)
     }
 
@@ -683,8 +684,9 @@ private struct PopoverSurface: View {
             switch treatment {
             case .opaque:
                 Theme.traySurface
-            case .translucent:
-                // Clear so the panel's behind-window vibrancy backdrop (the desktop) shows through.
+            case .translucent, .scrim:
+                // Clear so what's behind the page shows through: the behind-window vibrancy backdrop
+                // (the desktop) for increased/ghost, or the animated party gradient for disco.
                 Color.clear
             }
         }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -46,10 +46,6 @@ struct DashboardView: View {
     /// pause while the popover is hidden (the SwiftUI tree survives a close, so they'd otherwise keep
     /// ticking and burn CPU). Updated by the `PopoverVisibilityReader` below.
     @State private var popoverVisible = false
-    /// Whether the popover is the key (focused) window. Drives `\.popoverIsKey` so the translucent
-    /// keepalive runs only while the popover is unfocused — focused content stays crisp (no sub-pixel
-    /// re-raster blur). Defaults to focused. Updated by the `PopoverVisibilityReader` below.
-    @State private var popoverKey = true
     /// Reset to the top whenever the popover closes, so it never reopens mid-scroll.
     @State private var dashboardScrollPosition = ScrollPosition(edge: .top)
     /// Row rhythm tracks the global density setting live.
@@ -148,23 +144,20 @@ struct DashboardView: View {
                 )
             )
             .background(
-                PopoverVisibilityReader(
-                    onChange: { visible in
-                        popoverVisible = visible    // pauses the egg animation loops while the popover is hidden
-                        if visible {
-                            // Reopen: the SwiftUI tree survives a close, so re-seed the height for whatever
-                            // screen we're opening on. Un-animated, and ≈ the controller's opening guess, so
-                            // there's no visible jump. If not yet measured, the measurement onChange seeds it.
-                            if let target = targetHeight() {
-                                didEstablishHeight = true
-                                animatedHeight = target
-                            }
-                        } else {
-                            resetTransientState()
+                PopoverVisibilityReader { visible in
+                    popoverVisible = visible    // pauses the egg animation loops while the popover is hidden
+                    if visible {
+                        // Reopen: the SwiftUI tree survives a close, so re-seed the height for whatever
+                        // screen we're opening on. Un-animated, and ≈ the controller's opening guess, so
+                        // there's no visible jump. If not yet measured, the measurement onChange seeds it.
+                        if let target = targetHeight() {
+                            didEstablishHeight = true
+                            animatedHeight = target
                         }
-                    },
-                    onKeyChange: { key in popoverKey = key }   // keepalive runs only while unfocused
-                )
+                    } else {
+                        resetTransientState()
+                    }
+                }
             )
             // A screen switch can tear the list down mid-drag, in which case the gesture's
             // `onEnded` never fires — clear the lift here or its overlay survives onto the new
@@ -243,9 +236,6 @@ struct DashboardView: View {
             // their clocks while the popover is hidden — outermost so it reaches the `.background`/`.overlay`
             // egg layers added by `tooMuchTransparency` as well as the in-content pulses.
             .environment(\.popoverIsVisible, popoverVisible)
-            // Gates the translucent keepalive: it re-rasters static content only while the popover is
-            // unfocused (the compositor cull hits non-key windows), so a focused popover stays crisp.
-            .environment(\.popoverIsKey, popoverKey)
     }
 
     private func resetTransientState() {

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -67,11 +67,12 @@ struct DashboardView: View {
             // content's height and this fill is a no-op; when content exceeds the screen cap the window
             // clamps and the scroll views inside take the overflow.
             .frame(maxHeight: .infinity, alignment: .top)
-            // Paint the opaque tray behind all content (and the footer) so the whole popover reads as
-            // one solid panel — the data region never shows the desktop through it. Outermost so the
-            // footer, header, and scroll content all sit on it; separation from the footer comes from
-            // the native soft scroll-edge fade (not a distinct bar). The resize handle is folded into
-            // the footer (see `footerBar`), so there's no separate root-level dragger inset anymore.
+            // Paint the page surface behind all content (and the footer). Opaque by default so the
+            // popover reads as one solid panel; under Increase Transparency / the egg it clears so the
+            // behind-window backdrop (or party gradient) shows through. Outermost so the footer, header,
+            // and scroll content all sit on it; separation from the footer comes from the native soft
+            // scroll-edge fade (not a distinct bar). The resize handle is folded into the footer (see
+            // `footerBar`), so there's no separate root-level dragger inset anymore.
             .background(PopoverSurface())
             // Drive the host panel's height on SwiftUI's clock. At the body root, OUTSIDE `modeBody`'s
             // `.animation(nil, value: layout.screenSlideID)`, so the height rides the active spring (the

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -227,6 +227,13 @@ struct DashboardView: View {
             // for "Drunk Mode". No-op for the normal/increased styles. Controls stay clickable (overlays
             // don't hit-test), so the Settings "Drunk Mode" toggle is reachable while it's running.
             .tooMuchTransparency(transparency.effectiveStyle)
+            // Gate the egg's animation loops on whether the popover is on-screen. Applied OUTSIDE
+            // `.tooMuchTransparency` so it reaches both the gradient/rim/drunk layers that modifier adds
+            // and the in-content `partyPulse`. Hidden → the loops unmount their `TimelineView` clocks, so a
+            // left-on egg spends no CPU; a fresh mount on reopen / in-place activation starts them at once.
+            // Sourced from the controller's show/hide chokepoints (`popoverShown`), not occlusion — a
+            // `.canJoinAllSpaces` panel is briefly occluded mid Space-switch while still on-screen.
+            .environment(\.popoverIsVisible, transparency.popoverShown)
     }
 
     private func resetTransientState() {

--- a/Sources/OpenUsage/Views/ProviderSectionHeader.swift
+++ b/Sources/OpenUsage/Views/ProviderSectionHeader.swift
@@ -29,7 +29,7 @@ struct ProviderSectionHeader<Trailing: View>: View {
     /// Header type and icon track the density setting like the rows do, so Compact shrinks the
     /// whole section anatomy — not just the rows under it.
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
-    /// Disco easter egg: pulse the provider mark. Off by default everywhere else.
+    /// Party easter egg: pulse the provider mark. Off by default everywhere else.
     @Environment(\.popoverPartyMode) private var partyMode
 
     init(provider: Provider, plan: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, showsDragHandle: Bool = false, @ViewBuilder trailing: () -> Trailing) {

--- a/Sources/OpenUsage/Views/ProviderSectionHeader.swift
+++ b/Sources/OpenUsage/Views/ProviderSectionHeader.swift
@@ -29,6 +29,8 @@ struct ProviderSectionHeader<Trailing: View>: View {
     /// Header type and icon track the density setting like the rows do, so Compact shrinks the
     /// whole section anatomy — not just the rows under it.
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    /// Disco easter egg: pulse the provider mark. Off by default everywhere else.
+    @Environment(\.popoverPartyMode) private var partyMode
 
     init(provider: Provider, plan: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, showsDragHandle: Bool = false, @ViewBuilder trailing: () -> Trailing) {
         self.provider = provider
@@ -94,6 +96,7 @@ struct ProviderSectionHeader<Trailing: View>: View {
             // default list-context padding.
             ProviderIcon(source: provider.icon, inset: 0.04)
                 .frame(width: density.headerIconSize, height: density.headerIconSize)
+                .partyPulse(partyMode)
             trailing
         }
         // With the grip leading, shave the left inset so the handle sits a touch closer to the card's

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -132,6 +132,11 @@ struct SettingsScreen: View {
                         Toggle("", isOn: $transparency.drunkMode)
                             .settingsSwitchStyle()
                     }
+                    // The egg yields to the accessibility flags too: when one is on the panel stays
+                    // opaque, so explain why the party looks normal rather than leaving it a mystery.
+                    if transparency.partyPaused {
+                        pausedNotice("macOS Reduce Transparency or Increase Contrast is on, so the party stays paused.")
+                    }
                 }
             }
             section("Usage Display") {

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -116,11 +116,11 @@ struct SettingsScreen: View {
                         .padding(.bottom, 8)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                // Surfaces only after the secret code has been entered — flips the readable disco into
-                // the unreadable ghost.
+                // Surfaces only after the secret code has been entered — escalates the readable party
+                // into the woozy, barely-readable drunk mode.
                 if transparency.secretCodeActive {
-                    row("Even More") {
-                        Toggle("", isOn: $transparency.evenMore)
+                    row("Drunk Mode") {
+                        Toggle("", isOn: $transparency.drunkMode)
                             .settingsSwitchStyle()
                     }
                 }

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -102,19 +102,21 @@ struct SettingsScreen: View {
                     picker($timeFormat, options: TimeFormatSetting.allCases, label: \.label)
                 }
                 // Translucent popover the proper way (behind-window vibrancy, text stays legible). It
-                // yields to the system accessibility settings — see the paused notice below.
+                // yields to the system accessibility settings, and to the party easter egg while that's
+                // running (the egg drives the look) — either way, see the paused notice below.
                 row("Increase Transparency") {
                     Toggle("", isOn: $transparency.increaseTransparency)
                         .settingsSwitchStyle()
+                        // Party mode owns the look while it's active, so disable (dim) the toggle to show
+                        // it has no effect right now — its stored value resumes once the egg is exited.
+                        .disabled(transparency.secretCodeActive)
                 }
-                if transparency.isPaused {
-                    // Same orange inline-notice idiom as the General section's error line.
-                    Text("macOS Reduce Transparency or Increase Contrast is on, so this stays paused.")
-                        .font(.caption)
-                        .foregroundStyle(Theme.notice)
-                        .padding(.horizontal, 12)
-                        .padding(.bottom, 8)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                // Egg first: while Party runs it overrides the toggle regardless of the system flags, so
+                // its notice takes precedence over the accessibility one.
+                if transparency.secretCodeActive {
+                    pausedNotice("Party mode is on, so this stays paused.")
+                } else if transparency.isPaused {
+                    pausedNotice("macOS Reduce Transparency or Increase Contrast is on, so this stays paused.")
                 }
                 // Surfaces only after the secret code has been entered — escalates the readable party
                 // into the woozy, barely-readable drunk mode.
@@ -426,6 +428,18 @@ struct SettingsScreen: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, density.controlRowPadding)
+    }
+
+    /// An inline "this setting is paused" caption under a row — the same orange notice idiom as the
+    /// General section's error line. Used for the Increase Transparency row (paused by a system
+    /// accessibility setting, or by Party mode taking over the look).
+    private func pausedNotice(_ text: String) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundStyle(Theme.notice)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// A trailing popup picker that hugs its selection — segmented controls don't fit the 320pt

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -118,9 +118,16 @@ struct SettingsScreen: View {
                 } else if transparency.isPaused {
                     pausedNotice("macOS Reduce Transparency or Increase Contrast is on, so this stays paused.")
                 }
-                // Surfaces only after the secret code has been entered — escalates the readable party
-                // into the woozy, barely-readable drunk mode.
+                // Both rows surface only after the secret code has been entered. Party Mode is the egg's
+                // own switch: turning it off (like re-typing the code) exits the egg and hides both rows,
+                // dropping back to the base state. Drunk Mode escalates the readable party into the woozy,
+                // barely-readable state and back — turning it off stays in the party (4 → 3), while turning
+                // Party Mode off from there clears Drunk Mode too (4 → base).
                 if transparency.secretCodeActive {
+                    row("Party Mode") {
+                        Toggle("", isOn: $transparency.partyModeActive)
+                            .settingsSwitchStyle()
+                    }
                     row("Drunk Mode") {
                         Toggle("", isOn: $transparency.drunkMode)
                             .settingsSwitchStyle()

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -46,6 +46,7 @@ struct SettingsScreen: View {
         @Bindable var store = container.dataStore
         @Bindable var layout = container.layout
         @Bindable var updater = updater
+        @Bindable var transparency = container.transparency
         @Bindable var notifications = container.notificationSettings
         // Same section rhythm as the dashboard and Customize (all read the density setting).
         return VStack(alignment: .leading, spacing: density.sectionSpacing) {
@@ -99,6 +100,28 @@ struct SettingsScreen: View {
                 }
                 row("Time Format") {
                     picker($timeFormat, options: TimeFormatSetting.allCases, label: \.label)
+                }
+                // Translucent popover the proper way (behind-window vibrancy, text stays legible). It
+                // yields to the system accessibility settings — see the paused notice below.
+                row("Increase Transparency") {
+                    Toggle("", isOn: $transparency.increaseTransparency)
+                        .settingsSwitchStyle()
+                }
+                if transparency.isPaused {
+                    // Same orange inline-notice idiom as the General section's error line.
+                    Text("macOS Reduce Transparency or Increase Contrast is on, so this stays paused.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.notice)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                // Surfaces only after the secret code has been entered — pushes the ghost even further.
+                if transparency.secretCodeActive {
+                    row("Even More") {
+                        Toggle("", isOn: $transparency.evenMore)
+                            .settingsSwitchStyle()
+                    }
                 }
             }
             section("Usage Display") {

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -116,7 +116,8 @@ struct SettingsScreen: View {
                         .padding(.bottom, 8)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                // Surfaces only after the secret code has been entered — pushes the ghost even further.
+                // Surfaces only after the secret code has been entered — flips the readable disco into
+                // the unreadable ghost.
                 if transparency.secretCodeActive {
                     row("Even More") {
                         Toggle("", isOn: $transparency.evenMore)

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -26,7 +26,7 @@ struct WidgetRowView: View {
     var condensedTop: Bool = false
 
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
-    /// Disco easter egg: fill meter bars with the party gradient instead of the severity color. Off by
+    /// Party easter egg: fill meter bars with the party gradient instead of the severity color. Off by
     /// default everywhere else.
     @Environment(\.popoverPartyMode) private var partyMode
 

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -26,6 +26,9 @@ struct WidgetRowView: View {
     var condensedTop: Bool = false
 
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    /// Disco easter egg: fill meter bars with the party gradient instead of the severity color. Off by
+    /// default everywhere else.
+    @Environment(\.popoverPartyMode) private var partyMode
 
     /// Both row fonts come from the density setting: point sizes — not just padding — are what make
     /// Compact read as a denser mode. The sizes are explicit because semantic
@@ -348,7 +351,7 @@ struct WidgetRowView: View {
                 // on glass and adapts to Increase Contrast / Reduce Transparency.
                 Capsule().fill(.quaternary)
                 Capsule()
-                    .fill(severityColor(state.severity))
+                    .fill(partyMode ? PartyMode.meterFill : severityColor(state.severity))
                     .frame(width: fillWidth(track: proxy.size.width))
             }
             .overlay(alignment: .leading) {

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -47,11 +47,11 @@ final class PopoverTransparencyStoreTests: XCTestCase {
     func testEffectiveStyleFollowsEgg() {
         // The egg path ignores the system accessibility flags, so these are deterministic on any host.
         let store = PopoverTransparencyStore(defaults: makeDefaults("style"))
-        store.toggleSecretCode()
+        store.toggleSecretCode()        // secret code -> readable disco
+        XCTAssertEqual(store.effectiveStyle, .disco)
+        XCTAssertEqual(store.surfaceTreatment, .scrim)
+        store.evenMore = true           // Even More -> unreadable ghost
         XCTAssertEqual(store.effectiveStyle, .ghost)
-        XCTAssertEqual(store.surfaceTreatment, .translucent)
-        store.evenMore = true
-        XCTAssertEqual(store.effectiveStyle, .ghostMore)
         store.toggleSecretCode()        // off; proper toggle is off too -> opaque regardless of host flags
         XCTAssertEqual(store.effectiveStyle, .opaque)
         XCTAssertEqual(store.surfaceTreatment, .opaque)

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class PopoverTransparencyStoreTests: XCTestCase {
+    /// Isolated, throwaway defaults per test (pattern from `RefreshSettingTests`).
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.Transparency.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    func testIncreaseTransparencyDefaultsOff() {
+        let store = PopoverTransparencyStore(defaults: makeDefaults("default"))
+        XCTAssertFalse(store.increaseTransparency)
+    }
+
+    func testIncreaseTransparencyPersists() {
+        let defaults = makeDefaults("persist")
+        PopoverTransparencyStore(defaults: defaults).increaseTransparency = true
+        // A fresh store reading the same defaults sees the saved value.
+        XCTAssertTrue(PopoverTransparencyStore(defaults: defaults).increaseTransparency)
+    }
+
+    func testEggStateIsNeverPersisted() {
+        let defaults = makeDefaults("ephemeral")
+        let store = PopoverTransparencyStore(defaults: defaults)
+        store.toggleSecretCode()
+        store.evenMore = true
+        XCTAssertTrue(store.secretCodeActive)
+        // The egg is ephemeral: a fresh store (a relaunch) starts clean.
+        let reloaded = PopoverTransparencyStore(defaults: defaults)
+        XCTAssertFalse(reloaded.secretCodeActive)
+        XCTAssertFalse(reloaded.evenMore)
+    }
+
+    func testTurningEggOffClearsEvenMore() {
+        let store = PopoverTransparencyStore(defaults: makeDefaults("evenmore"))
+        store.toggleSecretCode()        // on
+        store.evenMore = true
+        store.toggleSecretCode()        // off
+        XCTAssertFalse(store.secretCodeActive)
+        XCTAssertFalse(store.evenMore, "Even More clears when the egg turns off")
+    }
+
+    func testEffectiveStyleFollowsEgg() {
+        // The egg path ignores the system accessibility flags, so these are deterministic on any host.
+        let store = PopoverTransparencyStore(defaults: makeDefaults("style"))
+        store.toggleSecretCode()
+        XCTAssertEqual(store.effectiveStyle, .ghost)
+        XCTAssertEqual(store.surfaceTreatment, .translucent)
+        store.evenMore = true
+        XCTAssertEqual(store.effectiveStyle, .ghostMore)
+        store.toggleSecretCode()        // off; proper toggle is off too -> opaque regardless of host flags
+        XCTAssertEqual(store.effectiveStyle, .opaque)
+        XCTAssertEqual(store.surfaceTreatment, .opaque)
+    }
+}

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -49,7 +49,7 @@ final class PopoverTransparencyStoreTests: XCTestCase {
         let store = PopoverTransparencyStore(defaults: makeDefaults("style"))
         store.toggleSecretCode()        // secret code -> readable party
         XCTAssertEqual(store.effectiveStyle, .party)
-        XCTAssertEqual(store.surfaceTreatment, .scrim)
+        XCTAssertEqual(store.surfaceTreatment, .translucent)
         store.drunkMode = true          // Drunk Mode -> woozy, barely-readable drunk
         XCTAssertEqual(store.effectiveStyle, .drunk)
         store.toggleSecretCode()        // off; proper toggle is off too -> opaque regardless of host flags

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -11,6 +11,16 @@ final class PopoverTransparencyStoreTests: XCTestCase {
         return defaults
     }
 
+    /// A store on throwaway defaults with the accessibility flags pinned (both off by default), so the
+    /// egg's resolved style is deterministic regardless of the test host's real accessibility settings.
+    private func makeStore(_ name: String,
+                           reduceTransparency: Bool = false,
+                           increaseContrast: Bool = false) -> PopoverTransparencyStore {
+        PopoverTransparencyStore(defaults: makeDefaults(name),
+                                 reduceTransparency: reduceTransparency,
+                                 increaseContrast: increaseContrast)
+    }
+
     func testIncreaseTransparencyDefaultsOff() {
         let store = PopoverTransparencyStore(defaults: makeDefaults("default"))
         XCTAssertFalse(store.increaseTransparency)
@@ -46,7 +56,7 @@ final class PopoverTransparencyStoreTests: XCTestCase {
     }
 
     func testTurningEggOffClearsDrunkMode() {
-        let store = PopoverTransparencyStore(defaults: makeDefaults("drunk"))
+        let store = makeStore("drunk")
         store.toggleSecretCode()        // on
         store.drunkMode = true
         store.toggleSecretCode()        // off
@@ -57,7 +67,7 @@ final class PopoverTransparencyStoreTests: XCTestCase {
     // MARK: - Party Mode toggle / state machine (Normal 1, Increase Transparency 2, Party 3, Drunk 4)
 
     func testPartyModeToggleMirrorsTheEgg() {
-        let store = PopoverTransparencyStore(defaults: makeDefaults("partyMirror"))
+        let store = makeStore("partyMirror")
         XCTAssertFalse(store.partyModeActive)
         store.toggleSecretCode()                    // cheat code in
         XCTAssertTrue(store.partyModeActive, "Party Mode reads the egg state")
@@ -67,7 +77,7 @@ final class PopoverTransparencyStoreTests: XCTestCase {
 
     func testPartyToggleOffFromState3ReturnsToBase() {
         // Base 1 (Increase Transparency off): 1 -> 3 -> 1. Egg off + base off is opaque on any host.
-        let store = PopoverTransparencyStore(defaults: makeDefaults("p3base1"))
+        let store = makeStore("p3base1")
         store.toggleSecretCode()                    // 1 -> 3
         XCTAssertEqual(store.effectiveStyle, .party)
         store.partyModeActive = false               // 3 -> 1
@@ -77,7 +87,7 @@ final class PopoverTransparencyStoreTests: XCTestCase {
 
     func testPartyToggleOffFromState4ClearsDrunkAndReturnsToBase() {
         // 1 -> 3 -> 4, then Party off goes 4 -> base (NOT 4 -> 3), clearing Drunk along the way.
-        let store = PopoverTransparencyStore(defaults: makeDefaults("p4base1"))
+        let store = makeStore("p4base1")
         store.toggleSecretCode()                    // 1 -> 3
         store.drunkMode = true                       // 3 -> 4
         XCTAssertEqual(store.effectiveStyle, .drunk)
@@ -89,7 +99,7 @@ final class PopoverTransparencyStoreTests: XCTestCase {
 
     func testDrunkToggleOffStaysInPartyState3() {
         // The only way 4 -> 3 is turning Drunk off; the egg stays active.
-        let store = PopoverTransparencyStore(defaults: makeDefaults("d4to3"))
+        let store = makeStore("d4to3")
         store.toggleSecretCode()                    // 1 -> 3
         store.drunkMode = true                       // 3 -> 4
         store.drunkMode = false                      // 4 -> 3
@@ -98,9 +108,9 @@ final class PopoverTransparencyStoreTests: XCTestCase {
     }
 
     func testBase2PartyRendersAndReturnsToIncreaseTransparency() {
-        // Direct 2 -> 3 -> 2: the egg renders the readable party even with base 2 (deterministic on any
-        // host because the egg path ignores the accessibility flags), and exiting restores base 2.
-        let store = PopoverTransparencyStore(defaults: makeDefaults("base2party"))
+        // Direct 2 -> 3 -> 2: the egg renders the readable party with base 2 (deterministic here because
+        // the store pins the accessibility flags off), and exiting restores base 2.
+        let store = makeStore("base2party")
         store.increaseTransparency = true            // base 2
         store.toggleSecretCode()                     // 2 -> 3
         XCTAssertEqual(store.effectiveStyle, .party)
@@ -112,8 +122,8 @@ final class PopoverTransparencyStoreTests: XCTestCase {
     func testBaseStateIsRememberedAcrossTheEgg() {
         // Older state memory: Increase Transparency (base 2) survives the whole 2 -> 3 -> 4 -> 2 round
         // trip untouched, because its Settings toggle is frozen while the egg runs. (Asserts the stored
-        // base, not effectiveStyle, so it stays host-independent of the live accessibility flags.)
-        let store = PopoverTransparencyStore(defaults: makeDefaults("remember"))
+        // base, not effectiveStyle.)
+        let store = makeStore("remember")
         store.increaseTransparency = true            // base 2
         store.toggleSecretCode()                     // 2 -> 3
         store.drunkMode = true                        // 3 -> 4
@@ -123,15 +133,49 @@ final class PopoverTransparencyStoreTests: XCTestCase {
     }
 
     func testEffectiveStyleFollowsEgg() {
-        // The egg path ignores the system accessibility flags, so these are deterministic on any host.
-        let store = PopoverTransparencyStore(defaults: makeDefaults("style"))
+        // With the accessibility flags pinned off, the egg resolves to the readable party / drunk.
+        let store = makeStore("style")
         store.toggleSecretCode()        // secret code -> readable party
         XCTAssertEqual(store.effectiveStyle, .party)
         XCTAssertEqual(store.surfaceTreatment, .translucent)
         store.drunkMode = true          // Drunk Mode -> woozy, barely-readable drunk
         XCTAssertEqual(store.effectiveStyle, .drunk)
-        store.toggleSecretCode()        // off; proper toggle is off too -> opaque regardless of host flags
+        store.toggleSecretCode()        // off; proper toggle is off too -> opaque
         XCTAssertEqual(store.effectiveStyle, .opaque)
         XCTAssertEqual(store.surfaceTreatment, .opaque)
+    }
+
+    // MARK: - Accessibility clamp (the egg yields to Reduce Transparency / Increase Contrast)
+
+    func testEggYieldsToReduceTransparency() {
+        // With Reduce Transparency on, entering the code keeps the panel opaque — the egg may not turn it
+        // translucent — and escalating to Drunk Mode doesn't change that.
+        let store = makeStore("eggA11yReduce", reduceTransparency: true)
+        store.toggleSecretCode()
+        XCTAssertTrue(store.secretCodeActive, "the egg is active as state")
+        XCTAssertEqual(store.effectiveStyle, .opaque, "but it renders opaque, yielding to the flag")
+        XCTAssertEqual(store.surfaceTreatment, .opaque)
+        store.drunkMode = true
+        XCTAssertEqual(store.effectiveStyle, .opaque, "drunk is clamped too — no window fade")
+    }
+
+    func testEggYieldsToIncreaseContrast() {
+        let store = makeStore("eggA11yContrast", increaseContrast: true)
+        store.toggleSecretCode()
+        XCTAssertEqual(store.effectiveStyle, .opaque)
+    }
+
+    func testPartyPausedReflectsAccessibility() {
+        // No flags: the party renders, so it's not paused.
+        let clear = makeStore("partyPausedClear")
+        clear.toggleSecretCode()
+        XCTAssertFalse(clear.partyPaused)
+        // A flag on while the egg is active: paused, so Settings can explain the normal-looking panel.
+        let reduced = makeStore("partyPausedReduce", reduceTransparency: true)
+        reduced.toggleSecretCode()
+        XCTAssertTrue(reduced.partyPaused)
+        // A flag on but no egg: not "party paused" (that notice is egg-specific).
+        let noEgg = makeStore("partyPausedNoEgg", increaseContrast: true)
+        XCTAssertFalse(noEgg.partyPaused)
     }
 }

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -27,31 +27,31 @@ final class PopoverTransparencyStoreTests: XCTestCase {
         let defaults = makeDefaults("ephemeral")
         let store = PopoverTransparencyStore(defaults: defaults)
         store.toggleSecretCode()
-        store.evenMore = true
+        store.drunkMode = true
         XCTAssertTrue(store.secretCodeActive)
         // The egg is ephemeral: a fresh store (a relaunch) starts clean.
         let reloaded = PopoverTransparencyStore(defaults: defaults)
         XCTAssertFalse(reloaded.secretCodeActive)
-        XCTAssertFalse(reloaded.evenMore)
+        XCTAssertFalse(reloaded.drunkMode)
     }
 
-    func testTurningEggOffClearsEvenMore() {
-        let store = PopoverTransparencyStore(defaults: makeDefaults("evenmore"))
+    func testTurningEggOffClearsDrunkMode() {
+        let store = PopoverTransparencyStore(defaults: makeDefaults("drunk"))
         store.toggleSecretCode()        // on
-        store.evenMore = true
+        store.drunkMode = true
         store.toggleSecretCode()        // off
         XCTAssertFalse(store.secretCodeActive)
-        XCTAssertFalse(store.evenMore, "Even More clears when the egg turns off")
+        XCTAssertFalse(store.drunkMode, "Drunk Mode clears when the egg turns off")
     }
 
     func testEffectiveStyleFollowsEgg() {
         // The egg path ignores the system accessibility flags, so these are deterministic on any host.
         let store = PopoverTransparencyStore(defaults: makeDefaults("style"))
-        store.toggleSecretCode()        // secret code -> readable disco
-        XCTAssertEqual(store.effectiveStyle, .disco)
+        store.toggleSecretCode()        // secret code -> readable party
+        XCTAssertEqual(store.effectiveStyle, .party)
         XCTAssertEqual(store.surfaceTreatment, .scrim)
-        store.evenMore = true           // Even More -> unreadable ghost
-        XCTAssertEqual(store.effectiveStyle, .ghost)
+        store.drunkMode = true          // Drunk Mode -> woozy, barely-readable drunk
+        XCTAssertEqual(store.effectiveStyle, .drunk)
         store.toggleSecretCode()        // off; proper toggle is off too -> opaque regardless of host flags
         XCTAssertEqual(store.effectiveStyle, .opaque)
         XCTAssertEqual(store.surfaceTreatment, .opaque)

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -23,6 +23,16 @@ final class PopoverTransparencyStoreTests: XCTestCase {
         XCTAssertTrue(PopoverTransparencyStore(defaults: defaults).increaseTransparency)
     }
 
+    func testIncreaseTransparencyTogglesBackOffAndPersists() {
+        // The normal 2 -> 1 direction: turning the base off again writes through (exercises the no-op
+        // didSet guard in both directions) and a relaunch reads it back as off.
+        let defaults = makeDefaults("toggleBack")
+        let store = PopoverTransparencyStore(defaults: defaults)
+        store.increaseTransparency = true
+        store.increaseTransparency = false
+        XCTAssertFalse(PopoverTransparencyStore(defaults: defaults).increaseTransparency)
+    }
+
     func testEggStateIsNeverPersisted() {
         let defaults = makeDefaults("ephemeral")
         let store = PopoverTransparencyStore(defaults: defaults)
@@ -42,6 +52,74 @@ final class PopoverTransparencyStoreTests: XCTestCase {
         store.toggleSecretCode()        // off
         XCTAssertFalse(store.secretCodeActive)
         XCTAssertFalse(store.drunkMode, "Drunk Mode clears when the egg turns off")
+    }
+
+    // MARK: - Party Mode toggle / state machine (Normal 1, Increase Transparency 2, Party 3, Drunk 4)
+
+    func testPartyModeToggleMirrorsTheEgg() {
+        let store = PopoverTransparencyStore(defaults: makeDefaults("partyMirror"))
+        XCTAssertFalse(store.partyModeActive)
+        store.toggleSecretCode()                    // cheat code in
+        XCTAssertTrue(store.partyModeActive, "Party Mode reads the egg state")
+        store.partyModeActive = false               // toggle off == exit
+        XCTAssertFalse(store.secretCodeActive)
+    }
+
+    func testPartyToggleOffFromState3ReturnsToBase() {
+        // Base 1 (Increase Transparency off): 1 -> 3 -> 1. Egg off + base off is opaque on any host.
+        let store = PopoverTransparencyStore(defaults: makeDefaults("p3base1"))
+        store.toggleSecretCode()                    // 1 -> 3
+        XCTAssertEqual(store.effectiveStyle, .party)
+        store.partyModeActive = false               // 3 -> 1
+        XCTAssertFalse(store.secretCodeActive)
+        XCTAssertEqual(store.effectiveStyle, .opaque)
+    }
+
+    func testPartyToggleOffFromState4ClearsDrunkAndReturnsToBase() {
+        // 1 -> 3 -> 4, then Party off goes 4 -> base (NOT 4 -> 3), clearing Drunk along the way.
+        let store = PopoverTransparencyStore(defaults: makeDefaults("p4base1"))
+        store.toggleSecretCode()                    // 1 -> 3
+        store.drunkMode = true                       // 3 -> 4
+        XCTAssertEqual(store.effectiveStyle, .drunk)
+        store.partyModeActive = false               // 4 -> base
+        XCTAssertFalse(store.secretCodeActive)
+        XCTAssertFalse(store.drunkMode, "can't be drunk without the party")
+        XCTAssertEqual(store.effectiveStyle, .opaque)
+    }
+
+    func testDrunkToggleOffStaysInPartyState3() {
+        // The only way 4 -> 3 is turning Drunk off; the egg stays active.
+        let store = PopoverTransparencyStore(defaults: makeDefaults("d4to3"))
+        store.toggleSecretCode()                    // 1 -> 3
+        store.drunkMode = true                       // 3 -> 4
+        store.drunkMode = false                      // 4 -> 3
+        XCTAssertTrue(store.secretCodeActive, "still in the party")
+        XCTAssertEqual(store.effectiveStyle, .party)
+    }
+
+    func testBase2PartyRendersAndReturnsToIncreaseTransparency() {
+        // Direct 2 -> 3 -> 2: the egg renders the readable party even with base 2 (deterministic on any
+        // host because the egg path ignores the accessibility flags), and exiting restores base 2.
+        let store = PopoverTransparencyStore(defaults: makeDefaults("base2party"))
+        store.increaseTransparency = true            // base 2
+        store.toggleSecretCode()                     // 2 -> 3
+        XCTAssertEqual(store.effectiveStyle, .party)
+        store.partyModeActive = false                // 3 -> 2
+        XCTAssertFalse(store.secretCodeActive)
+        XCTAssertTrue(store.increaseTransparency, "base 2 restored")
+    }
+
+    func testBaseStateIsRememberedAcrossTheEgg() {
+        // Older state memory: Increase Transparency (base 2) survives the whole 2 -> 3 -> 4 -> 2 round
+        // trip untouched, because its Settings toggle is frozen while the egg runs. (Asserts the stored
+        // base, not effectiveStyle, so it stays host-independent of the live accessibility flags.)
+        let store = PopoverTransparencyStore(defaults: makeDefaults("remember"))
+        store.increaseTransparency = true            // base 2
+        store.toggleSecretCode()                     // 2 -> 3
+        store.drunkMode = true                        // 3 -> 4
+        store.partyModeActive = false                // 4 -> base
+        XCTAssertFalse(store.secretCodeActive)
+        XCTAssertTrue(store.increaseTransparency, "the prior base (Increase Transparency) is restored")
     }
 
     func testEffectiveStyleFollowsEgg() {

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -178,4 +178,71 @@ final class PopoverTransparencyStoreTests: XCTestCase {
         let noEgg = makeStore("partyPausedNoEgg", increaseContrast: true)
         XCTAssertFalse(noEgg.partyPaused)
     }
+
+    // MARK: - Egg animation gate (no animation work while the popover is hidden — PR #784)
+
+    func testEggAnimationsInactiveWhileHidden() {
+        // The egg is active but the popover is closed (default popoverShown == false): no loop mounts, so
+        // no display link ticks. This is the ~30% idle-CPU regression the owner flagged on PR #784.
+        let store = makeStore("animHidden")
+        store.toggleSecretCode()
+        XCTAssertEqual(store.effectiveStyle, .party)
+        XCTAssertFalse(store.eggAnimationsActive, "no animation while the popover is hidden")
+        store.drunkMode = true
+        XCTAssertEqual(store.effectiveStyle, .drunk)
+        XCTAssertFalse(store.eggAnimationsActive, "drunk doesn't animate while hidden either")
+    }
+
+    func testEggAnimationsActiveOnInPlaceActivation() {
+        // Popover already on-screen, then the code is entered: the loops must activate immediately — the
+        // in-place-start guarantee the conditional mount restores over the reverted `.animation(paused:)`.
+        let store = makeStore("animInPlace")
+        store.setPopoverShown(true)
+        XCTAssertFalse(store.eggAnimationsActive, "no egg yet")
+        store.toggleSecretCode()
+        XCTAssertTrue(store.eggAnimationsActive, "party animates the moment it's switched on while shown")
+        store.drunkMode = true
+        XCTAssertTrue(store.eggAnimationsActive, "drunk animates in place too")
+    }
+
+    func testEggAnimationsStopWhenPopoverHides() {
+        // Shown + active, then the popover closes: the gate flips off so the loops unmount.
+        let store = makeStore("animHide")
+        store.setPopoverShown(true)
+        store.toggleSecretCode()
+        XCTAssertTrue(store.eggAnimationsActive)
+        store.setPopoverShown(false)
+        XCTAssertFalse(store.eggAnimationsActive, "closing the popover stops the animation")
+    }
+
+    func testEggAnimationsInactiveWithoutTheEgg() {
+        // Shown but no egg: nothing animates — the loops exist only for the party/drunk styles.
+        let store = makeStore("animNoEgg")
+        store.setPopoverShown(true)
+        XCTAssertFalse(store.eggAnimationsActive, "a normal popover never animates")
+        store.increaseTransparency = true
+        XCTAssertFalse(store.eggAnimationsActive, "Increase Transparency is static, not animated")
+    }
+
+    func testEggAnimationsYieldToAccessibilityClamp() {
+        // The accessibility clamp resolves the egg to .opaque, so even shown + code-entered there's no
+        // animation — consistent with the panel staying opaque.
+        for store in [makeStore("animReduce", reduceTransparency: true),
+                      makeStore("animContrast", increaseContrast: true)] {
+            store.setPopoverShown(true)
+            store.toggleSecretCode()
+            store.drunkMode = true
+            XCTAssertEqual(store.effectiveStyle, .opaque)
+            XCTAssertFalse(store.eggAnimationsActive, "a clamped egg renders opaque, so nothing animates")
+        }
+    }
+
+    func testPopoverShownIsNeverPersisted() {
+        // popoverShown is runtime-transient like the egg: a fresh store (a relaunch) starts hidden.
+        let defaults = makeDefaults("shownEphemeral")
+        let store = PopoverTransparencyStore(defaults: defaults)
+        store.setPopoverShown(true)
+        XCTAssertTrue(store.popoverShown)
+        XCTAssertFalse(PopoverTransparencyStore(defaults: defaults).popoverShown, "not persisted")
+    }
 }

--- a/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
@@ -56,14 +56,18 @@ final class PopoverTransparencyStyleTests: XCTestCase {
     func testSurfaceTreatmentPerStyle() {
         XCTAssertEqual(PopoverTransparencyStyle.opaque.surfaceTreatment, .opaque)
         XCTAssertEqual(PopoverTransparencyStyle.increased.surfaceTreatment, .translucent)
-        XCTAssertEqual(PopoverTransparencyStyle.party.surfaceTreatment, .scrim)
+        // Party shares Increase Transparency's translucent foundation (the blurred desktop shows through,
+        // tinted by the party gradient) rather than a distinct treatment.
+        XCTAssertEqual(PopoverTransparencyStyle.party.surfaceTreatment, .translucent)
         XCTAssertEqual(PopoverTransparencyStyle.drunk.surfaceTreatment, .translucent)
     }
 
     func testWindowAlphaKeepsPartyReadableAndDrunkFaintest() {
         XCTAssertEqual(PopoverTransparencyStyle.opaque.windowAlpha, 1)
         XCTAssertEqual(PopoverTransparencyStyle.increased.windowAlpha, 1)
-        XCTAssertGreaterThan(PopoverTransparencyStyle.party.windowAlpha, 0.85)    // stays readable
+        // Party keeps the window fully opaque like Increase Transparency — the desktop shows through the
+        // translucent backdrop, not by fading the window (which would dim the text too).
+        XCTAssertEqual(PopoverTransparencyStyle.party.windowAlpha, 1)
         XCTAssertLessThan(PopoverTransparencyStyle.drunk.windowAlpha,
                           PopoverTransparencyStyle.party.windowAlpha)             // faintest of all
     }

--- a/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
@@ -46,6 +46,15 @@ final class PopoverTransparencyStyleTests: XCTestCase {
                                reduceTransparency: false, increaseContrast: false), .drunk)
     }
 
+    func testDrunkModeIsIgnoredWithoutTheSecretCode() {
+        // Drunk can't exist without the party: with the code off, drunkMode is ignored entirely and the
+        // resolved style is just the base (opaque or increased), never .drunk.
+        XCTAssertEqual(resolve(increase: false, secretCode: false, drunkMode: true,
+                               reduceTransparency: false, increaseContrast: false), .opaque)
+        XCTAssertEqual(resolve(increase: true, secretCode: false, drunkMode: true,
+                               reduceTransparency: false, increaseContrast: false), .increased)
+    }
+
     func testEggIgnoresAccessibilityFlags() {
         XCTAssertEqual(resolve(increase: false, secretCode: true, drunkMode: false,
                                reduceTransparency: true, increaseContrast: true), .party)

--- a/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import OpenUsage
+
+/// The transparency precedence rules: the egg wins regardless of the system accessibility flags (it's an
+/// opt-in cheat code), while the proper "Increase Transparency" toggle yields to them.
+final class PopoverTransparencyStyleTests: XCTestCase {
+    private func resolve(increase: Bool, secretCode: Bool, evenMore: Bool,
+                         reduceTransparency: Bool, increaseContrast: Bool) -> PopoverTransparencyStyle {
+        PopoverTransparencyStyle.resolve(
+            increaseTransparency: increase,
+            secretCodeActive: secretCode,
+            evenMore: evenMore,
+            reduceTransparency: reduceTransparency,
+            increaseContrast: increaseContrast
+        )
+    }
+
+    func testDefaultIsOpaque() {
+        XCTAssertEqual(resolve(increase: false, secretCode: false, evenMore: false,
+                               reduceTransparency: false, increaseContrast: false), .opaque)
+    }
+
+    func testProperToggleIncreasesWhenNoSystemFlags() {
+        XCTAssertEqual(resolve(increase: true, secretCode: false, evenMore: false,
+                               reduceTransparency: false, increaseContrast: false), .increased)
+    }
+
+    func testProperToggleYieldsToReduceTransparency() {
+        XCTAssertEqual(resolve(increase: true, secretCode: false, evenMore: false,
+                               reduceTransparency: true, increaseContrast: false), .opaque)
+    }
+
+    func testProperToggleYieldsToIncreaseContrast() {
+        XCTAssertEqual(resolve(increase: true, secretCode: false, evenMore: false,
+                               reduceTransparency: false, increaseContrast: true), .opaque)
+    }
+
+    func testEggGhostsEvenWhenProperToggleIsOff() {
+        XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: false,
+                               reduceTransparency: false, increaseContrast: false), .ghost)
+    }
+
+    func testEvenMoreIsGhostMore() {
+        XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: true,
+                               reduceTransparency: false, increaseContrast: false), .ghostMore)
+    }
+
+    func testEggIgnoresAccessibilityFlags() {
+        XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: false,
+                               reduceTransparency: true, increaseContrast: true), .ghost)
+        XCTAssertEqual(resolve(increase: true, secretCode: true, evenMore: true,
+                               reduceTransparency: true, increaseContrast: true), .ghostMore)
+    }
+
+    func testSurfaceTreatmentPerStyle() {
+        XCTAssertEqual(PopoverTransparencyStyle.opaque.surfaceTreatment, .opaque)
+        XCTAssertEqual(PopoverTransparencyStyle.increased.surfaceTreatment, .translucent)
+        XCTAssertEqual(PopoverTransparencyStyle.ghost.surfaceTreatment, .translucent)
+        XCTAssertEqual(PopoverTransparencyStyle.ghostMore.surfaceTreatment, .translucent)
+    }
+
+    func testWindowAlphaPerStyle() {
+        XCTAssertEqual(PopoverTransparencyStyle.opaque.windowAlpha, 1)
+        XCTAssertEqual(PopoverTransparencyStyle.increased.windowAlpha, 1)
+        XCTAssertLessThan(PopoverTransparencyStyle.ghost.windowAlpha, 1)
+        XCTAssertLessThan(PopoverTransparencyStyle.ghostMore.windowAlpha,
+                          PopoverTransparencyStyle.ghost.windowAlpha)
+    }
+
+    func testShadowDroppedOnlyForGhostModes() {
+        XCTAssertTrue(PopoverTransparencyStyle.opaque.wantsShadow)
+        XCTAssertTrue(PopoverTransparencyStyle.increased.wantsShadow)
+        XCTAssertFalse(PopoverTransparencyStyle.ghost.wantsShadow)
+        XCTAssertFalse(PopoverTransparencyStyle.ghostMore.wantsShadow)
+    }
+}

--- a/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
@@ -2,76 +2,76 @@ import XCTest
 @testable import OpenUsage
 
 /// The transparency precedence rules: the egg wins regardless of the system accessibility flags (it's an
-/// opt-in cheat code) — the secret code is the readable `disco`, "Even More" is the unreadable `ghost` —
-/// while the proper "Increase Transparency" toggle yields to those flags.
+/// opt-in cheat code) — the secret code is the readable `party`, "Drunk Mode" is the barely-readable
+/// `drunk` — while the proper "Increase Transparency" toggle yields to those flags.
 final class PopoverTransparencyStyleTests: XCTestCase {
-    private func resolve(increase: Bool, secretCode: Bool, evenMore: Bool,
+    private func resolve(increase: Bool, secretCode: Bool, drunkMode: Bool,
                          reduceTransparency: Bool, increaseContrast: Bool) -> PopoverTransparencyStyle {
         PopoverTransparencyStyle.resolve(
             increaseTransparency: increase,
             secretCodeActive: secretCode,
-            evenMore: evenMore,
+            drunkMode: drunkMode,
             reduceTransparency: reduceTransparency,
             increaseContrast: increaseContrast
         )
     }
 
     func testDefaultIsOpaque() {
-        XCTAssertEqual(resolve(increase: false, secretCode: false, evenMore: false,
+        XCTAssertEqual(resolve(increase: false, secretCode: false, drunkMode: false,
                                reduceTransparency: false, increaseContrast: false), .opaque)
     }
 
     func testProperToggleIncreasesWhenNoSystemFlags() {
-        XCTAssertEqual(resolve(increase: true, secretCode: false, evenMore: false,
+        XCTAssertEqual(resolve(increase: true, secretCode: false, drunkMode: false,
                                reduceTransparency: false, increaseContrast: false), .increased)
     }
 
     func testProperToggleYieldsToReduceTransparency() {
-        XCTAssertEqual(resolve(increase: true, secretCode: false, evenMore: false,
+        XCTAssertEqual(resolve(increase: true, secretCode: false, drunkMode: false,
                                reduceTransparency: true, increaseContrast: false), .opaque)
     }
 
     func testProperToggleYieldsToIncreaseContrast() {
-        XCTAssertEqual(resolve(increase: true, secretCode: false, evenMore: false,
+        XCTAssertEqual(resolve(increase: true, secretCode: false, drunkMode: false,
                                reduceTransparency: false, increaseContrast: true), .opaque)
     }
 
-    func testSecretCodeIsDiscoEvenWhenProperToggleIsOff() {
-        XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: false,
-                               reduceTransparency: false, increaseContrast: false), .disco)
+    func testSecretCodeIsPartyEvenWhenProperToggleIsOff() {
+        XCTAssertEqual(resolve(increase: false, secretCode: true, drunkMode: false,
+                               reduceTransparency: false, increaseContrast: false), .party)
     }
 
-    func testEvenMoreIsGhost() {
-        XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: true,
-                               reduceTransparency: false, increaseContrast: false), .ghost)
+    func testDrunkModeIsDrunk() {
+        XCTAssertEqual(resolve(increase: false, secretCode: true, drunkMode: true,
+                               reduceTransparency: false, increaseContrast: false), .drunk)
     }
 
     func testEggIgnoresAccessibilityFlags() {
-        XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: false,
-                               reduceTransparency: true, increaseContrast: true), .disco)
-        XCTAssertEqual(resolve(increase: true, secretCode: true, evenMore: true,
-                               reduceTransparency: true, increaseContrast: true), .ghost)
+        XCTAssertEqual(resolve(increase: false, secretCode: true, drunkMode: false,
+                               reduceTransparency: true, increaseContrast: true), .party)
+        XCTAssertEqual(resolve(increase: true, secretCode: true, drunkMode: true,
+                               reduceTransparency: true, increaseContrast: true), .drunk)
     }
 
     func testSurfaceTreatmentPerStyle() {
         XCTAssertEqual(PopoverTransparencyStyle.opaque.surfaceTreatment, .opaque)
         XCTAssertEqual(PopoverTransparencyStyle.increased.surfaceTreatment, .translucent)
-        XCTAssertEqual(PopoverTransparencyStyle.disco.surfaceTreatment, .scrim)
-        XCTAssertEqual(PopoverTransparencyStyle.ghost.surfaceTreatment, .translucent)
+        XCTAssertEqual(PopoverTransparencyStyle.party.surfaceTreatment, .scrim)
+        XCTAssertEqual(PopoverTransparencyStyle.drunk.surfaceTreatment, .translucent)
     }
 
-    func testWindowAlphaKeepsDiscoReadableAndGhostFaintest() {
+    func testWindowAlphaKeepsPartyReadableAndDrunkFaintest() {
         XCTAssertEqual(PopoverTransparencyStyle.opaque.windowAlpha, 1)
         XCTAssertEqual(PopoverTransparencyStyle.increased.windowAlpha, 1)
-        XCTAssertGreaterThan(PopoverTransparencyStyle.disco.windowAlpha, 0.85)   // stays readable
-        XCTAssertLessThan(PopoverTransparencyStyle.ghost.windowAlpha,
-                          PopoverTransparencyStyle.disco.windowAlpha)            // faintest of all
+        XCTAssertGreaterThan(PopoverTransparencyStyle.party.windowAlpha, 0.85)    // stays readable
+        XCTAssertLessThan(PopoverTransparencyStyle.drunk.windowAlpha,
+                          PopoverTransparencyStyle.party.windowAlpha)             // faintest of all
     }
 
-    func testShadowDroppedOnlyForGhost() {
+    func testShadowDroppedOnlyForDrunk() {
         XCTAssertTrue(PopoverTransparencyStyle.opaque.wantsShadow)
         XCTAssertTrue(PopoverTransparencyStyle.increased.wantsShadow)
-        XCTAssertTrue(PopoverTransparencyStyle.disco.wantsShadow)
-        XCTAssertFalse(PopoverTransparencyStyle.ghost.wantsShadow)
+        XCTAssertTrue(PopoverTransparencyStyle.party.wantsShadow)
+        XCTAssertFalse(PopoverTransparencyStyle.drunk.wantsShadow)
     }
 }

--- a/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
@@ -2,7 +2,8 @@ import XCTest
 @testable import OpenUsage
 
 /// The transparency precedence rules: the egg wins regardless of the system accessibility flags (it's an
-/// opt-in cheat code), while the proper "Increase Transparency" toggle yields to them.
+/// opt-in cheat code) — the secret code is the readable `disco`, "Even More" is the unreadable `ghost` —
+/// while the proper "Increase Transparency" toggle yields to those flags.
 final class PopoverTransparencyStyleTests: XCTestCase {
     private func resolve(increase: Bool, secretCode: Bool, evenMore: Bool,
                          reduceTransparency: Bool, increaseContrast: Bool) -> PopoverTransparencyStyle {
@@ -35,42 +36,42 @@ final class PopoverTransparencyStyleTests: XCTestCase {
                                reduceTransparency: false, increaseContrast: true), .opaque)
     }
 
-    func testEggGhostsEvenWhenProperToggleIsOff() {
+    func testSecretCodeIsDiscoEvenWhenProperToggleIsOff() {
         XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: false,
-                               reduceTransparency: false, increaseContrast: false), .ghost)
+                               reduceTransparency: false, increaseContrast: false), .disco)
     }
 
-    func testEvenMoreIsGhostMore() {
+    func testEvenMoreIsGhost() {
         XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: true,
-                               reduceTransparency: false, increaseContrast: false), .ghostMore)
+                               reduceTransparency: false, increaseContrast: false), .ghost)
     }
 
     func testEggIgnoresAccessibilityFlags() {
         XCTAssertEqual(resolve(increase: false, secretCode: true, evenMore: false,
-                               reduceTransparency: true, increaseContrast: true), .ghost)
+                               reduceTransparency: true, increaseContrast: true), .disco)
         XCTAssertEqual(resolve(increase: true, secretCode: true, evenMore: true,
-                               reduceTransparency: true, increaseContrast: true), .ghostMore)
+                               reduceTransparency: true, increaseContrast: true), .ghost)
     }
 
     func testSurfaceTreatmentPerStyle() {
         XCTAssertEqual(PopoverTransparencyStyle.opaque.surfaceTreatment, .opaque)
         XCTAssertEqual(PopoverTransparencyStyle.increased.surfaceTreatment, .translucent)
+        XCTAssertEqual(PopoverTransparencyStyle.disco.surfaceTreatment, .scrim)
         XCTAssertEqual(PopoverTransparencyStyle.ghost.surfaceTreatment, .translucent)
-        XCTAssertEqual(PopoverTransparencyStyle.ghostMore.surfaceTreatment, .translucent)
     }
 
-    func testWindowAlphaPerStyle() {
+    func testWindowAlphaKeepsDiscoReadableAndGhostFaintest() {
         XCTAssertEqual(PopoverTransparencyStyle.opaque.windowAlpha, 1)
         XCTAssertEqual(PopoverTransparencyStyle.increased.windowAlpha, 1)
-        XCTAssertLessThan(PopoverTransparencyStyle.ghost.windowAlpha, 1)
-        XCTAssertLessThan(PopoverTransparencyStyle.ghostMore.windowAlpha,
-                          PopoverTransparencyStyle.ghost.windowAlpha)
+        XCTAssertGreaterThan(PopoverTransparencyStyle.disco.windowAlpha, 0.85)   // stays readable
+        XCTAssertLessThan(PopoverTransparencyStyle.ghost.windowAlpha,
+                          PopoverTransparencyStyle.disco.windowAlpha)            // faintest of all
     }
 
-    func testShadowDroppedOnlyForGhostModes() {
+    func testShadowDroppedOnlyForGhost() {
         XCTAssertTrue(PopoverTransparencyStyle.opaque.wantsShadow)
         XCTAssertTrue(PopoverTransparencyStyle.increased.wantsShadow)
+        XCTAssertTrue(PopoverTransparencyStyle.disco.wantsShadow)
         XCTAssertFalse(PopoverTransparencyStyle.ghost.wantsShadow)
-        XCTAssertFalse(PopoverTransparencyStyle.ghostMore.wantsShadow)
     }
 }

--- a/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStyleTests.swift
@@ -1,9 +1,10 @@
 import XCTest
 @testable import OpenUsage
 
-/// The transparency precedence rules: the egg wins regardless of the system accessibility flags (it's an
-/// opt-in cheat code) — the secret code is the readable `party`, "Drunk Mode" is the barely-readable
-/// `drunk` — while the proper "Increase Transparency" toggle yields to those flags.
+/// The transparency precedence rules: Reduce Transparency / Increase Contrast clamp everything to opaque
+/// first (an accessibility need, not a preference), so both the proper "Increase Transparency" toggle and
+/// the secret-code egg yield to them. With the flags off the egg wins — the secret code is the readable
+/// `party`, "Drunk Mode" the barely-readable `drunk`.
 final class PopoverTransparencyStyleTests: XCTestCase {
     private func resolve(increase: Bool, secretCode: Bool, drunkMode: Bool,
                          reduceTransparency: Bool, increaseContrast: Bool) -> PopoverTransparencyStyle {
@@ -55,11 +56,26 @@ final class PopoverTransparencyStyleTests: XCTestCase {
                                reduceTransparency: false, increaseContrast: false), .increased)
     }
 
-    func testEggIgnoresAccessibilityFlags() {
+    func testEggYieldsToAccessibilityFlags() {
+        // Reduce Transparency / Increase Contrast are accessibility needs, so they clamp the panel to
+        // opaque even when the secret code (and Drunk Mode) is active — the hidden egg may not override
+        // them. Either flag alone is enough.
         XCTAssertEqual(resolve(increase: false, secretCode: true, drunkMode: false,
-                               reduceTransparency: true, increaseContrast: true), .party)
+                               reduceTransparency: true, increaseContrast: false), .opaque)
+        XCTAssertEqual(resolve(increase: false, secretCode: true, drunkMode: false,
+                               reduceTransparency: false, increaseContrast: true), .opaque)
+        XCTAssertEqual(resolve(increase: false, secretCode: true, drunkMode: true,
+                               reduceTransparency: true, increaseContrast: false), .opaque)
         XCTAssertEqual(resolve(increase: true, secretCode: true, drunkMode: true,
-                               reduceTransparency: true, increaseContrast: true), .drunk)
+                               reduceTransparency: true, increaseContrast: true), .opaque)
+    }
+
+    func testEggRendersWhenAccessibilityFlagsAreOff() {
+        // With both flags off the egg still wins over the proper toggle.
+        XCTAssertEqual(resolve(increase: true, secretCode: true, drunkMode: false,
+                               reduceTransparency: false, increaseContrast: false), .party)
+        XCTAssertEqual(resolve(increase: true, secretCode: true, drunkMode: true,
+                               reduceTransparency: false, increaseContrast: false), .drunk)
     }
 
     func testSurfaceTreatmentPerStyle() {

--- a/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
+++ b/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
@@ -2,14 +2,14 @@ import XCTest
 import AppKit
 @testable import OpenUsage
 
-/// Guards the first-show fix for the popover visibility signal that drives `\.popoverIsVisible` (which
-/// pauses the easter-egg animation loops while the popover is hidden).
+/// Guards the first-show fix for the popover visibility signal that drives the transient-state reset (on
+/// close) and the reopen height re-seed (on show).
 @MainActor
 final class PopoverVisibilityReaderTests: XCTestCase {
     /// Occlusion alone misses the very first show — a freshly-created panel's `occlusionState` already
-    /// contains `.visible`, so the first `makeKeyAndOrderFront` posts no change, leaving the egg frozen on
-    /// first activation until a close-and-reopen. Becoming key (every open fires it) is the safeguard, so
-    /// both triggers must stay wired.
+    /// contains `.visible`, so the first `makeKeyAndOrderFront` posts no change, leaving that first open
+    /// unreported until a close-and-reopen. Becoming key (every open fires it) is the safeguard, so both
+    /// triggers must stay wired.
     func testVisibilityTriggersCoverTheFirstShow() {
         let triggers = PopoverVisibilityReader.visibilityTriggers
         XCTAssertTrue(triggers.contains(NSWindow.didChangeOcclusionStateNotification),

--- a/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
+++ b/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import AppKit
+@testable import OpenUsage
+
+/// Guards the first-show fix for the popover visibility signal that drives `\.popoverIsVisible` (which
+/// pauses the easter-egg animation loops while the popover is hidden).
+@MainActor
+final class PopoverVisibilityReaderTests: XCTestCase {
+    /// Occlusion alone misses the very first show — a freshly-created panel's `occlusionState` already
+    /// contains `.visible`, so the first `makeKeyAndOrderFront` posts no change, leaving the egg frozen on
+    /// first activation until a close-and-reopen. Becoming key (every open fires it) is the safeguard, so
+    /// both triggers must stay wired.
+    func testVisibilityTriggersCoverTheFirstShow() {
+        let triggers = PopoverVisibilityReader.visibilityTriggers
+        XCTAssertTrue(triggers.contains(NSWindow.didChangeOcclusionStateNotification),
+                      "occlusion handles close and Space switches")
+        XCTAssertTrue(triggers.contains(NSWindow.didBecomeKeyNotification),
+                      "becoming key catches the first show occlusion misses")
+    }
+}

--- a/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
+++ b/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
@@ -8,16 +8,13 @@ import AppKit
 final class PopoverVisibilityReaderTests: XCTestCase {
     /// Occlusion alone misses the very first show — a freshly-created panel's `occlusionState` already
     /// contains `.visible`, so the first `makeKeyAndOrderFront` posts no change, leaving the egg frozen on
-    /// first activation until a close-and-reopen. Become-key (every open fires it) is that safeguard, and
-    /// the become/resign-key pair tracks focus for the translucent keepalive (which runs only while
-    /// unfocused). All three must stay wired.
-    func testWindowStateTriggersCoverFirstShowAndFocus() {
-        let triggers = PopoverVisibilityReader.windowStateTriggers
+    /// first activation until a close-and-reopen. Becoming key (every open fires it) is the safeguard, so
+    /// both triggers must stay wired.
+    func testVisibilityTriggersCoverTheFirstShow() {
+        let triggers = PopoverVisibilityReader.visibilityTriggers
         XCTAssertTrue(triggers.contains(NSWindow.didChangeOcclusionStateNotification),
                       "occlusion handles close and Space switches")
         XCTAssertTrue(triggers.contains(NSWindow.didBecomeKeyNotification),
-                      "becoming key catches the first show occlusion misses, and gains focus")
-        XCTAssertTrue(triggers.contains(NSWindow.didResignKeyNotification),
-                      "resigning key is when the keepalive must engage")
+                      "becoming key catches the first show occlusion misses")
     }
 }

--- a/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
+++ b/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
@@ -8,13 +8,16 @@ import AppKit
 final class PopoverVisibilityReaderTests: XCTestCase {
     /// Occlusion alone misses the very first show — a freshly-created panel's `occlusionState` already
     /// contains `.visible`, so the first `makeKeyAndOrderFront` posts no change, leaving the egg frozen on
-    /// first activation until a close-and-reopen. Becoming key (every open fires it) is the safeguard, so
-    /// both triggers must stay wired.
-    func testVisibilityTriggersCoverTheFirstShow() {
-        let triggers = PopoverVisibilityReader.visibilityTriggers
+    /// first activation until a close-and-reopen. Become-key (every open fires it) is that safeguard, and
+    /// the become/resign-key pair tracks focus for the translucent keepalive (which runs only while
+    /// unfocused). All three must stay wired.
+    func testWindowStateTriggersCoverFirstShowAndFocus() {
+        let triggers = PopoverVisibilityReader.windowStateTriggers
         XCTAssertTrue(triggers.contains(NSWindow.didChangeOcclusionStateNotification),
                       "occlusion handles close and Space switches")
         XCTAssertTrue(triggers.contains(NSWindow.didBecomeKeyNotification),
-                      "becoming key catches the first show occlusion misses")
+                      "becoming key catches the first show occlusion misses, and gains focus")
+        XCTAssertTrue(triggers.contains(NSWindow.didResignKeyNotification),
+                      "resigning key is when the keepalive must engage")
     }
 }

--- a/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
+++ b/Tests/OpenUsageTests/PopoverVisibilityReaderTests.swift
@@ -17,4 +17,45 @@ final class PopoverVisibilityReaderTests: XCTestCase {
         XCTAssertTrue(triggers.contains(NSWindow.didBecomeKeyNotification),
                       "becoming key catches the first show occlusion misses")
     }
+
+    // MARK: - Delivery rule (suppress a `false` before any `true` — PR #784 right-click → Settings)
+
+    func testSuppressesPreShowFalseBeforeAnyShow() {
+        // The regression: the reader mounts into the not-yet-ordered-front panel and reports false. That
+        // must NOT be delivered — delivering it runs resetTransientState and clobbers a Settings screen
+        // openSettings pre-set before showing.
+        XCTAssertFalse(PopoverVisibilityReader.shouldDeliver(false, lastVisible: nil))
+    }
+
+    func testDeliversFirstShow() {
+        XCTAssertTrue(PopoverVisibilityReader.shouldDeliver(true, lastVisible: nil))
+    }
+
+    func testDeliversRealDismissalAfterAShow() {
+        XCTAssertTrue(PopoverVisibilityReader.shouldDeliver(false, lastVisible: true))
+    }
+
+    func testDeliversReshow() {
+        XCTAssertTrue(PopoverVisibilityReader.shouldDeliver(true, lastVisible: false))
+    }
+
+    func testDedupesUnchangedReports() {
+        XCTAssertFalse(PopoverVisibilityReader.shouldDeliver(false, lastVisible: false))
+        XCTAssertFalse(PopoverVisibilityReader.shouldDeliver(true, lastVisible: true))
+    }
+
+    func testTypicalSequenceDeliversOnlyShowAndRealDismissal() {
+        // Walk the lifecycle through the same logic `report` uses: pre-show false (suppressed) → first
+        // show (delivered) → close (delivered).
+        var last: Bool?
+        var delivered: [Bool] = []
+        func report(_ visible: Bool) {
+            if PopoverVisibilityReader.shouldDeliver(visible, lastVisible: last) { delivered.append(visible) }
+            last = visible
+        }
+        report(false)   // reader mounts into the not-yet-shown panel
+        report(true)    // makeKeyAndOrderFront
+        report(false)   // orderOut
+        XCTAssertEqual(delivered, [true, false], "only the real show and the real dismissal are delivered")
+    }
 }

--- a/Tests/OpenUsageTests/SecretCodeMatcherTests.swift
+++ b/Tests/OpenUsageTests/SecretCodeMatcherTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import OpenUsage
+
+final class SecretCodeMatcherTests: XCTestCase {
+    private let code = SecretCodeMatcher.sequence
+
+    func testCompletesOnFinalTokenOnly() {
+        var matcher = SecretCodeMatcher()
+        for token in code.dropLast() {
+            XCTAssertFalse(matcher.accept(token), "should not match before the final token")
+        }
+        XCTAssertTrue(matcher.accept(code.last!), "the final token completes the sequence")
+    }
+
+    func testExtraLeadingKeysStillMatch() {
+        var matcher = SecretCodeMatcher()
+        // Two stray ups before a clean entry: the sliding window keeps only the last N, so it matches.
+        let stream: [SecretCodeKey] = [.up, .up] + code
+        var matched = false
+        for token in stream { matched = matcher.accept(token) }
+        XCTAssertTrue(matched)
+    }
+
+    func testWrongKeyMidSequenceThenCleanEntryMatches() {
+        var matcher = SecretCodeMatcher()
+        _ = matcher.accept(.up)
+        _ = matcher.accept(.up)
+        _ = matcher.accept(.down)
+        _ = matcher.accept(.left) // wrong (expected .down) — run broken
+        var matched = false
+        for token in code { matched = matcher.accept(token) }
+        XCTAssertTrue(matched, "a clean entry after a fumble still matches")
+    }
+
+    func testNoMatchForIncompleteSequence() {
+        var matcher = SecretCodeMatcher()
+        var matched = false
+        for token in code.dropLast() { matched = matcher.accept(token) || matched }
+        XCTAssertFalse(matched)
+    }
+
+    func testResetClearsPartialProgress() {
+        var matcher = SecretCodeMatcher()
+        _ = matcher.accept(.up)
+        _ = matcher.accept(.up)
+        matcher.reset()
+        // After reset the tail alone must not complete — progress was cleared.
+        var matched = false
+        for token in code.dropFirst(2) { matched = matcher.accept(token) || matched }
+        XCTAssertFalse(matched)
+        // A fresh full entry still matches.
+        matched = false
+        for token in code { matched = matcher.accept(token) }
+        XCTAssertTrue(matched)
+    }
+
+    func testReentryMatchesAgain() {
+        var matcher = SecretCodeMatcher()
+        for token in code { _ = matcher.accept(token) }
+        // The buffer clears after a match, so a second full entry matches again (re-type to toggle off).
+        var matched = false
+        for token in code { matched = matcher.accept(token) }
+        XCTAssertTrue(matched)
+    }
+}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,6 +17,7 @@ Settings lives inside the popover — there is no separate window. Open it from 
 | Theme | System / Light / Dark | App-wide appearance override for the popover. |
 | Density | Default / Compact | Default breathes; Compact is a real information-dense mode — text steps down one size, rows and provider sections pull together, and Customize / Settings rows tighten with them. In both, consecutive one-line metrics (Today / Yesterday / …) pull together; Compact pulls harder. |
 | Time Format | Auto / 12-hour / 24-hour | How exact times read (e.g. "Resets today at 6:38 PM" vs "18:38"). Auto follows the system. |
+| Increase Transparency | Off / On | Off (default) keeps the popover a solid panel. On makes it translucent so your desktop shows through, while keeping the numbers legible. It pauses automatically when you have the macOS **Reduce Transparency** or **Increase Contrast** accessibility setting turned on (a note explains why), so it never works against those preferences. |
 
 ## Usage Display
 


### PR DESCRIPTION
## TL;DR

Two opt-in additions to the popover's appearance, both **off by default** so the normal look is unchanged: a proper **Increase Transparency** toggle in Settings, and a hidden secret-code easter egg that turns the popover into a loud-but-readable **Party** mode with an escalation **Drunk** mode.

## What was happening

- The popover was always a solid, opaque panel — there was no supported way to make it translucent.
- Earlier translucency experiments washed the text out (a bare low-opacity fill over the desktop) instead of following Apple's material guidance, and nothing tied a translucency treatment to the macOS accessibility settings that exist to control exactly this.

## What this changes

### 1. Increase Transparency (Settings → Appearance)

- A persisted, default-off toggle that makes the popover translucent the HIG-correct way: the opaque tray is swapped for a behind-window vibrancy layer (`PopoverBackdropView`) so the **blurred desktop shows through with system vibrancy**, and the data cards switch to a frosted `.regularMaterial` so the numbers stay legible. Liquid Glass stays reserved for the footer/top-bar chrome, never the content cards.
- **Yields to accessibility:** forces the opaque look (with a "paused" note in Settings explaining why) whenever macOS **Reduce Transparency** or **Increase Contrast** is on, so it never fights those preferences.

### 2. Secret-code easter egg (hidden)

- Typing **↑↑↓↓←→←→ B A** while the popover is focused toggles the egg. It's ephemeral (cleared on quit), and it **yields to macOS Reduce Transparency / Increase Contrast** the same way the Increase Transparency toggle does — those are accessibility needs, not preferences, and a hidden cheat code doesn't make overriding them safe. When a flag suppresses it the panel stays opaque and Settings shows a "party paused" note.
- **Party mode — loud but readable.** A churning party-gradient backdrop and a rotating glowing rim wrap the popover, meter bars fill with a party gradient, and provider marks pulse — all *behind* crisp text on the same frosted cards. It's built on the Increase Transparency foundation, so the party colors blend with the real desktop showing through rather than painting over it.
- **Drunk mode — the barely-readable escalation.** Blur, a pink-glass wash, and a woozy sway layered *over* the content, with the window going see-through.
- Adds **Party Mode** and **Drunk Mode** toggles in Settings (shown only while the code is active) and formalizes a four-state machine:
  - **1 Normal · 2 Increase Transparency · 3 Party · 4 Party + Drunk**
  - You move freely between 1 and 2. The code (or the Party toggle) takes 1→3 / 2→3; turning Party off returns to whichever of 1/2 you came from.
  - Drunk requires Party: 4 is reachable only from 3, and turning the Drunk toggle off goes 4→3. Turning Party off from 4 clears Drunk and returns to 1/2.
  - The egg never persists across a restart — the app reopens in the base state (1 or 2). While the egg is on, the Increase Transparency toggle is shown as paused (it has no effect there).
- Enabling/disabling the egg crossfades (window alpha + backdrop ease together) instead of snapping.

### 3. Reliability + energy (translucent surfaces)

- **No more blanking when unfocused.** A non-opaque, non-key window has its *static* SwiftUI layers culled by the compositor, so translucent content would disappear on a Space switch or when the popover lost key focus (Cmd-Tab). The Space-switch reporter now reads `isVisible` instead of occlusion state, and the translucent content — both the plain Increase Transparency surface and party — is kept resident with a sub-pixel re-raster, the same mechanism that already kept drunk mode's continuously-animated content alive.
- **No idle CPU.** All egg animation loops pause when the popover is hidden (`popoverIsVisible`) and otherwise run at the display's native refresh (ProMotion included), so a closed popover spends nothing and an open one looks exactly as designed — a deliberate optimization rather than a blanket frame-rate cap.

## Architecture

- Pure, unit-tested logic: `SecretCodeMatcher` (sliding-window key matcher) and the `PopoverTransparencyStyle` resolver — precedence is **accessibility clamp (opaque) > egg > Increase Transparency > opaque**.
- `PopoverTransparencyStore` (`@MainActor @Observable`, owned by `AppContainer`): the persisted toggle, the ephemeral egg state machine, and the live `NSWorkspace` accessibility flags it yields to. Read by both the SwiftUI surface and the AppKit panel.
- `PopoverBackdropView`: a permanent opaque tray plus a behind-window `NSVisualEffectView`, crossfaded by treatment; `StatusItemController` observes `effectiveStyle` via `withObservationTracking`.
- `TooMuchTransparencyKeyReader` (a sibling of the existing key reader that never consumes keys) and `TooMuchTransparencyEffect` (the party/drunk layers); `PartyMode` carries the `popoverPartyMode` / `popoverIsVisible` environment flags, the party meter fill, and the pulsing-mark modifier.
- Environment values default to the normal look (`popoverSurfaceTreatment = .opaque`, `popoverPartyMode = false`, `popoverIsVisible = false`), so the windowless ShareCard export and every normal surface are untouched.

## Tests

- New/updated: `SecretCodeMatcherTests`, `PopoverTransparencyStyleTests` (the full resolver matrix incl. party/drunk + accessibility precedence), `PopoverTransparencyStoreTests` (persistence, the ephemeral egg, and the state-machine transitions).
- Full suite green: **648 tests, 0 failures**.

## Docs

- `docs/settings.md` documents the Increase Transparency toggle and its accessibility pause. The egg is intentionally left undocumented.

## Screenshots

<img width="384" height="720" alt="CleanShot 2026-06-29 at 16 01 15@2x" src="https://github.com/user-attachments/assets/6645c220-87ba-4b49-8fdb-4a772e8bc385" />
<img width="384" height="720" alt="CleanShot 2026-06-29 at 16 01 28@2x" src="https://github.com/user-attachments/assets/6a4dbec7-7796-4928-b346-29706bf10673" />
<img width="386" height="783" alt="CleanShot 2026-06-29 at 16 01 51@2x" src="https://github.com/user-attachments/assets/816262ef-6d74-47a9-bf32-ad89f3a4a7df" />

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

All changes are opt-in defaults-off features; the normal opaque popover path is untouched. The accessibility clamp is well-tested and the animation-loop gate prevents idle CPU regression.

The state machine is pure and exhaustively unit-tested (full resolver matrix including every accessibility combination). The AppKit layer is carefully refactored — the stored PopoverBackdropView is correctly inserted into the container view hierarchy, and withObservationTracking re-arms mirror the established updateButtonImage pattern. No data-loss, security, or crash-path issues were found.

No files require special attention.

<sub>Reviews (19): Last reviewed commit: ["fix(popover): don&#39;t reset the screen on ..."](https://github.com/robinebers/openusage/commit/41907584bd8841decc10d2001db51273f44e67c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40331478)</sub>

<!-- /greptile_comment -->