### PR TITLE
fix(notifications): open popover when a pace alert is tapped

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -120,6 +120,10 @@ final class StatusItemController: NSObject {
         MenuBarPopover.dismissHandler = { [weak self] in
             self?.hidePanel()
         }
+        MenuBarPopover.showHandler = { [weak self] in
+            self?.container.layout.screen = .dashboard
+            self?.showPopover()
+        }
 
         // The panel auto-fits its content: SwiftUI owns one animated height (the single animation
         // clock) and the panel just follows it. `applyHeight` is the per-frame follower; `clampHeight`
@@ -336,6 +340,17 @@ final class StatusItemController: NSObject {
         } else {
             showPanel()
         }
+    }
+
+    /// Opens the dashboard panel without toggling it shut when already visible — used when an external
+    /// trigger (a tapped pace notification) should surface the popover.
+    func showPopover() {
+        if panel.isVisible {
+            panel.makeKeyAndOrderFront(nil)
+            statusItem.button?.highlight(true)
+            return
+        }
+        showPanel()
     }
 
     private func showPanel() {

--- a/Sources/OpenUsage/Support/AppNotifications.swift
+++ b/Sources/OpenUsage/Support/AppNotifications.swift
@@ -153,4 +153,23 @@ final class AppNotifications: NSObject, UNUserNotificationCenterDelegate {
     ) {
         completionHandler([.banner, .sound])
     }
+
+    /// Tapping a pace alert opens the menu-bar popover so the user lands on the dashboard.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+              response.notification.request.content.threadIdentifier == "openusage"
+        else {
+            completionHandler()
+            return
+        }
+        Task { @MainActor in
+            AppLog.info(.notifications, "notification tapped; opening popover")
+            MenuBarPopover.show()
+        }
+        completionHandler()
+    }
 }

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -268,6 +268,10 @@ enum MenuBarPopover {
     /// path as a status-item click.
     static var dismissHandler: (() -> Void)?
 
+    /// Installed by `StatusItemController` at launch; opens the popover (e.g. when the user taps a
+    /// quota pace notification banner).
+    static var showHandler: (() -> Void)?
+
     /// Auto-resize bridge — the "single clock". SwiftUI owns the animated height and the AppKit panel
     /// is a passive follower: `applyHeight` is called once per animation frame from a SwiftUI
     /// `Animatable` modifier with the interpolated height, and the controller hops it onto the main
@@ -287,5 +291,9 @@ enum MenuBarPopover {
         } else {
             window?.orderOut(nil)
         }
+    }
+
+    static func show() {
+        showHandler?()
     }
 }

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -155,9 +155,6 @@ struct SettingsScreen: View {
                 }
             }
             notificationsSection
-            #if DEBUG
-            debugNotificationsSection
-            #endif
             section("Privacy") {
                 row("Share Anonymous Usage") {
                     Toggle("", isOn: Binding(
@@ -322,46 +319,6 @@ struct SettingsScreen: View {
         default: notificationsAuth = .authorized
         }
     }
-
-    #if DEBUG
-    /// Temporary debug buttons that post real quota notifications so the copy, stacking, and permission
-    /// flow can be verified on demand without waiting for a real worsening. DEBUG-only — never in a
-    /// release build. Remove once notification behavior is confirmed.
-    private var debugNotificationsSection: some View {
-        section("Debug") {
-            row("Almost Out") {
-                Button("Fire") { fire(.underTenPercent) }.buttonStyle(.bordered)
-            }
-            row("Cutting It Close") {
-                Button("Fire") { fire(.healthyToClose) }.buttonStyle(.bordered)
-            }
-            row("Will Run Out") {
-                Button("Fire") { fire(.closeToRunningOut) }.buttonStyle(.bordered)
-            }
-            row("All Three") {
-                Button("Fire") {
-                    fire(.underTenPercent)
-                    fire(.healthyToClose)
-                    fire(.closeToRunningOut)
-                }
-                .buttonStyle(.bordered)
-            }
-        }
-    }
-
-    /// Post one real notification for a milestone so the banner title/subtitle/body and stacking can be
-    /// checked directly. Bypasses the dedup/prime logic — a manual trigger for testing only.
-    private func fire(_ milestone: PaceMilestone) {
-        Task {
-            _ = await AppNotifications.shared.post(
-                idPrefix: "debug.\(milestone.rawValue)",
-                title: milestone.notificationTitle,
-                subtitle: "Claude Session",
-                body: milestone.body
-            )
-        }
-    }
-    #endif
 
     // MARK: - Advanced (logging)
 

--- a/Tests/OpenUsageTests/AppNotificationsTests.swift
+++ b/Tests/OpenUsageTests/AppNotificationsTests.swift
@@ -13,6 +13,14 @@ final class AppNotificationsTests: XCTestCase {
         XCTAssertTrue(AppNotifications.isRunningUnderTests)
     }
 
+    func testShowHandlerIsInvokedByShow() {
+        var opened = false
+        MenuBarPopover.showHandler = { opened = true }
+        defer { MenuBarPopover.showHandler = nil }
+        MenuBarPopover.show()
+        XCTAssertTrue(opened)
+    }
+
     func testPostIsANoOpUnderTestsAndNeverTouchesTheCenter() async {
         let probe = CenterProbe()
         let notifications = AppNotifications(centerProvider: {

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -39,7 +39,7 @@ OpenUsage can alert you with a macOS notification when a metric's pace gets wors
 
 Each alert fires **once per metric per reset period**, so you get a heads-up without repeats on every refresh. Alerts fire only when a quota *worsens* while OpenUsage is running — a quota that's already in a bad state when you launch won't alert until it recovers and worsens again, or a new period begins. If a metric recovers (its pace eases back) and later worsens again, it can alert again. When a new period begins, the slate is wiped clean. Metrics without a reset window, or while their data can't be read, don't pace and never alert. Turn all three off to silence everything. When several alerts fire at once, they stack into a single grouped banner.
 
-All three alerts default off. The first time you turn one on, OpenUsage asks for notification permission; if you decline (or turn notifications off for OpenUsage in System Settings later), a warning mark appears on the Notifications header and an "Open System Settings" button shows under the toggles so you can re-enable them. A notification's title is the alert name, its subtitle names the provider and metric, and its body is the plain-language verdict.
+All three alerts default off. The first time you turn one on, OpenUsage asks for notification permission; if you decline (or turn notifications off for OpenUsage in System Settings later), a warning mark appears on the Notifications header and an "Open System Settings" button shows under the toggles so you can re-enable them. A notification's title is the alert name, its subtitle names the provider and metric, and its body is the plain-language verdict. Tapping an alert opens the popover on the dashboard.
 
 ## Privacy
 


### PR DESCRIPTION
## TL;DR
Tapping a quota pace notification now opens the menu-bar popover on the dashboard; the temporary DEBUG “Fire” notification controls are removed from Settings.

## What was happening
- Pace alerts were delivered and shown, but `AppNotifications` only implemented `willPresent` — there was no `didReceive` handler, so clicking a banner did nothing useful.
- Settings still had a DEBUG-only block of manual “Fire” buttons left over from notification QA.

## What this changes
- Handle default taps on OpenUsage notifications (`threadIdentifier == "openusage"`) and call `MenuBarPopover.show()`.
- Wire `showHandler` in `StatusItemController` to switch to the dashboard and open (or re-key) the panel without toggling it closed.
- Remove the DEBUG notification fire section from Settings.
- Document tap-to-open in `docs/settings.md`.

## Heads-up
If the popover was already open on another screen, the tap now switches to the dashboard and brings the panel forward instead of leaving you on Settings/Customize.

## Tests
- `AppNotificationsTests.testShowHandlerIsInvokedByShow`
- Manual: dev build — pace alert tap opens dashboard popover


Made with [Cursor](https://cursor.com)