### PR TITLE
Fix notification reset timestamp jitter

### DIFF
--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -178,10 +178,12 @@ final class WidgetDataStore {
             guard data.isBounded else { continue }
             let state = data.meterState(now: now)
             let previous = notificationState[key] ?? NotificationState()
-            // Debug-only decision trace: record the inputs to each pace-notification check so a repeat
-            // alert can be matched against the exact state, reset timestamp, and prior dedupe flags.
             let currentBucket = PaceNotificationLogic.bucket(for: state)
-            AppLog.debug(.notifications, "check \(key): metric=\(data.title) state=\(Self.notificationStateDescription(state)) bucket=\(Self.bucketDescription(currentBucket)) previousBucket=\(Self.bucketDescription(previous.previousBucket)) remaining=\(Self.percentDescription(data.remainingFraction)) reset=\(Self.dateDescription(data.resetsAt)) previousReset=\(Self.dateDescription(previous.resetsAt)) resetAdvanced=\(Self.resetAdvanced(current: data.resetsAt, previous: previous.resetsAt)) primed=\(previous.primed) wasUnderTen=\(previous.wasUnderTenPercent) firedBefore=\(Self.milestoneDescription(previous.firedMilestones)) toggles=\(Self.toggleDescription(toggles))")
+            let resetDelta = Self.resetDelta(current: data.resetsAt, previous: previous.resetsAt)
+            let resetAdvanced = PaceNotificationLogic.resetWindowAdvanced(
+                resetsAt: data.resetsAt,
+                previousReset: previous.resetsAt
+            )
             let result = PaceNotificationLogic.transitions(
                 state: state,
                 fraction: data.remainingFraction,
@@ -189,7 +191,9 @@ final class WidgetDataStore {
                 previous: previous,
                 toggles: toggles
             )
-            AppLog.debug(.notifications, "decision \(key): fire=\(Self.milestoneDescription(result.fire)) newBucket=\(Self.bucketDescription(result.newState.previousBucket)) newReset=\(Self.dateDescription(result.newState.resetsAt)) newWasUnderTen=\(result.newState.wasUnderTenPercent) newPrimed=\(result.newState.primed) newFired=\(Self.milestoneDescription(result.newState.firedMilestones))")
+            if !result.fire.isEmpty || resetAdvanced || Self.isPositiveResetMovement(resetDelta) {
+                AppLog.debug(.notifications, "decision \(key): metric=\(data.title) state=\(Self.notificationStateDescription(state)) bucket=\(Self.bucketDescription(currentBucket)) previousBucket=\(Self.bucketDescription(previous.previousBucket)) remaining=\(Self.percentDescription(data.remainingFraction)) reset=\(Self.dateDescription(data.resetsAt)) previousReset=\(Self.dateDescription(previous.resetsAt)) resetDelta=\(Self.resetDeltaDescription(resetDelta)) resetReason=\(Self.resetReasonDescription(delta: resetDelta, advanced: resetAdvanced)) primed=\(previous.primed) wasUnderTen=\(previous.wasUnderTenPercent) firedBefore=\(Self.milestoneDescription(previous.firedMilestones)) fire=\(Self.milestoneDescription(result.fire)) newBucket=\(Self.bucketDescription(result.newState.previousBucket)) newFired=\(Self.milestoneDescription(result.newState.firedMilestones)) toggles=\(Self.toggleDescription(toggles))")
+            }
             // Deliver each fired milestone, then commit dedup state only for the ones that actually
             // delivered. The logic doesn't mark milestones fired — that's done here, after delivery
             // succeeds, so a skipped/failed delivery (not authorized, or `add` errored) leaves the
@@ -234,19 +238,29 @@ final class WidgetDataStore {
         )
     }
 
-    /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch
-    /// from real outcomes rather than cumulative error state. `.backedOff` is a probe deliberately skipped
-    /// because the provider failed within the last `failureRetryBackoff` — distinct from `.skipped`
-    /// (disabled / unknown / already in flight) so a wake-burst's suppression is visible in the logs.
-    enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
-
     // MARK: - Notification decision trace helpers (debug logging only)
 
-    /// True when the reset timestamp moved later or appeared where there was none — the condition that
-    /// would reset pace-notification dedupe. Logged so a repeat alert can be tied back to a rolling window.
-    private static func resetAdvanced(current: Date?, previous: Date?) -> Bool {
-        guard let current else { return false }
-        return previous == nil || current > (previous ?? .distantPast)
+    private static func resetDelta(current: Date?, previous: Date?) -> TimeInterval? {
+        guard let current, let previous else { return nil }
+        return current.timeIntervalSince(previous)
+    }
+
+    private static func isPositiveResetMovement(_ delta: TimeInterval?) -> Bool {
+        guard let delta else { return false }
+        return delta > 0
+    }
+
+    private static func resetReasonDescription(delta: TimeInterval?, advanced: Bool) -> String {
+        guard let delta else { return "firstOrMissingReset" }
+        if advanced { return "advanced" }
+        if delta > 0 { return "ignoredJitter" }
+        if delta < 0 { return "movedEarlier" }
+        return "unchanged"
+    }
+
+    private static func resetDeltaDescription(_ delta: TimeInterval?) -> String {
+        guard let delta else { return "nil" }
+        return String(format: "%.3fs", delta)
     }
 
     private static func dateDescription(_ date: Date?) -> String {
@@ -294,6 +308,12 @@ final class WidgetDataStore {
             }
         }
     }
+
+    /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch
+    /// from real outcomes rather than cumulative error state. `.backedOff` is a probe deliberately skipped
+    /// because the provider failed within the last `failureRetryBackoff` — distinct from `.skipped`
+    /// (disabled / unknown / already in flight) so a wake-burst's suppression is visible in the logs.
+    enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
 
     @discardableResult
     func refresh(providerID: String, force: Bool = false) async -> RefreshOutcome {

--- a/Sources/OpenUsage/Support/PaceNotificationLogic.swift
+++ b/Sources/OpenUsage/Support/PaceNotificationLogic.swift
@@ -119,7 +119,9 @@ enum PaceNotificationLogic {
     /// Decide which milestones to fire for one metric this pass, and the state to persist.
     ///
     /// Rules:
-    /// - A new reset window (a later `resetsAt`) clears the fired set so milestones can fire again.
+    /// - A new reset window (a meaningfully later `resetsAt`) clears the fired set so milestones can fire
+    ///   again. Provider timestamps can jitter by milliseconds between refreshes, so tiny differences are
+    ///   treated as the same reset window for notification dedupe.
     /// - `healthyToClose` / `closeToRunningOut` fire only on a worsening *edge* between adjacent
     ///   buckets, only if not already fired this window, and only if their toggle is on.
     /// - `underTenPercent` fires the first time remaining crosses under 10% this window; recovering
@@ -139,9 +141,9 @@ enum PaceNotificationLogic {
     ) -> Transition {
         var next = previous
 
-        // New window: reset dedup. A nil-or-equal reset keeps the window; a strictly later reset (or a
-        // reset appearing where there was none) starts fresh.
-        if let resetsAt, previous.resetsAt == nil || resetsAt > (previous.resetsAt ?? .distantPast) {
+        // New window: reset dedup. A nil-or-equal reset keeps the window; a reset appearing where there
+        // was none or moving later by more than the jitter tolerance starts fresh.
+        if resetWindowAdvanced(resetsAt: resetsAt, previousReset: previous.resetsAt) {
             next.firedMilestones = []
             next.wasUnderTenPercent = false
             next.previousBucket = .untracked
@@ -246,5 +248,15 @@ enum PaceNotificationLogic {
         case .close: return 1
         case .runningOut: return 2
         }
+    }
+
+    /// Reset timestamps can carry provider-side millisecond jitter. For notification dedupe, only a
+    /// meaningful advance re-arms milestones; the UI can still display the exact provider timestamp.
+    static let resetWindowJitterTolerance: TimeInterval = 1
+
+    static func resetWindowAdvanced(resetsAt: Date?, previousReset: Date?) -> Bool {
+        guard let resetsAt else { return false }
+        guard let previousReset else { return true }
+        return resetsAt.timeIntervalSince(previousReset) > resetWindowJitterTolerance
     }
 }

--- a/Tests/OpenUsageTests/PaceNotificationLogicTests.swift
+++ b/Tests/OpenUsageTests/PaceNotificationLogicTests.swift
@@ -94,6 +94,30 @@ final class PaceNotificationLogicTests: XCTestCase {
         XCTAssertEqual(refired.fire, [.healthyToClose])
     }
 
+    func testResetJitterDoesNotRearmRunningOutAlert() {
+        var state = step(healthy).newState
+        state = step(running, from: state).newState   // fires closeToRunningOut this window
+
+        let jitteredReset = reset.addingTimeInterval(0.09)
+        let stillRunningOut = step(running, resetsAt: jitteredReset, from: state)
+
+        XCTAssertTrue(stillRunningOut.fire.isEmpty)
+        XCTAssertEqual(stillRunningOut.newState.previousBucket, .runningOut)
+        XCTAssertEqual(stillRunningOut.newState.resetsAt, jitteredReset)
+    }
+
+    func testResetJitterDoesNotRearmCloseAlert() {
+        var state = step(healthy).newState
+        state = step(close, from: state).newState   // fires healthyToClose this window
+
+        let jitteredReset = reset.addingTimeInterval(0.09)
+        let stillClose = step(close, resetsAt: jitteredReset, from: state)
+
+        XCTAssertTrue(stillClose.fire.isEmpty)
+        XCTAssertEqual(stillClose.newState.previousBucket, .close)
+        XCTAssertEqual(stillClose.newState.resetsAt, jitteredReset)
+    }
+
     // MARK: - Recovery re-arms
 
     func testRecoveryThenReworseningRefires() {

--- a/Tests/OpenUsageTests/WidgetDataStoreNotificationTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreNotificationTests.swift
@@ -56,12 +56,12 @@ final class WidgetDataStoreNotificationTests: XCTestCase {
         )
     }
 
-    private func snapshot(used: Double) -> ProviderSnapshot {
+    private func snapshot(used: Double, resetsAt: Date? = nil) -> ProviderSnapshot {
         ProviderSnapshot(
             providerID: Self.provider.id,
             displayName: Self.provider.displayName,
             lines: [.progress(label: "Session", used: used, limit: 100, format: .percent,
-                              resetsAt: resetsAt, periodDurationMs: Int(week * 1000))]
+                              resetsAt: resetsAt ?? self.resetsAt, periodDurationMs: Int(week * 1000))]
         )
     }
 
@@ -139,6 +139,26 @@ final class WidgetDataStoreNotificationTests: XCTestCase {
         XCTAssertTrue(recorder.posts.contains { $0.0 == "test.closeToRunningOut" })
         XCTAssertTrue(recorder.posts.contains { $0.3 == "Projected to finish before the limit resets." })
         XCTAssertTrue(recorder.posts.contains { $0.2 == "Test Session" })
+    }
+
+    func testResetJitterDoesNotRefireRunningOutThroughTheStore() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("jitter-settings"))
+        allOn(settings)
+        let recorder = Recorder()
+        let (store, runtime, _) = makeStore(used: 80, settings: settings, recorder: recorder, defaultsName: "jitter")
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base)   // healthy -> primes, no fire
+
+        runtime.snapshot = snapshot(used: 95)
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base)   // -> red, fires once
+        XCTAssertEqual(recorder.posts.filter { $0.0 == "test.closeToRunningOut" }.count, 1)
+
+        runtime.snapshot = snapshot(used: 95, resetsAt: resetsAt.addingTimeInterval(0.09))
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base)   // same red state, reset jitter only
+
+        XCTAssertEqual(recorder.posts.filter { $0.0 == "test.closeToRunningOut" }.count, 1)
     }
 
     func testAllTogglesOffSuppressesAllPosts() async {


### PR DESCRIPTION
## TL;DR
Stop repeated pace notifications caused by millisecond-level reset timestamp jitter from provider APIs.

## What was happening
- Notification dedupe treated any later `resetsAt` timestamp as a brand-new reset window.
- Claude reset timestamps can move by tiny fractions of a second between refreshes, which re-armed already-fired yellow/red alerts even though the usage state had not meaningfully changed.

## What this changes
- Adds a one-second tolerance before a later reset timestamp counts as a new notification window.
- Keeps exact reset timestamps in stored state and UI data, while using the tolerance only for notification dedupe.
- Refines notification debug logs with `resetDelta` and `resetReason` so future repeat alerts show whether reset movement was ignored jitter or a real window advance.
- Adds logic and store-level regression tests for jittered reset timestamps in yellow/red states.

## Tests
- `swift test --filter 'PaceNotificationLogicTests|WidgetDataStoreNotificationTests'`
- `./script/build_and_run.sh verify`

Made with [Cursor](https://cursor.com)