### PR TITLE
fix(claude): surface rate-limited state as a header warning instead of a silent blank

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -119,6 +119,9 @@ final class ClaudeProvider: ProviderRuntime {
         switch authStore.liveUsageAvailability(state) {
         case .available:
             mapped = try await fetchLiveUsage(state: &state)
+            // A rate-limited fetch rides its "Updates blocked by Anthropic" notice on the mapped usage so
+            // it reaches the header triangle even when the badge/note lines aren't in the user's layout.
+            warning = mapped.warning
         case .missingProfileScope:
             // The login authenticates for inference but lacks the `user:profile` scope the usage endpoint
             // needs (typically a `claude setup-token` token). Don't leave the session/weekly bars silently
@@ -203,6 +206,7 @@ final class ClaudeProvider: ProviderRuntime {
             return ClaudeUsageMapper.rateLimitedUsage(credentials: credentials, retryAfterSeconds: retryAfterSeconds)
         }
         mapped.lines.append(ClaudeUsageMapper.rateLimitedNote(retryAfterSeconds: retryAfterSeconds))
+        mapped.warning = ClaudeUsageMapper.rateLimitedWarning(retryAfterSeconds: retryAfterSeconds)
         return mapped
     }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageMapper.swift
@@ -3,6 +3,9 @@ import Foundation
 struct ClaudeMappedUsage: Equatable, Sendable {
     var plan: String?
     var lines: [MetricLine]
+    /// Provider header notice (amber triangle + tooltip) riding along with this usage, e.g. the
+    /// rate-limited warning. `nil` for a clean fetch.
+    var warning: String?
 }
 
 enum ClaudeUsageMapper {
@@ -43,8 +46,19 @@ enum ClaudeUsageMapper {
             lines: [
                 .badge(label: "Status", text: waitText, colorHex: "#F59E0B"),
                 rateLimitedNote(retryAfterSeconds: retryAfterSeconds)
-            ]
+            ],
+            warning: rateLimitedWarning(retryAfterSeconds: retryAfterSeconds)
         )
+    }
+
+    /// Provider header warning (the amber triangle + tooltip) for the rate-limited state. The badge/note
+    /// lines above only render when their metrics are enabled in the layout, so without this the default
+    /// dashboard showed bare "No data" rows with no hint of why. Also warns the
+    /// user off manual refreshes, which extend Anthropic's rate limiting.
+    static func rateLimitedWarning(retryAfterSeconds: Int?) -> String {
+        let base = "Updates blocked by Anthropic. Be patient — manual refreshes will make it worse."
+        guard let retryText = retryAfterSeconds.map(formatRateLimitMinutes) else { return base }
+        return "\(base) Retrying in ~\(retryText)."
     }
 
     /// Provider warning shown on the Claude header (the amber triangle + tooltip, like Z.ai's "no coding

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -617,6 +617,12 @@ final class ClaudeProviderTests: XCTestCase {
 
         XCTAssertEqual(snapshot.plan, "Pro")
         XCTAssertEqual(badge(snapshot.lines, "Status")?.hasPrefix("Rate limited"), true)
+        // The badge/note lines only render when enabled in the layout, so the state must also reach the
+        // provider header warning (amber triangle) — without it the default dashboard is silently blank.
+        XCTAssertEqual(
+            snapshot.warning,
+            "Updates blocked by Anthropic. Be patient — manual refreshes will make it worse. Retrying in ~10m."
+        )
     }
 
     func testRateLimitServesLastGoodUsageThenBacksOff() async {
@@ -654,20 +660,25 @@ final class ClaudeProviderTests: XCTestCase {
             pricing: { TestPricing.bundled }
         )
 
-        // 1) Live fetch succeeds and is cached.
+        // 1) Live fetch succeeds and is cached; no warning rides along.
         let first = await provider.refresh()
         XCTAssertEqual(Self.progress(first.lines, "Session")?.used, 25)
+        XCTAssertNil(first.warning)
 
-        // 2) 429: still shows the cached Session bar plus the staleness note, not a bare "Status" badge.
+        // 2) 429: still shows the cached Session bar plus the staleness note, not a bare "Status" badge —
+        // and the header warning flags the rate-limited state even when the note line isn't in the layout.
         let second = await provider.refresh()
         XCTAssertEqual(Self.progress(second.lines, "Session")?.used, 25)
         XCTAssertEqual(text(second.lines, "Note")?.contains("rate limited"), true)
         XCTAssertNil(badge(second.lines, "Status"))
+        XCTAssertEqual(second.warning?.hasPrefix("Updates blocked by Anthropic"), true)
 
-        // 3) Within the cooldown the live call is skipped entirely; the cached bar is still shown.
+        // 3) Within the cooldown the live call is skipped entirely; the cached bar is still shown and the
+        // warning persists.
         clock.set(t0.addingTimeInterval(60))
         let third = await provider.refresh()
         XCTAssertEqual(Self.progress(third.lines, "Session")?.used, 25)
+        XCTAssertEqual(third.warning?.hasPrefix("Updates blocked by Anthropic"), true)
         XCTAssertEqual(httpClient.requests.filter { $0.url.absoluteString.hasSuffix("/api/oauth/usage") }.count, 2)
     }
 

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -33,7 +33,7 @@ Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the C
 - **"Not logged in"** — run `claude` and sign in, then refresh.
 - **"Signed in to the Claude desktop app?"** — a login done only in the Claude desktop app is stored encrypted in a way OpenUsage can't read. Run `claude` in a terminal and sign in once; both logins coexist, and OpenUsage picks up the CLI one.
 - **"Re-login for live usage"** (an amber warning on the Claude header) — your saved login can authenticate for inference but can't read your subscription limits, because it lacks the `user:profile` access (this is what an inference-only token from `claude setup-token` carries). Run `claude` and sign in again with your Claude account, then refresh; the spend tiles keep working in the meantime.
-- **"Rate limited, retry in ~Nm"** — the usage API is throttling; OpenUsage shows when to expect data again and keeps your last values.
+- **"Updates blocked by Anthropic"** (an amber warning on the Claude header) — the usage API is throttling OpenUsage. It keeps your last values, shows when it will retry, and backs off in the meantime — manual refreshes only extend the block, so the best fix is patience.
 - **Spend tiles show "No data"** — OpenUsage found no Claude Code logs in the last 30 days. If your logs live somewhere custom, set `CLAUDE_CONFIG_DIR` so both Claude Code and OpenUsage look in the same place.
 
 ## Under the hood


### PR DESCRIPTION
## TL;DR
When Anthropic rate-limits the usage endpoint, the Claude widget went silently blank ("No data" everywhere, refresh reported ok). It now shows the amber header warning.

## What was happening
- On a 429, the provider returned a snapshot with only `Status`/`Note` lines. Those labels match no widget descriptor, so the dashboard dropped them.
- The refresh counted as successful, so no header triangle appeared and the blank snapshot was cached for the TTL.
- A user report (log + screenshot) showed exactly this: all Claude bars "No data" with zero explanation while Anthropic was throttling.

## What this changes
- `ClaudeMappedUsage` carries an optional `warning`; both rate-limited paths (fresh 429 and the cooldown short-circuit) set it, and `probe` passes it into the snapshot so the existing amber header triangle renders it regardless of the user's metric layout.
- Copy: "Updates blocked by Anthropic. Be patient — manual refreshes will make it worse." plus "Retrying in ~Nm." when Retry-After is known.
- Last-good bars keep showing during the cooldown (unchanged), now with the persistent warning instead of silence.
- Updated the rate-limit entry in `docs/providers/claude.md`.

## Tests
- Extended `testRateLimitedResponseMapsToRetryBadgeNotError` (asserts the exact warning copy on the badge-only snapshot).
- Extended `testRateLimitServesLastGoodUsageThenBacksOff` (warning appears on 429, persists through cooldown, absent on a clean fetch).
- Full suite: 841 tests, 0 failures. Bugbot review: no findings.

Made with [Cursor](https://cursor.com)