### PR TITLE
feat(claude): track Fable model-scoped weekly limit

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -43,6 +43,7 @@ final class ClaudeProvider: ProviderRuntime {
             .percent(id: "claude.session", provider: provider, title: "Session"),
             .percent(id: "claude.weekly", provider: provider, title: "Weekly"),
             .percent(id: "claude.sonnet", provider: provider, title: "Sonnet"),
+            .percent(id: "claude.fable", provider: provider, title: "Fable"),
             .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent"),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -24,6 +24,7 @@ enum ClaudeUsageMapper {
         appendUsageWindow(body["five_hour"], label: "Session", periodDurationMs: sessionPeriodMs, to: &lines)
         appendUsageWindow(body["seven_day"], label: "Weekly", periodDurationMs: weeklyPeriodMs, to: &lines)
         appendUsageWindow(body["seven_day_sonnet"], label: "Sonnet", periodDurationMs: weeklyPeriodMs, to: &lines)
+        appendScopedWeeklyLimit(body["limits"], modelName: "Fable", label: "Fable", to: &lines)
         appendExtraUsage(body["extra_usage"], to: &lines)
 
         return ClaudeMappedUsage(
@@ -106,6 +107,32 @@ enum ClaudeUsageMapper {
             resetsAt: resetDate(object["resets_at"]),
             periodDurationMs: periodDurationMs
         ))
+    }
+
+    /// A model-scoped weekly limit from the `limits` array — `kind: "weekly_scoped"` with
+    /// `scope.model.display_name` naming the model (e.g. "Fable"). Anthropic moved the per-model
+    /// weekly windows off the legacy top-level `seven_day_<model>` keys (which now come back null)
+    /// and into this array, so each scoped row is read by display name. `percent` is 0–100.
+    private static func appendScopedWeeklyLimit(_ limits: Any?, modelName: String, label: String, to lines: inout [MetricLine]) {
+        guard let array = limits as? [Any] else { return }
+        for entry in array {
+            guard let object = entry as? [String: Any],
+                  object["kind"] as? String == "weekly_scoped",
+                  let scope = object["scope"] as? [String: Any],
+                  let model = scope["model"] as? [String: Any],
+                  model["display_name"] as? String == modelName,
+                  let used = ProviderParse.number(object["percent"])
+            else { continue }
+            lines.append(.progress(
+                label: label,
+                used: used,
+                limit: 100,
+                format: .percent,
+                resetsAt: resetDate(object["resets_at"]),
+                periodDurationMs: weeklyPeriodMs
+            ))
+            return
+        }
     }
 
     private static func appendExtraUsage(_ value: Any?, to lines: inout [MetricLine]) {

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -74,7 +74,7 @@ enum DefaultLayout {
         "antigravity.claude",
         // Claude's core meters (Session, Weekly, Extra, Usage Trend) stay above the fold; spend-history
         // rows sit below the caret. Matches every other provider's "core above, history below" shape.
-        "claude.sonnet", "claude.today", "claude.yesterday", "claude.last30",
+        "claude.sonnet", "claude.fable", "claude.today", "claude.yesterday", "claude.last30",
         // Codex's core Session/Weekly meters and Usage Trend stay above the fold; Spark (the optional
         // model-specific limits), credits, reset details, and spend rows sit below the caret.
         "codex.spark", "codex.sparkWeekly",

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -173,6 +173,38 @@ final class ClaudeUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Extra usage spent")?.limit, 10)
     }
 
+    func testMapsFableScopedWeeklyLimitFromLimitsArray() throws {
+        // Anthropic moved per-model weekly windows into `limits[]` as `weekly_scoped` rows keyed by
+        // `scope.model.display_name`; the legacy `seven_day_<model>` top-level keys now come back null.
+        let response = HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data("""
+            {
+              "five_hour": { "utilization": 10, "resets_at": "2099-01-01T00:00:00.000Z" },
+              "seven_day": { "utilization": 20, "resets_at": "2099-01-01T00:00:00.000Z" },
+              "seven_day_sonnet": null,
+              "limits": [
+                { "kind": "session", "group": "session", "percent": 10, "resets_at": "2099-01-01T00:00:00.000Z" },
+                { "kind": "weekly_all", "group": "weekly", "percent": 20, "resets_at": "2099-01-08T00:00:00.000Z" },
+                { "kind": "weekly_scoped", "group": "weekly", "percent": 7,
+                  "resets_at": "2099-01-08T00:00:00.000Z",
+                  "scope": { "model": { "display_name": "Fable", "id": null }, "surface": null } }
+              ]
+            }
+            """.utf8)
+        )
+
+        let mapped = try ClaudeUsageMapper.mapUsageResponse(
+            response,
+            credentials: ClaudeOAuth(subscriptionType: "max")
+        )
+
+        XCTAssertEqual(progress(mapped.lines, "Fable")?.used, 7)
+        XCTAssertEqual(progress(mapped.lines, "Fable")?.limit, 100)
+        XCTAssertEqual(progress(mapped.lines, "Fable")?.periodDurationMs, ClaudeUsageMapper.weeklyPeriodMs)
+    }
+
     func testUncappedExtraUsageIsAnUnboundedValuesRow() throws {
         // No `monthly_limit`: the spend has no cap, so it's an unbounded `.values` row (which formats
         // through `MetricFormatter`, matching the spend tiles) rather than a baked full-currency `.text`.

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -610,7 +610,7 @@ final class LayoutStoreTests: XCTestCase {
         let store = LayoutStore(registry: registry, defaults: makeDefaults("FreshCustomizeOrder"), storageKey: "layout")
 
         XCTAssertEqual(store.orderedSupportedMetrics(for: "claude").map(\.id), [
-            "claude.session", "claude.weekly", "claude.sonnet", "claude.extra",
+            "claude.session", "claude.weekly", "claude.sonnet", "claude.fable", "claude.extra",
             "claude.trend", "claude.today", "claude.yesterday", "claude.last30"
         ])
         XCTAssertEqual(store.orderedSupportedMetrics(for: "codex").map(\.id), [
@@ -668,7 +668,7 @@ final class LayoutStoreTests: XCTestCase {
         // Claude's core meters (Session, Weekly, Extra, Usage Trend) stay primary; spend-history rows
         // go below the caret — the same "core above, history below" shape as the other providers.
         XCTAssertEqual(primaryByProvider["claude"], ["claude.session", "claude.weekly", "claude.extra", "claude.trend"])
-        XCTAssertEqual(expandedByProvider["claude"], ["claude.sonnet", "claude.today", "claude.yesterday", "claude.last30"])
+        XCTAssertEqual(expandedByProvider["claude"], ["claude.sonnet", "claude.fable", "claude.today", "claude.yesterday", "claude.last30"])
         XCTAssertEqual(primaryByProvider["codex"], ["codex.session", "codex.weekly", "codex.trend"])
         // Spark (the optional model-specific limits) leads the expanded section, before credits.
         XCTAssertEqual(expandedByProvider["codex"], [

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -9,6 +9,7 @@ Tracks your Claude subscription limits using the login you already have from Cla
 | Session | 5-hour rolling window usage |
 | Weekly | 7-day window usage |
 | Sonnet | Separate weekly Sonnet limit (plan-dependent) |
+| Fable | Separate weekly Fable limit (model-scoped window from the `limits` array) |
 | Extra Usage | Extra-usage credits spent against your monthly cap |
 | Today / Yesterday / Last 30 Days | Local spend, as cost, tokens, or both (see below) |
 | Plan | Your plan name (optional widget) |


### PR DESCRIPTION
## TL;DR
Adds a **Fable** weekly usage meter to the Claude provider, read from Anthropic's new `limits[]` array shape.

## What was happening
Anthropic moved the per-model weekly windows off the legacy top-level `seven_day_<model>` keys (which now come back `null`) into the `limits` array as `weekly_scoped` rows keyed by `scope.model.display_name`. The existing Sonnet row reads `body["seven_day_sonnet"]`, which is now null, so model-scoped limits had no source.

## What this changes
- New `appendScopedWeeklyLimit` in `ClaudeUsageMapper` scans `limits[]` for `kind == "weekly_scoped"` matching a model display name, reads `percent` (0–100), and emits a `.progress` line.
- Maps the `"Fable"` model to a new **Fable** metric (`claude.fable`), declared right after Sonnet.
- Default placement mirrors Sonnet: secondary (below the expand caret), disabled by default.
- New mapper test `testMapsFableScopedWeeklyLimitFromLimitsArray`; updated the two layout ordering/expanded assertions.
- `docs/providers/claude.md` adds a Fable row.

## Heads-up
The mapper matches by display name (`"Fable"`). If Anthropic renames the scope model display name, the row silently stops appearing — same fragility as any name-keyed lookup, and consistent with how the legacy `seven_day_sonnet` key was named.

## Tests
- `ClaudeUsageMapperTests`: 6/6 passed (incl. new Fable case).
- `LayoutStoreTests`: 67/67 passed.
- Built and launched the dev bundle via `./script/build_and_run.sh verify`; process verified running.

Made with [Cursor](https://cursor.com)