### PR TITLE
fix(antigravity): merged Gemini pool + weekly limits via RetrieveUserQuotaSummary

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Either way, the app updates itself in place via signed, notarized [Sparkle](docs
 
 ## Supported Providers
 
-- **[Antigravity](docs/providers/antigravity.md)** — Gemini Pro/Flash and Claude model quotas
+- **[Antigravity](docs/providers/antigravity.md)** — shared Gemini and Claude pool quotas, 5-hour and weekly windows
 - **[Claude](docs/providers/claude.md)** — session, weekly, Sonnet, extra usage, local daily spend (ccusage)
 - **[Codex](docs/providers/codex.md)** — session, weekly, credits, local daily spend (ccusage)
 - **[Cursor](docs/providers/cursor.md)** — credits, total/auto/API usage, requests, on-demand, per-day spend

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -559,9 +559,11 @@ extension WidgetData {
 
     private static let sessionWindowWidgetIDs: Set<String> = [
         "codex.session", "claude.session",
-        // Antigravity's three quota pools are rolling 5-hour windows too: an unused pool reports
+        // Antigravity's two pool meters are rolling 5-hour windows too: an unused pool reports
         // `used == 0` with a reset a full period out, so it gets the same "Not started" treatment.
-        "antigravity.geminiPro", "antigravity.geminiFlash", "antigravity.claude"
+        // The weekly meters deliberately aren't listed — like Claude/Codex, only session windows
+        // read "Not started".
+        "antigravity.geminiPro", "antigravity.claude"
     ]
 
     /// True when the bounded primary row's trailing text is a concrete reset countdown (so the row makes

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityMetric.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityMetric.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// The four Antigravity widget IDs and metric labels, shared by `AntigravityProvider.widgetDescriptors`
+/// and `AntigravityUsageMapper` so both sides of the exact-string label binding
+/// (`WidgetDescriptor.metricLabel` == `MetricLine.label`, resolved in `WidgetDataStore.data(for:)`)
+/// come from one place — label drift there is a silent "No data" failure.
+///
+/// Antigravity merged its quota pools on 2026-05-19: Gemini Pro and Flash now draw from one shared
+/// pool, every non-Gemini model (Claude, GPT-OSS) shares a second, and each pool has a rolling 5-hour
+/// window plus a weekly window. `geminiID` keeps its historical `antigravity.geminiPro` raw value so
+/// existing users' layout state (enabled/pin/order) carries over to the merged meter with zero migration.
+enum AntigravityMetric {
+    static let geminiID = "antigravity.geminiPro"
+    static let geminiWeeklyID = "antigravity.geminiWeekly"
+    static let claudeID = "antigravity.claude"
+    static let claudeWeeklyID = "antigravity.claudeWeekly"
+
+    static let geminiLabel = "Gemini"
+    static let geminiWeeklyLabel = "Gemini Weekly"
+    static let claudeLabel = "Claude"
+    static let claudeWeeklyLabel = "Claude Weekly"
+}

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityMetric.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityMetric.swift
@@ -7,16 +7,18 @@ import Foundation
 ///
 /// Antigravity merged its quota pools on 2026-05-19: Gemini Pro and Flash now draw from one shared
 /// pool, every non-Gemini model (Claude, GPT-OSS) shares a second, and each pool has a rolling 5-hour
-/// window plus a weekly window. `geminiID` keeps its historical `antigravity.geminiPro` raw value so
-/// existing users' layout state (enabled/pin/order) carries over to the merged meter with zero migration.
+/// window plus a weekly window. The Gemini pool pair is titled "Session" / "Weekly" to match the
+/// Claude/Codex rows; the non-Gemini pool keeps its "Claude" name, mirroring Codex's Spark /
+/// Spark Weekly pair. `geminiID` keeps its historical `antigravity.geminiPro` raw value so existing
+/// users' layout state (enabled/pin/order) carries over to the merged meter with zero migration.
 enum AntigravityMetric {
     static let geminiID = "antigravity.geminiPro"
     static let geminiWeeklyID = "antigravity.geminiWeekly"
     static let claudeID = "antigravity.claude"
     static let claudeWeeklyID = "antigravity.claudeWeekly"
 
-    static let geminiLabel = "Gemini"
-    static let geminiWeeklyLabel = "Gemini Weekly"
+    static let sessionLabel = "Session"
+    static let weeklyLabel = "Weekly"
     static let claudeLabel = "Claude"
     static let claudeWeeklyLabel = "Claude Weekly"
 }

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
@@ -1,13 +1,17 @@
 import Foundation
 
-/// Tracks per-model quota for Antigravity (Google's Codeium/Windsurf-derived AI IDE). Quotas are
-/// fraction-based and shown as three percent meters: Gemini Pro, Gemini Flash, and Claude (the shared
-/// non-Gemini pool).
+/// Tracks pool quota for Antigravity (Google's Codeium/Windsurf-derived AI IDE). Quotas are
+/// fraction-based and shown as up to four percent meters: the shared Gemini pool and the shared
+/// non-Gemini pool (Claude, GPT-OSS), each with a rolling 5-hour and a weekly window.
 ///
 /// Probe order, best source first:
 /// 1. Antigravity language server (running app) — richest, gives the authoritative plan.
 /// 2. `agy` language server (running CLI).
 /// 3. Keychain token → Google Cloud Code (works with the app closed); refreshes via Google OAuth.
+///
+/// On each source, `RetrieveUserQuotaSummary` is tried first (the only endpoint reporting the merged
+/// pools and the weekly windows); builds without it fall back to the legacy per-model endpoints,
+/// which are 5h-only — the weekly meters read "No data" there.
 @MainActor
 final class AntigravityProvider: ProviderRuntime {
     let provider = Provider(id: "antigravity", displayName: "Antigravity", icon: .providerMark("antigravity"))
@@ -31,9 +35,10 @@ final class AntigravityProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "antigravity.geminiPro", provider: provider, title: "Gemini Pro"),
-            .percent(id: "antigravity.geminiFlash", provider: provider, title: "Gemini Flash"),
-            .percent(id: "antigravity.claude", provider: provider, title: "Claude")
+            .percent(id: AntigravityMetric.geminiID, provider: provider, title: AntigravityMetric.geminiLabel),
+            .percent(id: AntigravityMetric.geminiWeeklyID, provider: provider, title: AntigravityMetric.geminiWeeklyLabel),
+            .percent(id: AntigravityMetric.claudeID, provider: provider, title: AntigravityMetric.claudeLabel),
+            .percent(id: AntigravityMetric.claudeWeeklyID, provider: provider, title: AntigravityMetric.claudeWeeklyLabel)
         ]
     }
 
@@ -89,6 +94,30 @@ final class AntigravityProvider: ProviderRuntime {
         }
 
         for endpoint in endpoints {
+            // The quota summary is authoritative (merged pools + weekly windows), so it goes first.
+            // A parsed summary — even one with zero usable buckets — ends the probe: the legacy
+            // endpoints below fabricate "fully used" from missing quota info, so an authoritative
+            // answer must never fall through to them. Empty lines render as "No data" rows.
+            if let summary = await usageClient.callLS(scheme: endpoint.scheme, port: endpoint.port, csrf: discovered.csrf, method: "RetrieveUserQuotaSummary") {
+                if (200..<300).contains(summary.statusCode) {
+                    if let lines = AntigravityUsageMapper.parseQuotaSummary(summary.body) {
+                        // The plan comes from an independent GetUserStatus call; the summary never
+                        // gates on it — a failed plan lookup just leaves the plan blank.
+                        var plan: String?
+                        if let status = await usageClient.callLS(scheme: endpoint.scheme, port: endpoint.port, csrf: discovered.csrf, method: "GetUserStatus"),
+                           (200..<300).contains(status.statusCode) {
+                            plan = AntigravityUsageMapper.parseUserStatus(status.body)?.plan
+                        }
+                        return StrategyResult(plan: plan, lines: lines)
+                    }
+                    // 2xx but not a summary payload — the parser warned; fall to the legacy flow.
+                } else if summary.statusCode != 404 {
+                    // 404 = a build without the RPC (expected; legacy is the truth there, no retry).
+                    // Anything else is surprising enough to say before degrading to 5h-only data.
+                    AppLog.warn(LogTag.plugin("antigravity"), "RetrieveUserQuotaSummary HTTP \(summary.statusCode); falling back to legacy quota endpoints")
+                }
+            }
+
             guard let response = await usageClient.callLS(scheme: endpoint.scheme, port: endpoint.port, csrf: discovered.csrf, method: "GetUserStatus"),
                   (200..<300).contains(response.statusCode)
             else {
@@ -174,7 +203,23 @@ final class AntigravityProvider: ProviderRuntime {
     }
 
     private func fetchCloudCode(token: String) async -> CloudCodeProbe {
-        // Primary: fetchAvailableModels — the full Antigravity model set (Gemini + Claude + GPT-OSS).
+        // Authoritative first: the quota summary (merged pools + weekly windows). A parsed summary —
+        // even one with zero usable buckets — is the answer and must never fall into the legacy chain
+        // below, which fabricates "fully used" from missing quota info. A 404 (build without the RPC)
+        // reads as `.unavailable` and falls through.
+        switch await usageClient.cloudCode(path: AntigravityUsageClient.quotaSummaryPath, token: token, userAgent: "antigravity", body: [:]) {
+        case .authFailed:
+            return .authFailed
+        case .ok(let data):
+            if let lines = AntigravityUsageMapper.parseQuotaSummary(data) {
+                return .success(StrategyResult(plan: await loadPlan(token: token), lines: lines))
+            }
+            // 2xx but not a summary payload — the parser warned; fall to the legacy chain.
+        case .unavailable:
+            break
+        }
+
+        // Legacy: fetchAvailableModels — the full Antigravity model set (Gemini + Claude + GPT-OSS).
         switch await usageClient.cloudCode(path: AntigravityUsageClient.fetchModelsPath, token: token, userAgent: "antigravity", body: [:]) {
         case .authFailed:
             return .authFailed

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
@@ -35,8 +35,8 @@ final class AntigravityProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: AntigravityMetric.geminiID, provider: provider, title: AntigravityMetric.geminiLabel),
-            .percent(id: AntigravityMetric.geminiWeeklyID, provider: provider, title: AntigravityMetric.geminiWeeklyLabel),
+            .percent(id: AntigravityMetric.geminiID, provider: provider, title: AntigravityMetric.sessionLabel),
+            .percent(id: AntigravityMetric.geminiWeeklyID, provider: provider, title: AntigravityMetric.weeklyLabel),
             .percent(id: AntigravityMetric.claudeID, provider: provider, title: AntigravityMetric.claudeLabel),
             .percent(id: AntigravityMetric.claudeWeeklyID, provider: provider, title: AntigravityMetric.claudeWeeklyLabel)
         ]

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityUsageClient.swift
@@ -27,6 +27,7 @@ struct AntigravityUsageClient: Sendable {
     static let fetchModelsPath = "/v1internal:fetchAvailableModels"
     static let loadCodeAssistPath = "/v1internal:loadCodeAssist"
     static let retrieveQuotaPath = "/v1internal:retrieveUserQuota"
+    static let quotaSummaryPath = "/v1internal:retrieveUserQuotaSummary"
     static let googleOAuthURL = "https://oauth2.googleapis.com/token"
     // Google OAuth "installed application" client credentials, extracted verbatim from the Antigravity
     // app bundle — the same pair the shipped app and the legacy Tauri plugin use. For installed-app OAuth

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityUsageMapper.swift
@@ -10,14 +10,15 @@ struct AntigravityModelConfig: Sendable, Equatable {
     var resetTime: Date?
 }
 
-/// Turns Antigravity's per-model quota responses into the app's metric vocabulary. Antigravity exposes
-/// many fine-grained models that share a handful of quota pools, so models collapse into three meters —
-/// "Gemini Pro", "Gemini Flash", and "Claude" (every non-Gemini model, incl. GPT-OSS) — each keeping the
-/// worst (lowest) remaining fraction in its pool.
+/// Turns Antigravity's quota responses into the app's metric vocabulary.
+///
+/// The authoritative source is the `RetrieveUserQuotaSummary` RPC (`parseQuotaSummary`): two pools
+/// (Gemini; Claude = every non-Gemini model incl. GPT-OSS), each with a rolling 5-hour and a weekly
+/// window — up to four meters. Builds without that RPC fall back to the legacy per-model endpoints,
+/// whose fine-grained models collapse into the two pool meters ("Gemini", "Claude"), each keeping the
+/// worst (lowest) remaining fraction in its pool; the legacy data is 5h-only, so the weekly meters
+/// read "No data" there.
 enum AntigravityUsageMapper {
-    /// Quotas reset on a rolling 5-hour window.
-    static let quotaPeriodMs = 5 * 60 * 60 * 1000
-
     /// Internal/duplicate model IDs that should never surface as a meter. Matched against the model ID
     /// (LS `modelOrAlias.model`, Cloud Code `model`/key); the Cloud Code path also drops `isInternal`.
     static let modelBlacklist: Set<String> = [
@@ -27,7 +28,58 @@ enum AntigravityUsageMapper {
         "MODEL_PLACEHOLDER_M19", "MODEL_PLACEHOLDER_M9", "MODEL_PLACEHOLDER_M12"
     ]
 
-    // MARK: - Response parsing
+    // MARK: - Quota summary (the authoritative source)
+
+    /// The four pool buckets `RetrieveUserQuotaSummary` reports, matched by **exact `bucketId` only** —
+    /// a future bucket (e.g. `gemini-image-5h`) must never silently join a pool, and pool identity is
+    /// never inferred from `displayName`/`window`.
+    static let summaryBuckets: [(bucketID: String, label: String, periodMs: Int)] = [
+        ("gemini-5h", AntigravityMetric.geminiLabel, MetricPeriod.sessionMs),
+        ("gemini-weekly", AntigravityMetric.geminiWeeklyLabel, MetricPeriod.weekMs),
+        ("3p-5h", AntigravityMetric.claudeLabel, MetricPeriod.sessionMs),
+        ("3p-weekly", AntigravityMetric.claudeWeeklyLabel, MetricPeriod.weekMs)
+    ]
+
+    /// `RetrieveUserQuotaSummary` → up to four pool meters, ordered Gemini, Gemini Weekly, Claude,
+    /// Claude Weekly. Accepts both the LS envelope (`{"response": {"groups": …}}`) and the bare remote
+    /// payload (`{"groups": …}`).
+    ///
+    /// Nil means "not a summary" (undecodable body / no `groups` anywhere) and the caller may fall back
+    /// to the legacy endpoints. A non-nil result — even an empty one — is authoritative: the legacy
+    /// path fabricates "fully used" from missing quota info, so a parsed summary must never fall
+    /// through to it. Buckets decode leniently (one malformed bucket never voids the envelope); a
+    /// bucket with a missing/unusable `remainingFraction` drops its line (the row reads "No data")
+    /// rather than fabricating 0% or 100%.
+    static func parseQuotaSummary(_ data: Data) -> [MetricLine]? {
+        guard let envelope = try? JSONDecoder().decode(QuotaSummaryEnvelope.self, from: data),
+              let groups = envelope.response?.groups ?? envelope.groups
+        else {
+            // Callers only parse 2xx bodies, so an undecodable one is schema drift — say so loudly.
+            AppLog.warn(LogTag.plugin("antigravity"), "quota summary response has no decodable groups; treating as not-a-summary")
+            return nil
+        }
+
+        var pooled: [String: (fraction: Double, resetTime: Date?)] = [:]
+        for bucket in groups.flatMap({ $0.buckets ?? [] }) {
+            guard let id = bucket.bucketId, summaryBuckets.contains(where: { $0.bucketID == id }) else {
+                AppLog.warn(LogTag.plugin("antigravity"), "quota summary: skipping unrecognized bucket id '\(bucket.bucketId ?? "<absent>")'")
+                continue
+            }
+            guard pooled[id] == nil else { continue } // duplicate bucket id — first one wins
+            guard let fraction = bucket.remainingFraction, fraction.isFinite else {
+                AppLog.warn(LogTag.plugin("antigravity"), "quota summary: bucket '\(id)' has no usable remainingFraction; dropping its line")
+                continue
+            }
+            pooled[id] = (fraction, bucket.resetTime.flatMap { OpenUsageISO8601.date(from: $0) })
+        }
+
+        return summaryBuckets.compactMap { spec in
+            guard let entry = pooled[spec.bucketID] else { return nil }
+            return line(pool: spec.label, fraction: entry.fraction, resetTime: entry.resetTime, periodMs: spec.periodMs)
+        }
+    }
+
+    // MARK: - Response parsing (legacy per-model endpoints)
 
     /// LS `GetUserStatus` → plan name + model configs. Nil when the body has no `userStatus`.
     static func parseUserStatus(_ data: Data) -> (plan: String?, configs: [AntigravityModelConfig])? {
@@ -95,10 +147,10 @@ enum AntigravityUsageMapper {
         (try? JSONDecoder().decode(CCLoadEnvelope.self, from: data))?.cloudaicompanionProject?.nilIfEmpty
     }
 
-    // MARK: - Line building
+    // MARK: - Line building (legacy pooling)
 
-    /// Collapse model configs into the three quota-pool meters, keeping the worst fraction per pool and
-    /// ordering Gemini Pro → Gemini Flash → Claude. Blacklisted and empty-label models are dropped.
+    /// Collapse model configs into the two quota-pool meters, keeping the worst fraction per pool and
+    /// ordering Gemini → Claude. Blacklisted and empty-label models are dropped.
     static func buildLines(_ configs: [AntigravityModelConfig]) -> [MetricLine] {
         var pooled: [String: (fraction: Double, resetTime: Date?)] = [:]
         for config in configs {
@@ -119,19 +171,19 @@ enum AntigravityUsageMapper {
 
         return pooled
             .sorted { sortKey($0.key) < sortKey($1.key) }
-            .map { line(pool: $0.key, fraction: $0.value.fraction, resetTime: $0.value.resetTime) }
+            .map { line(pool: $0.key, fraction: $0.value.fraction, resetTime: $0.value.resetTime, periodMs: MetricPeriod.sessionMs) }
     }
 
-    static func line(pool: String, fraction: Double, resetTime: Date?) -> MetricLine {
+    static func line(pool: String, fraction: Double, resetTime: Date?, periodMs: Int) -> MetricLine {
         let clamped = max(0, min(1, fraction))
         let used = (1 - clamped) * 100
         return .progress(
             label: pool,
-            used: used.rounded(),
+            used: used.rounded(), // keep whole percents so a fresh window reads 0 and "Not started" works
             limit: 100,
             format: .percent,
             resetsAt: resetTime,
-            periodDurationMs: quotaPeriodMs
+            periodDurationMs: periodMs
         )
     }
 
@@ -146,23 +198,15 @@ enum AntigravityUsageMapper {
     }
 
     static func poolLabel(_ normalizedLabel: String) -> String {
-        let lower = normalizedLabel.lowercased()
-        // Any Gemini model maps to a Gemini pool — Flash variants to "Gemini Flash", everything else
-        // (Pro, Ultra, bare names) to "Gemini Pro" — so a Gemini model never leaks into the Claude pool.
-        if lower.contains("gemini") {
-            return lower.contains("flash") ? "Gemini Flash" : "Gemini Pro"
-        }
-        // Claude, GPT-OSS, and any other non-Gemini model share one pool.
-        return "Claude"
+        // Pro and Flash draw from one shared pool since Antigravity's 2026-05-19 quota merge, so every
+        // Gemini model (Pro, Flash, Ultra, bare names) maps to the single "Gemini" meter; Claude,
+        // GPT-OSS, and any other non-Gemini model share the other pool.
+        normalizedLabel.lowercased().contains("gemini") ? AntigravityMetric.geminiLabel : AntigravityMetric.claudeLabel
     }
 
     static func sortKey(_ poolLabel: String) -> String {
-        let lower = poolLabel.lowercased()
-        if lower.contains("gemini"), lower.contains("pro") { return "0a_\(poolLabel)" }
-        if lower.contains("gemini") { return "0b_\(poolLabel)" }
-        if lower.contains("claude"), lower.contains("opus") { return "1a_\(poolLabel)" }
-        if lower.contains("claude") { return "1b_\(poolLabel)" }
-        return "2_\(poolLabel)"
+        // Gemini before Claude, matching the widget declaration order.
+        poolLabel.lowercased().contains("gemini") ? "0_\(poolLabel)" : "1_\(poolLabel)"
     }
 
     /// Normalize a raw plan/tier string to a short label. LS returns "Google AI Pro" (strip the prefix,
@@ -194,6 +238,40 @@ enum AntigravityUsageMapper {
 }
 
 // MARK: - Wire types (the documented response shapes; validated only at this boundary)
+
+/// `RetrieveUserQuotaSummary`, both envelopes: the LS wraps the payload in `{"response": {...}}`,
+/// the remote Cloud Code endpoint returns it bare. Every field is optional — third-party parsers have
+/// already regressed by assuming absent fields (defaulting a missing `remainingFraction` to "full").
+private struct QuotaSummaryEnvelope: Decodable {
+    let response: QuotaSummaryRoot?
+    let groups: [QuotaSummaryGroup]?
+}
+
+private struct QuotaSummaryRoot: Decodable {
+    let groups: [QuotaSummaryGroup]?
+}
+
+private struct QuotaSummaryGroup: Decodable {
+    let buckets: [QuotaSummaryBucket]?
+}
+
+/// A bucket that never fails its containing array: a malformed element (not an object, or a field of
+/// the wrong type) decodes to nil fields instead of throwing the whole summary into the legacy
+/// fallback. The mapper then drops the unusable bucket with a warning and keeps the rest.
+private struct QuotaSummaryBucket: Decodable {
+    let bucketId: String?
+    let remainingFraction: Double?
+    let resetTime: String?
+
+    private enum CodingKeys: String, CodingKey { case bucketId, remainingFraction, resetTime }
+
+    init(from decoder: Decoder) {
+        let container = try? decoder.container(keyedBy: CodingKeys.self)
+        bucketId = container.flatMap { (try? $0.decodeIfPresent(String.self, forKey: .bucketId)) ?? nil }
+        remainingFraction = container.flatMap { (try? $0.decodeIfPresent(Double.self, forKey: .remainingFraction)) ?? nil }
+        resetTime = container.flatMap { (try? $0.decodeIfPresent(String.self, forKey: .resetTime)) ?? nil }
+    }
+}
 
 private struct AntigravityQuotaInfo: Decodable {
     let remainingFraction: Double?

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityUsageMapper.swift
@@ -13,9 +13,10 @@ struct AntigravityModelConfig: Sendable, Equatable {
 /// Turns Antigravity's quota responses into the app's metric vocabulary.
 ///
 /// The authoritative source is the `RetrieveUserQuotaSummary` RPC (`parseQuotaSummary`): two pools
-/// (Gemini; Claude = every non-Gemini model incl. GPT-OSS), each with a rolling 5-hour and a weekly
-/// window — up to four meters. Builds without that RPC fall back to the legacy per-model endpoints,
-/// whose fine-grained models collapse into the two pool meters ("Gemini", "Claude"), each keeping the
+/// (Gemini, shown as "Session"/"Weekly"; Claude = every non-Gemini model incl. GPT-OSS), each with a
+/// rolling 5-hour and a weekly window — up to four meters. Builds without that RPC fall back to the
+/// legacy per-model endpoints, whose fine-grained models collapse into the two 5h pool meters
+/// ("Session", "Claude"), each keeping the
 /// worst (lowest) remaining fraction in its pool; the legacy data is 5h-only, so the weekly meters
 /// read "No data" there.
 enum AntigravityUsageMapper {
@@ -34,13 +35,13 @@ enum AntigravityUsageMapper {
     /// a future bucket (e.g. `gemini-image-5h`) must never silently join a pool, and pool identity is
     /// never inferred from `displayName`/`window`.
     static let summaryBuckets: [(bucketID: String, label: String, periodMs: Int)] = [
-        ("gemini-5h", AntigravityMetric.geminiLabel, MetricPeriod.sessionMs),
-        ("gemini-weekly", AntigravityMetric.geminiWeeklyLabel, MetricPeriod.weekMs),
+        ("gemini-5h", AntigravityMetric.sessionLabel, MetricPeriod.sessionMs),
+        ("gemini-weekly", AntigravityMetric.weeklyLabel, MetricPeriod.weekMs),
         ("3p-5h", AntigravityMetric.claudeLabel, MetricPeriod.sessionMs),
         ("3p-weekly", AntigravityMetric.claudeWeeklyLabel, MetricPeriod.weekMs)
     ]
 
-    /// `RetrieveUserQuotaSummary` → up to four pool meters, ordered Gemini, Gemini Weekly, Claude,
+    /// `RetrieveUserQuotaSummary` → up to four pool meters, ordered Session, Weekly, Claude,
     /// Claude Weekly. Accepts both the LS envelope (`{"response": {"groups": …}}`) and the bare remote
     /// payload (`{"groups": …}`).
     ///
@@ -150,7 +151,7 @@ enum AntigravityUsageMapper {
     // MARK: - Line building (legacy pooling)
 
     /// Collapse model configs into the two quota-pool meters, keeping the worst fraction per pool and
-    /// ordering Gemini → Claude. Blacklisted and empty-label models are dropped.
+    /// ordering the Gemini pool ("Session") before Claude. Blacklisted and empty-label models are dropped.
     static func buildLines(_ configs: [AntigravityModelConfig]) -> [MetricLine] {
         var pooled: [String: (fraction: Double, resetTime: Date?)] = [:]
         for config in configs {
@@ -199,14 +200,14 @@ enum AntigravityUsageMapper {
 
     static func poolLabel(_ normalizedLabel: String) -> String {
         // Pro and Flash draw from one shared pool since Antigravity's 2026-05-19 quota merge, so every
-        // Gemini model (Pro, Flash, Ultra, bare names) maps to the single "Gemini" meter; Claude,
+        // Gemini model (Pro, Flash, Ultra, bare names) maps to the single "Session" meter; Claude,
         // GPT-OSS, and any other non-Gemini model share the other pool.
-        normalizedLabel.lowercased().contains("gemini") ? AntigravityMetric.geminiLabel : AntigravityMetric.claudeLabel
+        normalizedLabel.lowercased().contains("gemini") ? AntigravityMetric.sessionLabel : AntigravityMetric.claudeLabel
     }
 
     static func sortKey(_ poolLabel: String) -> String {
-        // Gemini before Claude, matching the widget declaration order.
-        poolLabel.lowercased().contains("gemini") ? "0_\(poolLabel)" : "1_\(poolLabel)"
+        // The Gemini pool ("Session") before Claude, matching the widget declaration order.
+        poolLabel == AntigravityMetric.sessionLabel ? "0_\(poolLabel)" : "1_\(poolLabel)"
     }
 
     /// Normalize a raw plan/tier string to a short label. LS returns "Google AI Pro" (strip the prefix,

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -7,7 +7,7 @@ import Foundation
 /// here: an empty saved order reconciles to plain registry order in `LayoutStore`.
 enum DefaultLayout {
     static let metricIDs: [String] = [
-        "antigravity.geminiPro", "antigravity.geminiFlash", "antigravity.claude",
+        "antigravity.geminiPro", "antigravity.geminiWeekly", "antigravity.claude", "antigravity.claudeWeekly",
 
         "claude.session", "claude.weekly", "claude.trend",
         "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
@@ -51,11 +51,11 @@ enum DefaultLayout {
     ]
 
     /// Metrics pinned to the menu bar on first launch, so the app shows real numbers out of the box
-    /// instead of a lone icon. Two per provider for Claude, Codex, and Cursor — the per-provider cap
-    /// (`LayoutStore.maxPinsPerProvider`). Filtered to the active
+    /// instead of a lone icon. Two per provider for Antigravity, Claude, Codex, and Cursor — the
+    /// per-provider cap (`LayoutStore.maxPinsPerProvider`). Filtered to the active
     /// registry by `LayoutStore`, like `metricIDs`.
     static let pinnedMetricIDs: [String] = [
-        "antigravity.geminiPro",
+        "antigravity.geminiPro", "antigravity.geminiWeekly",
         "claude.session", "claude.weekly",
         "codex.session", "codex.weekly",
         "cursor.auto", "cursor.api",
@@ -70,8 +70,9 @@ enum DefaultLayout {
     /// Filtered to the active registry by `LayoutStore`, and only seeded on a genuinely fresh launch
     /// (existing layouts keep everything always-shown unless they reset customization).
     static let expandedMetricIDs: [String] = [
-        // Antigravity: Gemini Pro + Flash stay above the fold; only the non-Gemini (Claude) pool is secondary.
-        "antigravity.claude",
+        // Antigravity: the Gemini pool pair (5h + weekly) stays above the fold; the non-Gemini
+        // (Claude) pool pair sits below the caret.
+        "antigravity.claude", "antigravity.claudeWeekly",
         // Claude's core meters (Session, Weekly, Extra, Usage Trend) stay above the fold; spend-history
         // rows sit below the caret. Matches every other provider's "core above, history below" shape.
         "claude.sonnet", "claude.fable", "claude.today", "claude.yesterday", "claude.last30",

--- a/Tests/OpenUsageTests/AntigravityLayoutTests.swift
+++ b/Tests/OpenUsageTests/AntigravityLayoutTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import OpenUsage
+
+/// Layout defaults and migration behavior for Antigravity's four metrics (merged quota pools +
+/// weekly limits fix). Uses the real provider's registry — `MockData` carries no Antigravity
+/// fixtures — with the real `DefaultLayout` seeds.
+@MainActor
+final class AntigravityLayoutTests: XCTestCase {
+
+    func testFreshDefaultsSeedFourMetricsTwoPinsAndClaudePairSecondary() {
+        let store = makeStore("FreshDefaults")
+
+        // All four metrics enabled, in declaration order.
+        XCTAssertEqual(store.placed.map(\.descriptorID), [
+            "antigravity.geminiPro", "antigravity.geminiWeekly",
+            "antigravity.claude", "antigravity.claudeWeekly"
+        ])
+
+        // The Gemini pair is pinned (2-per-provider cap), mirroring Claude/Codex Session+Weekly.
+        XCTAssertEqual(store.pinnedMetricIDs, ["antigravity.geminiPro", "antigravity.geminiWeekly"])
+
+        // Gemini pair above the fold; the Claude pool pair below the caret.
+        let group = store.customizeGroups.first { $0.provider.id == "antigravity" }
+        XCTAssertEqual(group?.alwaysShownMetrics.map(\.id), ["antigravity.geminiPro", "antigravity.geminiWeekly"])
+        XCTAssertEqual(group?.expandedMetrics.map(\.id), ["antigravity.claude", "antigravity.claudeWeekly"])
+    }
+
+    func testExistingUserLayoutAutoSeedsWeeklyMetricsBelowCaretForClaudePool() {
+        // A layout from before the weekly metrics shipped: Antigravity is absent from the migration
+        // baseline, so `seedNewDefaultMetrics` auto-enables both new weekly metrics once. Claude
+        // Weekly (a default-expanded metric) enters below the caret; metrics the user already lived
+        // with stay always-shown.
+        let defaults = makeDefaults("SeedWeeklies")
+        saveStored([
+            PlacedWidget(descriptorID: "antigravity.geminiPro"),
+            PlacedWidget(descriptorID: "antigravity.claude")
+        ], forKey: "layout", in: defaults)
+
+        let store = LayoutStore(registry: .antigravityOnly, defaults: defaults, storageKey: "layout")
+
+        XCTAssertTrue(store.isMetricEnabled("antigravity.geminiWeekly"))
+        XCTAssertTrue(store.isMetricEnabled("antigravity.claudeWeekly"))
+        XCTAssertTrue(store.isMetricExpanded("antigravity.claudeWeekly"))
+        XCTAssertFalse(store.isMetricExpanded("antigravity.geminiWeekly"))
+        XCTAssertFalse(store.isMetricExpanded("antigravity.claude"),
+                       "a metric the user already lived with is never silently tucked away")
+    }
+
+    func testSavedGeminiFlashStateIsFilteredEverywhere() {
+        // `antigravity.geminiFlash` no longer exists (owner-approved: its layout state drops with no
+        // migration). Every load path filters unknown IDs against the registry, so stale saved state
+        // self-heals.
+        let defaults = makeDefaults("FlashFilter")
+        saveStored([
+            PlacedWidget(descriptorID: "antigravity.geminiPro"),
+            PlacedWidget(descriptorID: "antigravity.geminiFlash"),
+            PlacedWidget(descriptorID: "antigravity.claude")
+        ], forKey: "layout", in: defaults)
+        defaults.set(["antigravity.geminiPro", "antigravity.geminiFlash"], forKey: "layout.menuBarPins")
+        saveStored(
+            ["antigravity": ["antigravity.geminiFlash", "antigravity.geminiPro", "antigravity.claude"]],
+            forKey: "layout.metricOrderByProvider", in: defaults
+        )
+
+        let store = LayoutStore(registry: .antigravityOnly, defaults: defaults, storageKey: "layout")
+
+        XCTAssertFalse(store.isMetricEnabled("antigravity.geminiFlash"))
+        XCTAssertFalse(store.orderedSupportedMetrics(for: "antigravity").map(\.id).contains("antigravity.geminiFlash"))
+        // The saved pin set is respected exactly (dead ID dropped, no weekly pin auto-added).
+        XCTAssertEqual(store.pinnedMetricIDs, ["antigravity.geminiPro"])
+    }
+
+    func testAbsentPinsKeyAdoptsGeminiWeeklyPinOnUpgrade() {
+        // Pins re-derive from current defaults whenever the pins key is absent, and init never
+        // persists pins — so an existing user who never touched pins automatically gains the
+        // Gemini Weekly pin (still within the 2-per-provider cap).
+        let defaults = makeDefaults("PinsAbsent")
+        saveStored([
+            PlacedWidget(descriptorID: "antigravity.geminiPro"),
+            PlacedWidget(descriptorID: "antigravity.claude")
+        ], forKey: "layout", in: defaults)
+
+        let store = LayoutStore(registry: .antigravityOnly, defaults: defaults, storageKey: "layout")
+        XCTAssertEqual(store.pinnedMetricIDs, ["antigravity.geminiPro", "antigravity.geminiWeekly"])
+    }
+
+    func testSavedPinsKeyIsRespectedExactly() {
+        let defaults = makeDefaults("PinsPresent")
+        saveStored([PlacedWidget(descriptorID: "antigravity.geminiPro")], forKey: "layout", in: defaults)
+        defaults.set(["antigravity.claude"], forKey: "layout.menuBarPins")
+
+        let store = LayoutStore(registry: .antigravityOnly, defaults: defaults, storageKey: "layout")
+        XCTAssertEqual(store.pinnedMetricIDs, ["antigravity.claude"],
+                       "a user-saved pin set must not gain the new default pins")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeStore(_ name: String) -> LayoutStore {
+        LayoutStore(registry: .antigravityOnly, defaults: makeDefaults(name), storageKey: "layout")
+    }
+
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.AntigravityLayout.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func saveStored<T: Encodable>(_ value: T, forKey key: String, in defaults: UserDefaults) {
+        defaults.set(try! JSONEncoder().encode(value), forKey: key)
+    }
+}
+
+private extension WidgetRegistry {
+    /// A registry with just the live Antigravity provider, so `DefaultLayout`'s seeds filter down to
+    /// its four metrics.
+    @MainActor
+    static var antigravityOnly: WidgetRegistry { .from([AntigravityProvider()]) }
+}

--- a/Tests/OpenUsageTests/AntigravityProviderTests.swift
+++ b/Tests/OpenUsageTests/AntigravityProviderTests.swift
@@ -27,10 +27,11 @@ final class AntigravityProviderTests: XCTestCase {
         ]
         let lines = AntigravityUsageMapper.buildLines(configs)
 
-        XCTAssertEqual(lines.map(\.label), ["Gemini Pro", "Gemini Flash", "Claude"])
-        XCTAssertEqual(used(lines[0]), 50)  // worst Gemini Pro fraction (0.5) -> 50% used
-        XCTAssertEqual(used(lines[1]), 0)   // Flash full
-        XCTAssertEqual(used(lines[2]), 70)  // worst non-Gemini (Claude 0.3) -> 70% used
+        // Pro and Flash share one pool since Antigravity's 2026-05-19 quota merge, so all Gemini
+        // models collapse into a single "Gemini" meter (worst fraction wins across the whole pool).
+        XCTAssertEqual(lines.map(\.label), ["Gemini", "Claude"])
+        XCTAssertEqual(used(lines[0]), 50)  // worst Gemini fraction (Pro Low 0.5) -> 50% used
+        XCTAssertEqual(used(lines[1]), 70)  // worst non-Gemini (Claude 0.3) -> 70% used
     }
 
     func testBuildLinesDedupKeepsWorstFractionAndItsReset() {
@@ -53,7 +54,7 @@ final class AntigravityProviderTests: XCTestCase {
             AntigravityModelConfig(label: "Gemini 3.1 Pro (High)", modelID: "ok", remainingFraction: 0.6, resetTime: nil)
         ]
         let lines = AntigravityUsageMapper.buildLines(configs)
-        XCTAssertEqual(lines.map(\.label), ["Gemini Pro"])
+        XCTAssertEqual(lines.map(\.label), ["Gemini"])
         XCTAssertEqual(used(lines[0]), 40)
     }
 
@@ -63,19 +64,20 @@ final class AntigravityProviderTests: XCTestCase {
             AntigravityModelConfig(label: "Claude Opus", modelID: "b", remainingFraction: -0.2, resetTime: nil)
         ]
         let lines = AntigravityUsageMapper.buildLines(configs)
-        XCTAssertEqual(used(lines.first { $0.label == "Gemini Pro" }), 0)   // clamped to full
-        XCTAssertEqual(used(lines.first { $0.label == "Claude" }), 100)     // clamped to empty
+        XCTAssertEqual(used(lines.first { $0.label == "Gemini" }), 0)    // clamped to full
+        XCTAssertEqual(used(lines.first { $0.label == "Claude" }), 100)  // clamped to empty
     }
 
     func testPoolLabelClassification() {
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.1 Pro"), "Gemini Pro")
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.5 Flash"), "Gemini Flash")
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.1 Flash Lite"), "Gemini Flash")
+        // Pro and Flash merged into one shared Gemini pool (2026-05-19 quota restructure).
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.1 Pro"), "Gemini")
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.5 Flash"), "Gemini")
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.1 Flash Lite"), "Gemini")
         XCTAssertEqual(AntigravityUsageMapper.poolLabel("Claude Opus 4.6"), "Claude")
         XCTAssertEqual(AntigravityUsageMapper.poolLabel("GPT-OSS 120B"), "Claude")
-        // A Gemini model that is neither Pro nor Flash must stay in a Gemini pool, never Claude.
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini Ultra"), "Gemini Pro")
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("gemini-3"), "Gemini Pro")
+        // Any Gemini model must stay in the Gemini pool, never Claude.
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini Ultra"), "Gemini")
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("gemini-3"), "Gemini")
     }
 
     func testNormalizeLabelStripsTrailingParenthetical() {
@@ -110,7 +112,7 @@ final class AntigravityProviderTests: XCTestCase {
         let parsed = AntigravityUsageMapper.parseUserStatus(Data(json.utf8))
         XCTAssertEqual(parsed?.plan, "Pro")
         let lines = AntigravityUsageMapper.buildLines(parsed?.configs ?? [])
-        XCTAssertEqual(lines.map(\.label), ["Gemini Pro", "Claude"])
+        XCTAssertEqual(lines.map(\.label), ["Gemini", "Claude"])
         XCTAssertEqual(used(lines[0]), 50)
         XCTAssertEqual(used(lines[1]), 0)
         XCTAssertNotNil(resetsAt(lines[0]))
@@ -133,7 +135,7 @@ final class AntigravityProviderTests: XCTestCase {
         // isInternal (b) and empty-displayName (d) dropped at parse; blacklist (c) survives to buildLines.
         XCTAssertEqual(configs.count, 2)
         let lines = AntigravityUsageMapper.buildLines(configs)
-        XCTAssertEqual(lines.map(\.label), ["Gemini Pro"])  // c filtered by blacklist
+        XCTAssertEqual(lines.map(\.label), ["Gemini"])  // c filtered by blacklist
     }
 
     func testParseCloudCodeModelsTreatsMissingQuotaAsDepleted() {
@@ -157,7 +159,8 @@ final class AntigravityProviderTests: XCTestCase {
                     {"modelId":"gemini-3-flash-preview","remainingFraction":1}]}
         """
         let lines = AntigravityUsageMapper.buildLines(AntigravityUsageMapper.parseQuotaBuckets(Data(json.utf8)))
-        XCTAssertEqual(lines.map(\.label), ["Gemini Pro", "Gemini Flash"])
+        // Pro and Flash buckets pool into the one Gemini meter; the worst fraction (0.5) wins.
+        XCTAssertEqual(lines.map(\.label), ["Gemini"])
         XCTAssertEqual(used(lines[0]), 50)
     }
 
@@ -272,6 +275,10 @@ final class AntigravityProviderTests: XCTestCase {
 
         let routing = RoutingHTTPClient { request in
             let path = request.url.path
+            // Builds without the summary RPC 404 it — this test also covers summary-404 → legacy.
+            if path.contains("retrieveUserQuotaSummary") {
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
             if path.contains("fetchAvailableModels") {
                 return HTTPResponse(statusCode: 200, headers: [:], body: Data(modelsJSON.utf8))
             }
@@ -292,10 +299,10 @@ final class AntigravityProviderTests: XCTestCase {
 
         let snapshot = await provider.refresh()
         XCTAssertEqual(snapshot.plan, "Pro")
-        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini Pro", "Gemini Flash", "Claude"])
+        // Legacy per-model data merges into the two pool meters (worst fraction per pool).
+        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini", "Claude"])
         XCTAssertEqual(used(snapshot.lines[0]), 60)
-        XCTAssertEqual(used(snapshot.lines[1]), 0)
-        XCTAssertEqual(used(snapshot.lines[2]), 30)
+        XCTAssertEqual(used(snapshot.lines[1]), 30)
     }
 
     @MainActor

--- a/Tests/OpenUsageTests/AntigravityProviderTests.swift
+++ b/Tests/OpenUsageTests/AntigravityProviderTests.swift
@@ -28,8 +28,8 @@ final class AntigravityProviderTests: XCTestCase {
         let lines = AntigravityUsageMapper.buildLines(configs)
 
         // Pro and Flash share one pool since Antigravity's 2026-05-19 quota merge, so all Gemini
-        // models collapse into a single "Gemini" meter (worst fraction wins across the whole pool).
-        XCTAssertEqual(lines.map(\.label), ["Gemini", "Claude"])
+        // models collapse into a single "Session" meter (worst fraction wins across the whole pool).
+        XCTAssertEqual(lines.map(\.label), ["Session", "Claude"])
         XCTAssertEqual(used(lines[0]), 50)  // worst Gemini fraction (Pro Low 0.5) -> 50% used
         XCTAssertEqual(used(lines[1]), 70)  // worst non-Gemini (Claude 0.3) -> 70% used
     }
@@ -54,7 +54,7 @@ final class AntigravityProviderTests: XCTestCase {
             AntigravityModelConfig(label: "Gemini 3.1 Pro (High)", modelID: "ok", remainingFraction: 0.6, resetTime: nil)
         ]
         let lines = AntigravityUsageMapper.buildLines(configs)
-        XCTAssertEqual(lines.map(\.label), ["Gemini"])
+        XCTAssertEqual(lines.map(\.label), ["Session"])
         XCTAssertEqual(used(lines[0]), 40)
     }
 
@@ -64,20 +64,21 @@ final class AntigravityProviderTests: XCTestCase {
             AntigravityModelConfig(label: "Claude Opus", modelID: "b", remainingFraction: -0.2, resetTime: nil)
         ]
         let lines = AntigravityUsageMapper.buildLines(configs)
-        XCTAssertEqual(used(lines.first { $0.label == "Gemini" }), 0)    // clamped to full
+        XCTAssertEqual(used(lines.first { $0.label == "Session" }), 0)   // clamped to full
         XCTAssertEqual(used(lines.first { $0.label == "Claude" }), 100)  // clamped to empty
     }
 
     func testPoolLabelClassification() {
-        // Pro and Flash merged into one shared Gemini pool (2026-05-19 quota restructure).
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.1 Pro"), "Gemini")
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.5 Flash"), "Gemini")
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.1 Flash Lite"), "Gemini")
+        // Pro and Flash merged into one shared Gemini pool (2026-05-19 quota restructure), shown as
+        // the "Session" meter.
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.1 Pro"), "Session")
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.5 Flash"), "Session")
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini 3.1 Flash Lite"), "Session")
         XCTAssertEqual(AntigravityUsageMapper.poolLabel("Claude Opus 4.6"), "Claude")
         XCTAssertEqual(AntigravityUsageMapper.poolLabel("GPT-OSS 120B"), "Claude")
         // Any Gemini model must stay in the Gemini pool, never Claude.
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini Ultra"), "Gemini")
-        XCTAssertEqual(AntigravityUsageMapper.poolLabel("gemini-3"), "Gemini")
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("Gemini Ultra"), "Session")
+        XCTAssertEqual(AntigravityUsageMapper.poolLabel("gemini-3"), "Session")
     }
 
     func testNormalizeLabelStripsTrailingParenthetical() {
@@ -112,7 +113,7 @@ final class AntigravityProviderTests: XCTestCase {
         let parsed = AntigravityUsageMapper.parseUserStatus(Data(json.utf8))
         XCTAssertEqual(parsed?.plan, "Pro")
         let lines = AntigravityUsageMapper.buildLines(parsed?.configs ?? [])
-        XCTAssertEqual(lines.map(\.label), ["Gemini", "Claude"])
+        XCTAssertEqual(lines.map(\.label), ["Session", "Claude"])
         XCTAssertEqual(used(lines[0]), 50)
         XCTAssertEqual(used(lines[1]), 0)
         XCTAssertNotNil(resetsAt(lines[0]))
@@ -135,7 +136,7 @@ final class AntigravityProviderTests: XCTestCase {
         // isInternal (b) and empty-displayName (d) dropped at parse; blacklist (c) survives to buildLines.
         XCTAssertEqual(configs.count, 2)
         let lines = AntigravityUsageMapper.buildLines(configs)
-        XCTAssertEqual(lines.map(\.label), ["Gemini"])  // c filtered by blacklist
+        XCTAssertEqual(lines.map(\.label), ["Session"])  // c filtered by blacklist
     }
 
     func testParseCloudCodeModelsTreatsMissingQuotaAsDepleted() {
@@ -159,8 +160,8 @@ final class AntigravityProviderTests: XCTestCase {
                     {"modelId":"gemini-3-flash-preview","remainingFraction":1}]}
         """
         let lines = AntigravityUsageMapper.buildLines(AntigravityUsageMapper.parseQuotaBuckets(Data(json.utf8)))
-        // Pro and Flash buckets pool into the one Gemini meter; the worst fraction (0.5) wins.
-        XCTAssertEqual(lines.map(\.label), ["Gemini"])
+        // Pro and Flash buckets pool into the one "Session" meter; the worst fraction (0.5) wins.
+        XCTAssertEqual(lines.map(\.label), ["Session"])
         XCTAssertEqual(used(lines[0]), 50)
     }
 
@@ -300,7 +301,7 @@ final class AntigravityProviderTests: XCTestCase {
         let snapshot = await provider.refresh()
         XCTAssertEqual(snapshot.plan, "Pro")
         // Legacy per-model data merges into the two pool meters (worst fraction per pool).
-        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini", "Claude"])
+        XCTAssertEqual(snapshot.lines.map(\.label), ["Session", "Claude"])
         XCTAssertEqual(used(snapshot.lines[0]), 60)
         XCTAssertEqual(used(snapshot.lines[1]), 30)
     }

--- a/Tests/OpenUsageTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/OpenUsageTests/AntigravityQuotaSummaryTests.swift
@@ -1,0 +1,332 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the `RetrieveUserQuotaSummary` support added by the merged-pools + weekly-limits fix:
+/// the lenient summary parser and the "a parsed summary is authoritative — even empty — and never
+/// falls through to the legacy per-model endpoints" control flow on both transports.
+final class AntigravityQuotaSummaryTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func used(_ line: MetricLine?) -> Double? {
+        guard case .progress(_, let used, _, _, _, _, _)? = line else { return nil }
+        return used
+    }
+
+    private func resetsAt(_ line: MetricLine?) -> Date? {
+        guard case .progress(_, _, _, _, let resetsAt, _, _)? = line else { return nil }
+        return resetsAt
+    }
+
+    private func periodMs(_ line: MetricLine?) -> Int? {
+        guard case .progress(_, _, _, _, _, let periodMs, _)? = line else { return nil }
+        return periodMs
+    }
+
+    /// All four buckets, in scrambled group order, with the shapes seen in live probes.
+    private let fullGroupsJSON = """
+    "groups":[
+      {"displayName":"Claude and other models","buckets":[
+        {"bucketId":"3p-weekly","displayName":"Weekly","window":"weekly","remainingFraction":1,"resetTime":"2026-07-06T07:00:00Z"},
+        {"bucketId":"3p-5h","displayName":"5-hour","window":"5h","remainingFraction":0.4,"resetTime":"2026-07-02T15:30:00Z"}
+      ]},
+      {"displayName":"Gemini models","buckets":[
+        {"bucketId":"gemini-5h","displayName":"5-hour","window":"5h","remainingFraction":0.75,"resetTime":"2026-07-02T16:00:00Z"},
+        {"bucketId":"gemini-weekly","displayName":"Weekly","window":"weekly","remainingFraction":0.9,"resetTime":"2026-07-06T07:00:00Z"}
+      ]}
+    ]
+    """
+
+    // MARK: - Parser
+
+    func testWrappedAndBarePayloadsProduceIdenticalFourLines() {
+        let bare = AntigravityUsageMapper.parseQuotaSummary(Data("{\(fullGroupsJSON)}".utf8))
+        let wrapped = AntigravityUsageMapper.parseQuotaSummary(Data("{\"response\":{\(fullGroupsJSON)}}".utf8))
+        XCTAssertEqual(bare, wrapped)
+
+        guard let lines = bare else { return XCTFail("full summary did not parse") }
+        XCTAssertEqual(lines.map(\.label), ["Gemini", "Gemini Weekly", "Claude", "Claude Weekly"])
+        XCTAssertEqual(lines.map { used($0) }, [25, 10, 60, 0])
+        XCTAssertEqual(resetsAt(lines[0]), OpenUsageISO8601.date(from: "2026-07-02T16:00:00Z"))
+        XCTAssertEqual(resetsAt(lines[2]), OpenUsageISO8601.date(from: "2026-07-02T15:30:00Z"))
+        XCTAssertEqual(lines.map { periodMs($0) }, [
+            MetricPeriod.sessionMs, MetricPeriod.weekMs, MetricPeriod.sessionMs, MetricPeriod.weekMs
+        ])
+    }
+
+    func testBucketWithoutRemainingFractionDropsItsLineOnly() {
+        // Never fabricate 0% or 100% from an absent fraction (a real-world third-party parser
+        // regression came from defaulting to "full") — the bucket's line just drops.
+        let json = """
+        {"groups":[{"buckets":[
+          {"bucketId":"gemini-5h","resetTime":"2026-07-02T16:00:00Z"},
+          {"bucketId":"gemini-weekly","remainingFraction":0.5,"resetTime":"2026-07-06T07:00:00Z"}
+        ]}]}
+        """
+        let lines = AntigravityUsageMapper.parseQuotaSummary(Data(json.utf8))
+        XCTAssertEqual(lines?.map(\.label), ["Gemini Weekly"])
+        XCTAssertEqual(used(lines?.first), 50)
+    }
+
+    func testMalformedBucketDoesNotVoidTheEnvelope() {
+        // One garbage element (not an object) and one wrong-typed fraction must not fail the whole
+        // summary into the legacy fallback — the valid bucket survives.
+        let json = """
+        {"groups":[{"buckets":[
+          "junk",
+          {"bucketId":"3p-5h","remainingFraction":"lots"},
+          {"bucketId":"gemini-5h","remainingFraction":0.25,"resetTime":"2026-07-02T16:00:00Z"}
+        ]}]}
+        """
+        let lines = AntigravityUsageMapper.parseQuotaSummary(Data(json.utf8))
+        XCTAssertEqual(lines?.map(\.label), ["Gemini"])
+        XCTAssertEqual(used(lines?.first), 75)
+    }
+
+    func testMissingResetTimeYieldsNilResetsAt() {
+        let json = #"{"groups":[{"buckets":[{"bucketId":"gemini-5h","remainingFraction":0.5}]}]}"#
+        let lines = AntigravityUsageMapper.parseQuotaSummary(Data(json.utf8))
+        XCTAssertEqual(lines?.count, 1)
+        XCTAssertEqual(used(lines?.first), 50)
+        XCTAssertNil(resetsAt(lines?.first))
+    }
+
+    func testUnknownOrAbsentBucketIDIsSkippedNeverPooledByDisplayName() {
+        // A future bucket (gemini-image-5h) and an id-less bucket must never join a pool via their
+        // displayName — only the exact known bucketIds bind.
+        let json = """
+        {"groups":[{"buckets":[
+          {"bucketId":"gemini-image-5h","displayName":"Gemini","window":"5h","remainingFraction":0.1},
+          {"displayName":"Gemini","window":"5h","remainingFraction":0.2},
+          {"bucketId":"gemini-5h","remainingFraction":0.75}
+        ]}]}
+        """
+        let lines = AntigravityUsageMapper.parseQuotaSummary(Data(json.utf8))
+        XCTAssertEqual(lines?.map(\.label), ["Gemini"])
+        XCTAssertEqual(used(lines?.first), 25)
+    }
+
+    func testWeeklyOnlyAndSessionOnlyShapes() {
+        // Free tier may lack the 5h buckets; Ultra may lack the weekly ones. Both are valid summaries.
+        let weeklyOnly = """
+        {"response":{"groups":[{"buckets":[
+          {"bucketId":"gemini-weekly","remainingFraction":0.8},
+          {"bucketId":"3p-weekly","remainingFraction":0.6}
+        ]}]}}
+        """
+        let weeklyLines = AntigravityUsageMapper.parseQuotaSummary(Data(weeklyOnly.utf8))
+        XCTAssertEqual(weeklyLines?.map(\.label), ["Gemini Weekly", "Claude Weekly"])
+        XCTAssertEqual(weeklyLines?.compactMap { periodMs($0) }, [MetricPeriod.weekMs, MetricPeriod.weekMs])
+
+        let sessionOnly = """
+        {"groups":[{"buckets":[
+          {"bucketId":"gemini-5h","remainingFraction":0.8},
+          {"bucketId":"3p-5h","remainingFraction":0.6}
+        ]}]}
+        """
+        let sessionLines = AntigravityUsageMapper.parseQuotaSummary(Data(sessionOnly.utf8))
+        XCTAssertEqual(sessionLines?.map(\.label), ["Gemini", "Claude"])
+        XCTAssertEqual(sessionLines?.compactMap { periodMs($0) }, [MetricPeriod.sessionMs, MetricPeriod.sessionMs])
+    }
+
+    func testUndecodableOrGrouplessBodyIsNotASummary() {
+        XCTAssertNil(AntigravityUsageMapper.parseQuotaSummary(Data("not json".utf8)))
+        XCTAssertNil(AntigravityUsageMapper.parseQuotaSummary(Data("{}".utf8)))
+        XCTAssertNil(AntigravityUsageMapper.parseQuotaSummary(Data(#"{"response":{}}"#.utf8)))
+    }
+
+    func testEmptyGroupsParseAsAuthoritativeEmptySummary() {
+        // Non-nil-but-empty means "the summary answered and there are no usable buckets" — the caller
+        // must stop there, never fall into the legacy chain that fabricates 100%-used.
+        XCTAssertEqual(AntigravityUsageMapper.parseQuotaSummary(Data(#"{"groups":[]}"#.utf8)), [])
+        XCTAssertEqual(AntigravityUsageMapper.parseQuotaSummary(Data(#"{"response":{"groups":[]}}"#.utf8)), [])
+    }
+
+    // MARK: - Label binding (metricLabel == MetricLine.label, exact string)
+
+    @MainActor
+    func testDescriptorLabelsMatchMapperEmittedLabels() {
+        let descriptorLabels = Set(AntigravityProvider().widgetDescriptors.map(\.metricLabel))
+        XCTAssertEqual(Set(AntigravityUsageMapper.summaryBuckets.map(\.label)), descriptorLabels)
+
+        let summaryLines = AntigravityUsageMapper.parseQuotaSummary(Data("{\(fullGroupsJSON)}".utf8)) ?? []
+        XCTAssertEqual(Set(summaryLines.map(\.label)), descriptorLabels)
+
+        // The legacy path emits the two 5h pool labels — a strict subset of the descriptors.
+        let legacyLabels = Set(AntigravityUsageMapper.buildLines([
+            AntigravityModelConfig(label: "Gemini 3 Pro", modelID: "a", remainingFraction: 1, resetTime: nil),
+            AntigravityModelConfig(label: "Claude Opus", modelID: "b", remainingFraction: 1, resetTime: nil)
+        ]).map(\.label))
+        XCTAssertEqual(legacyLabels, ["Gemini", "Claude"])
+        XCTAssertTrue(legacyLabels.isSubset(of: descriptorLabels))
+    }
+
+    // MARK: - Provider integration: Cloud Code transport
+
+    @MainActor
+    private func makeCloudCodeProvider(routing: RoutingHTTPClient) -> AntigravityProvider {
+        let inner = #"{"token":{"access_token":"ya29.kc","refresh_token":"1//r","expiry":"2099-01-01T00:00:00Z"}}"#
+        let wrapped = "go-keyring-base64:" + Data(inner.utf8).base64EncodedString()
+        return AntigravityProvider(
+            authStore: AntigravityAuthStore(keychain: FakeKeychain(wrapped), files: FakeFiles()),
+            usageClient: AntigravityUsageClient(lsHTTP: routing, http: routing),
+            discovery: LanguageServerDiscovery(processRunner: NoProcessRunner())
+        )
+    }
+
+    @MainActor
+    func testCloudCodeSummaryProducesFourMetersAndPlan() async {
+        let groupsJSON = fullGroupsJSON
+        let routing = RoutingHTTPClient { request in
+            let path = request.url.path
+            if path.contains("retrieveUserQuotaSummary") {
+                // The remote endpoint returns the payload bare (no "response" wrapper).
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data("{\(groupsJSON)}".utf8))
+            }
+            if path.contains("loadCodeAssist") {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"paidTier":{"name":"Google AI Pro"}}"#.utf8))
+            }
+            return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+        let provider = makeCloudCodeProvider(routing: routing)
+
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.plan, "Pro")
+        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini", "Gemini Weekly", "Claude", "Claude Weekly"])
+        XCTAssertEqual(snapshot.lines.map { used($0) }, [25, 10, 60, 0])
+        XCTAssertFalse(routing.requests.contains { $0.url.path.contains("fetchAvailableModels") },
+                       "a parsed summary must not touch the legacy model endpoints")
+    }
+
+    @MainActor
+    func testCloudCodeAuthoritativeEmptySummarySkipsLegacyChain() async {
+        // A 200 summary with zero usable buckets is still the answer: the provider must return a
+        // non-error snapshot with empty lines ("No data" rows) — even when the plan lookup fails —
+        // and must never call fetchAvailableModels / retrieveUserQuota, which would fabricate
+        // 100%-used meters from missing quota info.
+        let routing = RoutingHTTPClient { request in
+            if request.url.path.contains("retrieveUserQuotaSummary") {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"groups":[]}"#.utf8))
+            }
+            return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+        let provider = makeCloudCodeProvider(routing: routing)
+
+        let snapshot = await provider.refresh()
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(snapshot.lines.isEmpty)
+        XCTAssertNil(snapshot.plan)
+        XCTAssertFalse(routing.requests.contains { $0.url.path.contains("fetchAvailableModels") })
+        XCTAssertFalse(routing.requests.contains { $0.url.path == AntigravityUsageClient.retrieveQuotaPath })
+    }
+
+    // MARK: - Provider integration: language-server transport
+
+    @MainActor
+    private func makeLSProvider(routing: RoutingHTTPClient) -> AntigravityProvider {
+        AntigravityProvider(
+            authStore: AntigravityAuthStore(keychain: FakeKeychain(nil), files: FakeFiles()),
+            usageClient: AntigravityUsageClient(lsHTTP: routing, http: routing),
+            discovery: LanguageServerDiscovery(processRunner: FakeLSProcessRunner())
+        )
+    }
+
+    @MainActor
+    func testLSWrappedSummaryWinsOverLegacyEndpointsAndTakesPlanFromUserStatus() async {
+        let groupsJSON = fullGroupsJSON
+        let routing = RoutingHTTPClient { request in
+            let path = request.url.path
+            if path.hasSuffix("/RetrieveUserQuotaSummary") {
+                // The LS wraps the payload in {"response": ...}.
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data("{\"response\":{\(groupsJSON)}}".utf8))
+            }
+            if path.hasSuffix("/GetUserStatus") {
+                let body = """
+                {"userStatus":{"userTier":{"name":"Google AI Pro"},
+                "cascadeModelConfigData":{"clientModelConfigs":[
+                  {"label":"Gemini 3 Pro","quotaInfo":{"remainingFraction":0.99}}
+                ]}}}
+                """
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(body.utf8))
+            }
+            return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+        }
+        let provider = makeLSProvider(routing: routing)
+
+        let snapshot = await provider.refresh()
+        // Summary values win — not the single 1%-used line the legacy GetUserStatus configs would pool to.
+        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini", "Gemini Weekly", "Claude", "Claude Weekly"])
+        XCTAssertEqual(snapshot.lines.map { used($0) }, [25, 10, 60, 0])
+        XCTAssertEqual(snapshot.plan, "Pro")
+        XCTAssertFalse(routing.requests.contains { $0.url.path.hasSuffix("/GetCommandModelConfigs") })
+    }
+
+    @MainActor
+    func testLSAuthoritativeEmptySummaryStopsProbeEvenWhenPlanCallFails() async {
+        let routing = RoutingHTTPClient { request in
+            if request.url.path.hasSuffix("/RetrieveUserQuotaSummary") {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"response":{"groups":[]}}"#.utf8))
+            }
+            return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+        }
+        let provider = makeLSProvider(routing: routing)
+
+        let snapshot = await provider.refresh()
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(snapshot.lines.isEmpty)
+        XCTAssertNil(snapshot.plan)
+        XCTAssertFalse(routing.requests.contains { $0.url.path.hasSuffix("/GetCommandModelConfigs") })
+        // The authoritative answer stops the probe on the first endpoint: no other LS port, and
+        // never the Cloud Code fallback.
+        XCTAssertTrue(routing.requests.allSatisfy { $0.url.host == "127.0.0.1" && $0.url.port == 52168 })
+    }
+
+    @MainActor
+    func testLSSummary404FallsBackToLegacyMergedPools() async {
+        // Builds without the RPC 404 it; the legacy GetUserStatus flow stays the source (5h-only).
+        let routing = RoutingHTTPClient { request in
+            let path = request.url.path
+            if path.hasSuffix("/RetrieveUserQuotaSummary") {
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+            if path.hasSuffix("/GetUserStatus") {
+                let body = """
+                {"userStatus":{"userTier":{"name":"Google AI Pro"},
+                "cascadeModelConfigData":{"clientModelConfigs":[
+                  {"label":"Gemini 3 Pro","quotaInfo":{"remainingFraction":0.5}},
+                  {"label":"Claude Sonnet 4.6","quotaInfo":{"remainingFraction":0.8}}
+                ]}}}
+                """
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(body.utf8))
+            }
+            return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+        }
+        let provider = makeLSProvider(routing: routing)
+
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini", "Claude"])
+        XCTAssertEqual(snapshot.lines.map { used($0) }, [50, 20])
+        XCTAssertEqual(snapshot.plan, "Pro")
+    }
+}
+
+/// Returns empty output for every subprocess, so language-server discovery finds nothing and the
+/// provider deterministically exercises the Cloud Code path.
+private struct NoProcessRunner: ProcessRunning {
+    func run(executable: String, arguments: [String], environment: [String: String], timeout: TimeInterval) throws -> ProcessResult {
+        ProcessResult(exitCode: 0, stdout: "", stderr: "")
+    }
+}
+
+/// Fakes a running Antigravity `language_server` (pid 4276, one listening port 52168) so provider
+/// tests exercise the LS probe without real subprocesses.
+private struct FakeLSProcessRunner: ProcessRunning {
+    func run(executable: String, arguments: [String], environment: [String: String], timeout: TimeInterval) throws -> ProcessResult {
+        if executable.hasSuffix("/ps") {
+            let ps = "4276 /Applications/Antigravity.app/Contents/Resources/bin/language_server --standalone --override_ide_name antigravity --csrf_token tok --app_data_dir antigravity\n"
+            return ProcessResult(exitCode: 0, stdout: ps, stderr: "")
+        }
+        let lsof = "language_ 4276 user 6u IPv4 0x0 0t0 TCP 127.0.0.1:52168 (LISTEN)\n"
+        return ProcessResult(exitCode: 0, stdout: lsof, stderr: "")
+    }
+}

--- a/Tests/OpenUsageTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/OpenUsageTests/AntigravityQuotaSummaryTests.swift
@@ -45,7 +45,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
         XCTAssertEqual(bare, wrapped)
 
         guard let lines = bare else { return XCTFail("full summary did not parse") }
-        XCTAssertEqual(lines.map(\.label), ["Gemini", "Gemini Weekly", "Claude", "Claude Weekly"])
+        XCTAssertEqual(lines.map(\.label), ["Session", "Weekly", "Claude", "Claude Weekly"])
         XCTAssertEqual(lines.map { used($0) }, [25, 10, 60, 0])
         XCTAssertEqual(resetsAt(lines[0]), OpenUsageISO8601.date(from: "2026-07-02T16:00:00Z"))
         XCTAssertEqual(resetsAt(lines[2]), OpenUsageISO8601.date(from: "2026-07-02T15:30:00Z"))
@@ -64,7 +64,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
         ]}]}
         """
         let lines = AntigravityUsageMapper.parseQuotaSummary(Data(json.utf8))
-        XCTAssertEqual(lines?.map(\.label), ["Gemini Weekly"])
+        XCTAssertEqual(lines?.map(\.label), ["Weekly"])
         XCTAssertEqual(used(lines?.first), 50)
     }
 
@@ -79,7 +79,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
         ]}]}
         """
         let lines = AntigravityUsageMapper.parseQuotaSummary(Data(json.utf8))
-        XCTAssertEqual(lines?.map(\.label), ["Gemini"])
+        XCTAssertEqual(lines?.map(\.label), ["Session"])
         XCTAssertEqual(used(lines?.first), 75)
     }
 
@@ -96,13 +96,13 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
         // displayName — only the exact known bucketIds bind.
         let json = """
         {"groups":[{"buckets":[
-          {"bucketId":"gemini-image-5h","displayName":"Gemini","window":"5h","remainingFraction":0.1},
-          {"displayName":"Gemini","window":"5h","remainingFraction":0.2},
+          {"bucketId":"gemini-image-5h","displayName":"Session","window":"5h","remainingFraction":0.1},
+          {"displayName":"Session","window":"5h","remainingFraction":0.2},
           {"bucketId":"gemini-5h","remainingFraction":0.75}
         ]}]}
         """
         let lines = AntigravityUsageMapper.parseQuotaSummary(Data(json.utf8))
-        XCTAssertEqual(lines?.map(\.label), ["Gemini"])
+        XCTAssertEqual(lines?.map(\.label), ["Session"])
         XCTAssertEqual(used(lines?.first), 25)
     }
 
@@ -115,7 +115,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
         ]}]}}
         """
         let weeklyLines = AntigravityUsageMapper.parseQuotaSummary(Data(weeklyOnly.utf8))
-        XCTAssertEqual(weeklyLines?.map(\.label), ["Gemini Weekly", "Claude Weekly"])
+        XCTAssertEqual(weeklyLines?.map(\.label), ["Weekly", "Claude Weekly"])
         XCTAssertEqual(weeklyLines?.compactMap { periodMs($0) }, [MetricPeriod.weekMs, MetricPeriod.weekMs])
 
         let sessionOnly = """
@@ -125,7 +125,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
         ]}]}
         """
         let sessionLines = AntigravityUsageMapper.parseQuotaSummary(Data(sessionOnly.utf8))
-        XCTAssertEqual(sessionLines?.map(\.label), ["Gemini", "Claude"])
+        XCTAssertEqual(sessionLines?.map(\.label), ["Session", "Claude"])
         XCTAssertEqual(sessionLines?.compactMap { periodMs($0) }, [MetricPeriod.sessionMs, MetricPeriod.sessionMs])
     }
 
@@ -157,7 +157,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
             AntigravityModelConfig(label: "Gemini 3 Pro", modelID: "a", remainingFraction: 1, resetTime: nil),
             AntigravityModelConfig(label: "Claude Opus", modelID: "b", remainingFraction: 1, resetTime: nil)
         ]).map(\.label))
-        XCTAssertEqual(legacyLabels, ["Gemini", "Claude"])
+        XCTAssertEqual(legacyLabels, ["Session", "Claude"])
         XCTAssertTrue(legacyLabels.isSubset(of: descriptorLabels))
     }
 
@@ -192,7 +192,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
 
         let snapshot = await provider.refresh()
         XCTAssertEqual(snapshot.plan, "Pro")
-        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini", "Gemini Weekly", "Claude", "Claude Weekly"])
+        XCTAssertEqual(snapshot.lines.map(\.label), ["Session", "Weekly", "Claude", "Claude Weekly"])
         XCTAssertEqual(snapshot.lines.map { used($0) }, [25, 10, 60, 0])
         XCTAssertFalse(routing.requests.contains { $0.url.path.contains("fetchAvailableModels") },
                        "a parsed summary must not touch the legacy model endpoints")
@@ -255,7 +255,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
 
         let snapshot = await provider.refresh()
         // Summary values win — not the single 1%-used line the legacy GetUserStatus configs would pool to.
-        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini", "Gemini Weekly", "Claude", "Claude Weekly"])
+        XCTAssertEqual(snapshot.lines.map(\.label), ["Session", "Weekly", "Claude", "Claude Weekly"])
         XCTAssertEqual(snapshot.lines.map { used($0) }, [25, 10, 60, 0])
         XCTAssertEqual(snapshot.plan, "Pro")
         XCTAssertFalse(routing.requests.contains { $0.url.path.hasSuffix("/GetCommandModelConfigs") })
@@ -304,7 +304,7 @@ final class AntigravityQuotaSummaryTests: XCTestCase {
         let provider = makeLSProvider(routing: routing)
 
         let snapshot = await provider.refresh()
-        XCTAssertEqual(snapshot.lines.map(\.label), ["Gemini", "Claude"])
+        XCTAssertEqual(snapshot.lines.map(\.label), ["Session", "Claude"])
         XCTAssertEqual(snapshot.lines.map { used($0) }, [50, 20])
         XCTAssertEqual(snapshot.plan, "Pro")
     }

--- a/Tests/OpenUsageTests/ResetDisplayTests.swift
+++ b/Tests/OpenUsageTests/ResetDisplayTests.swift
@@ -53,7 +53,7 @@ final class ResetDisplayTests: XCTestCase {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let period: TimeInterval = 5 * 3600
         for id in ["codex.session", "claude.session",
-                   "antigravity.geminiPro", "antigravity.geminiFlash", "antigravity.claude"] {
+                   "antigravity.geminiPro", "antigravity.claude"] {
             var data = WidgetData(title: "Session", icon: .symbol("clock"), kind: .percent, used: 0, limit: 100)
             data.widgetID = id
             data.periodDurationMs = Int(period * 1000)
@@ -70,6 +70,22 @@ final class ResetDisplayTests: XCTestCase {
             XCTAssertEqual(state, .level(.normal), id)
             XCTAssertNil(state.tooltip, id)
             XCTAssertNil(data.paceTick(for: state, now: now), id)
+        }
+    }
+
+    func testAntigravityWeeklyRowsNeverReadNotStarted() {
+        // Antigravity's weekly meters are calendar windows, not rolling sessions — like Claude/Codex,
+        // only the 5h rows get the "Not started" treatment (fix: merged pools + weekly limits).
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let period: TimeInterval = 7 * 24 * 3600
+        for id in ["antigravity.geminiWeekly", "antigravity.claudeWeekly"] {
+            var data = WidgetData(title: "Weekly", icon: .symbol("clock"), kind: .percent, used: 0, limit: 100)
+            data.widgetID = id
+            data.periodDurationMs = Int(period * 1000)
+            data.resetsAt = now.addingTimeInterval(period / 2)
+            XCTAssertFalse(data.isFreshSessionWindow(now: now), id)
+            XCTAssertNotEqual(data.boundedTrailingText(now: now), "Not started", id)
+            XCTAssertEqual(data.boundedTrailingText(now: now)?.hasPrefix("Resets"), true, id)
         }
     }
 

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -10,7 +10,7 @@ Right-click (or control-click) the menu bar icon for a quick menu with **Setting
 
 Star a metric from any row's right-click menu, or from the star that appears when hovering rows in Customize.
 
-- On first launch the app ships with a default set of stars (Claude Session/Weekly, Codex Session/Weekly, Cursor Auto Usage/API Usage) so the strip shows numbers right away. Change them anytime; Reset in Customize restores this set.
+- On first launch the app ships with a default set of stars (Antigravity Gemini/Gemini Weekly, Claude Session/Weekly, Codex Session/Weekly, Cursor Auto Usage/API Usage, Copilot Credits, OpenRouter Credits, Z.ai Session/Weekly) so the strip shows numbers right away. Change them anytime; Reset in Customize restores this set.
 - At most **2 stars per provider**.
 - When a star isn't allowed, the star button stays clickable — clicking it shakes and shows the reason in the footer (e.g. "Up to 2 stars per provider").
 - The Customize footer shows your count: `n starred`.

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -10,7 +10,7 @@ Right-click (or control-click) the menu bar icon for a quick menu with **Setting
 
 Star a metric from any row's right-click menu, or from the star that appears when hovering rows in Customize.
 
-- On first launch the app ships with a default set of stars (Antigravity Gemini/Gemini Weekly, Claude Session/Weekly, Codex Session/Weekly, Cursor Auto Usage/API Usage, Copilot Credits, OpenRouter Credits, Z.ai Session/Weekly) so the strip shows numbers right away. Change them anytime; Reset in Customize restores this set.
+- On first launch the app ships with a default set of stars (Antigravity Session/Weekly, Claude Session/Weekly, Codex Session/Weekly, Cursor Auto Usage/API Usage, Copilot Credits, OpenRouter Credits, Z.ai Session/Weekly) so the strip shows numbers right away. Change them anytime; Reset in Customize restores this set.
 - At most **2 stars per provider**.
 - When a star isn't allowed, the star button stays clickable — clicking it shakes and shows the reason in the footer (e.g. "Up to 2 stars per provider").
 - The Customize footer shows your count: `n starred`.

--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -1,21 +1,22 @@
 # Antigravity
 
-Tracks per-model quota for Antigravity (Google's AI IDE) using credentials the app or the `agy` CLI already stored on your Mac.
+Tracks pool quotas for Antigravity (Google's AI IDE) using credentials the app or the `agy` CLI already stored on your Mac.
 
 ## What it tracks
 
-Antigravity exposes a separate quota for each model, which OpenUsage groups into three meters:
+Antigravity has two shared quota pools, and each pool has two windows — a rolling 5-hour window and a weekly window:
 
 | Metric | Meaning |
 |---|---|
-| Gemini Pro | Remaining quota for the Gemini Pro models (worst-case across variants) |
-| Gemini Flash | Remaining quota for the Gemini Flash models |
-| Claude | Remaining quota for every non-Gemini model (Claude, GPT-OSS, …), which share one pool |
+| Gemini | The shared Gemini pool (Pro and Flash draw from the same quota), rolling 5-hour window |
+| Gemini Weekly | The same Gemini pool's weekly window |
+| Claude | The shared non-Gemini pool (Claude, GPT-OSS, …), rolling 5-hour window |
+| Claude Weekly | The same non-Gemini pool's weekly window |
 | Plan | Your subscription tier, e.g. `Pro` or `Ultra` (optional widget) |
 
-Each meter shows how much of the rolling 5-hour window you've used, and when it resets. Quotas are reported as a fraction (full = 0% used), so there are no token or dollar spend tiles. The model lineup is read live from Antigravity, so new models appear on their own.
+Gemini Pro and Gemini Flash are one pool: using either model drains the same quota, so OpenUsage shows one Gemini meter per window instead of separate Pro and Flash meters. Every non-Gemini model shares the second pool, shown under the Claude name. Quotas are reported as a fraction (full = 0% used), so there are no token or dollar spend tiles.
 
-While a pool's rolling 5-hour window has no usage yet, that meter reads **Not started** on the trailing label instead of a reset countdown; hover explains that the window begins after your first message to that model.
+While a pool's rolling 5-hour window has no usage yet, that meter reads **Not started** on the trailing label instead of a reset countdown; hover explains that the session begins after your first message. The weekly meters always show a normal reset countdown.
 
 ## Where credentials come from
 
@@ -29,11 +30,13 @@ If neither is available you'll see *Start Antigravity or run `agy` and try again
 ## Troubleshooting
 
 - **"Start Antigravity or run `agy`…"** — sign in to the Antigravity app (or run `agy`) so a usable token exists, then refresh.
-- **A meter shows "No data"** — that model pool wasn't in the latest response (e.g. no Gemini Flash model provisioned). The other meters still update.
-- **Quotas look full after heavy use** — they reset every ~5 hours; the reset time is shown on each meter.
+- **The weekly meters show "No data"** — your Antigravity build doesn't expose the quota-summary endpoint yet (only newer builds do). The 5-hour meters still work from the older endpoints; updating Antigravity brings the weekly meters back.
+- **A meter shows "No data"** — that pool/window wasn't in the latest response (some tiers only report certain windows). The other meters still update.
+- **Gemini Pro and Flash look identical** — they are: both draw from the one shared Gemini pool, which is why there's a single Gemini meter now.
+- **Quotas look full after heavy use** — the 5-hour windows reset on a rolling basis and the weekly windows once a week; the reset time is shown on each meter.
 
 ## Under the hood
 
-Best source first: the local language server (`GetUserStatus`, falling back to `GetCommandModelConfigs`) discovered by scanning for the `language_server` / `agy` process and reading its CSRF token and listening ports; then Google Cloud Code (`fetchAvailableModels` for quota, `loadCodeAssist` for the plan) using the Keychain token, refreshed via Google OAuth when needed. The plan name prefers Antigravity's own `userTier` over the inherited Windsurf plan field. Internal and duplicate models are filtered out before the pools are built.
+Best source first: the local language server discovered by scanning for the `language_server` / `agy` process and reading its CSRF token and listening ports; then Google Cloud Code using the Keychain token, refreshed via Google OAuth when needed. On each source OpenUsage asks the quota-summary endpoint first (`RetrieveUserQuotaSummary` on the language server, `v1internal:retrieveUserQuotaSummary` on Cloud Code) — the only endpoint that reports the merged pools and the weekly windows. Builds without it fall back to the legacy per-model endpoints (`GetUserStatus` / `GetCommandModelConfigs` locally, `fetchAvailableModels` / `retrieveUserQuota` remotely), whose per-model quotas are merged into the two pools by keeping each pool's worst remaining fraction; those endpoints only know the 5-hour windows. The plan name prefers Antigravity's own `userTier` over the inherited Windsurf plan field.
 
 > Reverse-engineered from the app and language-server binary; endpoints and storage may change without notice.

--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -8,13 +8,13 @@ Antigravity has two shared quota pools, and each pool has two windows — a roll
 
 | Metric | Meaning |
 |---|---|
-| Gemini | The shared Gemini pool (Pro and Flash draw from the same quota), rolling 5-hour window |
-| Gemini Weekly | The same Gemini pool's weekly window |
+| Session | The shared Gemini pool (Pro and Flash draw from the same quota), rolling 5-hour window |
+| Weekly | The same Gemini pool's weekly window |
 | Claude | The shared non-Gemini pool (Claude, GPT-OSS, …), rolling 5-hour window |
 | Claude Weekly | The same non-Gemini pool's weekly window |
 | Plan | Your subscription tier, e.g. `Pro` or `Ultra` (optional widget) |
 
-Gemini Pro and Gemini Flash are one pool: using either model drains the same quota, so OpenUsage shows one Gemini meter per window instead of separate Pro and Flash meters. Every non-Gemini model shares the second pool, shown under the Claude name. Quotas are reported as a fraction (full = 0% used), so there are no token or dollar spend tiles.
+Gemini Pro and Gemini Flash are one pool: using either model drains the same quota, so OpenUsage shows one meter per window instead of separate Pro and Flash meters. That pair is named Session and Weekly to match the other providers' rows. Every non-Gemini model shares the second pool, shown under the Claude name (like Codex's Spark pair). Quotas are reported as a fraction (full = 0% used), so there are no token or dollar spend tiles.
 
 While a pool's rolling 5-hour window has no usage yet, that meter reads **Not started** on the trailing label instead of a reset countdown; hover explains that the session begins after your first message. The weekly meters always show a normal reset countdown.
 
@@ -32,7 +32,7 @@ If neither is available you'll see *Start Antigravity or run `agy` and try again
 - **"Start Antigravity or run `agy`…"** — sign in to the Antigravity app (or run `agy`) so a usable token exists, then refresh.
 - **The weekly meters show "No data"** — your Antigravity build doesn't expose the quota-summary endpoint yet (only newer builds do). The 5-hour meters still work from the older endpoints; updating Antigravity brings the weekly meters back.
 - **A meter shows "No data"** — that pool/window wasn't in the latest response (some tiers only report certain windows). The other meters still update.
-- **Gemini Pro and Flash look identical** — they are: both draw from the one shared Gemini pool, which is why there's a single Gemini meter now.
+- **Where did the Gemini Pro and Flash meters go?** — merged: both models draw from the one shared Gemini pool, which is now the single Session meter.
 - **Quotas look full after heavy use** — the 5-hour windows reset on a rolling basis and the weekly windows once a week; the reset time is shown on each meter.
 
 ## Under the hood


### PR DESCRIPTION
## TL;DR

Antigravity merged its Gemini Pro/Flash quotas into one shared pool and added weekly limits; the widget now shows the two real pools across both windows — **Session, Weekly, Claude, Claude Weekly** — driven by the new `RetrieveUserQuotaSummary` RPC, with the old per-model endpoints kept as a 5h-only fallback.

## What was happening

- Antigravity restructured its quotas on 2026-05-19 (confirmed by Google's blog): Gemini Pro and Flash now draw from **one shared pool**, non-Gemini models (Claude, GPT-OSS) share a second pool, and each pool has **both a rolling 5-hour window and a weekly window**.
- OpenUsage still showed three independent 5-hour meters (Gemini Pro, Gemini Flash, Claude). The two Gemini meters were not independently exhaustible — using either model drained both — and weekly limits were missing entirely.

## What this changes

- **New authoritative source:** `RetrieveUserQuotaSummary` is queried first on both transports — the local language server (payload wrapped in `{"response": …}`) and the remote Cloud Code endpoint (bare payload). It reports the merged pools and both windows directly.
- **Rows:** Session, Weekly (the merged Gemini pool), Claude, Claude Weekly (the non-Gemini pool). The Gemini pair is named exactly like the Claude/Codex rows; the Claude pair mirrors Codex's Spark/Spark Weekly placement (secondary pool below the caret).
- **Strict parsing:** exact `bucketId` matching only (`gemini-5h`, `gemini-weekly`, `3p-5h`, `3p-weekly`); unknown buckets are skipped loudly, never inferred from display names. Buckets decode leniently (one malformed bucket never voids the summary); a missing/unusable `remainingFraction` drops that line ("No data") instead of fabricating 0% or 100%.
- **Authoritative-empty:** a parsed summary — even with zero usable buckets — ends the probe. It never falls through to the legacy chain, which fabricates "fully used" from missing quota info.
- **Legacy fallback:** builds without the RPC (404) keep working via the old endpoints; all Gemini models now pool into the single Session meter there (worst fraction wins). Legacy data is 5h-only, so weekly rows read "No data" on those builds.
- **IDs:** `antigravity.geminiPro` is kept for the merged Gemini pool's Session meter (existing layouts carry over with zero migration); `antigravity.geminiWeekly` / `antigravity.claudeWeekly` are new; `antigravity.geminiFlash` is removed.
- **Defaults:** all four enabled; Session/Weekly pair primary and pinned (2-pin cap); Claude pool pair below the caret; the two weekly metrics auto-seed once for existing users. "Not started" stays limited to the two 5h rows.
- **Docs:** `docs/providers/antigravity.md` rewritten (two pools × two windows, endpoint list, troubleshooting); README provider line and the menu-bar default-star list updated.

## Heads-up

- `antigravity.geminiFlash` layout state (enabled/pin/order) drops without migration — owner-approved; every LayoutStore load path filters unknown IDs, so saved state self-heals.
- Users who never touched their pins **automatically gain the new Weekly pin** (pins re-derive from defaults while the pins key is absent — pre-existing mechanism, still ≤ 2 per provider). Users with a saved pin set keep exactly their pins.
- Metric line labels changed (`Gemini Pro`/`Gemini Flash` → `Session`, plus the new `Weekly` / `Claude Weekly` labels) — visible to local HTTP API consumers (`/v1/usage/antigravity`).
- Weekly rows read "No data" on Antigravity builds without the summary RPC (documented in the provider doc).
- The RPC is reverse-engineered and version-dependent — worth shipping through an Early Access beta first. No version bump in this PR.

## Tests

- `swift build && swift test` — all 745 tests pass.
- New `AntigravityQuotaSummaryTests`: wrapped vs. bare payloads parse identically; lenient bucket decode (malformed bucket survives, fraction-less bucket drops its line); exact-bucketId matching (a `gemini-image-5h` impostor never joins a pool); weekly-only / 5h-only tier shapes; authoritative-empty stops both the LS endpoint iteration and the Cloud Code legacy chain, even when the plan call fails; summary-404 → legacy merged pools; label-drift guard (descriptor `metricLabel` set == mapper's emitted label set).
- New `AntigravityLayoutTests` (first Antigravity layout coverage): fresh defaults (4 metrics, Gemini pool pair pinned, Claude pair secondary), weekly auto-seeding for existing users (Claude Weekly enters below the caret), `geminiFlash` filtered from saved placed/pins/order, pins-key present vs. absent behavior.
- Updated `AntigravityProviderTests` (merged pooling, summary-404 routed explicitly) and `ResetDisplayTests` (weekly rows never read "Not started").
- Live-verified on this machine against the running Antigravity IDE (LS path): 4 rows matching the IDE's Model Quota UI and a manual `curl` of `RetrieveUserQuotaSummary` (Gemini pool Weekly 1% used, reset 2026-07-07T22:51:13Z), plan `Pro`; local HTTP API returns the four new lines.

## Screenshots

<img width="1052" height="807" alt="CleanShot 2026-07-02 at 15 05 36@2x" src="https://github.com/user-attachments/assets/02068bac-ce03-4fcc-848e-40e4bb348aa8" />

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge; logic is well-guarded, the authoritative-empty invariant is correctly enforced on both transports, and the layout migration is self-healing.

The authoritative-empty contract (a parsed summary — even zero-bucket — stops the probe) is correctly implemented on both the LS endpoint loop and the Cloud Code switch block. Bucket-level leniency via the non-throwing QuotaSummaryBucket.init(from:) matches the documented and tested guarantees. The dual-envelope decode (response?.groups ?? groups) handles both LS and Cloud Code payload shapes without ambiguity. The geminiFlash layout drop is owner-approved and self-heals via the existing unknown-ID filter. Test coverage is unusually thorough for the new code paths.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fix(antigravity): rename pool rows to Se..."](https://github.com/robinebers/openusage/commit/7ab92087fde58915ea2d2fc5b540cfce5f369d95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41353726)</sub>

<!-- /greptile_comment -->