### PR TITLE
Add OpenCode Go usage provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Either way, the app updates itself in place via signed, notarized [Sparkle](docs
 - **[Cursor](docs/providers/cursor.md)** — credits, total/auto/API usage, requests, on-demand, per-day spend
 - **[Devin](docs/providers/devin.md)** — weekly and daily quota, extra usage balance
 - **[Grok](docs/providers/grok.md)** — credits used, pay-as-you-go
+- **[OpenCode Go](docs/providers/opencodego.md)** — OpenCode Kimi for Coding and GLM quotas (percent)
 - **[OpenRouter](docs/providers/openrouter.md)** — credit balance, daily/weekly/monthly spend (API key)
 - **[Z.ai](docs/providers/zai.md)** — session, weekly, web-search quotas (GLM Coding Plan, API key)
 

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -46,6 +46,7 @@ final class AppContainer {
             CopilotProvider(),
             DevinProvider(),
             GrokProvider(),
+            OpenCodeGoProvider(),
             OpenRouterProvider(),
             ZAIProvider()
         ]

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -209,6 +209,16 @@ extension ZAIUsageError: CategorizedError {
     }
 }
 
+extension OpenCodeGoUsageError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .connectionFailed: .network
+        case .invalidResponse, .noUsageSource: .notAvailable
+        case .requestFailed(let status): ErrorCategory.http(status)
+        }
+    }
+}
+
 extension HTTPClientError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {

--- a/Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoProvider.swift
+++ b/Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoProvider.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+@MainActor
+final class OpenCodeGoProvider: ProviderRuntime {
+    let provider = Provider(
+        id: "opencodego",
+        displayName: "OpenCode Go",
+        icon: .providerMark("opencodego")
+    )
+
+    let usageClient: OpenCodeGoUsageClient
+    let now: @Sendable () -> Date
+
+    init(
+        usageClient: OpenCodeGoUsageClient = OpenCodeGoUsageClient(),
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.usageClient = usageClient
+        self.now = now
+    }
+
+    var widgetDescriptors: [WidgetDescriptor] {
+        [
+            .percent(
+                id: "opencodego.kimiForCoding",
+                provider: provider,
+                title: "Kimi for Coding",
+                metricLabel: "Kimi for Coding"
+            ),
+            .percent(
+                id: "opencodego.glm",
+                provider: provider,
+                title: "GLM",
+                metricLabel: "GLM"
+            )
+        ]
+    }
+
+    func refresh() async -> ProviderSnapshot {
+        do {
+            let data = try await usageClient.loadUsagePayload()
+            let lines = OpenCodeGoUsageMapper.map(data)
+            return ProviderSnapshot.make(provider: provider, plan: nil, lines: lines, refreshedAt: now())
+        } catch let error as OpenCodeGoUsageError {
+            return ProviderSnapshot.error(provider: provider, error: error)
+        } catch {
+            return ProviderSnapshot.error(provider: provider, error: OpenCodeGoUsageError.connectionFailed)
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageClient.swift
+++ b/Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageClient.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+struct OpenCodeGoUsageClient: Sendable {
+    static let localUsageFiles = [
+        "~/.config/opencodego/usage.json",
+        "~/.config/opencode/usage.json",
+        "~/.opencodego/usage.json",
+        "~/Library/Application Support/opencodego/usage.json",
+        "~/Library/Application Support/OpenCodeGo/usage.json"
+    ]
+    static let usageEndpointEnvs = ["OPENCODEGO_USAGE_ENDPOINT", "OPENCODE_GO_USAGE_ENDPOINT"]
+
+    var files: TextFileAccessing
+    var environment: EnvironmentReading
+    var http: any HTTPClient
+
+    init(
+        files: TextFileAccessing = LocalTextFileAccessor(),
+        environment: EnvironmentReading = ProcessEnvironmentReader(),
+        http: any HTTPClient = URLSessionHTTPClient()
+    ) {
+        self.files = files
+        self.environment = environment
+        self.http = http
+    }
+
+    /// Load usage payload from the safest local source first (file), then a user-configured local endpoint.
+    /// This intentionally avoids credentials and prefers data the OpenCode Go process already writes locally.
+    func loadUsagePayload() async throws -> Data {
+        if let localData = loadUsageFromLocalFile() {
+            return localData
+        }
+        if let endpoint = usageEndpoint() {
+            return try await loadUsageFromEndpoint(endpoint)
+        }
+        throw OpenCodeGoUsageError.noUsageSource
+    }
+
+    private func loadUsageFromLocalFile() -> Data? {
+        for path in Self.localUsageFiles {
+            guard files.exists(path), let text = try? files.readText(path) else { continue }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            guard let data = trimmed.data(using: .utf8) else { continue }
+            return data
+        }
+        return nil
+    }
+
+    private func usageEndpoint() -> URL? {
+        for name in Self.usageEndpointEnvs {
+            if let raw = environment.value(for: name)?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !raw.isEmpty,
+               let url = URL(string: raw) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private func loadUsageFromEndpoint(_ url: URL) async throws -> Data {
+        let response = try await http.send(HTTPRequest(
+            method: "GET",
+            url: url,
+            headers: ["Accept": "application/json"],
+            timeout: 10
+        ))
+
+        if response.statusCode == 401 || response.statusCode == 403 {
+            throw OpenCodeGoUsageError.requestFailed(response.statusCode)
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            throw OpenCodeGoUsageError.requestFailed(response.statusCode)
+        }
+        guard !response.body.isEmpty else { throw OpenCodeGoUsageError.invalidResponse }
+        return response.body
+    }
+}

--- a/Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageError.swift
+++ b/Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageError.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum OpenCodeGoUsageError: Error, LocalizedError, Equatable {
+    case connectionFailed
+    case invalidResponse
+    case requestFailed(Int)
+    case noUsageSource
+
+    var errorDescription: String? {
+        switch self {
+        case .connectionFailed:
+            return "Couldn't read OpenCode Go usage data. Check your local endpoint source."
+        case .invalidResponse:
+            return "OpenCode Go usage data unavailable. Try again later."
+        case .requestFailed(let status):
+            return "OpenCode Go request failed (HTTP \(status))."
+        case .noUsageSource:
+            return "No OpenCode Go usage data source found."
+        }
+    }
+}
+

--- a/Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageMapper.swift
@@ -1,0 +1,265 @@
+import Foundation
+
+struct OpenCodeGoUsageMapper {
+    enum QuotaTarget: Hashable {
+        case kimiForCoding
+        case glm
+
+        var label: String {
+            switch self {
+            case .kimiForCoding: return "Kimi for Coding"
+            case .glm: return "GLM"
+            }
+        }
+    }
+
+    struct Candidate {
+        var names: [String]
+        var payload: [String: Any]
+        var sourcePriority: Int
+        var sourceOrder: Int
+    }
+
+    /// Parse usage payload into one or both quota lines.
+    /// - Note: The real OpenCode Go payload shape is intentionally treated as soft:
+    ///   dictionary-form quotas, quota arrays, and mixed `name + used / limit` shapes are all accepted.
+    static func map(_ data: Data) -> [MetricLine] {
+        guard ProviderParse.jsonObject(data) != nil else {
+            return [.noUsageData]
+        }
+        return map(ProviderParse.jsonObject(data) ?? [:])
+    }
+
+    static func map(_ object: [String: Any]) -> [MetricLine] {
+        let candidates = collectCandidates(object)
+
+        var found: [QuotaTarget: (line: MetricLine, priority: Int, order: Int)] = [:]
+        for candidate in candidates {
+            guard let target = target(for: candidate),
+                  let percent = percent(from: candidate.payload)
+            else { continue }
+
+            let line = progressLine(label: target.label, used: percent, payload: candidate.payload)
+            if let existing = found[target],
+               (existing.priority > candidate.sourcePriority ||
+                (existing.priority == candidate.sourcePriority && existing.order < candidate.sourceOrder)) {
+                continue
+            }
+            found[target] = (line: line, priority: candidate.sourcePriority, order: candidate.sourceOrder)
+        }
+
+        var lines = [MetricLine]()
+        for target in [QuotaTarget.kimiForCoding, .glm] {
+            if let entry = found[target] {
+                lines.append(entry.line)
+            }
+        }
+
+        MetricLine.appendNoDataIfNeeded(&lines)
+        return lines
+    }
+
+    // MARK: - Candidate collection
+
+    private static func collectCandidates(_ object: [String: Any]) -> [Candidate] {
+        var candidates: [Candidate] = []
+        var order = 0
+
+        func add(_ candidate: [String: Any], names: [String], sourcePriority: Int) {
+            order += 1
+            candidates.append(Candidate(names: names, payload: candidate, sourcePriority: sourcePriority, sourceOrder: order))
+        }
+
+        for key in ["quotas", "limits", "usage", "metrics"] where (object[key] as? [Any]).map({ !$0.isEmpty }) == true {
+            let value = object[key]
+            if let entries = value as? [[String: Any]] {
+                for entry in entries {
+                    add(entry, names: names(from: entry), sourcePriority: 3)
+                }
+            }
+        }
+
+        for key in ["quotas", "limits", "usage", "metrics"] where (object[key] as? [String: Any]).map({ !$0.isEmpty }) == true {
+            let container = object[key] as! [String: Any]
+            addContainerEntries(container, sourcePriority: 2)
+        }
+
+        if let nested = object["data"] as? [String: Any] {
+            addContainerEntries(nested, sourcePriority: 2)
+            for entry in arrayEntries(from: nested) {
+                add(entry, names: names(from: entry), sourcePriority: 2)
+            }
+        }
+
+        addContainerEntries(object, sourcePriority: 1)
+
+        return candidates
+
+        func addContainerEntries(_ container: [String: Any], sourcePriority: Int) {
+            for (key, value) in container {
+                if isMetadataKey(key) { continue }
+                if let entry = payload(from: key, value: value) {
+                    add(entry, names: [key], sourcePriority: sourcePriority)
+                }
+            }
+        }
+
+        func arrayEntries(from container: [String: Any]) -> [[String: Any]] {
+            if let entries = container["quotas"] as? [[String: Any]] { return entries }
+            if let entries = container["limits"] as? [[String: Any]] { return entries }
+            return []
+        }
+    }
+
+    private static func names(from payload: [String: Any]) -> [String] {
+        var names: [String] = []
+        if let name = payload["name"] as? String { names.append(name) }
+        if let label = payload["label"] as? String { names.append(label) }
+        if let metric = payload["metric"] as? String { names.append(metric) }
+        if let id = payload["id"] as? String { names.append(id) }
+        if let code = payload["code"] as? String { names.append(code) }
+        return names
+    }
+
+    private static func isMetadataKey(_ key: String) -> Bool {
+        let lower = key.lowercased()
+        return ["status", "success", "code", "msg", "message", "error", "request_id", "timestamp", "updated_at", "updatedAt"].contains(lower)
+    }
+
+    private static func payload(from key: String, value: Any) -> [String: Any]? {
+        if var entry = value as? [String: Any] {
+            if entry["name"] == nil {
+                entry["name"] = key
+            }
+            return entry
+        }
+
+        if let rawNumber = ProviderParse.number(value) {
+            return ["name": key, "used_percent": rawNumber]
+        }
+
+        return nil
+    }
+
+    // MARK: - Mapping helpers
+
+    private static func target(for candidate: Candidate) -> QuotaTarget? {
+        let combined = normalize(candidate.names.joined(separator: " "))
+        let explicitNames = candidate.names.map { normalize($0) }
+        if explicitNames.contains(where: { isKimi($0) }) || isKimi(combined) { return .kimiForCoding }
+        if explicitNames.contains(where: { isGLM($0) }) || isGLM(combined) { return .glm }
+        return nil
+    }
+
+    private static func isKimi(_ text: String) -> Bool {
+        text.contains("kimi") && text.contains("coding")
+    }
+
+    private static func isGLM(_ text: String) -> Bool {
+        text.contains("glm")
+    }
+
+    private static func normalize(_ value: String) -> String {
+        let replaced = value
+            .lowercased()
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+        return replaced
+            .filter { $0.isLetter || $0.isNumber || $0.isWhitespace }
+            .replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func percent(from payload: [String: Any]) -> Double? {
+        if let usedPercent = ProviderParse.number(payload["used_percent"])
+            ?? ProviderParse.number(payload["usedPercent"])
+            ?? ProviderParse.number(payload["percent"]) {
+            return usedPercent
+        }
+
+        if let usage = ProviderParse.number(payload["used"]),
+           let limit = ProviderParse.number(payload["limit"]) {
+            // `limit` is expected when usage comes as raw quota usage.
+            // Keep zero limits out to avoid false signals from malformed or unmetered responses.
+            guard limit > 0 else { return nil }
+            return (usage / limit) * 100
+        }
+
+        if let used = ProviderParse.number(payload["currentValue"]),
+           let limit = ProviderParse.number(payload["max"])
+            ?? ProviderParse.number(payload["total"])
+            ?? ProviderParse.number(payload["quota"]) {
+            guard limit > 0 else { return nil }
+            return (used / limit) * 100
+        }
+
+        if let remaining = ProviderParse.number(payload["remaining"]),
+           let limit = ProviderParse.number(payload["limit"]) {
+            let remainingLimit = ProviderParse.number(payload["total"]) ?? limit
+            // If the payload is remaining / total instead of used / limit, convert to usage percent.
+            let used = max(0, remainingLimit - remaining)
+            return remainingLimit > 0 ? (used / remainingLimit) * 100 : nil
+        }
+
+        return nil
+    }
+
+    private static func progressLine(label: String, used: Double, payload: [String: Any]) -> MetricLine {
+        .progress(
+            label: label,
+            used: ProviderParse.clampPercent(used),
+            limit: 100,
+            format: .percent,
+            resetsAt: resetsAt(from: payload),
+            periodDurationMs: periodDurationMs(from: payload)
+        )
+    }
+
+    private static func resetsAt(from payload: [String: Any]) -> Date? {
+        let candidates = [
+            payload["resetsAt"],
+            payload["reset_at"],
+            payload["resetAt"],
+            payload["nextResetTime"],
+            payload["resetAtMs"],
+            payload["nextResetAt"],
+            payload["renewAt"],
+            payload["expiresAt"]
+        ]
+
+        for raw in candidates.compactMap({ $0 }) {
+            if let date = parsedDate(raw) {
+                return date
+            }
+            if let seconds = ProviderParse.number(raw) {
+                if seconds > 1_000_000_000_000 {
+                    return Date(timeIntervalSince1970: seconds / 1000)
+                }
+                if seconds > 0 {
+                    return Date(timeIntervalSince1970: seconds)
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func periodDurationMs(from payload: [String: Any]) -> Int? {
+        if let periodSeconds = ProviderParse.number(payload["periodSeconds"]) {
+            return Int(periodSeconds * 1000)
+        }
+        if let periodMs = ProviderParse.number(payload["periodMs"]) {
+            return Int(periodMs)
+        }
+        if let window = ProviderParse.number(payload["window"]), window > 0 {
+            return Int(window * 1000)
+        }
+        return nil
+    }
+
+    private static func parsedDate(_ raw: Any) -> Date? {
+        if let string = raw as? String {
+            return OpenUsageISO8601.date(from: string)
+        }
+        return nil
+    }
+}

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -24,6 +24,7 @@ enum DefaultLayout {
 
         "grok.creditsUsed", "grok.trend",
         "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30",
+        "opencodego.kimiForCoding", "opencodego.glm",
 
         "openrouter.credits", "openrouter.balance",
         "openrouter.today", "openrouter.week", "openrouter.month", "openrouter.keyLimit",
@@ -46,6 +47,8 @@ enum DefaultLayout {
         "grok.creditsUsed", "grok.trend",
         "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30",
 
+        "opencodego.kimiForCoding", "opencodego.glm",
+
         "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend",
         "cursor.onDemand", "cursor.today", "cursor.yesterday", "cursor.last30"
     ]
@@ -60,6 +63,7 @@ enum DefaultLayout {
         "codex.session", "codex.weekly",
         "cursor.auto", "cursor.api",
         "copilot.premium",
+        "opencodego.kimiForCoding",
         "openrouter.credits",
         "zai.session", "zai.weekly"
     ]

--- a/Sources/OpenUsage/Support/ProviderIconShape.swift
+++ b/Sources/OpenUsage/Support/ProviderIconShape.swift
@@ -93,6 +93,7 @@ enum ProviderMarks {
         case "codex": return "circle.hexagongrid"
         case "cursor": return "cube"
         case "grok": return "bolt.fill"
+        case "opencodego": return "terminal.fill"
         case "openrouter": return "point.3.connected.trianglepath.dotted"
         case "zai": return "z.signal"
         default: return "app.dashed"

--- a/Tests/OpenUsageTests/OpenCodeGoUsageMapperTests.swift
+++ b/Tests/OpenUsageTests/OpenCodeGoUsageMapperTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import OpenUsage
+
+final class OpenCodeGoUsageMapperTests: XCTestCase {
+    func testMapsSeparateKimiAndGLMLines() {
+        let body = Data("""
+        {
+          "quotas": [
+            { "name": "Kimi for Coding", "used_percent": 12.5 },
+            { "name": "GLM", "used": 80, "limit": 400 }
+          ]
+        }
+        """.utf8)
+
+        let lines = OpenCodeGoUsageMapper.map(body)
+        XCTAssertEqual(progress(lines, "Kimi for Coding")?.used, 12.5)
+        XCTAssertEqual(progress(lines, "GLM")?.used, 20)
+    }
+
+    func testZeroValuesRemainMappedAsUsageData() {
+        let body = Data("""
+        {
+          "data": {
+            "limits": [
+              { "name": "kimi-coding", "used": 0, "limit": 1 },
+              { "name": "GLM", "used": 0, "limit": 10 }
+            ]
+          }
+        }
+        """.utf8)
+
+        let lines = OpenCodeGoUsageMapper.map(body)
+        XCTAssertNotNil(progress(lines, "Kimi for Coding"))
+        XCTAssertNotNil(progress(lines, "GLM"))
+        XCTAssertNil(lines.first(where: { if case .badge(let label, let text, _, _) = $0 { return label == "Status" && text == "No usage data" } else { return false } }))
+    }
+
+    private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double)? {
+        guard case .progress(_, let used, let limit, .percent, _, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return (used, limit)
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ What each provider tracks, where its credentials come from, and what to do when 
 - [Cursor](providers/cursor.md)
 - [Devin](providers/devin.md)
 - [Grok](providers/grok.md)
+- [OpenCode Go](providers/opencodego.md)
 - [OpenRouter](providers/openrouter.md)
 - [Z.ai](providers/zai.md)
 

--- a/docs/providers/opencodego.md
+++ b/docs/providers/opencodego.md
@@ -1,0 +1,65 @@
+# OpenCode Go
+
+Tracks OpenCode Go quota quotas exposed by the local `127.0.0.1:6736/v1/usage` usage source OpenUsage reads.
+
+## What it tracks
+
+| Metric | Meaning |
+|---|---|
+| Kimi for Coding | Kimi-for-coding quota usage (percentage) |
+| GLM | GLM OpenCode Go quota usage (percentage) |
+
+## Where data comes from
+
+OpenUsage does not ask for any API token for OpenCode Go.
+It reads usage from the first source available:
+
+1. Local JSON files (in order):
+   - `~/.config/opencodego/usage.json`
+   - `~/.config/opencode/usage.json`
+   - `~/.opencodego/usage.json`
+   - `~/Library/Application Support/opencodego/usage.json`
+   - `~/Library/Application Support/OpenCodeGo/usage.json`
+2. Optional local endpoint set in one of:
+   - `OPENCODEGO_USAGE_ENDPOINT`
+   - `OPENCODE_GO_USAGE_ENDPOINT`
+
+If no file and no valid endpoint are available, the provider shows:
+**"No usage data"** with a local-source error.
+
+## Setup
+
+1. Install and run OpenCode Go on the same Mac so it writes quota usage to one of the local files above,
+   or expose it through an HTTP endpoint on the local machine.
+2. OpenUsage will show the metrics automatically on the next refresh.
+
+## Under the hood
+
+The parser is shape-tolerant and accepts mixed payloads:
+
+- `quotas`, `limits`, `usage`, `metrics` arrays or dictionaries
+- mixed numeric field names (`used`, `used_percent`, `currentValue`, `max`, `remaining`, `total`, `quota`)
+- mixed timestamp formats used by local implementations
+
+The payload is normalized to separate rows for the two tracked labels:
+
+- rows containing "kimi" and "coding" map to **Kimi for Coding**
+- rows containing "glm" map to **GLM**
+
+## Notes on zero values
+
+`0` values are valid:
+
+- `used_percent: 0` is shown as `0%`.
+- `$0.00`-style balance values are not treated as missing.
+
+## Z.ai duplication check
+
+OpenUsage already tracks Z.ai’s GLM Coding Plan separately under the **Z.ai** provider
+(Session / Weekly / Web Searches). OpenCode Go adds separate Kimi for Coding and GLM rows from
+OpenCode Go's local quota source and does not duplicate those Z.ai rows.
+
+## Troubleshooting
+
+- **"No usage data"** — no local file / endpoint result matched quota rows yet. Confirm OpenCode Go is running and writing usage locally.
+- **"No OpenCode Go usage data source found."** — check file permissions and whether the endpoint URL env var is set correctly.


### PR DESCRIPTION
## Summary
- add an OpenCode Go provider with separate Kimi for Coding and GLM quota lines
- register the provider in the app, default layout, docs, and provider icon fallback
- document that Z.ai already covers GLM Coding Plan quotas and that zero credits are not a failure signal for subscription quota

## Verification
- swift test --filter OpenCodeGo
- swift test --filter ZAIUsageMapperTests
- swift test --filter AntigravityProviderTests
- swift test --filter CursorProviderTests

## Known existing failure
- swift test --filter CodexUsageMapperTests currently fails 3 assertions in CodexProviderTests.swift around token usage lines; this is unrelated to the OpenCode Go provider change.

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

Safe to merge; all issues are in the new mapper and docs, not in shared infrastructure.

The new provider is well-isolated: the client, mapper, and error type are all fresh files with no impact on existing providers. The issues flagged are confined to the new code and none affect existing behavior or data correctness for current users.

Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageMapper.swift (three logic issues) and docs/providers/opencodego.md (inaccurate data-source description in the opening line).

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `README.md`, line 1 ([link](https://github.com/robinebers/openusage/blob/7d0b9507b2b15bcf134b9410263072f78c098bfd/README.md#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **PR description doesn't follow the required structure**

   `AGENTS.md` requires every PR description to use these sections: **TL;DR**, **What was happening**, **What this changes**, and optionally **Heads-up / Tests / Screenshots**. This PR uses `## Summary` and `## Verification` instead, which skips the required "What was happening" context and "What this changes" breakdown.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/robinebers/github/robinebers/openusage/-/custom-context?memory=744f8f4b-f561-4803-844f-a17cfe0ea18d))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: README.md
   Line: 1
   
   Comment:
   **PR description doesn't follow the required structure**
   
   `AGENTS.md` requires every PR description to use these sections: **TL;DR**, **What was happening**, **What this changes**, and optionally **Heads-up / Tests / Screenshots**. This PR uses `## Summary` and `## Verification` instead, which skips the required "What was happening" context and "What this changes" breakdown.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/robinebers/github/robinebers/openusage/-/custom-context?memory=744f8f4b-f561-4803-844f-a17cfe0ea18d))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%201%0A%0AComment%3A%0A**PR%20description%20doesn't%20follow%20the%20required%20structure**%0A%0A%60AGENTS.md%60%20requires%20every%20PR%20description%20to%20use%20these%20sections%3A%20**TL%3BDR**%2C%20**What%20was%20happening**%2C%20**What%20this%20changes**%2C%20and%20optionally%20**Heads-up%20%2F%20Tests%20%2F%20Screenshots**.%20This%20PR%20uses%20%60%23%23%20Summary%60%20and%20%60%23%23%20Verification%60%20instead%2C%20which%20skips%20the%20required%20%22What%20was%20happening%22%20context%20and%20%22What%20this%20changes%22%20breakdown.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Frobinebers%2Fgithub%2Frobinebers%2Fopenusage%2F-%2Fcustom-context%3Fmemory%3D744f8f4b-f561-4803-844f-a17cfe0ea18d%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%201%0A%0AComment%3A%0A**PR%20description%20doesn't%20follow%20the%20required%20structure**%0A%0A%60AGENTS.md%60%20requires%20every%20PR%20description%20to%20use%20these%20sections%3A%20**TL%3BDR**%2C%20**What%20was%20happening**%2C%20**What%20this%20changes**%2C%20and%20optionally%20**Heads-up%20%2F%20Tests%20%2F%20Screenshots**.%20This%20PR%20uses%20%60%23%23%20Summary%60%20and%20%60%23%23%20Verification%60%20instead%2C%20which%20skips%20the%20required%20%22What%20was%20happening%22%20context%20and%20%22What%20this%20changes%22%20breakdown.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Frobinebers%2Fgithub%2Frobinebers%2Fopenusage%2F-%2Fcustom-context%3Fmemory%3D744f8f4b-f561-4803-844f-a17cfe0ea18d%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robinebers%2Fopenusage&pr=812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robinebers%2Fopenusage%22%20on%20the%20existing%20branch%20%22codex%2Fkimi-zai-opencodego-usage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fkimi-zai-opencodego-usage%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%201%0A%0AComment%3A%0A**PR%20description%20doesn't%20follow%20the%20required%20structure**%0A%0A%60AGENTS.md%60%20requires%20every%20PR%20description%20to%20use%20these%20sections%3A%20**TL%3BDR**%2C%20**What%20was%20happening**%2C%20**What%20this%20changes**%2C%20and%20optionally%20**Heads-up%20%2F%20Tests%20%2F%20Screenshots**.%20This%20PR%20uses%20%60%23%23%20Summary%60%20and%20%60%23%23%20Verification%60%20instead%2C%20which%20skips%20the%20required%20%22What%20was%20happening%22%20context%20and%20%22What%20this%20changes%22%20breakdown.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Frobinebers%2Fgithub%2Frobinebers%2Fopenusage%2F-%2Fcustom-context%3Fmemory%3D744f8f4b-f561-4803-844f-a17cfe0ea18d%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robinebers%2Fopenusage&pr=812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A126%0AThe%20%60%22updatedAt%22%60%20entry%20in%20this%20list%20is%20dead%20code.%20%60lower%60%20is%20always%20the%20result%20of%20%60key.lowercased%28%29%60%2C%20so%20it%20is%20always%20all-lowercase%20%E2%80%94%20it%20will%20never%20equal%20%60%22updatedAt%22%60%20%28which%20contains%20an%20uppercase%20%60A%60%29.%20A%20JSON%20field%20literally%20named%20%60%22updatedAt%22%60%20will%20slip%20through%20this%20filter%20undetected.%20The%20snake-case%20companion%20%60%22updated_at%22%60%20is%20already%20present%20and%20works%20correctly%3B%20the%20camelCase%20variant%20should%20be%20%60%22updatedat%22%60%20to%20match%20the%20lowercased%20comparison.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20%5B%22status%22%2C%20%22success%22%2C%20%22code%22%2C%20%22msg%22%2C%20%22message%22%2C%20%22error%22%2C%20%22request_id%22%2C%20%22timestamp%22%2C%20%22updated_at%22%2C%20%22updatedat%22%5D.contains%28lower%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A26-31%0A%60ProviderParse.jsonObject%28data%29%60%20is%20called%20twice%3A%20once%20to%20nil-check%20in%20the%20%60guard%60%2C%20and%20again%20immediately%20after%20to%20extract%20the%20actual%20value.%20The%20second%20call's%20%60%3F%3F%20%5B%3A%5D%60%20fallback%20is%20unreachable%20because%20the%20guard%20already%20ensures%20the%20first%20call%20returned%20non-nil.%20Parse%20once%20and%20reuse%20the%20result.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20func%20map%28_%20data%3A%20Data%29%20-%3E%20%5BMetricLine%5D%20%7B%0A%20%20%20%20%20%20%20%20guard%20let%20object%20%3D%20ProviderParse.jsonObject%28data%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20%5B.noUsageData%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20map%28object%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A82-85%0AThis%20force%20cast%20is%20guarded%20by%20the%20%60where%60%20clause%2C%20so%20it%20is%20safe%20today%2C%20but%20it%20is%20fragile%3A%20any%20future%20edit%20to%20the%20%60where%60%20predicate%20without%20updating%20this%20line%20would%20crash.%20Prefer%20a%20conditional%20cast%20with%20%60guard%60%20%2F%20%60continue%60%20to%20make%20the%20invariant%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20key%20in%20%5B%22quotas%22%2C%20%22limits%22%2C%20%22usage%22%2C%20%22metrics%22%5D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20container%20%3D%20object%5Bkey%5D%20as%3F%20%5BString%3A%20Any%5D%2C%20!container.isEmpty%20else%20%7B%20continue%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20addContainerEntries%28container%2C%20sourcePriority%3A%202%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%205%0Adocs%2Fproviders%2Fopencodego.md%3A3%0AThe%20opening%20sentence%20contains%20two%20issues%3A%20%22quota%20quotas%22%20is%20redundant%2C%20and%20the%20%60127.0.0.1%3A6736%2Fv1%2Fusage%60%20URL%20refers%20to%20OpenUsage's%20*own*%20local%20API%20server%20%28the%20%60LocalUsageServer%60%20that%20OpenUsage%20**serves**%20so%20that%20other%20apps%20can%20read%20from%20it%29%2C%20not%20a%20source%20that%20OpenUsage%20reads%20for%20OpenCode%20Go%20data.%20The%20OpenCode%20Go%20client%20reads%20from%20local%20JSON%20files%20or%20a%20user-configured%20env-var%20endpoint%20%E2%80%94%20neither%20of%20which%20is%20that%20address.%0A%0A%60%60%60suggestion%0ATracks%20OpenCode%20Go%20quota%20usage%20from%20local%20JSON%20files%20written%20by%20the%20running%20OpenCode%20Go%20process%2C%20or%20from%20a%20user-configured%20local%20endpoint.%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0AREADME.md%3A1%0A**PR%20description%20doesn't%20follow%20the%20required%20structure**%0A%0A%60AGENTS.md%60%20requires%20every%20PR%20description%20to%20use%20these%20sections%3A%20**TL%3BDR**%2C%20**What%20was%20happening**%2C%20**What%20this%20changes**%2C%20and%20optionally%20**Heads-up%20%2F%20Tests%20%2F%20Screenshots**.%20This%20PR%20uses%20%60%23%23%20Summary%60%20and%20%60%23%23%20Verification%60%20instead%2C%20which%20skips%20the%20required%20%22What%20was%20happening%22%20context%20and%20%22What%20this%20changes%22%20breakdown.%0A%0A&pr=812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A126%0AThe%20%60%22updatedAt%22%60%20entry%20in%20this%20list%20is%20dead%20code.%20%60lower%60%20is%20always%20the%20result%20of%20%60key.lowercased%28%29%60%2C%20so%20it%20is%20always%20all-lowercase%20%E2%80%94%20it%20will%20never%20equal%20%60%22updatedAt%22%60%20%28which%20contains%20an%20uppercase%20%60A%60%29.%20A%20JSON%20field%20literally%20named%20%60%22updatedAt%22%60%20will%20slip%20through%20this%20filter%20undetected.%20The%20snake-case%20companion%20%60%22updated_at%22%60%20is%20already%20present%20and%20works%20correctly%3B%20the%20camelCase%20variant%20should%20be%20%60%22updatedat%22%60%20to%20match%20the%20lowercased%20comparison.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20%5B%22status%22%2C%20%22success%22%2C%20%22code%22%2C%20%22msg%22%2C%20%22message%22%2C%20%22error%22%2C%20%22request_id%22%2C%20%22timestamp%22%2C%20%22updated_at%22%2C%20%22updatedat%22%5D.contains%28lower%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A26-31%0A%60ProviderParse.jsonObject%28data%29%60%20is%20called%20twice%3A%20once%20to%20nil-check%20in%20the%20%60guard%60%2C%20and%20again%20immediately%20after%20to%20extract%20the%20actual%20value.%20The%20second%20call's%20%60%3F%3F%20%5B%3A%5D%60%20fallback%20is%20unreachable%20because%20the%20guard%20already%20ensures%20the%20first%20call%20returned%20non-nil.%20Parse%20once%20and%20reuse%20the%20result.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20func%20map%28_%20data%3A%20Data%29%20-%3E%20%5BMetricLine%5D%20%7B%0A%20%20%20%20%20%20%20%20guard%20let%20object%20%3D%20ProviderParse.jsonObject%28data%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20%5B.noUsageData%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20map%28object%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A82-85%0AThis%20force%20cast%20is%20guarded%20by%20the%20%60where%60%20clause%2C%20so%20it%20is%20safe%20today%2C%20but%20it%20is%20fragile%3A%20any%20future%20edit%20to%20the%20%60where%60%20predicate%20without%20updating%20this%20line%20would%20crash.%20Prefer%20a%20conditional%20cast%20with%20%60guard%60%20%2F%20%60continue%60%20to%20make%20the%20invariant%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20key%20in%20%5B%22quotas%22%2C%20%22limits%22%2C%20%22usage%22%2C%20%22metrics%22%5D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20container%20%3D%20object%5Bkey%5D%20as%3F%20%5BString%3A%20Any%5D%2C%20!container.isEmpty%20else%20%7B%20continue%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20addContainerEntries%28container%2C%20sourcePriority%3A%202%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%205%0Adocs%2Fproviders%2Fopencodego.md%3A3%0AThe%20opening%20sentence%20contains%20two%20issues%3A%20%22quota%20quotas%22%20is%20redundant%2C%20and%20the%20%60127.0.0.1%3A6736%2Fv1%2Fusage%60%20URL%20refers%20to%20OpenUsage's%20*own*%20local%20API%20server%20%28the%20%60LocalUsageServer%60%20that%20OpenUsage%20**serves**%20so%20that%20other%20apps%20can%20read%20from%20it%29%2C%20not%20a%20source%20that%20OpenUsage%20reads%20for%20OpenCode%20Go%20data.%20The%20OpenCode%20Go%20client%20reads%20from%20local%20JSON%20files%20or%20a%20user-configured%20env-var%20endpoint%20%E2%80%94%20neither%20of%20which%20is%20that%20address.%0A%0A%60%60%60suggestion%0ATracks%20OpenCode%20Go%20quota%20usage%20from%20local%20JSON%20files%20written%20by%20the%20running%20OpenCode%20Go%20process%2C%20or%20from%20a%20user-configured%20local%20endpoint.%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0AREADME.md%3A1%0A**PR%20description%20doesn't%20follow%20the%20required%20structure**%0A%0A%60AGENTS.md%60%20requires%20every%20PR%20description%20to%20use%20these%20sections%3A%20**TL%3BDR**%2C%20**What%20was%20happening**%2C%20**What%20this%20changes**%2C%20and%20optionally%20**Heads-up%20%2F%20Tests%20%2F%20Screenshots**.%20This%20PR%20uses%20%60%23%23%20Summary%60%20and%20%60%23%23%20Verification%60%20instead%2C%20which%20skips%20the%20required%20%22What%20was%20happening%22%20context%20and%20%22What%20this%20changes%22%20breakdown.%0A%0A&repo=robinebers%2Fopenusage&pr=812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robinebers%2Fopenusage%22%20on%20the%20existing%20branch%20%22codex%2Fkimi-zai-opencodego-usage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fkimi-zai-opencodego-usage%22.%0A%0AFix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A126%0AThe%20%60%22updatedAt%22%60%20entry%20in%20this%20list%20is%20dead%20code.%20%60lower%60%20is%20always%20the%20result%20of%20%60key.lowercased%28%29%60%2C%20so%20it%20is%20always%20all-lowercase%20%E2%80%94%20it%20will%20never%20equal%20%60%22updatedAt%22%60%20%28which%20contains%20an%20uppercase%20%60A%60%29.%20A%20JSON%20field%20literally%20named%20%60%22updatedAt%22%60%20will%20slip%20through%20this%20filter%20undetected.%20The%20snake-case%20companion%20%60%22updated_at%22%60%20is%20already%20present%20and%20works%20correctly%3B%20the%20camelCase%20variant%20should%20be%20%60%22updatedat%22%60%20to%20match%20the%20lowercased%20comparison.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20%5B%22status%22%2C%20%22success%22%2C%20%22code%22%2C%20%22msg%22%2C%20%22message%22%2C%20%22error%22%2C%20%22request_id%22%2C%20%22timestamp%22%2C%20%22updated_at%22%2C%20%22updatedat%22%5D.contains%28lower%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A26-31%0A%60ProviderParse.jsonObject%28data%29%60%20is%20called%20twice%3A%20once%20to%20nil-check%20in%20the%20%60guard%60%2C%20and%20again%20immediately%20after%20to%20extract%20the%20actual%20value.%20The%20second%20call's%20%60%3F%3F%20%5B%3A%5D%60%20fallback%20is%20unreachable%20because%20the%20guard%20already%20ensures%20the%20first%20call%20returned%20non-nil.%20Parse%20once%20and%20reuse%20the%20result.%0A%0A%60%60%60suggestion%0A%20%20%20%20static%20func%20map%28_%20data%3A%20Data%29%20-%3E%20%5BMetricLine%5D%20%7B%0A%20%20%20%20%20%20%20%20guard%20let%20object%20%3D%20ProviderParse.jsonObject%28data%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20%5B.noUsageData%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20return%20map%28object%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0ASources%2FOpenUsage%2FProviders%2FOpenCodeGo%2FOpenCodeGoUsageMapper.swift%3A82-85%0AThis%20force%20cast%20is%20guarded%20by%20the%20%60where%60%20clause%2C%20so%20it%20is%20safe%20today%2C%20but%20it%20is%20fragile%3A%20any%20future%20edit%20to%20the%20%60where%60%20predicate%20without%20updating%20this%20line%20would%20crash.%20Prefer%20a%20conditional%20cast%20with%20%60guard%60%20%2F%20%60continue%60%20to%20make%20the%20invariant%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20key%20in%20%5B%22quotas%22%2C%20%22limits%22%2C%20%22usage%22%2C%20%22metrics%22%5D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20guard%20let%20container%20%3D%20object%5Bkey%5D%20as%3F%20%5BString%3A%20Any%5D%2C%20!container.isEmpty%20else%20%7B%20continue%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20addContainerEntries%28container%2C%20sourcePriority%3A%202%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%205%0Adocs%2Fproviders%2Fopencodego.md%3A3%0AThe%20opening%20sentence%20contains%20two%20issues%3A%20%22quota%20quotas%22%20is%20redundant%2C%20and%20the%20%60127.0.0.1%3A6736%2Fv1%2Fusage%60%20URL%20refers%20to%20OpenUsage's%20*own*%20local%20API%20server%20%28the%20%60LocalUsageServer%60%20that%20OpenUsage%20**serves**%20so%20that%20other%20apps%20can%20read%20from%20it%29%2C%20not%20a%20source%20that%20OpenUsage%20reads%20for%20OpenCode%20Go%20data.%20The%20OpenCode%20Go%20client%20reads%20from%20local%20JSON%20files%20or%20a%20user-configured%20env-var%20endpoint%20%E2%80%94%20neither%20of%20which%20is%20that%20address.%0A%0A%60%60%60suggestion%0ATracks%20OpenCode%20Go%20quota%20usage%20from%20local%20JSON%20files%20written%20by%20the%20running%20OpenCode%20Go%20process%2C%20or%20from%20a%20user-configured%20local%20endpoint.%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0AREADME.md%3A1%0A**PR%20description%20doesn't%20follow%20the%20required%20structure**%0A%0A%60AGENTS.md%60%20requires%20every%20PR%20description%20to%20use%20these%20sections%3A%20**TL%3BDR**%2C%20**What%20was%20happening**%2C%20**What%20this%20changes**%2C%20and%20optionally%20**Heads-up%20%2F%20Tests%20%2F%20Screenshots**.%20This%20PR%20uses%20%60%23%23%20Summary%60%20and%20%60%23%23%20Verification%60%20instead%2C%20which%20skips%20the%20required%20%22What%20was%20happening%22%20context%20and%20%22What%20this%20changes%22%20breakdown.%0A%0A&repo=robinebers%2Fopenusage&pr=812&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageMapper.swift:126
The `"updatedAt"` entry in this list is dead code. `lower` is always the result of `key.lowercased()`, so it is always all-lowercase — it will never equal `"updatedAt"` (which contains an uppercase `A`). A JSON field literally named `"updatedAt"` will slip through this filter undetected. The snake-case companion `"updated_at"` is already present and works correctly; the camelCase variant should be `"updatedat"` to match the lowercased comparison.

```suggestion
        return ["status", "success", "code", "msg", "message", "error", "request_id", "timestamp", "updated_at", "updatedat"].contains(lower)
```

### Issue 2 of 5
Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageMapper.swift:26-31
`ProviderParse.jsonObject(data)` is called twice: once to nil-check in the `guard`, and again immediately after to extract the actual value. The second call's `?? [:]` fallback is unreachable because the guard already ensures the first call returned non-nil. Parse once and reuse the result.

```suggestion
    static func map(_ data: Data) -> [MetricLine] {
        guard let object = ProviderParse.jsonObject(data) else {
            return [.noUsageData]
        }
        return map(object)
    }
```

### Issue 3 of 5
Sources/OpenUsage/Providers/OpenCodeGo/OpenCodeGoUsageMapper.swift:82-85
This force cast is guarded by the `where` clause, so it is safe today, but it is fragile: any future edit to the `where` predicate without updating this line would crash. Prefer a conditional cast with `guard` / `continue` to make the invariant explicit.

```suggestion
        for key in ["quotas", "limits", "usage", "metrics"] {
            guard let container = object[key] as? [String: Any], !container.isEmpty else { continue }
            addContainerEntries(container, sourcePriority: 2)
        }
```

### Issue 4 of 5
docs/providers/opencodego.md:3
The opening sentence contains two issues: "quota quotas" is redundant, and the `127.0.0.1:6736/v1/usage` URL refers to OpenUsage's *own* local API server (the `LocalUsageServer` that OpenUsage **serves** so that other apps can read from it), not a source that OpenUsage reads for OpenCode Go data. The OpenCode Go client reads from local JSON files or a user-configured env-var endpoint — neither of which is that address.

```suggestion
Tracks OpenCode Go quota usage from local JSON files written by the running OpenCode Go process, or from a user-configured local endpoint.
```

### Issue 5 of 5
README.md:1
**PR description doesn't follow the required structure**

`AGENTS.md` requires every PR description to use these sections: **TL;DR**, **What was happening**, **What this changes**, and optionally **Heads-up / Tests / Screenshots**. This PR uses `## Summary` and `## Verification` instead, which skips the required "What was happening" context and "What this changes" breakdown.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add OpenCode Go usage provider"](https://github.com/robinebers/openusage/commit/7d0b9507b2b15bcf134b9410263072f78c098bfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41038216)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/robinebers/github/robinebers/openusage/-/custom-context?memory=744f8f4b-f561-4803-844f-a17cfe0ea18d))

<!-- /greptile_comment -->