### PR TITLE
fix(copilot): don't let a placeholder Extra Usage row block the org billing lookup

### DIFF
--- a/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
@@ -70,11 +70,12 @@ final class CopilotProvider: ProviderRuntime {
 
             let mapped = try CopilotUsageMapper.map(response)
 
-            // An org-managed (token-based-billing) seat has no per-seat quota, so the mapper returns no
-            // lines; the real usage lives in the org's billing. Look it up there — best-effort: an org
-            // admin sees Org Credits / Org Spend, everyone else keeps the plan-only card as before.
+            // An org-managed (token-based-billing) seat has no per-seat quota, so the real usage lives
+            // in the org's billing. Look it up there — best-effort: an org admin sees Org Credits /
+            // Org Spend, everyone else keeps the plan-only card as before. Gated on the mapper's
+            // explicit flag, never on `lines` being empty (issue #839).
             var lines = mapped.lines
-            if lines.isEmpty {
+            if mapped.isOrgManagedSeat {
                 lines = await orgBillingLines(token: token.value)
             }
 

--- a/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
@@ -3,11 +3,18 @@ import Foundation
 struct CopilotMappedUsage: Equatable, Sendable {
     var plan: String?
     var lines: [MetricLine]
+    /// True for an org-managed (token-based-billing) seat whose response carried no usable per-seat
+    /// meters — the signal that the real usage lives in *organization* billing, where the provider
+    /// should look next. Kept as an explicit flag so the org lookup is never gated on the incidental
+    /// shape of `lines` (see issue #839: a placeholder `overage_permitted` used to sneak an
+    /// "Extra Usage: 0" row in and block the lookup).
+    var isOrgManagedSeat: Bool = false
 }
 
 /// Normalizes the `/copilot_internal/user` response into meters. Since 2026-06-01 every plan is on
 /// usage-based billing (AI Credits), so the `premium_interactions` bucket is surfaced as **Credits**
-/// (used % of the monthly allotment), with **Extra Usage** carrying overage beyond it. Paid plans report
+/// (used % of the monthly allotment), with **Extra Usage** carrying overage beyond it (emitted only
+/// alongside a real Credits meter — overage is meaningless without an included pool). Paid plans report
 /// `chat`/`completions` as the `-1` "unlimited" sentinel (suppressed); free plans carry real `chat` and
 /// `completions` counts — either inside `quota_snapshots` (current) or, on older responses, as
 /// `limited_user_quotas` against `monthly_quotas`. Zero-entitlement placeholder snapshots — what GitHub
@@ -30,11 +37,17 @@ enum CopilotUsageMapper {
 
         var lines: [MetricLine] = []
 
-        // The metered premium pool is shown as "Credits"; overage beyond it as "Extra Usage".
+        // The metered premium pool is shown as "Credits"; overage beyond it as "Extra Usage". Extra
+        // Usage only exists relative to an included pool, so it's tied to the Credits meter: an
+        // org-managed placeholder can carry `overage_permitted: true` on a zero-entitlement bucket,
+        // and rendering "0" for it would be meaningless (and used to block the org-billing fallback).
         let snapshots = body["quota_snapshots"] as? [String: Any]
         let premium = snapshots?["premium_interactions"]
-        appendIfPresent(&lines, snapshotLine(label: "Credits", premium, resetsAt: resetsAt))
-        appendIfPresent(&lines, overageLine(premium))
+        let creditsLine = snapshotLine(label: "Credits", premium, resetsAt: resetsAt)
+        appendIfPresent(&lines, creditsLine)
+        if creditsLine != nil {
+            appendIfPresent(&lines, overageLine(premium))
+        }
 
         // Chat + completions: real per-bucket counts on free; the `-1` "unlimited" sentinel on paid
         // (suppressed by `snapshotLine`). Older free responses without `quota_snapshots` fall back to
@@ -59,7 +72,7 @@ enum CopilotUsageMapper {
         // or garbled payload (no token-based-billing marker) is a real problem and fails loudly.
         guard !lines.isEmpty else {
             if readBool(body["token_based_billing"]) == true {
-                return CopilotMappedUsage(plan: plan, lines: [])
+                return CopilotMappedUsage(plan: plan, lines: [], isOrgManagedSeat: true)
             }
             throw CopilotUsageError.quotaUnavailable
         }

--- a/Tests/OpenUsageTests/CopilotProviderTests.swift
+++ b/Tests/OpenUsageTests/CopilotProviderTests.swift
@@ -281,6 +281,44 @@ final class CopilotUsageMapperTests: XCTestCase {
 
         XCTAssertEqual(mapped.plan, "Business")
         XCTAssertTrue(mapped.lines.isEmpty)
+        XCTAssertTrue(mapped.isOrgManagedSeat)
+    }
+
+    func testPlaceholderOveragePermittedDoesNotEmitExtraUsageOrBlockOrgFlag() throws {
+        // Regression for issue #839's second report: the org-managed placeholder carries
+        // `overage_permitted: true` on a zero-entitlement premium bucket. That must not render a
+        // meaningless "Extra Usage: 0" row — and must still flag the seat as org-managed so the
+        // provider runs the org-billing lookup.
+        var body: [String: Any] = [
+            "copilot_plan": "business",
+            "token_based_billing": true,
+            "quota_snapshots": [
+                "premium_interactions": [
+                    "entitlement": 0, "remaining": 0, "unlimited": true,
+                    "overage_permitted": true, "overage_count": 0, "token_based_billing": true
+                ]
+            ]
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
+        XCTAssertTrue(mapped.lines.isEmpty)
+        XCTAssertTrue(mapped.isOrgManagedSeat)
+
+        // A paid account with a real credit pool keeps its Extra Usage row.
+        body = makePaidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        var premium = quota["premium_interactions"] as! [String: Any]
+        premium["overage_permitted"] = true
+        premium["overage_count"] = 12
+        quota["premium_interactions"] = premium
+        body["quota_snapshots"] = quota
+
+        let paid = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(countValue(paid.lines, "Extra Usage"), 12)
+        XCTAssertFalse(paid.isOrgManagedSeat)
     }
 
     func testThrowsQuotaUnavailableWhenEmpty() {
@@ -414,6 +452,8 @@ final class CopilotProviderTests: XCTestCase {
         XCTAssertEqual(snapshot.plan, "Business")
         XCTAssertEqual(orgCount(snapshot.lines, "Org Credits") ?? -1, 298.698546, accuracy: 0.0001)
         XCTAssertEqual(orgDollars(snapshot.lines, "Org Spend"), 0)
+        // The placeholder's `overage_permitted: true` must not leave a meaningless Extra Usage row.
+        XCTAssertNil(snapshot.lines.first(where: { $0.label == "Extra Usage" }))
         XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
     }
 
@@ -555,14 +595,26 @@ private func routedClient(_ routes: [(substring: String, response: HTTPResponse)
     }
 }
 
-/// The `/copilot_internal/user` shape of an org-managed Copilot Business seat (issue #839): plan is
-/// reported but every quota bucket is a zero-entitlement token-based-billing placeholder.
+/// The exact `/copilot_internal/user` shape of an org-managed Copilot Business seat from issue #839:
+/// plan is reported but every quota bucket is a zero-entitlement token-based-billing placeholder.
+/// Crucially, the premium bucket carries `overage_permitted: true` — the field that used to sneak an
+/// "Extra Usage: 0" row into the mapped lines and block the org-billing fallback.
 private func makeBusinessPlaceholderBody() -> [String: Any] {
-    [
+    func bucket(_ id: String, overagePermitted: Bool) -> [String: Any] {
+        [
+            "overage_count": 0, "overage_entitlement": 0, "overage_permitted": overagePermitted,
+            "percent_remaining": 100.0, "quota_id": id, "quota_remaining": 0.0, "unlimited": true,
+            "has_quota": true, "quota_reset_at": 0, "token_based_billing": true,
+            "remaining": 0, "entitlement": 0
+        ]
+    }
+    return [
         "copilot_plan": "business",
         "token_based_billing": true,
         "quota_snapshots": [
-            "premium_interactions": ["entitlement": 0, "remaining": 0, "unlimited": true, "token_based_billing": true]
+            "chat": bucket("chat", overagePermitted: false),
+            "completions": bucket("completions", overagePermitted: false),
+            "premium_interactions": bucket("premium_interactions", overagePermitted: true)
         ]
     ]
 }


### PR DESCRIPTION
## TL;DR

Follow-up to #843: the org-billing lookup for org-managed Copilot seats never ran for the #839 reporter because his placeholder response sneaks an "Extra Usage: 0" row into the mapped lines, and the lookup was gated on the lines being empty. The gate is now an explicit mapper flag, and the meaningless placeholder row is suppressed.

## What was happening

- The reporter tested the #843 beta and still saw Org Credits / Org Spend as "No data", with no `GET /user/orgs` in the logs.
- His `premium_interactions` placeholder carries `overage_permitted: true` (with zero entitlement and `unlimited: true`), so the mapper emitted "Extra Usage: 0".
- That made `mapped.lines` non-empty, so the `lines.isEmpty` gate skipped the org-billing fallback entirely — his own diagnosis in the issue, confirmed in code.
- The #843 test fixture didn't set `overage_permitted`, which is why the tests passed while the real payload failed.

## What this changes

- Extra Usage is emitted only alongside a real Credits meter — overage is meaningless without an included pool, so the zero-entitlement placeholder no longer renders a misleading "0".
- `CopilotUsageMapper` now returns an explicit `isOrgManagedSeat` flag (token-based billing + no usable per-seat meters), and `CopilotProvider` gates the org lookup on that flag instead of the incidental shape of the lines array.
- The Business-placeholder test fixture is now the reporter's exact payload (all three buckets, `overage_permitted: true` on premium), so every org-path test exercises the regression; plus dedicated mapper tests for the placeholder-suppression and the flag.

## Tests

- New: placeholder with `overage_permitted: true` → no Extra Usage row, `isOrgManagedSeat` true, org lookup runs end-to-end; paid accounts with a real pool keep their Extra Usage row.
- Full suite: 842 tests, 0 failures.

Made with [Cursor](https://cursor.com)