### PR TITLE
feat(codex): bring back GPT-5.3-Codex-Spark rate-limit meters

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -33,6 +33,11 @@ final class CodexProvider: ProviderRuntime {
         [
             .percent(id: "codex.session", provider: provider, title: "Session"),
             .percent(id: "codex.weekly", provider: provider, title: "Weekly"),
+            // Model-specific Spark limits (GPT-5.3-Codex-Spark), parsed from `additional_rate_limits`.
+            // Declared right after Weekly so they group with the core rate-limit meters; seeded as
+            // secondary (below the caret) and unpinned in `DefaultLayout`.
+            .percent(id: "codex.spark", provider: provider, title: "Spark"),
+            .percent(id: "codex.sparkWeekly", provider: provider, title: "Spark Weekly"),
             .combined(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
             .values(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
             .usageTrend(provider: provider)

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -76,6 +76,11 @@ enum CodexUsageMapper {
             ))
         }
 
+        // Model-specific limits (e.g. GPT-5.3-Codex-Spark) ride in a separate `additional_rate_limits`
+        // array, each entry reusing the primary/secondary window shape. Surfaced as their own Spark /
+        // Spark Weekly meters (issue #796) — the JS edition had these; the Swift rewrite dropped them.
+        lines.append(contentsOf: sparkLines(body: body, now: now))
+
         // On-demand rate-limit reset credits, shown before Credits — mirrors the JS plugin (PR #577).
         // The row reads "2 available" (the count is carried raw, so the menu-bar tile reads the same
         // number); each still-available credit's expiry rides along in `expiriesAt` and surfaces in the
@@ -112,6 +117,58 @@ enum CodexUsageMapper {
             resetsAt: resetDate(resetWindow, now: now),
             periodDurationMs: periodDurationMs
         )
+    }
+
+    /// Spark (and any future model-specific) limits from `additional_rate_limits`. Each array entry is a
+    /// named limit whose `rate_limit` reuses the primary (5-hour) / secondary (weekly) window shape, so
+    /// the parsing mirrors the core Session/Weekly path exactly — including the fresh-window 1%→0
+    /// normalization. We surface the entry whose `limit_name`/`metered_feature` names Spark as the
+    /// `Spark` and `Spark Weekly` meters; a non-dictionary or null array element is skipped rather than
+    /// discarding its valid siblings. Returns an empty list when the field is absent or carries no Spark
+    /// entry (the common case for accounts without the limit), so those rows simply read "No data".
+    private static func sparkLines(body: [String: Any], now: Date) -> [MetricLine] {
+        guard let rawEntries = body["additional_rate_limits"] as? [Any] else { return [] }
+        let entries = rawEntries.compactMap { $0 as? [String: Any] }
+        guard let spark = entries.first(where: isSparkEntry),
+              let rateLimit = spark["rate_limit"] as? [String: Any]
+        else {
+            return []
+        }
+
+        var lines: [MetricLine] = []
+        let primaryWindow = rateLimit["primary_window"] as? [String: Any]
+        let secondaryWindow = rateLimit["secondary_window"] as? [String: Any]
+
+        if let used = ProviderParse.number(primaryWindow?["used_percent"]) {
+            let periodDurationMs = readPeriodMs(primaryWindow) ?? sessionPeriodMs
+            lines.append(progress(
+                label: "Spark",
+                used: normalizedUsedPercent(used, resetWindow: primaryWindow, now: now, periodDurationMs: periodDurationMs),
+                resetWindow: primaryWindow,
+                now: now,
+                periodDurationMs: periodDurationMs
+            ))
+        }
+        if let used = ProviderParse.number(secondaryWindow?["used_percent"]) {
+            let periodDurationMs = readPeriodMs(secondaryWindow) ?? weeklyPeriodMs
+            lines.append(progress(
+                label: "Spark Weekly",
+                used: normalizedUsedPercent(used, resetWindow: secondaryWindow, now: now, periodDurationMs: periodDurationMs),
+                resetWindow: secondaryWindow,
+                now: now,
+                periodDurationMs: periodDurationMs
+            ))
+        }
+        return lines
+    }
+
+    /// True when an `additional_rate_limits` entry is the Spark limit — matched on either `limit_name`
+    /// ("GPT-5.3-Codex-Spark") or `metered_feature`, case-insensitively, so a wording change on either
+    /// field still resolves it.
+    private static func isSparkEntry(_ entry: [String: Any]) -> Bool {
+        [entry["limit_name"], entry["metered_feature"]]
+            .compactMap { ($0 as? String)?.lowercased() }
+            .contains { $0.contains("spark") }
     }
 
     private static func resetDate(_ window: [String: Any]?, now: Date) -> Date? {

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -12,7 +12,7 @@ enum DefaultLayout {
         "claude.session", "claude.weekly", "claude.trend",
         "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
 
-        "codex.session", "codex.weekly", "codex.trend",
+        "codex.session", "codex.weekly", "codex.spark", "codex.sparkWeekly", "codex.trend",
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
 
         "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend",
@@ -75,6 +75,9 @@ enum DefaultLayout {
         // Claude's core meters (Session, Weekly, Extra, Usage Trend) stay above the fold; spend-history
         // rows sit below the caret. Matches every other provider's "core above, history below" shape.
         "claude.sonnet", "claude.today", "claude.yesterday", "claude.last30",
+        // Codex's core Session/Weekly meters and Usage Trend stay above the fold; Spark (the optional
+        // model-specific limits), credits, reset details, and spend rows sit below the caret.
+        "codex.spark", "codex.sparkWeekly",
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
         "cursor.onDemand", "cursor.requests", "cursor.credits",
         "cursor.today", "cursor.yesterday", "cursor.last30",

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -242,6 +242,99 @@ final class CodexUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 7)
     }
 
+    func testSurfacesSparkLinesFromAdditionalRateLimits() throws {
+        // The usage body carries model-specific limits in `additional_rate_limits`; the Spark entry's
+        // primary/secondary windows become the Spark (5-hour) and Spark Weekly meters. Regression for
+        // issue #796 — the Swift edition dropped these when it didn't port the JS plugin's parsing.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let nowSec = Int(now.timeIntervalSince1970)
+        let body = Data("""
+        {
+          "rate_limit": {
+            "primary_window": { "used_percent": 5, "reset_after_seconds": 60 },
+            "secondary_window": { "used_percent": 10, "reset_after_seconds": 120 }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "GPT-5.3-Codex-Spark",
+              "metered_feature": "codex_bengalfox",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 25,
+                  "limit_window_seconds": 18000,
+                  "reset_after_seconds": 3600,
+                  "reset_at": \(nowSec + 3600)
+                },
+                "secondary_window": {
+                  "used_percent": 40,
+                  "limit_window_seconds": 604800,
+                  "reset_after_seconds": 86400,
+                  "reset_at": \(nowSec + 86400)
+                }
+              }
+            }
+          ]
+        }
+        """.utf8)
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(response, now: now)
+
+        XCTAssertEqual(progress(mapped.lines, "Spark")?.used, 25)
+        XCTAssertEqual(progress(mapped.lines, "Spark")?.periodDurationMs, 18_000_000)
+        XCTAssertEqual(progress(mapped.lines, "Spark")?.resetsAt,
+                       Date(timeIntervalSince1970: TimeInterval(nowSec + 3600)))
+        XCTAssertEqual(progress(mapped.lines, "Spark Weekly")?.used, 40)
+        XCTAssertEqual(progress(mapped.lines, "Spark Weekly")?.periodDurationMs, 604_800_000)
+        // The core Session/Weekly windows are unaffected by the new parsing.
+        XCTAssertEqual(progress(mapped.lines, "Session")?.used, 5)
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 10)
+    }
+
+    func testMatchesSparkByMeteredFeatureWhenLimitNameLacksSpark() throws {
+        // `limit_name` wording can shift; matching `metered_feature` too keeps the row resolving.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let body = Data("""
+        {
+          "additional_rate_limits": [
+            {
+              "limit_name": "Research Preview",
+              "metered_feature": "codex_spark_preview",
+              "rate_limit": { "primary_window": { "used_percent": 12, "reset_after_seconds": 60 } }
+            }
+          ]
+        }
+        """.utf8)
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(response, now: now)
+
+        XCTAssertEqual(progress(mapped.lines, "Spark")?.used, 12)
+    }
+
+    func testIgnoresNonSparkAndMalformedAdditionalRateLimits() throws {
+        // Non-Spark model limits have no descriptors, so they aren't surfaced; a null/non-dictionary
+        // element is skipped without discarding its siblings; a Spark entry missing `rate_limit` yields
+        // no lines. None of this should ever throw.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let body = Data("""
+        {
+          "additional_rate_limits": [
+            null,
+            { "limit_name": "Some Other Model", "rate_limit": { "primary_window": { "used_percent": 50, "reset_after_seconds": 60 } } },
+            { "limit_name": "GPT-5.3-Codex-Spark" }
+          ]
+        }
+        """.utf8)
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(response, now: now)
+
+        XCTAssertNil(progress(mapped.lines, "Spark"))
+        XCTAssertNil(progress(mapped.lines, "Spark Weekly"))
+        XCTAssertNil(progress(mapped.lines, "Some Other Model"))
+    }
+
     func testAppendsTokenUsageLines() {
         var lines: [MetricLine] = []
         let usage = DailyUsageSeries(daily: [

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -614,7 +614,8 @@ final class LayoutStoreTests: XCTestCase {
             "claude.trend", "claude.today", "claude.yesterday", "claude.last30"
         ])
         XCTAssertEqual(store.orderedSupportedMetrics(for: "codex").map(\.id), [
-            "codex.session", "codex.weekly", "codex.credits", "codex.rateLimitResets",
+            "codex.session", "codex.weekly", "codex.spark", "codex.sparkWeekly",
+            "codex.credits", "codex.rateLimitResets",
             "codex.trend", "codex.today", "codex.yesterday", "codex.last30"
         ])
         XCTAssertEqual(store.orderedSupportedMetrics(for: "devin").map(\.id), [
@@ -644,7 +645,7 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(Set(store.placed.map(\.descriptorID)), Set([
             "claude.session", "claude.weekly", "claude.trend",
             "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
-            "codex.session", "codex.weekly", "codex.trend",
+            "codex.session", "codex.weekly", "codex.spark", "codex.sparkWeekly", "codex.trend",
             "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
             "devin.daily", "devin.weekly", "devin.extra",
             "grok.creditsUsed", "grok.trend",
@@ -669,7 +670,9 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(primaryByProvider["claude"], ["claude.session", "claude.weekly", "claude.extra", "claude.trend"])
         XCTAssertEqual(expandedByProvider["claude"], ["claude.sonnet", "claude.today", "claude.yesterday", "claude.last30"])
         XCTAssertEqual(primaryByProvider["codex"], ["codex.session", "codex.weekly", "codex.trend"])
+        // Spark (the optional model-specific limits) leads the expanded section, before credits.
         XCTAssertEqual(expandedByProvider["codex"], [
+            "codex.spark", "codex.sparkWeekly",
             "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30"
         ])
         XCTAssertEqual(primaryByProvider["devin"], ["devin.daily", "devin.weekly"])

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -8,6 +8,7 @@ Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI
 |---|---|
 | Session | 5-hour rolling window usage |
 | Weekly | 7-day window usage |
+| Spark / Spark Weekly | GPT-5.3-Codex-Spark model limits — a 5-hour and a weekly window. Shown only when your account has the limit (otherwise "No data"), and tucked below the "show more" caret by default |
 | Rate Limit Resets | On-demand rate-limit reset credits, shown as a count (e.g. `2 available`); hover for each credit's expiry, with a warning triangle when one is about to expire |
 | Extra Usage | Flex credits, shown verbatim as dollars + credits (e.g. `$31.84 · 796 credits`) |
 | Today / Yesterday / Last 30 Days | Local spend, as cost, tokens, or both (see below) |
@@ -30,6 +31,8 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Codex logs b
 ## Under the hood
 
 `GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry. Session and Weekly are read from the usage window in that response, with the response headers used only when the window fields are missing.
+
+Spark and Spark Weekly come from the same response's `additional_rate_limits` array — model-specific limits that reuse the Session/Weekly window shape. OpenUsage surfaces the entry whose name identifies GPT-5.3-Codex-Spark as those two meters; accounts without the limit simply omit the entry, so the rows read "No data". Other model limits in that array aren't shown.
 
 When a rolling window still has a full period left before reset (`reset_after_seconds` ≈ `limit_window_seconds`), OpenUsage treats it as a fresh window: a `used_percent` of 0–1% is normalized to unused (Codex’s whole-percent floor), and burn-rate pacing waits until the window has materially started before projecting. While the current Session window has no usage, the Session row reads **Not started** on the trailing label, and the hover explains that the session begins after your first message.
 


### PR DESCRIPTION
## Approved issue

Fixes #796

## TL;DR

Brings back the Codex **Spark** (GPT-5.3-Codex-Spark) 5-hour and weekly rate-limit meters that disappeared in 0.7.0, by parsing the usage API's `additional_rate_limits` the way the legacy edition did.

## What was happening

- The legacy (Tauri/JS) edition parsed `wham/usage`'s `additional_rate_limits` array and showed Codex Spark as `Spark` + `Spark Weekly` lines.
- The Swift rewrite never ported that parsing, so since **0.7.0 there's no way to see Spark or any other per-model limit** — the regression in #796.
- Multiple Pro users asked for it back ("a lot of pro users use spark").

## What this changes

- **Parsing** ([`CodexUsageMapper`](Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift)) — reads `additional_rate_limits[]`, finds the entry whose `limit_name`/`metered_feature` names Spark (case-insensitive), and emits `Spark` (primary/5-hour) + `Spark Weekly` (secondary) progress lines. Reuses the existing Session/Weekly window path, including the fresh-window 1%→0 normalization. Null/malformed array elements are skipped, not fatal.
- **Descriptors** ([`CodexProvider`](Sources/OpenUsage/Providers/Codex/CodexProvider.swift)) — two `.percent` widgets (`codex.spark`, `codex.sparkWeekly`) declared right after Weekly.
- **Defaults** ([`DefaultLayout`](Sources/OpenUsage/Stores/DefaultLayout.swift)) — placed after Weekly and seeded **secondary** (below the per-provider caret); **not pinned**. Existing users get them auto-added once below the caret via the seeded-defaults migration.
- **Docs** — documented the new rows and their source in `docs/providers/codex.md`.

These four placement defaults (on/off, primary/secondary, pinned, order) were confirmed with the owner per the AGENTS.md metric-placement rule.

## Heads-up

- **Spark is a Pro-only research preview.** Plus/Free accounts get an *empty* `additional_rate_limits`, so the two rows read **"No data"** — by design, no conditional appear/disappear logic. Verified against a live Plus account (empty array) and the issue reporter's Pro account (populated).
- The usage response also carries a top-level `code_review_rate_limit` (present even on Plus) — the issue's "other types of limits." Left out of scope here; easy follow-up if wanted.

## Tests

- New regression tests in `CodexProviderTests`: full Spark + Spark Weekly mapping, `metered_feature`-only match, and skip of non-Spark/malformed/null entries.
- Updated the two `LayoutStoreTests` that pin the default Codex layout.
- Full suite green (669 tests, 0 failures) on top of current `main`.

## Screenshots

The rows render identically to Session/Weekly (same `WidgetRowView` meter path) and sit below the Codex "show more" caret, leading the expanded section. A populated real screenshot isn't possible on the maintainer's **Plus** test account (Spark is Pro-only — it shows "No data" there); the approved design mockup was reviewed with the owner during implementation. Pacing/anatomy match the existing meters exactly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Codex usage parsing and UI metrics only; no auth, billing, or shared infrastructure changes.
> 
> **Overview**
> Restores **Spark** and **Spark Weekly** Codex usage meters (fixes #796) by parsing `additional_rate_limits` from the wham/usage API—the behavior the legacy JS app had but the Swift rewrite dropped.
> 
> **`CodexUsageMapper`** adds `sparkLines` / `isSparkEntry` to find the Spark entry via `limit_name` or `metered_feature`, map primary/secondary windows to percent progress lines (same fresh-window normalization as Session/Weekly), and tolerate null or malformed array elements.
> 
> **`CodexProvider`** registers `codex.spark` and `codex.sparkWeekly` percent widgets after Weekly. **`DefaultLayout`** enables them in default metrics, seeds them **below the caret** (not pinned), and existing users get them via the usual default-migration path.
> 
> Tests cover mapping, alternate Spark identification, and ignored junk entries; layout tests and **`docs/providers/codex.md`** are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1b90e8e0f132516cd905fcca7df6f1f861d98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->