### PR TITLE
feat(share): Share Screenshot footer submenu + copied-to-clipboard pill

### DIFF
--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -697,6 +697,15 @@ final class LayoutStore {
         }
     }
 
+    /// Clear any showing "Copied to clipboard" confirmation and cancel its auto-clear task. Called when
+    /// the popover closes so a pill mid-countdown can't reappear stale on the next open — the timer is
+    /// otherwise the only clearer, and the layout store outlives the popover.
+    func clearShareConfirmation() {
+        shareConfirmation = false
+        shareConfirmationClearTask?.cancel()
+        shareConfirmationClearTask = nil
+    }
+
     /// Pin or unpin a metric for the menu bar. Pinning is a no-op when it would exceed a cap, so callers
     /// can gate the control on `canPin` and trust this never over-pins. Undoable like the other layout
     /// actions — the no-op guards mean a denied or redundant pin records no step.

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -82,6 +82,15 @@ final class LayoutStore {
     private(set) var pinNoticeShakeTrigger = 0
     private var pinNoticeClearTask: Task<Void, Never>?
 
+    /// Transient confirmation that a provider's screenshot was copied to the clipboard — drives the
+    /// floating "Copied to clipboard" pill above the footer. Set by `presentShareConfirmation`,
+    /// cleared automatically a couple of seconds later. Never persisted.
+    private(set) var shareConfirmation = false
+    /// Bumped on every successful share so the pill replays its pop-in even when the same provider is
+    /// copied twice in a row (the pill's text doesn't change, so without this it wouldn't re-animate).
+    private(set) var shareConfirmationTrigger = 0
+    private var shareConfirmationClearTask: Task<Void, Never>?
+
     /// Bounded, app-wide undo stack for layout customization (remove/add a metric, reorder metrics or
     /// providers, pin/unpin, move across the expand caret). UI-only state (not persisted): undo is a
     /// within-session affordance, so a relaunch starts fresh. Each entry is a pre-change `LayoutSnapshot`;
@@ -671,6 +680,20 @@ final class LayoutStore {
             try? await Task.sleep(for: .seconds(3))
             guard !Task.isCancelled else { return }
             self?.pinLimitNotice = nil
+        }
+    }
+
+    /// Record a successful "Share Screenshot" copy so the floating "Copied to clipboard" pill can
+    /// confirm it. Shown for a couple of seconds then cleared — the success-side counterpart to
+    /// `notePinDenied`'s transient denial notice, with the same lifecycle.
+    func presentShareConfirmation() {
+        shareConfirmation = true
+        shareConfirmationTrigger += 1
+        shareConfirmationClearTask?.cancel()
+        shareConfirmationClearTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2.5))
+            guard !Task.isCancelled else { return }
+            self?.shareConfirmation = false
         }
     }
 

--- a/Sources/OpenUsage/Support/ShareCardRenderer.swift
+++ b/Sources/OpenUsage/Support/ShareCardRenderer.swift
@@ -48,8 +48,10 @@ enum ShareCardRenderer {
         }
     }
 
-    /// Orchestrates a Copy as Image action end to end: resolve the provider's visible rows from the data
+    /// Orchestrates a Share Screenshot action end to end: resolve the provider's visible rows from the data
     /// store, build the card with the effective appearance, render it, and copy the PNG to the clipboard.
+    /// On a successful copy it asks the layout store to surface a transient "Copied to clipboard" pill —
+    /// a clipboard write gives no other signal that it landed.
     /// The rows mirror what the dashboard shows — always-shown plus expanded only when the provider's
     /// caret is open — so the export matches what the user sees.
     ///
@@ -96,5 +98,8 @@ enum ShareCardRenderer {
             return
         }
         copyToPasteboard(image)
+        // Surface a confirmation so the user knows the screenshot landed on the clipboard (a copy gives
+        // no other signal). Drives the floating "Copied to clipboard" pill above the footer.
+        layout.presentShareConfirmation()
     }
 }

--- a/Sources/OpenUsage/Support/ShareCardRenderer.swift
+++ b/Sources/OpenUsage/Support/ShareCardRenderer.swift
@@ -33,19 +33,23 @@ enum ShareCardRenderer {
 
     /// Writes the card's PNG onto the general pasteboard (replacing its contents). Beeps and logs if the
     /// PNG can't be encoded or the pasteboard rejects it, so a failed copy isn't silently swallowed.
-    static func copyToPasteboard(_ image: NSImage) {
+    /// Returns `true` only when the PNG actually landed on the pasteboard, so callers can gate a success
+    /// confirmation on it (and not claim "copied" when nothing was written).
+    @discardableResult
+    static func copyToPasteboard(_ image: NSImage) -> Bool {
         guard let png = pngData(from: image) else {
             AppLog.error(.lifecycle, "share card: failed to encode PNG for clipboard")
             NSSound.beep()
-            return
+            return false
         }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         guard pasteboard.setData(png, forType: .png) else {
             AppLog.error(.lifecycle, "share card: pasteboard rejected the PNG")
             NSSound.beep()
-            return
+            return false
         }
+        return true
     }
 
     /// Orchestrates a Share Screenshot action end to end: resolve the provider's visible rows from the data
@@ -97,9 +101,9 @@ enum ShareCardRenderer {
             NSSound.beep()
             return
         }
-        copyToPasteboard(image)
-        // Surface a confirmation so the user knows the screenshot landed on the clipboard (a copy gives
-        // no other signal). Drives the floating "Copied to clipboard" pill above the footer.
+        // Only surface the "Copied to clipboard" pill when the PNG actually landed on the pasteboard —
+        // a failed encode or a pasteboard rejection must not read as success.
+        guard copyToPasteboard(image) else { return }
         layout.presentShareConfirmation()
     }
 }

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -32,6 +32,10 @@ enum Theme {
     /// system orange at full strength, matching the meter fills.
     static let notice = AnyShapeStyle(Color(nsColor: .systemOrange))
 
+    /// Inline success tint (the "screenshot copied to clipboard" confirmation) — the system green at
+    /// full strength, the positive counterpart to `notice`'s orange.
+    static let positive = AnyShapeStyle(Color(nsColor: .systemGreen))
+
     // MARK: - Surfaces
 
     /// The popover's opaque backdrop ("tray") behind the grouped cards — `textBackgroundColor`, the

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -532,6 +532,41 @@ struct DashboardView: View {
             measuredFooter[screen] = height
             recomposeIdeal(for: screen)
         }
+        // A successful "Share Screenshot" springs a small "Copied ✓" pill up just above the footer —
+        // a floating success toast that's more glanceable than the in-footer text line, and separate
+        // from it. Dashboard-only (share is a dashboard action). The pill re-identifies on the trigger
+        // so back-to-back copies of the same provider each replay the pop-in.
+        .overlay(alignment: .top) {
+            if screen == .dashboard, layout.shareConfirmation {
+                shareCopiedPill
+                    // Float just above the footer's top edge with a small gap (the pill is ~28pt, so -34
+                    // leaves ~6pt of clear space) — a toast over the bottom content, not covering the
+                    // footer's own identity row / Settings button.
+                    .offset(y: -34)
+            }
+        }
+        .animation(Motion.spring, value: layout.shareConfirmation)
+        .animation(Motion.spring, value: layout.shareConfirmationTrigger)
+    }
+
+    /// The floating "Copied to clipboard" pill that springs up just above the footer when a provider
+    /// screenshot is copied — a small frosted capsule that reads as a transient success toast. `.id` on
+    /// the trigger so a repeat copy of the same provider re-pops instead of sitting motionless.
+    private var shareCopiedPill: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 11, weight: .semibold))
+            Text("Copied to clipboard")
+                .font(.system(size: 12, weight: .semibold))
+        }
+        .foregroundStyle(Theme.positive)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(.separator, lineWidth: 0.5))
+        .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
+        .id(layout.shareConfirmationTrigger)
+        .transition(.scale(scale: 0.85).combined(with: .opacity))
     }
 
     /// Count of enabled ("active") metrics across providers — the "N active" half of the Customize footer

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -212,6 +212,9 @@ struct DashboardView: View {
         if layout.screen != .dashboard { layout.screen = .dashboard }
         reorderLift = nil
         layout.cancelDrag()
+        // A "Copied to clipboard" pill mid-countdown would otherwise reappear stale on the next open,
+        // since the layout store survives the popover and only the timer clears it.
+        layout.clearShareConfirmation()
         // Drop the driven height so the next open re-establishes it (un-animated) from the reopened
         // screen's measurement instead of springing from this session's last value. Until then the
         // 0 sentinel keeps `PanelHeightModifier` from pushing, so the controller's opening guess stands.

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -4,9 +4,9 @@ import SwiftUI
 /// The dashboard footer's trailing control: a **split button** in Liquid Glass — one capsule with
 /// "Settings" on the left and a chevron segment on the right, divided by a hairline (the Export ▾
 /// idiom system apps use). Clicking "Settings" opens the Settings screen; clicking the chevron opens
-/// the overflow menu (Customize / Check for Updates / About / Quit). Settings leads because everyday
-/// layout edits (reorder, hide, pin) are already reachable by dragging and right-clicking on the
-/// dashboard itself, so Settings is the more frequent deliberate destination.
+/// the overflow menu (Customize / Share Screenshot / Check for Updates / About / Quit). Settings leads
+/// because everyday layout edits (reorder, hide, pin) are already reachable by dragging and
+/// right-clicking on the dashboard itself, so Settings is the more frequent deliberate destination.
 ///
 /// The joined-capsule look comes from one glass surface behind the *whole* control: an `HStack` of two
 /// `.buttonStyle(.plain)` tap targets (a `Button` and a chevron `Menu`) split by a `Divider`, with a
@@ -28,7 +28,9 @@ import SwiftUI
 /// unowned elsewhere, so it rides its menu item directly.
 struct HeaderView: View {
     @Environment(LayoutStore.self) private var layout
+    @Environment(WidgetDataStore.self) private var dataStore
     @Environment(UpdaterController.self) private var updater
+    @Environment(\.colorScheme) private var colorScheme
     /// The current screen. The footer is fixed chrome keyed off `layout.screen` (it no longer slides
     /// per-page), so this control shows only when that's `.dashboard` and swaps in place on a switch.
     let screen: PopoverScreen
@@ -106,6 +108,9 @@ struct HeaderView: View {
             Label("Customize", systemImage: "slider.horizontal.3")
         }
         .keyboardShortcut(.return, modifiers: [])
+
+        shareScreenshotMenu
+
         Button { updater.checkForUpdates() } label: {
             Label("Check for Updates…", systemImage: "arrow.triangle.2.circlepath")
         }
@@ -120,6 +125,45 @@ struct HeaderView: View {
             Label("Quit OpenUsage", systemImage: "power")
         }
         .keyboardShortcut("q") // ⌘Q — unowned elsewhere, so safe to register on the item.
+    }
+
+    /// The footer's "Share Screenshot" submenu: one entry per provider currently showing on the
+    /// dashboard (`displayGroups` — enabled providers with at least one visible metric), so a screenshot
+    /// is reachable without right-clicking a card. Each entry runs the same render path as the per-provider
+    /// right-click "Share Screenshot": a branded PNG of that provider's card copied to the clipboard. The
+    /// menu renders in its own `NSMenu`-backed window, so firing an item doesn't close the popover the way
+    /// a navigation toggle would — the share card reads the same live stores the dashboard does.
+    @ViewBuilder
+    private var shareScreenshotMenu: some View {
+        let groups = layout.displayGroups
+        Menu {
+            if groups.isEmpty {
+                // No provider is showing anything to screenshot — grey the item out instead of offering
+                // an empty submenu.
+                Button("No Enabled Providers") {}
+                    .disabled(true)
+            } else {
+                ForEach(groups) { group in
+                    Button(group.provider.displayName) { shareCard(group) }
+                }
+            }
+        } label: {
+            Label("Share Screenshot", systemImage: "square.and.arrow.up")
+        }
+    }
+
+    /// Renders the provider's branded share card and copies the PNG to the clipboard — the same action as
+    /// the dashboard's per-provider right-click "Share Screenshot". The appearance comes from the
+    /// popover's own `colorScheme`: the footer lives in the popover panel, whose appearance is
+    /// `AppearanceSetting.current` (explicit for Light/Dark, the menu bar for System), so the export
+    /// matches the card on screen instead of guessing from `NSApp.effectiveAppearance`.
+    private func shareCard(_ group: ProviderGroup) {
+        ShareCardRenderer.share(
+            group: group,
+            dataStore: dataStore,
+            layout: layout,
+            appearance: colorScheme
+        )
     }
 
     private func toggle(_ screen: PopoverScreen) {

--- a/Sources/OpenUsage/Views/ShareCardView.swift
+++ b/Sources/OpenUsage/Views/ShareCardView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// An off-screen, branded PNG of one provider's usage, rendered for the right-click "Copy as Image"
+/// An off-screen, branded PNG of one provider's usage, rendered for the right-click "Share Screenshot"
 /// action. It is a static snapshot — no drag grips, spinners, staleness tags, or refresh warnings — that
 /// mirrors what the provider's card currently shows in the popover (respecting whether the caret is
 /// expanded), drawn at the popover's own scale and rasterized at ×4 for a crisp, large share image.

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -71,14 +71,16 @@ struct WidgetGroupedListView: View {
                 withAnimation(Motion.modeSwitch) { layout.isEditing = true }
             }
             Divider()
-            Button("Copy as Image") { shareCard(group) }
+            Button("Share Screenshot") { shareCard(group) }
         }
     }
 
     /// Renders the provider's branded share card and copies the PNG to the clipboard. The appearance is
     /// taken from the popover's own `colorScheme` — this view is hosted in the popover panel, whose
     /// appearance is `AppearanceSetting.current` (explicit for Light/Dark, the menu bar for System) — so
-    /// the export matches the card on screen instead of guessing from `NSApp.effectiveAppearance`.
+    /// the export matches the card on screen instead of guessing from `NSApp.effectiveAppearance`. The
+    /// same render path backs the footer's "Share Screenshot" submenu, which reaches it without a
+    /// right-click.
     private func shareCard(_ group: ProviderGroup) {
         ShareCardRenderer.share(
             group: group,

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -999,6 +999,21 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(store.placed.map(\.descriptorID), before)
     }
 
+    // MARK: - Share confirmation
+
+    /// `clearShareConfirmation` hides the pill immediately and cancels the auto-clear task, so a
+    /// confirmation mid-countdown can't reappear stale after the popover closes and reopens.
+    func testClearShareConfirmationHidesPillAndCancelsTimer() {
+        let store = makeStore("ShareConfirmationClear")
+        XCTAssertFalse(store.shareConfirmation)
+
+        store.presentShareConfirmation()
+        XCTAssertTrue(store.shareConfirmation, "present sets the confirmation the pill reads")
+
+        store.clearShareConfirmation()
+        XCTAssertFalse(store.shareConfirmation, "clear hides the pill immediately")
+    }
+
     private func makeStore(_ name: String) -> LayoutStore {
         LayoutStore(registry: .mock, defaults: makeDefaults(name), storageKey: "layout")
     }

--- a/Tests/OpenUsageTests/ShareCardRendererTests.swift
+++ b/Tests/OpenUsageTests/ShareCardRendererTests.swift
@@ -73,4 +73,29 @@ final class ShareCardRendererTests: XCTestCase {
                            "row \(i) condensing should not bridge the expand caret boundary")
         }
     }
+
+    // MARK: - Clipboard write result
+
+    /// `copyToPasteboard` reports `false` when the image can't be PNG-encoded, so `share` can gate the
+    /// "Copied to clipboard" confirmation on a real successful write instead of claiming success after a
+    /// silent encode/pasteboard failure. Regression guard for the success-pill-after-copy-failure bug.
+    func testCopyToPasteboardReturnsFalseForUnencodableImage() {
+        // An empty NSImage has no representations, so tiffRepresentation is nil and PNG encoding fails.
+        let empty = NSImage()
+        XCTAssertFalse(ShareCardRenderer.copyToPasteboard(empty),
+                       "a failed encode must report false, not silently return success")
+    }
+
+    /// `copyToPasteboard` reports `true` and actually writes PNG data onto the pasteboard for a valid
+    /// image — the success contract the confirmation gates on.
+    func testCopyToPasteboardWritesPNGAndReturnsTrueForValidImage() throws {
+        let image = try XCTUnwrap(ShareCardRenderer.image(for: sampleCard()))
+        XCTAssertTrue(ShareCardRenderer.copyToPasteboard(image))
+
+        let png = try XCTUnwrap(NSPasteboard.general.data(forType: .png))
+        XCTAssertFalse(png.isEmpty)
+        // PNG magic bytes confirm the pasteboard holds an actual PNG, not just non-empty data.
+        let magic: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+        XCTAssertEqual(Array(png.prefix(magic.count)), magic)
+    }
 }

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -30,17 +30,20 @@ Rows with a reset date tick every 30 seconds, so countdowns and pace stay live b
 ## Right-click menus
 
 Every row: **Hide · Pin to menu bar / Unpin · Refresh \<provider\> · Customize…**
-Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on under Settings ▸ Providers.) plus **Copy as Image** (see below).
+Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on under Settings ▸ Providers.) plus **Share Screenshot** (see below).
 
 ## Share
 
-Right-click a provider header and choose **Copy as Image** to copy a clean, branded PNG of that provider's usage to your clipboard, ready to paste into a chat, a tweet, or a doc.
+Copy a clean, branded PNG of one provider's usage to your clipboard, ready to paste into a chat, a tweet, or a doc. There are two ways to reach it:
+
+- Right-click a provider header and choose **Share Screenshot**.
+- Open the footer's **⌄** menu and choose **Share Screenshot** ▸ *\<provider\>*. The submenu lists every provider currently showing on the dashboard.
 
 The image is a flexible-height PNG using the app's look — the provider's mark and name up top, the metric rows you currently see for that provider, and a small OpenUsage mark centered at the bottom. It follows your Light/Dark appearance and shows everything on the card as-is (nothing is hidden or blurred).
 
 ## Footer
 
-The bar pinned to the bottom of the popover. On the left: the app version, and a live "Next update in …" countdown you can click (or press **⌘R**) to refresh right away. On the right: a **Customize** button paired with a **⌄** menu. The menu holds the app-level actions — **Settings**, **Check for Updates…**, **About OpenUsage**, and **Quit OpenUsage**.
+The bar pinned to the bottom of the popover. On the left: the app version, and a live "Next update in …" countdown you can click (or press **⌘R**) to refresh right away. On the right: a **Settings** button paired with a **⌄** menu. The menu holds the app-level actions — **Customize**, **Share Screenshot** (submenu of providers), **Check for Updates…**, **About OpenUsage**, and **Quit OpenUsage**.
 
 ## Customize
 


### PR DESCRIPTION
## TL;DR

Renames the per-provider "Copy as Image" action to **Share Screenshot**, exposes it from the footer ⌄ menu as a per-provider submenu, and adds a transient **"Copied to clipboard"** pill so a successful copy is no longer silent.

## What was happening

- Sharing a provider's usage card was only reachable by right-clicking a provider header ("Copy as Image"), so it was easy to miss.
- A successful copy gave **zero feedback** (it only beeped on failure), so there was no signal the PNG had landed on the clipboard.

## What this changes

- Renames the right-click action **Copy as Image → Share Screenshot** in the provider header context menu (and updates the related doc comments in `ShareCardView` / `ShareCardRenderer`).
- Adds a **Share Screenshot ▸** submenu to the footer ℄ overflow menu, directly under Customize, with one entry per enabled provider (`layout.displayGroups`). Each entry calls the same `ShareCardRenderer.share` path as the right-click, so the PNG is identical.
- On a successful copy, springs a transient **"Copied to clipboard"** pill just above the footer (green checkmark, frosted capsule, ~2.5s, spring-pop in / fade out). Repeat copies of the same provider re-pop it via a trigger counter.
- The confirmation state lives on `LayoutStore` (`shareConfirmation` flag + `shareConfirmationTrigger`), mirroring the existing `pinLimitNotice` / `notePinDenied` transient-notice lifecycle. It's fired from `ShareCardRenderer.share`, so both entry points confirm for free.
- Adds `Theme.positive` (system green) as the success counterpart to `Theme.notice` (orange).
- Updates `docs/dashboard.md` (rename, the new submenu entry point, and the footer menu list).

## Heads-up

- **No click haptic:** `Haptics.swift` is explicit that haptics are drag-only (a click pulse stacks on the trackpad's release click and reads as a double vibration — tried and reverted before), so the pill is visual-only.
- The pill is dashboard-only (share is a dashboard action); switching screens mid-confirmation just hides it there, and the 2.5s timer still clears it.
- The submenu greys out a "No Enabled Providers" row when `displayGroups` is empty rather than showing an empty submenu.

## Tests

- `./script/build_and_run.sh verify` — release build clean, app launches and runs. No new compiler warnings (the two pre-existing warnings are in `LocalUsageServer.swift` / `ProviderSnapshotCache.swift`, unrelated).
- `ShareCardRendererTests` still covers `image(for:)`, `pngData`, and `condensedTextRowIndices`; the `share(...)` orchestrator change is exercised by the live run.

## Screenshots

<img width="397" height="236" alt="image" src="https://github.com/user-attachments/assets/2701dde5-8d34-4c74-9f61-80523c990ea8" />

<img width="1440" height="924" alt="image" src="https://github.com/user-attachments/assets/538cc39a-4403-4c12-b19c-2fc7d6fd14cb" />

## Checklist

- [x] Targets `main`
- [x] Behavior change — updated `docs/dashboard.md` in this same PR
- [x] No new dependencies
- [x] `swift build` succeeds (release build via `./script/build_and_run.sh verify`)

Made with [Cursor](https://cursor.com)