### PR TITLE
feat(popover): Customize leads the footer; cross-link Customize and Settings

### DIFF
--- a/Sources/OpenUsage/Views/CustomizeProviderListView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderListView.swift
@@ -25,6 +25,14 @@ struct CustomizeProviderListView: View {
                 }
             }
             .cardSurface()
+            // App behavior/appearance options live on the other screen; catch users who came here
+            // hunting for them once they've scanned past the provider list.
+            ScreenCrossLinkRow(
+                systemImage: "gearshape",
+                title: "Settings",
+                subtitle: "Notifications, appearance and more",
+                destination: .settings
+            )
         }
         .animation(Motion.spring, value: orderedRows.map(\.id))
     }

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -2,11 +2,11 @@ import AppKit
 import SwiftUI
 
 /// The dashboard footer's trailing control: a **split button** in Liquid Glass — one capsule with
-/// "Settings" on the left and a chevron segment on the right, divided by a hairline (the Export ▾
-/// idiom system apps use). Clicking "Settings" opens the Settings screen; clicking the chevron opens
-/// the overflow menu (Customize / Share Screenshot / Check for Updates / About / Quit). Settings leads
-/// because everyday layout edits (reorder, hide, pin) are already reachable by dragging and
-/// right-clicking on the dashboard itself, so Settings is the more frequent deliberate destination.
+/// "Customize" on the left and a chevron segment on the right, divided by a hairline (the Export ▾
+/// idiom system apps use). Clicking "Customize" opens the Customize screen; clicking the chevron opens
+/// the overflow menu (Settings / Share Screenshot / Check for Updates / About / Quit). Customize leads
+/// because it's the screen users reach for most when shaping the dashboard; Settings stays one click
+/// away in the overflow (and always via ⌘,).
 ///
 /// The joined-capsule look comes from one glass surface behind the *whole* control: an `HStack` of two
 /// `.buttonStyle(.plain)` tap targets (a `Button` and a chevron `Menu`) split by a `Divider`, with a
@@ -48,7 +48,7 @@ struct HeaderView: View {
     private var leadingControl: some View {
         if screen == .dashboard {
             HStack(spacing: 0) {
-                settingsHalf
+                customizeHalf
                 Divider()
                     .frame(height: 16)
                 chevronHalf
@@ -58,13 +58,13 @@ struct HeaderView: View {
         }
     }
 
-    /// Left half: opens Settings. `.buttonStyle(.plain)` strips the system chrome so the shared glass
-    /// is the only surface; `contentShape` makes the whole padded half clickable. ⌘, opens Settings
+    /// Left half: opens Customize. `.buttonStyle(.plain)` strips the system chrome so the shared glass
+    /// is the only surface; `contentShape` makes the whole padded half clickable. ⏎ opens Customize
     /// from anywhere via `PopoverKeyReader`, so the shortcut isn't registered here (which would also
     /// flag the button as the window's default and draw a pulsing ring) — the tooltip surfaces it.
-    private var settingsHalf: some View {
-        Button { toggle(.settings) } label: {
-            Text("Settings")
+    private var customizeHalf: some View {
+        Button { toggle(.customize) } label: {
+            Text("Customize")
                 .font(.system(size: 13, weight: .semibold))
                 .padding(.leading, 14)
                 .padding(.trailing, 11)
@@ -72,7 +72,7 @@ struct HeaderView: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .hoverTooltip("Settings (⌘,)")
+        .hoverTooltip("Customize (⏎)")
     }
 
     /// Right half: the chevron pull-down. `.menuStyle(.button)` + `.buttonStyle(.plain)` strip the menu
@@ -98,16 +98,16 @@ struct HeaderView: View {
 
     /// The chevron's overflow items, mirroring their in-popover entry points. `autoenablesItems` has no
     /// SwiftUI equivalent, so the Check for Updates item disables itself when Sparkle can't currently
-    /// check — e.g. dev builds with no feed, or while a check is already in flight. Customize carries its
-    /// bare-⏎ key equivalent so the menu shows the shortcut: when the menu is open the item handles ⏎;
-    /// when it's closed the `PopoverDismissReader` monitor handles (and consumes) ⏎ first, so the item's
-    /// equivalent can't double-fire. Same split as the old Settings ⌘, item / the Quit ⌘Q item below.
+    /// check — e.g. dev builds with no feed, or while a check is already in flight. Settings carries its
+    /// ⌘, key equivalent so the menu shows the shortcut: when the menu is open the item handles ⌘,;
+    /// when it's closed the `PopoverDismissReader` monitor handles (and consumes) ⌘, first, so the item's
+    /// equivalent can't double-fire. Same split as the Quit ⌘Q item below.
     @ViewBuilder
     private var moreMenuItems: some View {
-        Button { toggle(.customize) } label: {
-            Label("Customize", systemImage: "slider.horizontal.3")
+        Button { toggle(.settings) } label: {
+            Label("Settings", systemImage: "gearshape")
         }
-        .keyboardShortcut(.return, modifiers: [])
+        .keyboardShortcut(",")
 
         shareScreenshotMenu
 

--- a/Sources/OpenUsage/Views/ScreenCrossLink.swift
+++ b/Sources/OpenUsage/Views/ScreenCrossLink.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// The "wrong door" cross-link pinned under the last card of Customize (L1) and Settings.
+/// Customize and Settings sound alike, so people regularly open one while hunting for the other.
+/// This is the Apple-native shape for "go somewhere else" in a settings surface: a grouped-card
+/// navigation row — icon, label, trailing chevron — matching the provider rows above it, rather
+/// than a text link (footnote text is Apple's idiom for explanations, not navigation). The whole
+/// row is tappable and slides to the destination with the same animation as the footer buttons.
+struct ScreenCrossLinkRow: View {
+    @Environment(LayoutStore.self) private var layout
+
+    /// SF Symbol leading the row, e.g. "gearshape".
+    let systemImage: String
+    /// The row's title, e.g. "App Settings".
+    let title: String
+    /// One-line secondary description of what lives there.
+    let subtitle: String
+    /// Where the row navigates.
+    let destination: PopoverScreen
+
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    var body: some View {
+        Button {
+            withAnimation(Motion.modeSwitch) {
+                layout.screen = destination
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 18, height: 18)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(title)
+                        .font(.system(size: density.headerPointSize, weight: .semibold))
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.system(size: density.planBadgePointSize))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, density.controlRowPadding)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .cardSurface()
+    }
+}

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -202,6 +202,13 @@ struct SettingsScreen: View {
                     .padding(.vertical, density.controlRowPadding)
                 }
             }
+            // Mirror of the Customize cross-link — the layout controls live on the other screen.
+            ScreenCrossLinkRow(
+                systemImage: "slider.horizontal.3",
+                title: "Customize",
+                subtitle: "Choose what's visible and where",
+                destination: .customize
+            )
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -43,11 +43,11 @@ The image is a flexible-height PNG using the app's look — the provider's mark 
 
 ## Footer
 
-The bar pinned to the bottom of the popover. On the left: the app version, and a live "Next update in …" countdown you can click (or press **⌘R**) to refresh right away. On the right: a **Settings** button paired with a **⌄** menu. The menu holds the app-level actions — **Customize**, **Share Screenshot** (submenu of providers), **Check for Updates…**, **About OpenUsage**, and **Quit OpenUsage**.
+The bar pinned to the bottom of the popover. On the left: the app version, and a live "Next update in …" countdown you can click (or press **⌘R**) to refresh right away. On the right: a **Customize** button paired with a **⌄** menu. The menu holds the app-level actions — **Settings**, **Share Screenshot** (submenu of providers), **Check for Updates…**, **About OpenUsage**, and **Quit OpenUsage**.
 
 ## Customize
 
-Open Customize from the **⌄** menu next to the footer's Settings button (or press **Return**). It's a two-level screen: a list of providers, then a provider's detail.
+Open Customize from the footer's **Customize** button (or press **Return**). It's a two-level screen: a list of providers, then a provider's detail.
 
 The **provider list** shows every provider with a switch to turn it on or off, an Active/Inactive status, a count of its metrics, and a chevron into its detail. Turn a provider off and it stays in the list, greyed — its metrics hide from the dashboard and menu bar but keep their setup for when you turn it back on. Drag providers by their grip to reorder; tap a row to open its detail.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-Settings lives inside the popover — there is no separate window. Open it from the footer's **Settings** button, with ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen, which carries a back button in its top-left corner. Go back with that button, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
+Settings lives inside the popover — there is no separate window. Open it from the footer's **⌄** menu next to the Customize button, with ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen, which carries a back button in its top-left corner. Go back with that button, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
 
 ## Startup
 


### PR DESCRIPTION
## TL;DR

Flips the footer split button so Customize is primary (Settings moves to the ⌄ overflow menu), and adds a native navigation-row card at the bottom of each screen linking to the other, so landing in the "wrong" one is a one-click fix.

## What was happening

- The footer's primary button was Settings, with Customize tucked in the overflow menu.
- "Customize" and "Settings" sound alike, so people regularly opened one while hunting for the other — and there was no way to recover without backing out and guessing again.

## What this changes

- Footer split button: **Customize** is now the primary half; **Settings** moves into the ⌄ menu (shown with its ⌘, shortcut label). All keyboard shortcuts are unchanged (⏎ Customize, ⌘, Settings, both global via the key monitor).
- New `ScreenCrossLinkRow` view: a grouped-card navigation row (icon, title, subtitle, chevron) matching the existing card language.
  - Bottom of Customize: **Settings** — "Notifications, appearance and more".
  - Bottom of Settings: **Customize** — "Choose what's visible and where".
- Docs updated (`docs/dashboard.md`, `docs/settings.md`) to match the new entry points.

## Heads-up

- The cross-link rows are permanent (not dismissible) by design — they double as wayfinding, styled like the rows around them.

## Tests

- Built and ran the dev bundle (`./script/build_and_run.sh verify`); exercised the flipped footer button, the overflow menu, both cross-link rows, and the ⏎ / ⌘, shortcuts.

## Screenshots

<img width="393" height="628" alt="image" src="https://github.com/user-attachments/assets/760245e1-54f0-4b60-aa93-4f34151c8dd0" />

Made with [Cursor](https://cursor.com)