### PR TITLE
fix(tests): allow OpenRouter Activity/Credits quick-link labels

### DIFF
--- a/Tests/OpenUsageTests/ProviderLinksTests.swift
+++ b/Tests/OpenUsageTests/ProviderLinksTests.swift
@@ -75,7 +75,7 @@ final class ProviderLinksTests: XCTestCase {
     /// Every installed provider ships at most two quick links with standard labels.
     @MainActor
     func testInstalledProvidersRespectQuickLinkCap() {
-        let allowed = Set(["Status", "Dashboard", "API Keys", "Usage"])
+        let allowed = Set(["Status", "Dashboard", "API Keys", "Usage", "Activity", "Credits"])
         let providers: [ProviderRuntime] = [
             ClaudeProvider(), CodexProvider(), CursorProvider(),
             AntigravityProvider(), CopilotProvider(), DevinProvider(),


### PR DESCRIPTION
**TL;DR**

Fix the red `main`: the quick-link test rejected OpenRouter's `Activity` and `Credits` labels that #795 shipped.

**What was happening**

- #795 (`feat(openrouter): add Activity and Credits quick-link buttons`) added two quick links to OpenRouter labelled `Activity` and `Credits`.
- `ProviderLinksTests.testInstalledProvidersRespectQuickLinkCap` enforces an allow-list of "standard" quick-link labels (`Status`, `Dashboard`, `API Keys`, `Usage`) and was never updated for the new labels.
- As a result `main` has been failing the `Build and Test` CI check since #795 merged — and because that check is required by branch protection, it blocks every other PR from merging.

**What this changes**

- Adds `Activity` and `Credits` to the allow-list so the test reflects the shipped UI. No production code changes.

**Tests**

- This is a test-only change; CI's `Build and Test` job confirms the suite is green again.

**Screenshots**

Not applicable (test-only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to an assertion allow-list; no runtime behavior.
> 
> **Overview**
> Unblocks CI after OpenRouter gained **Activity** and **Credits** quick links: `testInstalledProvidersRespectQuickLinkCap` only permitted `Status`, `Dashboard`, `API Keys`, and `Usage`, so the new labels failed the “standard label” assertion.
> 
> The allow-list in `ProviderLinksTests` now includes **Activity** and **Credits**. No app or provider code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1700aa2d617e954b529889c2dcb6c12fa66a6f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->