### PR TITLE
fix(claude): surface re-login warning when login lacks user:profile scope (#782)

### DIFF
--- a/Sources/OpenUsage/Models/ProviderSnapshot.swift
+++ b/Sources/OpenUsage/Models/ProviderSnapshot.swift
@@ -7,6 +7,12 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
     var plan: String?
     var lines: [MetricLine]
     var refreshedAt: Date
+    /// A soft, non-blocking notice carried on a *successful* snapshot — e.g. Claude's "Re-login for live
+    /// usage" when the saved login lacks the `user:profile` scope. Distinct from `errorCategory` (which is
+    /// only on error snapshots): the refresh succeeded and partial data (spend tiles) still loads, so this
+    /// surfaces as the provider header's amber triangle rather than blanking the provider. Cached with the
+    /// snapshot; cleared on the next refresh when the condition resolves.
+    var warning: String?
     /// Set only on error snapshots: a stable, non-PII bucket for the failure, read by telemetry on the
     /// failure path. Always `nil` on success (and error snapshots aren't cached), so it never persists.
     var errorCategory: ErrorCategory?
@@ -17,6 +23,7 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
         plan: String? = nil,
         lines: [MetricLine],
         refreshedAt: Date = Date(),
+        warning: String? = nil,
         errorCategory: ErrorCategory? = nil
     ) {
         self.providerID = providerID
@@ -24,6 +31,7 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
         self.plan = plan
         self.lines = lines
         self.refreshedAt = refreshedAt
+        self.warning = warning
         self.errorCategory = errorCategory
     }
 
@@ -34,13 +42,14 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
     /// The success-path counterpart to `error(provider:message:)`: derives `providerID`/`displayName`
     /// from the provider so every runtime builds its snapshot the same way (`refreshedAt` is required
     /// so each call passes its own `now()`).
-    static func make(provider: Provider, plan: String?, lines: [MetricLine], refreshedAt: Date) -> ProviderSnapshot {
+    static func make(provider: Provider, plan: String?, lines: [MetricLine], refreshedAt: Date, warning: String? = nil) -> ProviderSnapshot {
         ProviderSnapshot(
             providerID: provider.id,
             displayName: provider.displayName,
             plan: plan,
             lines: lines,
-            refreshedAt: refreshedAt
+            refreshedAt: refreshedAt,
+            warning: warning
         )
     }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -176,10 +176,34 @@ struct ClaudeAuthStore: Sendable {
         AppLog.debug(LogTag.auth("claude"), "persisted rotated credentials (source=\(state.source.label))")
     }
 
+    /// Why the live-usage endpoint (`/api/oauth/usage`, which backs Session / Weekly / Sonnet / Extra
+    /// Usage) can or can't be called for a credential. Reading usage requires the `user:profile` scope,
+    /// so a token that only carries `user:inference` (e.g. one minted by `claude setup-token`) can't —
+    /// and the provider surfaces that as a friendly "re-login" notice instead of silently blank bars.
+    enum LiveUsageAvailability: Equatable, Sendable {
+        case available
+        /// An explicit `CLAUDE_CODE_OAUTH_TOKEN`: inference-only by design, so there's nothing to fetch
+        /// and nothing to nag about — the spend tiles still load from local logs.
+        case inferenceOnlyToken
+        /// A stored login whose granted scopes lack `user:profile`. The usage endpoint would reject it,
+        /// so the session/weekly bars can't load until the user signs in again with `claude`.
+        case missingProfileScope
+    }
+
+    /// The required scope for the usage endpoint. A credential missing it can authenticate for inference
+    /// but can't read subscription usage windows.
+    static let usageScope = "user:profile"
+
+    func liveUsageAvailability(_ state: ClaudeCredentialState) -> LiveUsageAvailability {
+        if state.inferenceOnly { return .inferenceOnlyToken }
+        // Older credentials predate the scopes field; treat an absent/empty list as "unknown, allow" so
+        // we don't suppress usage for tokens that actually carry the access (and would 403 loudly if not).
+        guard let scopes = state.oauth.scopes, !scopes.isEmpty else { return .available }
+        return scopes.contains(Self.usageScope) ? .available : .missingProfileScope
+    }
+
     func canFetchLiveUsage(_ state: ClaudeCredentialState) -> Bool {
-        guard !state.inferenceOnly else { return false }
-        guard let scopes = state.oauth.scopes, !scopes.isEmpty else { return true }
-        return scopes.contains("user:profile")
+        liveUsageAvailability(state) == .available
     }
 
     func claudeHomeOverride() -> String? {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -96,8 +96,22 @@ final class ClaudeProvider: ProviderRuntime {
             lines: []
         )
 
-        if authStore.canFetchLiveUsage(state) {
+        var warning: String?
+        switch authStore.liveUsageAvailability(state) {
+        case .available:
             mapped = try await fetchLiveUsage(state: &state)
+        case .missingProfileScope:
+            // The login authenticates for inference but lacks the `user:profile` scope the usage endpoint
+            // needs (typically a `claude setup-token` token). Don't leave the session/weekly bars silently
+            // blank — log it for diagnosis and surface a provider header warning (the amber triangle, like
+            // Z.ai's "no coding plan" notice) telling the user a re-login restores them. The ccusage spend
+            // tiles below are unaffected and still load.
+            AppLog.warn(LogTag.plugin("claude"), "live usage unavailable: credential lacks the user:profile scope (inference-only token); re-login with `claude` to restore session/weekly limits")
+            warning = ClaudeUsageMapper.missingProfileScopeWarning
+        case .inferenceOnlyToken:
+            // An explicit CLAUDE_CODE_OAUTH_TOKEN is inference-only by design; nothing to fetch and nothing
+            // to nag about — the spend tiles still load below.
+            break
         }
 
         await SpendTileMapper.appendCcusageUsage(
@@ -106,7 +120,7 @@ final class ClaudeProvider: ProviderRuntime {
         )
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)
-        return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
+        return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now(), warning: warning)
     }
 
     private func fetchLiveUsage(state: inout ClaudeCredentialState) async throws -> ClaudeMappedUsage {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -46,6 +46,13 @@ enum ClaudeUsageMapper {
         )
     }
 
+    /// Provider warning shown on the Claude header (the amber triangle + tooltip, like Z.ai's "no coding
+    /// plan" notice) when the stored login can't read live usage because it lacks the `user:profile` scope
+    /// (an inference-only token, e.g. from `claude setup-token`). Without it the Session / Weekly bars just
+    /// read "No data" with no hint that a re-login restores them. The ccusage spend tiles are unaffected
+    /// and still load.
+    static let missingProfileScopeWarning = "Re-login for live usage. Run `claude` and sign in again to restore session and weekly limits."
+
     /// The "live usage is rate limited" note appended to a last-good snapshot so the still-shown bars are
     /// flagged as possibly stale. Shared with `rateLimitedUsage` so the wording stays in one place.
     static func rateLimitedNote(retryAfterSeconds: Int?) -> MetricLine {

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -300,6 +300,24 @@ final class WidgetDataStore {
         providerErrors[providerID]
     }
 
+    /// A soft, non-blocking notice from the provider's latest *successful* snapshot (e.g. Claude's
+    /// "Re-login for live usage" when the login lacks the `user:profile` scope). `nil` when there's no
+    /// warning. After a *failed* refresh the store keeps the last good snapshot (so this warning can
+    /// linger) while setting `providerErrors` — use `headerNotice(for:)` for the rendered triangle so a
+    /// current hard error isn't masked by a stale soft warning.
+    func warningMessage(for providerID: String) -> String? {
+        snapshots[providerID]?.warning
+    }
+
+    /// The provider header's amber-triangle notice: a hard refresh error takes precedence over a stale
+    /// soft warning from the last successful snapshot. After a failed refresh the store keeps the last
+    /// good snapshot (so `warningMessage` still returns its warning) while `errorMessage` holds the
+    /// current failure — the error must win, or a stale "Re-login for live usage" warning would hide a
+    /// real "Token expired" failure. When there's no error, the soft warning (if any) shows.
+    func headerNotice(for providerID: String) -> String? {
+        errorMessage(for: providerID) ?? warningMessage(for: providerID)
+    }
+
     /// A snapshot that carries only error lines is a failed refresh; its message comes from the badge.
     private static func errorMessage(in snapshot: ProviderSnapshot) -> String? {
         guard !snapshot.lines.isEmpty, snapshot.lines.allSatisfy(\.isError) else { return nil }

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -48,7 +48,7 @@ struct WidgetGroupedListView: View {
         ProviderSectionHeader(
             provider: group.provider,
             plan: dataStore.plan(for: group.provider.id),
-            warning: dataStore.errorMessage(for: group.provider.id),
+            warning: dataStore.headerNotice(for: group.provider.id),
             refreshing: dataStore.refreshingProviderIDs.contains(group.provider.id),
             staleness: dataStore.stalenessHint(for: group.provider.id),
             showsDragHandle: true

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -99,6 +99,29 @@ final class ClaudeAuthStoreTests: XCTestCase {
 
         XCTAssertEqual(credentials?.oauth.accessToken, "env-token")
         XCTAssertFalse(store.canFetchLiveUsage(credentials!))
+        XCTAssertEqual(store.liveUsageAvailability(credentials!), .inferenceOnlyToken)
+    }
+
+    func testLiveUsageAvailabilityReflectsProfileScope() {
+        let store = ClaudeAuthStore(environment: FakeEnvironment(), files: FakeFiles(), keychain: FakeKeychain())
+        func state(_ scopes: [String]?, inferenceOnly: Bool = false) -> ClaudeCredentialState {
+            ClaudeCredentialState(
+                oauth: ClaudeOAuth(accessToken: "token", scopes: scopes),
+                source: .keychainCurrentUser(service: "Claude Code-credentials"),
+                fullData: nil,
+                inferenceOnly: inferenceOnly
+            )
+        }
+
+        // Older credentials predate the scopes field; an absent/empty list is "unknown, allow".
+        XCTAssertEqual(store.liveUsageAvailability(state(nil)), .available)
+        XCTAssertEqual(store.liveUsageAvailability(state([])), .available)
+        XCTAssertEqual(store.liveUsageAvailability(state(["user:inference", "user:profile"])), .available)
+        // An inference-only token (e.g. from `claude setup-token`) lacks user:profile → can't read usage.
+        XCTAssertEqual(store.liveUsageAvailability(state(["user:inference"])), .missingProfileScope)
+        XCTAssertFalse(store.canFetchLiveUsage(state(["user:inference"])))
+        // An explicit env token is inference-only by design: silent, not a missing-scope notice.
+        XCTAssertEqual(store.liveUsageAvailability(state(["user:inference"], inferenceOnly: true)), .inferenceOnlyToken)
     }
 
     func testMalformedCustomOAuthURLThrowsInsteadOfCrashing() {
@@ -275,6 +298,49 @@ final class ClaudeProviderTests: XCTestCase {
                         MetricValue(number: 150, kind: .count, label: "tokens")])
         XCTAssertEqual(processRunner.lastCcusageEnvironment?["CLAUDE_CONFIG_DIR"], "/tmp/claude")
         XCTAssertTrue(httpClient.requests.contains { $0.url.absoluteString == "https://api.anthropic.com/api/oauth/usage" })
+    }
+
+    func testInferenceOnlyScopeSurfacesReloginWarningAndSkipsUsageCallButKeepsSpendTiles() async {
+        // A credential that authenticates for inference but lacks the `user:profile` scope (e.g. a
+        // `claude setup-token` token) can't read the usage endpoint. The provider must NOT silently leave
+        // Session/Weekly blank: it surfaces a soft provider warning (the header's amber triangle, like
+        // Z.ai's "no coding plan" notice) telling the user to re-login, skips the usage HTTP call, and
+        // still loads the local ccusage spend tiles.
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let httpClient = FakeHTTPClient(response: HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data(#"{"five_hour":{"utilization":25,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+        ))
+        let provider = ClaudeProvider(
+            authStore: ClaudeAuthStore(
+                environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+                files: FakeFiles([
+                    "/tmp/claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"token","subscriptionType":"max","rateLimitTier":"default_claude_max_5x","scopes":["user:inference"]}}"#
+                ]),
+                keychain: FakeKeychain(),
+                now: { now }
+            ),
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            ccusageRunner: CcusageRunner(
+                processRunner: FakeProcessRunner(),
+                homeDirectory: { URL(fileURLWithPath: "/Users/test") }
+            ),
+            now: { now }
+        )
+
+        let snapshot = await provider.refresh()
+
+        // A soft provider warning explains the missing scope — not a hard error badge, and the live-usage
+        // meters stay blank (no "Session" line) rather than silently loading nothing.
+        XCTAssertEqual(snapshot.warning, ClaudeUsageMapper.missingProfileScopeWarning)
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+        XCTAssertNil(snapshot.line(label: "Session"))
+        // The usage endpoint was never called — that's the whole point of the scope gate.
+        XCTAssertFalse(httpClient.requests.contains { $0.url.absoluteString.hasSuffix("/api/oauth/usage") })
+        // Local spend tiles are unaffected and still load.
+        XCTAssertNotNil(values(snapshot.lines, "Today"))
+        XCTAssertEqual(snapshot.plan, "Max 5x")
     }
 
     func testLiveClaudeUsageReportsResetFields() async throws {

--- a/Tests/OpenUsageTests/TestSupport.swift
+++ b/Tests/OpenUsageTests/TestSupport.swift
@@ -153,6 +153,31 @@ final class CountingProviderRuntime: ProviderRuntime {
     }
 }
 
+/// A runtime that returns `first` on the first refresh and `second` on every refresh after — for
+/// sequences like a success that later turns into a failure (e.g. testing that a hard error takes
+/// precedence over a stale soft warning from the prior success).
+@MainActor
+final class TogglingProviderRuntime: ProviderRuntime {
+    let provider: Provider
+    let widgetDescriptors: [WidgetDescriptor]
+    private let first: ProviderSnapshot
+    private let second: ProviderSnapshot
+    private var refreshed = false
+
+    init(provider: Provider, descriptors: [WidgetDescriptor], first: ProviderSnapshot, second: ProviderSnapshot) {
+        self.provider = provider
+        self.widgetDescriptors = descriptors
+        self.first = first
+        self.second = second
+    }
+
+    func refresh() async -> ProviderSnapshot {
+        if refreshed { return second }
+        refreshed = true
+        return first
+    }
+}
+
 /// Routes each request through a handler and records every request — for multi-request flows like
 /// the 401 → token refresh → retry sequence, where a single canned response can't express the flow.
 final class RoutingHTTPClient: HTTPClient, @unchecked Sendable {

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -43,6 +43,78 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(store.menuBarPrimaryText, "58%")
     }
 
+    func testSoftWarningSurfacesOnHeaderWhilePartialDataStillLoads() async {
+        // A *successful* snapshot carrying a `warning` (e.g. Claude's "Re-login for live usage" when the
+        // login lacks user:profile) surfaces as the header's amber triangle via `warningMessage(for:)`,
+        // while the partial data still loads and it is NOT treated as a hard refresh error.
+        let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("claude"))
+        let meter = WidgetDescriptor(
+            id: "test.session",
+            providerID: provider.id,
+            metricLabel: "Session",
+            sample: WidgetData(title: "Session", icon: provider.icon, kind: .percent, used: 0, limit: 100)
+        )
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [meter],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.progress(label: "Session", used: 42, limit: 100, format: .percent)],
+                warning: "Re-login for live usage. Run `claude` and sign in again."
+            )
+        )
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [meter]),
+            providers: [runtime],
+            defaults: makeUserDefaults("soft-warning")
+        )
+
+        await store.refreshAll()
+
+        XCTAssertEqual(store.warningMessage(for: provider.id), "Re-login for live usage. Run `claude` and sign in again.")
+        XCTAssertNil(store.errorMessage(for: provider.id))  // soft warning, not a hard error
+        XCTAssertTrue(store.data(for: meter).hasData)       // partial data still loads
+    }
+
+    func testHardErrorTakesPrecedenceOverStaleSoftWarning() async {
+        // Bugbot: after a failed refresh the store keeps the last good snapshot (with its `warning`) while
+        // setting `providerErrors`. The header must show the current hard error, not the stale soft warning
+        // from the prior success — so `headerNotice(for:)` is `errorMessage ?? warningMessage`.
+        let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("claude"))
+        let meter = WidgetDescriptor(
+            id: "test.session",
+            providerID: provider.id,
+            metricLabel: "Session",
+            sample: WidgetData(title: "Session", icon: provider.icon, kind: .percent, used: 0, limit: 100)
+        )
+        let runtime = TogglingProviderRuntime(
+            provider: provider,
+            descriptors: [meter],
+            first: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.progress(label: "Session", used: 42, limit: 100, format: .percent)],
+                warning: "Re-login for live usage."
+            ),
+            second: ProviderSnapshot.error(provider: provider, message: "Token expired. Run `claude` to log in again.")
+        )
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [meter]),
+            providers: [runtime],
+            defaults: makeUserDefaults("header-notice")
+        )
+
+        await store.refreshAll(force: true)  // success with warning
+        XCTAssertEqual(store.warningMessage(for: provider.id), "Re-login for live usage.")
+        XCTAssertEqual(store.headerNotice(for: provider.id), "Re-login for live usage.")
+
+        await store.refreshAll(force: true)  // failure
+        XCTAssertEqual(store.errorMessage(for: provider.id), "Token expired. Run `claude` to log in again.")
+        XCTAssertEqual(store.warningMessage(for: provider.id), "Re-login for live usage.")  // stale, still present
+        XCTAssertEqual(store.headerNotice(for: provider.id), "Token expired. Run `claude` to log in again.")  // error wins
+    }
+
     func testRemainingProgressWithoutResetUsesPeriodDurationLabel() {
         let session = WidgetData(
             title: "Session",

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -30,6 +30,7 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Claude Code 
 ## Troubleshooting
 
 - **"Not logged in"** — run `claude` and sign in, then refresh.
+- **"Re-login for live usage"** (an amber warning on the Claude header) — your saved login can authenticate for inference but can't read your subscription limits, because it lacks the `user:profile` access (this is what an inference-only token from `claude setup-token` carries). Run `claude` and sign in again with your Claude account, then refresh; the spend tiles keep working in the meantime.
 - **"Rate limited, retry in ~Nm"** — the usage API is throttling; OpenUsage shows when to expect data again and keeps your last values.
 - **Spend tiles show "No data"** — OpenUsage needs a package runner on its `PATH` to run `ccusage`. Install [Bun](https://bun.sh) (`curl -fsSL https://bun.sh/install | bash`), or make sure `npx`/`npm` is available (any Node.js install). If you use a version manager (nvm, fnm, volta), OpenUsage looks in the common locations, but a global Bun or Node install is the most reliable.
 


### PR DESCRIPTION
## TL;DR
When a saved Claude login lacks the `user:profile` scope (an inference-only token, e.g. from `claude setup-token`), Session/Weekly/Sonnet/Extra no longer sit on silent "No data" — the Claude header shows an amber **"Re-login for live usage"** warning (hover for the fix), while the local spend tiles keep loading. Closes #782.

## What was happening
- Reading `/api/oauth/usage` requires the `user:profile` scope. An inference-only token (e.g. `claude setup-token`) carries only `user:inference`.
- `ClaudeAuthStore.canFetchLiveUsage` returned false for such a token, so `ClaudeProvider.probe()` silently skipped the live-usage call — no log, no badge.
- With ccusage spend tiles present, `appendNoDataIfNeeded` didn't fire, so Session/Weekly/Sonnet/Extra each rendered "No data" individually while the spend tiles loaded and the refresh reported `ok`. It read as a bug, not a credential issue (root cause of #777).

## What this changes
- `ClaudeAuthStore`: new `LiveUsageAvailability` (`.available` / `.inferenceOnlyToken` / `.missingProfileScope`); `canFetchLiveUsage` becomes a thin wrapper. Absent/empty scopes still read as "available" (unchanged for older credentials).
- `ClaudeProvider.probe()`: switches on availability. `.missingProfileScope` logs a warning (diagnosable from the log file) and attaches a soft `warning` to the snapshot instead of silently blanking. `.inferenceOnlyToken` (explicit `CLAUDE_CODE_OAUTH_TOKEN`) stays silent by design.
- `ProviderSnapshot`: new optional `warning` field for non-blocking notices on a *successful* snapshot (cached with it; cleared on the next refresh when the condition resolves).
- `WidgetDataStore.warningMessage(for:)` → `WidgetGroupedListView` passes it to the provider header, reusing the existing amber-triangle + tooltip rendering — the same surface Z.ai's "no coding plan" notice uses.
- `docs/providers/claude.md`: troubleshooting entry.

## Heads-up
- This mirrors Z.ai's "no coding plan" UX (header warning), but unlike Z.ai, Claude has ccusage spend tiles, so it's a **soft warning on a success snapshot** rather than a hard `ProviderSnapshot.error` — the spend tiles keep loading. If you'd prefer it to exactly match Z.ai (hard error that also blanks the spend tiles), it's a small change.
- The live-usage meters (Session/Weekly/Sonnet/Extra) still read "No data" in this state; the header warning is what explains them, consistent with how Z.ai explains its blank meters.
- `Sources/OpenUsage/Views/SettingsScreen.swift` has a pre-existing unrelated edit that is intentionally excluded from this PR.

## Tests
- `testLiveUsageAvailabilityReflectsProfileScope` — scope-gate unit test (`.available` / `.missingProfileScope` / `.inferenceOnlyToken`; absent/empty scopes stay `.available`).
- `testInferenceOnlyScopeSurfacesReloginWarningAndSkipsUsageCallButKeepsSpendTiles` — end-to-end: warning is set, no usage HTTP call, no hard error badge, spend tiles load, plan correct.
- `testSoftWarningSurfacesOnHeaderWhilePartialDataStillLoads` — `WidgetDataStore` surfaces `warningMessage(for:)` on a success snapshot without treating it as a hard error, and partial data still loads.
- Full suite passes; app builds and launches.

## Screenshots

<img width="396" height="217" alt="image" src="https://github.com/user-attachments/assets/c40a8b7e-133d-44ba-a346-9bf461a05d85" />


Made with [Cursor](https://cursor.com)