### PR TITLE
fix(tests): port #828's desktop-app test off the removed CcusageRunner

### DIFF
--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -563,10 +563,8 @@ final class ClaudeProviderTests: XCTestCase {
                     keychain: FakeKeychain()
                 ),
                 usageClient: ClaudeUsageClient(httpClient: FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data()))),
-                ccusageRunner: CcusageRunner(
-                    processRunner: FakeProcessRunner(),
-                    homeDirectory: { URL(fileURLWithPath: "/Users/test") }
-                )
+                logUsageScanner: ClaudeLogFixture.scanner(home: nil),
+                pricing: { TestPricing.bundled }
             )
         }
 


### PR DESCRIPTION
## TL;DR

Fixes the CI failure on `main`: a semantic merge conflict between #828 and #827 left one test referencing the deleted `CcusageRunner`.

## What was happening

- #828 (merged 15:50) added `testDesktopAppOnlyLoginExplainsCLILoginInsteadOfNotLoggedIn`, constructing `ClaudeProvider` with the then-current `ccusageRunner:` parameter.
- #827 (merged 15:51) deleted `CcusageRunner` and changed `ClaudeProvider.init` to take `logUsageScanner:`/`pricing:`.
- Both PRs passed CI on their own branches, but the combination on `main` doesn't compile — CI on `main` (and every branch cut from it) has been red since.

## What this changes

- The test now builds the provider the same way the rest of the suite does post-#827: `logUsageScanner: ClaudeLogFixture.scanner(home: nil)` and `pricing: { TestPricing.bundled }`. No behavior change to what the test asserts.

## Tests

- `swift test --filter ClaudeProviderTests`: 10 tests, 0 failures.

Made with [Cursor](https://cursor.com)