### PR TITLE
fix(cursor): price Claude Sonnet 5 in spend imputation manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ AGENTS.md is the source of truth for agent instructions in this repository. CLAU
 Conventions for the per-provider modules under `Sources/OpenUsage/Providers/<Name>/`.
 
 - **Structure:** one folder per provider with an auth store (reads credentials already on the user's machine), a usage client (calls the provider API), and a mapper (normalizes to `MetricLine`), conforming to `ProviderRuntime`. See `docs/adding-a-provider.md`.
+- **Cursor spend imputation:** per-model token rates live in `Sources/OpenUsage/Resources/model_manifest.json`. Sync new or changed models from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md) (update `retrieved_at`, pricing entries, and `alias_rules` for CSV model slugs).
 - **Default order:** Claude, Codex, Cursor first (the established providers, in that order), then every other provider alphabetically by display name (Antigravity, Devin, Grok, …). The order is the array order in `AppContainer`, which seeds `LayoutStore`'s default provider order (and `resetToDefault`). A new provider slots into the alphabetical tail.
 - **Metric placement defaults:** when adding or changing a metric, confirm its four defaults with the owner before choosing — never pick silently:
   1. enabled on/off (`DefaultLayout.metricIDs`),

--- a/Sources/OpenUsage/Providers/Cursor/CursorModelManifest.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorModelManifest.swift
@@ -3,6 +3,8 @@ import Foundation
 /// Bundled model-pricing manifest used to impute Cursor spend from the usage CSV.
 /// Ported from `../cursorcat/Sources/CursorCat/Support/ModelManifest.swift`; the only
 /// behavioral change is loading via `Bundle.module` instead of cursorcat's `AppBundle`.
+/// When adding models, sync rates from Cursor's docs:
+/// https://cursor.com/docs/models-and-pricing.md
 struct CursorModelManifest: Decodable, Sendable {
     let retrievedAt: String
     let pricing: [String: CursorModelManifestPricingEntry]

--- a/Sources/OpenUsage/Resources/model_manifest.json
+++ b/Sources/OpenUsage/Resources/model_manifest.json
@@ -1,5 +1,5 @@
 {
-  "retrieved_at": "2026-06-09",
+  "retrieved_at": "2026-07-01",
   "pricing": {
     "auto": {
       "display_name": "Auto",
@@ -224,6 +224,17 @@
       "cache_read_per_million": 1.0,
       "output_per_million": 50.0,
       "apply_max_mode_uplift": false
+    },
+    "claude-sonnet-5": {
+      "display_name": "Claude Sonnet 5",
+      "provider": "anthropic",
+      "family_id": "claude-sonnet-5",
+      "family_display_name": "Claude Sonnet 5",
+      "input_per_million": 3.0,
+      "cache_write_per_million": 3.75,
+      "cache_read_per_million": 0.3,
+      "output_per_million": 15.0,
+      "apply_max_mode_uplift": true
     },
     "gemini-3-flash": {
       "display_name": "Gemini 3 Flash",
@@ -625,6 +636,7 @@
     { "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-4.8-opus-fast" },
     { "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-4.8-opus" },
     { "pattern": "^claude-fable-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-fable-5" },
+    { "pattern": "^claude-sonnet-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-sonnet-5" },
     { "pattern": "^gemini-2\\.5-flash$", "canonical": "gemini-2.5-flash" },
     { "pattern": "^gemini-3-flash(?:-preview)?$", "canonical": "gemini-3-flash" },
     { "pattern": "^gemini-3\\.5-flash(?:-preview)?$", "canonical": "gemini-3.5-flash" },

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -82,6 +82,25 @@ final class CursorPricingTests: XCTestCase {
         XCTAssertEqual(fable.outputPerMillion, opus48.outputPerMillion * 2)
     }
 
+    /// Claude Sonnet 5 (2026-07-01): same API pool rates as Claude 4.6 Sonnet; thinking/effort slugs
+    /// resolve to one canonical entry. Cursor's page notes a launch promo ($2/$10 per M) through Aug 2026;
+    /// imputation uses the listed API rates ($3/$15) like other Sonnet rows.
+    func testClaudeSonnet5PricingAndAliases() throws {
+        XCTAssertEqual(CursorPricing.canonicalModel(for: "claude-sonnet-5"), "claude-sonnet-5")
+        XCTAssertEqual(CursorPricing.canonicalModel(for: "claude-sonnet-5-thinking-high"), "claude-sonnet-5")
+
+        let sonnet5 = try XCTUnwrap(CursorPricing.pricingEntry(for: "claude-sonnet-5"))
+        XCTAssertEqual(sonnet5.familyDisplayName, "Claude Sonnet 5")
+        XCTAssertEqual(sonnet5.inputPerMillion, 3.0)
+        XCTAssertEqual(sonnet5.cacheWritePerMillion, 3.75)
+        XCTAssertEqual(sonnet5.cacheReadPerMillion, 0.3)
+        XCTAssertEqual(sonnet5.outputPerMillion, 15.0)
+
+        let sonnet46 = try XCTUnwrap(CursorPricing.pricingEntry(for: "claude-4.6-sonnet"))
+        XCTAssertEqual(sonnet5.inputPerMillion, sonnet46.inputPerMillion)
+        XCTAssertEqual(sonnet5.outputPerMillion, sonnet46.outputPerMillion)
+    }
+
     /// GLM 5.2 (Z.ai) was added to Cursor's pricing page after the 2026-06-09 manifest sync. It ships
     /// as two reasoning-effort variants — `glm-5.2-high` and `glm-5.2-max` — which both resolve to the
     /// one canonical `glm-5.2` entry. The pricing page lists no separate cache-write price, so cache

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -29,4 +29,4 @@ Cursor's per-day spend tiles (Today / Yesterday / Last 30 Days) and the Usage Tr
 
 ## Under the hood
 
-Connect RPC on `api2.cursor.sh` (dashboard usage), REST fallback at `cursor.com/api/usage` for request-based accounts, and Stripe balance at `cursor.com/api/auth/stripe`. A 401/403 triggers one token refresh and retry. (The usage-events CSV export at `cursor.com/api/dashboard/export-usage-events-csv` previously fed the spend history; it's not currently fetched — see above.)
+Connect RPC on `api2.cursor.sh` (dashboard usage), REST fallback at `cursor.com/api/usage` for request-based accounts, and Stripe balance at `cursor.com/api/auth/stripe`. A 401/403 triggers one token refresh and retry. Per-day spend imputation uses token counts and bundled rates in `model_manifest.json` (maintainers sync from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md)). (The usage-events CSV export at `cursor.com/api/dashboard/export-usage-events-csv` previously fed the spend history; it's not currently fetched — see above.)


### PR DESCRIPTION
## TL;DR

Adds Claude Sonnet 5 to Cursor’s bundled `model_manifest.json` so spend imputation and Grok log pricing recognize the new model, and documents where to sync future Cursor model rates.

## What was happening

- Cursor shipped **Claude Sonnet 5** on its API pool, but OpenUsage’s manifest had no entry or alias rules for it.
- Usage on that model priced at **$0** and could trigger the **unknown pricing** warning on spend tiles.

## What this changes

- Adds `claude-sonnet-5` at Cursor’s listed API rates ($3 / $3.75 / $0.3 / $15 per M) plus alias rules for thinking/effort slugs.
- Bumps manifest `retrieved_at` to 2026-07-01.
- Records the maintainer source URL in `AGENTS.md`, `docs/providers/cursor.md`, and `CursorModelManifest.swift`.
- Adds `testClaudeSonnet5PricingAndAliases`.

## Heads-up

- Cursor’s page notes a **launch promo** ($2 / $10 per M through Aug 31, 2026). Imputation uses the **table API rates** ($3 / $15), consistent with other Sonnet rows—not the promo. We can switch to promo rates if imputed spend should match discounted billing during the offer.

## Tests

- `swift test --filter CursorPricingTests`

Made with [Cursor](https://cursor.com)