### PR TITLE
chore: strict issue-first PR policy + faster stale + AGENTS-aligned PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,33 @@
-## Description
+<!-- OpenUsage has a strict, issue-first PR policy. External pull requests are closed
+automatically unless they link an issue a maintainer has approved with the `approved`
+label, stay under 1,000 changed lines, and include screenshots for visual changes.
+See CONTRIBUTING.md. Maintainers and collaborators may open PRs directly. -->
 
-<!-- What does this PR do and why? -->
+## Approved issue
 
-## Related Issue
+<!-- External PRs require an open issue approved with the `approved` label. -->
+Fixes #
 
-<!-- Link to the issue this PR addresses: Fixes #123 -->
+## TL;DR
 
-## Type of Change
+<!-- One or two plain-English sentences: what does this PR do? -->
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] New provider
-- [ ] Documentation
-- [ ] Performance improvement
-- [ ] Other (describe below)
+## What was happening
 
-## Testing
+<!-- The prior behavior, bug, or gap that motivated this change. -->
 
-- [ ] I ran `swift build` and it succeeded
-- [ ] I ran `swift test` and all tests pass
-- [ ] I tested the change locally with `./script/build_and_run.sh`
+## What this changes
+
+<!-- What this PR actually changes. -->
+
+## Heads-up
+
+<!-- Optional: risks, follow-ups, or trade-offs a reviewer should know. Delete if none. -->
+
+## Tests
+
+<!-- Optional: how you verified the change. Delete if none. -->
 
 ## Screenshots
 
-<!-- Required for UI changes. Remove this section if not applicable. -->
-
-## Checklist
-
-- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
-- [ ] My PR targets the `main` branch
-- [ ] **Behavior change?** I updated the matching `docs/` page(s) in this same PR (required when user-visible behavior changes — a docs/code mismatch is treated as a bug)
-- [ ] I did not introduce new dependencies without justification
+<!-- Required for any visual change: include before/after images. Write "Not applicable" if this isn't a visual change. -->

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,10 +2,6 @@ provider:
   - changed-files:
       - any-glob-to-any-file: "Sources/OpenUsage/Providers/**"
 
-core:
-  - changed-files:
-      - any-glob-to-any-file: "Sources/**"
-
 tests:
   - changed-files:
       - any-glob-to-any-file: "Tests/**"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,16 +16,16 @@ jobs:
       - uses: actions/stale@v10
         with:
           stale-issue-message: >
-            This issue has been inactive for 7 days. It will be closed in 7 days
+            This issue has been inactive for 7 days. It will be closed in 3 days
             unless there is new activity. If this is still relevant, please comment.
           stale-pr-message: >
-            This PR has been inactive for 7 days. It will be closed in 7 days
+            This PR has been inactive for 7 days. It will be closed in 3 days
             unless there is new activity. If this is still relevant, please comment
             or push an update.
           close-issue-message: Closed due to inactivity.
           close-pr-message: Closed due to inactivity.
           days-before-stale: 7
-          days-before-close: 7
+          days-before-close: 3
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: "pinned,security,approved,help wanted"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,17 +16,17 @@ jobs:
       - uses: actions/stale@v10
         with:
           stale-issue-message: >
-            This issue has been inactive for 30 days. It will be closed in 7 days
+            This issue has been inactive for 7 days. It will be closed in 7 days
             unless there is new activity. If this is still relevant, please comment.
           stale-pr-message: >
-            This PR has been inactive for 30 days. It will be closed in 7 days
+            This PR has been inactive for 7 days. It will be closed in 7 days
             unless there is new activity. If this is still relevant, please comment
             or push an update.
           close-issue-message: Closed due to inactivity.
           close-pr-message: Closed due to inactivity.
-          days-before-stale: 30
+          days-before-stale: 7
           days-before-close: 7
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: "pinned,security,help wanted"
-          exempt-pr-labels: "pinned,security"
+          exempt-issue-labels: "pinned,security,approved,help wanted"
+          exempt-pr-labels: "pinned,security,keep-open,approved,pre-approved"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,4 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: "pinned,security,approved,help wanted"
-          exempt-pr-labels: "pinned,security,keep-open,approved,pre-approved"
+          exempt-pr-labels: "pinned,security,keep-open,approved,gate-passed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,33 @@
 # Contributing to OpenUsage
 
-OpenUsage accepts contributions, but has a high quality bar. Read this entire document before opening a PR.
+OpenUsage accepts contributions through a strict, issue-first workflow, and the quality bar is deliberately high. **By design, most external pull requests are closed** — automation closes any that don't follow the rules below. Read this entire document before opening a PR.
 
 ## Philosophy
 
 OpenUsage is highly opinionated. It focuses on clean design, fast performance, and a great user experience. The feature set is intentionally limited to core functionality: tracking AI coding subscription usage, nothing more. Contributions that try to expand that scope, add unnecessary complexity, or compromise the UX will be closed.
 
-If you're unsure whether your idea fits, open an issue first.
+If you're unsure whether your idea fits, open an issue first. External pull requests without a linked, maintainer-approved issue are closed automatically — without review.
 
 ## Ground Rules
 
+- **Open an approved issue first.** External PRs must link an open issue a maintainer has approved with the `approved` label. No approved issue, no review.
+- **Most external PRs get closed, by design.** It's not personal — it keeps a small, focused project sane. See the Pull Request Policy below.
 - No feature creep. If it's not about usage tracking, it doesn't belong here.
 - No AI-generated commit messages. Write your own.
 - Test your changes. If it touches UI, include before/after screenshots.
 - Keep it simple. Don't over-engineer.
 - One PR per concern. Don't bundle unrelated changes.
 - Match the existing design language. OpenUsage has a specific look and feel — [AGENTS.md](AGENTS.md) documents the display conventions.
+
+## Pull Request Policy
+
+External pull requests are gatekept automatically and **closed** if they:
+
+- **Have no approved issue** — they don't link an open issue labeled `approved`.
+- **Are too large** — they change more than 1,000 lines. Split the work into smaller PRs.
+- **Miss screenshots** — they make a visual change without before/after screenshots.
+
+Closures aren't personal and are reversible: get the issue approved (or fix the problem), then reopen or open a focused replacement. Maintainers and collaborators may open PRs directly, and can override the automation with the `keep-open` label.
 
 ## License Agreement
 
@@ -25,17 +37,18 @@ By submitting a pull request, you agree that your contribution is licensed under
 
 ### Fork and PR workflow
 
-1. Fork the repo
-2. Create a branch (`feat/my-change`, `fix/some-bug`, etc.)
-3. Make your changes
-4. Run `swift build` and `swift test` to verify nothing is broken
-5. Open a PR against `main`
+1. Open an issue describing the change, and wait for a maintainer to approve it with the `approved` label
+2. Fork the repo
+3. Create a branch (`feat/my-change`, `fix/some-bug`, etc.)
+4. Make only the approved change
+5. Run `swift build` and `swift test` to verify nothing is broken
+6. Open a PR against `main` and link the approved issue with `Fixes #<issue>`
 
 ### Add a provider
 
 Each provider is a small Swift module under `Sources/OpenUsage/Providers/<Name>/` that conforms to `ProviderRuntime`: an auth store reads credentials already on the user's machine, a usage client calls the provider's API, and a mapper normalizes the response into metric lines. See [docs/adding-a-provider.md](docs/adding-a-provider.md) for the full walkthrough (and [docs/architecture.md](docs/architecture.md) for how the pieces fit together).
 
-1. Check open issues and `docs/providers/` to see if it's already requested or in progress
+1. Open an issue and get it approved (`approved` label) — include why the provider fits and how its usage data is accessible
 2. Create `Sources/OpenUsage/Providers/<Name>/` and implement `ProviderRuntime`
 3. Register the provider in `AppContainer`
 4. Add focused tests under `Tests/OpenUsageTests/`
@@ -47,14 +60,14 @@ You can also [open an issue](https://github.com/robinebers/openusage/issues/new?
 
 ### Fix a bug
 
-1. Reference the issue number in your PR
+1. Reference the approved issue number in your PR
 2. Describe the root cause and fix
 3. Include before/after screenshots for UI bugs
 4. Add a regression test if applicable
 
 ### Request a feature
 
-Don't open a PR for large features without discussing first. [Open an issue](https://github.com/robinebers/openusage/issues/new?template=feature_request.yml) and make your case.
+Don't open a PR for a feature without an approved issue first. [Open an issue](https://github.com/robinebers/openusage/issues/new?template=feature_request.yml), make your case, and wait for the `approved` label.
 
 ## What Gets Accepted
 
@@ -66,6 +79,8 @@ Don't open a PR for large features without discussing first. [Open an issue](htt
 
 ## What Gets Rejected
 
+- External PRs without an approved issue (closed automatically)
+- PRs over 1,000 lines, or that bundle unrelated changes
 - Features that expand the scope beyond usage tracking
 - Changes that compromise speed, simplicity, or the existing UX
 - PRs without testing evidence

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The repository must be public (Sparkle fetches the DMG and appcast anonymously),
 
 ## Contributing
 
-Issues and PRs are welcome — read [CONTRIBUTING.md](CONTRIBUTING.md) first; the quality bar is deliberately high. Report security issues privately per [SECURITY.md](SECURITY.md). The OpenUsage name and logo are covered by the [trademark policy](TRADEMARK.md).
+Issues are welcome. Pull requests are **strict and issue-first**: external PRs must link an issue a maintainer has approved with the `approved` label, and automation closes anything that doesn't follow the rules — so **most external PRs are closed by design**. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening one. Report security issues privately per [SECURITY.md](SECURITY.md). The OpenUsage name and logo are covered by the [trademark policy](TRADEMARK.md).
 
 ## License
 


### PR DESCRIPTION
**TL;DR**

Tighten OpenUsage into a simple, strict, issue-first PR policy: align the PR template with the format documented in AGENTS.md, make the "most external PRs are closed by design" stance explicit in CONTRIBUTING and the README, speed up stale archiving, and drop a dead labeler rule.

**What was happening**

- The PR template (`Description` / `Related Issue` / `Type of Change` / checklist) didn't match the PR description format documented in `AGENTS.md` (TL;DR → What was happening → What this changes → Heads-up → Tests → Screenshots).
- CONTRIBUTING and the README didn't state the strict, issue-first policy — that external PRs need a maintainer-approved issue and that most get closed automatically.
- The Stale workflow waited 30 days before flagging inactivity, which is slow for keeping the queue clear.
- `labeler.yml` still mapped a `core` label (since deleted) to `Sources/**` — it tagged nearly every code PR and overlapped `provider`.

**What this changes**

- **PR template** now follows the `AGENTS.md` structure, plus an `Approved issue` (`Fixes #`) section at the top and a `Screenshots` section with the "Not applicable" convention the gatekeeper checks.
- **CONTRIBUTING.md** adds a short **Pull Request Policy** (the three auto-close rules: no approved issue · over 1,000 lines · visual change without screenshots), states external PRs need an issue labeled `approved`, and says closures are reversible (`keep-open` override).
- **README.md** contributing blurb now states the strict, issue-first policy up front.
- **Stale workflow**: 30 → **7 days** to stale (close still +7 days); now exempts `approved`, `keep-open`, and `gate-passed` so approved issues and gate-passed/maintainer-protected PRs are never swept.
- **labeler.yml**: removed the `core` rule (the label is gone).

**Heads-up**

- Enforcement of the three rules lives in a separate scheduled/triggered **gatekeeper automation** (outside this repo). This PR is only the docs + config side.
- Label changes were already applied to the repo directly: deleted `core`, `release`, `good first issue`, `question`, and the unused `needs-author-action` / `blocked-on-maintainer` / `needs-ai-disclosure` / `needs-human-explanation`; renamed `status:approved` → `approved`; added `gate-passed`.
- Repo **settings** recommendations (fork-workflow approval tier, read-only default token, branch protection / required checks) are not in this diff — they need to be toggled in the GitHub UI.

**Tests**

- Validated `stale.yml`, `labeler.yml`, and `workflows/labeler.yml` with Ruby's YAML parser.

**Screenshots**

Not applicable (docs and CI config only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and GitHub workflow/labeler config only; no application runtime or security-sensitive code paths change.
> 
> **Overview**
> Documents and configures a **strict, issue-first** contribution model: external PRs need a linked issue with the `approved` label, and automation is described as closing most PRs that break size, screenshot, or approval rules.
> 
> The **PR template** is rewritten to match **AGENTS.md** (TL;DR → What was happening → What this changes → Heads-up → Tests → Screenshots), with an **Approved issue** / `Fixes #` section and a header pointing contributors to **CONTRIBUTING.md**. **CONTRIBUTING.md** adds a **Pull Request Policy** (three auto-close rules, `keep-open` override) and updates fork/PR, provider, bug, and feature flows to require approval first. **README.md**’s contributing blurb states the same stance up front.
> 
> **Stale** timing moves from 30+7 days to **7+3** days, with new exemptions for `approved`, `keep-open`, and `gate-passed`. **labeler.yml** drops the obsolete **`core`** rule that tagged all of `Sources/**`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e89cab5ab0660135a13bdbca61f52b2f854055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->