### PR TITLE
chore(worktree-setup): exclude stale agent worktrees from rsync

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -13,7 +13,7 @@ swift package resolve
 for d in .agents .claude .codex .cursor; do
     if [ -d "$CODEX_SOURCE_TREE_PATH/$d" ]; then
         mkdir -p "$CODEX_WORKTREE_PATH/$d"
-        rsync -a "$CODEX_SOURCE_TREE_PATH/$d/." "$CODEX_WORKTREE_PATH/$d/"
+        rsync -a --exclude worktrees --exclude scheduled_tasks.lock "$CODEX_SOURCE_TREE_PATH/$d/." "$CODEX_WORKTREE_PATH/$d/"
     fi
 done
 

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,7 +1,7 @@
 {
   "setup-worktree": [
     "swift package resolve",
-    "for d in .agents .claude .codex .cursor; do [ -d \"$ROOT_WORKTREE_PATH/$d\" ] && mkdir -p \"$d\" && rsync -a \"$ROOT_WORKTREE_PATH/$d/.\" \"$d/\"; done",
+    "for d in .agents .claude .codex .cursor; do [ -d \"$ROOT_WORKTREE_PATH/$d\" ] && mkdir -p \"$d\" && rsync -a --exclude worktrees --exclude scheduled_tasks.lock \"$ROOT_WORKTREE_PATH/$d/.\" \"$d/\"; done",
     "for f in .env .env.local .env.development .env.production; do [ -f \"$ROOT_WORKTREE_PATH/$f\" ] && cp \"$ROOT_WORKTREE_PATH/$f\" \"$f\" || true; done"
   ]
 }


### PR DESCRIPTION
## TL;DR
Stop copying 8.9 GB of stale Claude Code agent worktrees into every new agent worktree — add `--exclude worktrees --exclude scheduled_tasks.lock` to the Cursor and Codex setup rsync calls, cutting worktree setup from ~1-2 min to well under a second.

## What was happening
- Both Cursor (`.cursor/worktrees.json`) and Codex (`.codex/environments/environment.toml`) run a setup script when spawning a new agent worktree that rsyncs `.agents .claude .codex .cursor` from the source repo into the new worktree.
- `.agents/worktrees/` holds Claude Code's background-agent checkouts — 14 stale worktrees totaling 8.9 GB in this repo (`.claude` is a symlink to `.agents`, so Claude Code's `.claude/worktrees/` lands there physically).
- That directory is runtime state from past background-agent runs, already gitignored (`.gitignore:6`), but the rsync didn't exclude it, so every new worktree duplicated all 8.9 GB. This dominated setup time (1-2 min) and snowballed — copied worktrees would get re-copied into the next worktree.
- `swift package resolve` (3 deps, cached) and the `.env` copy were never the bottleneck; the rsync of `.agents/worktrees/` was.

## What this changes
- Adds `--exclude worktrees --exclude scheduled_tasks.lock` to the rsync in both `.cursor/worktrees.json` and `.codex/environments/environment.toml`.
- Only the actual config now copies over: `.agents/skills` (~276 KB), `.cursor`, `.codex`, and `.env` files.
- No behavior change to what agents need — skills, rules, and tool configs still land in the worktree exactly as before.

## Heads-up
- This only affects **new** worktrees created after this commit. The 14 existing worktrees in `.agents/worktrees/` are untouched; Claude Code owns their lifecycle and cleans them up on its own (or they can be pruned manually once no background agent is using them).
- The loop still lists `.claude` alongside `.agents` even though `.claude` is a symlink to `.agents`, so the skills get rsync'd twice into the same place. Harmless (~276 KB) and left as-is to keep the change minimal; could drop `.claude` from the list in a follow-up.

## Tests
- `python3 -c "import json; json.load(open('.cursor/worktrees.json'))"` — validates the edited JSON.
- Diff is exactly the two `--exclude` additions; no other lines touched.

Made with [Cursor](https://cursor.com)