### PR TITLE
fix(refresh): fetch newly detected providers immediately and speed up first-run credential detection

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -172,8 +172,23 @@ final class AppContainer {
     /// cache, so it only hits the network once a snapshot has actually expired. `@Observable` propagates
     /// the resulting snapshot changes to the menu-bar label and any open widgets, so the UI refreshes on
     /// its own instead of only when the popover opens.
+    ///
+    /// Between passes the loop sleeps via `RefreshWakeSignal`, which wakes it early when the user
+    /// enables/disables a provider so a newly-enabled provider is fetched promptly instead of waiting out
+    /// the full interval. The signal subscribes BEFORE the first pass and buffers, so an enablement change
+    /// landing while a pass is still running (first-run credential detection, `NewProviderSeeder`, the
+    /// Customize "Reset All" reseed — all of which typically finish faster than the network fetches) is
+    /// never lost. Each pass still honors the cache (and the per-provider failure backoff), so an early
+    /// wake only hits the network for a provider whose snapshot has actually expired.
+    ///
+    /// The wake is deliberately scoped to `ProviderEnablementStore.didChangeNotification` — NOT the
+    /// firehose `UserDefaults.didChangeNotification`, which fires for the app's own snapshot-cache writes,
+    /// Sparkle's update bookkeeping, and unrelated global-domain changes from other processes. Waking on
+    /// that, with no minimum interval before re-refreshing, collapsed the fixed 5-minute cadence into a
+    /// refresh storm.
     private static func startPeriodicRefresh(dataStore: WidgetDataStore, telemetry: TelemetryRecorder) -> Task<Void, Never> {
         Task {
+            let wakeSignal = RefreshWakeSignal()
             while !Task.isCancelled {
                 await dataStore.refreshAll()
                 // Re-evaluate quota pace milestones every tick — after the refresh so it sees fresh data,
@@ -184,33 +199,8 @@ final class AppContainer {
                 // prior-day provider rollups. Runs on launch and every interval, so always-running
                 // instances still produce a daily-active signal.
                 telemetry.tick()
-                await waitForNextRefresh()
+                await wakeSignal.waitForWake(timeout: RefreshSetting.interval)
             }
-        }
-    }
-
-    /// Sleep for the refresh interval, but wake early when the user enables/disables a provider so a
-    /// newly-enabled provider is fetched promptly instead of waiting out the full interval. Each pass still
-    /// honors the cache (and the per-provider failure backoff), so an early wake only hits the network for
-    /// a provider whose snapshot has actually expired.
-    ///
-    /// Deliberately scoped to `ProviderEnablementStore.didChangeNotification` — NOT the firehose
-    /// `UserDefaults.didChangeNotification`, which fires for the app's own snapshot-cache writes, Sparkle's
-    /// update bookkeeping, and unrelated global-domain changes from other processes. Waking on that, with
-    /// no minimum interval before re-refreshing, collapsed the fixed 5-minute cadence into a refresh storm.
-    private static func waitForNextRefresh() async {
-        let interval = RefreshSetting.interval
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try? await Task.sleep(for: .seconds(interval))
-            }
-            group.addTask {
-                for await _ in NotificationCenter.default.notifications(named: ProviderEnablementStore.didChangeNotification) {
-                    break
-                }
-            }
-            _ = await group.next()
-            group.cancelAll()
         }
     }
 }

--- a/Sources/OpenUsage/App/FirstRunSeeder.swift
+++ b/Sources/OpenUsage/App/FirstRunSeeder.swift
@@ -70,12 +70,21 @@ enum FirstRunSeeder {
     }
 
     /// Local-only credential probe across every provider: the set whose `hasLocalCredentials()` (config
-    /// files/keychain, never the network) reports a login on this machine. Shared by first-run seeding
-    /// and the Customize "Reset All" reseed so both detect installed tools the same way.
+    /// files/keychain, never the network) reports a login on this machine. Shared by first-run seeding,
+    /// `NewProviderSeeder`, and the Customize "Reset All" reseed so all detect installed tools the same way.
+    ///
+    /// Probes run concurrently — the same MainActor-safe fan-out as `WidgetDataStore.refreshAll` (one
+    /// `Task {}` per provider; the overlap happens at the off-main-actor loads inside each probe). A
+    /// single probe can shell out to `security`/`sqlite3` with waits of up to ~5s, so probing the whole
+    /// registry sequentially made detection take the *sum* of those waits — long enough that detected
+    /// providers visibly trickled in on first launch.
     static func detectLocalProviders(_ providers: [ProviderRuntime]) async -> Set<String> {
+        let probes = providers.map { provider in
+            (provider.provider.id, Task { await provider.hasLocalCredentials() })
+        }
         var detected = Set<String>()
-        for provider in providers where await provider.hasLocalCredentials() {
-            detected.insert(provider.provider.id)
+        for (id, probe) in probes where await probe.value {
+            detected.insert(id)
         }
         return detected
     }

--- a/Sources/OpenUsage/App/NewProviderSeeder.swift
+++ b/Sources/OpenUsage/App/NewProviderSeeder.swift
@@ -36,9 +36,10 @@ enum NewProviderSeeder {
         AppLog.info(.config, "new providers since last run: \(newIDs.sorted()); probing local credentials")
 
         return Task {
-            for provider in providers where newIDs.contains(provider.provider.id) {
-                let id = provider.provider.id
-                guard await provider.hasLocalCredentials() else { continue }
+            // Same concurrent local-only probe as first-run detection and the Reset All reseed.
+            let newProviders = providers.filter { newIDs.contains($0.provider.id) }
+            let detected = await FirstRunSeeder.detectLocalProviders(newProviders)
+            for id in detected.sorted() {
                 // The probe takes a moment; if the user already turned the provider on themselves,
                 // leave their toggle alone (setEnabled would be a no-op anyway).
                 guard !enablement.isEnabled(id) else { continue }

--- a/Sources/OpenUsage/App/RefreshWakeSignal.swift
+++ b/Sources/OpenUsage/App/RefreshWakeSignal.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// The refresh loop's between-passes wait: sleeps one refresh interval, but wakes early when the
+/// enabled-provider set changes — and, crucially, never loses a change that lands *during* a pass.
+///
+/// The bug this replaces: the loop used to subscribe to
+/// `ProviderEnablementStore.didChangeNotification` only inside its wait, after `refreshAll()` had
+/// finished. First-run credential detection is local-only and fast while the first refresh pass does
+/// network I/O and is slow, so the "providers enabled" notification almost always fired mid-pass with
+/// nobody listening — `NotificationCenter.notifications(named:)` doesn't buffer events from before
+/// iteration starts. The wake was silently dropped and the newly detected providers sat dataless until
+/// the next scheduled pass or a manual refresh. The same lost wake hit `NewProviderSeeder` and the
+/// Customize "Reset All" reseed.
+///
+/// Here the subscription is installed once, synchronously, in `init` — before the loop's first pass —
+/// feeding an `AsyncStream` with `.bufferingNewest(1)`: a wake posted while nobody is waiting is
+/// retained, and a burst coalesces into a single pending wake, so the next `waitForWake` returns
+/// immediately instead of sleeping out the interval.
+@MainActor
+final class RefreshWakeSignal {
+    private let stream: AsyncStream<Void>
+    private let continuation: AsyncStream<Void>.Continuation
+    private let center: NotificationCenter
+    /// `nonisolated(unsafe)` so the nonisolated `deinit` can unregister the observer; it is immutable
+    /// after `init`, and `NotificationCenter` is documented thread-safe.
+    private nonisolated(unsafe) let observer: NSObjectProtocol
+
+    init(
+        name: Notification.Name = ProviderEnablementStore.didChangeNotification,
+        center: NotificationCenter = .default
+    ) {
+        let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
+        self.stream = stream
+        self.continuation = continuation
+        self.center = center
+        // Registered synchronously, so no notification posted after `init` returns can be missed.
+        // The continuation is `Sendable`; yielding from whatever context posts is safe.
+        self.observer = center.addObserver(forName: name, object: nil, queue: nil) { _ in
+            continuation.yield()
+        }
+    }
+
+    deinit {
+        center.removeObserver(observer)
+        continuation.finish()
+    }
+
+    /// Returns when a wake has been posted — including one buffered while the caller was doing other
+    /// work — or when `timeout` elapses, whichever comes first (the timer feeds the same stream). Also
+    /// returns promptly when the surrounding task is cancelled. If the timeout and a wake race, the
+    /// loser stays buffered; the resulting extra pass is all cache hits, so it stays harmless.
+    ///
+    /// The refresh loop is the signal's only consumer, and only ever sequentially: each call makes a
+    /// fresh iterator over the shared stream (fine sequentially — the buffer lives on the stream), so
+    /// no actor-isolated iterator state has to survive a suspension.
+    func waitForWake(timeout: TimeInterval) async {
+        let timer = Task { [continuation] in
+            try? await Task.sleep(for: .seconds(timeout))
+            guard !Task.isCancelled else { return }
+            continuation.yield()
+        }
+        defer { timer.cancel() }
+        var iterator = stream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+}

--- a/Tests/OpenUsageTests/FirstRunSeederTests.swift
+++ b/Tests/OpenUsageTests/FirstRunSeederTests.swift
@@ -142,6 +142,23 @@ final class FirstRunSeederTests: XCTestCase {
         XCTAssertEqual(enablement.enabledIDs, ["claude", "cursor"])
     }
 
+    // MARK: - Concurrent detection
+
+    func testDetectLocalProvidersProbesConcurrently() async {
+        // A single probe can block on a `security`/`sqlite3` subprocess for seconds, so probing
+        // sequentially made first-launch detection take the sum of all providers' waits. Each gated
+        // stub suspends until every probe has *started* (and reports a credential only then), so a
+        // sequential regression — where the first probe would finish before the second begins — fails
+        // the assertion instead of detecting anything.
+        let ids = ["claude", "codex", "cursor", "grok"]
+        let gate = ProbeGate(expected: ids.count)
+        let providers = ids.map { GatedCredentialProvider(id: $0, gate: gate) }
+
+        let detected = await FirstRunSeeder.detectLocalProviders(providers)
+
+        XCTAssertEqual(detected, Set(ids), "all probes must be in flight at once, not one after another")
+    }
+
     // MARK: - OnboardingStore persistence
 
     func testCustomizeHintFlagPersistsAcrossInstances() {
@@ -187,4 +204,60 @@ private final class CredentialStubProvider: ProviderRuntime {
     }
 
     func hasLocalCredentials() async -> Bool { hasCredentials }
+}
+
+/// A provider whose credential probe suspends on a shared `ProbeGate` until all expected probes have
+/// started — "credentials found" therefore means "my probe overlapped every other probe".
+@MainActor
+private final class GatedCredentialProvider: ProviderRuntime {
+    let provider: Provider
+    let widgetDescriptors: [WidgetDescriptor] = []
+    private let gate: ProbeGate
+
+    init(id: String, gate: ProbeGate) {
+        self.provider = Provider(id: id, displayName: id.capitalized, icon: .providerMark(id))
+        self.gate = gate
+    }
+
+    func refresh() async -> ProviderSnapshot {
+        ProviderSnapshot.make(provider: provider, plan: nil, lines: [], refreshedAt: Date())
+    }
+
+    func hasLocalCredentials() async -> Bool { await gate.arrive() }
+}
+
+/// Suspends each arriver until `expected` arrivals are in flight, then resumes them all with `true`.
+/// A safety valve resumes stragglers with `false` after a few seconds, so a sequential-probing
+/// regression fails the test's assertion instead of hanging the suite.
+@MainActor
+private final class ProbeGate {
+    private let expected: Int
+    private var arrived = 0
+    private var nextWaiterID = 0
+    private var waiters: [Int: CheckedContinuation<Bool, Never>] = [:]
+
+    init(expected: Int) {
+        self.expected = expected
+    }
+
+    func arrive() async -> Bool {
+        arrived += 1
+        if arrived == expected {
+            for waiter in waiters.values {
+                waiter.resume(returning: true)
+            }
+            waiters = [:]
+            return true
+        }
+        let id = nextWaiterID
+        nextWaiterID += 1
+        return await withCheckedContinuation { continuation in
+            waiters[id] = continuation
+            Task { [weak self] in
+                try? await Task.sleep(for: .seconds(5))
+                guard let waiter = self?.waiters.removeValue(forKey: id) else { return }
+                waiter.resume(returning: false)
+            }
+        }
+    }
 }

--- a/Tests/OpenUsageTests/RefreshWakeSignalTests.swift
+++ b/Tests/OpenUsageTests/RefreshWakeSignalTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the refresh loop's between-passes wait. The regression that motivates these tests: the loop
+/// used to subscribe to the enablement-change notification only *inside* its wait, so a change posted
+/// while a refresh pass was still running (first-run credential detection finishing, `NewProviderSeeder`,
+/// the Reset All reseed) was silently dropped, and newly enabled providers sat dataless until the next
+/// scheduled pass. `RefreshWakeSignal` subscribes in `init` and buffers, so a wake can never be lost.
+@MainActor
+final class RefreshWakeSignalTests: XCTestCase {
+    private let wakeName = Notification.Name("RefreshWakeSignalTests.wake")
+
+    func testWakePostedBeforeWaitBeginsIsNotLost() async {
+        // The lost-wake bug: the notification fires while the loop is busy refreshing (nobody is
+        // suspended in a wait yet). The signal must buffer it and return immediately — a regression
+        // here would sleep out the full (long) timeout and trip the elapsed assertion.
+        let center = NotificationCenter()
+        let signal = RefreshWakeSignal(name: wakeName, center: center)
+
+        center.post(name: wakeName, object: nil)
+
+        let start = Date()
+        await signal.waitForWake(timeout: 60)
+        XCTAssertLessThan(
+            Date().timeIntervalSince(start), 5,
+            "a wake posted before the wait began must be buffered, not lost"
+        )
+    }
+
+    func testWakeWhileWaitingResumesBeforeTimeout() async {
+        let center = NotificationCenter()
+        let signal = RefreshWakeSignal(name: wakeName, center: center)
+
+        let start = Date()
+        let wait = Task { await signal.waitForWake(timeout: 60) }
+        // Let the wait suspend before posting, so this exercises the live-wake path (not the buffer).
+        await Task.yield()
+        center.post(name: wakeName, object: nil)
+
+        await wait.value
+        XCTAssertLessThan(Date().timeIntervalSince(start), 5)
+    }
+
+    func testNoWakeFallsBackToTimeout() async {
+        let center = NotificationCenter()
+        let signal = RefreshWakeSignal(name: wakeName, center: center)
+
+        let start = Date()
+        await signal.waitForWake(timeout: 0.1)
+        // `Task.sleep` never fires early; returning proves the timer path works without any wake.
+        XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), 0.09)
+    }
+
+    func testWakeBurstCoalescesIntoASingleWake() async {
+        let center = NotificationCenter()
+        let signal = RefreshWakeSignal(name: wakeName, center: center)
+
+        for _ in 0..<3 {
+            center.post(name: wakeName, object: nil)
+        }
+
+        // The burst collapses into one buffered wake: the first wait consumes it immediately...
+        await signal.waitForWake(timeout: 60)
+
+        // ...and the second finds nothing buffered, so it sleeps out its full timeout.
+        let start = Date()
+        await signal.waitForWake(timeout: 0.1)
+        XCTAssertGreaterThanOrEqual(
+            Date().timeIntervalSince(start), 0.09,
+            "a burst of wakes must coalesce into one, not queue up extra refresh passes"
+        )
+    }
+}

--- a/docs/provider-enablement.md
+++ b/docs/provider-enablement.md
@@ -4,7 +4,7 @@ How OpenUsage decides which providers start on, what happens when an update adds
 
 ## First install
 
-A fresh install doesn't turn on every provider OpenUsage knows about. It starts with Claude, Codex, and Cursor, then quickly checks which AI tools are actually set up on your Mac — by looking for their local logins (config files, keychain); nothing is sent anywhere — and switches to exactly that set. If nothing is found, the Claude/Codex/Cursor starter set stays. See [Dashboard § First launch](dashboard.md#first-launch) for how the dashboard presents this.
+A fresh install doesn't turn on every provider OpenUsage knows about. It starts with Claude, Codex, and Cursor, then quickly checks which AI tools are actually set up on your Mac — by looking for their local logins (config files, keychain); nothing is sent anywhere — and switches to exactly that set. All providers are checked at once, so detection takes as long as the slowest single check, not the sum of them. If nothing is found, the Claude/Codex/Cursor starter set stays. Providers the check turns on are fetched right away, so they appear with data instead of waiting for the next scheduled refresh. See [Dashboard § First launch](dashboard.md#first-launch) for how the dashboard presents this.
 
 ## When an update adds a new provider
 

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -3,6 +3,7 @@
 ## When data updates
 
 - All enabled providers refresh together: at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Providers fetch in parallel — one slow provider doesn't delay the others.
+- Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running.
 - The popover footer shows `Next update in Nm`. **Clicking it (or ⌘R)** refreshes immediately, skipping the cache.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.
 


### PR DESCRIPTION
## TL;DR

On a fresh install (or after wiping settings), detected providers showed up on the dashboard but sat without data until the next 5-minute refresh or a manual ⌘R. This fixes the race that caused it, and makes detection itself finish in a fraction of the time.

## What was happening

- The refresh loop only started listening for "the enabled-provider set changed" *between* refresh passes. First-run credential detection is local-only and fast, while the first refresh pass does network fetches and is slow — so the "providers enabled" signal almost always fired mid-pass, with nobody listening, and was silently dropped.
- The newly detected providers (Antigravity, OpenRouter, …) were then stuck dataless until the next scheduled pass (5 minutes) or a manual refresh.
- The same lost wake affected providers added by an update (`NewProviderSeeder`) and the Customize "Reset All" reseed.
- Separately, the credential probe checked all 9 providers one after another. A single probe can block on a `security`/`sqlite3` subprocess for seconds, so detection took the *sum* of those waits — the visible delay before detected providers appeared at all.

## What this changes

- New `RefreshWakeSignal`: the loop's between-passes wait. It subscribes to the enablement-change notification once, up front (before the first pass), buffering into an `AsyncStream` with `.bufferingNewest(1)` — a wake landing mid-pass is retained, and a burst coalesces into a single follow-up pass. The timeout timer feeds the same stream.
- `AppContainer`'s refresh loop uses that signal instead of subscribing inside the wait, so an enablement change during a pass triggers a prompt fetch of just the newly enabled providers (everything else is a cache hit).
- `FirstRunSeeder.detectLocalProviders` probes all providers concurrently (same fan-out as `refreshAll`), so detection takes the slowest single probe instead of the sum. `NewProviderSeeder` reuses the shared probe.
- Docs updated (`provider-enablement.md`, `refreshing.md`).

## Heads-up

- User-facing semantics are unchanged: fallback-first synchronous seeding, "user toggle wins" during the probe, provider ordering, and the 5-minute cadence all stay as they were.

## Tests

- New `RefreshWakeSignalTests`: a wake posted before the wait begins is not lost (the regression), a live wake resumes promptly, no wake falls back to the timeout, a burst coalesces into one wake.
- New `FirstRunSeederTests.testDetectLocalProvidersProbesConcurrently`: gated stubs only report credentials when every probe overlaps, so a sequential regression fails the assertion (with a safety valve so it can't hang the suite).
- Full suite passes (`swift test --build-system native`).
- Verified live: wiped the dev build's settings and relaunched — detection finished in ~225ms (was multi-second), and the follow-up pass for the 6 newly enabled providers started immediately after the first pass instead of 5 minutes later:

```
08:28:49.682 first run: seeded providers [claude, codex, cursor]; probing
08:28:49.846 batch start (3 providers)
08:28:49.907 first run: detected credentials for [antigravity, claude, codex, copilot, cursor, devin, grok, openrouter, zai]
08:28:56.701 batch end
08:28:56.703 batch start (9 providers)   <- immediate, previously 5 minutes away
08:28:59.000 batch end (5 ok / 1 failed / 3 cached)
```

Made with [Cursor](https://cursor.com)