### PR TITLE
feat(codex): status dot for reset-credit expiry

### DIFF
--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -325,16 +325,19 @@ struct WidgetData: Hashable {
         return "\(valueText) \(word)"
     }
 
-    /// A soonest-expiry inside this window flips the row to a warning state (the ⚠ triangle next to the
-    /// count) — a reset credit you're about to lose if you don't use it.
-    static let expiryWarningWindow: TimeInterval = 24 * 60 * 60
+    /// Color bands for reset-credit expiries: blue normally, amber under a week, red under 48 hours.
+    /// A past-due expiry remains critical until the next refresh drops it from the available list.
+    static let expiryWarningWindow: TimeInterval = 7 * 24 * 60 * 60
+    static let expiryCriticalWindow: TimeInterval = 48 * 60 * 60
 
-    /// True when the soonest still-available reset credit expires within `expiryWarningWindow` (a past-due
-    /// one counts too). Drives the row's warning triangle; recomputes on the popover's 30s tick because
+    /// Visual status for rows carrying reset-credit expiries. Recomputes on the popover's 30s tick because
     /// the row keeps ticking while it carries expiries.
-    var hasImminentExpiry: Bool {
-        guard hasData, let soonest = expiriesAt.min() else { return false }
-        return soonest.timeIntervalSince(Date()) <= Self.expiryWarningWindow
+    func expirySeverity(now: Date = Date()) -> MeterSeverity? {
+        guard hasData, let soonest = expiriesAt.min() else { return nil }
+        let timeRemaining = soonest.timeIntervalSince(now)
+        if timeRemaining <= Self.expiryCriticalWindow { return .critical }
+        if timeRemaining <= Self.expiryWarningWindow { return .warning }
+        return .normal
     }
 
     /// Hover tooltip for a row carrying expiry instants (the Codex reset-credit row, "2 available"):

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -269,7 +269,7 @@ struct WidgetRowView: View {
             Spacer(minLength: 12)
             VStack(alignment: .trailing, spacing: 2) {
                 HStack(spacing: 4) {
-                    expiryWarningIcon
+                    expiryStatusDot
                     Text(data.unboundedDetail)
                         .font(supportingFont)
                         .foregroundStyle(.primary) // the value is the row's payload — match the bounded headline
@@ -329,17 +329,25 @@ struct WidgetRowView: View {
         }
     }
 
-    /// Amber warning triangle shown just before the value when a reset credit is about to expire
-    /// (`hasImminentExpiry`). Carries the same expiry tooltip as the value, so hovering it reveals which
-    /// credits are expiring and when. Renders nothing otherwise.
+    /// Small blue/yellow/red status dot shown just before the value when the row carries reset-credit
+    /// expiries. Carries the same expiry tooltip as the value, so hovering it reveals which credits are
+    /// expiring and when. Renders nothing otherwise.
     @ViewBuilder
-    private var expiryWarningIcon: some View {
-        if data.hasImminentExpiry {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: density.supportingPointSize - 1))
-                .foregroundStyle(severityColor(.warning))
+    private var expiryStatusDot: some View {
+        if let severity = data.expirySeverity() {
+            Circle()
+                .fill(severityColor(severity))
+                .frame(width: 6, height: 6)
                 .hoverTooltip(data.unboundedValueTooltip)
-                .accessibilityLabel("A reset credit is expiring soon")
+                .accessibilityLabel(expiryStatusAccessibilityLabel(severity))
+        }
+    }
+
+    private func expiryStatusAccessibilityLabel(_ severity: WidgetData.MeterSeverity) -> String {
+        switch severity {
+        case .normal: return "Reset credits expire in more than 7 days"
+        case .warning: return "A reset credit expires within 7 days"
+        case .critical: return "A reset credit expires within 48 hours"
         }
     }
 

--- a/Tests/OpenUsageTests/ResetDisplayTests.swift
+++ b/Tests/OpenUsageTests/ResetDisplayTests.swift
@@ -123,27 +123,32 @@ final class ResetDisplayTests: XCTestCase {
         XCTAssertEqual(data.expiryTooltip, "Resets expire in:\n1. 12d 18h\n2. 22d 12h")
     }
 
-    func testHasImminentExpiryTracksWarningWindow() {
-        // The warning triangle fires when the soonest credit expires within `expiryWarningWindow`.
-        // Anchored to the constant so it survives the eventual 21d→24h revert.
+    func testExpirySeverityTracksSoonestExpiry() {
+        // The reset-credit dot reflects the soonest expiry: blue normally, yellow under 7 days, red under
+        // 48 hours.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
         var data = WidgetData(title: "Rate Limit Resets", icon: .symbol("clock"),
                               kind: .count, used: 0, limit: nil)
         data.values = [MetricValue(number: 2, kind: .count, label: "available")]
 
-        // Soonest just inside the window → warning (even though a later credit is well outside it).
+        // Soonest under 48 hours -> red, even though a later credit is well outside it.
         data.expiriesAt = [
-            Date().addingTimeInterval(WidgetData.expiryWarningWindow - 3600),
-            Date().addingTimeInterval(WidgetData.expiryWarningWindow + 10 * 24 * 3600)
+            now.addingTimeInterval(WidgetData.expiryCriticalWindow - 3600),
+            now.addingTimeInterval(WidgetData.expiryWarningWindow + 10 * 24 * 3600)
         ]
-        XCTAssertTrue(data.hasImminentExpiry)
+        XCTAssertEqual(data.expirySeverity(now: now), .critical)
 
-        // Every credit comfortably outside the window → no warning.
-        data.expiriesAt = [Date().addingTimeInterval(WidgetData.expiryWarningWindow + 24 * 3600)]
-        XCTAssertFalse(data.hasImminentExpiry)
+        // Under 7 days but outside 48 hours -> yellow.
+        data.expiriesAt = [now.addingTimeInterval(WidgetData.expiryCriticalWindow + 3600)]
+        XCTAssertEqual(data.expirySeverity(now: now), .warning)
 
-        // No expiries at all → no warning.
+        // Every credit comfortably outside the warning window -> blue.
+        data.expiriesAt = [now.addingTimeInterval(WidgetData.expiryWarningWindow + 24 * 3600)]
+        XCTAssertEqual(data.expirySeverity(now: now), .normal)
+
+        // No expiries at all -> no dot.
         data.expiriesAt = []
-        XCTAssertFalse(data.hasImminentExpiry)
+        XCTAssertNil(data.expirySeverity(now: now))
     }
 
     func testNoExpiryTooltipWhenNoExpiries() {


### PR DESCRIPTION
## TL;DR
The Codex "Rate Limit Resets" row now shows a small blue/yellow/red status dot so you can see at a glance how soon your next reset credit expires — without needing to hover.

## What was happening
- The row only showed an amber warning triangle, and only within the final 24 hours before a credit expired.
- Outside that window there was no visual cue at all — you had to hover the value to learn when credits expire.

## What this changes
- Replaces the imminent-only triangle with an always-present status dot before the value:
  - **Blue** — soonest credit expires in more than 7 days
  - **Yellow** — expires within 7 days
  - **Red** — expires within 48 hours
- Hovering the dot still reveals the same per-credit expiry breakdown as before.
- Recomputes on the popover's 30s clock tick, so the color stays live.

## Heads-up
- The expiry thresholds live in `WidgetData` (`expiryWarningWindow` = 7d, `expiryCriticalWindow` = 48h); adjust there if the bands need tuning.

## Tests
- Updated `ResetDisplayTests` to cover the three color bands (blue/yellow/red) and the no-expiry (no dot) case.

## Screenshots

<img width="638" height="290" alt="image" src="https://github.com/user-attachments/assets/037ba204-7f70-447e-adf4-57ecd077bfb9" />

Made with [Cursor](https://cursor.com)