### PR TITLE
fix: dynamic widget height for single-provider users (#800)

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -49,8 +49,10 @@ final class StatusItemController: NSObject {
     private static let topGap: CGFloat = 4
     /// Corner radius of the panel surface; tuned to read like a system menu-bar popover.
     private static let cornerRadius: CGFloat = 13
-    /// Smallest the panel can be dragged — room for the footer plus a couple of rows.
-    private static let minPanelHeight: CGFloat = 480
+    /// Smallest the panel can be — room for the footer plus a single provider card. Kept low so the
+    /// auto-fit morph can shrink the panel to match its content instead of showing blank space when
+    /// only one or two providers are enabled (#800).
+    private static let minPanelHeight: CGFloat = 200
     /// Opening height before the user has ever resized the panel.
     private static let defaultPanelHeight: CGFloat = 800
     /// True while a SwiftUI-driven height morph is in flight. Outside-click dismissal is suspended for


### PR DESCRIPTION
## TL;DR

Lowered the panel's minimum height floor from 480pt to 200pt so the widget shrinks to fit its content instead of showing ~280pt of blank space when only one or two providers are enabled.

## What was happening

- The menu-bar panel auto-fits its height to the measured content via a SwiftUI-driven morph (`PanelHeightModifier` → `applyMorphHeight`).
- However, `minPanelHeight` was set to 480pt, and `clampHeight` applied that as a floor to every height target.
- When a user enabled only one provider (e.g. just Antigravity, ~200-300pt of content), the panel was forced to stay at 480pt, leaving a large blank region below the provider card.
- The owner confirmed in the issue: *"we can reduce the minimum height!"*

## What this changes

- `StatusItemController.minPanelHeight`: 480 → 200. The auto-fit morph can now shrink the panel down to fit as few as one provider card plus the footer, while still respecting the screen-max clamp (`maxPanelHeight()`).
- No change to the auto-fit mechanism itself, the opening height guess, or the screen-max clamp — only the floor moved.

## Heads-up

- The 200pt floor is deliberately generous (footer ≈ 50pt + one provider header + one or two metric rows). It won't clip a single-provider dashboard in either density.
- Users who previously dragged the panel to a height below the old 480pt floor already had that height persisted per-screen in `PanelHeightStore`; those persisted heights are unaffected since they were always above the old floor and remain above the new one.

## Tests

- `swift build` ✅
- `swift test` — all 674 tests pass (1 skipped), 0 failures.

Closes #800.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant and comment change in panel sizing; no auth, data, or morph logic changes beyond allowing a smaller clamp floor.
> 
> **Overview**
> **Lowers the menu bar dashboard panel’s minimum height from 480pt to 200pt** so content-driven auto-fit can shrink the window when only one or two providers are enabled, instead of leaving a large empty area below the cards.
> 
> The change is limited to `StatusItemController.minPanelHeight` and its comment; the same floor still applies everywhere heights are clamped (`MenuBarPopover.clampHeight`, `applyPanelSize`, `applyMorphHeight`). Screen max height and persisted per-screen heights are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb3fef8d00228434f78fb1467919ec8b647b372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->