### PR TITLE
[codex] Add Codex multi-account support

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -6,9 +6,11 @@ import Observation
 @MainActor
 @Observable
 final class AppContainer {
-    let registry: WidgetRegistry
+    var registry: WidgetRegistry
     let layout: LayoutStore
     let dataStore: WidgetDataStore
+    let codexAccounts: CodexAccountStore
+    let codexOAuth: CodexOAuthCoordinator
     /// Single source of truth for which providers the user has turned off. Both stores consult it (via
     /// injected closures) and the Providers settings tab drives it.
     let enablement: ProviderEnablementStore
@@ -38,6 +40,7 @@ final class AppContainer {
     /// The new-provider credential-detection pass (see `NewProviderSeeder`); `nil` unless this launch is
     /// the first with a provider the install has never seen.
     private let newProviderTask: Task<Void, Never>?
+    private var providers: [ProviderRuntime]
 
     /// `isFreshInstall` must be captured by the caller BEFORE `SettingsMigrator.migrate()` runs (the
     /// migrator's schema stamp makes the defaults domain non-empty). See `AppDelegate`.
@@ -52,23 +55,18 @@ final class AppContainer {
         // order is the default provider order (`LayoutStore.orderedProviderIDs` falls back to it, and
         // `resetToDefault` seeds it), so the dashboard, Customize sections, and the per-provider reset
         // menu all read this way.
-        let providers: [ProviderRuntime] = [
-            ClaudeProvider(),
-            CodexProvider(),
-            CursorProvider(),
-            AntigravityProvider(),
-            CopilotProvider(),
-            DevinProvider(),
-            GrokProvider(),
-            OpenRouterProvider(),
-            ZAIProvider()
-        ]
+        let codexAccounts = CodexAccountStore()
+        let providers = Self.makeProviders(codexAccounts: codexAccounts)
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
         let enablement = ProviderEnablementStore()
         let notificationSettings = NotificationSettingsStore()
         let layout = LayoutStore(
             registry: registry,
+            defaultMetricIDs: Self.defaultMetricIDs(for: providers),
+            migrationBaselineMetricIDs: DefaultLayout.migrationBaselineMetricIDs,
+            defaultPinnedMetricIDs: Self.defaultPinnedMetricIDs(for: providers),
+            defaultExpandedMetricIDs: Self.defaultExpandedMetricIDs(for: providers),
             isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
         )
         let dataStore = WidgetDataStore(
@@ -98,7 +96,10 @@ final class AppContainer {
             enablement: enablement
         )
         self.onboarding = onboarding
+        self.codexAccounts = codexAccounts
+        self.codexOAuth = CodexOAuthCoordinator(accountStore: codexAccounts)
         self.registry = registry
+        self.providers = providers
         self.enablement = enablement
         self.apiKeyProviders = apiKeyProviders
         self.notificationSettings = notificationSettings
@@ -148,6 +149,90 @@ final class AppContainer {
         // effectively always is. Notification authorization is requested the first time a trigger is
         // turned on (from Settings), not at launch — triggers default off. No-op under tests.
         AppNotifications.shared.registerAsDelegate()
+    }
+
+    func reloadCodexAccounts(forgetRemoved removedProviderID: String? = nil) {
+        let nextProviders = Self.makeProviders(codexAccounts: codexAccounts)
+        let nextRegistry = WidgetRegistry.from(nextProviders)
+        let currentIDs = Set(registry.providers.map(\.id))
+        let nextIDs = Set(nextRegistry.providers.map(\.id))
+        registry = nextRegistry
+        providers = nextProviders
+        layout.updateRegistry(
+            nextRegistry,
+            defaultMetricIDs: Self.defaultMetricIDs(for: nextProviders),
+            migrationBaselineMetricIDs: DefaultLayout.migrationBaselineMetricIDs,
+            defaultPinnedMetricIDs: Self.defaultPinnedMetricIDs(for: nextProviders),
+            defaultExpandedMetricIDs: Self.defaultExpandedMetricIDs(for: nextProviders)
+        )
+        dataStore.updateRegistry(nextRegistry, providers: nextProviders)
+        let added = nextIDs.subtracting(currentIDs)
+        if !added.isEmpty {
+            enablement.registerKnownProviders(added)
+            for id in added {
+                enablement.setEnabled(true, for: id)
+            }
+        }
+        if let removedProviderID {
+            dataStore.forgetProvider(removedProviderID)
+        }
+    }
+
+    private static func makeProviders(codexAccounts: CodexAccountStore) -> [ProviderRuntime] {
+        let codexProviders = codexAccounts.accountContexts().map { context in
+            CodexProvider(
+                providerID: context.record.providerID,
+                displayName: context.record.displayName,
+                authStore: context.authStore,
+                logUsageScanner: context.logUsageScanner
+            )
+        }
+        return [
+            ClaudeProvider()
+        ] + codexProviders + [
+            CursorProvider(),
+            AntigravityProvider(),
+            CopilotProvider(),
+            DevinProvider(),
+            GrokProvider(),
+            OpenRouterProvider(),
+            ZAIProvider()
+        ]
+    }
+
+    private static func defaultMetricIDs(for providers: [ProviderRuntime]) -> [String] {
+        var ids = DefaultLayout.metricIDs
+        for provider in providers where provider.provider.id.hasPrefix("codex.") {
+            ids.append(contentsOf: provider.widgetDescriptors.map(\.id))
+        }
+        return ids
+    }
+
+    private static func defaultExpandedMetricIDs(for providers: [ProviderRuntime]) -> [String] {
+        var ids = DefaultLayout.expandedMetricIDs
+        for provider in providers where provider.provider.id.hasPrefix("codex.") {
+            ids.append(contentsOf: [
+                "\(provider.provider.id).spark",
+                "\(provider.provider.id).sparkWeekly",
+                "\(provider.provider.id).credits",
+                "\(provider.provider.id).rateLimitResets",
+                "\(provider.provider.id).today",
+                "\(provider.provider.id).yesterday",
+                "\(provider.provider.id).last30"
+            ])
+        }
+        return ids
+    }
+
+    private static func defaultPinnedMetricIDs(for providers: [ProviderRuntime]) -> [String] {
+        var ids = DefaultLayout.pinnedMetricIDs
+        for provider in providers where provider.provider.id.hasPrefix("codex.") {
+            ids.append(contentsOf: [
+                "\(provider.provider.id).session",
+                "\(provider.provider.id).credits"
+            ])
+        }
+        return ids
     }
 
     deinit {

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -225,7 +225,11 @@ struct WidgetData: Hashable {
             }
             return MetricFormatter.number(displayedValue, kind: kind, style: .tray)
         }
-        if let first = selectedValues.first {
+        let selected = selectedValues
+        if selected.count > 1 {
+            return selected.map { MetricFormatter.string(for: $0, style: .tray) }.joined(separator: " · ")
+        }
+        if let first = selected.first {
             if title == "Rate Limit Resets", first.kind == .count {
                 return "\(MetricFormatter.number(first.number, kind: .count, style: .tray)) resets"
             }

--- a/Sources/OpenUsage/Providers/Codex/CodexAccountStore.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexAccountStore.swift
@@ -1,0 +1,319 @@
+import Foundation
+import Observation
+
+struct CodexAccountRecord: Codable, Hashable, Identifiable, Sendable {
+    enum Source: String, Codable, Sendable {
+        case managed
+        case cliFile
+        case cliKeychain
+    }
+
+    var id: String
+    var identity: String
+    var providerID: String
+    var displayName: String
+    var source: Source
+    var keychainService: String?
+    var authPath: String?
+    var hidden: Bool
+}
+
+struct CodexAccountContext: Sendable {
+    var record: CodexAccountRecord
+    var authStore: CodexAuthStore
+    var logUsageScanner: CodexLogUsageScanner
+}
+
+@MainActor
+@Observable
+final class CodexAccountStore {
+    private static let metadataKey = "openusage.codex.accounts.v1"
+    private static let hiddenCLIKey = "openusage.codex.hiddenCLIIdentities.v1"
+    private static let managedKeychainPrefix = "OpenUsage Codex Account"
+
+    private let defaults: UserDefaults
+    private let keychain: KeychainAccessing
+    private let environment: EnvironmentReading
+    private let files: TextFileAccessing
+    private let homeDirectory: @Sendable () -> URL
+
+    private(set) var managedAccounts: [CodexAccountRecord]
+    private(set) var lastError: String?
+
+    init(
+        defaults: UserDefaults = .standard,
+        keychain: KeychainAccessing = SecurityKeychainAccessor(),
+        environment: EnvironmentReading = ProcessEnvironmentReader(),
+        files: TextFileAccessing = LocalTextFileAccessor(),
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser }
+    ) {
+        self.defaults = defaults
+        self.keychain = keychain
+        self.environment = environment
+        self.files = files
+        self.homeDirectory = homeDirectory
+        self.managedAccounts = Self.decodeManagedAccounts(from: defaults)
+    }
+
+    func accountContexts() -> [CodexAccountContext] {
+        let visibleManaged = managedAccounts.filter { !$0.hidden }
+        let cliRecords = discoverCLIAccounts(hiddenIdentities: hiddenCLIIdentities())
+        var records = Self.mergeAndAssignProviderIDs(managed: visibleManaged, cli: cliRecords)
+        if records.isEmpty {
+            records = [CodexAccountRecord(
+                id: "default",
+                identity: "default",
+                providerID: "codex",
+                displayName: "Codex",
+                source: .cliFile,
+                keychainService: nil,
+                authPath: nil,
+                hidden: false
+            )]
+        }
+        return records.map { record in
+            CodexAccountContext(
+                record: record,
+                authStore: authStore(for: record),
+                logUsageScanner: logScanner(for: record)
+            )
+        }
+    }
+
+    func visibleRecords() -> [CodexAccountRecord] {
+        accountContexts().map(\.record)
+    }
+
+    func settingsRecords() -> [CodexAccountRecord] {
+        Self.mergeAndAssignProviderIDs(
+            managed: managedAccounts.filter { !$0.hidden },
+            cli: discoverCLIAccounts(hiddenIdentities: hiddenCLIIdentities())
+        )
+    }
+
+    func saveManagedAuth(_ auth: CodexAuth) throws -> CodexAccountRecord {
+        let identity = Self.identity(for: auth) ?? "local-\(UUID().uuidString)"
+        let service = Self.managedService(identity: identity)
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(auth)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw CodexAuthError.invalidAuthPayload
+        }
+        try keychain.writeGenericPassword(service: service, value: text)
+
+        var next = managedAccounts
+        if let index = next.firstIndex(where: { $0.identity == identity }) {
+            next[index].hidden = false
+            next[index].keychainService = service
+        } else {
+            let displayName = next.isEmpty ? "Codex" : "Codex \(next.count + 1)"
+            next.append(CodexAccountRecord(
+                id: identity,
+                identity: identity,
+                providerID: "",
+                displayName: displayName,
+                source: .managed,
+                keychainService: service,
+                authPath: nil,
+                hidden: false
+            ))
+        }
+        managedAccounts = next
+        persistManagedAccounts()
+        lastError = nil
+        return managedAccounts.first { $0.identity == identity }!
+    }
+
+    func rename(_ record: CodexAccountRecord, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let index = managedAccounts.firstIndex(where: { $0.identity == record.identity })
+        else { return }
+        managedAccounts[index].displayName = trimmed
+        persistManagedAccounts()
+    }
+
+    func removeManaged(_ record: CodexAccountRecord) {
+        guard record.source == .managed else { return }
+        do {
+            if let service = record.keychainService {
+                try keychain.deleteGenericPassword(service: service)
+            }
+            managedAccounts.removeAll { $0.identity == record.identity }
+            persistManagedAccounts()
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+            AppLog.error(LogTag.auth("codex"), "failed to remove managed Codex account: \(error.localizedDescription)")
+        }
+    }
+
+    func hideCLI(_ record: CodexAccountRecord) {
+        guard record.source != .managed else { return }
+        var hidden = hiddenCLIIdentities()
+        hidden.insert(record.identity)
+        defaults.set(Array(hidden).sorted(), forKey: Self.hiddenCLIKey)
+    }
+
+    private func authStore(for record: CodexAccountRecord) -> CodexAuthStore {
+        switch record.source {
+        case .managed:
+            return CodexAuthStore(
+                environment: environment,
+                files: files,
+                keychain: keychain,
+                authPathsOverride: [],
+                keychainService: record.keychainService ?? Self.managedService(identity: record.identity)
+            )
+        case .cliFile:
+            guard let authPath = record.authPath else {
+                return CodexAuthStore(environment: environment, files: files, keychain: keychain)
+            }
+            return CodexAuthStore(
+                environment: environment,
+                files: files,
+                keychain: keychain,
+                authPathsOverride: [authPath],
+                keychainService: "__unused__"
+            )
+        case .cliKeychain:
+            return CodexAuthStore(
+                environment: environment,
+                files: files,
+                keychain: keychain,
+                authPathsOverride: [],
+                keychainService: CodexAuthStore.defaultKeychainService
+            )
+        }
+    }
+
+    private func logScanner(for record: CodexAccountRecord) -> CodexLogUsageScanner {
+        if record.source == .cliFile, let path = record.authPath {
+            let home = URL(fileURLWithPath: path).deletingLastPathComponent()
+            return CodexLogUsageScanner(homesOverride: [home])
+        }
+        return CodexLogUsageScanner(environment: environment, homeDirectory: homeDirectory)
+    }
+
+    private func discoverCLIAccounts(hiddenIdentities: Set<String>) -> [CodexAccountRecord] {
+        let store = CodexAuthStore(environment: environment, files: files, keychain: keychain)
+        let (fileCandidates, _) = store.loadAuthCandidates()
+        var records: [CodexAccountRecord] = []
+        for candidate in fileCandidates where candidate.hasUsableAccessToken {
+            guard let identity = Self.identity(for: candidate.auth),
+                  !hiddenIdentities.contains(identity)
+            else { continue }
+            let path: String?
+            if case .file(let value) = candidate.source { path = value } else { path = nil }
+            records.append(CodexAccountRecord(
+                id: identity,
+                identity: identity,
+                providerID: "",
+                displayName: "Codex",
+                source: .cliFile,
+                keychainService: nil,
+                authPath: path,
+                hidden: false
+            ))
+        }
+        if let keychainState = store.loadKeychainAuth(),
+           keychainState.hasUsableAccessToken,
+           let identity = Self.identity(for: keychainState.auth),
+           !hiddenIdentities.contains(identity) {
+            records.append(CodexAccountRecord(
+                id: identity,
+                identity: identity,
+                providerID: "",
+                displayName: "Codex",
+                source: .cliKeychain,
+                keychainService: CodexAuthStore.defaultKeychainService,
+                authPath: nil,
+                hidden: false
+            ))
+        }
+        return records
+    }
+
+    private static func mergeAndAssignProviderIDs(
+        managed: [CodexAccountRecord],
+        cli: [CodexAccountRecord]
+    ) -> [CodexAccountRecord] {
+        var merged: [CodexAccountRecord] = []
+        var seen = Set<String>()
+        let managedByIdentity = Dictionary(uniqueKeysWithValues: managed.map { ($0.identity, $0) })
+        for record in cli {
+            let preferred = managedByIdentity[record.identity] ?? record
+            guard !seen.contains(preferred.identity) else { continue }
+            seen.insert(preferred.identity)
+            merged.append(preferred)
+        }
+        for record in managed where !seen.contains(record.identity) {
+            seen.insert(record.identity)
+            merged.append(record)
+        }
+        return merged.enumerated().map { index, record in
+            var copy = record
+            copy.providerID = index == 0 ? "codex" : "codex.\(shortHash(record.identity))"
+            if copy.displayName == "Codex", index > 0 {
+                copy.displayName = "Codex \(index + 1)"
+            }
+            return copy
+        }
+    }
+
+    static func identity(for auth: CodexAuth) -> String? {
+        if let accountID = auth.tokens?.accountID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !accountID.isEmpty {
+            return "account:\(accountID)"
+        }
+        if let idToken = auth.tokens?.idToken,
+           let sub = ProviderParse.jwtPayload(idToken)?["sub"] as? String,
+           !sub.isEmpty {
+            return "sub:\(sub)"
+        }
+        if let accessToken = auth.tokens?.accessToken,
+           let sub = ProviderParse.jwtPayload(accessToken)?["sub"] as? String,
+           !sub.isEmpty {
+            return "access-sub:\(sub)"
+        }
+        return nil
+    }
+
+    private func hiddenCLIIdentities() -> Set<String> {
+        Set(defaults.stringArray(forKey: Self.hiddenCLIKey) ?? [])
+    }
+
+    private func persistManagedAccounts() {
+        do {
+            defaults.set(try JSONEncoder().encode(managedAccounts), forKey: Self.metadataKey)
+        } catch {
+            AppLog.warn(.config, "failed to persist Codex accounts: \(error.localizedDescription)")
+        }
+    }
+
+    private static func decodeManagedAccounts(from defaults: UserDefaults) -> [CodexAccountRecord] {
+        guard let data = defaults.data(forKey: metadataKey) else { return [] }
+        do {
+            return try JSONDecoder().decode([CodexAccountRecord].self, from: data)
+        } catch {
+            AppLog.warn(.config, "saved Codex accounts failed to decode: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    private static func managedService(identity: String) -> String {
+        "\(managedKeychainPrefix) \(shortHash(identity))"
+    }
+
+    private static func shortHash(_ value: String) -> String {
+        String(value.utf8.reduce(UInt64(14_695_981_039_346_656_037)) { hash, byte in
+            (hash ^ UInt64(byte)) &* 1_099_511_628_211
+        }, radix: 16)
+    }
+}
+
+private func shortHash(_ value: String) -> String {
+    String(value.utf8.reduce(UInt64(14_695_981_039_346_656_037)) { hash, byte in
+        (hash ^ UInt64(byte)) &* 1_099_511_628_211
+    }, radix: 16)
+}

--- a/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
@@ -82,7 +82,7 @@ enum CodexAuthError: Error, LocalizedError, Equatable {
 }
 
 struct CodexAuthStore: Sendable {
-    static let keychainService = "Codex Auth"
+    static let defaultKeychainService = "Codex Auth"
     /// Refresh once the access token is within this window of its JWT `exp` — the same 5-minute slack
     /// the `codex` CLI itself uses, so OpenUsage rotates on the same schedule rather than guessing.
     static let accessTokenRefreshWindow: TimeInterval = 5 * 60
@@ -93,17 +93,23 @@ struct CodexAuthStore: Sendable {
     var files: TextFileAccessing
     var keychain: KeychainAccessing
     var now: @Sendable () -> Date
+    var authPathsOverride: [String]?
+    var keychainService: String
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
         files: TextFileAccessing = LocalTextFileAccessor(),
         keychain: KeychainAccessing = SecurityKeychainAccessor(),
-        now: @escaping @Sendable () -> Date = Date.init
+        now: @escaping @Sendable () -> Date = Date.init,
+        authPathsOverride: [String]? = nil,
+        keychainService: String = Self.defaultKeychainService
     ) {
         self.environment = environment
         self.files = files
         self.keychain = keychain
         self.now = now
+        self.authPathsOverride = authPathsOverride
+        self.keychainService = keychainService
     }
 
     func loadAuthCandidates() -> ([CodexAuthState], [String]) {
@@ -137,7 +143,7 @@ struct CodexAuthStore: Sendable {
     }
 
     func loadKeychainAuth() -> CodexAuthState? {
-        guard let value = try? keychain.readGenericPassword(service: Self.keychainService),
+        guard let value = try? keychain.readGenericPassword(service: keychainService),
               let auth = Self.parseAuth(value),
               Self.hasTokenLikeAuth(auth)
         else {
@@ -158,7 +164,7 @@ struct CodexAuthStore: Sendable {
         case .file(let path):
             try files.writeText(path, text)
         case .keychain:
-            try keychain.writeGenericPassword(service: Self.keychainService, value: text)
+            try keychain.writeGenericPassword(service: keychainService, value: text)
         }
     }
 
@@ -192,6 +198,9 @@ struct CodexAuthStore: Sendable {
     }
 
     func authPaths() -> [String] {
+        if let authPathsOverride {
+            return authPathsOverride
+        }
         if let codexHome = codexHome() {
             return [joinPath(codexHome, Self.authFile)]
         }
@@ -228,4 +237,3 @@ private extension CodexAuthState.Source {
         return false
     }
 }
-

--- a/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
@@ -27,13 +27,16 @@ import Foundation
 actor CodexLogUsageScanner {
     private let environment: EnvironmentReading
     private let homeDirectory: @Sendable () -> URL
+    private let homesOverride: [URL]?
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
-        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser }
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        homesOverride: [URL]? = nil
     ) {
         self.environment = environment
         self.homeDirectory = homeDirectory
+        self.homesOverride = homesOverride
     }
 
     /// One turn's token usage, normalized from a `token_count` line (deltas already applied).
@@ -93,6 +96,9 @@ actor CodexLogUsageScanner {
 
     /// `CODEX_HOME` entries (comma-separated) when set, else `~/.codex` — same as ccusage.
     private func codexHomes() -> [URL] {
+        if let homesOverride {
+            return homesOverride
+        }
         if let raw = environment.value(for: "CODEX_HOME")?.trimmingCharacters(in: .whitespacesAndNewlines),
            !raw.isEmpty {
             return raw.split(separator: ",")

--- a/Sources/OpenUsage/Providers/Codex/CodexOAuthCoordinator.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexOAuthCoordinator.swift
@@ -1,0 +1,311 @@
+import AppKit
+import CryptoKit
+import Foundation
+import Network
+import Observation
+
+enum CodexOAuthError: Error, LocalizedError, Equatable {
+    case alreadyInProgress
+    case callbackPortUnavailable
+    case callbackTimedOut
+    case callbackCancelled
+    case invalidCallback
+    case stateMismatch
+    case missingCode
+
+    var errorDescription: String? {
+        switch self {
+        case .alreadyInProgress:
+            "A Codex login is already in progress."
+        case .callbackPortUnavailable:
+            "Codex login could not start because localhost port 1455 is already in use."
+        case .callbackTimedOut:
+            "Codex login timed out. Try again."
+        case .callbackCancelled:
+            "Codex login was cancelled."
+        case .invalidCallback:
+            "Codex login returned an invalid callback."
+        case .stateMismatch:
+            "Codex login returned a mismatched state. Try again."
+        case .missingCode:
+            "Codex login did not return an authorization code."
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class CodexOAuthCoordinator {
+    enum Status: Equatable {
+        case idle
+        case waiting
+        case failed(String)
+        case succeeded
+    }
+
+    private static let callbackPort: UInt16 = 1455
+    private static let callbackPath = "/auth/callback"
+    private static let timeoutSeconds: TimeInterval = 5 * 60
+
+    private let accountStore: CodexAccountStore
+    private let usageClient: CodexUsageClient
+    private var server: CodexOAuthCallbackServer?
+    private var task: Task<Void, Never>?
+
+    var status: Status = .idle
+    var isWaiting: Bool { status == .waiting }
+
+    init(accountStore: CodexAccountStore, usageClient: CodexUsageClient = CodexUsageClient()) {
+        self.accountStore = accountStore
+        self.usageClient = usageClient
+    }
+
+    func start(onAccountAdded: @escaping @MainActor () -> Void) {
+        guard task == nil else {
+            status = .failed(CodexOAuthError.alreadyInProgress.localizedDescription)
+            return
+        }
+
+        let state = Self.randomURLSafeString(byteCount: 32)
+        let verifier = Self.randomURLSafeString(byteCount: 32)
+        let challenge = Self.codeChallenge(for: verifier)
+        let redirectURI = "http://localhost:\(Self.callbackPort)\(Self.callbackPath)"
+        guard let authorizeURL = Self.authorizeURL(
+            state: state,
+            codeChallenge: challenge,
+            redirectURI: redirectURI
+        ) else {
+            status = .failed(CodexOAuthError.invalidCallback.localizedDescription)
+            return
+        }
+
+        status = .waiting
+        task = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let callback = try await self.waitForCallback(state: state)
+                let response = try await self.usageClient.exchangeAuthorizationCode(
+                    code: callback.code,
+                    redirectURI: redirectURI,
+                    codeVerifier: verifier
+                )
+                var auth = CodexAuth(
+                    tokens: CodexTokens(
+                        accessToken: response.accessToken,
+                        refreshToken: response.refreshToken,
+                        idToken: response.idToken,
+                        accountID: response.accountID
+                    ),
+                    lastRefresh: OpenUsageISO8601.string(from: Date()),
+                    apiKey: nil
+                )
+                if auth.tokens?.accountID == nil,
+                   let accountID = ProviderParse.jwtPayload(response.idToken ?? "")?["https://api.openai.com/auth"] as? [String: Any],
+                   let value = accountID["chatgpt_account_id"] as? String {
+                    auth.tokens?.accountID = value
+                }
+                _ = try self.accountStore.saveManagedAuth(auth)
+                self.status = .succeeded
+                onAccountAdded()
+            } catch {
+                if !(error is CancellationError) {
+                    self.status = .failed(error.localizedDescription)
+                    AppLog.warn(LogTag.auth("codex"), "Codex OAuth failed: \(error.localizedDescription)")
+                }
+            }
+            self.stopServer()
+            self.task = nil
+        }
+
+        NSWorkspace.shared.open(authorizeURL)
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+        stopServer()
+        status = .idle
+    }
+
+    private func waitForCallback(state: String) async throws -> CodexOAuthCallback {
+        let server = CodexOAuthCallbackServer(port: Self.callbackPort, expectedState: state)
+        self.server = server
+        do {
+            return try await withThrowingTaskGroup(of: CodexOAuthCallback.self) { group in
+                group.addTask { try await server.startAndWait() }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(Self.timeoutSeconds * 1_000_000_000))
+                    throw CodexOAuthError.callbackTimedOut
+                }
+                guard let result = try await group.next() else {
+                    throw CodexOAuthError.invalidCallback
+                }
+                group.cancelAll()
+                return result
+            }
+        } catch {
+            stopServer()
+            throw error
+        }
+    }
+
+    private func stopServer() {
+        server?.stop()
+        server = nil
+    }
+
+    private static func authorizeURL(state: String, codeChallenge: String, redirectURI: String) -> URL? {
+        var components = URLComponents(url: CodexUsageClient.authorizeURL, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: CodexUsageClient.clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: "openid profile email offline_access"),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "id_token_add_organizations", value: "true"),
+            URLQueryItem(name: "codex_cli_simplified_flow", value: "true"),
+            URLQueryItem(name: "originator", value: "openusage"),
+            URLQueryItem(name: "state", value: state)
+        ]
+        return components?.url
+    }
+
+    private static func codeChallenge(for verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return Data(digest).base64URLEncodedString()
+    }
+
+    private static func randomURLSafeString(byteCount: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64URLEncodedString()
+    }
+}
+
+struct CodexOAuthCallback: Sendable, Equatable {
+    var code: String
+}
+
+final class CodexOAuthCallbackServer: @unchecked Sendable {
+    private let port: UInt16
+    private let expectedState: String
+    private let queue = DispatchQueue(label: "openusage.codex-oauth")
+    private var listener: NWListener?
+    private var continuation: CheckedContinuation<CodexOAuthCallback, Error>?
+
+    init(port: UInt16, expectedState: String) {
+        self.port = port
+        self.expectedState = expectedState
+    }
+
+    func startAndWait() async throws -> CodexOAuthCallback {
+        try start()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+            }
+        } onCancel: {
+            self.stop()
+        }
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+        if let continuation {
+            self.continuation = nil
+            continuation.resume(throwing: CodexOAuthError.callbackCancelled)
+        }
+    }
+
+    private func start() throws {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = NWEndpoint.hostPort(
+            host: "127.0.0.1",
+            port: NWEndpoint.Port(rawValue: port)!
+        )
+        do {
+            let listener = try NWListener(using: parameters)
+            listener.newConnectionHandler = { [weak self] connection in
+                self?.accept(connection)
+            }
+            listener.start(queue: queue)
+            self.listener = listener
+        } catch {
+            throw CodexOAuthError.callbackPortUnavailable
+        }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { [weak self] data, _, _, _ in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            let head = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            let result = self.parse(head: head)
+            self.respond(result: result, over: connection)
+            if case .success(let callback) = result {
+                let continuation = self.continuation
+                self.continuation = nil
+                self.listener?.cancel()
+                self.listener = nil
+                continuation?.resume(returning: callback)
+            } else if case .failure(let error) = result {
+                let continuation = self.continuation
+                self.continuation = nil
+                self.listener?.cancel()
+                self.listener = nil
+                continuation?.resume(throwing: error)
+            }
+        }
+    }
+
+    private func parse(head: String) -> Result<CodexOAuthCallback, CodexOAuthError> {
+        guard let requestLine = head.split(separator: "\r\n", maxSplits: 1).first else {
+            return .failure(.invalidCallback)
+        }
+        let parts = requestLine.split(separator: " ")
+        guard parts.count >= 2,
+              let components = URLComponents(string: "http://localhost\(parts[1])"),
+              components.path == "/auth/callback"
+        else {
+            return .failure(.invalidCallback)
+        }
+        let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+        guard items["state"] == expectedState else { return .failure(.stateMismatch) }
+        guard let code = items["code"], !code.isEmpty else { return .failure(.missingCode) }
+        return .success(CodexOAuthCallback(code: code))
+    }
+
+    private func respond(result: Result<CodexOAuthCallback, CodexOAuthError>, over connection: NWConnection) {
+        let message: String
+        switch result {
+        case .success:
+            message = "Codex login complete. You can return to OpenUsage."
+        case .failure:
+            message = "Codex login failed. You can return to OpenUsage and try again."
+        }
+        let body = Data("""
+        <!doctype html><html><body><p>\(message)</p></body></html>
+        """.utf8)
+        var head = "HTTP/1.1 200 OK\r\n"
+        head += "Content-Type: text/html; charset=utf-8\r\n"
+        head += "Content-Length: \(body.count)\r\n"
+        head += "Connection: close\r\n\r\n"
+        connection.send(content: Data(head.utf8) + body, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+}
+
+private extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -2,15 +2,7 @@ import Foundation
 
 @MainActor
 final class CodexProvider: ProviderRuntime {
-    let provider = Provider(
-        id: "codex",
-        displayName: "Codex",
-        icon: .providerMark("codex"),
-        links: [
-            .init(label: "Status", url: "https://status.openai.com/"),
-            .init(label: "Dashboard", url: "https://chatgpt.com/codex/settings/usage")
-        ]
-    )
+    let provider: Provider
 
     let authStore: CodexAuthStore
     let usageClient: CodexUsageClient
@@ -19,12 +11,23 @@ final class CodexProvider: ProviderRuntime {
     let pricing: @Sendable () async -> ModelPricing
 
     init(
+        providerID: String = "codex",
+        displayName: String = "Codex",
         authStore: CodexAuthStore = CodexAuthStore(),
         usageClient: CodexUsageClient = CodexUsageClient(),
         logUsageScanner: CodexLogUsageScanner = CodexLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
         pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
     ) {
+        self.provider = Provider(
+            id: providerID,
+            displayName: displayName,
+            icon: .providerMark("codex"),
+            links: [
+                .init(label: "Status", url: "https://status.openai.com/"),
+                .init(label: "Dashboard", url: "https://chatgpt.com/codex/settings/usage")
+            ]
+        )
         self.authStore = authStore
         self.usageClient = usageClient
         self.logUsageScanner = logUsageScanner
@@ -34,15 +37,15 @@ final class CodexProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "codex.session", provider: provider, title: "Session"),
-            .percent(id: "codex.weekly", provider: provider, title: "Weekly"),
+            .percent(id: "\(provider.id).session", provider: provider, title: "Session"),
+            .percent(id: "\(provider.id).weekly", provider: provider, title: "Weekly"),
             // Model-specific Spark limits (GPT-5.3-Codex-Spark), parsed from `additional_rate_limits`.
             // Declared right after Weekly so they group with the core rate-limit meters; seeded as
             // secondary (below the caret) and unpinned in `DefaultLayout`.
-            .percent(id: "codex.spark", provider: provider, title: "Spark"),
-            .percent(id: "codex.sparkWeekly", provider: provider, title: "Spark Weekly"),
-            .combined(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
-            .values(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
+            .percent(id: "\(provider.id).spark", provider: provider, title: "Spark"),
+            .percent(id: "\(provider.id).sparkWeekly", provider: provider, title: "Spark Weekly"),
+            .combined(id: "\(provider.id).credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
+            .values(id: "\(provider.id).rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets"),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)
     }
@@ -198,6 +201,9 @@ final class CodexProvider: ProviderRuntime {
         }
         if let idToken = response.idToken {
             authState.auth.tokens?.idToken = idToken
+        }
+        if let accountID = response.accountID {
+            authState.auth.tokens?.accountID = accountID
         }
         authState.auth.lastRefresh = OpenUsageISO8601.string(from: now())
         // Fail loudly: a swallowed save strands the rotated token on disk (next launch re-refreshes /

--- a/Sources/OpenUsage/Providers/Codex/CodexUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageClient.swift
@@ -4,10 +4,12 @@ struct CodexRefreshResponse: Sendable, Equatable {
     var accessToken: String
     var refreshToken: String?
     var idToken: String?
+    var accountID: String?
 }
 
 struct CodexUsageClient: Sendable {
     static let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+    static let authorizeURL = URL(string: "https://auth.openai.com/oauth/authorize")!
     static let refreshURL = URL(string: "https://auth.openai.com/oauth/token")!
     static let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
     static let resetCreditsURL = URL(string: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits")!
@@ -71,7 +73,42 @@ struct CodexUsageClient: Sendable {
         return CodexRefreshResponse(
             accessToken: accessToken,
             refreshToken: body["refresh_token"] as? String,
-            idToken: body["id_token"] as? String
+            idToken: body["id_token"] as? String,
+            accountID: body["account_id"] as? String
+        )
+    }
+
+    func exchangeAuthorizationCode(
+        code: String,
+        redirectURI: String,
+        codeVerifier: String
+    ) async throws -> CodexRefreshResponse {
+        let body =
+            "grant_type=authorization_code" +
+            "&client_id=\(Self.clientID.urlFormEncoded)" +
+            "&code=\(code.urlFormEncoded)" +
+            "&redirect_uri=\(redirectURI.urlFormEncoded)" +
+            "&code_verifier=\(codeVerifier.urlFormEncoded)"
+
+        let response = try await http.send(HTTPRequest(
+            method: "POST",
+            url: Self.refreshURL,
+            headers: ["Content-Type": "application/x-www-form-urlencoded"],
+            body: Data(body.utf8),
+            timeout: 15
+        ))
+        guard (200..<300).contains(response.statusCode),
+              let body = ProviderParse.jsonObject(response.body),
+              let accessToken = body["access_token"] as? String,
+              !accessToken.isEmpty
+        else {
+            throw CodexUsageError.requestFailed(response.statusCode)
+        }
+        return CodexRefreshResponse(
+            accessToken: accessToken,
+            refreshToken: body["refresh_token"] as? String,
+            idToken: body["id_token"] as? String,
+            accountID: body["account_id"] as? String
         )
     }
 
@@ -118,4 +155,3 @@ struct CodexUsageClient: Sendable {
     }
 
 }
-

--- a/Sources/OpenUsage/Services/SystemClients.swift
+++ b/Sources/OpenUsage/Services/SystemClients.swift
@@ -106,6 +106,7 @@ enum SQLiteError: Error, LocalizedError, Equatable {
 protocol KeychainAccessing: Sendable {
     func readGenericPassword(service: String) throws -> String?
     func writeGenericPassword(service: String, value: String) throws
+    func deleteGenericPassword(service: String) throws
     func readGenericPasswordForCurrentUser(service: String) throws -> String?
     func writeGenericPasswordForCurrentUser(service: String, value: String) throws
     /// Read a generic password scoped to an explicit account (`-a`). Used when another app stored the
@@ -122,6 +123,8 @@ extension KeychainAccessing {
     func writeGenericPasswordForCurrentUser(service: String, value: String) throws {
         try writeGenericPassword(service: service, value: value)
     }
+
+    func deleteGenericPassword(service: String) throws {}
 
     /// Default for mocks that don't model accounts: fall back to the service-only lookup. The real
     /// `SecurityKeychainAccessor` overrides this to pass `-a <account>`.
@@ -177,12 +180,24 @@ struct SecurityKeychainAccessor: KeychainAccessing {
     func writeGenericPassword(service: String, value: String) throws {
         let result = try processRunner.run(
             executable: "/usr/bin/security",
-            arguments: ["add-generic-password", "-U", "-s", service, "-w", value],
+            arguments: ["add-generic-password", "-U", "-a", currentUserAccount(), "-s", service, "-w", value],
             environment: [:],
             timeout: 5
         )
         if !result.succeeded {
             throw KeychainError.writeFailed(result.stderr)
+        }
+    }
+
+    func deleteGenericPassword(service: String) throws {
+        let result = try processRunner.run(
+            executable: "/usr/bin/security",
+            arguments: ["delete-generic-password", "-s", service],
+            environment: [:],
+            timeout: 5
+        )
+        if !result.succeeded && result.exitCode != Self.itemNotFoundExitCode {
+            throw KeychainError.deleteFailed(result.stderr)
         }
     }
 
@@ -207,6 +222,7 @@ struct SecurityKeychainAccessor: KeychainAccessing {
 enum KeychainError: Error, LocalizedError {
     case writeFailed(String)
     case readFailed(String)
+    case deleteFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -214,6 +230,8 @@ enum KeychainError: Error, LocalizedError {
             return message.isEmpty ? "Keychain write failed." : message
         case .readFailed(let message):
             return message.isEmpty ? "Keychain read failed." : message
+        case .deleteFailed(let message):
+            return message.isEmpty ? "Keychain delete failed." : message
         }
     }
 }
@@ -224,4 +242,3 @@ func expandHome(_ path: String) -> String {
     if path == "~" { return home }
     return home + String(path.dropFirst())
 }
-

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -126,7 +126,7 @@ final class LayoutStore {
         didSet { defaults.set(menuBarStyle.rawValue, forKey: menuBarStyleKey) }
     }
 
-    private let registry: WidgetRegistry
+    private var registry: WidgetRegistry
     private let defaults: UserDefaults
     private let storageKey: String
     private let providerOrderKey: String
@@ -137,10 +137,10 @@ final class LayoutStore {
     private let expandOnEnableKey: String
     private let expandedProvidersKey: String
     private let menuBarStyleKey: String
-    private let defaultMetricIDs: [String]
-    private let migrationBaselineMetricIDs: [String]
-    private let defaultPinnedMetricIDs: [String]
-    private let defaultExpandedMetricIDs: [String]
+    private var defaultMetricIDs: [String]
+    private var migrationBaselineMetricIDs: [String]
+    private var defaultPinnedMetricIDs: [String]
+    private var defaultExpandedMetricIDs: [String]
     private var defaultExpandedOnEnableIDs: Set<String>
     private let isProviderEnabled: @MainActor (String) -> Bool
 
@@ -926,6 +926,66 @@ final class LayoutStore {
         persistExpandedProviders()
         persistSeededDefaults(Set(Self.knownMetricIDs(defaultMetricIDs, registry: registry)))
         persist()
+    }
+
+    func updateRegistry(
+        _ nextRegistry: WidgetRegistry,
+        defaultMetricIDs nextDefaultMetricIDs: [String],
+        migrationBaselineMetricIDs nextMigrationBaselineMetricIDs: [String],
+        defaultPinnedMetricIDs nextDefaultPinnedMetricIDs: [String],
+        defaultExpandedMetricIDs nextDefaultExpandedMetricIDs: [String]
+    ) {
+        cancelDrag()
+        let oldProviderIDs = Set(registry.providers.map(\.id))
+        registry = nextRegistry
+        defaultMetricIDs = nextDefaultMetricIDs
+        migrationBaselineMetricIDs = nextMigrationBaselineMetricIDs
+        defaultPinnedMetricIDs = nextDefaultPinnedMetricIDs
+        defaultExpandedMetricIDs = nextDefaultExpandedMetricIDs
+
+        placed = placed.filter { registry.descriptor(id: $0.descriptorID) != nil }
+        let seeded = Self.seedNewDefaultMetrics(
+            into: placed,
+            defaults: defaults,
+            key: seededDefaultsKey,
+            hasStoredLayout: true,
+            registry: registry,
+            defaultMetricIDs: defaultMetricIDs,
+            migrationBaselineMetricIDs: migrationBaselineMetricIDs
+        )
+        placed = seeded.placed
+        if seeded.shouldPersistSeededDefaults {
+            persistSeededDefaults(seeded.seededDefaults)
+        }
+
+        let knownProviders = Set(registry.providers.map(\.id))
+        var nextOrder = providerOrder.filter { knownProviders.contains($0) }
+        for provider in registry.providers where !nextOrder.contains(provider.id) {
+            nextOrder.append(provider.id)
+        }
+        providerOrder = nextOrder
+        persistProviderOrder()
+
+        metricOrderByProvider = Self.normalizedMetricOrder(metricOrderByProvider, registry: registry)
+        persistMetricOrder()
+
+        let newProviderIDs = Set(registry.providers.map(\.id)).subtracting(oldProviderIDs)
+        pinnedMetricIDs = pinnedMetricIDs.filter { registry.descriptor(id: $0) != nil }
+        pinnedMetricIDs.formUnion(defaultPinnedMetricIDs.filter { id in
+            guard let descriptor = registry.descriptor(id: id) else { return false }
+            return newProviderIDs.contains(descriptor.providerID)
+        })
+        persistPins()
+
+        expandedMetricIDs = expandedMetricIDs.filter { registry.descriptor(id: $0) != nil }
+        expandedMetricIDs.formUnion(seeded.newlyPlaced.filter { defaultExpandedMetricIDs.contains($0) })
+        defaultExpandedOnEnableIDs = defaultExpandedOnEnableIDs.filter { registry.descriptor(id: $0) != nil }
+        persistExpanded()
+        persistExpandOnEnable()
+
+        expandedProviderIDs = expandedProviderIDs.filter { knownProviders.contains($0) }
+        persistExpandedProviders()
+        syncPlacedOrder()
     }
 
     /// Reset a single provider's customization to default — its enabled metrics, metric order, pins,

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -97,9 +97,16 @@ struct ProviderSnapshotCache {
         AppLog.debug(.cache, "write \(snapshot.providerID)")
         // Mark this provider as written *this session* so its snapshot now satisfies the freshness gate
         // (a launch-loaded snapshot never does — see `sessionWrites`).
-        sessionWrites.withLock { $0.insert(snapshot.providerID) }
+        _ = sessionWrites.withLock { $0.insert(snapshot.providerID) }
         var payload = loadPayload()
         payload.snapshots[snapshot.providerID] = snapshot
+        save(payload)
+    }
+
+    func remove(providerID: String) {
+        var payload = loadPayload()
+        payload.snapshots.removeValue(forKey: providerID)
+        _ = sessionWrites.withLock { $0.remove(providerID) }
         save(payload)
     }
 

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -12,8 +12,8 @@ struct StalenessHint: Equatable {
 @MainActor
 @Observable
 final class WidgetDataStore {
-    private let registry: WidgetRegistry
-    private let providersByID: [String: ProviderRuntime]
+    private var registry: WidgetRegistry
+    private var providersByID: [String: ProviderRuntime]
     private let cache: ProviderSnapshotCache
     private let defaults: UserDefaults
     /// Whether a provider is currently enabled. Injected so the store consults the single
@@ -120,6 +120,25 @@ final class WidgetDataStore {
         // dashboard show last-known values immediately at launch instead of "—"; the refresh loop
         // replaces them as soon as fresh data lands.
         self.snapshots = cache.loadSnapshots(providerIDs: registry.providers.map(\.id))
+    }
+
+    func updateRegistry(_ nextRegistry: WidgetRegistry, providers: [ProviderRuntime]) {
+        registry = nextRegistry
+        providersByID = Dictionary(uniqueKeysWithValues: providers.map { ($0.provider.id, $0) })
+        let known = Set(nextRegistry.providers.map(\.id))
+        snapshots = snapshots.filter { known.contains($0.key) }
+        providerErrors = providerErrors.filter { known.contains($0.key) }
+        failureRetryAfter = failureRetryAfter.filter { known.contains($0.key) }
+        refreshingProviderIDs = refreshingProviderIDs.filter { known.contains($0) }
+        snapshots.merge(cache.loadSnapshots(providerIDs: nextRegistry.providers.map(\.id))) { current, _ in current }
+    }
+
+    func forgetProvider(_ providerID: String) {
+        snapshots.removeValue(forKey: providerID)
+        providerErrors.removeValue(forKey: providerID)
+        failureRetryAfter.removeValue(forKey: providerID)
+        refreshingProviderIDs.remove(providerID)
+        cache.remove(providerID: providerID)
     }
 
     /// Refresh every enabled provider, concurrently — one slow provider never delays the rest.
@@ -630,4 +649,3 @@ final class WidgetDataStore {
         return Double(value[match].replacingOccurrences(of: ",", with: ""))
     }
 }
-

--- a/Sources/OpenUsage/Views/CodexAccountsSection.swift
+++ b/Sources/OpenUsage/Views/CodexAccountsSection.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+struct CodexAccountsSection: View {
+    @Environment(AppContainer.self) private var container
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @State private var renameDrafts: [String: String] = [:]
+
+    var body: some View {
+        @Bindable var oauth = container.codexOAuth
+        let records = container.codexAccounts.settingsRecords()
+        return VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
+            Text("Codex Accounts")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+            VStack(spacing: 0) {
+                ForEach(records) { record in
+                    accountRow(record)
+                    if record.id != records.last?.id {
+                        Divider()
+                    }
+                }
+                Divider()
+                actionBlock(status: oauth.status, waiting: oauth.isWaiting)
+            }
+            .cardSurface()
+            .clipShape(Theme.cardShape)
+        }
+        .onAppear {
+            for record in records {
+                renameDrafts[record.identity] = record.displayName
+            }
+        }
+    }
+
+    private func accountRow(_ record: CodexAccountRecord) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                ProviderIcon(source: .providerMark("codex"))
+                    .frame(width: 18, height: 18)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(record.displayName)
+                    Text(sourceLabel(record.source))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 8)
+                if record.source == .managed {
+                    Button("Remove") {
+                        remove(record)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                } else {
+                    Button("Hide") {
+                        hide(record)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+            if record.source == .managed {
+                HStack(spacing: 8) {
+                    TextField("Account Name", text: Binding(
+                        get: { renameDrafts[record.identity] ?? record.displayName },
+                        set: { renameDrafts[record.identity] = $0 }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                    Button("Save") {
+                        container.codexAccounts.rename(record, to: renameDrafts[record.identity] ?? "")
+                        container.reloadCodexAccounts()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+
+    @ViewBuilder
+    private func actionBlock(status: CodexOAuthCoordinator.Status, waiting: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Button(waiting ? "Waiting for Browser…" : "Add Codex Account") {
+                    container.codexOAuth.start {
+                        container.reloadCodexAccounts()
+                        Task { await container.dataStore.refreshAll(force: true) }
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(waiting)
+                if waiting {
+                    Button("Cancel") {
+                        container.codexOAuth.cancel()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+            switch status {
+            case .idle:
+                EmptyView()
+            case .waiting:
+                Text("Finish signing in with ChatGPT in your browser.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .failed(let message):
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(Theme.notice)
+            case .succeeded:
+                Text("Codex account added.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Rectangle().fill(.fill.quinary))
+    }
+
+    private func remove(_ record: CodexAccountRecord) {
+        container.codexAccounts.removeManaged(record)
+        container.reloadCodexAccounts(forgetRemoved: record.providerID)
+    }
+
+    private func hide(_ record: CodexAccountRecord) {
+        container.codexAccounts.hideCLI(record)
+        container.enablement.setEnabled(false, for: record.providerID)
+        container.reloadCodexAccounts(forgetRemoved: record.providerID)
+    }
+
+    private func sourceLabel(_ source: CodexAccountRecord.Source) -> String {
+        switch source {
+        case .managed: "Signed in with OpenUsage"
+        case .cliFile, .cliKeychain: "Imported from Codex CLI"
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -84,6 +84,7 @@ struct SettingsScreen: View {
                         .hoverTooltip("Open OpenUsage from anywhere")
                 }
             }
+            CodexAccountsSection()
             section("Appearance") {
                 row("Icon Style") {
                     picker($layout.menuBarStyle, options: MenuBarStyle.allCases, label: \.label)

--- a/Tests/OpenUsageTests/CodexAccountStoreTests.swift
+++ b/Tests/OpenUsageTests/CodexAccountStoreTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class CodexAccountStoreTests: XCTestCase {
+    func testDefaultAccountExistsWithoutCredentials() {
+        let store = CodexAccountStore(
+            defaults: isolatedDefaults(),
+            keychain: ServiceKeychain(),
+            environment: FakeEnvironment([:]),
+            files: FakeFiles()
+        )
+
+        let contexts = store.accountContexts()
+
+        XCTAssertEqual(contexts.map(\.record.providerID), ["codex"])
+        XCTAssertEqual(contexts.first?.record.displayName, "Codex")
+    }
+
+    func testManagedAccountUsesLegacyCodexProviderIDWhenFirst() throws {
+        let keychain = ServiceKeychain()
+        let store = CodexAccountStore(
+            defaults: isolatedDefaults(),
+            keychain: keychain,
+            environment: FakeEnvironment([:]),
+            files: FakeFiles()
+        )
+        _ = try store.saveManagedAuth(auth(accountID: "acct_1"))
+
+        let records = store.visibleRecords()
+
+        XCTAssertEqual(records.map(\.providerID), ["codex"])
+        XCTAssertEqual(records.map(\.source), [.managed])
+        XCTAssertFalse(keychain.values.isEmpty)
+    }
+
+    func testDuplicateManagedLoginRefreshesExistingAccount() throws {
+        let store = CodexAccountStore(
+            defaults: isolatedDefaults(),
+            keychain: ServiceKeychain(),
+            environment: FakeEnvironment([:]),
+            files: FakeFiles()
+        )
+        _ = try store.saveManagedAuth(auth(access: "first", accountID: "acct_1"))
+        store.rename(store.visibleRecords()[0], to: "Work")
+        _ = try store.saveManagedAuth(auth(access: "second", accountID: "acct_1"))
+
+        let records = store.visibleRecords()
+
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].displayName, "Work")
+    }
+
+    func testManagedAccountWinsOverMatchingCLIAccount() throws {
+        let files = FakeFiles([
+            "/tmp/codex/auth.json": #"{"tokens":{"access_token":"cli","account_id":"acct_1"}}"#
+        ])
+        let store = CodexAccountStore(
+            defaults: isolatedDefaults(),
+            keychain: ServiceKeychain(),
+            environment: FakeEnvironment(["CODEX_HOME": "/tmp/codex"]),
+            files: files
+        )
+        _ = try store.saveManagedAuth(auth(accountID: "acct_1"))
+
+        let records = store.visibleRecords()
+
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].source, .managed)
+    }
+
+    func testExtraAccountGetsStablePrefixedProviderID() throws {
+        let files = FakeFiles([
+            "/tmp/codex/auth.json": #"{"tokens":{"access_token":"cli","account_id":"acct_cli"}}"#
+        ])
+        let store = CodexAccountStore(
+            defaults: isolatedDefaults(),
+            keychain: ServiceKeychain(),
+            environment: FakeEnvironment(["CODEX_HOME": "/tmp/codex"]),
+            files: files
+        )
+        _ = try store.saveManagedAuth(auth(accountID: "acct_managed"))
+
+        let records = store.visibleRecords()
+
+        XCTAssertEqual(records[0].providerID, "codex")
+        XCTAssertEqual(records[0].source, .cliFile)
+        XCTAssertTrue(records[1].providerID.hasPrefix("codex."))
+        XCTAssertEqual(records[1].source, .managed)
+    }
+
+    private func auth(access: String = "access", accountID: String) -> CodexAuth {
+        CodexAuth(tokens: CodexTokens(accessToken: access, refreshToken: "refresh", idToken: nil, accountID: accountID))
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suite = "OpenUsageCodexAccountStoreTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+}

--- a/Tests/OpenUsageTests/KeychainAccessorTests.swift
+++ b/Tests/OpenUsageTests/KeychainAccessorTests.swift
@@ -11,6 +11,14 @@ final class KeychainAccessorTests: XCTestCase {
         }
     }
 
+    private final class CapturingRunner: ProcessRunning, @unchecked Sendable {
+        var arguments: [String] = []
+        func run(executable: String, arguments: [String], environment: [String: String], timeout: TimeInterval) throws -> ProcessResult {
+            self.arguments = arguments
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+        }
+    }
+
     func testItemNotFoundExitReturnsNil() throws {
         // Exit 44 (errSecItemNotFound) is the legitimate "no credential stored" case → nil.
         let accessor = SecurityKeychainAccessor(processRunner: StubRunner(
@@ -37,5 +45,16 @@ final class KeychainAccessorTests: XCTestCase {
             result: ProcessResult(exitCode: 0, stdout: "secret-token\n", stderr: "")
         ))
         XCTAssertEqual(try accessor.readGenericPassword(service: "Test"), "secret-token")
+    }
+
+    func testWriteGenericPasswordIncludesRequiredAccountName() throws {
+        let runner = CapturingRunner()
+        let accessor = SecurityKeychainAccessor(processRunner: runner)
+
+        try accessor.writeGenericPassword(service: "Test", value: "secret-token")
+
+        XCTAssertTrue(runner.arguments.contains("-a"))
+        XCTAssertTrue(runner.arguments.contains("-s"))
+        XCTAssertTrue(runner.arguments.contains("Test"))
     }
 }

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -729,6 +729,35 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(store.pinnedMetricIDs, expected)
     }
 
+    func testRegistryUpdatePinsDefaultsForNewProviderOnly() {
+        let defaults = makeDefaults("UpdateRegistryPins")
+        let store = LayoutStore(
+            registry: .mock,
+            defaults: defaults,
+            storageKey: "layout",
+            defaultPinnedMetricIDs: ["codex.session"]
+        )
+        let extra = Provider(id: "codex.extra", displayName: "Codex 2", icon: .providerMark("codex"))
+        let extraSession = WidgetDescriptor.percent(id: "codex.extra.session", provider: extra, title: "Session")
+        let extraCredits = WidgetDescriptor.combined(id: "codex.extra.credits", provider: extra, title: "Extra Usage", metricLabel: "Credits")
+        let registry = WidgetRegistry(
+            providers: MockData.providers + [extra],
+            descriptors: MockData.descriptors + [extraSession, extraCredits]
+        )
+
+        store.updateRegistry(
+            registry,
+            defaultMetricIDs: ["codex.session", "codex.extra.session", "codex.extra.credits"],
+            migrationBaselineMetricIDs: [],
+            defaultPinnedMetricIDs: ["codex.session", "codex.extra.session", "codex.extra.credits"],
+            defaultExpandedMetricIDs: []
+        )
+
+        XCTAssertTrue(store.isPinned("codex.session"))
+        XCTAssertTrue(store.isPinned("codex.extra.session"))
+        XCTAssertTrue(store.isPinned("codex.extra.credits"))
+    }
+
     func testUnpinningEverythingPersistsAndIsNotReseeded() {
         let defaults = makeDefaults("UnpinAll")
         let store = LayoutStore(registry: .mock, defaults: defaults, storageKey: "layout")

--- a/Tests/OpenUsageTests/TestSupport.swift
+++ b/Tests/OpenUsageTests/TestSupport.swift
@@ -246,6 +246,10 @@ final class FakeKeychain: KeychainAccessing, @unchecked Sendable {
     func writeGenericPassword(service: String, value: String) throws {
         self.value = value
     }
+
+    func deleteGenericPassword(service: String) throws {
+        value = nil
+    }
 }
 
 final class ServiceKeychain: KeychainAccessing, @unchecked Sendable {
@@ -263,6 +267,10 @@ final class ServiceKeychain: KeychainAccessing, @unchecked Sendable {
 
     func writeGenericPassword(service: String, value: String) throws {
         values[service] = value
+    }
+
+    func deleteGenericPassword(service: String) throws {
+        values.removeValue(forKey: service)
     }
 
     func readGenericPasswordForCurrentUser(service: String) throws -> String? {

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -255,7 +255,7 @@ final class WidgetDataStoreTests: XCTestCase {
         let remaining = store.data(for: descriptor)
         XCTAssertFalse(remaining.isBounded)
         XCTAssertEqual(remaining.unboundedDetail, "$40.00 · 1K credits")
-        XCTAssertEqual(remaining.menuBarValue, "$40")   // dollar value → compact tray reading
+        XCTAssertEqual(remaining.menuBarValue, "$40 · 1K credits")
         XCTAssertNil(remaining.unboundedSubtitle)
 
         store.meterStyle = .used
@@ -493,10 +493,10 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(tokenData.unboundedTooltip, "891,000 tokens")
         XCTAssertNil(tokenData.infoNote)
 
-        // Combined: both values joined; the tray glances at the leading dollar value, the tooltip is full.
+        // Combined: both values joined in the row and tray; the tooltip is full precision.
         let combinedData = store.data(for: combined)
         XCTAssertEqual(combinedData.unboundedDetail, "$478.00 · 891K tokens")
-        XCTAssertEqual(combinedData.menuBarValue, "$478")
+        XCTAssertEqual(combinedData.menuBarValue, "$478 · 891K tokens")
         XCTAssertEqual(combinedData.unboundedTooltip, "$478.00 · 891,000 tokens")
         XCTAssertEqual(combinedData.infoNote, WidgetData.localEstimateNote)
 

--- a/Tests/OpenUsageTests/WidgetUsagePeriodTests.swift
+++ b/Tests/OpenUsageTests/WidgetUsagePeriodTests.swift
@@ -34,6 +34,14 @@ final class WidgetUsagePeriodTests: XCTestCase {
         XCTAssertEqual(descriptors.first { $0.id == "codex.today" }?.sample.isUsagePeriod, true)
     }
 
+    func testCodexAccountDescriptorsUseProviderIDPrefix() {
+        let descriptors = CodexProvider(providerID: "codex.abc", displayName: "Codex 2").widgetDescriptors
+
+        XCTAssertNotNil(descriptors.first { $0.id == "codex.abc.session" })
+        XCTAssertNotNil(descriptors.first { $0.id == "codex.abc.today" })
+        XCTAssertNil(descriptors.first { $0.id == "codex.session" })
+    }
+
     /// A depleted balance (every value zero, not a usage period): `isZeroUsage` is still true, but the
     /// note gate `isZeroUsage && isUsagePeriod` is false, so no "No usage in this period" note shows.
     func testZeroBalanceRowIsGatedOutOfTheNote() {

--- a/docs/provider-enablement.md
+++ b/docs/provider-enablement.md
@@ -4,7 +4,7 @@ How OpenUsage decides which providers start on, what happens when an update adds
 
 ## First install
 
-A fresh install doesn't turn on every provider OpenUsage knows about. It starts with Claude, Codex, and Cursor, then quickly checks which AI tools are actually set up on your Mac — by looking for their local logins (config files, keychain); nothing is sent anywhere — and switches to exactly that set. If nothing is found, the Claude/Codex/Cursor starter set stays. See [Dashboard § First launch](dashboard.md#first-launch) for how the dashboard presents this.
+A fresh install doesn't turn on every provider OpenUsage knows about. It starts with Claude, Codex, and Cursor, then quickly checks which AI tools are actually set up on your Mac — by looking for their local logins (config files, keychain); nothing is sent anywhere — and switches to exactly that set. If nothing is found, the Claude/Codex/Cursor starter set stays. Codex can have multiple accounts: OpenUsage-managed Codex accounts and imported Codex CLI logins appear as separate Codex cards when present. See [Dashboard § First launch](dashboard.md#first-launch) for how the dashboard presents this.
 
 ## When an update adds a new provider
 

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -1,6 +1,6 @@
 # Codex
 
-Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI.
+Tracks your ChatGPT/Codex subscription limits using accounts signed in through OpenUsage, with existing Codex CLI logins imported read-only.
 
 ## What it tracks
 
@@ -16,7 +16,11 @@ Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI
 
 ## Where credentials come from
 
-Sign in once with the Codex CLI (`codex`); OpenUsage reads the same auth files (`$CODEX_HOME` respected) with a keychain fallback. Tokens refresh automatically and rotate back into the auth file.
+Open **Settings → Codex Accounts → Add Codex Account** to sign in with ChatGPT in your browser. OpenUsage stores those account tokens in its own macOS keychain entries, refreshes them automatically, and never writes them into the Codex CLI auth files.
+
+OpenUsage also still imports existing Codex CLI logins read-only (`$CODEX_HOME` respected, plus the standard Codex auth locations and keychain fallback). Imported CLI accounts can be hidden in OpenUsage, but OpenUsage does not delete or modify the CLI's auth.
+
+Each signed-in account appears as its own Codex card. The first account keeps the regular **Codex** name and existing layout; additional accounts show as **Codex 2**, **Codex 3**, and can be renamed locally in Settings.
 
 ## The spend tiles
 
@@ -24,7 +28,7 @@ Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the C
 
 ## Troubleshooting
 
-- **"Not logged in"** — run `codex` and sign in, then refresh.
+- **"Not logged in"** — add a Codex account in OpenUsage Settings, or sign in with the Codex CLI for a read-only imported account.
 - **API-key-only setups** can't read subscription usage — sign in with your ChatGPT account instead.
 - **Spend tiles show "No data"** — OpenUsage found no Codex session logs in the last 30 days. If your Codex home lives somewhere custom, set `CODEX_HOME` so both the Codex CLI and OpenUsage look in the same place.
 


### PR DESCRIPTION
**TL;DR**
Adds Codex multi-account support so OpenUsage can track separately signed-in Codex accounts while continuing to import existing Codex CLI credentials read-only.

**What was happening**
- Codex was modeled as a single provider backed by the Codex CLI auth state.
- Existing CLI credentials were reused directly, which limited OpenUsage to one Codex account view.
- Layout and cache state assumed stable single-provider Codex widget IDs.

**What this changes**
- Adds a Codex account store that discovers CLI accounts, stores OpenUsage-managed Codex accounts in keychain entries, and assigns per-account provider IDs.
- Adds a Codex OAuth coordinator and Settings UI for adding, renaming, hiding, and removing Codex accounts.
- Updates provider registry, layout defaults, cache handling, and widget data refreshes to handle Codex provider changes at runtime.
- Updates Codex docs to describe OpenUsage-managed accounts and read-only CLI imports.
- Adds regression coverage for account discovery, keychain behavior, layout migration, provider ID-prefixed descriptors, and widget store behavior.

**Heads-up**
- The OAuth callback listens on localhost port 1455, matching the new coordinator implementation.

**Tests**
- `swift test`
