### PR TITLE
fix(claude): explain CLI login when only the desktop app is signed in

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -57,6 +57,7 @@ struct ClaudeCredentialState: Hashable, Sendable {
 
 enum ClaudeAuthError: Error, LocalizedError, Equatable {
     case notLoggedIn
+    case desktopAppOnly
     case sessionExpired
     case tokenExpired
     case invalidOAuthURL(String)
@@ -65,6 +66,8 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
         switch self {
         case .notLoggedIn:
             return "Not logged in. Run `claude` to authenticate."
+        case .desktopAppOnly:
+            return "Signed in to the Claude desktop app? OpenUsage needs a CLI login — run `claude` in a terminal and sign in once."
         case .sessionExpired:
             return "Session expired. Run `claude` to log in again."
         case .tokenExpired:
@@ -84,7 +87,7 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
         switch self {
         case .sessionExpired, .tokenExpired:
             return true
-        case .notLoggedIn, .invalidOAuthURL:
+        case .notLoggedIn, .desktopAppOnly, .invalidOAuthURL:
             return false
         }
     }
@@ -149,6 +152,21 @@ struct ClaudeAuthStore: Sendable {
     /// callers that only need a single source.
     func loadCredentials() -> ClaudeCredentialState? {
         loadCredentialCandidates().first
+    }
+
+    /// Data folders the Claude desktop app keeps under `~/Library/Application Support` — the standalone
+    /// Claude Code app and the Claude Code area inside the main Claude app. Their presence (checked only
+    /// when no CLI credentials exist anywhere) means the user likely signed in through the desktop app,
+    /// whose session lives in an Electron `safeStorage`-encrypted blob OpenUsage can't read (#825).
+    private static let desktopAppDataPaths = [
+        "~/Library/Application Support/Claude Code",
+        "~/Library/Application Support/Claude/claude-code"
+    ]
+
+    /// Whether a desktop-app login is the likely reason no CLI credentials were found, so the provider
+    /// can explain that a one-time `claude` CLI login is needed instead of a bare "Not logged in".
+    func hasDesktopAppData() -> Bool {
+        Self.desktopAppDataPaths.contains { files.exists($0) }
     }
 
     func needsRefresh(_ oauth: ClaudeOAuth) -> Bool {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -53,6 +53,13 @@ final class ClaudeProvider: ProviderRuntime {
         let candidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
             .filter { $0.oauth.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
         guard !candidates.isEmpty else {
+            // No CLI credentials anywhere. A login done only in the Claude desktop app is stored in an
+            // Electron-encrypted blob OpenUsage can't read, so a bare "Not logged in" reads as wrong to
+            // a user who is clearly signed in (#825) — point them at the one-time CLI login instead.
+            if await loadOffMainActor({ [authStore] in authStore.hasDesktopAppData() }) {
+                AppLog.info(LogTag.auth("claude"), "no CLI credentials, but desktop app data found — CLI login needed")
+                return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.desktopAppOnly)
+            }
             AppLog.info(LogTag.auth("claude"), "no access token, not logged in")
             return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.notLoggedIn)
         }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -50,13 +50,16 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     func refresh() async -> ProviderSnapshot {
-        let candidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
+        let storedCandidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
+        let candidates = storedCandidates
             .filter { $0.oauth.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
         guard !candidates.isEmpty else {
             // No CLI credentials anywhere. A login done only in the Claude desktop app is stored in an
             // Electron-encrypted blob OpenUsage can't read, so a bare "Not logged in" reads as wrong to
             // a user who is clearly signed in (#825) — point them at the one-time CLI login instead.
-            if await loadOffMainActor({ [authStore] in authStore.hasDesktopAppData() }) {
+            // Gated on the store finding nothing at all: a stored-but-blank token means the CLI *did*
+            // write credentials, so the plain "Not logged in" is the right guidance there.
+            if storedCandidates.isEmpty, await loadOffMainActor({ [authStore] in authStore.hasDesktopAppData() }) {
                 AppLog.info(LogTag.auth("claude"), "no CLI credentials, but desktop app data found — CLI login needed")
                 return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.desktopAppOnly)
             }

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -52,7 +52,7 @@ protocol CategorizedError: Error {
 extension ClaudeAuthError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {
-        case .notLoggedIn: .notLoggedIn
+        case .notLoggedIn, .desktopAppOnly: .notLoggedIn
         case .sessionExpired, .tokenExpired: .authExpired
         case .invalidOAuthURL: .authInvalid
         }

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -550,6 +550,39 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.sessionExpired.localizedDescription)
     }
 
+    func testDesktopAppOnlyLoginExplainsCLILoginInsteadOfNotLoggedIn() async {
+        // #825: a login done only in the Claude desktop app lives in an Electron-encrypted blob the app
+        // can't read, so a bare "Not logged in" reads as wrong to a signed-in user. When no CLI
+        // credentials exist but the desktop app's data folder does, the error must point at the
+        // one-time `claude` CLI login instead.
+        func makeProvider(files: FakeFiles) -> ClaudeProvider {
+            ClaudeProvider(
+                authStore: ClaudeAuthStore(
+                    environment: FakeEnvironment(),
+                    files: files,
+                    keychain: FakeKeychain()
+                ),
+                usageClient: ClaudeUsageClient(httpClient: FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data()))),
+                ccusageRunner: CcusageRunner(
+                    processRunner: FakeProcessRunner(),
+                    homeDirectory: { URL(fileURLWithPath: "/Users/test") }
+                )
+            )
+        }
+
+        let desktopOnly = makeProvider(files: FakeFiles([
+            "~/Library/Application Support/Claude/claude-code": ""
+        ]))
+        let desktopSnapshot = await desktopOnly.refresh()
+        XCTAssertEqual(badge(desktopSnapshot.lines, "Error"), ClaudeAuthError.desktopAppOnly.localizedDescription)
+        XCTAssertEqual(desktopSnapshot.errorCategory, .notLoggedIn)
+
+        // Without any desktop-app data the plain "Not logged in" guidance stays.
+        let noneAtAll = makeProvider(files: FakeFiles())
+        let plainSnapshot = await noneAtAll.refresh()
+        XCTAssertEqual(badge(plainSnapshot.lines, "Error"), ClaudeAuthError.notLoggedIn.localizedDescription)
+    }
+
     func testRateLimitedResponseMapsToRetryBadgeNotError() async {
         let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
         let httpClient = FakeHTTPClient(response: HTTPResponse(

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -581,6 +581,16 @@ final class ClaudeProviderTests: XCTestCase {
         let noneAtAll = makeProvider(files: FakeFiles())
         let plainSnapshot = await noneAtAll.refresh()
         XCTAssertEqual(badge(plainSnapshot.lines, "Error"), ClaudeAuthError.notLoggedIn.localizedDescription)
+
+        // A stored-but-blank CLI token (whitespace accessToken survives the store's isEmpty check but is
+        // dropped by the provider's trim filter) means the CLI did write credentials — the desktop-app
+        // hint must not fire even when the desktop folder exists; plain "Not logged in" is correct.
+        let corruptCLI = makeProvider(files: FakeFiles([
+            "~/.claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"   "}}"#,
+            "~/Library/Application Support/Claude/claude-code": ""
+        ]))
+        let corruptSnapshot = await corruptCLI.refresh()
+        XCTAssertEqual(badge(corruptSnapshot.lines, "Error"), ClaudeAuthError.notLoggedIn.localizedDescription)
     }
 
     func testRateLimitedResponseMapsToRetryBadgeNotError() async {

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -31,6 +31,7 @@ Today / Yesterday / Last 30 Days are computed **locally** from your Claude Code 
 ## Troubleshooting
 
 - **"Not logged in"** — run `claude` and sign in, then refresh.
+- **"Signed in to the Claude desktop app?"** — a login done only in the Claude desktop app is stored encrypted in a way OpenUsage can't read. Run `claude` in a terminal and sign in once; both logins coexist, and OpenUsage picks up the CLI one.
 - **"Re-login for live usage"** (an amber warning on the Claude header) — your saved login can authenticate for inference but can't read your subscription limits, because it lacks the `user:profile` access (this is what an inference-only token from `claude setup-token` carries). Run `claude` and sign in again with your Claude account, then refresh; the spend tiles keep working in the meantime.
 - **"Rate limited, retry in ~Nm"** — the usage API is throttling; OpenUsage shows when to expect data again and keeps your last values.
 - **Spend tiles show "No data"** — OpenUsage needs a package runner on its `PATH` to run `ccusage`. Install [Bun](https://bun.sh) (`curl -fsSL https://bun.sh/install | bash`), or make sure `npx`/`npm` is available (any Node.js install). If you use a version manager (nvm, fnm, volta), OpenUsage looks in the common locations, but a global Bun or Node install is the most reliable.


### PR DESCRIPTION
## TL;DR

When someone is signed in only through the Claude desktop app, OpenUsage now explains that a one-time `claude` CLI login is needed, instead of showing a misleading "Not logged in". Fixes #825.

## What was happening

- The Claude provider reads credentials from the places the Claude Code **CLI** writes them: the keychain item and `~/.claude/.credentials.json`.
- A login done only in the Claude desktop app is stored in an Electron-encrypted blob (`safeStorage`) OpenUsage can't read, so neither source exists.
- The user then saw "Not logged in. Run `claude` to authenticate." while being visibly signed in — which reads as a bug (#825).

## What this changes

- `ClaudeAuthStore` gains a `hasDesktopAppData()` check for the desktop app's data folders (`~/Library/Application Support/Claude Code` and `~/Library/Application Support/Claude/claude-code`), plus a new `desktopAppOnly` error case.
- When no CLI credentials exist anywhere but desktop-app data is present, the provider shows: *"Signed in to the Claude desktop app? OpenUsage needs a CLI login — run `claude` in a terminal and sign in once."* Both logins coexist, so one CLI sign-in fixes it for good.
- The new case is bucketed as `not_logged_in` for telemetry (same expected-noise category).
- `docs/providers/claude.md` gets a troubleshooting entry.

## Heads-up

- The credential fallback order and token refresh are untouched; the new path only triggers when there are no CLI credentials at all.
- The thread's larger proposal (OpenUsage running its own OAuth login flow) is out of scope here and would be its own feature.

## Tests

- New regression test covering both branches: desktop data present → CLI-login guidance; nothing at all → the plain "Not logged in".
- Full suite passes (748 tests, 0 failures).
- Built and relaunched the dev app locally; on a machine with a CLI login Claude refreshes normally. End-to-end confirmation of the desktop-only state would come from the issue reporter, who offered to test a beta.

Made with [Cursor](https://cursor.com)