### PR TITLE
feat(copilot): track AI Credits + Extra Usage; fix paid quota rendering

### DIFF
--- a/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
@@ -28,7 +28,8 @@ final class CopilotProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "copilot.premium", provider: provider, title: "Premium"),
+            .percent(id: "copilot.premium", provider: provider, title: "Credits"),
+            .values(id: "copilot.extra", provider: provider, title: "Extra Usage", selection: .kind(.count)),
             .percent(id: "copilot.chat", provider: provider, title: "Chat"),
             .percent(id: "copilot.completions", provider: provider, title: "Completions")
         ]

--- a/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
@@ -5,12 +5,14 @@ struct CopilotMappedUsage: Equatable, Sendable {
     var lines: [MetricLine]
 }
 
-/// Normalizes the `/copilot_internal/user` response into progress meters. The endpoint reports each
-/// bucket as percent *remaining*; every meter flips that to percent *used*. Two response shapes are
-/// handled: paid plans expose `quota_snapshots` (Premium / Chat / Completions), free plans expose
-/// `limited_user_quotas` against `monthly_quotas` (Chat / Completions). Zero-entitlement placeholder
-/// snapshots — what GitHub returns for Copilot Business token-based-billing seats — carry no real quota
-/// signal and are suppressed rather than rendered as a misleading "0% used" bar.
+/// Normalizes the `/copilot_internal/user` response into meters. Since 2026-06-01 every plan is on
+/// usage-based billing (AI Credits), so the `premium_interactions` bucket is surfaced as **Credits**
+/// (used % of the monthly allotment), with **Extra Usage** carrying overage beyond it. Paid plans report
+/// `chat`/`completions` as the `-1` "unlimited" sentinel (suppressed); free plans carry real `chat` and
+/// `completions` counts — either inside `quota_snapshots` (current) or, on older responses, as
+/// `limited_user_quotas` against `monthly_quotas`. Zero-entitlement placeholder snapshots — what GitHub
+/// returns for Copilot Business token-based-billing seats — carry no real signal and are suppressed
+/// rather than rendered as a misleading "0% used" bar.
 enum CopilotUsageMapper {
     static let periodMs = MetricPeriod.monthMs
 
@@ -28,14 +30,21 @@ enum CopilotUsageMapper {
 
         var lines: [MetricLine] = []
 
-        // Paid tier: per-bucket quota snapshots.
+        // The metered premium pool is shown as "Credits"; overage beyond it as "Extra Usage".
         let snapshots = body["quota_snapshots"] as? [String: Any]
-        appendIfPresent(&lines, snapshotLine(label: "Premium", snapshots?["premium_interactions"], resetsAt: resetsAt))
-        appendIfPresent(&lines, snapshotLine(label: "Chat", snapshots?["chat"], resetsAt: resetsAt))
-        appendIfPresent(&lines, snapshotLine(label: "Completions", snapshots?["completions"], resetsAt: resetsAt))
+        let premium = snapshots?["premium_interactions"]
+        appendIfPresent(&lines, snapshotLine(label: "Credits", premium, resetsAt: resetsAt))
+        appendIfPresent(&lines, overageLine(premium))
 
-        // Free tier: remaining counts (`limited_user_quotas`) against monthly limits (`monthly_quotas`).
-        if lines.isEmpty {
+        // Chat + completions: real per-bucket counts on free; the `-1` "unlimited" sentinel on paid
+        // (suppressed by `snapshotLine`). Older free responses without `quota_snapshots` fall back to
+        // `limited_user_quotas` / `monthly_quotas` below.
+        let chat = snapshotLine(label: "Chat", snapshots?["chat"], resetsAt: resetsAt)
+        let completions = snapshotLine(label: "Completions", snapshots?["completions"], resetsAt: resetsAt)
+        appendIfPresent(&lines, chat)
+        appendIfPresent(&lines, completions)
+
+        if chat == nil, completions == nil {
             let limited = body["limited_user_quotas"] as? [String: Any]
             let monthly = body["monthly_quotas"] as? [String: Any]
             appendIfPresent(&lines, limitedLine(label: "Chat", remaining: limited?["chat"], total: monthly?["chat"], resetsAt: resetsAt))
@@ -58,20 +67,21 @@ enum CopilotUsageMapper {
 
     // MARK: - Lines
 
-    /// A paid-tier `quota_snapshots` bucket → percent-used meter. `nil` for a missing bucket, an
-    /// `unlimited` bucket rendered as an empty (0% used) meter with no reset, or a zero-entitlement
-    /// placeholder seat (suppressed).
+    /// A `quota_snapshots` bucket → percent-used meter, or `nil` to suppress. Suppressed for: a missing
+    /// bucket; an `unlimited` bucket or the `-1` entitlement/remaining sentinel (paid chat & completions
+    /// under usage-based billing carry no real meter, so they're hidden rather than shown as a misleading
+    /// 0%); and a zero-entitlement placeholder (e.g. Credits on a free account, which has no allotment).
     private static func snapshotLine(label: String, _ raw: Any?, resetsAt: Date?) -> MetricLine? {
         guard let snapshot = raw as? [String: Any] else { return nil }
-
-        if readBool(snapshot["unlimited"]) == true {
-            return .progress(label: label, used: 0, limit: 100, format: .percent, resetsAt: nil, periodDurationMs: nil)
-        }
 
         let entitlement = ProviderParse.number(snapshot["entitlement"])
         let remaining = ProviderParse.number(snapshot["remaining"])
 
-        // Zero entitlement = no real allotment (token-based-billing placeholder). Drop it.
+        // Unlimited: the explicit flag, or GitHub's `-1` sentinel on entitlement/remaining. Suppress.
+        if readBool(snapshot["unlimited"]) == true || entitlement == -1 || remaining == -1 {
+            return nil
+        }
+        // Zero entitlement = no real allotment (token-based-billing placeholder, or Credits on free). Drop it.
         if entitlement == 0 { return nil }
 
         let usedPercent: Double
@@ -91,6 +101,20 @@ enum CopilotUsageMapper {
             resetsAt: resetsAt,
             periodDurationMs: periodMs
         )
+    }
+
+    /// "Extra Usage" — premium interactions consumed beyond the included Credits pool. Surfaced only once
+    /// the user has enabled additional (overage) spend (`overage_permitted`); a real zero is then shown
+    /// ("0"), per the show-real-zeros rule. When overage isn't enabled it's genuinely N/A → `nil`
+    /// ("No data"). No spending cap is exposed on this endpoint, so this is an unbounded count, not a meter.
+    private static func overageLine(_ raw: Any?) -> MetricLine? {
+        guard let snapshot = raw as? [String: Any],
+              readBool(snapshot["overage_permitted"]) == true
+        else {
+            return nil
+        }
+        let overage = max(0, ProviderParse.number(snapshot["overage_count"]) ?? 0)
+        return .values(label: "Extra Usage", values: [MetricValue(number: overage, kind: .count)])
     }
 
     /// A free-tier bucket: `remaining` against a `total` monthly limit → percent-used meter. `nil` unless

--- a/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
@@ -39,12 +39,14 @@ enum CopilotUsageMapper {
         // Chat + completions: real per-bucket counts on free; the `-1` "unlimited" sentinel on paid
         // (suppressed by `snapshotLine`). Older free responses without `quota_snapshots` fall back to
         // `limited_user_quotas` / `monthly_quotas` below.
-        let chat = snapshotLine(label: "Chat", snapshots?["chat"], resetsAt: resetsAt)
-        let completions = snapshotLine(label: "Completions", snapshots?["completions"], resetsAt: resetsAt)
-        appendIfPresent(&lines, chat)
-        appendIfPresent(&lines, completions)
+        appendIfPresent(&lines, snapshotLine(label: "Chat", snapshots?["chat"], resetsAt: resetsAt))
+        appendIfPresent(&lines, snapshotLine(label: "Completions", snapshots?["completions"], resetsAt: resetsAt))
 
-        if chat == nil, completions == nil {
+        // Legacy free-tier shape (predates `quota_snapshots`): remaining counts against monthly limits.
+        // Gated on nothing else having been produced — otherwise a paid account (Credits present,
+        // chat/completions suppressed as unlimited) that still carried `limited_user_quotas` would
+        // wrongly show free-tier meters alongside Credits.
+        if lines.isEmpty {
             let limited = body["limited_user_quotas"] as? [String: Any]
             let monthly = body["monthly_quotas"] as? [String: Any]
             appendIfPresent(&lines, limitedLine(label: "Chat", remaining: limited?["chat"], total: monthly?["chat"], resetsAt: resetsAt))

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -18,7 +18,7 @@ enum DefaultLayout {
         "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend",
         "cursor.onDemand", "cursor.today", "cursor.yesterday", "cursor.last30",
 
-        "copilot.premium", "copilot.chat", "copilot.completions",
+        "copilot.premium", "copilot.extra", "copilot.chat", "copilot.completions",
 
         "devin.daily", "devin.weekly", "devin.extra",
 
@@ -78,8 +78,9 @@ enum DefaultLayout {
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
         "cursor.onDemand", "cursor.requests", "cursor.credits",
         "cursor.today", "cursor.yesterday", "cursor.last30",
-        // Copilot: only Premium (premium-request quota) stays above the fold; Chat + Completions sit
-        // below the caret. Completions has data on free tier only, so it's commonly "No data" for paid.
+        // Copilot: Credits (the metered premium pool) + Extra Usage stay above the fold; Chat +
+        // Completions sit below the caret. They carry real counts on free only — on paid they're
+        // unlimited (suppressed), so they read "No data" there.
         "copilot.chat", "copilot.completions",
         "devin.extra",
         "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30",

--- a/Tests/OpenUsageTests/CopilotProviderTests.swift
+++ b/Tests/OpenUsageTests/CopilotProviderTests.swift
@@ -132,27 +132,65 @@ final class CopilotAuthStoreTests: XCTestCase {
 }
 
 final class CopilotUsageMapperTests: XCTestCase {
-    func testMapsPaidPremiumAndChatAsPercentUsed() throws {
+    func testMapsPaidCreditsAndChatAsPercentUsed() throws {
         let mapped = try CopilotUsageMapper.map(body: makePaidBody())
 
         XCTAssertEqual(mapped.plan, "Pro")
-        XCTAssertEqual(progress(mapped.lines, "Premium")?.used, 59)
+        XCTAssertEqual(progress(mapped.lines, "Credits")?.used, 59)
         XCTAssertEqual(progress(mapped.lines, "Chat")?.used, 5)
-        XCTAssertNotNil(progress(mapped.lines, "Premium")?.resetsAt)
-        XCTAssertEqual(progress(mapped.lines, "Premium")?.periodDurationMs, CopilotUsageMapper.periodMs)
+        XCTAssertNotNil(progress(mapped.lines, "Credits")?.resetsAt)
+        XCTAssertEqual(progress(mapped.lines, "Credits")?.periodDurationMs, CopilotUsageMapper.periodMs)
     }
 
-    func testUnlimitedBucketRendersEmptyMeterWithoutReset() throws {
-        var snapshots = makePaidBody()
-        var quota = snapshots["quota_snapshots"] as! [String: Any]
+    func testSuppressesUnlimitedAndSentinelBuckets() throws {
+        // Paid plans report chat/completions as unlimited — both the explicit flag and the `-1`
+        // entitlement/remaining sentinel — which carry no real meter and must be suppressed, leaving
+        // just Credits.
+        var body = makePaidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
         quota["chat"] = ["unlimited": true, "entitlement": 0, "remaining": 0, "quota_id": "chat"]
-        snapshots["quota_snapshots"] = quota
+        quota["completions"] = ["entitlement": -1, "remaining": -1, "quota_id": "completions"]
+        body["quota_snapshots"] = quota
 
-        let mapped = try CopilotUsageMapper.map(body: snapshots)
+        let mapped = try CopilotUsageMapper.map(body: body)
 
-        XCTAssertEqual(progress(mapped.lines, "Chat")?.used, 0)
-        XCTAssertNil(progress(mapped.lines, "Chat")?.resetsAt)
-        XCTAssertNil(progress(mapped.lines, "Chat")?.periodDurationMs)
+        XCTAssertNil(progress(mapped.lines, "Chat"))
+        XCTAssertNil(progress(mapped.lines, "Completions"))
+        XCTAssertEqual(progress(mapped.lines, "Credits")?.used, 59)
+    }
+
+    func testEmitsExtraUsageWhenOveragePermitted() throws {
+        var body = makePaidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        var premium = quota["premium_interactions"] as! [String: Any]
+        premium["overage_permitted"] = true
+        premium["overage_count"] = 36
+        quota["premium_interactions"] = premium
+        body["quota_snapshots"] = quota
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(countValue(mapped.lines, "Extra Usage"), 36)
+    }
+
+    func testShowsExtraUsageZeroWhenPermittedButUnused() throws {
+        var body = makePaidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        var premium = quota["premium_interactions"] as! [String: Any]
+        premium["overage_permitted"] = true
+        premium["overage_count"] = 0
+        quota["premium_interactions"] = premium
+        body["quota_snapshots"] = quota
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(countValue(mapped.lines, "Extra Usage"), 0)
+    }
+
+    func testSuppressesExtraUsageWhenNotPermitted() throws {
+        // makePaidBody's premium has no overage flag → extra usage is genuinely N/A.
+        let mapped = try CopilotUsageMapper.map(body: makePaidBody())
+        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
     }
 
     func testSuppressesZeroEntitlementPlaceholder() throws {
@@ -166,8 +204,33 @@ final class CopilotUsageMapperTests: XCTestCase {
 
         let mapped = try CopilotUsageMapper.map(body: body)
 
-        XCTAssertNil(progress(mapped.lines, "Premium"))
+        XCTAssertNil(progress(mapped.lines, "Credits"))
         XCTAssertEqual(progress(mapped.lines, "Chat")?.used, 20)
+    }
+
+    func testMapsLiveFreeAccountSnapshots() throws {
+        // The exact shape a free `individual` account returns today: real chat/completions counts in
+        // `quota_snapshots`, a zero-entitlement premium bucket, and `token_based_billing` on every bucket.
+        // Credits + Extra Usage suppress (no allotment / overage off); Chat + Completions render.
+        let body: [String: Any] = [
+            "copilot_plan": "individual",
+            "access_type_sku": "free_limited_copilot",
+            "token_based_billing": true,
+            "quota_reset_date": "2099-07-01",
+            "quota_snapshots": [
+                "chat": ["entitlement": 200, "remaining": 182, "percent_remaining": 91.0, "overage_permitted": false, "token_based_billing": true],
+                "completions": ["entitlement": 2000, "remaining": 1989, "percent_remaining": 99.4, "overage_permitted": false, "token_based_billing": true],
+                "premium_interactions": ["entitlement": 0, "remaining": 0, "percent_remaining": 0.0, "overage_permitted": false, "token_based_billing": true]
+            ]
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(mapped.plan, "Individual")
+        XCTAssertNil(progress(mapped.lines, "Credits"))
+        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
+        XCTAssertEqual(progress(mapped.lines, "Chat")?.used ?? -1, 9, accuracy: 0.0001)
+        XCTAssertEqual(progress(mapped.lines, "Completions")?.used ?? -1, 0.6, accuracy: 0.0001)
     }
 
     func testMapsFreeTierLimitedQuotas() throws {
@@ -244,7 +307,7 @@ final class CopilotProviderTests: XCTestCase {
 
         XCTAssertNil(snapshot.errorCategory)
         XCTAssertEqual(snapshot.plan, "Pro")
-        XCTAssertEqual(snapshot.line(label: "Premium")?.label, "Premium")
+        XCTAssertEqual(snapshot.line(label: "Credits")?.label, "Credits")
         XCTAssertEqual(http.requests.first?.headers["Authorization"], "token gho_editor")
     }
 
@@ -296,4 +359,11 @@ private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, 
         return nil
     }
     return (used, limit, resetsAt, periodDurationMs)
+}
+
+private func countValue(_ lines: [MetricLine], _ label: String) -> Double? {
+    guard case .values(_, let values, _, _, _) = lines.first(where: { $0.label == label }) else {
+        return nil
+    }
+    return values.first?.number
 }

--- a/Tests/OpenUsageTests/CopilotProviderTests.swift
+++ b/Tests/OpenUsageTests/CopilotProviderTests.swift
@@ -193,6 +193,25 @@ final class CopilotUsageMapperTests: XCTestCase {
         XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
     }
 
+    func testIgnoresLegacyLimitedQuotasWhenSnapshotsPresent() throws {
+        // A paid response with Credits present and chat/completions unlimited (-1) must NOT fall back to
+        // the legacy limited_user_quotas path, even if the payload still carries it — doing so would show
+        // free-tier Chat/Completions meters on a paid account alongside Credits.
+        var body = makePaidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        quota["chat"] = ["entitlement": -1, "remaining": -1, "quota_id": "chat"]
+        quota["completions"] = ["entitlement": -1, "remaining": -1, "quota_id": "completions"]
+        body["quota_snapshots"] = quota
+        body["limited_user_quotas"] = ["chat": 100, "completions": 1000]
+        body["monthly_quotas"] = ["chat": 500, "completions": 4000]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertNotNil(progress(mapped.lines, "Credits"))
+        XCTAssertNil(progress(mapped.lines, "Chat"))
+        XCTAssertNil(progress(mapped.lines, "Completions"))
+    }
+
     func testSuppressesZeroEntitlementPlaceholder() throws {
         let body: [String: Any] = [
             "copilot_plan": "business",

--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -6,17 +6,20 @@ Tracks your GitHub Copilot quota using a GitHub token that Copilot tooling alrea
 
 | Metric | Meaning |
 |---|---|
-| Premium | Premium-request quota used (the headline meter) |
+| Credits | Share of your monthly AI-credit allotment used (the headline meter) |
+| Extra Usage | Premium interactions used beyond your included credits, once extra spend is enabled |
 | Chat | Chat-message quota used |
 | Completions | Code-completion quota used |
 
-Each meter shows percent used and, when the response includes one, a countdown to the next quota reset. The plan name (Pro, Business, Free, …) shows next to the provider.
+Credits and Extra Usage show above the fold; Chat and Completions sit under the "Shown on expand" caret. Each meter shows percent used and, when the response includes one, a countdown to the next reset. The plan name (Pro, Business, Free, …) shows next to the provider.
 
-Which meters appear depends on your plan:
+Since June 2026 GitHub Copilot bills all plans by **AI credits**, so what each account shows differs by plan:
 
-- **Paid plans** expose Premium and Chat (and sometimes Completions). Buckets a plan treats as unlimited show an empty meter; on most paid plans Completions has no quota to track and reads "No data".
-- **Free plans** expose Chat and Completions (no Premium).
-- **Copilot Business / token-based billing** returns no per-seat quota, so there's nothing to meter. The provider still shows the plan; the meters read "No data" rather than fabricating numbers. (GitHub only exposes that spend through its logged-in web billing page, which would require reading browser cookies — OpenUsage does not do that.)
+- **Paid plans** meter the credit pool — so you see Credits (and Extra Usage if you've turned on additional spend). Chat and completions are unlimited on paid plans, so those rows read "No data".
+- **Free plans** have no credits, so Credits reads "No data"; instead you see your fixed Chat and Completions counts under the caret.
+- **Copilot Business / token-based billing** returns no per-seat quota, so there's nothing to meter. The provider still shows the plan; the meters read "No data" rather than fabricating numbers.
+
+A dollar credit figure (e.g. "$12 of $15 used") isn't shown: GitHub only exposes that through its logged-in web billing page, which would require reading browser cookies — OpenUsage does not do that. Editors like VS Code show the same credit *percentage* from this endpoint, not a dollar amount.
 
 ## Where credentials come from
 


### PR DESCRIPTION
## TL;DR

GitHub Copilot moved every plan to AI-credit billing on 2026-06-01, so OpenUsage's old Premium/Chat/Completions framing no longer matches reality — paid accounts read ~0%. This reworks the Copilot provider to show **Credits** + **Extra Usage** as the headline metrics, keeps Chat/Completions as secondary, and fixes the unlimited-bucket handling that caused the 0% bug ([#803](https://github.com/robinebers/openusage/issues/803)).

## What was happening

- Since June 1, 2026, all Copilot plans bill by **AI credits**; "premium requests" is retired as a billing unit (the API field is still named `premium_interactions`).
- On **paid** accounts, `chat`/`completions` now come back as the `-1` "unlimited" sentinel, and the only metered pool is `premium_interactions`. The mapper only recognized the `unlimited: true` boolean — not `-1` — so paid users saw a misleading **0%** across Premium/Chat/Completions (the issue report).
- On **free** accounts the legacy path still worked (Chat/Completions counts), so free wasn't broken — the bug was paid-only.

## What this changes

- **Credits** (`copilot.premium`, primary + pinned): `premium_interactions` is now surfaced as "Credits". The id is kept, so no layout/pin state migrates; the title and the menu-bar tray label both read "Credits".
- **Extra Usage** (`copilot.extra`, new, primary): overage beyond the included credit pool, shown only once additional/overage spend is enabled (`overage_permitted`); a real `0` when enabled-but-unused, "No data" when not.
- **Unlimited handling**: the `-1` entitlement/remaining sentinel (and the explicit `unlimited` flag) now **suppress** the row instead of rendering a hollow 0% meter — so paid Chat/Completions simply don't show.
- **Chat + Completions** stay as secondary metrics (under the expand caret); they carry real counts on free, and suppress (unlimited) on paid.
- Docs (`docs/providers/copilot.md`) rewritten for the credits model.

No core changes — the free/paid difference is emergent from which buckets carry data, not a code branch. Buttons unchanged (Status + Dashboard→billing already fit and pass the link-label test).

## Heads-up

- **A dollar credit figure (e.g. "$12 of $15") is deliberately out of scope.** It isn't on `/copilot_internal/user`; it needs a billing-scoped token (404s with our token) or browser cookies, which this provider doesn't use. VS Code shows the same credit *percentage* from this endpoint, not dollars — so we're at parity with what editors surface without cookies.
- **Free accounts** have neither credits nor overage, so Credits + Extra Usage (the primary rows) read "No data" and the real Chat/Completions numbers sit under the expand caret. That's a consequence of the chosen layout (Credits primary). Surfacing Chat as a free headline would need plan-aware logic, intentionally avoided here.
- Copilot has session/weekly rate-limit windows (Claude-style), but GitHub only exposes them in live inference-response headers, so a passive poller can't read them.

## Tests

- `swift build` clean; 25 Copilot tests pass.
- New cases cover the paid `-1`/unlimited suppression, Extra Usage (permitted/zero/not-permitted), and a regression test built from the **exact live free-account JSON** (Chat 9%, Completions 0.6%, Credits + Extra Usage suppressed).
- Full suite green except 2 pre-existing, unrelated failures in `ProviderLinksTests` (OpenRouter "Activity"/"Credits" labels from #795).
- Verified live: built + launched the dev app; `GET /v1/usage/copilot` on a real free account returns Chat 9% / Completions 0.6% with Credits + Extra Usage correctly suppressed.

## Screenshots

<img width="1440" height="1288" alt="image" src="https://github.com/user-attachments/assets/f9b2714f-76ac-473f-930b-6371b0eabf39" />
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quota parsing and display logic for all Copilot users; behavior is well-tested but wrong mapping would affect every plan type.
> 
> **Overview**
> Aligns the Copilot provider with GitHub’s **AI-credit** billing model: `premium_interactions` is shown as **Credits** (same `copilot.premium` id), and a new **Extra Usage** count appears when `overage_permitted` is set on that bucket.
> 
> **`CopilotUsageMapper`** stops treating unlimited chat/completions as empty 0% bars—`-1` entitlements/remains and `unlimited: true` now **suppress** those rows (fixes misleading ~0% on paid plans). Legacy `limited_user_quotas` only runs when no snapshot lines were produced, so paid payloads that still carry old free-tier fields don’t duplicate Chat/Completions next to Credits.
> 
> Default layout seeds **`copilot.extra`** above the fold with Credits; docs describe plan-specific visibility. Tests cover overage, suppression, and live-shaped free-account JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd8e0a5c1777ae3b262c5c30652df46303275626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->