### PR TITLE
fix(menubar): render Bars style per provider

### DIFF
--- a/Sources/OpenUsage/Models/MenuBarContent.swift
+++ b/Sources/OpenUsage/Models/MenuBarContent.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Resolved, ordered, capped data for the menu-bar strip, built from the pinned metrics and their live
 /// values. The renderers consume this: `groups` drives the Text style (one segment per pinned provider,
-/// each with its 1–2 pinned metrics), `bars` drives the Bars style (the first four bounded metrics — any
-/// with a fill, not just percentages — in order). `isEmpty` means render the plain app icon.
+/// each with its 1–2 pinned metrics), `bars` drives the Bars style (the first bounded metric per
+/// provider, capped to four providers). `isEmpty` means render the plain app icon.
 struct MenuBarContent: Equatable {
     /// One resolved pinned metric.
     struct Metric: Equatable {
@@ -27,7 +27,7 @@ struct MenuBarContent: Equatable {
     /// have real data appear, and a provider whose pinned metrics all lack data drops out entirely
     /// (no orphan icon) — so the strip never renders "—" placeholders.
     let groups: [Group]
-    /// Bounded metrics (those with a fill) for the Bars style, flattened in order and capped to four.
+    /// Bounded metrics (those with a fill) for the Bars style, one per provider and capped to four.
     let bars: [Metric]
 
     /// Nothing is pinned, every pinned provider is disabled, or no pinned metric has data yet — the
@@ -43,12 +43,23 @@ struct MenuBarContent: Equatable {
         }
         .joined(separator: "; ")
     }
+
+    /// VoiceOver summary for Bars style. Bars renders at most one metric per provider, so its
+    /// accessibility text must not announce the extra starred metrics that Text style can show.
+    var barsAccessibilityText: String {
+        let barIDs = Set(bars.map(\.id))
+        return groups.compactMap { group in
+            guard let metric = group.metrics.first(where: { barIDs.contains($0.id) }) else { return nil }
+            return "\(group.displayName) \(metric.label) \(metric.value)"
+        }
+        .joined(separator: "; ")
+    }
 }
 
 @MainActor
 enum MenuBarContentBuilder {
-    /// Max bars the compact style renders (matches the original OpenUsage tray).
-    static let maxBars = 4
+    /// Max providers the compact style renders.
+    static let maxBarProviders = 4
 
     /// Resolve pinned provider groups into menu-bar content. `groups` is `LayoutStore.pinnedGroups`
     /// (already ordered, disabled providers excluded); `data` resolves each descriptor to its live
@@ -69,12 +80,12 @@ enum MenuBarContentBuilder {
                 metrics: metrics
             )
         }
-        // Bars show any *bounded* metric (it has a fill), not just percentages. Unbounded values (raw
-        // spend/credits, no limit) have no fill and are dropped.
+        // Bars show the first *bounded* metric (it has a fill) per provider. Text can stack two starred
+        // values for a provider; Bars stays provider-count based so enabling two providers yields two
+        // bars instead of four.
         let bars = resolvedGroups
-            .flatMap(\.metrics)
-            .filter(\.isBounded)
-            .prefix(maxBars)
+            .compactMap { $0.metrics.first(where: \.isBounded) }
+            .prefix(maxBarProviders)
         return MenuBarContent(groups: resolvedGroups, bars: Array(bars))
     }
 

--- a/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
+++ b/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
@@ -88,7 +88,7 @@ enum MenuBarStripRenderer {
         return CGRect(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)
     }
 
-    /// The compact Bars glyph (≤4 bounded-metric bars), or `nil` when no pinned metric has a fill.
+    /// The compact Bars glyph (≤4 provider bars), or `nil` when no pinned metric has a fill.
     static func barsImage(for content: MenuBarContent) -> NSImage? {
         let fractions = content.bars.map(\.fraction)
         guard !fractions.isEmpty else { return nil }
@@ -96,7 +96,7 @@ enum MenuBarStripRenderer {
         renderer.scale = 2
         guard let image = renderer.nsImage else { return nil }
         image.isTemplate = true
-        image.accessibilityDescription = content.accessibilityText
+        image.accessibilityDescription = content.barsAccessibilityText
         return image
     }
 

--- a/Tests/OpenUsageTests/MenuBarContentTests.swift
+++ b/Tests/OpenUsageTests/MenuBarContentTests.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import OpenUsage
 
 /// Covers `MenuBarContentBuilder`: it resolves pinned provider groups into Text groups (order, labels,
-/// and values preserved) and Bars entries (bounded metrics only, first four in order), and reports empty
-/// when nothing is pinned.
+/// and values preserved) and Bars entries (first bounded metric per provider, first four providers in
+/// order), and reports empty when nothing is pinned.
 @MainActor
 final class MenuBarContentTests: XCTestCase {
     func testEmptyWhenNoGroups() {
@@ -25,33 +25,42 @@ final class MenuBarContentTests: XCTestCase {
         XCTAssertEqual(content.groups[1].metrics.map(\.id), ["b.m1"])
     }
 
-    func testBarsIncludeBoundedMetricsAndDropUnbounded() {
-        // A bounded dollar metric has a fill, so it belongs in Bars. An unbounded value (raw spend,
-        // no limit) has no fill and is dropped.
+    func testBarsUseFirstBoundedMetricPerProviderAndDropUnboundedProviders() {
+        // A bounded dollar metric has a fill, so it can represent a provider in Bars. An unbounded
+        // value (raw spend, no limit) has no fill, so Bars skips to the provider's first bounded pin.
         let content = MenuBarContentBuilder.build(
-            groups: [group("a",
-                percent("a.pct", "Pct", 40),
-                boundedDollars("a.credits", "Credits", used: 12000, limit: 18000),
-                unbounded("a.spend", "Spend"))],
+            groups: [
+                group("a",
+                    percent("a.pct", "Pct", 40),
+                    boundedDollars("a.credits", "Credits", used: 12000, limit: 18000),
+                    unbounded("a.spend", "Spend")),
+                group("b",
+                    unbounded("b.spend", "Spend"),
+                    boundedDollars("b.credits", "Credits", used: 12000, limit: 18000)),
+                group("c",
+                    unbounded("c.spend", "Spend"))
+            ],
             data: { $0.sample }
         )
 
         XCTAssertEqual(content.groups[0].metrics.map(\.id), ["a.pct", "a.credits", "a.spend"])  // Text: all
-        XCTAssertEqual(content.bars.map(\.id), ["a.pct", "a.credits"])                          // Bars: bounded only
+        XCTAssertEqual(content.bars.map(\.id), ["a.pct", "b.credits"])                          // Bars: one bounded per provider
     }
 
-    func testBarsCappedToFourInOrder() {
+    func testBarsCappedToFourProvidersInOrder() {
         let content = MenuBarContentBuilder.build(
             groups: [
                 group("a", percent("a.m1", "M1", 10), percent("a.m2", "M2", 20)),
                 group("b", percent("b.m1", "M1", 30), percent("b.m2", "M2", 40)),
-                group("c", percent("c.m1", "M1", 50), percent("c.m2", "M2", 60))
+                group("c", percent("c.m1", "M1", 50), percent("c.m2", "M2", 60)),
+                group("d", percent("d.m1", "M1", 70), percent("d.m2", "M2", 80)),
+                group("e", percent("e.m1", "M1", 90), percent("e.m2", "M2", 95))
             ],
             data: { $0.sample }
         )
 
         XCTAssertEqual(content.bars.count, 4)
-        XCTAssertEqual(content.bars.map(\.id), ["a.m1", "a.m2", "b.m1", "b.m2"])
+        XCTAssertEqual(content.bars.map(\.id), ["a.m1", "b.m1", "c.m1", "d.m1"])
     }
 
     func testNoDataMetricsDropFromStrip() {
@@ -85,6 +94,20 @@ final class MenuBarContentTests: XCTestCase {
             data: { $0.sample }
         )
         XCTAssertEqual(content.accessibilityText, "A Session 41%, Weekly 12%")
+    }
+
+    func testBarsAccessibilityTextSummarizesRenderedBarsOnly() {
+        let content = MenuBarContentBuilder.build(
+            groups: [
+                group("a", percent("a.session", "Session", 41), percent("a.weekly", "Weekly", 12)),
+                group("b", unbounded("b.spend", "Spend"), boundedDollars("b.credits", "Credits", used: 12000, limit: 18000))
+            ],
+            data: { $0.sample }
+        )
+
+        XCTAssertEqual(content.accessibilityText, "A Session 41%, Weekly 12%; B Spend $42, Credits $12K")
+        XCTAssertEqual(content.bars.map(\.id), ["a.session", "b.credits"])
+        XCTAssertEqual(content.barsAccessibilityText, "A Session 41%; B Credits $12K")
     }
 
     func testTrayLabelsShortenLongTimeWindows() {

--- a/Tests/OpenUsageTests/MenuBarStripMemoTests.swift
+++ b/Tests/OpenUsageTests/MenuBarStripMemoTests.swift
@@ -25,6 +25,30 @@ final class MenuBarStripMemoTests: XCTestCase {
         XCTAssertNotIdentical(text, bars)
     }
 
+    func testBarsImageUsesBarsAccessibilityText() throws {
+        let session = MenuBarContent.Metric(
+            id: "claude.session", label: "Session", value: "42%",
+            fraction: 0.42, isBounded: true, hasData: true
+        )
+        let weekly = MenuBarContent.Metric(
+            id: "claude.weekly", label: "Weekly", value: "87%",
+            fraction: 0.87, isBounded: true, hasData: true
+        )
+        let content = MenuBarContent(
+            groups: [MenuBarContent.Group(
+                providerID: "claude",
+                displayName: "Claude",
+                icon: .providerMark("claude"),
+                metrics: [session, weekly]
+            )],
+            bars: [session]
+        )
+
+        let bars = try XCTUnwrap(MenuBarStripRenderer.image(for: content, style: .bars))
+        XCTAssertEqual(content.accessibilityText, "Claude Session 42%, Weekly 87%")
+        XCTAssertEqual(bars.accessibilityDescription, "Claude Session 42%")
+    }
+
     private func makeContent(value: String) -> MenuBarContent {
         let metric = MenuBarContent.Metric(
             id: "claude.session", label: "Session", value: value,

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -20,7 +20,7 @@ Star a metric from any row's right-click menu, or from the star that appears whe
 Settings → Appearance → Menu Style:
 
 - **Text** — provider icon plus values; two starred metrics from the same provider stack as a labeled pair.
-- **Bars** — compact vertical bars, one per starred metric that has a limit (metrics without limits only appear in Text style).
+- **Bars** — compact vertical bars, one per provider with a starred metric that has a limit. When a provider has multiple starred metrics, Bars uses the first limited metric in your Customize order; metrics without limits only appear in Text style.
 
 ## What the strip shows
 


### PR DESCRIPTION
## Approved issue

Fixes #808

## TL;DR

Bars menu style now renders one representative bounded metric per enabled provider, so the menu bar reflects provider count instead of metric count. Text style keeps showing every starred metric exactly as before.

## What was happening

- Bars style flattened all starred bounded metrics across providers and then capped the first four.
- Providers can have multiple starred bounded metrics, so the menu bar could show more bars than the enabled provider count suggested.
- That made the menu bar look inconsistent with the Customize provider toggles.

## What this changes

- `MenuBarContentBuilder` now picks the first bounded starred metric per provider for Bars style.
- Text style still renders each provider's starred metrics, including stacked pairs.
- Bars style now uses accessibility text for the bars it actually renders instead of announcing hidden Text-style metrics.
- Updated the menu-bar docs and renderer wording to describe provider-count Bars behavior.
- Added regression coverage for first-bounded-per-provider selection, unbounded fallback, renderer accessibility text, and the four-provider cap.

## Heads-up

- Bars still caps at four entries, but the cap is now four providers rather than four metrics.
- If a provider's first starred metric is unbounded, Bars uses that provider's next starred bounded metric; providers with no bounded starred data still drop out.

## Tests

- `swift test --filter 'MenuBarContentTests|MenuBarStripMemoTests|MenuBarPinTests|ProviderEnablementEnforcementTests'`
- `swift test` (676 tests, 1 skipped, 0 failures)
- `git diff --check`

## Screenshots

<img width="1080" height="948" alt="bars-before-after-comparison" src="https://github.com/user-attachments/assets/e1e33138-19cc-4491-b698-248eebcd2394" />

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small, logically correct, and fully covered by new and updated unit tests.

The builder change is a one-line swap with a clear semantic meaning, the new `barsAccessibilityText` property derives its output directly from the same `bars` array the renderer uses, the `maxBars` → `maxBarProviders` rename has no other callers, and the four new/updated test cases cover the critical paths (first-bounded-per-provider selection, all-unbounded provider drop-out, four-provider cap, and renderer accessibility text).

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(menubar): render bars per provider"](https://github.com/robinebers/openusage/commit/e5db414552d6ad4607af0f86afeb62b49974c90c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41003829)</sub>

<!-- /greptile_comment -->