### PR TITLE
Customize: provider list → detail, on/off + API keys in Customize, stars

### DIFF
--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -72,12 +72,9 @@ enum DefaultLayout {
     static let expandedMetricIDs: [String] = [
         // Antigravity: Gemini Pro + Flash stay above the fold; only the non-Gemini (Claude) pool is secondary.
         "antigravity.claude",
-        // Claude is de-emphasized: only its Session meter stays above the fold; everything else sits below
-        // the caret. The dashboard always keeps ≥1 primary row per provider (it promotes metrics when all
-        // are marked secondary), so leaving Session primary is what makes the caret appear at all.
-        // See AGENTS.md "## Providers".
-        "claude.weekly", "claude.trend",
-        "claude.sonnet", "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
+        // Claude's core meters (Session, Weekly, Extra, Usage Trend) stay above the fold; spend-history
+        // rows sit below the caret. Matches every other provider's "core above, history below" shape.
+        "claude.sonnet", "claude.today", "claude.yesterday", "claude.last30",
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
         "cursor.onDemand", "cursor.requests", "cursor.credits",
         "cursor.today", "cursor.yesterday", "cursor.last30",

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -101,6 +101,17 @@ final class LayoutStore {
     private(set) var shareConfirmationTrigger = 0
     private var shareConfirmationClearTask: Task<Void, Never>?
 
+    /// Transient in-Customize notice that drives the floating pill above the Customize content (e.g.
+    /// "Starred for menu bar", or the orange "Up to 2 stars per provider" denial). Set by
+    /// `presentCustomizationNotice`, cleared automatically after a couple of seconds. Never persisted;
+    /// cleared on popover close via `clearCustomizationNotice`.
+    private(set) var customizationNotice: String?
+    /// The notice's tone: `.positive` (green checkmark, success) or `.notice` (orange, the cap denial).
+    private(set) var customizationNoticeTone: CustomizationNoticeTone = .positive
+    /// Bumped on every present so the pill replays its pop-in even when the same notice repeats.
+    private(set) var customizationNoticeTrigger = 0
+    private var customizationNoticeClearTask: Task<Void, Never>?
+
     /// Bounded, app-wide undo stack for layout customization (remove/add a metric, reorder metrics or
     /// providers, pin/unpin, move across the expand caret). UI-only state (not persisted): undo is a
     /// within-session affordance, so a relaunch starts fresh. Each entry is a pre-change `LayoutSnapshot`;
@@ -797,6 +808,29 @@ final class LayoutStore {
         shareConfirmationClearTask = nil
     }
 
+    /// Show a transient in-Customize pill (the floating confirmation above the Customize content).
+    /// `tone` picks the green success style or the orange denial style. Auto-clears after a couple of
+    /// seconds; also cleared on popover close via `clearCustomizationNotice`.
+    func presentCustomizationNotice(_ message: String, tone: CustomizationNoticeTone = .positive) {
+        customizationNotice = message
+        customizationNoticeTone = tone
+        customizationNoticeTrigger += 1
+        customizationNoticeClearTask?.cancel()
+        customizationNoticeClearTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2.5))
+            guard !Task.isCancelled else { return }
+            self?.customizationNotice = nil
+        }
+    }
+
+    /// Clear any showing Customize pill and cancel its auto-clear task. Called when the popover closes
+    /// so a pill mid-countdown can't reappear stale on the next open.
+    func clearCustomizationNotice() {
+        customizationNotice = nil
+        customizationNoticeClearTask?.cancel()
+        customizationNoticeClearTask = nil
+    }
+
     /// Pin or unpin a metric for the menu bar. Pinning is a no-op when it would exceed a cap, so callers
     /// can gate the control on `canPin` and trust this never over-pins. Undoable like the other layout
     /// actions — the no-op guards mean a denied or redundant pin records no step.
@@ -1153,4 +1187,11 @@ struct ProviderRow: Identifiable {
     let metricCount: Int
     let pinnedCount: Int
     var id: String { provider.id }
+}
+
+/// Tone for the transient in-Customize pill (`LayoutStore.customizationNotice`): green success or
+/// orange denial.
+enum CustomizationNoticeTone {
+    case positive
+    case notice
 }

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -36,6 +36,10 @@ final class LayoutStore {
             // DashboardView reads these on its very next render to slide in from the screen being left.
             screenSlideFrom = oldValue
             screenSlideID += 1
+            // Leaving Customize drops the L2 detail selection so reopening Customize shows the list,
+            // never a stranded detail screen. The popover-closed reset sets `screen = .dashboard`, so
+            // this also covers close/reopen.
+            if screen != .customize { customizeProviderID = nil }
         }
     }
     /// Supports DashboardView's horizontal screen-switch slide: the screen being left, plus a counter
@@ -48,6 +52,12 @@ final class LayoutStore {
         get { screen == .customize }
         set { screen = newValue ? .customize : .dashboard }
     }
+    /// The provider whose Customize detail (L2) is showing. nil shows the provider list (L1); a set id
+    /// shows that provider's metric sections and API key. UI-only (not persisted): transient navigation
+    /// like `draggingID`, cleared when leaving Customize (see `screen`'s didSet) and on popover close
+    /// (DashboardView resets `screen` to `.dashboard`). Kept separate from `expandedProviderIDs` —
+    /// that's the dashboard caret, unrelated to this master/detail route.
+    var customizeProviderID: String?
     /// Placed widget being drag-reordered (transient). `PlacedWidget.id`, never persisted.
     var draggingID: UUID?
     /// Persisted provider display order (provider IDs). Drives both the dashboard groups and the
@@ -335,6 +345,43 @@ final class LayoutStore {
                 expandedMetrics: metrics.filter { expandedMetricIDs.contains($0.id) }
             )
         }
+    }
+
+    /// The L1 Customize list: every known provider in the user's saved order, regardless of enablement.
+    /// Disabled providers appear here (greyed in the UI) so the user can re-enable them or open their
+    /// detail — unlike `customizeGroups`, which filters them out for the dashboard and the old flat
+    /// Customize. Each row carries the enablement flag, the total metric count (the badge number), and
+    /// the pinned count.
+    var customizeProviderRows: [ProviderRow] {
+        orderedProviders().map { provider in
+            ProviderRow(
+                provider: provider,
+                isEnabled: isProviderEnabled(provider.id),
+                metricCount: metricCount(for: provider.id),
+                pinnedCount: pinnedCount(forProvider: provider.id)
+            )
+        }
+    }
+
+    /// Total metrics a provider supports — the L1 row's badge number. Registry descriptor count,
+    /// independent of how many the user has enabled.
+    func metricCount(for providerID: String) -> Int {
+        registry.descriptors(for: providerID).count
+    }
+
+    /// The L2 Customize detail for one provider: every metric it supports, split across the
+    /// "Always Visible" / "On Demand" divider, in its saved metric order. Available even when the
+    /// provider is disabled so L2 can render dimmed-but-editable. nil for an unknown provider or one
+    /// with no metrics — the per-provider slice of `customizeGroups` without the enablement guard.
+    func customizeDetail(for providerID: String) -> ProviderMetrics? {
+        guard let provider = registry.provider(id: providerID) else { return nil }
+        let metrics = orderedSupportedMetrics(for: providerID)
+        guard !metrics.isEmpty else { return nil }
+        return ProviderMetrics(
+            provider: provider,
+            alwaysShownMetrics: metrics.filter { !expandedMetricIDs.contains($0.id) },
+            expandedMetrics: metrics.filter { expandedMetricIDs.contains($0.id) }
+        )
     }
 
     /// A provider's supported metrics in custom order, independent of whether each metric is enabled.
@@ -708,7 +755,7 @@ final class LayoutStore {
         guard !canPin(descriptorID) else { return nil }
         if let providerID = registry.descriptor(id: descriptorID)?.providerID,
            pinnedCount(forProvider: providerID) >= Self.maxPinsPerProvider {
-            return "Up to \(Self.maxPinsPerProvider) pins per provider"
+            return "Up to \(Self.maxPinsPerProvider) stars per provider"
         }
         return nil
     }
@@ -1094,4 +1141,16 @@ struct ProviderMetrics: Identifiable {
     /// Every supported metric in custom order (always-shown first, then expanded).
     var metrics: [WidgetDescriptor] { alwaysShownMetrics + expandedMetrics }
     var hasExpandedMetrics: Bool { !expandedMetrics.isEmpty }
+}
+
+/// One row in the Customize provider list (L1): the provider plus the derived bits the row renders —
+/// whether it's enabled (the master toggle + Active/Inactive label), how many metrics it supports
+/// (the badge), and how many are pinned. Drives `CustomizeProviderListView`. Unlike `ProviderMetrics`,
+/// this includes disabled providers so they stay visible in the list.
+struct ProviderRow: Identifiable {
+    let provider: Provider
+    let isEnabled: Bool
+    let metricCount: Int
+    let pinnedCount: Int
+    var id: String { provider.id }
 }

--- a/Sources/OpenUsage/Views/APIKeysSection.swift
+++ b/Sources/OpenUsage/Views/APIKeysSection.swift
@@ -38,7 +38,7 @@ struct APIKeysSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
-            Text("API Keys")
+            Text(providers.count == 1 ? "API Key" : "API Keys")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 8)

--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -1,0 +1,266 @@
+import SwiftUI
+
+/// The Customize detail for one provider (L2): a provider header (mark + name + Active/Inactive +
+/// the master on/off toggle) over a single card holding two labeled sections — **Always Visible**
+/// (metrics shown above the dashboard caret) and **On Demand** (metrics behind the caret) — split by
+/// the dashed divider. Dragging a metric across that divider moves it between sections via the
+/// existing `applyMetricDividerOrder` sentinel mechanic. Each metric row is toggle · name · star ·
+/// grip (the star is the menu-bar pin). Available even when the provider is disabled: the sections
+/// render dimmed but stay editable, with the header toggle as the primary re-enable action.
+struct CustomizeProviderDetailView: View {
+    @Environment(LayoutStore.self) private var layout
+    @Environment(AppContainer.self) private var container
+    let providerID: String
+    let reorderSpaceName: String
+    @Binding var reorderLift: ReorderLift?
+    let rowFrames: [String: CGRect]
+
+    @State private var activeMetricID: String?
+    @State private var hoveredMetricID: String?
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    var body: some View {
+        if let group = layout.customizeDetail(for: providerID),
+           let provider = layout.provider(id: providerID) {
+            let isEnabled = container.enablement.isEnabled(providerID)
+            VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
+                providerHeader(provider, isEnabled: isEnabled)
+                metricCard(group)
+                    .opacity(isEnabled ? 1 : 0.6)
+                // Providers that need a user-supplied key (OpenRouter today) get their own "API Key"
+                // section here — the same editor logic the Settings ▸ API Keys card used, scoped to this
+                // one provider. Hidden for providers that don't need a key.
+                if let keyProvider = container.apiKeyProviders.first(where: { $0.provider.id == providerID }) {
+                    APIKeysSection(providers: [keyProvider])
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .animation(Motion.spring, value: layout.expandedMetricIDs)
+        } else {
+            // Unknown provider — L1 only lists known providers, so this is unreachable in practice.
+            EmptyView()
+        }
+    }
+
+    // MARK: - Provider header
+
+    private func providerHeader(_ provider: Provider, isEnabled: Bool) -> some View {
+        HStack(spacing: 10) {
+            ProviderIcon(source: provider.icon)
+                .frame(width: 18, height: 18)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(provider.displayName)
+                    .font(.system(size: density.headerPointSize, weight: .semibold))
+                    .foregroundStyle(isEnabled ? Color.primary : Color.secondary)
+                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(isEnabled ? Theme.positive : AnyShapeStyle(Color.secondary.opacity(0.6)))
+                        .frame(width: 6, height: 6)
+                    Text(isEnabled ? "Active" : "Inactive")
+                        .font(.system(size: density.planBadgePointSize))
+                        .foregroundStyle(isEnabled ? Theme.positive : AnyShapeStyle(.secondary))
+                }
+            }
+            Spacer(minLength: 8)
+            // The master on/off toggle — the primary action, especially when the provider is disabled.
+            Toggle("", isOn: Binding(
+                get: { isEnabled },
+                set: { container.enablement.setEnabled($0, for: provider.id) }
+            ))
+            .settingsSwitchStyle()
+        }
+        .padding(.horizontal, 8)
+    }
+
+    // MARK: - Metric card
+
+    private func metricCard(_ group: ProviderMetrics) -> some View {
+        VStack(spacing: 0) {
+            ForEach(metricCardRows(for: group)) { row in
+                switch row {
+                case .sectionLabel(let label):
+                    sectionLabel(label)
+                case .metric(let metric):
+                    metricRow(metric, in: group.provider.id)
+                case .divider:
+                    expandedDivider(providerID: group.provider.id)
+                }
+            }
+        }
+        .cardSurface()
+    }
+
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 4)
+    }
+
+    private func metricCardRows(for group: ProviderMetrics) -> [CustomizeMetricCardRow] {
+        [.sectionLabel("Always Visible")]
+            + group.alwaysShownMetrics.map(CustomizeMetricCardRow.metric)
+            + [.divider]
+            + [.sectionLabel("On Demand")]
+            + group.expandedMetrics.map(CustomizeMetricCardRow.metric)
+    }
+
+    private func metricRow(_ metric: WidgetDescriptor, in providerID: String) -> some View {
+        let isActive = activeMetricID == metric.id
+        return CustomizeMetricRow(
+            title: metric.title,
+            handle: { $0.highPriorityGesture(metricDragGesture(for: metric.id, providerID: providerID, title: metric.title)) },
+            leading: {
+                Toggle("", isOn: Binding(
+                    get: { layout.isMetricEnabled(metric.id) },
+                    set: { layout.setMetricEnabled(metric.id, $0) }
+                ))
+                .settingsSwitchStyle()
+            },
+            trailing: {
+                starButton(metric)
+            }
+        )
+        .contentShape(Rectangle())
+        .opacity(isActive ? 0 : 1)
+        .onHover { hovering in
+            if hovering {
+                hoveredMetricID = metric.id
+            } else if hoveredMetricID == metric.id {
+                hoveredMetricID = nil
+            }
+        }
+        .reorderFrame(id: metric.id, in: .named(reorderSpaceName))
+    }
+
+    /// The star (menu-bar pin) control on a metric row: a filled star when starred, an outline star on
+    /// row hover otherwise. At a cap the star dims but stays clickable — a denied click routes through
+    /// `notePinDenied`, which surfaces the reason in the footer (WhatsApp-style feedback) instead of
+    /// silently doing nothing.
+    @ViewBuilder
+    private func starButton(_ metric: WidgetDescriptor) -> some View {
+        if metric.pinnable {
+            let pinned = layout.isPinned(metric.id)
+            let blocked = !layout.canPin(metric.id)   // false when pinned, so unstar always works
+            let visible = pinned || hoveredMetricID == metric.id
+            Button {
+                if blocked {
+                    layout.notePinDenied(metric.id)
+                } else {
+                    layout.togglePin(metric.id)
+                }
+            } label: {
+                Image(systemName: pinned ? "star.fill" : "star")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(pinned ? Color.accentColor : Color.secondary)
+            .opacity(visible ? (blocked ? 0.35 : 1) : 0)
+            .allowsHitTesting(visible)
+            .hoverTooltip(starHelp(metric))
+            .animation(Motion.spring, value: visible)
+            .animation(Motion.spring, value: pinned)
+        }
+    }
+
+    private func starHelp(_ metric: WidgetDescriptor) -> String {
+        if layout.isPinned(metric.id) { return "Unstar" }
+        return layout.pinDenialReason(metric.id) ?? "Star for menu bar"
+    }
+
+    // MARK: - Divider
+
+    /// The single dashed boundary between Always Visible and On Demand. Kept visually simple so it
+    /// reads as one drop target instead of several moving controls.
+    private func expandedDivider(providerID: String) -> some View {
+        let yOutset = max(0, (density.estimatedMetricRowHeight - density.customizeDividerRowHeight) / 2)
+        return dashedRule
+            .padding(.horizontal, 12)
+            .frame(height: density.customizeDividerRowHeight)
+            .reorderFrame(id: expandedDividerID(for: providerID), in: .named(reorderSpaceName), yOutset: yOutset)
+            .accessibilityLabel("On Demand divider")
+    }
+
+    private var dashedRule: some View {
+        Rectangle()
+            .fill(.clear)
+            .frame(height: 1)
+            .overlay(
+                Line()
+                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                    .foregroundStyle(.tertiary)
+            )
+    }
+
+    // MARK: - Metric drag-reorder
+
+    private func metricDragGesture(for metricID: String, providerID: String, title: String) -> some Gesture {
+        reorderDragGesture(
+            id: metricID,
+            coordinateSpaceName: reorderSpaceName,
+            rowFrames: rowFrames,
+            active: $activeMetricID,
+            lift: $reorderLift,
+            makeLift: { makeMetricLift(metricID: metricID, title: title, value: $0) },
+            orderedIDs: { reorderTargetIDs(for: providerID) },
+            reorder: { target in
+                let current = reorderTargetIDs(for: providerID)
+                guard let next = LayoutStore.reordered(current, dragged: metricID, target: target) else {
+                    return false
+                }
+                return layout.applyMetricDividerOrder(next, dragged: metricID, dividerID: expandedDividerID(for: providerID), in: providerID)
+            }
+        )
+    }
+
+    private func reorderTargetIDs(for providerID: String) -> [String] {
+        layout.metricOrderWithDivider(for: providerID, dividerID: expandedDividerID(for: providerID))
+    }
+
+    private func expandedDividerID(for providerID: String) -> String {
+        "\(providerID)::expanded-divider"
+    }
+
+    private func makeMetricLift(metricID: String, title: String, value: DragGesture.Value) -> ReorderLift? {
+        ReorderLift.make(
+            id: metricID,
+            payload: .customizeMetric(title: title),
+            value: value,
+            frames: rowFrames
+        )
+    }
+}
+
+/// A single horizontal line, used as the dashed On Demand rule. A plain `Divider` can't carry a dash
+/// pattern, so the separator strokes this shape instead.
+private struct Line: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX, y: rect.midY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+        return path
+    }
+}
+
+private enum CustomizeMetricCardRow: Identifiable {
+    case sectionLabel(String)
+    case metric(WidgetDescriptor)
+    case divider
+
+    var id: String {
+        switch self {
+        case .sectionLabel(let label):
+            "section:\(label)"
+        case .metric(let metric):
+            "metric:\(metric.id)"
+        case .divider:
+            "expanded-divider"
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -1,18 +1,19 @@
 import SwiftUI
 
 /// The Customize detail for one provider (L2): two distinct cards — **Always Visible** (shown on the
-/// dashboard card) and **On Demand** (tucked behind the card's caret). Drag a metric onto a row in
-/// the other card to move it across; an empty card shows a small dashed "Drag metrics here" drop zone
-/// that's also the drop target for moving a metric into it. Each metric row is grip · name · star ·
-/// toggle (drag left, toggle right — same shape as the provider rows). The star is always visible:
-/// outline when not starred, filled accent when starred. Providers that need an API key get their own
-/// "API Key" section here too.
+/// dashboard card) and **On Demand** (tucked behind the card's caret). Drag a metric by its grip
+/// onto a row in the other card to move it across; an empty card shows a small dashed "Drag metrics
+/// here" drop zone that's also the drop target for moving a metric into it. Each metric row is
+/// grip · name · star · toggle (drag left, toggle right — same shape as the provider rows). The star
+/// is always visible: outline when not starred, filled accent when starred; tapping it pops a
+/// transient confirmation pill (and an orange denial pill over the per-provider cap). Providers that
+/// need an API key get their own "API Key" section here too.
 ///
-/// The two sections are separate `ForEach`es (so they're visually distinct cards). That reintroduces
-/// the stuck-drag risk: when a dragged row crosses into the other card, SwiftUI tears down the source
-/// view (and its gesture) mid-drag, so `onEnded` never fires and the lift overlay would stick. Each
-/// row clears the drag state on `.onDisappear` — by the time the source view is removed, the metric
-/// has already moved to the other card, so the drag is genuinely over and the lift unsticks.
+/// The drag gesture lives on the container, not on each row. With a per-row gesture, SwiftUI tears
+/// down the dragged row (and its gesture) when it crosses between the two cards' `ForEach`es,
+/// dropping the drag mid-gesture. A single container-level gesture stays attached to the persistent
+/// section stack, so the drag survives the cross — no force-drop, no stuck overlay. Each row's grip
+/// publishes its own frame so the container gesture can tell which row a drag started on.
 struct CustomizeProviderDetailView: View {
     @Environment(LayoutStore.self) private var layout
     @Environment(AppContainer.self) private var container
@@ -27,11 +28,8 @@ struct CustomizeProviderDetailView: View {
     var body: some View {
         if let group = layout.customizeDetail(for: providerID) {
             VStack(alignment: .leading, spacing: density.sectionSpacing) {
-                metricSection("Always Visible", metrics: group.alwaysShownMetrics, providerID: providerID)
-                metricSection("On Demand", metrics: group.expandedMetrics, providerID: providerID)
-                // Providers that need a user-supplied key (OpenRouter today) get their own "API Key"
-                // section here — the same editor logic the Settings ▸ API Keys card used, scoped to
-                // this one provider. Hidden for providers that don't need a key.
+                metricSections(group)
+                    .simultaneousGesture(metricDragGesture())
                 if let keyProvider = container.apiKeyProviders.first(where: { $0.provider.id == providerID }) {
                     APIKeysSection(providers: [keyProvider])
                 }
@@ -41,6 +39,13 @@ struct CustomizeProviderDetailView: View {
         } else {
             // Unknown provider — L1 only lists known providers, so this is unreachable in practice.
             EmptyView()
+        }
+    }
+
+    private func metricSections(_ group: ProviderMetrics) -> some View {
+        VStack(alignment: .leading, spacing: density.sectionSpacing) {
+            metricSection("Always Visible", metrics: group.alwaysShownMetrics, providerID: group.provider.id)
+            metricSection("On Demand", metrics: group.expandedMetrics, providerID: group.provider.id)
         }
     }
 
@@ -88,7 +93,12 @@ struct CustomizeProviderDetailView: View {
         let isActive = activeMetricID == metric.id
         return CustomizeMetricRow(
             title: metric.title,
-            handle: { $0.highPriorityGesture(metricDragGesture(for: metric.id, providerID: providerID, title: metric.title)) },
+            // The grip is visual-only and publishes its frame (id "grip:<metric>") so the container
+            // gesture can tell which row a drag started on. The drag gesture itself is on the section
+            // stack, not the grip — see `metricDragGesture`.
+            handle: { grip in
+                AnyView(grip.reorderFrame(id: "grip:\(metric.id)", in: .named(reorderSpaceName)))
+            },
             trailing: {
                 StarButton(metric: metric)
                 Toggle("", isOn: Binding(
@@ -100,38 +110,50 @@ struct CustomizeProviderDetailView: View {
         )
         .contentShape(Rectangle())
         .opacity(isActive ? 0 : 1)
-        // Two-card stuck-drag safeguard: when a dragged row crosses into the other section's card,
-        // SwiftUI removes this source view (and its drag gesture) mid-drag, so onEnded never fires and
-        // the lift overlay would stick. By the time onDisappear fires, the metric has already moved to
-        // the other card, so the drag is genuinely over — clear the state so the lift unsticks.
-        .onDisappear {
-            if activeMetricID == metric.id {
-                activeMetricID = nil
-                reorderLift = nil
-            }
-        }
         .reorderFrame(id: metric.id, in: .named(reorderSpaceName))
     }
 
-    // MARK: - Metric drag-reorder
+    // MARK: - Container drag-reorder
 
-    private func metricDragGesture(for metricID: String, providerID: String, title: String) -> some Gesture {
-        reorderDragGesture(
-            id: metricID,
-            coordinateSpaceName: reorderSpaceName,
-            rowFrames: rowFrames,
-            active: $activeMetricID,
-            lift: $reorderLift,
-            makeLift: { makeMetricLift(metricID: metricID, title: title, value: $0) },
-            orderedIDs: { reorderTargetIDs(for: providerID) },
-            reorder: { target in
-                let current = reorderTargetIDs(for: providerID)
-                guard let next = LayoutStore.reordered(current, dragged: metricID, target: target) else {
-                    return false
+    /// One drag gesture on the section stack (not per-row), so it survives a metric crossing between
+    /// the two cards. On start, the grip under the pointer identifies the dragged metric; afterwards
+    /// it tracks the pointer, hit-tests row + divider frames, and reorders through
+    /// `applyMetricDividerOrder`.
+    private func metricDragGesture() -> some Gesture {
+        DragGesture(minimumDistance: 4, coordinateSpace: .named(reorderSpaceName))
+            .onChanged { value in
+                if activeMetricID == nil {
+                    if let id = metricID(at: value.startLocation) {
+                        activeMetricID = id
+                        if let lift = makeLift(metricID: id, value: value) {
+                            reorderLift = lift
+                        }
+                    }
                 }
-                return layout.applyMetricDividerOrder(next, dragged: metricID, dividerID: expandedDividerID(for: providerID), in: providerID)
+                guard let id = activeMetricID else { return }
+                reorderLift?.location = value.location
+                let divider = expandedDividerID(for: providerID)
+                let ordered = reorderTargetIDs(for: providerID)
+                guard let target = reorderTarget(at: value.location, in: rowFrames, excluding: id, orderedIDs: ordered),
+                      let next = LayoutStore.reordered(ordered, dragged: id, target: target) else { return }
+                withAnimation(Motion.spring) {
+                    _ = layout.applyMetricDividerOrder(next, dragged: id, dividerID: divider, in: providerID)
+                }
             }
-        )
+            .onEnded { _ in
+                activeMetricID = nil
+                reorderLift = nil
+            }
+    }
+
+    /// The metric a drag started on, by hit-testing the drag start against the grip frames
+    /// ("grip:<metric>" entries in `rowFrames`). Nil when the drag didn't start on a grip.
+    private func metricID(at point: CGPoint) -> String? {
+        for (key, frame) in rowFrames {
+            guard key.hasPrefix("grip:"), frame.insetBy(dx: 0, dy: -2).contains(point) else { continue }
+            return String(key.dropFirst("grip:".count))
+        }
+        return nil
     }
 
     private func reorderTargetIDs(for providerID: String) -> [String] {
@@ -142,19 +164,16 @@ struct CustomizeProviderDetailView: View {
         "\(providerID)::expanded-divider"
     }
 
-    private func makeMetricLift(metricID: String, title: String, value: DragGesture.Value) -> ReorderLift? {
-        ReorderLift.make(
-            id: metricID,
-            payload: .customizeMetric(title: title),
-            value: value,
-            frames: rowFrames
-        )
+    private func makeLift(metricID: String, value: DragGesture.Value) -> ReorderLift? {
+        let title = layout.customizeDetail(for: providerID)?.metrics.first { $0.id == metricID }?.title ?? ""
+        return ReorderLift.make(id: metricID, payload: .customizeMetric(title: title), value: value, frames: rowFrames)
     }
 }
 
 /// The star (menu-bar pin) control on a metric row — always visible: an outline star when not
-/// starred, a filled accent star when starred. A denied click (over the per-provider cap) shakes the
-/// star; the hover tooltip carries the reason.
+/// starred, a filled accent star when starred. Tapping it pops a transient confirmation pill (green
+/// "Starred for menu bar" / "Removed from menu bar"); a denied tap over the per-provider cap shakes
+/// the star and pops an orange denial pill. No tooltips.
 private struct StarButton: View {
     let metric: WidgetDescriptor
     @Environment(LayoutStore.self) private var layout
@@ -166,8 +185,10 @@ private struct StarButton: View {
             Button {
                 if layout.canPin(metric.id) {
                     layout.togglePin(metric.id)
+                    layout.presentCustomizationNotice(pinned ? "Removed from menu bar" : "Starred for menu bar")
                 } else {
                     shakeTrigger += 1
+                    layout.presentCustomizationNotice(layout.pinDenialReason(metric.id) ?? "Up to 2 stars per provider", tone: .notice)
                 }
             } label: {
                 Image(systemName: pinned ? "star.fill" : "star")
@@ -177,7 +198,6 @@ private struct StarButton: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(pinned ? Color.accentColor : Color.secondary)
-            .hoverTooltip(pinned ? "Unstar" : (layout.pinDenialReason(metric.id) ?? "Star for menu bar"))
             .denyShake(trigger: shakeTrigger)
             .animation(Motion.spring, value: pinned)
         }

--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -1,12 +1,18 @@
 import SwiftUI
 
-/// The Customize detail for one provider (L2): a provider header (mark + name + Active/Inactive +
-/// the master on/off toggle) over a single card holding two labeled sections — **Always Visible**
-/// (metrics shown above the dashboard caret) and **On Demand** (metrics behind the caret) — split by
-/// the dashed divider. Dragging a metric across that divider moves it between sections via the
-/// existing `applyMetricDividerOrder` sentinel mechanic. Each metric row is toggle · name · star ·
-/// grip (the star is the menu-bar pin). Available even when the provider is disabled: the sections
-/// render dimmed but stay editable, with the header toggle as the primary re-enable action.
+/// The Customize detail for one provider (L2): two distinct cards — **Always Visible** (shown on the
+/// dashboard card) and **On Demand** (tucked behind the card's caret). Drag a metric onto a row in
+/// the other card to move it across; an empty card shows a small dashed "Drag metrics here" drop zone
+/// that's also the drop target for moving a metric into it. Each metric row is grip · name · star ·
+/// toggle (drag left, toggle right — same shape as the provider rows). The star is always visible:
+/// outline when not starred, filled accent when starred. Providers that need an API key get their own
+/// "API Key" section here too.
+///
+/// The two sections are separate `ForEach`es (so they're visually distinct cards). That reintroduces
+/// the stuck-drag risk: when a dragged row crosses into the other card, SwiftUI tears down the source
+/// view (and its gesture) mid-drag, so `onEnded` never fires and the lift overlay would stick. Each
+/// row clears the drag state on `.onDisappear` — by the time the source view is removed, the metric
+/// has already moved to the other card, so the drag is genuinely over and the lift unsticks.
 struct CustomizeProviderDetailView: View {
     @Environment(LayoutStore.self) private var layout
     @Environment(AppContainer.self) private var container
@@ -16,20 +22,16 @@ struct CustomizeProviderDetailView: View {
     let rowFrames: [String: CGRect]
 
     @State private var activeMetricID: String?
-    @State private var hoveredMetricID: String?
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
     var body: some View {
-        if let group = layout.customizeDetail(for: providerID),
-           let provider = layout.provider(id: providerID) {
-            let isEnabled = container.enablement.isEnabled(providerID)
-            VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
-                providerHeader(provider, isEnabled: isEnabled)
-                metricCard(group)
-                    .opacity(isEnabled ? 1 : 0.6)
+        if let group = layout.customizeDetail(for: providerID) {
+            VStack(alignment: .leading, spacing: density.sectionSpacing) {
+                metricSection("Always Visible", metrics: group.alwaysShownMetrics, providerID: providerID)
+                metricSection("On Demand", metrics: group.expandedMetrics, providerID: providerID)
                 // Providers that need a user-supplied key (OpenRouter today) get their own "API Key"
-                // section here — the same editor logic the Settings ▸ API Keys card used, scoped to this
-                // one provider. Hidden for providers that don't need a key.
+                // section here — the same editor logic the Settings ▸ API Keys card used, scoped to
+                // this one provider. Hidden for providers that don't need a key.
                 if let keyProvider = container.apiKeyProviders.first(where: { $0.provider.id == providerID }) {
                     APIKeysSection(providers: [keyProvider])
                 }
@@ -42,71 +44,44 @@ struct CustomizeProviderDetailView: View {
         }
     }
 
-    // MARK: - Provider header
+    // MARK: - Metric sections
 
-    private func providerHeader(_ provider: Provider, isEnabled: Bool) -> some View {
-        HStack(spacing: 10) {
-            ProviderIcon(source: provider.icon)
-                .frame(width: 18, height: 18)
-            VStack(alignment: .leading, spacing: 0) {
-                Text(provider.displayName)
-                    .font(.system(size: density.headerPointSize, weight: .semibold))
-                    .foregroundStyle(isEnabled ? Color.primary : Color.secondary)
-                    .lineLimit(1)
-                HStack(spacing: 4) {
-                    Circle()
-                        .fill(isEnabled ? Theme.positive : AnyShapeStyle(Color.secondary.opacity(0.6)))
-                        .frame(width: 6, height: 6)
-                    Text(isEnabled ? "Active" : "Inactive")
-                        .font(.system(size: density.planBadgePointSize))
-                        .foregroundStyle(isEnabled ? Theme.positive : AnyShapeStyle(.secondary))
+    private func metricSection(_ title: String, metrics: [WidgetDescriptor], providerID: String) -> some View {
+        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+            VStack(spacing: 0) {
+                if metrics.isEmpty {
+                    emptyDropZone(providerID: providerID)
+                } else {
+                    ForEach(metrics, id: \.id) { metric in
+                        metricRow(metric, in: providerID)
+                    }
                 }
             }
-            Spacer(minLength: 8)
-            // The master on/off toggle — the primary action, especially when the provider is disabled.
-            Toggle("", isOn: Binding(
-                get: { isEnabled },
-                set: { container.enablement.setEnabled($0, for: provider.id) }
-            ))
-            .settingsSwitchStyle()
+            .cardSurface()
         }
-        .padding(.horizontal, 8)
     }
 
-    // MARK: - Metric card
-
-    private func metricCard(_ group: ProviderMetrics) -> some View {
-        VStack(spacing: 0) {
-            ForEach(metricCardRows(for: group)) { row in
-                switch row {
-                case .sectionLabel(let label):
-                    sectionLabel(label)
-                case .metric(let metric):
-                    metricRow(metric, in: group.provider.id)
-                case .divider:
-                    expandedDivider(providerID: group.provider.id)
-                }
-            }
-        }
-        .cardSurface()
-    }
-
-    private func sectionLabel(_ text: String) -> some View {
-        Text(text)
-            .font(.caption.weight(.semibold))
-            .foregroundStyle(.secondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 4)
-    }
-
-    private func metricCardRows(for group: ProviderMetrics) -> [CustomizeMetricCardRow] {
-        [.sectionLabel("Always Visible")]
-            + group.alwaysShownMetrics.map(CustomizeMetricCardRow.metric)
-            + [.divider]
-            + [.sectionLabel("On Demand")]
-            + group.expandedMetrics.map(CustomizeMetricCardRow.metric)
+    /// A small dashed drop target shown when a section is empty, so there's always somewhere to drop
+    /// a metric into. It carries the divider's reorder frame — dropping a metric here moves it into
+    /// this section via `applyMetricDividerOrder` (the sentinel sits at the empty section's edge).
+    private func emptyDropZone(providerID: String) -> some View {
+        let yOutset = max(0, (density.estimatedMetricRowHeight - 30) / 2)
+        return RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+            .foregroundStyle(.tertiary)
+            .frame(height: 30)
+            .padding(8)
+            .overlay(
+                Text("Drag metrics here")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            )
+            .reorderFrame(id: expandedDividerID(for: providerID), in: .named(reorderSpaceName), yOutset: yOutset)
+            .accessibilityLabel("Drag metrics here")
     }
 
     private func metricRow(_ metric: WidgetDescriptor, in providerID: String) -> some View {
@@ -114,88 +89,28 @@ struct CustomizeProviderDetailView: View {
         return CustomizeMetricRow(
             title: metric.title,
             handle: { $0.highPriorityGesture(metricDragGesture(for: metric.id, providerID: providerID, title: metric.title)) },
-            leading: {
+            trailing: {
+                StarButton(metric: metric)
                 Toggle("", isOn: Binding(
                     get: { layout.isMetricEnabled(metric.id) },
                     set: { layout.setMetricEnabled(metric.id, $0) }
                 ))
                 .settingsSwitchStyle()
-            },
-            trailing: {
-                starButton(metric)
             }
         )
         .contentShape(Rectangle())
         .opacity(isActive ? 0 : 1)
-        .onHover { hovering in
-            if hovering {
-                hoveredMetricID = metric.id
-            } else if hoveredMetricID == metric.id {
-                hoveredMetricID = nil
+        // Two-card stuck-drag safeguard: when a dragged row crosses into the other section's card,
+        // SwiftUI removes this source view (and its drag gesture) mid-drag, so onEnded never fires and
+        // the lift overlay would stick. By the time onDisappear fires, the metric has already moved to
+        // the other card, so the drag is genuinely over — clear the state so the lift unsticks.
+        .onDisappear {
+            if activeMetricID == metric.id {
+                activeMetricID = nil
+                reorderLift = nil
             }
         }
         .reorderFrame(id: metric.id, in: .named(reorderSpaceName))
-    }
-
-    /// The star (menu-bar pin) control on a metric row: a filled star when starred, an outline star on
-    /// row hover otherwise. At a cap the star dims but stays clickable — a denied click routes through
-    /// `notePinDenied`, which surfaces the reason in the footer (WhatsApp-style feedback) instead of
-    /// silently doing nothing.
-    @ViewBuilder
-    private func starButton(_ metric: WidgetDescriptor) -> some View {
-        if metric.pinnable {
-            let pinned = layout.isPinned(metric.id)
-            let blocked = !layout.canPin(metric.id)   // false when pinned, so unstar always works
-            let visible = pinned || hoveredMetricID == metric.id
-            Button {
-                if blocked {
-                    layout.notePinDenied(metric.id)
-                } else {
-                    layout.togglePin(metric.id)
-                }
-            } label: {
-                Image(systemName: pinned ? "star.fill" : "star")
-                    .font(.system(size: 11, weight: .semibold))
-                    .frame(width: 18, height: 18)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(pinned ? Color.accentColor : Color.secondary)
-            .opacity(visible ? (blocked ? 0.35 : 1) : 0)
-            .allowsHitTesting(visible)
-            .hoverTooltip(starHelp(metric))
-            .animation(Motion.spring, value: visible)
-            .animation(Motion.spring, value: pinned)
-        }
-    }
-
-    private func starHelp(_ metric: WidgetDescriptor) -> String {
-        if layout.isPinned(metric.id) { return "Unstar" }
-        return layout.pinDenialReason(metric.id) ?? "Star for menu bar"
-    }
-
-    // MARK: - Divider
-
-    /// The single dashed boundary between Always Visible and On Demand. Kept visually simple so it
-    /// reads as one drop target instead of several moving controls.
-    private func expandedDivider(providerID: String) -> some View {
-        let yOutset = max(0, (density.estimatedMetricRowHeight - density.customizeDividerRowHeight) / 2)
-        return dashedRule
-            .padding(.horizontal, 12)
-            .frame(height: density.customizeDividerRowHeight)
-            .reorderFrame(id: expandedDividerID(for: providerID), in: .named(reorderSpaceName), yOutset: yOutset)
-            .accessibilityLabel("On Demand divider")
-    }
-
-    private var dashedRule: some View {
-        Rectangle()
-            .fill(.clear)
-            .frame(height: 1)
-            .overlay(
-                Line()
-                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
-                    .foregroundStyle(.tertiary)
-            )
     }
 
     // MARK: - Metric drag-reorder
@@ -237,30 +152,34 @@ struct CustomizeProviderDetailView: View {
     }
 }
 
-/// A single horizontal line, used as the dashed On Demand rule. A plain `Divider` can't carry a dash
-/// pattern, so the separator strokes this shape instead.
-private struct Line: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        path.move(to: CGPoint(x: rect.minX, y: rect.midY))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
-        return path
-    }
-}
+/// The star (menu-bar pin) control on a metric row — always visible: an outline star when not
+/// starred, a filled accent star when starred. A denied click (over the per-provider cap) shakes the
+/// star; the hover tooltip carries the reason.
+private struct StarButton: View {
+    let metric: WidgetDescriptor
+    @Environment(LayoutStore.self) private var layout
+    @State private var shakeTrigger = 0
 
-private enum CustomizeMetricCardRow: Identifiable {
-    case sectionLabel(String)
-    case metric(WidgetDescriptor)
-    case divider
-
-    var id: String {
-        switch self {
-        case .sectionLabel(let label):
-            "section:\(label)"
-        case .metric(let metric):
-            "metric:\(metric.id)"
-        case .divider:
-            "expanded-divider"
+    var body: some View {
+        if metric.pinnable {
+            let pinned = layout.isPinned(metric.id)
+            Button {
+                if layout.canPin(metric.id) {
+                    layout.togglePin(metric.id)
+                } else {
+                    shakeTrigger += 1
+                }
+            } label: {
+                Image(systemName: pinned ? "star.fill" : "star")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(pinned ? Color.accentColor : Color.secondary)
+            .hoverTooltip(pinned ? "Unstar" : (layout.pinDenialReason(metric.id) ?? "Star for menu bar"))
+            .denyShake(trigger: shakeTrigger)
+            .animation(Motion.spring, value: pinned)
         }
     }
 }

--- a/Sources/OpenUsage/Views/CustomizeProviderListView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderListView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// The Customize provider list (L1): every known provider as a row, in the user's saved order —
+/// including disabled ones (greyed), so the user can re-enable them or open their detail. Each row
+/// carries the master on/off toggle, an Active/Inactive status, a metric-count badge, and a chevron
+/// into the provider's detail (L2). Providers drag-reorder by the leading grip; tapping a row opens
+/// L2 (`layout.customizeProviderID = id`).
+struct CustomizeProviderListView: View {
+    @Environment(LayoutStore.self) private var layout
+    @Environment(AppContainer.self) private var container
+    let reorderSpaceName: String
+    @Binding var reorderLift: ReorderLift?
+    let rowFrames: [String: CGRect]
+
+    @State private var activeProviderID: String?
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    private var orderedRows: [ProviderRow] { layout.customizeProviderRows }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.sectionSpacing) {
+            VStack(spacing: 0) {
+                ForEach(orderedRows) { row in
+                    providerRow(row)
+                }
+            }
+            .cardSurface()
+        }
+        .animation(Motion.spring, value: orderedRows.map(\.id))
+    }
+
+    private func providerRow(_ row: ProviderRow) -> some View {
+        ProviderListRow(
+            provider: row.provider,
+            isEnabled: row.isEnabled,
+            metricCount: row.metricCount,
+            // Drag-reorder is enabled only for active providers — `reorderProvider` operates on the
+            // enabled set, so a disabled row's grip stays inert (the row still opens/toggles).
+            handle: { grip in
+                if row.isEnabled {
+                    AnyView(grip.highPriorityGesture(providerDragGesture(for: row)))
+                } else {
+                    grip
+                }
+            },
+            onToggle: { container.enablement.setEnabled($0, for: row.id) },
+            onOpen: { withAnimation(Motion.spring) { layout.customizeProviderID = row.id } }
+        )
+        .opacity(activeProviderID == row.id ? 0 : 1)
+        .reorderFrame(id: row.id, in: .named(reorderSpaceName))
+    }
+
+    private func providerDragGesture(for row: ProviderRow) -> some Gesture {
+        reorderDragGesture(
+            id: row.id,
+            coordinateSpaceName: reorderSpaceName,
+            rowFrames: rowFrames,
+            active: $activeProviderID,
+            lift: $reorderLift,
+            makeLift: { makeProviderLift(for: row, value: $0) },
+            // Hit-test only enabled providers (the set `reorderProvider` can actually move); disabled
+            // rows keep their tail position and aren't reorder targets.
+            orderedIDs: { layout.customizeGroups.map(\.provider.id) },
+            reorder: { layout.reorderProvider(dragged: row.id, target: $0) }
+        )
+    }
+
+    private func makeProviderLift(for row: ProviderRow, value: DragGesture.Value) -> ReorderLift? {
+        ReorderLift.make(
+            id: row.id,
+            payload: .customizeProviderRow(provider: row.provider, isEnabled: row.isEnabled, metricCount: row.metricCount),
+            value: value,
+            frames: rowFrames
+        )
+    }
+}

--- a/Sources/OpenUsage/Views/CustomizeProviderListView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderListView.swift
@@ -34,8 +34,9 @@ struct CustomizeProviderListView: View {
             provider: row.provider,
             isEnabled: row.isEnabled,
             metricCount: row.metricCount,
-            // Drag-reorder is enabled only for active providers — `reorderProvider` operates on the
-            // enabled set, so a disabled row's grip stays inert (the row still opens/toggles).
+            // The grip leads the tappable bar; a tap opens L2, a drag reorders. Drag-reorder is enabled
+            // only for active providers — `reorderProvider` operates on the enabled set, so a disabled
+            // row's grip stays inert (the row still opens/toggles).
             handle: { grip in
                 if row.isEnabled {
                     AnyView(grip.highPriorityGesture(providerDragGesture(for: row)))

--- a/Sources/OpenUsage/Views/CustomizeRow.swift
+++ b/Sources/OpenUsage/Views/CustomizeRow.swift
@@ -1,36 +1,32 @@
 import SwiftUI
 
-/// The Customize metric row shape, shared by the live row in `CustomizeView` and the lifted drag
-/// preview in `ReorderLiftPreview`. Defining the grip + label + trailing layout (and its
-/// density-derived padding) once is what keeps the floating preview pixel-identical to the row the
-/// user is dragging — the two used to be hand-rebuilt separately and drifted apart.
+/// The Customize metric row shape, shared by the live row in `CustomizeProviderDetailView` and the
+/// lifted drag preview in `ReorderLiftPreview`. The layout is **toggle · label · star · grip** — the
+/// toggle leads with the metric name beside it (left-aligned), the star (menu-bar pin) and the drag
+/// grip trail. Defining the grip + label slot once is what keeps the floating preview pixel-identical
+/// to the row the user is dragging — the two used to be hand-rebuilt separately and drifted apart.
 ///
-/// The leading grip + label form the drag *handle* (the live row attaches its reorder gesture to
-/// just that region, leaving the trailing pin + toggle normally tappable); the trailing slot is
-/// supplied by the caller — the live row passes its real pin button + `Toggle`, the preview a
-/// static switch placeholder.
-struct CustomizeMetricRow<Handle: View, Trailing: View>: View {
+/// `leading` is the on/off toggle (live) or a placeholder (preview). `trailing` is the star button
+/// (live) or a placeholder (preview). `handle` wraps the trailing drag grip — the live row attaches
+/// its reorder gesture through it; the preview leaves it inert.
+struct CustomizeMetricRow<Leading: View, Handle: View, Trailing: View>: View {
     let title: String
-    /// Wraps the leading grip + label + spacer (the drag-handle region). The live row threads its
-    /// `contentShape` + reorder gesture through here; the preview leaves it untouched.
+    /// Wraps the trailing drag grip. The live row threads its reorder gesture through here; the
+    /// preview leaves it untouched.
     let handle: (AnyView) -> Handle
+    @ViewBuilder var leading: Leading
     @ViewBuilder var trailing: Trailing
 
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
     var body: some View {
         HStack(spacing: 10) {
-            handle(
-                AnyView(
-                    HStack(spacing: 10) {
-                        ReorderGrip()
-                        Text(title)
-                            .foregroundStyle(.primary)
-                        Spacer(minLength: 8)
-                    }
-                )
-            )
+            leading
+            Text(title)
+                .foregroundStyle(.primary)
+            Spacer(minLength: 8)
             trailing
+            handle(AnyView(ReorderGrip()))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, density.controlRowPadding)
@@ -38,9 +34,9 @@ struct CustomizeMetricRow<Handle: View, Trailing: View>: View {
 }
 
 extension CustomizeMetricRow where Handle == AnyView {
-    /// Static variant for the lifted drag preview: the handle region is rendered inert (no gesture).
-    init(title: String, @ViewBuilder trailing: () -> Trailing) {
-        self.init(title: title, handle: { $0 }, trailing: trailing)
+    /// Static variant for the lifted drag preview: the grip is rendered inert (no gesture).
+    init(title: String, @ViewBuilder leading: () -> Leading, @ViewBuilder trailing: () -> Trailing) {
+        self.init(title: title, handle: { $0 }, leading: leading, trailing: trailing)
     }
 }
 
@@ -52,5 +48,15 @@ struct CustomizeSwitchPlaceholder: View {
         Capsule()
             .fill(.quaternary)
             .frame(width: 28, height: 16)
+    }
+}
+
+/// The static star placeholder the lifted preview renders where the live row shows the star button.
+struct CustomizeStarPlaceholder: View {
+    var body: some View {
+        Image(systemName: "star")
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.quaternary)
+            .frame(width: 18, height: 18)
     }
 }

--- a/Sources/OpenUsage/Views/CustomizeRow.swift
+++ b/Sources/OpenUsage/Views/CustomizeRow.swift
@@ -1,32 +1,29 @@
 import SwiftUI
 
 /// The Customize metric row shape, shared by the live row in `CustomizeProviderDetailView` and the
-/// lifted drag preview in `ReorderLiftPreview`. The layout is **toggle · label · star · grip** — the
-/// toggle leads with the metric name beside it (left-aligned), the star (menu-bar pin) and the drag
-/// grip trail. Defining the grip + label slot once is what keeps the floating preview pixel-identical
-/// to the row the user is dragging — the two used to be hand-rebuilt separately and drifted apart.
+/// lifted drag preview in `ReorderLiftPreview`. The layout is **grip · label · star · toggle** — the
+/// drag grip leads (left), the name follows, and the star + on/off toggle trail on the right. This
+/// mirrors the provider row's "drag left, toggle right" arrangement. Defining the grip slot once is
+/// what keeps the floating preview pixel-identical to the row the user is dragging.
 ///
-/// `leading` is the on/off toggle (live) or a placeholder (preview). `trailing` is the star button
-/// (live) or a placeholder (preview). `handle` wraps the trailing drag grip — the live row attaches
-/// its reorder gesture through it; the preview leaves it inert.
-struct CustomizeMetricRow<Leading: View, Handle: View, Trailing: View>: View {
+/// `handle` wraps the leading drag grip — the live row threads its reorder gesture through it; the
+/// preview leaves it inert. `trailing` is the star button + toggle (live) or placeholders (preview).
+struct CustomizeMetricRow<Handle: View, Trailing: View>: View {
     let title: String
-    /// Wraps the trailing drag grip. The live row threads its reorder gesture through here; the
+    /// Wraps the leading drag grip. The live row threads its reorder gesture through here; the
     /// preview leaves it untouched.
     let handle: (AnyView) -> Handle
-    @ViewBuilder var leading: Leading
     @ViewBuilder var trailing: Trailing
 
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
     var body: some View {
         HStack(spacing: 10) {
-            leading
+            handle(AnyView(ReorderGrip()))
             Text(title)
                 .foregroundStyle(.primary)
             Spacer(minLength: 8)
             trailing
-            handle(AnyView(ReorderGrip()))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, density.controlRowPadding)
@@ -35,8 +32,8 @@ struct CustomizeMetricRow<Leading: View, Handle: View, Trailing: View>: View {
 
 extension CustomizeMetricRow where Handle == AnyView {
     /// Static variant for the lifted drag preview: the grip is rendered inert (no gesture).
-    init(title: String, @ViewBuilder leading: () -> Leading, @ViewBuilder trailing: () -> Trailing) {
-        self.init(title: title, handle: { $0 }, leading: leading, trailing: trailing)
+    init(title: String, @ViewBuilder trailing: () -> Trailing) {
+        self.init(title: title, handle: { $0 }, trailing: trailing)
     }
 }
 

--- a/Sources/OpenUsage/Views/CustomizeView.swift
+++ b/Sources/OpenUsage/Views/CustomizeView.swift
@@ -26,6 +26,34 @@ struct CustomizeView: View {
                 .frame(maxWidth: .infinity)
         }
         .onPreferenceChange(ReorderFramePreferenceKey.self) { rowFrames = $0 }
+        // The transient star/denial pill floats above the Customize content — the same capsule style
+        // as the dashboard's "Copied to clipboard" share pill. Green for a successful star/unstar,
+        // orange for the per-provider cap denial.
+        .overlay(alignment: .bottom) {
+            if layout.customizationNotice != nil {
+                customizationNoticePill
+                    .padding(.bottom, 12)
+            }
+        }
+        .animation(Motion.spring, value: layout.customizationNotice)
+        .animation(Motion.spring, value: layout.customizationNoticeTrigger)
+    }
+
+    private var customizationNoticePill: some View {
+        let isNotice = layout.customizationNoticeTone == .notice
+        return HStack(spacing: 5) {
+            Image(systemName: isNotice ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                .font(.system(size: 11, weight: .semibold))
+            Text(layout.customizationNotice ?? "")
+                .font(.system(size: 12, weight: .semibold))
+        }
+        .foregroundStyle(isNotice ? Theme.notice : Theme.positive)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(.separator, lineWidth: 0.5))
+        .id(layout.customizationNoticeTrigger)
+        .transition(.scale(scale: 0.85).combined(with: .opacity))
     }
 
     @ViewBuilder

--- a/Sources/OpenUsage/Views/CustomizeView.swift
+++ b/Sources/OpenUsage/Views/CustomizeView.swift
@@ -1,294 +1,50 @@
 import SwiftUI
 
-/// The Customize screen. One block per enabled provider: a draggable header (reorders whole providers) over a
-/// rounded card of metric rows, each a native `Toggle` with a drag grip (reorders metrics within that provider).
-/// The provider is the group; each metric is a toggle inside it — so heterogeneous metric sets (Claude has many,
-/// Grok has two) all read the same way.
+/// The Customize screen, now a two-level master/detail: the provider list (L1) or, when
+/// `layout.customizeProviderID` is set, that provider's detail (L2). The two slide horizontally — L2
+/// enters from the trailing edge, L1 returns from the leading edge — on the same spring. The back
+/// chevron (handled in `DashboardView`) is context-aware: L2 → L1, L1 → dashboard.
 ///
-/// Reordering uses `DragGesture` plus local row geometry. That keeps movement inside the menu-bar popover instead
-/// of relying on SwiftUI's pasteboard-backed drag/drop session, which does not engage reliably here.
+/// Reordering uses `DragGesture` plus local row geometry, kept inside the menu-bar popover instead
+/// of SwiftUI's pasteboard-backed drag/drop (unreliable here). The router owns the scroll view and
+/// the reorder-frame map; L1 and L2 read it for their drag hit-testing and emit frames via
+/// `.reorderFrame`. The `customizeProviderID` route lives in `LayoutStore` so the popover-closed
+/// reset and the Esc handler drive the same state.
 struct CustomizeView: View {
     @Environment(LayoutStore.self) private var layout
     let reorderSpaceName: String
     @Binding var reorderLift: ReorderLift?
 
     @State private var rowFrames: [String: CGRect] = [:]
-    @State private var activeProviderID: String?
-    @State private var activeMetricID: String?
-    @State private var hoveredMetricID: String?
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
-    private var isReordering: Bool { activeProviderID != nil || activeMetricID != nil }
-
     var body: some View {
-        scrollContent
-        .frame(maxWidth: .infinity)
-    }
-
-    /// Fills the region the dashboard's pinned footer leaves.
-    private var scrollContent: some View {
         PopoverScrollView {
             content
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .frame(maxWidth: .infinity)
         }
         .onPreferenceChange(ReorderFramePreferenceKey.self) { rowFrames = $0 }
     }
 
     @ViewBuilder
     private var content: some View {
-        if layout.customizeGroups.isEmpty {
-            VStack(spacing: 6) {
-                Text("No providers connected")
-                    .font(.callout)
-                Text("Turn providers on in Settings → Providers.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 40)
-        } else {
-            // Same section rhythm as the dashboard list (both read the density setting).
-            VStack(alignment: .leading, spacing: density.sectionSpacing) {
-                ForEach(layout.customizeGroups) { group in
-                    providerBlock(group)
-                }
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-            .animation(Motion.spring, value: layout.customizeGroups.map(\.provider.id))
-        }
-    }
-
-    private func providerBlock(_ group: ProviderMetrics) -> some View {
-        // Same header→card gap as the dashboard section (`WidgetGroupedListView`).
-        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
-            providerHeader(group)
-            metricCard(group)
-        }
-        .opacity(activeProviderID == group.provider.id ? 0 : 1)
-        .reorderFrame(id: group.provider.id, in: .named(reorderSpaceName))
-    }
-
-    private func providerHeader(_ group: ProviderMetrics) -> some View {
-        // The exact same header as the dashboard (`WidgetGroupedListView.header`): the leading
-        // dot-grid drag handle marks the line as draggable, the provider mark sits trailing. Customize
-        // just omits the plan, warning, and "Outdated" staleness tag — the only things that differ here.
-        ProviderSectionHeader(provider: group.provider, showsDragHandle: true)
-        // Align the header with the metric card's rows: rows are inset 12pt inside the card and the
-        // header carries its own internal inset, so +8 lines the provider name up with the row grip —
-        // the same inset on both edges.
-        .padding(.horizontal, 8)
-        .highPriorityGesture(providerDragGesture(for: group))
-    }
-
-    private func metricCard(_ group: ProviderMetrics) -> some View {
-        return VStack(spacing: 0) {
-            // One stable `ForEach` prevents SwiftUI from tearing down the active dragged row when it
-            // crosses the divider. With separate always-shown/expanded loops the source view can be
-            // removed mid-gesture, leaving the lift overlay stuck until another state change.
-            ForEach(metricCardRows(for: group)) { row in
-                switch row {
-                case .metric(let metric):
-                    metricRow(metric, in: group.provider.id)
-                case .divider:
-                    expandedDivider(providerID: group.provider.id)
-                }
-            }
-        }
-        .cardSurface()
-    }
-
-    private func metricCardRows(for group: ProviderMetrics) -> [CustomizeMetricCardRow] {
-        group.alwaysShownMetrics.map(CustomizeMetricCardRow.metric)
-            + [.divider]
-            + group.expandedMetrics.map(CustomizeMetricCardRow.metric)
-    }
-
-    /// The single dashed boundary between always-shown rows and rows revealed by the dashboard caret.
-    /// Kept visually simple so it reads as one drop target instead of several moving controls.
-    private func expandedDivider(providerID: String) -> some View {
-        let yOutset = max(0, (density.estimatedMetricRowHeight - density.customizeDividerRowHeight) / 2)
-        return dashedRule
-        .padding(.horizontal, 12)
-        .frame(height: density.customizeDividerRowHeight)
-        // The visible divider is compact, but its measured reorder frame remains row-sized. That keeps
-        // the same threshold behavior as metric rows without making the Customize card look gappy.
-        .reorderFrame(id: expandedDividerID(for: providerID), in: .named(reorderSpaceName), yOutset: yOutset)
-        .accessibilityLabel("Shown on expand divider")
-    }
-
-    private var dashedRule: some View {
-        Rectangle()
-            .fill(.clear)
-            .frame(height: 1)
-            .overlay(
-                Line()
-                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
-                    .foregroundStyle(.tertiary)
+        if let id = layout.customizeProviderID {
+            CustomizeProviderDetailView(
+                providerID: id,
+                reorderSpaceName: reorderSpaceName,
+                reorderLift: $reorderLift,
+                rowFrames: rowFrames
             )
-    }
-
-    private func metricRow(_ metric: WidgetDescriptor, in providerID: String) -> some View {
-        let isActive = activeMetricID == metric.id
-        // Same row builder the lifted preview uses, so the floating chip can't drift from the live row.
-        return CustomizeMetricRow(
-            title: metric.title,
-            // Grip + label form the drag handle; the trailing pin + toggle stay normal tappable controls.
-            handle: { handle in
-                handle
-                    .contentShape(Rectangle())
-                    .highPriorityGesture(
-                        metricDragGesture(
-                            for: metric.id,
-                            providerID: providerID,
-                            title: metric.title
-                        )
-                    )
-            },
-            trailing: {
-                pinButton(metric)
-                Toggle("", isOn: Binding(
-                    get: { layout.isMetricEnabled(metric.id) },
-                    set: { layout.setMetricEnabled(metric.id, $0) }
-                ))
-                .settingsSwitchStyle()
-            }
-        )
-        .contentShape(Rectangle())
-        .opacity(isActive ? 0 : 1)
-        .onHover { hovering in
-            if hovering {
-                hoveredMetricID = metric.id
-            } else if hoveredMetricID == metric.id {
-                hoveredMetricID = nil
-            }
-        }
-        .reorderFrame(id: metric.id, in: .named(reorderSpaceName))
-    }
-
-    /// The pin-to-menu-bar control on a metric row: a filled pin when pinned (always shown), an outline
-    /// pin on row hover otherwise. At a cap the pin dims but stays clickable — a denied click routes
-    /// through `notePinDenied`, which surfaces the reason in the footer (WhatsApp-style feedback)
-    /// instead of silently doing nothing.
-    @ViewBuilder
-    private func pinButton(_ metric: WidgetDescriptor) -> some View {
-        // A non-pinnable widget (the Usage Trend chart) shows no pin affordance at all — the tray can't
-        // render it, so offering a pin would only ever be denied.
-        if metric.pinnable {
-            let pinned = layout.isPinned(metric.id)
-            let blocked = !layout.canPin(metric.id)   // false when pinned, so unpin always works
-            let visible = pinned || hoveredMetricID == metric.id
-            // No app haptic here: the physical click already plays its own press/release haptics, and an
-            // added pulse at mouse-up stacks against the release click and reads as a double vibration.
-            Button {
-                if blocked {
-                    layout.notePinDenied(metric.id)
-                } else {
-                    layout.togglePin(metric.id)
-                }
-            } label: {
-                Image(systemName: pinned ? "pin.fill" : "pin")
-                    .font(.system(size: 11, weight: .semibold))
-                    .frame(width: 18, height: 18)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(pinned ? Color.accentColor : Color.secondary)
-            .opacity(visible ? (blocked ? 0.35 : 1) : 0)
-            .allowsHitTesting(visible)
-            .hoverTooltip(pinHelp(metric))
-            .animation(Motion.spring, value: visible)
-            .animation(Motion.spring, value: pinned)
-        }
-    }
-
-    private func pinHelp(_ metric: WidgetDescriptor) -> String {
-        if layout.isPinned(metric.id) { return "Unpin" }
-        return layout.pinDenialReason(metric.id) ?? "Pin to menu bar"
-    }
-
-    private func providerDragGesture(for group: ProviderMetrics) -> some Gesture {
-        reorderDragGesture(
-            id: group.provider.id,
-            coordinateSpaceName: reorderSpaceName,
-            rowFrames: rowFrames,
-            active: $activeProviderID,
-            lift: $reorderLift,
-            makeLift: { makeProviderLift(for: group, value: $0) },
-            orderedIDs: { layout.customizeGroups.map(\.provider.id) },
-            reorder: { layout.reorderProvider(dragged: group.provider.id, target: $0) }
-        )
-    }
-
-    private func metricDragGesture(for metricID: String, providerID: String, title: String) -> some Gesture {
-        reorderDragGesture(
-            id: metricID,
-            coordinateSpaceName: reorderSpaceName,
-            rowFrames: rowFrames,
-            active: $activeMetricID,
-            lift: $reorderLift,
-            makeLift: { makeMetricLift(metricID: metricID, title: title, value: $0) },
-            orderedIDs: { reorderTargetIDs(for: providerID) },
-            reorder: { target in
-                let current = reorderTargetIDs(for: providerID)
-                guard let next = LayoutStore.reordered(current, dragged: metricID, target: target) else {
-                    return false
-                }
-                return layout.applyMetricDividerOrder(next, dragged: metricID, dividerID: expandedDividerID(for: providerID), in: providerID)
-            }
-        )
-    }
-
-    private func reorderTargetIDs(for providerID: String) -> [String] {
-        layout.metricOrderWithDivider(for: providerID, dividerID: expandedDividerID(for: providerID))
-    }
-
-    private func expandedDividerID(for providerID: String) -> String {
-        "\(providerID)::expanded-divider"
-    }
-
-    private func makeProviderLift(for group: ProviderMetrics, value: DragGesture.Value) -> ReorderLift? {
-        ReorderLift.make(
-            id: group.provider.id,
-            payload: .customizeProvider(
-                provider: group.provider,
-                rows: group.metrics.map(\.title)
-            ),
-            value: value,
-            frames: rowFrames
-        )
-    }
-
-    private func makeMetricLift(metricID: String, title: String, value: DragGesture.Value) -> ReorderLift? {
-        return ReorderLift.make(
-            id: metricID,
-            payload: .customizeMetric(title: title),
-            value: value,
-            frames: rowFrames
-        )
-    }
-}
-
-/// A single horizontal line, used as the dashed "Shown on expand" rule. A plain `Divider` can't carry
-/// a dash pattern, so the separator strokes this shape instead.
-private struct Line: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        path.move(to: CGPoint(x: rect.minX, y: rect.midY))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
-        return path
-    }
-}
-
-private enum CustomizeMetricCardRow: Identifiable {
-    case metric(WidgetDescriptor)
-    case divider
-
-    var id: String {
-        switch self {
-        case .metric(let metric):
-            "metric:\(metric.id)"
-        case .divider:
-            "expanded-divider"
+            .transition(.move(edge: .trailing))
+        } else {
+            CustomizeProviderListView(
+                reorderSpaceName: reorderSpaceName,
+                reorderLift: $reorderLift,
+                rowFrames: rowFrames
+            )
+            .transition(.move(edge: .leading))
         }
     }
 }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -91,6 +91,12 @@ struct DashboardView: View {
                 // through and dismiss the popover.
                 PopoverKeyReader(
                     onEscape: {
+                        // From a provider's L2 detail, back out to the L1 list first; only from L1 /
+                        // Settings drop to the dashboard. Pressing Esc again from L1 closes the popover.
+                        if layout.customizeProviderID != nil {
+                            withAnimation(Motion.spring) { layout.customizeProviderID = nil }
+                            return true
+                        }
                         guard layout.screen != .dashboard else { return false }
                         withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
                         return true
@@ -351,9 +357,26 @@ struct DashboardView: View {
         case .dashboard:
             EmptyView()
         case .customize:
-            navBar(title: "Customize", showsReset: true)
+            // Title swaps to the provider name on L2; back is context-aware (L2 → L1, L1 → dashboard).
+            navBar(title: customizeTitle, showsReset: true, back: customizeBack)
         case .settings:
-            navBar(title: "Settings")
+            navBar(title: "Settings") {
+                withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
+            }
+        }
+    }
+
+    /// The Customize top-bar title: the provider's name when its L2 detail is open, otherwise "Customize".
+    private var customizeTitle: String {
+        layout.customizeProviderID.flatMap { layout.provider(id: $0)?.displayName } ?? "Customize"
+    }
+
+    /// Customize's context-aware back: L2 → L1 (the slide), L1 → dashboard (the usual screen slide).
+    private func customizeBack() {
+        if layout.customizeProviderID != nil {
+            withAnimation(Motion.spring) { layout.customizeProviderID = nil }
+        } else {
+            withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
         }
     }
 
@@ -399,7 +422,7 @@ struct DashboardView: View {
     /// Customize/Settings and clears on the dashboard, while the content slides beneath it. Its
     /// `barGlass()` (Liquid Glass) background lenses the content scrolling under it — the same
     /// content-aware glass as the footer.
-    private func navBar(title: String, showsReset: Bool = false) -> some View {
+    private func navBar(title: String, showsReset: Bool = false, back: @escaping () -> Void) -> some View {
         // Centered title with the back control floating leading and the reset menu trailing — the macOS
         // toolbar convention (leading navigation · centered title · trailing actions). The title is
         // centered against the *full* bar width (a ZStack layer, not an HStack slot) so it stays
@@ -412,7 +435,7 @@ struct DashboardView: View {
                 .frame(maxWidth: .infinity)
 
             HStack(spacing: 0) {
-                backButton
+                backButton(action: back)
                 Spacer(minLength: 8)
                 if showsReset {
                     resetMenu
@@ -427,11 +450,10 @@ struct DashboardView: View {
     }
 
     /// The round glass back button (chevron leading), matching the footer's glass control idiom. Esc
-    /// and the system shortcuts back out too; this is the visible, expected affordance.
-    private var backButton: some View {
-        Button {
-            withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
-        } label: {
+    /// and the system shortcuts back out too; this is the visible, expected affordance. The action is
+    /// supplied by the caller so Customize can back L2 → L1 before L1 → dashboard.
+    private func backButton(action: @escaping () -> Void) -> some View {
+        Button(action: action) {
             Label("Back", systemImage: "chevron.backward")
                 .labelStyle(.iconOnly)
                 .frame(width: 16, height: 16)
@@ -504,10 +526,11 @@ struct DashboardView: View {
     private func footerBar(for screen: PopoverScreen) -> some View {
         Group {
             if screen == .customize {
-                // Customize summarizes the layout — active (enabled) metrics and how many are pinned —
-                // centered, using the same middot the metric rows use. ⌘Z (handled app-wide by the
-                // popover's key monitor) is the sole undo affordance; the footer stays a plain summary.
-                Text(layout.pinLimitNotice ?? "\(activeMetricCount) active · \(layout.pinnedCount) pinned")
+                // Customize summarizes the layout — active (enabled) metrics, how many are starred for
+                // the menu bar, and how many providers are on — centered, using the same middot the
+                // metric rows use. ⌘Z (handled app-wide by the popover's key monitor) is the sole undo
+                // affordance; the footer stays a plain summary.
+                Text(layout.pinLimitNotice ?? "\(activeMetricCount) active · \(layout.pinnedCount) starred · \(providersOn) of \(providersCount) providers on")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(layout.pinLimitNotice == nil ? AnyShapeStyle(.secondary) : Theme.notice)
                     .denyShake(trigger: layout.pinNoticeShakeTrigger)
@@ -579,6 +602,12 @@ struct DashboardView: View {
             count + group.metrics.filter { layout.isMetricEnabled($0.id) }.count
         }
     }
+
+    /// Providers turned on — the "K of P providers on" tail of the Customize footer summary. Counts
+    /// from `customizeProviderRows` (every provider) so a freshly shipped provider counts as "on" even
+    /// before the user has placed any of its metrics.
+    private var providersOn: Int { layout.customizeProviderRows.filter(\.isEnabled).count }
+    private var providersCount: Int { layout.customizeProviderRows.count }
 
     /// Leading side of the footer. Normal mode shows the app name with the live "Next update in …"
     /// line beneath it; Customize mode shows the pin count ("4 pinned") in the same slot.

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -221,6 +221,7 @@ struct DashboardView: View {
         // A "Copied to clipboard" pill mid-countdown would otherwise reappear stale on the next open,
         // since the layout store survives the popover and only the timer clears it.
         layout.clearShareConfirmation()
+        layout.clearCustomizationNotice()
         // Drop the driven height so the next open re-establishes it (un-animated) from the reopened
         // screen's measurement instead of springing from this session's last value. Until then the
         // 0 sentinel keeps `PanelHeightModifier` from pushing, so the controller's opening guess stands.

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -102,6 +102,12 @@ struct DashboardView: View {
                         return true
                     },
                     onReturn: {
+                        // From a provider's L2 detail, back out to the L1 list first — matching Esc —
+                        // so Return steps L2 → L1 → dashboard instead of jumping L2 → dashboard.
+                        if layout.customizeProviderID != nil {
+                            withAnimation(Motion.spring) { layout.customizeProviderID = nil }
+                            return true
+                        }
                         let target: PopoverScreen = layout.screen == .dashboard ? .customize : .dashboard
                         withAnimation(Motion.modeSwitch) { layout.screen = target }
                         return true

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -357,11 +357,22 @@ struct DashboardView: View {
         case .dashboard:
             EmptyView()
         case .customize:
-            // Title swaps to the provider name on L2; back is context-aware (L2 → L1, L1 → dashboard).
-            navBar(title: customizeTitle, showsReset: true, back: customizeBack)
+            // L2 (provider detail) shows a per-provider reset button; L1 (the list) has no trailing
+            // action. Title swaps to the provider name on L2; back is context-aware (L2 → L1, L1 → dashboard).
+            if let id = layout.customizeProviderID {
+                navBar(title: customizeTitle, back: customizeBack) {
+                    resetButton(for: id)
+                }
+            } else {
+                navBar(title: customizeTitle, back: customizeBack) {
+                    EmptyView()
+                }
+            }
         case .settings:
             navBar(title: "Settings") {
                 withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
+            } trailing: {
+                EmptyView()
             }
         }
     }
@@ -422,12 +433,11 @@ struct DashboardView: View {
     /// Customize/Settings and clears on the dashboard, while the content slides beneath it. Its
     /// `barGlass()` (Liquid Glass) background lenses the content scrolling under it — the same
     /// content-aware glass as the footer.
-    private func navBar(title: String, showsReset: Bool = false, back: @escaping () -> Void) -> some View {
-        // Centered title with the back control floating leading and the reset menu trailing — the macOS
+    private func navBar<Trailing: View>(title: String, back: @escaping () -> Void, @ViewBuilder trailing: () -> Trailing) -> some View {
+        // Centered title with the back control floating leading and a trailing action — the macOS
         // toolbar convention (leading navigation · centered title · trailing actions). The title is
         // centered against the *full* bar width (a ZStack layer, not an HStack slot) so it stays
-        // optically centered regardless of the leading/trailing control widths, and both flanks are
-        // matching circular glass controls.
+        // optically centered regardless of the leading/trailing control widths.
         ZStack {
             Text(title)
                 .font(.headline)
@@ -437,9 +447,7 @@ struct DashboardView: View {
             HStack(spacing: 0) {
                 backButton(action: back)
                 Spacer(minLength: 8)
-                if showsReset {
-                    resetMenu
-                }
+                trailing()
             }
         }
         .padding(.horizontal, Self.footerHorizontalPadding)
@@ -465,48 +473,24 @@ struct DashboardView: View {
         .accessibilityLabel("Back")
     }
 
-    /// The trailing "More" pull-down on the Customize header: a circular glass control mirroring the
-    /// leading back chevron, holding a per-provider reset for each provider plus "Reset all providers".
-    /// Resets are secondary, occasional actions — the macOS toolbar convention routes those into a More
-    /// menu rather than giving each a prominent bar button. Glass goes on the container via
-    /// `interactiveGlass(in: Circle())` with a `.plain`/`.menuStyle(.button)` menu: the system
-    /// `.buttonStyle(.glass)` renders flat on a `Menu` (its own chrome wins), so this matches the
-    /// footer's split-button idiom (`HeaderView`).
-    private var resetMenu: some View {
-        Menu {
-            resetMenuItems
+    /// The trailing reset button on a provider's L2 detail — a circular glass control mirroring the
+    /// leading back chevron. Resets just that provider's metrics, order, stars, and On Demand
+    /// membership (`resetProvider`), leaving other providers and the provider order untouched. Only
+    /// shown on L2; the L1 list has no trailing action.
+    private func resetButton(for providerID: String) -> some View {
+        Button {
+            withAnimation(Motion.spring) { layout.resetProvider(providerID) }
         } label: {
-            Image(systemName: "ellipsis")
+            Image(systemName: "arrow.counterclockwise")
                 .font(.system(size: 13, weight: .semibold))
-                .frame(width: 28, height: 28)
+                .frame(width: 16, height: 16)
                 .contentShape(Rectangle())
         }
-        .menuStyle(.button)
-        .buttonStyle(.plain)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .interactiveGlass(in: Circle())
+        .glassButtonStyle()
+        .buttonBorderShape(.circle)
+        .controlSize(.large)
+        .hoverTooltip("Reset \(layout.provider(id: providerID)?.displayName ?? providerID)")
         .accessibilityLabel("Reset")
-    }
-
-    /// One "Reset <Provider>" per provider currently shown in Customize (so the list tracks the enabled
-    /// providers and stays in the alphabetical registry order), then "Reset all providers" below a
-    /// divider. Per-provider items reset that provider's contents only; "Reset all" (destructive) is the
-    /// full `resetToDefault`, including provider order. No confirmation — a menu pick isn't a misfire,
-    /// and the destructive role flags the all-providers item.
-    @ViewBuilder
-    private var resetMenuItems: some View {
-        ForEach(layout.customizeGroups, id: \.provider.id) { group in
-            Button("Reset \(group.provider.displayName)") {
-                withAnimation(Motion.spring) { layout.resetProvider(group.provider.id) }
-            }
-        }
-
-        Divider()
-
-        Button("Reset all providers", role: .destructive) {
-            withAnimation(Motion.spring) { layout.resetToDefault() }
-        }
     }
 
     // MARK: - Pinned footer
@@ -526,16 +510,9 @@ struct DashboardView: View {
     private func footerBar(for screen: PopoverScreen) -> some View {
         Group {
             if screen == .customize {
-                // Customize summarizes the layout — active (enabled) metrics, how many are starred for
-                // the menu bar, and how many providers are on — centered, using the same middot the
-                // metric rows use. ⌘Z (handled app-wide by the popover's key monitor) is the sole undo
-                // affordance; the footer stays a plain summary.
-                Text(layout.pinLimitNotice ?? "\(activeMetricCount) active · \(layout.pinnedCount) starred · \(providersOn) of \(providersCount) providers on")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(layout.pinLimitNotice == nil ? AnyShapeStyle(.secondary) : Theme.notice)
-                    .denyShake(trigger: layout.pinNoticeShakeTrigger)
-                    .frame(maxWidth: .infinity)
-                    .animation(Motion.spring, value: layout.pinLimitNotice)
+                // No footer on Customize — the summary was retired with the old flat layout. A denied
+                // star shakes in place (StarButton) instead of surfacing a footer notice here.
+                EmptyView()
             } else {
                 HStack(alignment: .center, spacing: 8) {
                     footerIdentity
@@ -597,18 +574,6 @@ struct DashboardView: View {
 
     /// Count of enabled ("active") metrics across providers — the "N active" half of the Customize footer
     /// summary. Pinned metrics are a subset of these.
-    private var activeMetricCount: Int {
-        layout.customizeGroups.reduce(0) { count, group in
-            count + group.metrics.filter { layout.isMetricEnabled($0.id) }.count
-        }
-    }
-
-    /// Providers turned on — the "K of P providers on" tail of the Customize footer summary. Counts
-    /// from `customizeProviderRows` (every provider) so a freshly shipped provider counts as "on" even
-    /// before the user has placed any of its metrics.
-    private var providersOn: Int { layout.customizeProviderRows.filter(\.isEnabled).count }
-    private var providersCount: Int { layout.customizeProviderRows.count }
-
     /// Leading side of the footer. Normal mode shows the app name with the live "Next update in …"
     /// line beneath it; Customize mode shows the pin count ("4 pinned") in the same slot.
     /// Settings keeps the normal identity — the version line doubles as the About info there.

--- a/Sources/OpenUsage/Views/ProviderListRow.swift
+++ b/Sources/OpenUsage/Views/ProviderListRow.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+/// One row in the Customize provider list (L1). Carries the provider mark + name, an Active/Inactive
+/// status label, a metric-count badge, the master on/off toggle, and a chevron into the provider's
+/// detail (L2). The leading grip is the drag handle for reordering providers — the caller attaches
+/// the reorder gesture through `handle` (and leaves it inert for the lifted drag preview). The toggle
+/// drives `ProviderEnablementStore`; tapping the name or chevron opens L2. Disabled providers render
+/// greyed (`.opacity 0.55`) but stay visible and openable.
+struct ProviderListRow<Handle: View>: View {
+    let provider: Provider
+    let isEnabled: Bool
+    let metricCount: Int
+    let handle: (AnyView) -> Handle
+    var onToggle: ((Bool) -> Void) = { _ in }
+    var onOpen: () -> Void = {}
+
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    var body: some View {
+        HStack(spacing: 10) {
+            handle(AnyView(ReorderGrip()))
+            Button(action: onOpen) {
+                HStack(spacing: 10) {
+                    ProviderIcon(source: provider.icon)
+                        .frame(width: 18, height: 18)
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack(spacing: 6) {
+                            Text(provider.displayName)
+                                .font(.system(size: density.headerPointSize, weight: .semibold))
+                                .foregroundStyle(isEnabled ? Color.primary : Color.secondary)
+                                .lineLimit(1)
+                            countBadge
+                        }
+                        statusLabel
+                    }
+                    Spacer(minLength: 8)
+                }
+            }
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
+
+            Toggle("", isOn: Binding(get: { isEnabled }, set: { onToggle($0) }))
+                .settingsSwitchStyle()
+
+            Button(action: onOpen) {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 16, height: 16)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Open \(provider.displayName)")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+        .opacity(isEnabled ? 1 : 0.55)
+    }
+
+    private var countBadge: some View {
+        Text("\(metricCount)")
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(.quaternary))
+            .accessibilityLabel("\(metricCount) metrics")
+    }
+
+    private var statusLabel: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(isEnabled ? Theme.positive : AnyShapeStyle(Color.secondary.opacity(0.6)))
+                .frame(width: 6, height: 6)
+            Text(isEnabled ? "Active" : "Inactive")
+                .font(.system(size: density.planBadgePointSize))
+                .foregroundStyle(isEnabled ? Theme.positive : AnyShapeStyle(.secondary))
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/ProviderListRow.swift
+++ b/Sources/OpenUsage/Views/ProviderListRow.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
-/// One row in the Customize provider list (L1). Carries the provider mark + name, an Active/Inactive
-/// status label, a metric-count badge, the master on/off toggle, and a chevron into the provider's
-/// detail (L2). The leading grip is the drag handle for reordering providers — the caller attaches
-/// the reorder gesture through `handle` (and leaves it inert for the lifted drag preview). The toggle
-/// drives `ProviderEnablementStore`; tapping the name or chevron opens L2. Disabled providers render
-/// greyed (`.opacity 0.55`) but stay visible and openable.
+/// One row in the Customize provider list (L1). The drag grip leads (drag-only — a tap on it does
+/// nothing); the middle content (mark + name + count) is tappable to open the provider's detail (L2)
+/// and expands to fill, so the empty space between the name and the toggle is tappable too; the
+/// trailing on/off toggle toggles; the caret after the toggle also opens L2. So: tap anything except
+/// the grip or the toggle to open L2, drag the grip to reorder. The secondary line shows the
+/// provider's total metric count. Disabled providers render greyed but stay openable.
 struct ProviderListRow<Handle: View>: View {
     let provider: Provider
     let isEnabled: Bool
@@ -18,26 +18,30 @@ struct ProviderListRow<Handle: View>: View {
 
     var body: some View {
         HStack(spacing: 10) {
+            // Drag handle only — outside the open target so a tap on the grip doesn't open L2.
             handle(AnyView(ReorderGrip()))
-            Button(action: onOpen) {
-                HStack(spacing: 10) {
-                    ProviderIcon(source: provider.icon)
-                        .frame(width: 18, height: 18)
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack(spacing: 6) {
-                            Text(provider.displayName)
-                                .font(.system(size: density.headerPointSize, weight: .semibold))
-                                .foregroundStyle(isEnabled ? Color.primary : Color.secondary)
-                                .lineLimit(1)
-                            countBadge
-                        }
-                        statusLabel
-                    }
-                    Spacer(minLength: 8)
+
+            // Open target: mark + name + count, expanding to fill so the gap before the toggle is
+            // tappable. `onTapGesture` on a content-shaped, full-width view is the reliable way to make
+            // the whole area (including the empty spacer) hit-test, where a plain Button's hit area
+            // would shrink to its drawn content.
+            HStack(spacing: 10) {
+                ProviderIcon(source: provider.icon)
+                    .frame(width: 18, height: 18)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(provider.displayName)
+                        .font(.system(size: density.headerPointSize, weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text("\(metricCount) metrics")
+                        .font(.system(size: density.planBadgePointSize))
+                        .foregroundStyle(.secondary)
                 }
+                Spacer(minLength: 8)
             }
-            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
+            .onTapGesture { onOpen() }
 
             Toggle("", isOn: Binding(get: { isEnabled }, set: { onToggle($0) }))
                 .settingsSwitchStyle()
@@ -55,26 +59,5 @@ struct ProviderListRow<Handle: View>: View {
         .padding(.horizontal, 12)
         .padding(.vertical, density.controlRowPadding)
         .opacity(isEnabled ? 1 : 0.55)
-    }
-
-    private var countBadge: some View {
-        Text("\(metricCount)")
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 1)
-            .background(Capsule().fill(.quaternary))
-            .accessibilityLabel("\(metricCount) metrics")
-    }
-
-    private var statusLabel: some View {
-        HStack(spacing: 4) {
-            Circle()
-                .fill(isEnabled ? Theme.positive : AnyShapeStyle(Color.secondary.opacity(0.6)))
-                .frame(width: 6, height: 6)
-            Text(isEnabled ? "Active" : "Inactive")
-                .font(.system(size: density.planBadgePointSize))
-                .foregroundStyle(isEnabled ? Theme.positive : AnyShapeStyle(.secondary))
-        }
     }
 }

--- a/Sources/OpenUsage/Views/ReorderGeometry.swift
+++ b/Sources/OpenUsage/Views/ReorderGeometry.swift
@@ -4,7 +4,7 @@ struct ReorderLift {
     enum Payload {
         case dashboardProvider(provider: Provider, plan: String?, rows: [WidgetData])
         case dashboardMetric(data: WidgetData)
-        case customizeProvider(provider: Provider, rows: [String])
+        case customizeProviderRow(provider: Provider, isEnabled: Bool, metricCount: Int)
         case customizeMetric(title: String)
     }
 
@@ -65,8 +65,8 @@ struct ReorderLiftPreview: View {
             dashboardProviderPreview(provider: provider, plan: plan, rows: rows)
         case .dashboardMetric(let data):
             dashboardMetricPreview(data)
-        case .customizeProvider(let provider, let rows):
-            customizeProviderPreview(provider: provider, rows: rows)
+        case .customizeProviderRow(let provider, let isEnabled, let metricCount):
+            customizeProviderRowPreview(provider: provider, isEnabled: isEnabled, metricCount: metricCount)
         case .customizeMetric(let title):
             customizeMetricPreview(title)
         }
@@ -92,28 +92,24 @@ struct ReorderLiftPreview: View {
             .liftedRowSurface()
     }
 
-    private func customizeProviderPreview(provider: Provider, rows: [String]) -> some View {
-        // Same anatomy as the live Customize block (`CustomizeView.providerBlock`): header over the
-        // card of metric rows, at the density's header→card spacing.
-        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
-            ProviderSectionHeader(provider: provider, showsDragHandle: true)
-                .padding(.horizontal, 8)
-
-            VStack(spacing: 0) {
-                ForEach(Array(rows.enumerated()), id: \.offset) { _, title in
-                    CustomizeMetricRow(title: title) {
-                        CustomizeSwitchPlaceholder()
-                    }
-                }
-            }
-            .cardSurface(lifted: true)
-        }
+    private func customizeProviderRowPreview(provider: Provider, isEnabled: Bool, metricCount: Int) -> some View {
+        // Same row anatomy as the live L1 (`ProviderListRow`), rendered inert — the lift's shadow +
+        // scale read as the floating chip, and the whole preview is non-interactive (`.allowsHitTesting`
+        // false in `body`), so the toggle/chevron carry no live action.
+        ProviderListRow(
+            provider: provider,
+            isEnabled: isEnabled,
+            metricCount: metricCount,
+            handle: { $0 }
+        )
+        .liftedRowSurface()
     }
 
     private func customizeMetricPreview(_ title: String) -> some View {
-        CustomizeMetricRow(title: title) {
-            CustomizeSwitchPlaceholder()
-        }
+        CustomizeMetricRow(title: title,
+            leading: { CustomizeSwitchPlaceholder() },
+            trailing: { CustomizeStarPlaceholder() }
+        )
         .liftedRowSurface()
     }
 

--- a/Sources/OpenUsage/Views/ReorderGeometry.swift
+++ b/Sources/OpenUsage/Views/ReorderGeometry.swift
@@ -107,8 +107,10 @@ struct ReorderLiftPreview: View {
 
     private func customizeMetricPreview(_ title: String) -> some View {
         CustomizeMetricRow(title: title,
-            leading: { CustomizeSwitchPlaceholder() },
-            trailing: { CustomizeStarPlaceholder() }
+            trailing: {
+                CustomizeStarPlaceholder()
+                CustomizeSwitchPlaceholder()
+            }
         )
         .liftedRowSurface()
     }

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -120,17 +120,6 @@ struct SettingsScreen: View {
             #if DEBUG
             debugNotificationsSection
             #endif
-            section("Providers") {
-                ForEach(container.registry.providers) { provider in
-                    providerRow(provider)
-                }
-            }
-            // Key management for providers that need a user-supplied key (OpenRouter today). Sits in its
-            // own card so Providers stays pure enable toggles — the Option 2 split from the API-key UX
-            // canvas. Hidden when no installed provider needs a key.
-            if !container.apiKeyProviders.isEmpty {
-                APIKeysSection(providers: container.apiKeyProviders)
-            }
             section("Privacy") {
                 row("Share Anonymous Usage") {
                     Toggle("", isOn: Binding(
@@ -430,21 +419,5 @@ struct SettingsScreen: View {
         .pickerStyle(.menu)
         .labelsHidden()
         .fixedSize()
-    }
-
-    private func providerRow(_ provider: Provider) -> some View {
-        HStack(spacing: 10) {
-            ProviderIcon(source: provider.icon)
-                .frame(width: 18, height: 18)
-            Text(provider.displayName)
-            Spacer(minLength: 8)
-            Toggle("", isOn: Binding(
-                get: { container.enablement.isEnabled(provider.id) },
-                set: { container.enablement.setEnabled($0, for: provider.id) }
-            ))
-            .settingsSwitchStyle()
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, density.controlRowPadding)
     }
 }

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -243,14 +243,14 @@ struct WidgetGroupedListView: View {
 
     /// Desktop-native management for a single metric: hide it, pin/unpin it, refresh its provider, or jump
     /// into Customize — without a trip through Customize first. Hide leads (the most-reached-for verb), then
-    /// pin, then a divider before the two provider-/app-level actions.
+    /// star, then a divider before the two provider-/app-level actions.
     @ViewBuilder
     private func rowMenu(_ descriptor: WidgetDescriptor, providerID: String) -> some View {
         Button("Hide") {
             layout.setMetricEnabled(descriptor.id, false)
         }
         if descriptor.pinnable {
-            Button(layout.isPinned(descriptor.id) ? "Unpin" : "Pin to menu bar") {
+            Button(layout.isPinned(descriptor.id) ? "Unstar" : "Star for menu bar") {
                 if layout.isPinned(descriptor.id) {
                     layout.setPinned(false, for: descriptor.id)
                 } else if layout.canPin(descriptor.id) {

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -664,13 +664,10 @@ final class LayoutStoreTests: XCTestCase {
             ($0.provider.id, $0.expandedMetrics.map(\.id))
         })
 
-        // Claude is de-emphasized: only Session stays primary, the rest go below the caret (a provider
-        // always keeps ≥1 primary row) — see AGENTS.md "## Providers".
-        XCTAssertEqual(primaryByProvider["claude"], ["claude.session"])
-        XCTAssertEqual(expandedByProvider["claude"], [
-            "claude.weekly", "claude.sonnet", "claude.extra", "claude.trend",
-            "claude.today", "claude.yesterday", "claude.last30"
-        ])
+        // Claude's core meters (Session, Weekly, Extra, Usage Trend) stay primary; spend-history rows
+        // go below the caret — the same "core above, history below" shape as the other providers.
+        XCTAssertEqual(primaryByProvider["claude"], ["claude.session", "claude.weekly", "claude.extra", "claude.trend"])
+        XCTAssertEqual(expandedByProvider["claude"], ["claude.sonnet", "claude.today", "claude.yesterday", "claude.last30"])
         XCTAssertEqual(primaryByProvider["codex"], ["codex.session", "codex.weekly", "codex.trend"])
         XCTAssertEqual(expandedByProvider["codex"], [
             "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30"

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -1123,6 +1123,87 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(store.placed.map(\.descriptorID), before)
     }
 
+    // MARK: - Customize master/detail (L1 list + L2 detail)
+
+    func testCustomizeProviderRowsIncludesAllProvidersRegardlessOfEnablement() {
+        // Disable Codex; L1 must still list it (greyed), in the registry's provider order.
+        let store = LayoutStore(
+            registry: .mock,
+            defaults: makeDefaults("RowsIncludeDisabled"),
+            storageKey: "layout",
+            isProviderEnabled: { id in id != "codex" }
+        )
+        XCTAssertEqual(store.customizeProviderRows.map(\.id), MockData.providers.map(\.id))
+        let codex = store.customizeProviderRows.first { $0.id == "codex" }
+        XCTAssertNotNil(codex, "disabled provider stays visible in L1")
+        XCTAssertFalse(codex?.isEnabled ?? true, "disabled provider row reports isEnabled false")
+        XCTAssertTrue(store.customizeProviderRows.first { $0.id == "claude" }?.isEnabled ?? false)
+    }
+
+    func testCustomizeProviderRowsCarriesMetricAndPinnedCounts() {
+        let store = makeStore("RowCounts")
+        for row in store.customizeProviderRows {
+            XCTAssertEqual(row.metricCount, MockData.descriptors(for: row.id).count)
+            XCTAssertEqual(row.pinnedCount, store.pinnedCount(forProvider: row.id))
+        }
+    }
+
+    func testCustomizeDetailReturnsMetricsEvenWhenDisabled() {
+        let store = LayoutStore(
+            registry: .mock,
+            defaults: makeDefaults("DetailWhenDisabled"),
+            storageKey: "layout",
+            isProviderEnabled: { id in id != "codex" }
+        )
+        // customizeGroups drops the disabled provider; customizeDetail does not.
+        XCTAssertNil(store.customizeGroups.first { $0.provider.id == "codex" })
+        let detail = store.customizeDetail(for: "codex")
+        XCTAssertNotNil(detail, "disabled provider still has a detail to render dimmed")
+        XCTAssertEqual(detail?.metrics.map(\.id), store.orderedSupportedMetrics(for: "codex").map(\.id))
+    }
+
+    func testCustomizeDetailSplitsAcrossDivider() {
+        let store = LayoutStore(
+            registry: .mock,
+            defaults: makeDefaults("DetailSplit"),
+            storageKey: "layout",
+            defaultMetricIDs: ["claude.session", "claude.weekly"],
+            defaultExpandedMetricIDs: ["claude.weekly"]
+        )
+        let detail = store.customizeDetail(for: "claude")
+        XCTAssertEqual(detail?.expandedMetrics.map(\.id), ["claude.weekly"])
+        XCTAssertEqual(detail?.alwaysShownMetrics.map(\.id), ["claude.session", "claude.extra", "claude.today"])
+    }
+
+    func testCustomizeDetailIsNilForUnknownProvider() {
+        let store = makeStore("DetailUnknown")
+        XCTAssertNil(store.customizeDetail(for: "nope"))
+    }
+
+    func testMetricCountMatchesRegistryDescriptors() {
+        let store = makeStore("MetricCount")
+        for id in MockData.providers.map(\.id) {
+            XCTAssertEqual(store.metricCount(for: id), MockData.descriptors(for: id).count)
+        }
+        XCTAssertEqual(store.metricCount(for: "missing"), 0)
+    }
+
+    func testCustomizeProviderIDClearsWhenLeavingCustomize() {
+        let store = makeStore("RouteClears")
+        store.screen = .customize
+        store.customizeProviderID = "claude"
+        XCTAssertEqual(store.customizeProviderID, "claude")
+
+        store.screen = .dashboard
+        XCTAssertNil(store.customizeProviderID, "leaving Customize resets the L2 selection back to the list")
+
+        // A direct jump to Settings also clears it — never strand a detail selection on another screen.
+        store.screen = .customize
+        store.customizeProviderID = "codex"
+        store.screen = .settings
+        XCTAssertNil(store.customizeProviderID)
+    }
+
     // MARK: - Share confirmation
 
     /// `clearShareConfirmation` hides the pill immediately and cancels the auto-clear task, so a

--- a/Tests/OpenUsageTests/MenuBarPinTests.swift
+++ b/Tests/OpenUsageTests/MenuBarPinTests.swift
@@ -58,7 +58,7 @@ final class MenuBarPinTests: XCTestCase {
 
         store.setPinned(true, for: "a.m1")
         store.setPinned(true, for: "a.m2")
-        XCTAssertEqual(store.pinDenialReason("a.m3"), "Up to 2 pins per provider")
+        XCTAssertEqual(store.pinDenialReason("a.m3"), "Up to 2 stars per provider")
         XCTAssertNil(store.pinDenialReason("b.m1"))
 
         XCTAssertNil(store.pinDenialReason("b.m1"))
@@ -68,7 +68,7 @@ final class MenuBarPinTests: XCTestCase {
         XCTAssertNil(store.pinLimitNotice)
         XCTAssertEqual(store.pinNoticeShakeTrigger, 0)
         store.notePinDenied("a.m3")
-        XCTAssertEqual(store.pinLimitNotice, "Up to 2 pins per provider")
+        XCTAssertEqual(store.pinLimitNotice, "Up to 2 stars per provider")
         XCTAssertEqual(store.pinNoticeShakeTrigger, 1)
         store.notePinDenied("a.m3")
         XCTAssertEqual(store.pinNoticeShakeTrigger, 2)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -2,7 +2,7 @@
 
 The popover that opens from the menu bar icon. Providers are sections; each section shows the metrics you've enabled.
 
-Each provider card leads with its **always-shown** metrics. Any metrics you've moved below the **Shown on Expand** line are tucked away behind the in-card caret — click it to reveal them below the caret, click again to collapse. Open cards stay open across popover closes and app restarts. A provider with nothing tucked away shows no caret.
+Each provider card leads with its **Always Visible** metrics. Any metrics you've moved below the **On Demand** line are tucked away behind the in-card caret — click it to reveal them below the caret, click again to collapse. Open cards stay open across popover closes and app restarts. A provider with nothing tucked away shows no caret.
 
 When you expand a card, the tucked-away metrics open below the caret as a single-column list, so each detail row keeps the full card width.
 
@@ -23,14 +23,14 @@ A provider card can also show **quick-link buttons** pinned at the bottom of its
 
 **Metrics without a limit** (daily spend, balances) show as a single line like `$4.08 spent` or `1.2M tokens`. The daily spend rows (Today / Yesterday / Last 30 Days) come in three flavors you can add from Customize — cost (`$4.08 spent`), tokens (`1.2M tokens`), or both (`$4.08 · 1.2M tokens`). A day with no usage reads "No data" rather than a misleading `$0.00 · 0 tokens` — the same as when the source can't be loaded at all. Big numbers are abbreviated to keep rows tidy (`$2.06K`, `1.5B`) — hover the value to see the exact figures and source note, such as a local estimate.
 
-**Usage Trend** (Claude, Codex, and Grok) is a small bar chart of the last 30 days of token usage — one bar per day, drawn from the same source as that provider's spend rows (the provider's local logs). **Hover it** for the peak day, the date range, and the source. It's on by default; turn it off or reorder it from Customize like any other metric. It can't be pinned to the menu bar — the strip shows single values, not a chart.
+**Usage Trend** (Claude, Codex, and Grok) is a small bar chart of the last 30 days of token usage — one bar per day, drawn from the same source as that provider's spend rows (the provider's local logs). **Hover it** for the peak day, the date range, and the source. It's on by default; turn it off or reorder it from Customize like any other metric. It can't be starred for the menu bar — the strip shows single values, not a chart.
 
 Rows with a reset date tick every 30 seconds, so countdowns and pace stay live between refreshes.
 
 ## Right-click menus
 
-Every row: **Hide · Pin to menu bar / Unpin · Refresh \<provider\> · Customize…**
-Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on under Settings ▸ Providers.) plus **Share Screenshot** (see below).
+Every row: **Hide · Star for menu bar / Unstar · Refresh \<provider\> · Customize…**
+Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on in Customize.) plus **Share Screenshot** (see below).
 
 ## Share
 
@@ -47,15 +47,19 @@ The bar pinned to the bottom of the popover. On the left: the app version, and a
 
 ## Customize
 
-Open Customize from the **⌄** menu next to the footer's Settings button (or press **Return**): toggle metrics on/off, add ones that aren't placed yet, pin metrics for the menu bar, and drag to reorder. Drag-reorder also works directly on the dashboard — drag a row within its provider, drag it across the caret boundary while the card is open, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
+Open Customize from the **⌄** menu next to the footer's Settings button (or press **Return**). It's a two-level screen: a list of providers, then a provider's detail.
 
-Each provider card has a dashed **Shown on Expand** line. Metrics above it are always shown; metrics below it hide behind the dashboard caret. Drag a metric onto the dashed line to move it across the fold, or drag it onto a row on the other side — drop a metric under an expanded one and it becomes expanded too. Pinning, hiding, and order all work the same on either side.
+The **provider list** shows every provider with a switch to turn it on or off, an Active/Inactive status, a count of its metrics, and a chevron into its detail. Turn a provider off and it stays in the list, greyed — its metrics hide from the dashboard and menu bar but keep their setup for when you turn it back on. Drag providers by their grip to reorder; tap a row to open its detail.
 
-The default reset layout keeps each provider's core quota meters and Usage Trend always shown, then tucks balances, reset details, and spend-history rows behind the caret. Optional detail rows like Claude Sonnet and Cursor Requests/Credits stay off by default, but start below the divider if you enable them.
+A provider's **detail** has a header (the same on/off switch) and two metric sections: **Always Visible** (shown on the dashboard card) and **On Demand** (tucked behind the card's caret). Each metric row is a switch with its name beside it, a star to pin it to the menu bar, and a drag grip. Drag a metric across the dashed divider between the sections to move it between Always Visible and On Demand, or drag it onto a row on the other side. You can star up to two metrics per provider for the menu bar. Providers that need an API key (OpenRouter today) show an **API Key** section here too — add, edit, or clear the key for just that provider.
 
-Made a change you didn't mean to? Press **⌘Z** to undo — it works anywhere in the popover (the main dashboard and Customize alike) and steps back through your recent customization changes one at a time: hiding or showing a metric, reordering metrics or whole providers, pinning or unpinning, and moving a metric across the expand caret all undo. Each step restores the exact previous arrangement. Undo is per-session (it starts fresh after a relaunch), and resetting clears it.
+Drag-reorder also works directly on the dashboard — drag a row within its provider, drag it across the caret boundary while the card is open, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
 
-When OpenUsage ships a new default metric, existing layouts get it once. If you turn it off, it stays off. The **Reset** button in Customize restores the default metrics, order, menu-bar pins, and which metrics start behind the expand caret, but leaves provider settings and other preferences unchanged.
+The default reset layout keeps each provider's core quota meters and Usage Trend always visible, then tucks balances, reset details, and spend-history rows on demand. Optional detail rows like Claude Sonnet and Cursor Requests/Credits stay off by default, but start on demand if you enable them.
+
+Made a change you didn't mean to? Press **⌘Z** to undo — it works anywhere in the popover (the dashboard and Customize alike) and steps back through your recent customization changes one at a time: hiding or showing a metric, reordering metrics or whole providers, starring or unstarring, and moving a metric across the divider all undo. Each step restores the exact previous arrangement. Undo is per-session (it starts fresh after a relaunch), and resetting clears it.
+
+When OpenUsage ships a new default metric, existing layouts get it once. If you turn it off, it stays off. The **Reset** button in Customize restores the default metrics, order, menu-bar stars, and which metrics start on demand, but leaves other preferences unchanged.
 
 ## Keyboard
 

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -1,27 +1,27 @@
 # Menu Bar
 
-Pin your most important metrics straight into the menu bar strip.
+Star your most important metrics straight into the menu bar strip.
 
 ## Right-clicking the icon
 
 Right-click (or control-click) the menu bar icon for a quick menu with **Settings** and **Quit**. Left-click opens the popover as usual.
 
-## Pinning
+## Starring
 
-Pin from any row's right-click menu, or from the pin that appears when hovering rows in Customize.
+Star a metric from any row's right-click menu, or from the star that appears when hovering rows in Customize.
 
-- On first launch the app ships with a default set of pins (Claude Session/Weekly, Codex Session/Weekly, Cursor Auto Usage/API Usage) so the strip shows numbers right away. Change them anytime; Reset in Customize restores this set.
-- At most **2 pins per provider**.
-- When a pin isn't allowed, the pin button stays clickable — clicking it shakes and shows the reason in the footer (e.g. "Up to 2 pins per provider").
-- The Customize footer shows your count: `n pinned`.
+- On first launch the app ships with a default set of stars (Claude Session/Weekly, Codex Session/Weekly, Cursor Auto Usage/API Usage) so the strip shows numbers right away. Change them anytime; Reset in Customize restores this set.
+- At most **2 stars per provider**.
+- When a star isn't allowed, the star button stays clickable — clicking it shakes and shows the reason in the footer (e.g. "Up to 2 stars per provider").
+- The Customize footer shows your count: `n starred`.
 
 ## Styles
 
 Settings → Appearance → Menu Style:
 
-- **Text** — provider icon plus values; two pinned metrics from the same provider stack as a labeled pair.
-- **Bars** — compact vertical bars, one per pinned metric that has a limit (metrics without limits only appear in Text style).
+- **Text** — provider icon plus values; two starred metrics from the same provider stack as a labeled pair.
+- **Bars** — compact vertical bars, one per starred metric that has a limit (metrics without limits only appear in Text style).
 
 ## What the strip shows
 
-The strip only renders real data. A pinned metric with nothing fetched yet is skipped; a provider whose pins all lack data disappears entirely (icon included). When nothing has data, the strip falls back to the app icon. Pins follow your Customize order — always-shown metrics first, then ones behind the expand caret. A metric can be pinned whether it's always shown or tucked behind the caret.
+The strip only renders real data. A starred metric with nothing fetched yet is skipped; a provider whose stars all lack data disappears entirely (icon included). When nothing has data, the strip falls back to the app icon. Stars follow your Customize order — Always Visible metrics first, then On Demand ones. A metric can be starred whether it's Always Visible or On Demand.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -40,10 +40,6 @@ Each alert fires **once per metric per reset period**, so you get a heads-up wit
 
 All three alerts default off. The first time you turn one on, OpenUsage asks for notification permission; if you decline (or turn notifications off for OpenUsage in System Settings later), a warning mark appears on the Notifications header and an "Open System Settings" button shows under the toggles so you can re-enable them. A notification's title is the alert name, its subtitle names the provider and metric, and its body is the plain-language verdict.
 
-## Providers
-
-One switch per provider. Turning a provider **off** hides it everywhere (dashboard, Customize, menu bar, the collection endpoint of the [local HTTP API](local-http-api.md)) and pauses its updates. Nothing is deleted — turning it back on restores its metrics and order.
-
 ## Privacy
 
 | Setting | Options | What it does |


### PR DESCRIPTION
## TL;DR
Customize becomes a two-level screen — a provider list (L1) and a per-provider detail (L2) — with provider on/off and API key management moved out of Settings into Customize, pins renamed to stars, and two distinct **Always Visible** / **On Demand** metric cards with grip-initiated drag across them.

## What was happening
- Customize was one flat list of enabled providers; disabled providers were hidden entirely from Customize.
- Provider on/off lived in Settings ▸ Providers; API key management in Settings ▸ API Keys.
- Menu-bar metrics used a pin icon/verb.
- The metric sections were a single card with an internal divider (no explicit Always Visible / On Demand labels).

## What this changes
- **L1 (provider list):** every provider as a row (including disabled ones, greyed), with a master on/off toggle, an "x metrics" count, and a caret into L2. The whole bar (minus the drag grip and the toggle) opens L2; the grip reorders. No footer.
- **L2 (provider detail):** two distinct **Always Visible** and **On Demand** cards. Drag a metric by its grip onto a row in the other card (or into an empty card's "Drag metrics here" drop zone) to move it across. Rows are grip · name · star · toggle. A per-provider **Reset** button replaces the old 3-dot menu. No provider header (the name is in the top bar) and no footer — the on/off toggle lives on L1, so turning a provider off is done from the list.
- **Stars:** pin → star (icon + friendlier copy only — internal names like `pinnedMetricIDs`/`canPin`/`togglePin` are unchanged, so no persistence/telemetry change). Stars are always visible (outline gray / filled accent). Tapping pops a transient confirmation pill (green on star/unstar, orange + shake on the per-provider cap); star tooltips removed.
- **Relocations:** provider on/off and API keys move from Settings into Customize (the L1 row toggle for on/off; a per-provider "API Key" section in L2 for keys). Settings ▸ Providers and Settings ▸ API Keys are removed.
- **Navigation:** in-house L1↔L2 route via `LayoutStore.customizeProviderID` (no `NavigationStack` — the resizable popover chrome wouldn't accommodate it). Back chevron, Esc, and Return are context-aware (L2 → L1 → dashboard); the top-bar title swaps to the provider name.
- **Footer:** the Customize footer summary is retired; the dashboard footer is unchanged.
- **Claude default:** keep Session/Weekly/Extra/Usage Trend Always Visible so Claude matches the other providers' "core above, history below" shape (was Session-only primary).

## Heads-up
- **Cross-card drag:** the L2 reorder gesture lives on the section stack (container), not per-row, so it survives a metric crossing between the two cards' `ForEach`es — a per-row gesture tore the dragged row down mid-drag and force-dropped. Initiation is grip-only (each grip publishes its own frame). Trade-off: dragging across a card completes that cross on the existing drag; continuous multi-cross dragging in one motion isn't supported.
- **No migration:** the star rename is copy/icon only; on-disk keys and the telemetry field names are stable (no snapshot-cache bump).
- **Settings:** loses the Providers and API Keys sections (both moved into Customize). API key providers that aren't represented in the registry would no longer have a Settings home — none exist today (OpenRouter is the only one, and it has a registry entry).
- **L2 has no on/off toggle by design:** the provider header was removed from L2; on/off lives on the L1 row. This is intentional, not an oversight.
- macOS 15 path is covered by the existing `LiquidGlassFallbacks` `#available` branches; no new 26-only API is introduced.

## Tests
- New `LayoutStoreTests` for the L1/L2 accessors: `customizeProviderRows` includes disabled providers in order, `customizeDetail(for:)` returns metrics even when disabled, `metricCount`, and `customizeProviderID` clears when leaving Customize.
- Updated `testFreshDefaultLayoutMatchesRecommendedMetricSections` for Claude's new Always Visible set; `MenuBarPinTests` denial copy updated to "stars".
- Full suite: 665 tests, 0 failures (1 pre-existing skip). Note: `swift test` needs `Sparkle.framework` embedded into the `OpenUsageTests.xctest` bundle (SwiftPM doesn't do this for tests) — staged via `ditto` into `Contents/Frameworks/`.

## Screenshots
_(to be added manually)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted layout semantics only lightly (Claude default fold for new seeds; star rename is copy-only), but rehomes provider enablement and API key UX and rewrites Customize navigation/drag behavior where regressions would be user-visible.
> 
> **Overview**
> **Customize** is rebuilt as **L1 provider list → L2 per-provider detail** (`LayoutStore.customizeProviderID`), with horizontal slides and context-aware back/Esc/Return (L2 → L1 → dashboard). L1 lists **all** providers (disabled rows stay visible/greyed) with on/off, metric count, reorder grip, and chevron; L2 splits metrics into separate **Always Visible** and **On Demand** cards, grip-only drag across cards via a **container-level** gesture (avoids mid-drag teardown), per-provider **Reset** in the nav bar, embedded **API Key** section, and no Customize footer.
> 
> **Settings** drops **Providers** and **API Keys**; enablement and keys live in Customize instead.
> 
> **Menu bar pinning** is user-facing **stars** (copy/tooltips/context menu); stars are always visible on metric rows with green/orange **floating pills** in Customize (`presentCustomizationNotice`) instead of hover pins and the old footer pin summary.
> 
> **Defaults:** fresh installs tuck fewer Claude metrics behind the caret—**Session, Weekly, Extra, and Usage Trend** stay above the fold; spend/history rows go **On Demand**.
> 
> Docs (`dashboard`, `menu-bar`, `settings`) and tests cover L1/L2 store APIs, routing reset, and the Claude default layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1bb268d7641d79081e8fc69a88ace4a1af2f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->