### PR TITLE
fix(dashboard): provider Customize opens straight to metrics

### DIFF
--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -68,7 +68,7 @@ struct WidgetGroupedListView: View {
                 Task { await dataStore.refresh(providerID: group.provider.id, force: true) }
             }
             Button("Customize…") {
-                withAnimation(Motion.modeSwitch) { layout.isEditing = true }
+                openCustomize(for: group.provider.id)
             }
             Divider()
             Button("Share Screenshot") { shareCard(group) }
@@ -267,7 +267,15 @@ struct WidgetGroupedListView: View {
             }
         }
         Button("Customize…") {
-            withAnimation(Motion.modeSwitch) { layout.isEditing = true }
+            openCustomize(for: providerID)
+        }
+    }
+
+    /// From the dashboard, jump straight into this provider's Customize metrics (L2), not the provider list.
+    private func openCustomize(for providerID: String) {
+        withAnimation(Motion.modeSwitch) {
+            layout.customizeProviderID = providerID
+            layout.isEditing = true
         }
     }
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -29,8 +29,8 @@ Rows with a reset date tick every 30 seconds, so countdowns and pace stay live b
 
 ## Right-click menus
 
-Every row: **Hide · Star for menu bar / Unstar · Refresh \<provider\> · Customize…**
-Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on in Customize.) plus **Share Screenshot** (see below).
+Every row: **Hide · Star for menu bar / Unstar · Refresh \<provider\> · Customize…** (Customize opens straight to that provider's metrics.)
+Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on in Customize. Customize opens straight to that provider's metrics.) plus **Share Screenshot** (see below).
 
 ## Share
 


### PR DESCRIPTION
## TL;DR
Right-click **Customize…** on a provider header or metric row now opens that provider’s metric screen in Customize instead of the provider list.

## What was happening
- Dashboard context menus set `layout.isEditing = true` only, so **Customize…** always landed on Customize L1 (the full provider list).
- That was an extra tap when you already knew which provider you wanted to edit.

## What this changes
- Shared `openCustomize(for:)` sets `customizeProviderID` and opens Customize in one animated step.
- Provider header and metric row menus both use it.
- `docs/dashboard.md` documents the direct-to-metrics behavior.

## Heads-up
- Footer / **⌄** menu **Customize** and **Return** from the dashboard are unchanged — they still open Customize L1.

## Tests
- `./script/build_and_run.sh verify` (build + launch)


Made with [Cursor](https://cursor.com)