### PR TITLE
feat(openrouter): add Activity and Credits quick-link buttons

### DIFF
--- a/Sources/OpenUsage/Providers/OpenRouter/OpenRouterProvider.swift
+++ b/Sources/OpenUsage/Providers/OpenRouter/OpenRouterProvider.swift
@@ -2,7 +2,15 @@ import Foundation
 
 @MainActor
 final class OpenRouterProvider: ProviderRuntime {
-    let provider = Provider(id: "openrouter", displayName: "OpenRouter", icon: .providerMark("openrouter"))
+    let provider = Provider(
+        id: "openrouter",
+        displayName: "OpenRouter",
+        icon: .providerMark("openrouter"),
+        links: [
+            ProviderLink(label: "Activity", url: "https://openrouter.ai/activity"),
+            ProviderLink(label: "Credits", url: "https://openrouter.ai/settings/credits")
+        ]
+    )
 
     let authStore: OpenRouterAuthStore
     let usageClient: OpenRouterUsageClient


### PR DESCRIPTION
## TL;DR
Adds **Activity** and **Credits** quick-link buttons to the OpenRouter provider card's expanded area.

## What was happening
OpenRouter shipped no quick links, so its expanded card had no shortcut to the account's Activity or Credits pages — users had to navigate to them manually in the browser.

## What this changes
- Declares two `ProviderLink` entries on OpenRouter's `Provider` value:
  - **Activity** → https://openrouter.ai/activity
  - **Credits** → https://openrouter.ai/settings/credits
- Renders them as the existing button row in the card's expanded area, reusing the same mechanism Z.ai uses for Dashboard / API Keys.

## Heads-up
- No metric/layout/defaults changes — buttons only, so no `DefaultLayout` sign-off needed.
- URLs are `https`, so both pass the `visibleLinks` filter and render.

## Tests
Built and launched the dev app via `./script/build_and_run.sh verify`; expanded the OpenRouter card and confirmed both buttons appear and open the right URLs in the default browser.

## Screenshots
_To follow._

Made with [Cursor](https://cursor.com)