### PR TITLE
fix(providers): resolve env-var API keys from the login shell in packaged builds

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -28,6 +28,11 @@ final class AppContainer {
     private let refreshTask: Task<Void, Never>
 
     init() {
+        // Capture the user's login-shell environment off-main so provider keys exported in a shell
+        // profile (e.g. OPENROUTER_API_KEY) resolve in a Finder/Dock-launched build, not only when
+        // run from a terminal. Warmed here so the first refresh finds the cache ready.
+        LoginShellEnvironment.shared.prewarm()
+
         // Default provider order (see AGENTS.md "## Providers"): the three established providers first —
         // Claude, Codex, Cursor — then every other provider alphabetically by display name. This registry
         // order is the default provider order (`LayoutStore.orderedProviderIDs` falls back to it, and

--- a/Sources/OpenUsage/Providers/OpenRouter/OpenRouterAuthStore.swift
+++ b/Sources/OpenUsage/Providers/OpenRouter/OpenRouterAuthStore.swift
@@ -32,9 +32,10 @@ enum OpenRouterAuthError: Error, LocalizedError, Equatable {
 
 /// Reads an OpenRouter API key the user has already placed on the machine. Unlike the CLI-backed
 /// providers, OpenRouter has no companion app that stashes a credential in a known spot, so the key
-/// comes from an environment variable or a small config file. The GUI app does not inherit the shell
-/// environment, so the config file is the reliable path; the env var works when the app is launched
-/// from a shell (e.g. during development) or seeded via `launchctl setenv`.
+/// comes from an environment variable or a small config file. A GUI app launched from Finder/Dock
+/// doesn't inherit the interactive shell environment, so `ProcessEnvironmentReader` captures the
+/// login shell's environment at launch (see `LoginShellEnvironment`) — meaning an env var exported in
+/// a shell profile is honored even in a packaged build; the config file remains the explicit path.
 struct OpenRouterAuthStore: Sendable {
     /// Config files checked in order; first readable key wins. JSON (`apiKey` / `api_key` / `key`) or a
     /// plain-text file containing only the key.

--- a/Sources/OpenUsage/Services/LoginShellEnvironment.swift
+++ b/Sources/OpenUsage/Services/LoginShellEnvironment.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// A macOS GUI app launched from Finder, the Dock, or `open` inherits only the launchd session
+/// environment — not the variables a user exports in their interactive login shell
+/// (`~/.zshrc`, `~/.zprofile`, `~/.bash_profile`). Provider keys like `OPENROUTER_API_KEY` live
+/// there, so without this they are invisible to a packaged build; they only resolved when the
+/// binary was run straight from a terminal during development (which is why "it worked in dev"
+/// but not in the shipped beta).
+///
+/// This captures the login shell environment once, by running the user's `$SHELL` as a login +
+/// interactive shell and reading its `env`, then caches the result. `ProcessEnvironmentReader`
+/// consults it as a fallback after the process environment, so env-var keys resolve in the
+/// bundled app the same way they do from a terminal.
+final class LoginShellEnvironment: @unchecked Sendable {
+    static let shared = LoginShellEnvironment()
+
+    /// Sentinel tokens that bracket our `env` output, so a login shell's banner/MOTD (printed before
+    /// our command runs) is discarded instead of mis-parsed as variables.
+    private static let beginMarker = "__OPENUSAGE_ENV_BEGIN__"
+    private static let endMarker = "__OPENUSAGE_ENV_END__"
+    /// Cap the shell spawn so a slow or hanging profile can't stall a provider refresh forever.
+    private static let captureTimeout: TimeInterval = 5
+
+    private let runner: ProcessRunning
+    private let lock = NSLock()
+    private var cached: [String: String]?
+
+    init(runner: ProcessRunning = SystemProcessRunner()) {
+        self.runner = runner
+    }
+
+    /// The captured login-shell value for `name`, or `nil` if absent or empty.
+    func value(for name: String) -> String? {
+        environment()[name]?.nilIfEmpty
+    }
+
+    /// Capture the environment once and cache it. The lock is held across the (one-time) spawn so
+    /// concurrent callers wait for the single capture instead of each spawning their own shell.
+    func environment() -> [String: String] {
+        lock.lock()
+        defer { lock.unlock() }
+        if let cached { return cached }
+        let captured = capture()
+        cached = captured
+        return captured
+    }
+
+    /// Spawn the capture eagerly off the main thread so the first provider refresh (and any UI read)
+    /// finds the cache already warm and never blocks on the subprocess. Safe to call more than once.
+    func prewarm() {
+        Task.detached(priority: .utility) { [weak self] in
+            _ = self?.environment()
+        }
+    }
+
+    private func capture() -> [String: String] {
+        let shell = ProcessInfo.processInfo.environment["SHELL"]?.nilIfEmpty ?? "/bin/zsh"
+        // `-i -l -c`: interactive + login so both rc files (.zshrc/.bashrc) and profile files
+        // (.zprofile/.bash_profile) are sourced; `env -0` emits NUL-separated `KEY=VALUE`, robust
+        // against values that contain newlines.
+        let command = "printf '%s\\0' \(Self.beginMarker); /usr/bin/env -0; printf '%s\\0' \(Self.endMarker)"
+        do {
+            let result = try runner.run(
+                executable: shell,
+                arguments: ["-ilc", command],
+                environment: [:],
+                timeout: Self.captureTimeout
+            )
+            guard result.succeeded else {
+                AppLog.warn(.subprocess, "login-shell env capture exited \(result.exitCode)")
+                return [:]
+            }
+            return Self.parse(result.stdout)
+        } catch {
+            AppLog.warn(.subprocess, "login-shell env capture failed: \(error.localizedDescription)")
+            return [:]
+        }
+    }
+
+    /// Parse the NUL-separated `env -0` output, keeping only the `KEY=VALUE` tokens between the begin
+    /// and end markers and ignoring any shell banner printed outside them.
+    static func parse(_ output: String) -> [String: String] {
+        let tokens = output.components(separatedBy: "\0")
+        guard let begin = tokens.firstIndex(of: beginMarker) else { return [:] }
+        let end = tokens.firstIndex(of: endMarker) ?? tokens.count
+        guard begin < end else { return [:] }
+
+        var environment: [String: String] = [:]
+        for token in tokens[(begin + 1)..<end] {
+            guard let separator = token.firstIndex(of: "=") else { continue }
+            let key = String(token[..<separator])
+            guard !key.isEmpty else { continue }
+            environment[key] = String(token[token.index(after: separator)...])
+        }
+        return environment
+    }
+}

--- a/Sources/OpenUsage/Services/LoginShellEnvironment.swift
+++ b/Sources/OpenUsage/Services/LoginShellEnvironment.swift
@@ -11,6 +11,13 @@ import Foundation
 /// interactive shell and reading its `env`, then caches the result. `ProcessEnvironmentReader`
 /// consults it as a fallback after the process environment, so env-var keys resolve in the
 /// bundled app the same way they do from a terminal.
+///
+/// Threading: the capture subprocess never runs (or is waited on) while the state lock is held, so
+/// a cache read can't stall behind it. The **main thread** never triggers the capture — it reads
+/// whatever is cached and otherwise returns `nil`, so opening Settings before the cache warms can't
+/// freeze the UI. Off-main callers (provider refreshes) capture on demand and block only for the
+/// single, one-time spawn, so the first refresh still resolves the key. `prewarm()` kicks the
+/// capture at launch so the cache is normally warm before anything reads it.
 final class LoginShellEnvironment: @unchecked Sendable {
     static let shared = LoginShellEnvironment()
 
@@ -22,35 +29,52 @@ final class LoginShellEnvironment: @unchecked Sendable {
     private static let captureTimeout: TimeInterval = 5
 
     private let runner: ProcessRunning
-    private let lock = NSLock()
+    /// Guards `cached` only — held for microseconds, never across the subprocess.
+    private let stateLock = NSLock()
+    /// Serializes the capture so a single subprocess runs even under concurrent callers. Taken only
+    /// off the main thread (see `value(for:)`), so the UI thread can never wait on it.
+    private let captureLock = NSLock()
     private var cached: [String: String]?
 
     init(runner: ProcessRunning = SystemProcessRunner()) {
         self.runner = runner
     }
 
-    /// The captured login-shell value for `name`, or `nil` if absent or empty.
+    /// The captured login-shell value for `name`, or `nil` if absent or empty. Never blocks the main
+    /// thread on the subprocess: on the main thread it only reads the cache, returning `nil` until the
+    /// prewarm fills it; off the main thread it captures on demand if needed.
     func value(for name: String) -> String? {
-        environment()[name]?.nilIfEmpty
-    }
-
-    /// Capture the environment once and cache it. The lock is held across the (one-time) spawn so
-    /// concurrent callers wait for the single capture instead of each spawning their own shell.
-    func environment() -> [String: String] {
-        lock.lock()
-        defer { lock.unlock() }
-        if let cached { return cached }
-        let captured = capture()
-        cached = captured
-        return captured
+        if let env = cachedSnapshot() { return env[name]?.nilIfEmpty }
+        guard !Thread.isMainThread else { return nil }
+        return capturedEnvironment()[name]?.nilIfEmpty
     }
 
     /// Spawn the capture eagerly off the main thread so the first provider refresh (and any UI read)
     /// finds the cache already warm and never blocks on the subprocess. Safe to call more than once.
     func prewarm() {
         Task.detached(priority: .utility) { [weak self] in
-            _ = self?.environment()
+            _ = self?.capturedEnvironment()
         }
+    }
+
+    private func cachedSnapshot() -> [String: String]? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return cached
+    }
+
+    /// Capture the environment once and cache it. Off-main only. Serialized by `captureLock` so a
+    /// single subprocess runs; the spawn happens with no lock held, and the result is stored under a
+    /// brief `stateLock` so concurrent cache reads never block on the subprocess.
+    private func capturedEnvironment() -> [String: String] {
+        captureLock.lock()
+        defer { captureLock.unlock() }
+        if let env = cachedSnapshot() { return env }
+        let captured = capture()
+        stateLock.lock()
+        cached = captured
+        stateLock.unlock()
+        return captured
     }
 
     private func capture() -> [String: String] {

--- a/Sources/OpenUsage/Services/SystemClients.swift
+++ b/Sources/OpenUsage/Services/SystemClients.swift
@@ -6,7 +6,13 @@ protocol EnvironmentReading: Sendable {
 
 struct ProcessEnvironmentReader: EnvironmentReading {
     func value(for name: String) -> String? {
-        ProcessInfo.processInfo.environment[name]
+        // The process environment first (set by launchd, `launchctl setenv`, or a terminal launch),
+        // then the captured login-shell environment — so keys a user exports in their shell profile
+        // still resolve in a packaged app launched from Finder/Dock. See `LoginShellEnvironment`.
+        if let value = ProcessInfo.processInfo.environment[name]?.nilIfEmpty {
+            return value
+        }
+        return LoginShellEnvironment.shared.value(for: name)
     }
 }
 

--- a/Sources/OpenUsage/Views/APIKeysSection.swift
+++ b/Sources/OpenUsage/Views/APIKeysSection.swift
@@ -97,10 +97,7 @@ struct APIKeysSection: View {
             if status == .notSet {
                 // No key anywhere: the field is editable from the start.
                 keyField(provider, editable: true)
-                HStack(spacing: 8) {
-                    primaryButton("Save", disabled: !hasInput) { save(provider) }
-                    storageCaption(provider)
-                }
+                primaryButton("Save", disabled: !hasInput) { save(provider) }
             } else if status == .fromEnvironment {
                 // Env key, no custom key yet: read-only until "Override" is checked, then editable.
                 keyField(provider, editable: overrideChecked)
@@ -180,13 +177,6 @@ struct APIKeysSection: View {
         case .overrideActive: "Custom Key"
         case .notSet: ""
         }
-    }
-
-    private func storageCaption(_ provider: any APIKeyManaging) -> some View {
-        Text("Stored in \(provider.apiKeyStorageDescription)")
-            .font(.caption2)
-            .foregroundStyle(.tertiary)
-            .lineLimit(1)
     }
 
     private var hasInput: Bool {

--- a/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
+++ b/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
@@ -30,4 +30,44 @@ final class LoginShellEnvironmentTests: XCTestCase {
     func testMissingMarkersYieldEmpty() {
         XCTAssertTrue(LoginShellEnvironment.parse("PATH=/usr/bin\0HOME=/Users/x").isEmpty)
     }
+
+    func testResolvesKeyOffMainThread() {
+        let runner = RecordingRunner(stdout: [begin, "OPENROUTER_API_KEY=sk-or-test", end].joined(separator: "\0"))
+        let env = LoginShellEnvironment(runner: runner)
+        let captured = expectation(description: "captured off-main")
+        var value: String?
+        DispatchQueue.global().async {
+            value = env.value(for: "OPENROUTER_API_KEY")
+            captured.fulfill()
+        }
+        wait(for: [captured], timeout: 5)
+        XCTAssertEqual(value, "sk-or-test")
+        XCTAssertEqual(runner.callCount, 1)
+    }
+
+    /// The Bugbot fix: a main-thread read before the cache is warm must not spawn or wait on the
+    /// subprocess, so the UI can't freeze. It returns nil until the prewarm fills the cache.
+    func testMainThreadReadDoesNotRunSubprocess() {
+        let runner = RecordingRunner(stdout: [begin, "K=v", end].joined(separator: "\0"))
+        let env = LoginShellEnvironment(runner: runner)
+        XCTAssertNil(env.value(for: "K"))
+        XCTAssertEqual(runner.callCount, 0)
+    }
+}
+
+/// Returns a fixed stdout and counts how many times it was invoked, so tests can assert the capture
+/// ran exactly once (or not at all on the main thread).
+private final class RecordingRunner: ProcessRunning, @unchecked Sendable {
+    let stdout: String
+    private let lock = NSLock()
+    private var count = 0
+
+    var callCount: Int { lock.lock(); defer { lock.unlock() }; return count }
+
+    init(stdout: String) { self.stdout = stdout }
+
+    func run(executable: String, arguments: [String], environment: [String: String], timeout: TimeInterval) throws -> ProcessResult {
+        lock.lock(); count += 1; lock.unlock()
+        return ProcessResult(exitCode: 0, stdout: stdout, stderr: "")
+    }
 }

--- a/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
+++ b/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import OpenUsage
+
+final class LoginShellEnvironmentTests: XCTestCase {
+    private let begin = "__OPENUSAGE_ENV_BEGIN__"
+    private let end = "__OPENUSAGE_ENV_END__"
+
+    func testParsesKeysBetweenMarkers() {
+        let output = [begin, "OPENROUTER_API_KEY=sk-or-v1-abc", "PATH=/usr/bin:/bin", end]
+            .joined(separator: "\0")
+        let parsed = LoginShellEnvironment.parse(output)
+        XCTAssertEqual(parsed["OPENROUTER_API_KEY"], "sk-or-v1-abc")
+        XCTAssertEqual(parsed["PATH"], "/usr/bin:/bin")
+    }
+
+    func testIgnoresBannerOutsideMarkers() {
+        // A login shell can print an MOTD/banner before our command runs; it must not be parsed.
+        let output = ["Welcome to your shell!", "MOTD=should-be-ignored\0" + begin,
+                      "REAL=value", end, "trailing-noise"].joined(separator: "\0")
+        let parsed = LoginShellEnvironment.parse(output)
+        XCTAssertEqual(parsed["REAL"], "value")
+        XCTAssertNil(parsed["MOTD"])
+    }
+
+    func testKeepsValuesContainingEquals() {
+        let output = [begin, "TOKEN=a=b=c", end].joined(separator: "\0")
+        XCTAssertEqual(LoginShellEnvironment.parse(output)["TOKEN"], "a=b=c")
+    }
+
+    func testMissingMarkersYieldEmpty() {
+        XCTAssertTrue(LoginShellEnvironment.parse("PATH=/usr/bin\0HOME=/Users/x").isEmpty)
+    }
+}

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -31,10 +31,11 @@ You can also provide the key directly (checked in this order, first match wins):
 
    A plain-text file containing just the key, or `~/.config/openrouter/key.json`, also work.
 
-2. **Environment variable:** set `OPENROUTER_API_KEY`. Because the macOS app does not inherit your
-   shell environment, this only reaches the app when it's launched from a shell or seeded with
-   `launchctl setenv OPENROUTER_API_KEY sk-or-v1-...`. When a key is found here, the API Keys card
-   shows it as read-only ("From environment") with a checkbox to override it with a saved key.
+2. **Environment variable:** set `OPENROUTER_API_KEY` in your shell profile (e.g. `~/.zshrc` or
+   `~/.zprofile`). On launch the app reads your login shell's environment, so a key exported there is
+   picked up even when the app is started from Finder or the Dock — not just when run from a terminal.
+   When a key is found here, the API Keys card shows it as read-only ("From environment") with a
+   checkbox to override it with a saved key.
 
 A key saved through the app overrides an environment key (the config file is checked first); removing
 the saved key falls back to the environment key, or to none.


### PR DESCRIPTION
## TL;DR
Env-var API keys (e.g. `OPENROUTER_API_KEY`) now work in a shipped, Finder/Dock-launched build — not just when the binary is run from a terminal — by reading the user's login-shell environment at launch. Also removes the "Stored in …" caption from the API Keys editor.

## What was happening
- A user with `OPENROUTER_API_KEY` set in their shell saw the API Keys card report **no key** (red dot, "Add", placeholder) in beta-2.
- Root cause: a GUI app launched from Finder/Dock/`open` inherits only the **launchd session** environment, not the variables exported in an interactive login shell (`~/.zshrc`, `~/.zprofile`). The auth store read `ProcessInfo.processInfo.environment`, which is empty for those keys in that context.
- It "worked in dev" only because the app was run straight from a terminal, which does inherit the shell. Not a regression — a macOS env-inheritance gap.
- The editor also showed a redundant "Stored in ~/.config/openusage/openrouter.json" caption.

## What this changes
- Adds `LoginShellEnvironment`: captures the login shell's environment **once at launch**, off the main thread, by running `$SHELL -ilc 'env -0'` with a 5s timeout and sentinel-bracketed parsing. The result is cached for the session.
- `ProcessEnvironmentReader` now falls back to that capture after the process environment. This is at the **shared** env layer, so every provider that reads an env var benefits, not only OpenRouter.
- Prewarms the capture in `AppContainer` init so the first refresh/UI read finds the cache warm and the launch path never blocks.
- Removes the "Stored in …" caption (and its helper) from `APIKeysSection`.
- Updates `docs/providers/openrouter.md` and the auth-store comment to reflect that env keys now work in a Finder/Dock launch.

## Heads-up
- The capture is **once per launch** and cached (even a failed/timed-out capture is cached empty, so no repeated shell spawns). A key newly added to a shell profile while the app is running won't be seen until restart — same tradeoff as VS Code. Saving the key in-app (config file) still takes effect on the next refresh.
- `apiKeyStorageDescription` on the `APIKeyManaging` protocol is now only referenced by a test (the caption was its only UI use); left in place to keep the change tight.

## Tests
- New `LoginShellEnvironmentTests`: parser handles keys between markers, strips a shell banner outside the markers, keeps `=` inside values, and yields empty when markers are missing.
- Full suite green locally (613 tests, 1 skipped).
- Verified end-to-end: rebuilt via `script/build_and_run.sh` (which uses `open`, reproducing the no-shell-env condition) and the local usage API returned live OpenRouter data (plan + balance), confirming the key now resolves.

## Screenshots
Visual change is the removal of the "Stored in …" caption under the Save button in Settings → API Keys; the field, Save button, and status dot are unchanged. (Before state — the caption beneath the input — is what this removes.)

Made with [Cursor](https://cursor.com)