### PR TITLE
feat(ui): replace footer split button with a single Options menu

### DIFF
--- a/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
+++ b/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
@@ -42,10 +42,9 @@ extension View {
     }
 
     /// A single interactive Liquid Glass surface (in the given shape) drawn behind a *whole control* —
-    /// the footer's split button wraps its `HStack` (Customize + divider + chevron) in one
-    /// `interactiveGlass(in: Capsule())` so the two plain-styled tap targets sit on one continuous
-    /// capsule rather than two separate pills. Apply it to the container, never to each segment, and
-    /// keep the segments `.buttonStyle(.plain)` so this glass is the only surface — the system
+    /// the footer's Options menu button wraps its plain-styled label in one
+    /// `interactiveGlass(in: Capsule())` so it sits on one continuous capsule. Apply it to the
+    /// container, and keep the control `.buttonStyle(.plain)` so this glass is the only surface — the system
     /// `.buttonStyle(.glass)` renders flat on a `Menu` (its own button chrome wins), and per-segment
     /// glass would split the capsule. `.interactive()` adds the hover/press shimmer + scale that reads
     /// as Liquid Glass. macOS 15 gets a frosted material shape with a hairline border (no glass there).

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -92,7 +92,7 @@ struct DashboardView: View {
             .background(
                 // Esc backs out of Customize / Settings first; only from the dashboard does it close
                 // the popover. Return opens Customize from the dashboard (the same affordance the
-                // footer's Customize button carries) and returns to the
+                // footer's Options ▸ Customize menu item carries) and returns to the
                 // dashboard from Customize or Settings — matching Esc and the prominent "Done" control,
                 // never jumping Settings → Customize. Always consumed, so a bare Return can't fall
                 // through and dismiss the popover.

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -1,20 +1,16 @@
 import AppKit
 import SwiftUI
 
-/// The dashboard footer's trailing control: a **split button** in Liquid Glass — one capsule with
-/// "Customize" on the left and a chevron segment on the right, divided by a hairline (the Export ▾
-/// idiom system apps use). Clicking "Customize" opens the Customize screen; clicking the chevron opens
-/// the overflow menu (Settings / Share Screenshot / Check for Updates / About / Quit). Customize leads
-/// because it's the screen users reach for most when shaping the dashboard; Settings stays one click
-/// away in the overflow (and always via ⌘,).
+/// The dashboard footer's trailing control: a single **Options ⌄** menu button in Liquid Glass. The
+/// earlier split button ("Customize" + separate chevron) confused people — two tap targets in one
+/// capsule read as one — so everything now lives in one obvious menu: Customize / Settings / Share
+/// Screenshot / Check for Updates / About / Quit. Customize leads the menu because it's the screen
+/// users reach for most; Settings stays one click away (and always via ⌘,).
 ///
-/// The joined-capsule look comes from one glass surface behind the *whole* control: an `HStack` of two
-/// `.buttonStyle(.plain)` tap targets (a `Button` and a chevron `Menu`) split by a `Divider`, with a
-/// single `interactiveGlass(in: Capsule())` drawn behind all of it. Glass goes on the container, not
-/// each segment — per-segment glass would split it into two pills, and the system `.buttonStyle(.glass)`
-/// renders flat on a `Menu` (its own button chrome wins). This is the canonical macOS 26 pattern
-/// (custom `glassEffect` surface behind grouped controls); it falls back to a frosted material capsule
-/// on macOS 15. The menu renders in its own `NSMenu`-backed window, which
+/// The capsule is a `.buttonStyle(.plain)` `Menu` with a single `interactiveGlass(in: Capsule())`
+/// surface behind it — the system `.buttonStyle(.glass)` renders flat on a `Menu` (its own button
+/// chrome wins), so the glass goes on the container. It falls back to a frosted material capsule on
+/// macOS 15. The menu renders in its own `NSMenu`-backed window, which
 /// `StatusItemController.shouldKeepPanelOpen` keeps the popover open for.
 ///
 /// Only the dashboard shows this; the Customize and Settings screens carry their own top-leading back
@@ -35,79 +31,67 @@ struct HeaderView: View {
     /// per-page), so this control shows only when that's `.dashboard` and swaps in place on a switch.
     let screen: PopoverScreen
 
-    /// Shared height for both halves, so the capsule reads as one control.
+    /// Control height, so the capsule matches the footer's other chrome.
     private static let controlHeight: CGFloat = 28
 
     var body: some View {
         leadingControl
     }
 
-    /// On the dashboard, the split button: the two halves laid out edge to edge (spacing 0) with a
-    /// hairline `Divider` between, all on one glass capsule.
+    /// On the dashboard, the Options menu button on one glass capsule.
     @ViewBuilder
     private var leadingControl: some View {
         if screen == .dashboard {
-            HStack(spacing: 0) {
-                customizeHalf
-                Divider()
-                    .frame(height: 16)
-                chevronHalf
-            }
-            .fixedSize()
-            .interactiveGlass(in: Capsule())
+            optionsButton
+                .fixedSize()
+                .interactiveGlass(in: Capsule())
         }
     }
 
-    /// Left half: opens Customize. `.buttonStyle(.plain)` strips the system chrome so the shared glass
-    /// is the only surface; `contentShape` makes the whole padded half clickable. ⏎ opens Customize
-    /// from anywhere via `PopoverKeyReader`, so the shortcut isn't registered here (which would also
-    /// flag the button as the window's default and draw a pulsing ring) — the tooltip surfaces it.
-    private var customizeHalf: some View {
-        Button { toggle(.customize) } label: {
-            Text("Customize")
-                .font(.system(size: 13, weight: .semibold))
-                .padding(.leading, 14)
-                .padding(.trailing, 11)
-                .frame(height: Self.controlHeight)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .hoverTooltip("Customize (⏎)")
-    }
-
-    /// Right half: the chevron pull-down. `.menuStyle(.button)` + `.buttonStyle(.plain)` strip the menu
-    /// chrome to just the glyph; `.menuIndicator(.hidden)` drops the built-in arrow (the chevron already
-    /// reads as "more"). `.fixedSize` keeps the glyph from stretching the half.
-    private var chevronHalf: some View {
+    /// The Options pull-down: label plus its own chevron glyph. `.menuStyle(.button)` +
+    /// `.buttonStyle(.plain)` strip the menu chrome so the shared glass is the only surface;
+    /// `.menuIndicator(.hidden)` drops the built-in arrow in favor of our styled chevron.
+    private var optionsButton: some View {
         Menu {
-            moreMenuItems
+            menuItems
         } label: {
-            Image(systemName: "chevron.down")
-                .font(.system(size: 11, weight: .semibold))
-                .padding(.leading, 9)
-                .padding(.trailing, 12)
-                .frame(height: Self.controlHeight)
-                .contentShape(Rectangle())
+            HStack(spacing: 5) {
+                Text("Options")
+                    .font(.system(size: 13, weight: .semibold))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+            }
+            .padding(.leading, 14)
+            .padding(.trailing, 12)
+            .frame(height: Self.controlHeight)
+            .contentShape(Rectangle())
         }
         .menuStyle(.button)
         .buttonStyle(.plain)
         .menuIndicator(.hidden)
         .fixedSize()
-        .accessibilityLabel("More")
     }
 
-    /// The chevron's overflow items, mirroring their in-popover entry points. `autoenablesItems` has no
-    /// SwiftUI equivalent, so the Check for Updates item disables itself when Sparkle can't currently
-    /// check — e.g. dev builds with no feed, or while a check is already in flight. Settings carries its
-    /// ⌘, key equivalent so the menu shows the shortcut: when the menu is open the item handles ⌘,;
-    /// when it's closed the `PopoverDismissReader` monitor handles (and consumes) ⌘, first, so the item's
-    /// equivalent can't double-fire. Same split as the Quit ⌘Q item below.
+    /// The menu's items, mirroring their in-popover entry points. Customize leads, then Settings.
+    /// `autoenablesItems` has no SwiftUI equivalent, so the Check for Updates item disables itself when
+    /// Sparkle can't currently check — e.g. dev builds with no feed, or while a check is already in
+    /// flight. Customize and Settings carry their key equivalents so the menu shows the shortcuts: when
+    /// the menu is open the items handle them; when it's closed the `PopoverDismissReader` monitor
+    /// handles (and consumes) them first, so the equivalents can't double-fire. Same split as the Quit
+    /// ⌘Q item below.
     @ViewBuilder
-    private var moreMenuItems: some View {
+    private var menuItems: some View {
+        Button { toggle(.customize) } label: {
+            Label("Customize", systemImage: "slider.horizontal.3")
+        }
+        .keyboardShortcut(.return, modifiers: [])
+
         Button { toggle(.settings) } label: {
             Label("Settings", systemImage: "gearshape")
         }
         .keyboardShortcut(",")
+
+        Divider()
 
         shareScreenshotMenu
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -43,17 +43,17 @@ Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** 
 Copy a clean, branded PNG of one provider's usage to your clipboard, ready to paste into a chat, a tweet, or a doc. There are two ways to reach it:
 
 - Right-click a provider header and choose **Share Screenshot**.
-- Open the footer's **⌄** menu and choose **Share Screenshot** ▸ *\<provider\>*. The submenu lists every provider currently showing on the dashboard.
+- Open the footer's **Options** menu and choose **Share Screenshot** ▸ *\<provider\>*. The submenu lists every provider currently showing on the dashboard.
 
 The image is a flexible-height PNG using the app's look — the provider's mark and name up top, the metric rows you currently see for that provider, and a small OpenUsage mark centered at the bottom. It follows your Light/Dark appearance and shows everything on the card as-is (nothing is hidden or blurred).
 
 ## Footer
 
-The bar pinned to the bottom of the popover. On the left: the app version, and a live "Next update in …" countdown you can click (or press **⌘R**) to refresh right away. On the right: a **Customize** button paired with a **⌄** menu. The menu holds the app-level actions — **Settings**, **Share Screenshot** (submenu of providers), **Check for Updates…**, **About OpenUsage**, and **Quit OpenUsage**.
+The bar pinned to the bottom of the popover. On the left: the app version, and a live "Next update in …" countdown you can click (or press **⌘R**) to refresh right away. On the right: an **Options** menu button. It holds everything in one place — **Customize**, **Settings**, **Share Screenshot** (submenu of providers), **Check for Updates…**, **About OpenUsage**, and **Quit OpenUsage**.
 
 ## Customize
 
-Open Customize from the footer's **Customize** button (or press **Return**). It's a two-level screen: a list of providers, then a provider's detail.
+Open Customize from the footer's **Options** menu (or press **Return**). It's a two-level screen: a list of providers, then a provider's detail.
 
 The **provider list** shows every provider with a switch to turn it on or off, an Active/Inactive status, a count of its metrics, and a chevron into its detail. Turn a provider off and it stays in the list, greyed — its metrics hide from the dashboard and menu bar but keep their setup for when you turn it back on. Drag providers by their grip to reorder; tap a row to open its detail. On a fresh install only the providers detected on your Mac start on (see "First launch" above); this list is where you add the rest.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-Settings lives inside the popover — there is no separate window. Open it from the footer's **⌄** menu next to the Customize button, with ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen, which carries a back button in its top-left corner. Go back with that button, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
+Settings lives inside the popover — there is no separate window. Open it from the footer's **Options** menu, with ⌘, while the popover is showing, or by right-clicking the menu bar icon and choosing Settings. The dashboard slides over to the Settings screen, which carries a back button in its top-left corner. Go back with that button, the ⌘, shortcut, or Esc (Esc always backs out to the dashboard first — pressing it again closes the popover).
 
 ## Startup
 


### PR DESCRIPTION
## TL;DR

Replaces the dashboard footer's Customize + chevron split button with a single **Options ⌄** menu button that lists Customize and Settings (plus the existing overflow actions), so all entry points are visible at a glance.

## What was happening

- The footer showed a "Customize" button joined with a small chevron dropdown in one capsule.
- Many users didn't realize these were two separate controls, so they missed Settings and the other actions hidden behind the chevron.

## What this changes

- The footer control is now one **Options** menu button on the same glass capsule.
- The menu leads with **Customize** (⏎) and **Settings** (⌘,), then a divider, then the unchanged Share Screenshot, Check for Updates…, About, and Quit items.
- Keyboard shortcuts are untouched — ⏎ and ⌘, still work globally via the existing key monitor.
- Updated stale code comments (`DashboardView`, `LiquidGlassFallbacks`) and the docs (`docs/dashboard.md`, `docs/settings.md`) that described the old split button.

## Tests

- Built and ran the dev bundle via `./script/build_and_run.sh verify`; Bugbot review found no issues.

## Screenshots

- Verified locally in the running dev build; screenshot to be added from the menu bar app.

Made with [Cursor](https://cursor.com)