### PR TITLE
feat(accounts): multi-account support for Claude and Codex

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -26,6 +26,12 @@ final class AppContainer {
     /// ephemeral secret-code easter-egg state, and the system accessibility flags it yields to. Read by both
     /// the SwiftUI surface and the AppKit panel (`StatusItemController`).
     let transparency: PopoverTransparencyStore
+    /// Extra accounts (beyond the default CLI login) the user has added. Each is expanded into its own
+    /// provider instance below; the Accounts settings tab drives it (changes apply on next launch).
+    let accounts: AccountsStore
+    /// User-chosen names for accounts, keyed by email. Drives the dashboard card titles and is editable
+    /// in the Accounts settings; live (no relaunch needed) since it's read at render time.
+    let accountNames = AccountNamesStore()
     /// Read-only usage API on 127.0.0.1:6736 for other local apps (silently off when the port is taken).
     private let localAPI: LocalUsageServer
     // A `let` of a `Sendable` `Task` is implicitly nonisolated, so the nonisolated `deinit` can cancel it.
@@ -37,12 +43,13 @@ final class AppContainer {
         // run from a terminal. Warmed here so the first refresh finds the cache ready.
         LoginShellEnvironment.shared.prewarm()
 
+        let accounts = AccountsStore()
         // Default provider order (see AGENTS.md "## Providers"): the three established providers first —
         // Claude, Codex, Cursor — then every other provider alphabetically by display name. This registry
         // order is the default provider order (`LayoutStore.orderedProviderIDs` falls back to it, and
         // `resetToDefault` seeds it), so the dashboard, Customize sections, and the per-provider reset
         // menu all read this way.
-        let providers: [ProviderRuntime] = [
+        var providers: [ProviderRuntime] = [
             ClaudeProvider(),
             CodexProvider(),
             CursorProvider(),
@@ -53,6 +60,8 @@ final class AppContainer {
             OpenRouterProvider(),
             ZAIProvider()
         ]
+        // Expand the user's extra accounts into their own provider instances (Claude/Codex).
+        providers.append(contentsOf: AccountProviders.extraProviders(for: accounts.accounts))
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
         let enablement = ProviderEnablementStore()
@@ -71,10 +80,15 @@ final class AppContainer {
         // Re-enabling a provider should fetch it promptly, so clear any leftover failure backoff before
         // the enablement wake refreshes. `weak` breaks the cycle (dataStore already captures enablement).
         enablement.onProviderEnabled = { [weak dataStore] id in dataStore?.clearFailureBackoff(for: id) }
+        // Break the layout↔data cycle with a late binding: layout hides duplicate accounts using the
+        // emails the data store resolves at refresh time (and feeds them through `visiblePlaced`, so the
+        // dashboard, Customize, and menu bar all dedupe from this one input).
+        layout.accountEmailLookup = { [dataStore] in dataStore.accountEmail(for: $0) }
         self.registry = registry
         self.enablement = enablement
         self.apiKeyProviders = apiKeyProviders
         self.notificationSettings = notificationSettings
+        self.accounts = accounts
         self.layout = layout
         self.dataStore = dataStore
 

--- a/Sources/OpenUsage/Models/ExtraAccount.swift
+++ b/Sources/OpenUsage/Models/ExtraAccount.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// An additional provider account beyond the default one the CLI is logged into. Each becomes its
+/// own provider instance, pointed at its own config dir (`CLAUDE_CONFIG_DIR` / `CODEX_HOME`).
+struct ExtraAccount: Codable, Identifiable, Hashable, Sendable {
+    /// Base provider key this account belongs to: "claude" or "codex".
+    var provider: String
+    /// Short stable token that makes the instance id unique, e.g. "oxl5l1".
+    var slot: String
+    /// User-facing label shown in the dashboard group header, e.g. "Work".
+    var label: String
+    /// Absolute path to the account's CLI config dir (holds its credentials).
+    var configDir: String
+
+    var id: String { instanceID }
+
+    /// The provider instance id used everywhere ids key off (registry, layout, API): "claude@oxl5l1".
+    var instanceID: String { "\(provider)@\(slot)" }
+}

--- a/Sources/OpenUsage/Models/ProviderSnapshot.swift
+++ b/Sources/OpenUsage/Models/ProviderSnapshot.swift
@@ -5,6 +5,9 @@ struct ProviderSnapshot: Hashable, Sendable, Codable {
     let providerID: String
     let displayName: String
     var plan: String?
+    /// The signed-in account (email) this snapshot belongs to, for providers that support multiple
+    /// accounts. Set after construction; defaults to nil for providers/snapshots without one.
+    var accountEmail: String? = nil
     var lines: [MetricLine]
     var refreshedAt: Date
     /// A soft, non-blocking notice carried on a *successful* snapshot — e.g. Claude's "Re-login for live

--- a/Sources/OpenUsage/Providers/AccountIdentity.swift
+++ b/Sources/OpenUsage/Providers/AccountIdentity.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Resolves an account's signed-in email, dispatching to each provider's identity source (Claude's
+/// `/api/oauth/profile`, Codex's `id_token`). Pass the account's config dir, or nil for the default
+/// login. Returns nil for providers without an identity source or when the account isn't logged in.
+/// One seam so the Accounts UI and duplicate-rejection treat every multi-account provider alike.
+enum AccountIdentity {
+    @MainActor
+    static func email(provider: String, configDir: String?) async -> String? {
+        switch provider {
+        case "claude": return await ClaudeAccountIdentity.email(configDir: configDir)
+        case "codex": return CodexAccountIdentity.email(configHome: configDir)
+        default: return nil
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/AccountProviders.swift
+++ b/Sources/OpenUsage/Providers/AccountProviders.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Builds the extra provider instances for the user's additional accounts. Each instance reuses the
+/// normal provider pipeline, only pointed at the account's own config dir via `OverrideEnvironment`
+/// (`CLAUDE_CONFIG_DIR` / `CODEX_HOME`). Unknown providers are skipped (only Claude and Codex support
+/// the config-dir redirect).
+///
+/// De-duplication of accounts that resolve to the same email happens at the display layer (a provider
+/// whose account email already appeared is hidden), using each provider's resolved identity (Claude's
+/// profile API, Codex's `id_token`) — not here, where only the saved config is known.
+enum AccountProviders {
+    @MainActor
+    static func extraProviders(for accounts: [ExtraAccount]) -> [ProviderRuntime] {
+        accounts.compactMap { account in
+            switch account.provider {
+            case "claude":
+                return ClaudeProvider(
+                    instanceID: account.instanceID,
+                    displayName: "Claude · \(account.label)",
+                    authStore: ClaudeAuthStore(
+                        environment: OverrideEnvironment(["CLAUDE_CONFIG_DIR": account.configDir])
+                    )
+                )
+            case "codex":
+                return CodexProvider(
+                    instanceID: account.instanceID,
+                    displayName: "Codex · \(account.label)",
+                    authStore: CodexAuthStore(
+                        environment: OverrideEnvironment(["CODEX_HOME": account.configDir])
+                    )
+                )
+            default:
+                return nil
+            }
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAccountIdentity.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAccountIdentity.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Resolves a Claude account's email from the reliable `/api/oauth/profile` endpoint (token-derived,
+/// not the flip-flopping `.claude.json`). Pass the account's config dir, or nil for the default login.
+/// Used to label accounts in the Accounts settings and to reject adding a duplicate account.
+enum ClaudeAccountIdentity {
+    @MainActor
+    static func email(configDir: String?, usageClient: ClaudeUsageClient = ClaudeUsageClient()) async -> String? {
+        let environment: EnvironmentReading = configDir.map { OverrideEnvironment(["CLAUDE_CONFIG_DIR": $0]) }
+            ?? ProcessEnvironmentReader()
+        let authStore = ClaudeAuthStore(environment: environment)
+        guard let state = authStore.loadCredentials(),
+              let token = state.oauth.accessToken,
+              !token.isEmpty,
+              let config = try? authStore.oauthConfig()
+        else { return nil }
+        return await email(accessToken: token, usageClient: usageClient, config: config)
+    }
+
+    /// Shared profile lookup for an already-resolved access token (also used by `ClaudeProvider`, which
+    /// holds a live token, so the request/parse/status logic lives in one place). Best-effort: returns
+    /// nil on any failure — logged at debug, since identity is a labelling aid, not a gate.
+    @MainActor
+    static func email(accessToken: String, usageClient: ClaudeUsageClient, config: ClaudeOAuthConfig) async -> String? {
+        do {
+            let response = try await usageClient.fetchProfile(accessToken: accessToken, config: config)
+            guard (200..<300).contains(response.statusCode) else {
+                AppLog.debug(LogTag.auth("claude"), "profile lookup returned HTTP \(response.statusCode)")
+                return nil
+            }
+            return ClaudeProfile.email(fromProfileResponse: response.body)
+        } catch {
+            AppLog.debug(LogTag.auth("claude"), "profile lookup failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -92,6 +92,7 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
 
 struct ClaudeOAuthConfig: Hashable, Sendable {
     var usageURL: URL
+    var profileURL: URL
     var refreshURL: URL
     var clientID: String
     var oauthFileSuffix: String
@@ -263,11 +264,16 @@ struct ClaudeAuthStore: Sendable {
         guard let usageURL = URL(string: usageURLString) else {
             throw ClaudeAuthError.invalidOAuthURL(usageURLString)
         }
+        let profileURLString = "\(endpoints.baseAPI)/api/oauth/profile"
+        guard let profileURL = URL(string: profileURLString) else {
+            throw ClaudeAuthError.invalidOAuthURL(profileURLString)
+        }
         guard let refreshURL = URL(string: endpoints.refreshURL) else {
             throw ClaudeAuthError.invalidOAuthURL(endpoints.refreshURL)
         }
         return ClaudeOAuthConfig(
             usageURL: usageURL,
+            profileURL: profileURL,
             refreshURL: refreshURL,
             clientID: endpoints.clientID,
             oauthFileSuffix: endpoints.suffix

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -2,20 +2,14 @@ import Foundation
 
 @MainActor
 final class ClaudeProvider: ProviderRuntime {
-    let provider = Provider(
-        id: "claude",
-        displayName: "Claude",
-        icon: .providerMark("claude"),
-        links: [
-            .init(label: "Status", url: "https://status.anthropic.com/"),
-            .init(label: "Dashboard", url: "https://claude.ai/settings/usage")
-        ]
-    )
+    let provider: Provider
 
     let authStore: ClaudeAuthStore
     let usageClient: ClaudeUsageClient
     let ccusageRunner: CcusageRunner
     let now: @Sendable () -> Date
+    /// Cached once resolved — the token's account email is stable across refreshes.
+    private var resolvedAccountEmail: String?
 
     /// Last successful live-usage result and a rate-limit cooldown, carried across refreshes (the provider
     /// is a long-lived singleton). `/api/oauth/usage` rate-limits aggressively, so on a 429 we serve the
@@ -26,12 +20,26 @@ final class ClaudeProvider: ProviderRuntime {
     private var rateLimitedUntil: Date?
     private static let rateLimitCooldown: TimeInterval = 5 * 60
 
+    /// `instanceID` is the provider id: "claude" for the default account, "claude@<slot>" for an
+    /// extra account (whose `authStore` is pointed at its own config dir). `displayName` differs per
+    /// account so the dashboard shows distinct groups.
     init(
+        instanceID: String = "claude",
+        displayName: String = "Claude",
         authStore: ClaudeAuthStore = ClaudeAuthStore(),
         usageClient: ClaudeUsageClient = ClaudeUsageClient(),
         ccusageRunner: CcusageRunner = CcusageRunner(),
         now: @escaping @Sendable () -> Date = Date.init
     ) {
+        self.provider = Provider(
+            id: instanceID,
+            displayName: displayName,
+            icon: .providerMark("claude"),
+            links: [
+                .init(label: "Status", url: "https://status.anthropic.com/"),
+                .init(label: "Dashboard", url: "https://claude.ai/settings/usage")
+            ]
+        )
         self.authStore = authStore
         self.usageClient = usageClient
         self.ccusageRunner = ccusageRunner
@@ -40,11 +48,11 @@ final class ClaudeProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "claude.session", provider: provider, title: "Session"),
-            .percent(id: "claude.weekly", provider: provider, title: "Weekly"),
-            .percent(id: "claude.sonnet", provider: provider, title: "Sonnet"),
-            .percent(id: "claude.fable", provider: provider, title: "Fable"),
-            .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent"),
+            .percent(id: "\(provider.id).session", provider: provider, title: "Session"),
+            .percent(id: "\(provider.id).weekly", provider: provider, title: "Weekly"),
+            .percent(id: "\(provider.id).sonnet", provider: provider, title: "Sonnet"),
+            .percent(id: "\(provider.id).fable", provider: provider, title: "Fable"),
+            .boundedDollars(id: "\(provider.id).extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent"),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)
     }
@@ -101,6 +109,11 @@ final class ClaudeProvider: ProviderRuntime {
         switch authStore.liveUsageAvailability(state) {
         case .available:
             mapped = try await fetchLiveUsage(state: &state)
+            if resolvedAccountEmail == nil, let token = state.oauth.accessToken, !token.isEmpty {
+                resolvedAccountEmail = await ClaudeAccountIdentity.email(
+                    accessToken: token, usageClient: usageClient, config: try authStore.oauthConfig()
+                )
+            }
         case .missingProfileScope:
             // The login authenticates for inference but lacks the `user:profile` scope the usage endpoint
             // needs (typically a `claude setup-token` token). Don't leave the session/weekly bars silently
@@ -121,7 +134,9 @@ final class ClaudeProvider: ProviderRuntime {
         )
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)
-        return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now(), warning: warning)
+        var snapshot = ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now(), warning: warning)
+        snapshot.accountEmail = resolvedAccountEmail
+        return snapshot
     }
 
     private func fetchLiveUsage(state: inout ClaudeCredentialState) async throws -> ClaudeMappedUsage {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageClient.swift
@@ -73,5 +73,35 @@ struct ClaudeUsageClient: Sendable {
             )
         )
     }
+
+    /// Fetches the signed-in account's profile, used only to resolve the account email/identity.
+    func fetchProfile(accessToken: String, config: ClaudeOAuthConfig) async throws -> HTTPResponse {
+        try await httpClient.send(
+            HTTPRequest(
+                method: "GET",
+                url: config.profileURL,
+                headers: [
+                    "Authorization": "Bearer \(accessToken.trimmingCharacters(in: .whitespacesAndNewlines))",
+                    "Accept": "application/json",
+                    "anthropic-beta": "oauth-2025-04-20",
+                    "User-Agent": "claude-code/2.1.69"
+                ],
+                timeout: 10
+            )
+        )
+    }
+}
+
+/// Reads the account email from the `/api/oauth/profile` response (`account.email`). Derived from the
+/// token, so it identifies the account reliably regardless of the CLI's flip-flopping `.claude.json`.
+enum ClaudeProfile {
+    static func email(fromProfileResponse data: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let account = object["account"] as? [String: Any],
+              let email = account["email"] as? String,
+              email.contains("@")
+        else { return nil }
+        return email
+    }
 }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexAccountIdentity.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexAccountIdentity.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Resolves a Codex account's email from its `id_token` — the OpenAI OIDC token stored in `auth.json`,
+/// whose payload carries a top-level `email` claim, so no network call is needed. Pass the account's
+/// `CODEX_HOME`, or nil for the default login. Used to label accounts in the Accounts settings and to
+/// reject adding a duplicate account.
+enum CodexAccountIdentity {
+    @MainActor
+    static func email(configHome: String?) -> String? {
+        let environment: EnvironmentReading = configHome.map { OverrideEnvironment(["CODEX_HOME": $0]) }
+            ?? ProcessEnvironmentReader()
+        let authStore = CodexAuthStore(environment: environment)
+        let (fileCandidates, _) = authStore.loadAuthCandidates()
+        let idToken = fileCandidates.lazy.compactMap { $0.auth.tokens?.idToken }.first
+            ?? authStore.loadKeychainAuth()?.auth.tokens?.idToken
+        return email(fromIDToken: idToken)
+    }
+
+    /// Decodes the `email` claim from an OIDC `id_token` JWT payload. Best-effort: returns nil if the
+    /// token is absent, malformed, or carries no email — identity is a labelling aid, not a gate.
+    static func email(fromIDToken idToken: String?) -> String? {
+        guard let idToken else { return nil }
+        let segments = idToken.split(separator: ".")
+        guard segments.count >= 2 else { return nil }
+        // JWT segments are base64url with stripped padding; restore both before decoding.
+        var base64 = String(segments[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 { base64.append("=") }
+        guard let data = Data(base64Encoded: base64),
+              let claims = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let email = claims["email"] as? String,
+              !email.isEmpty
+        else { return nil }
+        return email
+    }
+}

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -2,27 +2,33 @@ import Foundation
 
 @MainActor
 final class CodexProvider: ProviderRuntime {
-    let provider = Provider(
-        id: "codex",
-        displayName: "Codex",
-        icon: .providerMark("codex"),
-        links: [
-            .init(label: "Status", url: "https://status.openai.com/"),
-            .init(label: "Dashboard", url: "https://chatgpt.com/codex/settings/usage")
-        ]
-    )
+    let provider: Provider
 
     let authStore: CodexAuthStore
     let usageClient: CodexUsageClient
     let ccusageRunner: CcusageRunner
     let now: @Sendable () -> Date
 
+    /// `instanceID` is the provider id: "codex" for the default account, "codex@<slot>" for an extra
+    /// account (whose `authStore` is pointed at its own `CODEX_HOME`). `displayName` differs per
+    /// account so the dashboard shows distinct groups.
     init(
+        instanceID: String = "codex",
+        displayName: String = "Codex",
         authStore: CodexAuthStore = CodexAuthStore(),
         usageClient: CodexUsageClient = CodexUsageClient(),
         ccusageRunner: CcusageRunner = CcusageRunner(),
         now: @escaping @Sendable () -> Date = Date.init
     ) {
+        self.provider = Provider(
+            id: instanceID,
+            displayName: displayName,
+            icon: .providerMark("codex"),
+            links: [
+                .init(label: "Status", url: "https://status.openai.com/"),
+                .init(label: "Dashboard", url: "https://chatgpt.com/codex/settings/usage")
+            ]
+        )
         self.authStore = authStore
         self.usageClient = usageClient
         self.ccusageRunner = ccusageRunner
@@ -31,15 +37,15 @@ final class CodexProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "codex.session", provider: provider, title: "Session"),
-            .percent(id: "codex.weekly", provider: provider, title: "Weekly"),
+            .percent(id: "\(provider.id).session", provider: provider, title: "Session"),
+            .percent(id: "\(provider.id).weekly", provider: provider, title: "Weekly"),
             // Model-specific Spark limits (GPT-5.3-Codex-Spark), parsed from `additional_rate_limits`.
             // Declared right after Weekly so they group with the core rate-limit meters; seeded as
             // secondary (below the caret) and unpinned in `DefaultLayout`.
-            .percent(id: "codex.spark", provider: provider, title: "Spark"),
-            .percent(id: "codex.sparkWeekly", provider: provider, title: "Spark Weekly"),
-            .combined(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
-            .values(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
+            .percent(id: "\(provider.id).spark", provider: provider, title: "Spark"),
+            .percent(id: "\(provider.id).sparkWeekly", provider: provider, title: "Spark Weekly"),
+            .combined(id: "\(provider.id).credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
+            .values(id: "\(provider.id).rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)
     }
@@ -115,7 +121,11 @@ final class CodexProvider: ProviderRuntime {
         )
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)
-        return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
+        var snapshot = ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
+        // The id_token in this account's auth carries the signed-in email — decode it (offline) so
+        // multiple Codex accounts are distinguishable and de-dupe like Claude accounts do.
+        snapshot.accountEmail = CodexAccountIdentity.email(fromIDToken: authState.auth.tokens?.idToken)
+        return snapshot
     }
 
     /// Fetches the on-demand reset-credit balance (and per-credit expiry) without ever failing the

--- a/Sources/OpenUsage/Services/AccountLogin.swift
+++ b/Sources/OpenUsage/Services/AccountLogin.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+struct AccountLoginSpec: Sendable {
+    let program: String
+    let arguments: [String]
+    let envVar: String
+}
+
+enum AccountLoginError: Error, LocalizedError {
+    case unsupported(String)
+    case cliNotFound(String)
+    case loginFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupported(let provider): return "\(provider) doesn't support in-app login."
+        case .cliNotFound(let program): return "`\(program)` CLI not found. Install it, then try again."
+        case .loginFailed(let message): return message.isEmpty ? "Login failed. Try again." : message
+        }
+    }
+}
+
+/// Logs a provider CLI into a specific config dir so an additional account's credentials land there
+/// (read back later via `CLAUDE_CONFIG_DIR` / `CODEX_HOME`). The CLI itself drives the browser OAuth
+/// flow and exits when it completes. Ported from the Tauri edition's `account_login.rs`.
+enum AccountLogin {
+    static func spec(for provider: String) -> AccountLoginSpec? {
+        switch provider {
+        case "claude": return AccountLoginSpec(program: "claude", arguments: ["auth", "login", "--claudeai"], envVar: "CLAUDE_CONFIG_DIR")
+        case "codex": return AccountLoginSpec(program: "codex", arguments: ["login"], envVar: "CODEX_HOME")
+        default: return nil
+        }
+    }
+
+    /// Where a newly logged-in account's config (credentials) is kept, isolated from the default login.
+    static func defaultConfigDir(provider: String, slot: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.openusage/accounts/\(provider)-\(slot)"
+    }
+
+    /// Runs the login off the main thread (it blocks up to 5 minutes while the user completes the
+    /// browser OAuth). Throws a friendly error on failure.
+    static func run(provider: String, configDir: String, runner: ProcessRunning = SystemProcessRunner()) async throws {
+        guard let spec = spec(for: provider) else { throw AccountLoginError.unsupported(provider) }
+        let dir = expandHome(configDir)
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+
+        let result = try await Task.detached(priority: .userInitiated) { () throws -> ProcessResult in
+            guard let program = resolveProgram(spec.program) else {
+                throw AccountLoginError.cliNotFound(spec.program)
+            }
+            AppLog.info(.subprocess, "account login: \(spec.program) → \(spec.envVar)")
+            return try runner.run(
+                executable: program,
+                arguments: spec.arguments,
+                environment: [spec.envVar: dir],
+                timeout: 300
+            )
+        }.value
+
+        guard result.succeeded else {
+            let lastLine = result.stderr
+                .split(whereSeparator: \.isNewline)
+                .last
+                .map { String($0).trimmingCharacters(in: .whitespaces) }
+            throw AccountLoginError.loginFailed(lastLine ?? "")
+        }
+    }
+
+    // MARK: - CLI resolution
+
+    /// Finds the provider CLI. GUI apps get a minimal PATH on macOS, so common install locations and
+    /// the login shell are also consulted.
+    private static func resolveProgram(_ program: String) -> String? {
+        var dirs: [String] = []
+        if let path = ProcessInfo.processInfo.environment["PATH"] {
+            dirs.append(contentsOf: path.split(separator: ":").map(String.init))
+        }
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        dirs.append(contentsOf: ["\(home)/.local/bin", "\(home)/bin", "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"])
+        for dir in dirs where !dir.isEmpty {
+            let candidate = "\(dir)/\(program)"
+            if FileManager.default.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+        for shell in ["/bin/zsh", "/bin/bash"] {
+            if let resolved = shellResolved(shell: shell, program: program) {
+                return resolved
+            }
+        }
+        AppLog.warn(.config, "could not resolve CLI '\(program)' on PATH or via a login shell")
+        return nil
+    }
+
+    private static func shellResolved(shell: String, program: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-lc", "command -v \(program)"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            AppLog.debug(.config, "shell resolve via \(shell) failed for \(program): \(error.localizedDescription)")
+            return nil
+        }
+        guard process.terminationStatus == 0 else { return nil }
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        guard let line = output.split(whereSeparator: \.isNewline).last.map(String.init)?.trimmingCharacters(in: .whitespaces),
+              !line.isEmpty,
+              FileManager.default.isExecutableFile(atPath: line)
+        else { return nil }
+        return line
+    }
+}

--- a/Sources/OpenUsage/Services/SystemClients.swift
+++ b/Sources/OpenUsage/Services/SystemClients.swift
@@ -16,6 +16,23 @@ struct ProcessEnvironmentReader: EnvironmentReading {
     }
 }
 
+/// Returns fixed overrides for some keys and falls through to a base reader for everything else.
+/// Used to point a provider instance at a specific account's config dir (`CLAUDE_CONFIG_DIR` /
+/// `CODEX_HOME`) without disturbing the rest of the process environment.
+struct OverrideEnvironment: EnvironmentReading {
+    let overrides: [String: String]
+    let base: EnvironmentReading
+
+    init(_ overrides: [String: String], base: EnvironmentReading = ProcessEnvironmentReader()) {
+        self.overrides = overrides
+        self.base = base
+    }
+
+    func value(for name: String) -> String? {
+        overrides[name] ?? base.value(for: name)
+    }
+}
+
 protocol TextFileAccessing: Sendable {
     func exists(_ path: String) -> Bool
     func readText(_ path: String) throws -> String

--- a/Sources/OpenUsage/Stores/AccountNamesStore.swift
+++ b/Sources/OpenUsage/Stores/AccountNamesStore.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Observation
+
+/// User-chosen display names for accounts, keyed by the account's email (not the config slot or
+/// whether it's the default login). Keying by email means a name follows the account to whichever card
+/// shows it — important because the Claude CLI's "default" login flip-flops between accounts.
+@MainActor
+@Observable
+final class AccountNamesStore {
+    private static let storageKey = "openusage.accountNames.v1"
+
+    private(set) var names: [String: String]
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.names = (defaults.dictionary(forKey: Self.storageKey) as? [String: String]) ?? [:]
+    }
+
+    /// The custom name for an email, or nil if none is set.
+    func name(for email: String?) -> String? {
+        guard let email, let name = names[email.lowercased()], !name.isEmpty else { return nil }
+        return name
+    }
+
+    /// Set (or clear, when blank) the custom name for an email.
+    func setName(_ name: String, for email: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = email.lowercased()
+        if trimmed.isEmpty {
+            names.removeValue(forKey: key)
+        } else {
+            names[key] = trimmed
+        }
+        defaults.set(names, forKey: Self.storageKey)
+    }
+}

--- a/Sources/OpenUsage/Stores/AccountsStore.swift
+++ b/Sources/OpenUsage/Stores/AccountsStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Observation
+
+/// Persisted list of extra provider accounts (beyond the default CLI login). The provider list is
+/// built from this at launch, so changes take effect on the next app start (matching how adding a
+/// CLI account works). The Accounts settings tab drives it.
+@MainActor
+@Observable
+final class AccountsStore {
+    private static let storageKey = "openusage.extraAccounts.v1"
+
+    private(set) var accounts: [ExtraAccount]
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        if let data = defaults.data(forKey: Self.storageKey),
+           let decoded = try? JSONDecoder().decode([ExtraAccount].self, from: data) {
+            self.accounts = decoded
+        } else {
+            self.accounts = []
+        }
+    }
+
+    func add(_ account: ExtraAccount) {
+        accounts.removeAll { $0.instanceID == account.instanceID }
+        accounts.append(account)
+        persist()
+    }
+
+    func remove(instanceID: String) {
+        accounts.removeAll { $0.instanceID == instanceID }
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? JSONEncoder().encode(accounts) else {
+            AppLog.error(.config, "failed to encode extra accounts")
+            return
+        }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+}

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -1,25 +1,6 @@
 import SwiftUI
 import Observation
 
-/// The screen showing inside the menu-bar popover. Customize and Settings replace the dashboard
-/// in place (the popover has no window stack); Esc backs out to the dashboard first.
-enum PopoverScreen: Hashable, Sendable {
-    case dashboard
-    case customize
-    case settings
-
-    /// Left-to-right order for the popover's horizontal screen-switch slide: the dashboard is home on
-    /// the left, with Customize and Settings to its right. The slide reads its direction from these
-    /// ranks — a higher-ranked target enters from the trailing edge, a lower one from the leading edge.
-    var slideRank: Int {
-        switch self {
-        case .dashboard: 0
-        case .customize: 1
-        case .settings: 2
-        }
-    }
-}
-
 /// Mutable layout: which widgets are enabled, provider order, and each provider's metric order.
 /// `placed` is the enabled set (with stable widget ids); `metricOrderByProvider` is the user's custom order.
 @MainActor
@@ -126,6 +107,12 @@ final class LayoutStore {
         didSet { defaults.set(menuBarStyle.rawValue, forKey: menuBarStyleKey) }
     }
 
+    /// Resolves a provider instance's signed-in account email from the live snapshots. Injected after
+    /// construction (the data store needs the layout, so the cycle is broken with a late binding); the
+    /// default "no email" keeps the layout usable headless, in tests, and during its own init. Single
+    /// input to duplicate-account hiding, so every surface agrees on which accounts are visible.
+    var accountEmailLookup: @MainActor (String) -> String? = { _ in nil }
+
     private let registry: WidgetRegistry
     private let defaults: UserDefaults
     private let storageKey: String
@@ -142,6 +129,7 @@ final class LayoutStore {
     private let defaultPinnedMetricIDs: [String]
     private let defaultExpandedMetricIDs: [String]
     private var defaultExpandedOnEnableIDs: Set<String>
+    private let seededAccountsKey: String
     private let isProviderEnabled: @MainActor (String) -> Bool
 
     init(
@@ -169,6 +157,7 @@ final class LayoutStore {
         self.migrationBaselineMetricIDs = migrationBaselineMetricIDs
         self.defaultPinnedMetricIDs = defaultPinnedMetricIDs
         self.defaultExpandedMetricIDs = defaultExpandedMetricIDs
+        self.seededAccountsKey = "\(storageKey).seededAccounts"
         self.isProviderEnabled = isProviderEnabled
 
         let hasStoredLayout = defaults.data(forKey: storageKey) != nil
@@ -190,6 +179,25 @@ final class LayoutStore {
             migrationBaselineMetricIDs: migrationBaselineMetricIDs
         )
         initialPlaced = seededResult.placed
+        // Seed a newly added extra-account provider (instance id "provider@slot") into the layout ONCE,
+        // mirroring the metrics its base type currently has placed, so the account shows up the first time
+        // it's seen instead of staying hidden. Tracked in `seededAccountIDs` so it never re-runs — turning
+        // off all of an account's metrics is then respected on the next launch instead of being resurrected.
+        // Ongoing toggles stay in sync across accounts via `setMetricEnabled`. Base providers are untouched.
+        var seededAccountIDs = Set(defaults.stringArray(forKey: seededAccountsKey) ?? [])
+        for provider in registry.providers where provider.id.contains("@") && !seededAccountIDs.contains(provider.id) {
+            let baseType = Self.baseProviderType(provider.id)
+            for descriptor in registry.descriptors(for: provider.id) {
+                let baseDescriptorID = "\(baseType).\(Self.metricSuffix(descriptor.id, providerID: provider.id))"
+                if initialPlaced.contains(where: { $0.descriptorID == baseDescriptorID }) {
+                    initialPlaced.append(PlacedWidget(descriptorID: descriptor.id))
+                }
+            }
+            seededAccountIDs.insert(provider.id)
+        }
+        // Forget accounts that no longer exist, so a removed-then-re-added account seeds fresh next time.
+        seededAccountIDs.formIntersection(registry.providers.map(\.id).filter { $0.contains("@") })
+        defaults.set(Array(seededAccountIDs), forKey: seededAccountsKey)
         placed = initialPlaced
 
         let initialProviderOrder: [String]
@@ -289,10 +297,26 @@ final class LayoutStore {
     }
 
     var visiblePlaced: [PlacedWidget] {
-        placed.filter { widget in
+        let duplicates = duplicateProviderIDs
+        return placed.filter { widget in
             guard let providerID = providerID(of: widget) else { return true }
-            return isProviderEnabled(providerID)
+            return isProviderEnabled(providerID) && !duplicates.contains(providerID)
         }
+    }
+
+    /// Provider instances hidden as duplicate accounts: walking the provider order, an instance whose
+    /// resolved account email already appeared is hidden (keeping the first — the default login is ordered
+    /// ahead of a later extra account, so the extra is the one dropped). The single source the dashboard,
+    /// Customize, and menu bar all read through `visiblePlaced`/`customizeGroups`, so every surface agrees.
+    /// Providers with no resolved email (single-account providers, or not yet loaded) are never hidden.
+    private var duplicateProviderIDs: Set<String> {
+        var seen = Set<String>()
+        var duplicates = Set<String>()
+        for id in orderedProviderIDs() {
+            guard let email = accountEmailLookup(id)?.lowercased(), !email.isEmpty else { continue }
+            if !seen.insert(email).inserted { duplicates.insert(id) }
+        }
+        return duplicates
     }
 
     var availableToAdd: [WidgetDescriptor] {
@@ -346,8 +370,9 @@ final class LayoutStore {
     /// Every enabled provider with *all* the metrics it supports, in its saved metric order. Enabled and
     /// disabled rows stay in-place; the switch only controls visibility.
     var customizeGroups: [ProviderMetrics] {
-        orderedProviders().compactMap { provider in
-            guard isProviderEnabled(provider.id) else { return nil }
+        let duplicates = duplicateProviderIDs
+        return orderedProviders().compactMap { provider in
+            guard isProviderEnabled(provider.id), !duplicates.contains(provider.id) else { return nil }
             let metrics = orderedSupportedMetrics(for: provider.id)
             guard !metrics.isEmpty else { return nil }
             return ProviderMetrics(
@@ -430,21 +455,38 @@ final class LayoutStore {
 
     // MARK: - Customize mutations
 
-    /// Toggle a metric on (add to the placed list) or off (remove it). The single seam the Customize
-    /// switches drive, so on/off goes through the same add/remove path the rest of the app uses.
+    /// Toggle a metric on (add to the placed list) or off (remove it). The change is mirrored to every
+    /// account of the same provider type, so a provider's enabled metrics stay in sync across all its
+    /// accounts (e.g. both Claude logins show the same statistics).
     func setMetricEnabled(_ descriptorID: String, _ enabled: Bool) {
         recordingUndoStep {
-            if enabled {
-                if defaultExpandedOnEnableIDs.remove(descriptorID) != nil {
-                    expandedMetricIDs.insert(descriptorID)
-                    persistExpanded()
-                    persistExpandOnEnable()
+            for id in sameTypeDescriptorIDs(matching: descriptorID) {
+                if enabled {
+                    if defaultExpandedOnEnableIDs.remove(id) != nil {
+                        expandedMetricIDs.insert(id)
+                        persistExpanded()
+                        persistExpandOnEnable()
+                    }
+                    add(id)
+                } else if let widget = placed.first(where: { $0.descriptorID == id }) {
+                    remove(widget.id)
                 }
-                add(descriptorID)
-            } else if let widget = placed.first(where: { $0.descriptorID == descriptorID }) {
-                remove(widget.id)
             }
         }
+    }
+
+    /// Every descriptor id across accounts of the same provider type that shares `descriptorID`'s metric
+    /// — e.g. "claude.session" -> ["claude.session", "claude@work.session", …]. Used so a metric toggle
+    /// applies to all accounts of a provider.
+    private func sameTypeDescriptorIDs(matching descriptorID: String) -> [String] {
+        guard let providerID = registry.descriptor(id: descriptorID)?.providerID else { return [descriptorID] }
+        let baseType = Self.baseProviderType(providerID)
+        let suffix = Self.metricSuffix(descriptorID, providerID: providerID)
+        return registry.providers
+            .map(\.id)
+            .filter { Self.baseProviderType($0) == baseType }
+            .map { "\($0).\(suffix)" }
+            .filter { registry.descriptor(id: $0) != nil }
     }
 
     // MARK: - Undo (#603)
@@ -735,6 +777,17 @@ final class LayoutStore {
         let insert = from < to ? adjusted + 1 : adjusted
         next.insert(dragged, at: min(insert, next.count))
         return next
+    }
+
+    /// The provider *type* of an instance id: "claude@work" -> "claude", "claude" -> "claude".
+    static func baseProviderType(_ providerID: String) -> String {
+        String(providerID.split(separator: "@").first ?? Substring(providerID))
+    }
+
+    /// The metric suffix of a descriptor id within its provider: "claude@work.session" -> "session".
+    static func metricSuffix(_ descriptorID: String, providerID: String) -> String {
+        let prefix = providerID + "."
+        return descriptorID.hasPrefix(prefix) ? String(descriptorID.dropFirst(prefix.count)) : descriptorID
     }
 
     // MARK: - Menu bar pins

--- a/Sources/OpenUsage/Stores/PopoverScreen.swift
+++ b/Sources/OpenUsage/Stores/PopoverScreen.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// The screen showing inside the menu-bar popover. Customize and Settings replace the dashboard
+/// in place (the popover has no window stack); Esc backs out to the dashboard first.
+enum PopoverScreen: Hashable, Sendable {
+    case dashboard
+    case customize
+    case settings
+
+    /// Left-to-right order for the popover's horizontal screen-switch slide: the dashboard is home on
+    /// the left, with Customize and Settings to its right. The slide reads its direction from these
+    /// ranks — a higher-ranked target enters from the trailing edge, a lower one from the leading edge.
+    var slideRank: Int {
+        switch self {
+        case .dashboard: 0
+        case .customize: 1
+        case .settings: 2
+        }
+    }
+}

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -471,6 +471,11 @@ final class WidgetDataStore {
         return StalenessHint(label: "Outdated", tooltip: "Last updated \(duration) ago")
     }
 
+    /// The signed-in account email for a provider's latest snapshot (Claude multi-account); nil otherwise.
+    func accountEmail(for providerID: String) -> String? {
+        snapshots[providerID]?.accountEmail
+    }
+
     var menuBarPrimaryText: String {
         // The tray mirrors the user's widget order: the first placed, enabled tile that has real data
         // drives it, skipping any no-data tile so it never shows a missing metric's placeholder. When

--- a/Sources/OpenUsage/Support/AppControl.swift
+++ b/Sources/OpenUsage/Support/AppControl.swift
@@ -1,0 +1,20 @@
+import AppKit
+
+/// Restarts the menu-bar app. Account changes only take effect at launch — the provider list is
+/// built once at startup — so adding or removing an account relaunches the app to apply it.
+@MainActor
+enum AppControl {
+    /// Launches a fresh instance, then terminates this one.
+    static func restart() {
+        let url = Bundle.main.bundleURL
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: url, configuration: configuration) { _, _ in }
+        // Best-effort handoff: give the new instance a moment to launch before this one exits. Not a
+        // correctness guarantee — `terminate` synchronizes UserDefaults, so persisted account changes
+        // are already on disk regardless of the timing here.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            NSApp.terminate(nil)
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/AccountsSettingsSection.swift
+++ b/Sources/OpenUsage/Views/AccountsSettingsSection.swift
@@ -1,0 +1,255 @@
+import AppKit
+import SwiftUI
+
+/// The Accounts settings section: lists extra provider accounts and an in-place "Add Account" flow
+/// that logs the provider CLI into a per-account config dir. New accounts apply on the next launch
+/// (the provider list is built once at startup), so a relaunch prompt appears after a change.
+struct AccountsSettingsSection: View {
+    @Environment(AppContainer.self) private var container
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    @State private var isAdding = false
+    @State private var newProvider = "claude"
+    @State private var newLabel = ""
+    @State private var loginState: LoginState = .idle
+    @State private var changedAccounts = false
+    /// Resolved account emails (instanceID -> email), filled in asynchronously so each row can show
+    /// which account it is (the reliable profile-API email, not the config-dir path).
+    @State private var emails: [String: String] = [:]
+
+    private enum LoginState: Equatable {
+        case idle
+        case loggingIn
+        case failed(String)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
+            Text("Accounts")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+            VStack(spacing: 0) {
+                ForEach(container.accounts.accounts) { account in
+                    accountRow(account)
+                }
+                if container.accounts.accounts.isEmpty, !isAdding {
+                    Text("Add Claude or Codex accounts beyond your default login.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, density.controlRowPadding)
+                }
+                if isAdding {
+                    addForm
+                } else {
+                    addButton
+                }
+                if changedAccounts {
+                    relaunchNotice
+                }
+            }
+            .cardSurface()
+        }
+        .task(id: container.accounts.accounts) {
+            await resolveEmails()
+        }
+    }
+
+    private func resolveEmails() async {
+        for account in container.accounts.accounts {
+            if emails[account.instanceID] == nil,
+               let email = await AccountIdentity.email(provider: account.provider, configDir: account.configDir) {
+                emails[account.instanceID] = email
+            }
+        }
+    }
+
+    /// Every email already signed in for `provider` — its default login plus each added account of that
+    /// provider, lowercased — so the add flow can reject logging the same account in twice.
+    private func existingEmails(forProvider provider: String) async -> Set<String> {
+        var result = Set<String>()
+        if let defaultEmail = await AccountIdentity.email(provider: provider, configDir: nil) {
+            result.insert(defaultEmail.lowercased())
+        }
+        for account in container.accounts.accounts where account.provider == provider {
+            if let email = await AccountIdentity.email(provider: provider, configDir: account.configDir) {
+                result.insert(email.lowercased())
+            }
+        }
+        return result
+    }
+
+    private func accountRow(_ account: ExtraAccount) -> some View {
+        HStack(spacing: 10) {
+            ProviderIcon(source: .providerMark(account.provider))
+                .frame(width: 18, height: 18)
+            VStack(alignment: .leading, spacing: 1) {
+                TextField(defaultName(for: account), text: nameBinding(for: account))
+                    .textFieldStyle(.plain)
+                    .disabled(emails[account.instanceID] == nil)
+                Text(emails[account.instanceID] ?? account.configDir)
+                    .font(.caption2)
+                    .foregroundStyle(emails[account.instanceID] != nil ? .secondary : .tertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 8)
+            Button(role: .destructive) {
+                container.accounts.remove(instanceID: account.instanceID)
+                changedAccounts = true
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Remove Account")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+
+    private var addButton: some View {
+        Button { isAdding = true } label: {
+            Label("Add Account…", systemImage: "plus").frame(maxWidth: .infinity)
+        }
+        .glassButtonStyle()
+        .controlSize(.regular)
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+
+    private var addForm: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Text("Provider")
+                Spacer(minLength: 8)
+                Picker("", selection: $newProvider) {
+                    Text("Claude").tag("claude")
+                    Text("Codex").tag("codex")
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .fixedSize()
+                .disabled(loginState == .loggingIn)
+            }
+            HStack(spacing: 10) {
+                Text("Label")
+                Spacer(minLength: 8)
+                TextField("Work", text: $newLabel)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 150)
+                    .disabled(loginState == .loggingIn)
+            }
+            if case .failed(let message) = loginState {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(Theme.notice)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if loginState == .loggingIn {
+                Text("Complete the login in your browser…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            HStack {
+                Button("Cancel") { resetForm() }
+                    .glassButtonStyle()
+                    .disabled(loginState == .loggingIn)
+                Spacer()
+                Button(action: logIn) {
+                    if loginState == .loggingIn {
+                        HStack(spacing: 6) {
+                            ProgressView().controlSize(.small)
+                            Text("Logging In…")
+                        }
+                    } else {
+                        Text("Log In")
+                    }
+                }
+                .glassButtonStyle()
+                .disabled(loginState == .loggingIn || newLabel.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+
+    private var relaunchNotice: some View {
+        HStack(spacing: 8) {
+            Text("Relaunch to apply account changes.")
+                .font(.caption)
+                .foregroundStyle(Theme.notice)
+            Spacer()
+            Button("Relaunch") { relaunch() }
+                .glassButtonStyle()
+                .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+
+    private func logIn() {
+        let label = newLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !label.isEmpty else { return }
+        let provider = newProvider
+        let slot = Self.makeSlot()
+        let dir = AccountLogin.defaultConfigDir(provider: provider, slot: slot)
+        loginState = .loggingIn
+        Task {
+            do {
+                try await AccountLogin.run(provider: provider, configDir: dir)
+                // Reject a duplicate: logging the same account in twice causes token conflicts. The CLI
+                // already wrote real credentials into `dir`, so remove that orphaned config on rejection.
+                if let newEmail = await AccountIdentity.email(provider: provider, configDir: dir),
+                   await existingEmails(forProvider: provider).contains(newEmail.lowercased()) {
+                    try? FileManager.default.removeItem(atPath: dir)
+                    loginState = .failed("\(newEmail) is already added — remove the existing one first.")
+                    return
+                }
+                container.accounts.add(ExtraAccount(provider: provider, slot: slot, label: label, configDir: dir))
+                changedAccounts = true
+                resetForm()
+                // The provider list is built at launch, and the popover has usually closed during the
+                // browser login — relaunch so the new account loads without hunting for a prompt.
+                relaunch()
+            } catch {
+                loginState = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    private func resetForm() {
+        isAdding = false
+        newLabel = ""
+        loginState = .idle
+    }
+
+    private func relaunch() {
+        AppControl.restart()
+    }
+
+    /// The card name for an account, bound to the names store by the account's (resolved) email so the
+    /// name follows the account across the dashboard — including whichever copy is the current default.
+    private func nameBinding(for account: ExtraAccount) -> Binding<String> {
+        Binding(
+            get: {
+                guard let email = emails[account.instanceID] else { return "" }
+                return container.accountNames.name(for: email) ?? ""
+            },
+            set: { newValue in
+                guard let email = emails[account.instanceID] else { return }
+                container.accountNames.setName(newValue, for: email)
+            }
+        )
+    }
+
+    private func defaultName(for account: ExtraAccount) -> String {
+        "\(account.provider == "codex" ? "Codex" : "Claude") · \(account.label)"
+    }
+
+    private static func makeSlot() -> String {
+        String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(6)).lowercased()
+    }
+}

--- a/Sources/OpenUsage/Views/ProviderSectionHeader.swift
+++ b/Sources/OpenUsage/Views/ProviderSectionHeader.swift
@@ -11,6 +11,10 @@ import SwiftUI
 struct ProviderSectionHeader<Trailing: View>: View {
     let provider: Provider
     var plan: String?
+    /// A user-chosen account name; replaces the provider's default display name when set.
+    var nameOverride: String?
+    /// The signed-in account email, shown as a subtitle under the name (Claude multi-account).
+    var accountEmail: String?
     var warning: String?
     /// Whether this provider's refresh is currently in flight — drives the small spinner beside the name
     /// so the section shows live feedback while values are being fetched (instead of silently sitting on
@@ -32,9 +36,11 @@ struct ProviderSectionHeader<Trailing: View>: View {
     /// Party easter egg: pulse the provider mark. Off by default everywhere else.
     @Environment(\.popoverPartyMode) private var partyMode
 
-    init(provider: Provider, plan: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, showsDragHandle: Bool = false, @ViewBuilder trailing: () -> Trailing) {
+    init(provider: Provider, plan: String? = nil, nameOverride: String? = nil, accountEmail: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, showsDragHandle: Bool = false, @ViewBuilder trailing: () -> Trailing) {
         self.provider = provider
         self.plan = plan
+        self.nameOverride = nameOverride
+        self.accountEmail = accountEmail
         self.warning = warning
         self.refreshing = refreshing
         self.staleness = staleness
@@ -52,43 +58,52 @@ struct ProviderSectionHeader<Trailing: View>: View {
                 DragHandleGrip()
                     .padding(.trailing, 4)
             }
-            // Baseline-aligned pair: the plan badge (and stale tag) are smaller type and sit on the
-            // name's text baseline, so the words line up along the bottom rather than floating centered.
-            HStack(alignment: .firstTextBaseline, spacing: 5) {
-                // Name + plan keep their width and stay on one line; under width pressure (a long plan
-                // name like "Super Grok Heavy") the lower-priority stale tag truncates first instead of
-                // wrapping the name to a second line.
-                Text(provider.displayName)
-                    .font(.system(size: density.headerPointSize, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                    .layoutPriority(1)
-                if let plan {
-                    ProviderPlanBadge(plan: plan)
-                        .layoutPriority(1)
-                }
-                // Tertiary, below the plan in hierarchy: outdated content, not something the user acts on.
-                // Short by design ("Outdated") so it never pushes the plan name onto a second line — the
-                // precise age rides in the hover tooltip. Hidden while a refresh is in flight: the spinner
-                // already says "working on it".
-                if let staleness, !refreshing {
-                    Text(staleness.label)
-                        .font(.system(size: density.planBadgePointSize))
-                        .foregroundStyle(.tertiary)
+            VStack(alignment: .leading, spacing: 1) {
+                // Baseline-aligned pair: the plan badge (and stale tag) are smaller type and sit on the
+                // name's text baseline, so the words line up along the bottom rather than floating centered.
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    // Name + plan keep their width and stay on one line; under width pressure (a long plan
+                    // name like "Super Grok Heavy") the lower-priority stale tag truncates first instead of
+                    // wrapping the name to a second line.
+                    Text(nameOverride ?? provider.displayName)
+                        .font(.system(size: density.headerPointSize, weight: .semibold))
+                        .foregroundStyle(.primary)
                         .lineLimit(1)
-                        .hoverTooltip(staleness.tooltip)
+                        .layoutPriority(1)
+                    if let plan {
+                        ProviderPlanBadge(plan: plan)
+                            .layoutPriority(1)
+                    }
+                    // Tertiary, below the plan in hierarchy: outdated content, not something the user acts on.
+                    // Short by design ("Outdated") so it never pushes the plan name onto a second line — the
+                    // precise age rides in the hover tooltip. Hidden while a refresh is in flight: the spinner
+                    // already says "working on it".
+                    if let staleness, !refreshing {
+                        Text(staleness.label)
+                            .font(.system(size: density.planBadgePointSize))
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                            .hoverTooltip(staleness.tooltip)
+                    }
+                    if refreshing {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .accessibilityLabel("Refreshing")
+                    } else if let warning {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(Theme.notice)
+                            .hoverTooltip(warning)
+                            .accessibilityLabel(warning)
+                    }
                 }
-            }
-            if refreshing {
-                ProgressView()
-                    .controlSize(.mini)
-                    .accessibilityLabel("Refreshing")
-            } else if let warning {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(Theme.notice)
-                    .hoverTooltip(warning)
-                    .accessibilityLabel(warning)
+                if let accountEmail, !accountEmail.isEmpty {
+                    Text(accountEmail)
+                        .font(.system(size: density.planBadgePointSize))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
             }
             Spacer(minLength: 8)
             // Match the menu-bar strip glyph: a near-zero inset lets the mark fill its box so the
@@ -109,8 +124,8 @@ struct ProviderSectionHeader<Trailing: View>: View {
 }
 
 extension ProviderSectionHeader where Trailing == EmptyView {
-    init(provider: Provider, plan: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, showsDragHandle: Bool = false) {
-        self.init(provider: provider, plan: plan, warning: warning, refreshing: refreshing, staleness: staleness, showsDragHandle: showsDragHandle) { EmptyView() }
+    init(provider: Provider, plan: String? = nil, nameOverride: String? = nil, accountEmail: String? = nil, warning: String? = nil, refreshing: Bool = false, staleness: StalenessHint? = nil, showsDragHandle: Bool = false) {
+        self.init(provider: provider, plan: plan, nameOverride: nameOverride, accountEmail: accountEmail, warning: warning, refreshing: refreshing, staleness: staleness, showsDragHandle: showsDragHandle) { EmptyView() }
     }
 }
 

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -175,6 +175,7 @@ struct SettingsScreen: View {
                     .padding(.bottom, 8)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+            AccountsSettingsSection()
             advancedSection
             // Visible whenever the updater is active (only the signed release build ships a feed; the
             // dev build and a bare `swift run`, with no feed, hide this).

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -26,13 +26,19 @@ struct WidgetGroupedListView: View {
         // Provider-section spacing is noticeably wider than the in-card row rhythm (so groups
         // still read as groups); the exact step comes from the density setting.
         VStack(alignment: .leading, spacing: density.sectionSpacing) {
-            ForEach(layout.displayGroups) { group in
+            ForEach(visibleGroups) { group in
                 section(group)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onPreferenceChange(ReorderFramePreferenceKey.self) { rowFrames = $0 }
-        .animation(Motion.spring, value: layout.displayGroups.map(\.provider.id))
+        .animation(Motion.spring, value: visibleGroups.map(\.provider.id))
+    }
+
+    /// Dashboard groups in layout order. Duplicate-account hiding now lives in `LayoutStore` (so the
+    /// dashboard, Customize, and menu bar all agree), so `displayGroups` already excludes duplicates.
+    private var visibleGroups: [ProviderGroup] {
+        layout.displayGroups
     }
 
     private func section(_ group: ProviderGroup) -> some View {
@@ -48,6 +54,8 @@ struct WidgetGroupedListView: View {
         ProviderSectionHeader(
             provider: group.provider,
             plan: dataStore.plan(for: group.provider.id),
+            nameOverride: container.accountNames.name(for: dataStore.accountEmail(for: group.provider.id)),
+            accountEmail: dataStore.accountEmail(for: group.provider.id),
             warning: dataStore.headerNotice(for: group.provider.id),
             refreshing: dataStore.refreshingProviderIDs.contains(group.provider.id),
             staleness: dataStore.stalenessHint(for: group.provider.id),

--- a/Tests/OpenUsageTests/AccountProvidersTests.swift
+++ b/Tests/OpenUsageTests/AccountProvidersTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class AccountProvidersTests: XCTestCase {
+    func testExpandsClaudeAndCodexInstancesWithUniqueIDs() {
+        let accounts = [
+            ExtraAccount(provider: "claude", slot: "work", label: "Work", configDir: "/tmp/claude-work"),
+            ExtraAccount(provider: "codex", slot: "alt", label: "Alt", configDir: "/tmp/codex-alt")
+        ]
+        let extras = AccountProviders.extraProviders(for: accounts)
+        let registry = WidgetRegistry.from([ClaudeProvider(), CodexProvider()] + extras)
+
+        // Extra instances register under unique ids and labeled display names.
+        XCTAssertNotNil(registry.provider(id: "claude@work"))
+        XCTAssertEqual(registry.provider(id: "claude@work")?.displayName, "Claude · Work")
+        XCTAssertNotNil(registry.provider(id: "codex@alt"))
+        XCTAssertEqual(registry.provider(id: "codex@alt")?.displayName, "Codex · Alt")
+
+        // The default accounts keep their original ids (no settings migration).
+        XCTAssertNotNil(registry.provider(id: "claude"))
+        XCTAssertNotNil(registry.descriptor(id: "claude.session"))
+
+        // Extra accounts get prefixed descriptor ids and the same metric set as that
+        // provider's default account — assert against the default's count rather than a
+        // fixed number, so this stays correct as providers gain or lose widgets upstream.
+        XCTAssertNotNil(registry.descriptor(id: "claude@work.session"))
+        XCTAssertEqual(registry.descriptors(for: "claude@work").count,
+                       registry.descriptors(for: "claude").count)
+        XCTAssertEqual(registry.descriptors(for: "codex@alt").count,
+                       registry.descriptors(for: "codex").count)
+    }
+
+    func testSkipsProvidersThatCannotMultiAccount() {
+        let accounts = [ExtraAccount(provider: "cursor", slot: "x", label: "X", configDir: "/tmp/x")]
+        XCTAssertTrue(AccountProviders.extraProviders(for: accounts).isEmpty)
+    }
+}

--- a/Tests/OpenUsageTests/ClaudeProfileTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProfileTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import OpenUsage
+
+final class ClaudeProfileTests: XCTestCase {
+    func testReadsEmailFromProfileAccount() {
+        let json = Data(#"{"account":{"uuid":"x","email":"jordan@westlinemarketing.com"},"organization":{}}"#.utf8)
+        XCTAssertEqual(ClaudeProfile.email(fromProfileResponse: json), "jordan@westlinemarketing.com")
+    }
+
+    func testReturnsNilWhenMissingOrInvalid() {
+        XCTAssertNil(ClaudeProfile.email(fromProfileResponse: Data(#"{"organization":{}}"#.utf8)))
+        XCTAssertNil(ClaudeProfile.email(fromProfileResponse: Data(#"{"account":{"email":"nope"}}"#.utf8)))
+        XCTAssertNil(ClaudeProfile.email(fromProfileResponse: Data("not json".utf8)))
+    }
+}

--- a/Tests/OpenUsageTests/CodexAccountIdentityTests.swift
+++ b/Tests/OpenUsageTests/CodexAccountIdentityTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import OpenUsage
+
+final class CodexAccountIdentityTests: XCTestCase {
+    /// Builds a JWT-shaped `header.payload.signature` string with the given payload JSON, base64url
+    /// encoded with padding stripped — exactly how real OIDC id_tokens are shaped.
+    private func makeIDToken(payload: String) -> String {
+        func base64url(_ string: String) -> String {
+            Data(string.utf8).base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        }
+        return "\(base64url("{\"alg\":\"RS256\"}")).\(base64url(payload)).signature"
+    }
+
+    func testExtractsEmailFromIDTokenPayload() {
+        let token = makeIDToken(payload: "{\"email\":\"dev@example.com\",\"email_verified\":true}")
+        XCTAssertEqual(CodexAccountIdentity.email(fromIDToken: token), "dev@example.com")
+    }
+
+    func testReturnsNilWhenNoEmailClaim() {
+        let token = makeIDToken(payload: "{\"sub\":\"abc123\"}")
+        XCTAssertNil(CodexAccountIdentity.email(fromIDToken: token))
+    }
+
+    func testReturnsNilForMalformedOrMissingToken() {
+        XCTAssertNil(CodexAccountIdentity.email(fromIDToken: "not-a-jwt"))
+        XCTAssertNil(CodexAccountIdentity.email(fromIDToken: ""))
+        XCTAssertNil(CodexAccountIdentity.email(fromIDToken: nil))
+    }
+}

--- a/Tests/OpenUsageTests/MultiAccountLayoutTests.swift
+++ b/Tests/OpenUsageTests/MultiAccountLayoutTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import OpenUsage
+
+/// Layout behavior specific to extra accounts: one-time seeding (no resurrection of disabled metrics)
+/// and duplicate-account hiding driven by the injected `accountEmailLookup`.
+@MainActor
+final class MultiAccountLayoutTests: XCTestCase {
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suite = "MultiAccountLayoutTests.\(name)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    /// A base provider ("claude") plus one extra account ("claude@work"), each with the same two metrics.
+    private func makeRegistry() -> WidgetRegistry {
+        let claude = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let work = Provider(id: "claude@work", displayName: "Claude · Work", icon: .providerMark("claude"))
+        func metric(_ id: String, _ provider: Provider) -> WidgetDescriptor {
+            WidgetDescriptor(
+                id: id, providerID: provider.id, metricLabel: "Metric",
+                sample: WidgetData(title: "Metric", icon: provider.icon, kind: .percent, used: 0, limit: 100)
+            )
+        }
+        return WidgetRegistry(
+            providers: [claude, work],
+            descriptors: [
+                metric("claude.session", claude), metric("claude.weekly", claude),
+                metric("claude@work.session", work), metric("claude@work.weekly", work)
+            ]
+        )
+    }
+
+    /// Pre-save a layout with the base account's two metrics placed, so seeding has something to mirror.
+    private func seedBaseLayout(_ defaults: UserDefaults) {
+        let placed = [PlacedWidget(descriptorID: "claude.session"), PlacedWidget(descriptorID: "claude.weekly")]
+        defaults.set(try! JSONEncoder().encode(placed), forKey: "layout")
+    }
+
+    func testNewAccountSeedsMirroringBase() {
+        let defaults = makeDefaults("Seed")
+        seedBaseLayout(defaults)
+        let store = LayoutStore(registry: makeRegistry(), defaults: defaults, storageKey: "layout")
+        XCTAssertTrue(store.placed.contains { $0.descriptorID == "claude@work.session" })
+        XCTAssertTrue(store.placed.contains { $0.descriptorID == "claude@work.weekly" })
+    }
+
+    /// Regression: disabling every metric of an extra account must stay disabled across a relaunch — the
+    /// old auto-place re-ran for any unplaced account and resurrected them.
+    func testDisablingAllAccountMetricsIsNotResurrectedOnReload() {
+        let defaults = makeDefaults("NoResurrect")
+        seedBaseLayout(defaults)
+        let store = LayoutStore(registry: makeRegistry(), defaults: defaults, storageKey: "layout")
+        for widget in store.placed where widget.descriptorID.hasPrefix("claude@work.") {
+            store.remove(widget.id)
+        }
+        XCTAssertFalse(store.placed.contains { $0.descriptorID.hasPrefix("claude@work.") })
+
+        let reloaded = LayoutStore(registry: makeRegistry(), defaults: defaults, storageKey: "layout")
+        XCTAssertFalse(reloaded.placed.contains { $0.descriptorID.hasPrefix("claude@work.") })
+    }
+
+    func testDuplicateEmailAccountHiddenFromDashboardAndCustomize() {
+        let defaults = makeDefaults("Dedup")
+        seedBaseLayout(defaults)
+        let store = LayoutStore(registry: makeRegistry(), defaults: defaults, storageKey: "layout")
+        store.accountEmailLookup = { ($0 == "claude" || $0 == "claude@work") ? "same@example.com" : nil }
+
+        XCTAssertFalse(store.visiblePlaced.contains { $0.descriptorID.hasPrefix("claude@work.") })
+        XCTAssertFalse(store.customizeGroups.contains { $0.provider.id == "claude@work" })
+        // The first occurrence (the default login) stays visible.
+        XCTAssertTrue(store.visiblePlaced.contains { $0.descriptorID == "claude.session" })
+    }
+
+    func testDistinctEmailAccountsBothVisible() {
+        let defaults = makeDefaults("Distinct")
+        seedBaseLayout(defaults)
+        let store = LayoutStore(registry: makeRegistry(), defaults: defaults, storageKey: "layout")
+        store.accountEmailLookup = { $0 == "claude" ? "a@example.com" : ($0 == "claude@work" ? "b@example.com" : nil) }
+
+        XCTAssertTrue(store.visiblePlaced.contains { $0.descriptorID.hasPrefix("claude@work.") })
+        XCTAssertTrue(store.customizeGroups.contains { $0.provider.id == "claude@work" })
+    }
+}

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -27,6 +27,10 @@ A provider card can also show **quick-link buttons** pinned at the bottom of its
 
 Rows with a reset date tick every 30 seconds, so countdowns and pace stay live between refreshes.
 
+## Accounts
+
+If you've added extra Claude or Codex logins in [Settings → Accounts](settings.md#accounts), each account is its own section, labeled with its name (or signed-in email) so the logins are easy to tell apart. Two logins that resolve to the same email collapse to a single section, so a duplicate never shows twice.
+
 ## Right-click menus
 
 Every row: **Hide · Star for menu bar / Unstar · Refresh \<provider\> · Customize…**

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -47,6 +47,16 @@ All three alerts default off. The first time you turn one on, OpenUsage asks for
 |---|---|---|
 | Share Anonymous Usage | On / Off | On (default) shares anonymous, daily usage summaries — no account details, credentials, or usage values. Off stops all sharing immediately. See [Privacy & Usage Data](privacy.md) for exactly what is and isn't sent. |
 
+## Accounts
+
+Add more than one **Claude** or **Codex** login so several subscriptions show side by side. Each account is listed with its signed-in email and appears as its own card on the [dashboard](dashboard.md).
+
+- **Add Account…** — pick the provider, give it a label (e.g. "Work"), and **Log In**. The provider's CLI opens its normal browser login, and the account is stored in its own config directory so it never disturbs your default login.
+- **Rename** — edit the name on an account row; names are keyed by email, so they follow the account across the dashboard.
+- **Remove** — the trash icon drops the account.
+
+Account changes apply on the next launch (the provider list is built at startup), so a **Relaunch** button appears after a change. A new account starts with the same metrics enabled as that provider's default login; after that, toggling a metric in Customize applies to every account of that provider, so they stay in sync. Logging in to an account that's already added is rejected, and if the same email ends up signed in twice the duplicate card is hidden.
+
 ## Advanced
 
 | Setting | Options | What it does |


### PR DESCRIPTION
## TL;DR

Track multiple Claude plans and multiple Codex plans side by side — each extra account gets its own dashboard card with its own meters, named however the user likes.

## What was happening

- OpenUsage reads the single CLI login per provider, so a user with two Claude plans (e.g. a personal Max and a work Pro) or two Codex plans could only ever see one of them.
- Switching plans in the CLI flips which one the dashboard shows; there was no way to watch both quotas at once, which is exactly when you want a usage widget most.

## What this changes

- **Accounts store + Settings section**: a new Accounts section in Settings lets the user add extra Claude/Codex accounts. Each extra account captures its own credentials into a dedicated config dir (`claude`/`codex` login flow via `AccountLogin`), so the default CLI login is never touched. Changes apply on next launch.
- **Provider instances per account**: `AccountProviders.extraProviders` expands each extra account into its own `ClaudeProvider`/`CodexProvider` instance with a namespaced id (`claude@<slot>`), pointed at that account's config dir. Metric ids derive from the instance id, so widgets/pins/layout all work per account unchanged.
- **Account identity**: providers resolve the logged-in account's email (`ClaudeAccountIdentity`/`CodexAccountIdentity`) and stamp it on snapshots; the dashboard header shows it, user-set display names (`AccountNamesStore`) override it, and `LayoutStore` dedupes accidental duplicate logins of the same account by email.
- **Layout sync across accounts**: toggling a metric on/off applies to every account of that provider type (`sameTypeDescriptorIDs`), so all Claude cards always show the same set of meters.
- Docs updated (`docs/dashboard.md`, `docs/settings.md`).

## Heads-up

- Extra accounts spawn one extra provider instance each, so refresh fan-out grows linearly with accounts; refresh cadence is unchanged.
- The Accounts section only offers Claude and Codex today; the expansion point is provider-agnostic if other providers grow multi-plan demand.
- Screenshots use redacted/demo account names; happy to re-capture anything else that helps review.

## Tests

- `swift test`: full suite passes on top of current `main` (756 tests, 1 skipped, 0 failures), including new coverage: `MultiAccountLayoutTests`, `AccountProvidersTests`, `ClaudeProfileTests`, `CodexAccountIdentityTests`.
- Dogfooded daily as a local build with two Claude plans and two Codex plans.

## Screenshots

Will attach dashboard + Settings ▸ Accounts screenshots (with demo account names) in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UY7n8qJqszHievvUfxsc7

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the snapshot-loss path in ClaudeProvider; the rest of the change is well-structured and test-covered.

The `try authStore.oauthConfig()` call in `ClaudeProvider.probe()` sits after a successful `fetchLiveUsage`, so if it throws the already-fetched usage data is dropped and the refresh surfaces an error instead — contrary to the best-effort email-labelling intent documented on the same code path. The fix is a one-line `try?` guard. The broader multi-account machinery (seeding, deduplication, cross-account sync) is clean and backed by targeted tests.

`Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift` (snapshot-loss on email resolution) and `Sources/OpenUsage/Views/AccountsSettingsSection.swift` (unstructured login task that can relaunch after popover is closed).

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/OpenUsage/Views/AccountsSettingsSection.swift`, line 1208-1228 ([link](https://github.com/robinebers/openusage/blob/7bd030fa96e013f915c685322b94f34a5c943939/Sources/OpenUsage/Views/AccountsSettingsSection.swift#L1208-L1228)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Uncancellable login task can relaunch without user interaction**

   The `Task` created in `logIn()` is unstructured and not stored anywhere. The Cancel button is disabled for the full 5-minute OAuth window (`loginState == .loggingIn`), so the only escape for the user is to close the popover. If the user dismisses the popover and the browser OAuth completes anyway, the old task still holds a live reference to `container` and will call `container.accounts.add(...)` followed by `AppControl.restart()` — triggering an app relaunch even though the user had already navigated away. Storing the task in a `@State var loginTask: Task<Void, Never>?` and calling `loginTask?.cancel()` in `resetForm()` would let the user actually abort a started login.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/OpenUsage/Views/AccountsSettingsSection.swift
   Line: 1208-1228

   Comment:
   **Uncancellable login task can relaunch without user interaction**

   The `Task` created in `logIn()` is unstructured and not stored anywhere. The Cancel button is disabled for the full 5-minute OAuth window (`loginState == .loggingIn`), so the only escape for the user is to close the popover. If the user dismisses the popover and the browser OAuth completes anyway, the old task still holds a live reference to `container` and will call `container.accounts.add(...)` followed by `AppControl.restart()` — triggering an app relaunch even though the user had already navigated away. Storing the task in a `@State var loginTask: Task<Void, Never>?` and calling `loginTask?.cancel()` in `resetForm()` would let the user actually abort a started login.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FOpenUsage%2FViews%2FAccountsSettingsSection.swift%0ALine%3A%201208-1228%0A%0AComment%3A%0A**Uncancellable%20login%20task%20can%20relaunch%20without%20user%20interaction**%0A%0AThe%20%60Task%60%20created%20in%20%60logIn%28%29%60%20is%20unstructured%20and%20not%20stored%20anywhere.%20The%20Cancel%20button%20is%20disabled%20for%20the%20full%205-minute%20OAuth%20window%20%28%60loginState%20%3D%3D%20.loggingIn%60%29%2C%20so%20the%20only%20escape%20for%20the%20user%20is%20to%20close%20the%20popover.%20If%20the%20user%20dismisses%20the%20popover%20and%20the%20browser%20OAuth%20completes%20anyway%2C%20the%20old%20task%20still%20holds%20a%20live%20reference%20to%20%60container%60%20and%20will%20call%20%60container.accounts.add%28...%29%60%20followed%20by%20%60AppControl.restart%28%29%60%20%E2%80%94%20triggering%20an%20app%20relaunch%20even%20though%20the%20user%20had%20already%20navigated%20away.%20Storing%20the%20task%20in%20a%20%60%40State%20var%20loginTask%3A%20Task%3CVoid%2C%20Never%3E%3F%60%20and%20calling%20%60loginTask%3F.cancel%28%29%60%20in%20%60resetForm%28%29%60%20would%20let%20the%20user%20actually%20abort%20a%20started%20login.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FOpenUsage%2FViews%2FAccountsSettingsSection.swift%0ALine%3A%201208-1228%0A%0AComment%3A%0A**Uncancellable%20login%20task%20can%20relaunch%20without%20user%20interaction**%0A%0AThe%20%60Task%60%20created%20in%20%60logIn%28%29%60%20is%20unstructured%20and%20not%20stored%20anywhere.%20The%20Cancel%20button%20is%20disabled%20for%20the%20full%205-minute%20OAuth%20window%20%28%60loginState%20%3D%3D%20.loggingIn%60%29%2C%20so%20the%20only%20escape%20for%20the%20user%20is%20to%20close%20the%20popover.%20If%20the%20user%20dismisses%20the%20popover%20and%20the%20browser%20OAuth%20completes%20anyway%2C%20the%20old%20task%20still%20holds%20a%20live%20reference%20to%20%60container%60%20and%20will%20call%20%60container.accounts.add%28...%29%60%20followed%20by%20%60AppControl.restart%28%29%60%20%E2%80%94%20triggering%20an%20app%20relaunch%20even%20though%20the%20user%20had%20already%20navigated%20away.%20Storing%20the%20task%20in%20a%20%60%40State%20var%20loginTask%3A%20Task%3CVoid%2C%20Never%3E%3F%60%20and%20calling%20%60loginTask%3F.cancel%28%29%60%20in%20%60resetForm%28%29%60%20would%20let%20the%20user%20actually%20abort%20a%20started%20login.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robinebers%2Fopenusage&pr=826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robinebers%2Fopenusage%22%20on%20the%20existing%20branch%20%22feat%2Fmulti-account%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmulti-account%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FOpenUsage%2FViews%2FAccountsSettingsSection.swift%0ALine%3A%201208-1228%0A%0AComment%3A%0A**Uncancellable%20login%20task%20can%20relaunch%20without%20user%20interaction**%0A%0AThe%20%60Task%60%20created%20in%20%60logIn%28%29%60%20is%20unstructured%20and%20not%20stored%20anywhere.%20The%20Cancel%20button%20is%20disabled%20for%20the%20full%205-minute%20OAuth%20window%20%28%60loginState%20%3D%3D%20.loggingIn%60%29%2C%20so%20the%20only%20escape%20for%20the%20user%20is%20to%20close%20the%20popover.%20If%20the%20user%20dismisses%20the%20popover%20and%20the%20browser%20OAuth%20completes%20anyway%2C%20the%20old%20task%20still%20holds%20a%20live%20reference%20to%20%60container%60%20and%20will%20call%20%60container.accounts.add%28...%29%60%20followed%20by%20%60AppControl.restart%28%29%60%20%E2%80%94%20triggering%20an%20app%20relaunch%20even%20though%20the%20user%20had%20already%20navigated%20away.%20Storing%20the%20task%20in%20a%20%60%40State%20var%20loginTask%3A%20Task%3CVoid%2C%20Never%3E%3F%60%20and%20calling%20%60loginTask%3F.cancel%28%29%60%20in%20%60resetForm%28%29%60%20would%20let%20the%20user%20actually%20abort%20a%20started%20login.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=robinebers%2Fopenusage&pr=826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ASources%2FOpenUsage%2FProviders%2FClaude%2FClaudeProvider.swift%3A112-116%0AThe%20email%20resolution%20call%20uses%20bare%20%60try%60%2C%20so%20if%20%60authStore.oauthConfig%28%29%60%20throws%2C%20it%20propagates%20out%20of%20%60probe%28%29%60%20and%20the%20already-successfully-fetched%20%60mapped%60%20usage%20data%20is%20silently%20discarded%20%E2%80%94%20the%20dashboard%20shows%20a%20refresh%20error%20instead%20of%20the%20values%20we%20just%20fetched.%20The%20companion%20%60ClaudeAccountIdentity.email%28configDir%3A%29%60%20uses%20%60try%3F%60%20precisely%20because%20email%20resolution%20is%20documented%20as%20best-effort%2C%20but%20that%20intent%20isn't%20reflected%20here.%20The%20fix%20is%20to%20protect%20the%20%60oauthConfig%28%29%60%20call%20with%20%60try%3F%60%20so%20a%20failure%20resolves%20to%20no%20email%20rather%20than%20to%20a%20thrown%20error.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20resolvedAccountEmail%20%3D%3D%20nil%2C%20let%20token%20%3D%20state.oauth.accessToken%2C%20!token.isEmpty%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20config%20%3D%20try%3F%20authStore.oauthConfig%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20resolvedAccountEmail%20%3D%20await%20ClaudeAccountIdentity.email%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20accessToken%3A%20token%2C%20usageClient%3A%20usageClient%2C%20config%3A%20config%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ASources%2FOpenUsage%2FViews%2FAccountsSettingsSection.swift%3A1208-1228%0A**Uncancellable%20login%20task%20can%20relaunch%20without%20user%20interaction**%0A%0AThe%20%60Task%60%20created%20in%20%60logIn%28%29%60%20is%20unstructured%20and%20not%20stored%20anywhere.%20The%20Cancel%20button%20is%20disabled%20for%20the%20full%205-minute%20OAuth%20window%20%28%60loginState%20%3D%3D%20.loggingIn%60%29%2C%20so%20the%20only%20escape%20for%20the%20user%20is%20to%20close%20the%20popover.%20If%20the%20user%20dismisses%20the%20popover%20and%20the%20browser%20OAuth%20completes%20anyway%2C%20the%20old%20task%20still%20holds%20a%20live%20reference%20to%20%60container%60%20and%20will%20call%20%60container.accounts.add%28...%29%60%20followed%20by%20%60AppControl.restart%28%29%60%20%E2%80%94%20triggering%20an%20app%20relaunch%20even%20though%20the%20user%20had%20already%20navigated%20away.%20Storing%20the%20task%20in%20a%20%60%40State%20var%20loginTask%3A%20Task%3CVoid%2C%20Never%3E%3F%60%20and%20calling%20%60loginTask%3F.cancel%28%29%60%20in%20%60resetForm%28%29%60%20would%20let%20the%20user%20actually%20abort%20a%20started%20login.%0A%0A%23%23%23%20Issue%203%20of%203%0ASources%2FOpenUsage%2FViews%2FWidgetGroupedListView.swift%3A38-42%0A**%60visibleGroups%60%20is%20a%20dead%20pass-through**%0A%0AThe%20%60visibleGroups%60%20computed%20property%20returns%20%60layout.displayGroups%60%20unchanged%2C%20and%20the%20drag-gesture%20helper%20on%20line%20290%20still%20references%20%60layout.displayGroups%60%20directly.%20The%20indirection%20adds%20a%20layer%20of%20naming%20without%20filtering%20or%20transforming%20anything.%20Consider%20removing%20it%20and%20using%20%60layout.displayGroups%60%20directly%20at%20both%20call%20sites%2C%20or%20keeping%20it%20but%20also%20updating%20%60providerDragGesture%60%20to%20use%20it%20for%20consistency.%0A%0A&pr=826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ASources%2FOpenUsage%2FProviders%2FClaude%2FClaudeProvider.swift%3A112-116%0AThe%20email%20resolution%20call%20uses%20bare%20%60try%60%2C%20so%20if%20%60authStore.oauthConfig%28%29%60%20throws%2C%20it%20propagates%20out%20of%20%60probe%28%29%60%20and%20the%20already-successfully-fetched%20%60mapped%60%20usage%20data%20is%20silently%20discarded%20%E2%80%94%20the%20dashboard%20shows%20a%20refresh%20error%20instead%20of%20the%20values%20we%20just%20fetched.%20The%20companion%20%60ClaudeAccountIdentity.email%28configDir%3A%29%60%20uses%20%60try%3F%60%20precisely%20because%20email%20resolution%20is%20documented%20as%20best-effort%2C%20but%20that%20intent%20isn't%20reflected%20here.%20The%20fix%20is%20to%20protect%20the%20%60oauthConfig%28%29%60%20call%20with%20%60try%3F%60%20so%20a%20failure%20resolves%20to%20no%20email%20rather%20than%20to%20a%20thrown%20error.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20resolvedAccountEmail%20%3D%3D%20nil%2C%20let%20token%20%3D%20state.oauth.accessToken%2C%20!token.isEmpty%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20config%20%3D%20try%3F%20authStore.oauthConfig%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20resolvedAccountEmail%20%3D%20await%20ClaudeAccountIdentity.email%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20accessToken%3A%20token%2C%20usageClient%3A%20usageClient%2C%20config%3A%20config%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ASources%2FOpenUsage%2FViews%2FAccountsSettingsSection.swift%3A1208-1228%0A**Uncancellable%20login%20task%20can%20relaunch%20without%20user%20interaction**%0A%0AThe%20%60Task%60%20created%20in%20%60logIn%28%29%60%20is%20unstructured%20and%20not%20stored%20anywhere.%20The%20Cancel%20button%20is%20disabled%20for%20the%20full%205-minute%20OAuth%20window%20%28%60loginState%20%3D%3D%20.loggingIn%60%29%2C%20so%20the%20only%20escape%20for%20the%20user%20is%20to%20close%20the%20popover.%20If%20the%20user%20dismisses%20the%20popover%20and%20the%20browser%20OAuth%20completes%20anyway%2C%20the%20old%20task%20still%20holds%20a%20live%20reference%20to%20%60container%60%20and%20will%20call%20%60container.accounts.add%28...%29%60%20followed%20by%20%60AppControl.restart%28%29%60%20%E2%80%94%20triggering%20an%20app%20relaunch%20even%20though%20the%20user%20had%20already%20navigated%20away.%20Storing%20the%20task%20in%20a%20%60%40State%20var%20loginTask%3A%20Task%3CVoid%2C%20Never%3E%3F%60%20and%20calling%20%60loginTask%3F.cancel%28%29%60%20in%20%60resetForm%28%29%60%20would%20let%20the%20user%20actually%20abort%20a%20started%20login.%0A%0A%23%23%23%20Issue%203%20of%203%0ASources%2FOpenUsage%2FViews%2FWidgetGroupedListView.swift%3A38-42%0A**%60visibleGroups%60%20is%20a%20dead%20pass-through**%0A%0AThe%20%60visibleGroups%60%20computed%20property%20returns%20%60layout.displayGroups%60%20unchanged%2C%20and%20the%20drag-gesture%20helper%20on%20line%20290%20still%20references%20%60layout.displayGroups%60%20directly.%20The%20indirection%20adds%20a%20layer%20of%20naming%20without%20filtering%20or%20transforming%20anything.%20Consider%20removing%20it%20and%20using%20%60layout.displayGroups%60%20directly%20at%20both%20call%20sites%2C%20or%20keeping%20it%20but%20also%20updating%20%60providerDragGesture%60%20to%20use%20it%20for%20consistency.%0A%0A&repo=robinebers%2Fopenusage&pr=826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22robinebers%2Fopenusage%22%20on%20the%20existing%20branch%20%22feat%2Fmulti-account%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmulti-account%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0ASources%2FOpenUsage%2FProviders%2FClaude%2FClaudeProvider.swift%3A112-116%0AThe%20email%20resolution%20call%20uses%20bare%20%60try%60%2C%20so%20if%20%60authStore.oauthConfig%28%29%60%20throws%2C%20it%20propagates%20out%20of%20%60probe%28%29%60%20and%20the%20already-successfully-fetched%20%60mapped%60%20usage%20data%20is%20silently%20discarded%20%E2%80%94%20the%20dashboard%20shows%20a%20refresh%20error%20instead%20of%20the%20values%20we%20just%20fetched.%20The%20companion%20%60ClaudeAccountIdentity.email%28configDir%3A%29%60%20uses%20%60try%3F%60%20precisely%20because%20email%20resolution%20is%20documented%20as%20best-effort%2C%20but%20that%20intent%20isn't%20reflected%20here.%20The%20fix%20is%20to%20protect%20the%20%60oauthConfig%28%29%60%20call%20with%20%60try%3F%60%20so%20a%20failure%20resolves%20to%20no%20email%20rather%20than%20to%20a%20thrown%20error.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20resolvedAccountEmail%20%3D%3D%20nil%2C%20let%20token%20%3D%20state.oauth.accessToken%2C%20!token.isEmpty%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20let%20config%20%3D%20try%3F%20authStore.oauthConfig%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20resolvedAccountEmail%20%3D%20await%20ClaudeAccountIdentity.email%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20accessToken%3A%20token%2C%20usageClient%3A%20usageClient%2C%20config%3A%20config%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0ASources%2FOpenUsage%2FViews%2FAccountsSettingsSection.swift%3A1208-1228%0A**Uncancellable%20login%20task%20can%20relaunch%20without%20user%20interaction**%0A%0AThe%20%60Task%60%20created%20in%20%60logIn%28%29%60%20is%20unstructured%20and%20not%20stored%20anywhere.%20The%20Cancel%20button%20is%20disabled%20for%20the%20full%205-minute%20OAuth%20window%20%28%60loginState%20%3D%3D%20.loggingIn%60%29%2C%20so%20the%20only%20escape%20for%20the%20user%20is%20to%20close%20the%20popover.%20If%20the%20user%20dismisses%20the%20popover%20and%20the%20browser%20OAuth%20completes%20anyway%2C%20the%20old%20task%20still%20holds%20a%20live%20reference%20to%20%60container%60%20and%20will%20call%20%60container.accounts.add%28...%29%60%20followed%20by%20%60AppControl.restart%28%29%60%20%E2%80%94%20triggering%20an%20app%20relaunch%20even%20though%20the%20user%20had%20already%20navigated%20away.%20Storing%20the%20task%20in%20a%20%60%40State%20var%20loginTask%3A%20Task%3CVoid%2C%20Never%3E%3F%60%20and%20calling%20%60loginTask%3F.cancel%28%29%60%20in%20%60resetForm%28%29%60%20would%20let%20the%20user%20actually%20abort%20a%20started%20login.%0A%0A%23%23%23%20Issue%203%20of%203%0ASources%2FOpenUsage%2FViews%2FWidgetGroupedListView.swift%3A38-42%0A**%60visibleGroups%60%20is%20a%20dead%20pass-through**%0A%0AThe%20%60visibleGroups%60%20computed%20property%20returns%20%60layout.displayGroups%60%20unchanged%2C%20and%20the%20drag-gesture%20helper%20on%20line%20290%20still%20references%20%60layout.displayGroups%60%20directly.%20The%20indirection%20adds%20a%20layer%20of%20naming%20without%20filtering%20or%20transforming%20anything.%20Consider%20removing%20it%20and%20using%20%60layout.displayGroups%60%20directly%20at%20both%20call%20sites%2C%20or%20keeping%20it%20but%20also%20updating%20%60providerDragGesture%60%20to%20use%20it%20for%20consistency.%0A%0A&repo=robinebers%2Fopenusage&pr=826&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift:112-116
The email resolution call uses bare `try`, so if `authStore.oauthConfig()` throws, it propagates out of `probe()` and the already-successfully-fetched `mapped` usage data is silently discarded — the dashboard shows a refresh error instead of the values we just fetched. The companion `ClaudeAccountIdentity.email(configDir:)` uses `try?` precisely because email resolution is documented as best-effort, but that intent isn't reflected here. The fix is to protect the `oauthConfig()` call with `try?` so a failure resolves to no email rather than to a thrown error.

```suggestion
            if resolvedAccountEmail == nil, let token = state.oauth.accessToken, !token.isEmpty,
               let config = try? authStore.oauthConfig() {
                resolvedAccountEmail = await ClaudeAccountIdentity.email(
                    accessToken: token, usageClient: usageClient, config: config
                )
            }
```

### Issue 2 of 3
Sources/OpenUsage/Views/AccountsSettingsSection.swift:1208-1228
**Uncancellable login task can relaunch without user interaction**

The `Task` created in `logIn()` is unstructured and not stored anywhere. The Cancel button is disabled for the full 5-minute OAuth window (`loginState == .loggingIn`), so the only escape for the user is to close the popover. If the user dismisses the popover and the browser OAuth completes anyway, the old task still holds a live reference to `container` and will call `container.accounts.add(...)` followed by `AppControl.restart()` — triggering an app relaunch even though the user had already navigated away. Storing the task in a `@State var loginTask: Task<Void, Never>?` and calling `loginTask?.cancel()` in `resetForm()` would let the user actually abort a started login.

### Issue 3 of 3
Sources/OpenUsage/Views/WidgetGroupedListView.swift:38-42
**`visibleGroups` is a dead pass-through**

The `visibleGroups` computed property returns `layout.displayGroups` unchanged, and the drag-gesture helper on line 290 still references `layout.displayGroups` directly. The indirection adds a layer of naming without filtering or transforming anything. Consider removing it and using `layout.displayGroups` directly at both call sites, or keeping it but also updating `providerDragGesture` to use it for consistency.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(accounts): multi-account support fo..."](https://github.com/robinebers/openusage/commit/7bd030fa96e013f915c685322b94f34a5c943939) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41378290)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->