### PR TITLE
feat(copilot): show org-level AI credit usage for org-managed Business/Enterprise seats

### DIFF
--- a/Sources/OpenUsage/Providers/Copilot/CopilotOrgBillingClient.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotOrgBillingClient.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Calls GitHub's public REST billing endpoints to find the organization that provides an org-managed
+/// Copilot seat and read its month-to-date usage. Used only when `/copilot_internal/user` reports a
+/// token-based-billing seat with no per-seat quota (Copilot Business/Enterprise managed by an org) —
+/// the usage then lives in *organization* billing, which the user-scoped endpoint never carries.
+///
+/// Reading an org's billing requires the caller to be an org owner or billing manager; a plain member
+/// gets 403. That's an expected state, handled by the provider, not an error here.
+struct CopilotOrgBillingClient: Sendable {
+    static let userOrgsURL = "https://api.github.com/user/orgs?per_page=100"
+
+    static func usageSummaryURL(org: String) -> URL? {
+        // Org slugs are alphanumeric-plus-hyphen, but encode defensively before splicing into the path.
+        guard let encoded = org.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
+            return nil
+        }
+        return URL(string: "https://api.github.com/orgs/\(encoded)/settings/billing/usage/summary")
+    }
+
+    var http: any HTTPClient
+
+    init(http: any HTTPClient = URLSessionHTTPClient()) {
+        self.http = http
+    }
+
+    /// The organizations the token's user belongs to (first page, 100 max — plenty for this purpose).
+    func fetchUserOrgs(token: String) async throws -> HTTPResponse {
+        guard let url = URL(string: Self.userOrgsURL) else {
+            throw CopilotUsageError.invalidResponse
+        }
+        return try await send(url: url, token: token)
+    }
+
+    /// Month-to-date billing usage summary for one organization.
+    func fetchUsageSummary(org: String, token: String) async throws -> HTTPResponse {
+        guard let url = Self.usageSummaryURL(org: org) else {
+            throw CopilotUsageError.invalidResponse
+        }
+        return try await send(url: url, token: token)
+    }
+
+    private func send(url: URL, token: String) async throws -> HTTPResponse {
+        try await http.send(HTTPRequest(
+            method: "GET",
+            url: url,
+            headers: [
+                "Authorization": "token \(token)",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "OpenUsage",
+                "X-GitHub-Api-Version": "2022-11-28"
+            ],
+            timeout: 15
+        ))
+    }
+}

--- a/Sources/OpenUsage/Providers/Copilot/CopilotOrgBillingMapper.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotOrgBillingMapper.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Normalizes GitHub organization billing responses into org-level Copilot meters. The billing usage
+/// summary (`/orgs/{org}/settings/billing/usage/summary`) reports month-to-date usage per product; the
+/// Copilot AI-credit items become **Org Credits** (credits consumed this month, an unbounded count — the
+/// endpoint exposes no allotment, so no percentage is fabricated) and **Org Spend** (dollars actually
+/// billed beyond included credits). Both are organization-wide totals, not the individual seat's usage —
+/// GitHub doesn't expose per-seat numbers for org-managed Copilot.
+enum CopilotOrgBillingMapper {
+    /// Org slugs from a `/user/orgs` response, in GitHub's order. Empty for a garbled body.
+    static func orgLogins(_ response: HTTPResponse) -> [String] {
+        guard let array = try? JSONSerialization.jsonObject(with: response.body) as? [[String: Any]] else {
+            return []
+        }
+        return array.compactMap { entry in
+            (entry["login"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        }
+    }
+
+    /// Metric lines from a billing usage summary, or `nil` when the summary carries no Copilot AI-credit
+    /// items (the org doesn't use Copilot credits — callers keep probing other orgs). Only items whose
+    /// `unitType` is credit-based (`ai-units` / `ai-credits`) are counted, so seat-fee line items with
+    /// other units can't pollute the totals.
+    static func usageLines(_ response: HTTPResponse) -> [MetricLine]? {
+        guard let body = ProviderParse.jsonObject(response.body) else { return nil }
+        return usageLines(body: body)
+    }
+
+    static func usageLines(body: [String: Any]) -> [MetricLine]? {
+        guard let items = body["usageItems"] as? [[String: Any]] else { return nil }
+
+        let creditItems = items.filter { item in
+            isCopilot(item["product"]) && isCreditUnit(item["unitType"])
+        }
+        guard !creditItems.isEmpty else { return nil }
+
+        let credits = creditItems.reduce(0.0) { $0 + max(0, ProviderParse.number($1["grossQuantity"]) ?? 0) }
+        let spend = creditItems.reduce(0.0) { $0 + max(0, ProviderParse.number($1["netAmount"]) ?? 0) }
+
+        return [
+            .values(label: "Org Credits", values: [MetricValue(number: credits, kind: .count, label: "credits")]),
+            .values(label: "Org Spend", values: [MetricValue(number: spend, kind: .dollars)])
+        ]
+    }
+
+    private static func isCopilot(_ value: Any?) -> Bool {
+        guard let product = value as? String else { return false }
+        return product.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "copilot"
+    }
+
+    private static func isCreditUnit(_ value: Any?) -> Bool {
+        guard let unit = value as? String else { return false }
+        let normalized = unit.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == "ai-units" || normalized == "ai-credits"
+    }
+}

--- a/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
@@ -2,6 +2,10 @@ import Foundation
 
 @MainActor
 final class CopilotProvider: ProviderRuntime {
+    /// `UserDefaults` key caching the slug of the org whose billing carried Copilot credit usage, so
+    /// steady-state refreshes make one billing call instead of re-probing every org.
+    static let billingOrgDefaultsKey = "copilot.billingOrg"
+
     let provider = Provider(
         id: "copilot",
         displayName: "Copilot",
@@ -14,15 +18,21 @@ final class CopilotProvider: ProviderRuntime {
 
     let authStore: CopilotAuthStore
     let usageClient: CopilotUsageClient
+    let orgBillingClient: CopilotOrgBillingClient
+    let defaults: UserDefaults
     let now: @Sendable () -> Date
 
     init(
         authStore: CopilotAuthStore = CopilotAuthStore(),
         usageClient: CopilotUsageClient = CopilotUsageClient(),
+        orgBillingClient: CopilotOrgBillingClient = CopilotOrgBillingClient(),
+        defaults: UserDefaults = .standard,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.authStore = authStore
         self.usageClient = usageClient
+        self.orgBillingClient = orgBillingClient
+        self.defaults = defaults
         self.now = now
     }
 
@@ -30,6 +40,8 @@ final class CopilotProvider: ProviderRuntime {
         [
             .percent(id: "copilot.premium", provider: provider, title: "Credits"),
             .values(id: "copilot.extra", provider: provider, title: "Extra Usage", selection: .kind(.count)),
+            .values(id: "copilot.orgCredits", provider: provider, title: "Org Credits", selection: .kind(.count)),
+            .values(id: "copilot.orgSpend", provider: provider, title: "Org Spend", selection: .kind(.dollars), valueWord: "spent"),
             .percent(id: "copilot.chat", provider: provider, title: "Chat"),
             .percent(id: "copilot.completions", provider: provider, title: "Completions")
         ]
@@ -57,11 +69,75 @@ final class CopilotProvider: ProviderRuntime {
             }
 
             let mapped = try CopilotUsageMapper.map(response)
-            return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
+
+            // An org-managed (token-based-billing) seat has no per-seat quota, so the mapper returns no
+            // lines; the real usage lives in the org's billing. Look it up there — best-effort: an org
+            // admin sees Org Credits / Org Spend, everyone else keeps the plan-only card as before.
+            var lines = mapped.lines
+            if lines.isEmpty {
+                lines = await orgBillingLines(token: token.value)
+            }
+
+            return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: lines, refreshedAt: now())
         } catch let error as CopilotUsageError {
             return ProviderSnapshot.error(provider: provider, error: error)
         } catch {
             return ProviderSnapshot.error(provider: provider, error: CopilotUsageError.connectionFailed)
         }
+    }
+
+    // MARK: - Org billing lookup
+
+    /// Org-level Copilot billing lines for an org-managed seat. Tries the cached org first, then probes
+    /// every org the user belongs to, remembering the first whose billing summary carries Copilot credit
+    /// usage. Returns `[]` when nothing is readable — a 403 is the *expected* outcome for a plain org
+    /// member (only owners and billing managers can read org billing), so it degrades to today's
+    /// plan-only card instead of erroring the provider.
+    private func orgBillingLines(token: String) async -> [MetricLine] {
+        do {
+            if let cached = defaults.string(forKey: Self.billingOrgDefaultsKey) {
+                if let lines = try await usageLines(org: cached, token: token) {
+                    return lines
+                }
+                // The cached org answered but no longer shows Copilot usage (left the org, lost the
+                // billing role, org stopped using Copilot) — forget it and re-probe from scratch.
+                defaults.removeObject(forKey: Self.billingOrgDefaultsKey)
+            }
+
+            let response = try await orgBillingClient.fetchUserOrgs(token: token)
+            guard response.statusCode == 200 else {
+                // 403 here means the token lacks `read:org` (editor-plugin tokens can) — expected, not
+                // an error. Anything else is still worth a diagnostic, never a failed card.
+                AppLog.info(LogTag.plugin("copilot"), "org list HTTP \(response.statusCode); skipping org billing lookup")
+                return []
+            }
+
+            for org in CopilotOrgBillingMapper.orgLogins(response) {
+                if let lines = try await usageLines(org: org, token: token) {
+                    defaults.set(org, forKey: Self.billingOrgDefaultsKey)
+                    return lines
+                }
+            }
+        } catch {
+            // Transient (network) failure: log it and keep the cached org for the next refresh.
+            AppLog.warn(LogTag.plugin("copilot"), "org billing lookup failed: \(error.localizedDescription)")
+        }
+        return []
+    }
+
+    /// One org's billing summary → metric lines, or `nil` when this org definitively has nothing to show
+    /// (no access — the expected 403 for plain members — or no Copilot credit usage in the summary).
+    /// Throws for transient failures (transport errors, 429, 5xx) so callers keep the cached org instead
+    /// of treating a brief outage as a stale org.
+    private func usageLines(org: String, token: String) async throws -> [MetricLine]? {
+        let response = try await orgBillingClient.fetchUsageSummary(org: org, token: token)
+        guard response.statusCode == 200 else {
+            AppLog.debug(LogTag.plugin("copilot"), "org billing summary for one org: HTTP \(response.statusCode)")
+            if response.statusCode == 429 || response.statusCode >= 500 {
+                throw CopilotUsageError.requestFailed(response.statusCode)
+            }
+            return nil
+        }
+        return CopilotOrgBillingMapper.usageLines(response)
     }
 }

--- a/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
@@ -94,16 +94,23 @@ final class CopilotProvider: ProviderRuntime {
     /// member (only owners and billing managers can read org billing), so it degrades to today's
     /// plan-only card instead of erroring the provider.
     private func orgBillingLines(token: String) async -> [MetricLine] {
-        do {
-            if let cached = defaults.string(forKey: Self.billingOrgDefaultsKey) {
+        if let cached = defaults.string(forKey: Self.billingOrgDefaultsKey) {
+            do {
                 if let lines = try await usageLines(org: cached, token: token) {
                     return lines
                 }
                 // The cached org answered but no longer shows Copilot usage (left the org, lost the
                 // billing role, org stopped using Copilot) — forget it and re-probe from scratch.
                 defaults.removeObject(forKey: Self.billingOrgDefaultsKey)
+            } catch {
+                // Transient failure: log it and keep the cached org for the next refresh.
+                AppLog.warn(LogTag.plugin("copilot"), "org billing lookup failed for the remembered org: \(error.localizedDescription)")
+                return []
             }
+        }
 
+        let orgs: [String]
+        do {
             let response = try await orgBillingClient.fetchUserOrgs(token: token)
             guard response.statusCode == 200 else {
                 // 403 here means the token lacks `read:org` (editor-plugin tokens can) — expected, not
@@ -111,16 +118,22 @@ final class CopilotProvider: ProviderRuntime {
                 AppLog.info(LogTag.plugin("copilot"), "org list HTTP \(response.statusCode); skipping org billing lookup")
                 return []
             }
+            orgs = CopilotOrgBillingMapper.orgLogins(response)
+        } catch {
+            AppLog.warn(LogTag.plugin("copilot"), "org list fetch failed: \(error.localizedDescription)")
+            return []
+        }
 
-            for org in CopilotOrgBillingMapper.orgLogins(response) {
+        for org in orgs {
+            do {
                 if let lines = try await usageLines(org: org, token: token) {
                     defaults.set(org, forKey: Self.billingOrgDefaultsKey)
                     return lines
                 }
+            } catch {
+                // One org's billing having an outage must not hide another org's usage — keep probing.
+                AppLog.warn(LogTag.plugin("copilot"), "org billing summary failed for one org; trying the next: \(error.localizedDescription)")
             }
-        } catch {
-            // Transient (network) failure: log it and keep the cached org for the next refresh.
-            AppLog.warn(LogTag.plugin("copilot"), "org billing lookup failed: \(error.localizedDescription)")
         }
         return []
     }

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -18,7 +18,8 @@ enum DefaultLayout {
         "cursor.usage", "cursor.auto", "cursor.api", "cursor.trend",
         "cursor.onDemand", "cursor.today", "cursor.yesterday", "cursor.last30",
 
-        "copilot.premium", "copilot.extra", "copilot.chat", "copilot.completions",
+        "copilot.premium", "copilot.extra", "copilot.orgCredits", "copilot.orgSpend",
+        "copilot.chat", "copilot.completions",
 
         "devin.daily", "devin.weekly", "devin.extra",
 
@@ -82,10 +83,11 @@ enum DefaultLayout {
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
         "cursor.onDemand", "cursor.requests", "cursor.credits",
         "cursor.today", "cursor.yesterday", "cursor.last30",
-        // Copilot: Credits (the metered premium pool) + Extra Usage stay above the fold; Chat +
-        // Completions sit below the caret. They carry real counts on free only — on paid they're
-        // unlimited (suppressed), so they read "No data" there.
-        "copilot.chat", "copilot.completions",
+        // Copilot: Credits (the metered premium pool), Extra Usage, and Org Credits (org-managed
+        // Business/Enterprise seats) stay above the fold; Org Spend and Chat + Completions sit below
+        // the caret. Chat/Completions carry real counts on free only — on paid they're unlimited
+        // (suppressed), so they read "No data" there.
+        "copilot.orgSpend", "copilot.chat", "copilot.completions",
         "devin.extra",
         "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30",
         // OpenRouter: Credits meter + Balance stay above the fold; period spend and the per-key cap

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -83,11 +83,11 @@ enum DefaultLayout {
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
         "cursor.onDemand", "cursor.requests", "cursor.credits",
         "cursor.today", "cursor.yesterday", "cursor.last30",
-        // Copilot: Credits (the metered premium pool), Extra Usage, and Org Credits (org-managed
-        // Business/Enterprise seats) stay above the fold; Org Spend and Chat + Completions sit below
-        // the caret. Chat/Completions carry real counts on free only — on paid they're unlimited
+        // Copilot: Credits (the metered premium pool) + Extra Usage stay above the fold; the org
+        // billing pair (org-managed Business/Enterprise seats) and Chat + Completions sit below the
+        // caret. Chat/Completions carry real counts on free only — on paid they're unlimited
         // (suppressed), so they read "No data" there.
-        "copilot.orgSpend", "copilot.chat", "copilot.completions",
+        "copilot.orgCredits", "copilot.orgSpend", "copilot.chat", "copilot.completions",
         "devin.extra",
         "grok.payAsYouGo", "grok.today", "grok.yesterday", "grok.last30",
         // OpenRouter: Credits meter + Balance stay above the fold; period spend and the per-key cap

--- a/Tests/OpenUsageTests/CopilotProviderTests.swift
+++ b/Tests/OpenUsageTests/CopilotProviderTests.swift
@@ -290,6 +290,57 @@ final class CopilotUsageMapperTests: XCTestCase {
     }
 }
 
+final class CopilotOrgBillingMapperTests: XCTestCase {
+    func testParsesOrgLogins() {
+        let body: [[String: Any]] = [["login": "acme", "id": 1], ["login": "globex"], ["id": 3]]
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: try! JSONSerialization.data(withJSONObject: body))
+
+        XCTAssertEqual(CopilotOrgBillingMapper.orgLogins(response), ["acme", "globex"])
+    }
+
+    func testOrgLoginsEmptyForGarbledBody() {
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: Data("<html>".utf8))
+        XCTAssertEqual(CopilotOrgBillingMapper.orgLogins(response), [])
+    }
+
+    func testMapsAICreditUsageFromSummary() throws {
+        // The exact shape reported in issue #839: one Copilot AI-unit item, fully covered by included
+        // credits (netAmount 0).
+        let lines = try XCTUnwrap(CopilotOrgBillingMapper.usageLines(body: makeOrgSummaryBody()))
+
+        XCTAssertEqual(orgCount(lines, "Org Credits") ?? -1, 298.698546, accuracy: 0.0001)
+        XCTAssertEqual(orgDollars(lines, "Org Spend"), 0)
+    }
+
+    func testSumsMultipleCreditItemsAndBilledSpend() throws {
+        var body = makeOrgSummaryBody()
+        body["usageItems"] = [
+            ["product": "Copilot", "sku": "copilot_ai_unit", "unitType": "ai-units", "grossQuantity": 100.5, "netAmount": 1.25],
+            ["product": "Copilot", "sku": "Copilot AI Credits", "unitType": "ai-credits", "grossQuantity": 50, "netAmount": 0.5]
+        ]
+
+        let lines = try XCTUnwrap(CopilotOrgBillingMapper.usageLines(body: body))
+
+        XCTAssertEqual(orgCount(lines, "Org Credits") ?? -1, 150.5, accuracy: 0.0001)
+        XCTAssertEqual(orgDollars(lines, "Org Spend") ?? -1, 1.75, accuracy: 0.0001)
+    }
+
+    func testNilWhenNoCopilotCreditItems() {
+        // Actions minutes and Copilot seat fees (non-credit units) must not produce org meters.
+        var body = makeOrgSummaryBody()
+        body["usageItems"] = [
+            ["product": "Actions", "sku": "actions_linux", "unitType": "minutes", "grossQuantity": 120, "netAmount": 0.96],
+            ["product": "Copilot", "sku": "copilot_business_seat", "unitType": "user-months", "grossQuantity": 10, "netAmount": 190]
+        ]
+
+        XCTAssertNil(CopilotOrgBillingMapper.usageLines(body: body))
+    }
+
+    func testNilWhenSummaryHasNoUsageItems() {
+        XCTAssertNil(CopilotOrgBillingMapper.usageLines(body: ["organization": "acme"]))
+    }
+}
+
 @MainActor
 final class CopilotProviderTests: XCTestCase {
     func testNotLoggedInWhenNoToken() async {
@@ -348,6 +399,125 @@ final class CopilotProviderTests: XCTestCase {
         XCTAssertTrue(snapshot.lines.isEmpty)
     }
 
+    func testOrgManagedSeatShowsOrgBillingLines() async {
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
+            ("/user/orgs", okJSON([["login": "acme"]])),
+            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        ])
+        let defaults = freshDefaults()
+        let provider = makeOrgProvider(http: http, defaults: defaults)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(snapshot.plan, "Business")
+        XCTAssertEqual(orgCount(snapshot.lines, "Org Credits") ?? -1, 298.698546, accuracy: 0.0001)
+        XCTAssertEqual(orgDollars(snapshot.lines, "Org Spend"), 0)
+        XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
+    }
+
+    func testOrgBillingForbiddenKeepsPlanOnlyCard() async {
+        // A plain org member (not owner/billing manager) gets 403 on org billing — the expected state,
+        // which must keep today's plan-only card rather than erroring the provider.
+        let forbidden = HTTPResponse(statusCode: 403, headers: [:], body: Data())
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
+            ("/user/orgs", okJSON([["login": "acme"]])),
+            ("/orgs/acme/settings/billing/usage/summary", forbidden)
+        ])
+        let defaults = freshDefaults()
+        let provider = makeOrgProvider(http: http, defaults: defaults)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(snapshot.plan, "Business")
+        XCTAssertTrue(snapshot.lines.isEmpty)
+        XCTAssertNil(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey))
+    }
+
+    func testUsesCachedOrgWithoutReprobing() async {
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
+            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        ])
+        let defaults = freshDefaults()
+        defaults.set("acme", forKey: CopilotProvider.billingOrgDefaultsKey)
+        let provider = makeOrgProvider(http: http, defaults: defaults)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNotNil(orgCount(snapshot.lines, "Org Credits"))
+        XCTAssertFalse(http.requests.contains { $0.url.absoluteString.contains("/user/orgs") })
+    }
+
+    func testEvictsStaleCachedOrgAndReprobes() async {
+        // The cached org answers without Copilot usage (e.g. the user changed orgs) — it must be
+        // forgotten and discovery re-run.
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
+            ("/orgs/oldorg/settings/billing/usage/summary", HTTPResponse(statusCode: 404, headers: [:], body: Data())),
+            ("/user/orgs", okJSON([["login": "acme"]])),
+            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        ])
+        let defaults = freshDefaults()
+        defaults.set("oldorg", forKey: CopilotProvider.billingOrgDefaultsKey)
+        let provider = makeOrgProvider(http: http, defaults: defaults)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNotNil(orgCount(snapshot.lines, "Org Credits"))
+        XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
+    }
+
+    func testTransientBillingFailureKeepsCachedOrg() async {
+        // A 5xx from the cached org's billing endpoint is a brief outage, not a stale org: the cache
+        // must survive (no re-discovery), and the refresh degrades to the plan-only card.
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
+            ("/orgs/acme/settings/billing/usage/summary", HTTPResponse(statusCode: 503, headers: [:], body: Data()))
+        ])
+        let defaults = freshDefaults()
+        defaults.set("acme", forKey: CopilotProvider.billingOrgDefaultsKey)
+        let provider = makeOrgProvider(http: http, defaults: defaults)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(snapshot.lines.isEmpty)
+        XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
+        XCTAssertFalse(http.requests.contains { $0.url.absoluteString.contains("/user/orgs") })
+    }
+
+    func testPersonalPaidAccountMakesNoOrgCalls() async {
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makePaidBody()))
+        ])
+        let provider = makeOrgProvider(http: http, defaults: freshDefaults())
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(http.requests.count, 1)
+    }
+
+    private func makeOrgProvider(http: RoutingHTTPClient, defaults: UserDefaults) -> CopilotProvider {
+        CopilotProvider(
+            authStore: editorTokenStore(),
+            usageClient: CopilotUsageClient(http: http),
+            orgBillingClient: CopilotOrgBillingClient(http: http),
+            defaults: defaults
+        )
+    }
+
+    private func freshDefaults() -> UserDefaults {
+        let suiteName = "CopilotProviderTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
     private func editorTokenStore() -> CopilotAuthStore {
         CopilotAuthStore(
             files: FakeFiles([CopilotAuthStore.editorAppsPath: #"{ "github.com": { "oauth_token": "gho_editor" } }"#]),
@@ -357,6 +527,69 @@ final class CopilotProviderTests: XCTestCase {
 }
 
 // MARK: - Helpers
+
+/// A `RoutingHTTPClient` answering with the first response whose URL-substring key matches; unmatched
+/// URLs 404.
+private func routedClient(_ routes: [(substring: String, response: HTTPResponse)]) -> RoutingHTTPClient {
+    RoutingHTTPClient { request in
+        routes.first(where: { request.url.absoluteString.contains($0.substring) })?.response
+            ?? HTTPResponse(statusCode: 404, headers: [:], body: Data())
+    }
+}
+
+/// The `/copilot_internal/user` shape of an org-managed Copilot Business seat (issue #839): plan is
+/// reported but every quota bucket is a zero-entitlement token-based-billing placeholder.
+private func makeBusinessPlaceholderBody() -> [String: Any] {
+    [
+        "copilot_plan": "business",
+        "token_based_billing": true,
+        "quota_snapshots": [
+            "premium_interactions": ["entitlement": 0, "remaining": 0, "unlimited": true, "token_based_billing": true]
+        ]
+    ]
+}
+
+/// The org billing usage summary from issue #839: one Copilot AI-unit item, fully covered by the
+/// included credits.
+private func makeOrgSummaryBody() -> [String: Any] {
+    [
+        "timePeriod": ["year": 2026, "month": 7],
+        "organization": "acme",
+        "usageItems": [
+            [
+                "product": "Copilot",
+                "sku": "copilot_ai_unit",
+                "unitType": "ai-units",
+                "pricePerUnit": 0.01,
+                "grossQuantity": 298.698546,
+                "grossAmount": 2.98698546,
+                "discountQuantity": 298.698546,
+                "discountAmount": 2.98698546,
+                "netQuantity": 0.0,
+                "netAmount": 0.0
+            ]
+        ]
+    ]
+}
+
+private func okJSON(_ array: [[String: Any]]) -> HTTPResponse {
+    HTTPResponse(statusCode: 200, headers: [:], body: try! JSONSerialization.data(withJSONObject: array))
+}
+
+private func orgCount(_ lines: [MetricLine], _ label: String) -> Double? {
+    value(lines, label: label, kind: .count)
+}
+
+private func orgDollars(_ lines: [MetricLine], _ label: String) -> Double? {
+    value(lines, label: label, kind: .dollars)
+}
+
+private func value(_ lines: [MetricLine], label: String, kind: MetricKind) -> Double? {
+    guard case .values(_, let values, _, _, _) = lines.first(where: { $0.label == label }) else {
+        return nil
+    }
+    return values.first(where: { $0.kind == kind })?.number
+}
 
 private func makePaidBody() -> [String: Any] {
     [

--- a/Tests/OpenUsageTests/CopilotProviderTests.swift
+++ b/Tests/OpenUsageTests/CopilotProviderTests.swift
@@ -471,6 +471,24 @@ final class CopilotProviderTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
     }
 
+    func testDiscoveryKeepsProbingPastAFailingOrg() async {
+        // One org's billing endpoint having an outage (5xx) must not abort discovery — the next org's
+        // usage should still be found and cached.
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
+            ("/user/orgs", okJSON([["login": "brokenorg"], ["login": "acme"]])),
+            ("/orgs/brokenorg/settings/billing/usage/summary", HTTPResponse(statusCode: 503, headers: [:], body: Data())),
+            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        ])
+        let defaults = freshDefaults()
+        let provider = makeOrgProvider(http: http, defaults: defaults)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNotNil(orgCount(snapshot.lines, "Org Credits"))
+        XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
+    }
+
     func testTransientBillingFailureKeepsCachedOrg() async {
         // A 5xx from the cached org's billing endpoint is a brief outage, not a stale org: the cache
         // must survive (no re-discovery), and the refresh degrades to the plan-only card.

--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -8,16 +8,21 @@ Tracks your GitHub Copilot quota using a GitHub token that Copilot tooling alrea
 |---|---|
 | Credits | Share of your monthly AI-credit allotment used (the headline meter) |
 | Extra Usage | Premium interactions used beyond your included credits, once extra spend is enabled |
+| Org Credits | AI credits your whole organization used this month (org-managed Business/Enterprise seats) |
+| Org Spend | Dollars your organization was billed for AI credits beyond the included pool |
 | Chat | Chat-message quota used |
 | Completions | Code-completion quota used |
 
-Credits and Extra Usage show above the fold; Chat and Completions sit under the "Shown on expand" caret. Each meter shows percent used and, when the response includes one, a countdown to the next reset. The plan name (Pro, Business, Free, …) shows next to the provider.
+Credits, Extra Usage, and Org Credits show above the fold; Org Spend, Chat, and Completions sit under the "Shown on expand" caret. Each meter shows percent used and, when the response includes one, a countdown to the next reset. The plan name (Pro, Business, Free, …) shows next to the provider.
 
 Since June 2026 GitHub Copilot bills all plans by **AI credits**, so what each account shows differs by plan:
 
 - **Paid plans** meter the credit pool — so you see Credits (and Extra Usage if you've turned on additional spend). Chat and completions are unlimited on paid plans, so those rows read "No data".
 - **Free plans** have no credits, so Credits reads "No data"; instead you see your fixed Chat and Completions counts under the caret.
-- **Copilot Business / token-based billing** returns no per-seat quota, so there's nothing to meter. The provider still shows the plan; the meters read "No data" rather than fabricating numbers.
+- **Org-managed seats (Copilot Business / Enterprise assigned by an organization)** return no per-seat quota, so the personal meters have nothing to show. OpenUsage then looks the usage up in the organization's billing instead: it lists your organizations, finds the one whose billing reports Copilot AI-credit usage, and shows **Org Credits** (credits the whole org used this month) and **Org Spend** (dollars billed beyond the included pool). Two caveats:
+  - The numbers are **organization-wide**, not your personal share — GitHub doesn't expose per-seat usage.
+  - Reading an org's billing requires you to be an **org owner or billing manager**. Regular members keep the previous behavior: the plan shows, the meters read "No data".
+- Org Credits is shown as a plain count, not a percentage: the billing API reports usage only, never the org's credit allotment, and OpenUsage doesn't fabricate a denominator.
 
 A dollar credit figure (e.g. "$12 of $15 used") isn't shown: GitHub only exposes that through its logged-in web billing page, which would require reading browser cookies — OpenUsage does not do that. Editors like VS Code show the same credit *percentage* from this endpoint, not a dollar amount.
 
@@ -44,8 +49,10 @@ Using Copilot in a supported editor is enough on its own — the editor writes t
 
 - **"Sign in to GitHub Copilot…"** — no token was found. Sign in to Copilot in your editor, or run `gh auth login`.
 - **"GitHub token invalid or expired"** — the token was rejected (401/403). Re-authenticate with `gh auth login`.
-- **Meters show "No data" but the plan is shown** — expected on Copilot Business / token-based-billing seats; GitHub doesn't expose per-seat quota for them.
+- **Meters show "No data" but the plan is shown** — expected on an org-managed Copilot Business/Enterprise seat when you aren't an owner or billing manager of the org (GitHub doesn't expose per-seat quota, and org billing is admin-only). If you *are* an org admin and still see no Org Credits, make sure your token can list your orgs — the GitHub CLI token from `gh auth login` can; some editor-plugin tokens can't.
 
 ## Under the hood
 
 `GET https://api.github.com/copilot_internal/user` with the standard Copilot client headers (API version `2025-04-01`). The response reports each bucket as percent *remaining*; the meters show percent *used*.
+
+For org-managed seats (identified by the token-based-billing placeholder in that response), the provider additionally calls the public REST billing API: `GET /user/orgs` to list your organizations, then `GET /orgs/{org}/settings/billing/usage/summary` per org until one reports Copilot AI-credit usage. The matching org is remembered, so steady-state refreshes make a single extra call; it's re-discovered automatically if it stops answering.

--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -13,7 +13,7 @@ Tracks your GitHub Copilot quota using a GitHub token that Copilot tooling alrea
 | Chat | Chat-message quota used |
 | Completions | Code-completion quota used |
 
-Credits, Extra Usage, and Org Credits show above the fold; Org Spend, Chat, and Completions sit under the "Shown on expand" caret. Each meter shows percent used and, when the response includes one, a countdown to the next reset. The plan name (Pro, Business, Free, …) shows next to the provider.
+Credits and Extra Usage show above the fold; Org Credits, Org Spend, Chat, and Completions sit under the "Shown on expand" caret. Each meter shows percent used and, when the response includes one, a countdown to the next reset. The plan name (Pro, Business, Free, …) shows next to the provider.
 
 Since June 2026 GitHub Copilot bills all plans by **AI credits**, so what each account shows differs by plan:
 


### PR DESCRIPTION
## TL;DR

Org-managed Copilot Business/Enterprise seats now show real usage: when the user-scoped endpoint returns only the token-based-billing placeholder, the provider looks the usage up in the organization's billing and shows **Org Credits** and **Org Spend**. Fixes #839.

## What was happening

- For a Copilot seat assigned by an organization, `GET /copilot_internal/user` reports the plan but every quota bucket is a zero-entitlement placeholder — there is no per-seat quota to show.
- The Copilot card therefore showed "Business" with all meters reading "No data", even though real AI-credit usage was visible in the org's GitHub Billing page (#839, follow-up to #803/#807).
- The real numbers live in the *organization* billing API, which the user-scoped endpoint never carries.

## What this changes

- New `CopilotOrgBillingClient`: `GET /user/orgs` + `GET /orgs/{org}/settings/billing/usage/summary` (public REST billing API, same GitHub token).
- New `CopilotOrgBillingMapper`: sums the summary's Copilot AI-credit items (`unitType` `ai-units`/`ai-credits`) into two new metric lines — **Org Credits** (credits the whole org used this month, an unbounded count) and **Org Spend** (dollars billed beyond the included pool, from `netAmount`).
- `CopilotProvider.refresh()` runs the org lookup only when the user endpoint returned the token-based-billing placeholder; personal plans make no extra calls. The matching org slug is cached in `UserDefaults`, so steady-state refreshes make a single extra request; the cache is evicted and re-discovered when the org stops answering with Copilot usage, and kept across transient failures (transport errors, 429, 5xx).
- Defaults: both metrics enabled; both below the "Shown on expand" caret; nothing newly pinned.
- Docs: `docs/providers/copilot.md` documents the new metrics, the admin-permission requirement, and the endpoints.

## Heads-up

- **Org-wide numbers, not per-seat.** GitHub doesn't expose per-seat usage for org-managed Copilot; the metrics are labeled "Org …" and documented accordingly.
- **Admin-only by API design.** Reading org billing requires an org owner or billing manager; a plain member's 403 degrades to the previous plan-only card (logged, never an error card). Same for tokens that can't list orgs (some editor-plugin tokens lack `read:org`; the `gh` CLI token has it).
- **No percentage meter.** The billing API reports usage only, never the org's credit allotment, so Org Credits is an honest count instead of a fabricated percentage.
- Built against the exact response shapes documented in #839 (we don't have an org account to test live); the reporter should verify on this build before release.

## Tests

- Mapper: org-list parsing, the #839 summary fixture, multi-item credit/spend summation, non-credit items (seat fees, Actions) excluded, no-Copilot summaries → `nil`.
- Provider: org discovery + caching, cached-org fast path (no re-listing), stale-cache eviction and re-probe, 403 → plan-only card without error, 5xx keeps the cache, personal plans make no org calls.
- Full suite: 827 tests, 0 failures.

Made with [Cursor](https://cursor.com)
