### PR TITLE
fix(pricing): override Opus 4.7/4.8 fast-mode rates with Cursor's published pricing

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within a day - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
-  "updated_at": "2026-07-02",
+  "updated_at": "2026-07-03",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -49,6 +49,20 @@
       "cache_write_per_million": 5.0,
       "cache_read_per_million": 0.5,
       "output_per_million": 30.0
+    },
+    "claude-opus-4-7-fast": {
+      "$comment": "Cursor bills Opus 4.7 fast mode at these rates; the models.dev entry carries higher (stale) numbers, so this override wins.",
+      "input_per_million": 30.0,
+      "cache_write_per_million": 37.5,
+      "cache_read_per_million": 3.0,
+      "output_per_million": 150.0
+    },
+    "claude-opus-4-8-fast": {
+      "$comment": "Cursor states Opus 4.8 fast mode is 3x lower per-token than Opus 4.7 fast mode (= 2x the Opus 4.8 base rate, matching LiteLLM's fast multiplier); the models.dev entry disagrees, so this override wins.",
+      "input_per_million": 10.0,
+      "cache_write_per_million": 12.5,
+      "cache_read_per_million": 1.0,
+      "output_per_million": 50.0
     },
     "claude-4-sonnet-1m": {
       "$comment": "Cursor's long-context Sonnet 4 tier: the whole request bills at the >200k rate.",

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -87,6 +87,21 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(sonnet5.outputPerMillion, sonnet46.outputPerMillion)
     }
 
+    /// Opus 4.7/4.8 fast modes: Cursor's published rates (supplement overrides) win over the
+    /// stale models.dev entries. Per Cursor, 4.8 fast is 3x cheaper per token than 4.7 fast.
+    func testOpusFastModeSupplementOverrides() throws {
+        let pricing = Self.pricing
+        let opus47Fast = try XCTUnwrap(pricing.resolve(model: "claude-opus-4-7-thinking-high-fast"))
+        XCTAssertEqual(opus47Fast.inputPerMillion, 30)
+        XCTAssertEqual(opus47Fast.cacheWritePerMillion, 37.5)
+        XCTAssertEqual(opus47Fast.cacheReadPerMillion, 3)
+        XCTAssertEqual(opus47Fast.outputPerMillion, 150)
+
+        let opus48Fast = try XCTUnwrap(pricing.resolve(model: "claude-opus-4-8-thinking-high-fast"))
+        XCTAssertEqual(opus48Fast.inputPerMillion, opus47Fast.inputPerMillion / 3)
+        XCTAssertEqual(opus48Fast.outputPerMillion, opus47Fast.outputPerMillion / 3)
+    }
+
     /// GLM 5.2: the high/max effort slugs resolve to the shared entry (LiteLLM's Cloudflare listing);
     /// no separate cache-write price, so cache writes bill at the input rate. Slugs outside the
     /// high/max allowlist stay unpriced.


### PR DESCRIPTION
## TL;DR

Adds supplement price overrides for Claude Opus 4.7 and 4.8 fast modes, whose models.dev catalog entries don't match what Cursor actually bills.

## What was happening

- `claude-opus-4-7-...-fast` slugs priced via models.dev at $36 / $45 / $3.6 / $180 (input / cache write / cache read / output per 1M tokens), but [Cursor's models & pricing page](https://cursor.com/docs/models-and-pricing.md) lists Opus 4.7 fast mode at **$30 / $37.5 / $3 / $150**.
- `claude-opus-4-8-...-fast` slugs priced via models.dev at $12 / $15 / $1.2 / $60, but Cursor states 4.8 fast mode is 3x lower per-token than 4.7 fast mode, i.e. **$10 / $12.5 / $1 / $50** (which also matches LiteLLM's 2x fast multiplier on the Opus 4.8 base rate).

## What this changes

- Adds `claude-opus-4-7-fast` (30 / 37.5 / 3 / 150) and `claude-opus-4-8-fast` (10 / 12.5 / 1 / 50) entries to `pricing_supplement.json` so the supplement layer wins over models.dev; bumps `updated_at` to 2026-07-03.
- Adds a regression test asserting both fast-mode slugs resolve to Cursor's rates and that 4.8 fast is exactly 3x cheaper than 4.7 fast.

## Heads-up

- Everything else on the Cursor page already matches the catalogs or existing supplement entries (Auto, Composer 1/1.5/2/2.5, Sonnet 1M tier, GLM 5.2, Kimi K2.5, Grok 4.20/4.3/Build 0.1, Gemini 3/3.1/3.5, GPT-5.x family, Fable 5) — verified against the bundled snapshots.
- Cursor lists a **Claude Sonnet 5 launch promotion** ($2/M input, $10/M output through Aug 31, 2026). Per owner decision, the promo is intentionally ignored: Sonnet 5 stays at the standard $3/$15 catalog rate, since a supplement override would also reprice Anthropic API/Claude Code usage where the promo may not apply.
- Gemini 3 Pro Image Preview needs no alias: LiteLLM carries `gemini-3-pro-image-preview` as an exact key.

## Tests

- `swift test --filter "ModelPricing|PricingBundledResource"` — 39 tests, all passing (includes the new regression test).
- Supplement validation script from the skill: `Supplement OK`.

Made with [Cursor](https://cursor.com)
