### PR TITLE
feat(customize): add Reset All Customization button with confirmation

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -499,6 +499,10 @@ final class StatusItemController: NSObject {
                 // While the panel is morphing its height, its frame is moving under a possibly
                 // stationary cursor — don't let a click land "outside" a frame that's mid-resize.
                 guard !self.isMorphing else { return }
+                // A sheet is attached to the panel (e.g. the Customize "Reset All Customization"
+                // confirmation alert). A click in another app would otherwise close the popover out
+                // from under the alert — keep the panel open for the sheet's lifetime.
+                guard self.panel.attachedSheet == nil else { return }
                 // Clicking the status item must NOT dismiss here — its own action toggles the panel.
                 // Dismissing on this click's mouse-down would close the panel, then the button action
                 // would reopen it on mouse-up (the close-then-reopen flicker).
@@ -526,6 +530,11 @@ final class StatusItemController: NSObject {
     private func shouldKeepPanelOpen(windowID: ObjectIdentifier?, windowTypeName: String?, screenPoint: NSPoint) -> Bool {
         // The frame is moving mid-morph; a hit-test against it would be racy, so keep the panel open.
         if isMorphing { return true }
+        // A sheet is attached to the panel (e.g. the Customize "Reset All Customization" confirmation
+        // alert). Its buttons live in a child window whose own `event.window` is the sheet, not the
+        // panel — without this guard a click on "Reset All" / "Cancel" reads as an outside click and
+        // dismisses the popover out from under the alert. Keep the panel open for the sheet's lifetime.
+        if panel.attachedSheet != nil { return true }
         if isOnStatusButton(screenPoint: screenPoint) { return true }
         if panel.frame.contains(screenPoint) { return true }
         guard let windowID, let windowTypeName else { return false }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -163,6 +163,13 @@ struct DashboardView: View {
                 reorderLift = nil
                 layout.cancelDrag()
             }
+            // The Reset All alert attaches to the Customize L1 nav bar. Leaving the list — back to the
+            // dashboard or into a provider's L2 detail — unmounts that host, which dismisses the alert
+            // but leaves `isPresentingResetAllConfirm` `true`. Drop it whenever L1 stops being visible
+            // so the destructive confirmation can't reappear stale on return without a fresh tap.
+            .onChange(of: layout.screen == .customize && layout.customizeProviderID == nil) { _, isL1Visible in
+                if !isL1Visible { isPresentingResetAllConfirm = false }
+            }
             // Each screen switch: pin to the outgoing screen for one render (`slideProgress = 0`),
             // then spring to the incoming one on the next runloop tick. Deferring the animation one
             // tick is what makes it animate — setting 0 then 1 in the same closure collapses to a

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -43,6 +43,10 @@ struct DashboardView: View {
     @State private var animatedSlideID = 0
     /// Reset to the top whenever the popover closes, so it never reopens mid-scroll.
     @State private var dashboardScrollPosition = ScrollPosition(edge: .top)
+    /// Drives the macOS-native confirmation sheet for the Customize "reset all" button. The alert
+    /// attaches to this panel as a sheet (see `StatusItemController`'s attached-sheet guard), so a
+    /// click on its buttons can't be misread as an outside click that dismisses the popover.
+    @State private var isPresentingResetAllConfirm = false
     /// Row rhythm tracks the global density setting live.
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
@@ -228,6 +232,9 @@ struct DashboardView: View {
         // since the layout store survives the popover and only the timer clears it.
         layout.clearShareConfirmation()
         layout.clearCustomizationNotice()
+        // Dismiss a pending Reset All confirmation if the popover closes mid-alert — the SwiftUI tree
+        // survives `orderOut`, so without this the sheet would reappear stale on the next open.
+        isPresentingResetAllConfirm = false
         // Drop the driven height so the next open re-establishes it (un-animated) from the reopened
         // screen's measurement instead of springing from this session's last value. Until then the
         // 0 sentinel keeps `PanelHeightModifier` from pushing, so the controller's opening guess stands.
@@ -364,15 +371,24 @@ struct DashboardView: View {
         case .dashboard:
             EmptyView()
         case .customize:
-            // L2 (provider detail) shows a per-provider reset button; L1 (the list) has no trailing
-            // action. Title swaps to the provider name on L2; back is context-aware (L2 → L1, L1 → dashboard).
+            // L2 (provider detail) shows a per-provider reset button; L1 (the list) carries the
+            // "reset all customization" button in the same trailing slot. Title swaps to the provider
+            // name on L2; back is context-aware (L2 → L1, L1 → dashboard).
             if let id = layout.customizeProviderID {
                 navBar(title: customizeTitle, back: customizeBack) {
                     resetButton(for: id)
                 }
             } else {
                 navBar(title: customizeTitle, back: customizeBack) {
-                    EmptyView()
+                    resetAllButton()
+                }
+                .alert("Reset All Customization?", isPresented: $isPresentingResetAllConfirm) {
+                    Button("Reset All", role: .destructive) {
+                        withAnimation(Motion.spring) { layout.resetToDefault() }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("Resets every provider, their metrics and the order. Are you sure?")
                 }
             }
         case .settings:
@@ -498,6 +514,27 @@ struct DashboardView: View {
         .controlSize(.large)
         .hoverTooltip("Reset \(layout.provider(id: providerID)?.displayName ?? providerID)")
         .accessibilityLabel("Reset")
+    }
+
+    /// The trailing "reset all customization" button on the L1 Customize list — the all-providers
+    /// counterpart to `resetButton`. Same circular glass idiom and reset icon; the scope (everything
+    /// vs. one provider) is conveyed by the tooltip and the confirmation sheet it opens. The sheet
+    /// (`isPresentingResetAllConfirm`) is a real macOS alert, so a destructive "Reset All" is a
+    /// deliberate two-step action — never a single mis-click that wipes the whole layout.
+    private func resetAllButton() -> some View {
+        Button {
+            isPresentingResetAllConfirm = true
+        } label: {
+            Image(systemName: "arrow.counterclockwise")
+                .font(.system(size: 13, weight: .semibold))
+                .frame(width: 16, height: 16)
+                .contentShape(Rectangle())
+        }
+        .glassButtonStyle()
+        .buttonBorderShape(.circle)
+        .controlSize(.large)
+        .hoverTooltip("Reset All Customization")
+        .accessibilityLabel("Reset All Customization")
     }
 
     // MARK: - Pinned footer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ The UI reads from a few observable stores:
 
 - `WidgetDataStore` — the latest snapshot per provider, plus refresh and caching. This is what the
   dashboard rows and menu-bar strip read.
-- `LayoutStore` — which metrics are shown, the provider/metric order, and which metrics are pinned to the
+- `LayoutStore` — which metrics are shown, the provider/metric order, and which metrics are starred for the
   menu bar.
 - `ProviderEnablementStore` — which providers the user has turned on or off.
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -51,7 +51,7 @@ Open Customize from the **⌄** menu next to the footer's Settings button (or pr
 
 The **provider list** shows every provider with a switch to turn it on or off, an Active/Inactive status, a count of its metrics, and a chevron into its detail. Turn a provider off and it stays in the list, greyed — its metrics hide from the dashboard and menu bar but keep their setup for when you turn it back on. Drag providers by their grip to reorder; tap a row to open its detail.
 
-A provider's **detail** has a header (the same on/off switch) and two metric sections: **Always Visible** (shown on the dashboard card) and **On Demand** (tucked behind the card's caret). Each metric row is a switch with its name beside it, a star to pin it to the menu bar, and a drag grip. Drag a metric across the dashed divider between the sections to move it between Always Visible and On Demand, or drag it onto a row on the other side. You can star up to two metrics per provider for the menu bar. Providers that need an API key (OpenRouter today) show an **API Key** section here too — add, edit, or clear the key for just that provider.
+A provider's **detail** has a header (the same on/off switch) and two metric sections: **Always Visible** (shown on the dashboard card) and **On Demand** (tucked behind the card's caret). Each metric row is a switch with its name beside it, a star to add it to the menu bar, and a drag grip. Drag a metric across the dashed divider between the sections to move it between Always Visible and On Demand, or drag it onto a row on the other side. You can star up to two metrics per provider for the menu bar. Providers that need an API key (OpenRouter today) show an **API Key** section here too — add, edit, or clear the key for just that provider.
 
 Drag-reorder also works directly on the dashboard — drag a row within its provider, drag it across the caret boundary while the card is open, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
 
@@ -59,7 +59,7 @@ The default reset layout keeps each provider's core quota meters and Usage Trend
 
 Made a change you didn't mean to? Press **⌘Z** to undo — it works anywhere in the popover (the dashboard and Customize alike) and steps back through your recent customization changes one at a time: hiding or showing a metric, reordering metrics or whole providers, starring or unstarring, and moving a metric across the divider all undo. Each step restores the exact previous arrangement. Undo is per-session (it starts fresh after a relaunch), and resetting clears it.
 
-When OpenUsage ships a new default metric, existing layouts get it once. If you turn it off, it stays off. The **Reset** button in Customize restores the default metrics, order, menu-bar stars, and which metrics start on demand, but leaves other preferences unchanged.
+When OpenUsage ships a new default metric, existing layouts get it once. If you turn it off, it stays off. A provider's **Reset** button (top right of its detail) restores that provider's default metrics, order, menu-bar stars, and which metrics start on demand, but leaves other providers and the provider order untouched. The **Reset All Customization** button (top right of the provider list) does the same for every provider at once and also restores the default provider order — it asks for confirmation first, since it wipes the whole layout and can't be undone.
 
 ## Keyboard
 

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -34,7 +34,7 @@ way, nothing leaves your Mac except the same API calls Z.ai's own subscription U
 export ZAI_API_KEY="YOUR_API_KEY"
 ```
 
-3. Z.ai appears on the dashboard and (after you pin a metric) the menu bar on the next refresh.
+3. Z.ai appears on the dashboard and (after you star a metric) the menu bar on the next refresh.
 
 ## Under the hood
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -13,7 +13,7 @@ Settings lives inside the popover — there is no separate window. Open it from 
 
 | Setting | Options | What it does |
 |---|---|---|
-| Menu Style | Text / Bars | How pinned metrics render in the menu bar. See [Menu bar](menu-bar.md). |
+| Menu Style | Text / Bars | How starred metrics render in the menu bar. See [Menu bar](menu-bar.md). |
 | Theme | System / Light / Dark | App-wide appearance override for the popover. |
 | Density | Default / Compact | Default breathes; Compact is a real information-dense mode — text steps down one size, rows and provider sections pull together, and Customize / Settings rows tighten with them. In both, consecutive one-line metrics (Today / Yesterday / …) pull together; Compact pulls harder. |
 | Time Format | Auto / 12-hour / 24-hour | How exact times read (e.g. "Resets today at 6:38 PM" vs "18:38"). Auto follows the system. |
@@ -60,4 +60,4 @@ See [Logging](logging.md) for the full behavior: subsystem tags, the file size c
 
 The app version shows in the popover footer.
 
-Your settings carry across updates — layout, pins, preferences, and the menu-bar shortcut all stay put. When an update changes how a setting is stored, the app upgrades it in place on launch, stepping through any in-between versions if you skipped a few. Nothing is reset. (Earlier betas wiped all settings on every update; that no longer happens.)
+Your settings carry across updates — layout, stars, preferences, and the menu-bar shortcut all stay put. When an update changes how a setting is stored, the app upgrades it in place on launch, stepping through any in-between versions if you skipped a few. Nothing is reset. (Earlier betas wiped all settings on every update; that no longer happens.)


### PR DESCRIPTION
## TL;DR
Adds a Reset All Customization button to the top-right of the Customize provider list that wipes the whole layout back to defaults, gated behind a macOS-native confirmation alert.

## What was happening
Customize had a per-provider reset (top-right of a provider's L2 detail) but no way to reset everything at once. Restoring the full default layout meant resetting each provider individually, with no way to also restore the default provider order.

## What this changes
- Adds `resetAllButton()` in the Customize L1 nav bar trailing slot — same circular glass idiom + `arrow.counterclockwise` icon as the per-provider reset. It does not reset directly; it sets `isPresentingResetAllConfirm = true`.
- Adds a native macOS `.alert` ("Reset All Customization?") with a destructive **Reset All** and a **Cancel**. Confirming calls `layout.resetToDefault()`, which restores every provider's enabled metrics, provider order, metric order, menu-bar stars, and caret sections to defaults and clears undo history.
- `StatusItemController.shouldKeepPanelOpen` keeps the panel open while `panel.attachedSheet != nil`, so a click on the alert's buttons (which live in a child window) isn't misread as an outside click that dismisses the popover.
- The global outside-click monitor gets the same `panel.attachedSheet == nil` guard, so a click in another app can't close the popover while the confirmation sheet is up.
- `resetTransientState` clears `isPresentingResetAllConfirm` on popover close, so a pending alert can't reappear stale on the next open.
- User-facing copy drops "pin(s)" in favor of "stars" to match the rest of the UI ("Up to 2 stars per provider", "Starred for menu bar"): the alert message, and the dashboard/settings/zai/architecture docs.

## Heads-up
- Internal code identifiers still use `pin` (`pinnedMetricIDs`, `pinLimitNotice`, `canPin`, etc.) — those aren't user-facing and renaming them is a larger churn with no visible effect, so they're left as-is.
- The alert copy is deliberately short: "Resets every provider, their metrics and the order. Are you sure?"

## Tests
- Built and launched locally via `script/build_and_run.sh verify` — `Build complete!` and `==> running`.
- Bugbot reviewed the branch changes and found no bugs.

Made with [Cursor](https://cursor.com)