### PR TITLE
refactor(LayoutStore): extract PopoverNavigationStore + generic TransientNotice

### DIFF
--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -10,8 +10,9 @@ final class LayoutStore {
 
     /// In-popover navigation (screen, Customize master/detail, screen-switch slide). Its own store so
     /// screen routing isn't tangled with layout state; the `screen`/`isEditing`/`customizeProviderID`/
-    /// `screenSlide*` surface below forwards to it, so existing call sites are unchanged.
-    let navigation = PopoverNavigationStore()
+    /// `screenSlide*` surface below forwards to it, so existing call sites are unchanged. Private so the
+    /// forwarding surface stays the ONLY spelling — two live paths to the same state invites drift.
+    private let navigation = PopoverNavigationStore()
 
     /// Which in-popover screen is showing. Drives the footer buttons, the Esc handler, and the
     /// popover-closed reset alike.
@@ -57,15 +58,12 @@ final class LayoutStore {
     /// stay open across popover closes and app restarts.
     private(set) var expandedProviderIDs: Set<String>
 
-    /// Transient explanation for a denied pin attempt (the WhatsApp-style "you can only pin N chats"
-    /// feedback). Set by `notePinDenied`, cleared automatically a few seconds later; the popover footer
-    /// renders it in place of the pin counter. Never persisted.
     /// The three transient popover pills, each an auto-clearing `TransientNotice` (was three copy-pasted
     /// value+trigger+clearTask machines). The public `pinLimitNotice`/`shareConfirmation`/
     /// `customizationNotice` surface below forwards to these, so call sites are unchanged.
     private let pinNotice = TransientNotice<String?>(clearedValue: nil, timeout: .seconds(3))
     private let shareNotice = TransientNotice<Bool>(clearedValue: false, timeout: .seconds(2.5))
-    private let customizationNoticeStore = TransientNotice<CustomizationNoticeContent?>(clearedValue: nil, timeout: .seconds(2.5))
+    private let customizeNotice = TransientNotice<CustomizationNoticeContent?>(clearedValue: nil, timeout: .seconds(2.5))
 
     /// Transient explanation for a denied pin attempt; the popover footer renders it in place of the pin
     /// counter. Set by `notePinDenied`, auto-cleared a few seconds later.
@@ -79,11 +77,14 @@ final class LayoutStore {
     var shareConfirmationTrigger: Int { shareNotice.trigger }
 
     /// Transient in-Customize notice (e.g. "Starred for menu bar", or the orange cap denial).
-    var customizationNotice: String? { customizationNoticeStore.value?.message }
-    /// The notice's tone: `.positive` (green checkmark) or `.notice` (orange denial).
-    var customizationNoticeTone: CustomizationNoticeTone { customizationNoticeStore.value?.tone ?? .positive }
+    var customizationNotice: String? { customizeNotice.value?.message }
+    /// The notice's tone: `.positive` (green checkmark) or `.notice` (orange denial). Falls back to
+    /// `.positive` once cleared (tone is only read while `customizationNotice` is non-nil, so the
+    /// snap-back is unobservable — message and tone now clear atomically, which the old split state
+    /// machine couldn't guarantee).
+    var customizationNoticeTone: CustomizationNoticeTone { customizeNotice.value?.tone ?? .positive }
     /// Bumped on every present so the pill replays its pop-in even when the same notice repeats.
-    var customizationNoticeTrigger: Int { customizationNoticeStore.trigger }
+    var customizationNoticeTrigger: Int { customizeNotice.trigger }
 
     /// Bounded, app-wide undo stack for layout customization (remove/add a metric, reorder metrics or
     /// providers, pin/unpin, move across the expand caret). UI-only state (not persisted): undo is a
@@ -783,13 +784,13 @@ final class LayoutStore {
     /// `tone` picks the green success style or the orange denial style. Auto-clears after a couple of
     /// seconds; also cleared on popover close via `clearCustomizationNotice`.
     func presentCustomizationNotice(_ message: String, tone: CustomizationNoticeTone = .positive) {
-        customizationNoticeStore.present(CustomizationNoticeContent(message: message, tone: tone))
+        customizeNotice.present(CustomizationNoticeContent(message: message, tone: tone))
     }
 
     /// Clear any showing Customize pill and cancel its auto-clear task. Called when the popover closes
     /// so a pill mid-countdown can't reappear stale on the next open.
     func clearCustomizationNotice() {
-        customizationNoticeStore.clear()
+        customizeNotice.clear()
     }
 
     /// Pin or unpin a metric for the menu bar. Pinning is a no-op when it would exceed a cap, so callers

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -1,63 +1,37 @@
 import SwiftUI
 import Observation
 
-/// The screen showing inside the menu-bar popover. Customize and Settings replace the dashboard
-/// in place (the popover has no window stack); Esc backs out to the dashboard first.
-enum PopoverScreen: Hashable, Sendable {
-    case dashboard
-    case customize
-    case settings
-
-    /// Left-to-right order for the popover's horizontal screen-switch slide: the dashboard is home on
-    /// the left, with Customize and Settings to its right. The slide reads its direction from these
-    /// ranks — a higher-ranked target enters from the trailing edge, a lower one from the leading edge.
-    var slideRank: Int {
-        switch self {
-        case .dashboard: 0
-        case .customize: 1
-        case .settings: 2
-        }
-    }
-}
-
 /// Mutable layout: which widgets are enabled, provider order, and each provider's metric order.
 /// `placed` is the enabled set (with stable widget ids); `metricOrderByProvider` is the user's custom order.
 @MainActor
 @Observable
 final class LayoutStore {
     var placed: [PlacedWidget]
-    /// Which in-popover screen is showing. Lives here (not per-view state) so the footer buttons,
-    /// the Esc handler, and the popover-closed reset all drive the same mode.
-    var screen = PopoverScreen.dashboard {
-        didSet {
-            guard screen != oldValue else { return }
-            // Recorded synchronously with the change — not via SwiftUI's `onChange`, which fires a
-            // frame later and would let the popover paint the destination before the slide begins.
-            // DashboardView reads these on its very next render to slide in from the screen being left.
-            screenSlideFrom = oldValue
-            screenSlideID += 1
-            // Leaving Customize drops the L2 detail selection so reopening Customize shows the list,
-            // never a stranded detail screen. The popover-closed reset sets `screen = .dashboard`, so
-            // this also covers close/reopen.
-            if screen != .customize { customizeProviderID = nil }
-        }
+
+    /// In-popover navigation (screen, Customize master/detail, screen-switch slide). Its own store so
+    /// screen routing isn't tangled with layout state; the `screen`/`isEditing`/`customizeProviderID`/
+    /// `screenSlide*` surface below forwards to it, so existing call sites are unchanged.
+    let navigation = PopoverNavigationStore()
+
+    /// Which in-popover screen is showing. Drives the footer buttons, the Esc handler, and the
+    /// popover-closed reset alike.
+    var screen: PopoverScreen {
+        get { navigation.screen }
+        set { navigation.screen = newValue }
     }
-    /// Supports DashboardView's horizontal screen-switch slide: the screen being left, plus a counter
-    /// that ticks on every switch so the view can detect and animate each transition. UI-only; not persisted.
-    private(set) var screenSlideFrom = PopoverScreen.dashboard
-    private(set) var screenSlideID = 0
-    /// Whether the Customize screen (per-provider metric toggles + reorder) is showing — a bridge
-    /// over `screen` for the many call sites that think in terms of edit mode.
+    /// The screen being left plus a per-switch counter, for DashboardView's horizontal slide.
+    var screenSlideFrom: PopoverScreen { navigation.screenSlideFrom }
+    var screenSlideID: Int { navigation.screenSlideID }
+    /// Whether the Customize screen is showing — a bridge over `screen` for edit-mode call sites.
     var isEditing: Bool {
-        get { screen == .customize }
-        set { screen = newValue ? .customize : .dashboard }
+        get { navigation.isEditing }
+        set { navigation.isEditing = newValue }
     }
-    /// The provider whose Customize detail (L2) is showing. nil shows the provider list (L1); a set id
-    /// shows that provider's metric sections and API key. UI-only (not persisted): transient navigation
-    /// like `draggingID`, cleared when leaving Customize (see `screen`'s didSet) and on popover close
-    /// (DashboardView resets `screen` to `.dashboard`). Kept separate from `expandedProviderIDs` —
-    /// that's the dashboard caret, unrelated to this master/detail route.
-    var customizeProviderID: String?
+    /// The provider whose Customize detail (L2) is showing (nil shows the L1 list).
+    var customizeProviderID: String? {
+        get { navigation.customizeProviderID }
+        set { navigation.customizeProviderID = newValue }
+    }
     /// Placed widget being drag-reordered (transient). `PlacedWidget.id`, never persisted.
     var draggingID: UUID?
     /// Persisted provider display order (provider IDs). Drives both the dashboard groups and the
@@ -86,31 +60,30 @@ final class LayoutStore {
     /// Transient explanation for a denied pin attempt (the WhatsApp-style "you can only pin N chats"
     /// feedback). Set by `notePinDenied`, cleared automatically a few seconds later; the popover footer
     /// renders it in place of the pin counter. Never persisted.
-    private(set) var pinLimitNotice: String?
-    /// Bumped on every denied pin click so the footer notice plays its deny shake each time — including
-    /// repeated clicks while the notice is already showing (where the text itself doesn't change).
-    private(set) var pinNoticeShakeTrigger = 0
-    private var pinNoticeClearTask: Task<Void, Never>?
+    /// The three transient popover pills, each an auto-clearing `TransientNotice` (was three copy-pasted
+    /// value+trigger+clearTask machines). The public `pinLimitNotice`/`shareConfirmation`/
+    /// `customizationNotice` surface below forwards to these, so call sites are unchanged.
+    private let pinNotice = TransientNotice<String?>(clearedValue: nil, timeout: .seconds(3))
+    private let shareNotice = TransientNotice<Bool>(clearedValue: false, timeout: .seconds(2.5))
+    private let customizationNoticeStore = TransientNotice<CustomizationNoticeContent?>(clearedValue: nil, timeout: .seconds(2.5))
 
-    /// Transient confirmation that a provider's screenshot was copied to the clipboard — drives the
-    /// floating "Copied to clipboard" pill above the footer. Set by `presentShareConfirmation`,
-    /// cleared automatically a couple of seconds later. Never persisted.
-    private(set) var shareConfirmation = false
-    /// Bumped on every successful share so the pill replays its pop-in even when the same provider is
-    /// copied twice in a row (the pill's text doesn't change, so without this it wouldn't re-animate).
-    private(set) var shareConfirmationTrigger = 0
-    private var shareConfirmationClearTask: Task<Void, Never>?
+    /// Transient explanation for a denied pin attempt; the popover footer renders it in place of the pin
+    /// counter. Set by `notePinDenied`, auto-cleared a few seconds later.
+    var pinLimitNotice: String? { pinNotice.value }
+    /// Bumped on every denied pin click so the footer notice plays its deny shake each time.
+    var pinNoticeShakeTrigger: Int { pinNotice.trigger }
 
-    /// Transient in-Customize notice that drives the floating pill above the Customize content (e.g.
-    /// "Starred for menu bar", or the orange "Up to 2 stars per provider" denial). Set by
-    /// `presentCustomizationNotice`, cleared automatically after a couple of seconds. Never persisted;
-    /// cleared on popover close via `clearCustomizationNotice`.
-    private(set) var customizationNotice: String?
-    /// The notice's tone: `.positive` (green checkmark, success) or `.notice` (orange, the cap denial).
-    private(set) var customizationNoticeTone: CustomizationNoticeTone = .positive
+    /// Transient "Copied to clipboard" confirmation for the floating pill above the footer.
+    var shareConfirmation: Bool { shareNotice.value }
+    /// Bumped on every successful share so the pill replays its pop-in even on a repeat copy.
+    var shareConfirmationTrigger: Int { shareNotice.trigger }
+
+    /// Transient in-Customize notice (e.g. "Starred for menu bar", or the orange cap denial).
+    var customizationNotice: String? { customizationNoticeStore.value?.message }
+    /// The notice's tone: `.positive` (green checkmark) or `.notice` (orange denial).
+    var customizationNoticeTone: CustomizationNoticeTone { customizationNoticeStore.value?.tone ?? .positive }
     /// Bumped on every present so the pill replays its pop-in even when the same notice repeats.
-    private(set) var customizationNoticeTrigger = 0
-    private var customizationNoticeClearTask: Task<Void, Never>?
+    var customizationNoticeTrigger: Int { customizationNoticeStore.trigger }
 
     /// Bounded, app-wide undo stack for layout customization (remove/add a metric, reorder metrics or
     /// providers, pin/unpin, move across the expand caret). UI-only state (not persisted): undo is a
@@ -789,60 +762,34 @@ final class LayoutStore {
     /// with a deny shake on every attempt).
     func notePinDenied(_ descriptorID: String) {
         guard let reason = pinDenialReason(descriptorID) else { return }
-        pinLimitNotice = reason
-        pinNoticeShakeTrigger += 1
-        pinNoticeClearTask?.cancel()
-        pinNoticeClearTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(3))
-            guard !Task.isCancelled else { return }
-            self?.pinLimitNotice = nil
-        }
+        pinNotice.present(reason)
     }
 
     /// Record a successful "Share Screenshot" copy so the floating "Copied to clipboard" pill can
     /// confirm it. Shown for a couple of seconds then cleared — the success-side counterpart to
     /// `notePinDenied`'s transient denial notice, with the same lifecycle.
     func presentShareConfirmation() {
-        shareConfirmation = true
-        shareConfirmationTrigger += 1
-        shareConfirmationClearTask?.cancel()
-        shareConfirmationClearTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(2.5))
-            guard !Task.isCancelled else { return }
-            self?.shareConfirmation = false
-        }
+        shareNotice.present(true)
     }
 
     /// Clear any showing "Copied to clipboard" confirmation and cancel its auto-clear task. Called when
     /// the popover closes so a pill mid-countdown can't reappear stale on the next open — the timer is
     /// otherwise the only clearer, and the layout store outlives the popover.
     func clearShareConfirmation() {
-        shareConfirmation = false
-        shareConfirmationClearTask?.cancel()
-        shareConfirmationClearTask = nil
+        shareNotice.clear()
     }
 
     /// Show a transient in-Customize pill (the floating confirmation above the Customize content).
     /// `tone` picks the green success style or the orange denial style. Auto-clears after a couple of
     /// seconds; also cleared on popover close via `clearCustomizationNotice`.
     func presentCustomizationNotice(_ message: String, tone: CustomizationNoticeTone = .positive) {
-        customizationNotice = message
-        customizationNoticeTone = tone
-        customizationNoticeTrigger += 1
-        customizationNoticeClearTask?.cancel()
-        customizationNoticeClearTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(2.5))
-            guard !Task.isCancelled else { return }
-            self?.customizationNotice = nil
-        }
+        customizationNoticeStore.present(CustomizationNoticeContent(message: message, tone: tone))
     }
 
     /// Clear any showing Customize pill and cancel its auto-clear task. Called when the popover closes
     /// so a pill mid-countdown can't reappear stale on the next open.
     func clearCustomizationNotice() {
-        customizationNotice = nil
-        customizationNoticeClearTask?.cancel()
-        customizationNoticeClearTask = nil
+        customizationNoticeStore.clear()
     }
 
     /// Pin or unpin a metric for the menu bar. Pinning is a no-op when it would exceed a cap, so callers
@@ -1203,4 +1150,10 @@ struct ProviderRow: Identifiable {
 enum CustomizationNoticeTone {
     case positive
     case notice
+}
+
+/// The message + tone carried by the Customize pill's `TransientNotice`, so its two fields clear together.
+struct CustomizationNoticeContent {
+    var message: String
+    var tone: CustomizationNoticeTone
 }

--- a/Sources/OpenUsage/Stores/PopoverNavigationStore.swift
+++ b/Sources/OpenUsage/Stores/PopoverNavigationStore.swift
@@ -1,4 +1,3 @@
-import SwiftUI
 import Observation
 
 /// The screen showing inside the menu-bar popover. Customize and Settings replace the dashboard

--- a/Sources/OpenUsage/Stores/PopoverNavigationStore.swift
+++ b/Sources/OpenUsage/Stores/PopoverNavigationStore.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import Observation
+
+/// The screen showing inside the menu-bar popover. Customize and Settings replace the dashboard
+/// in place (the popover has no window stack); Esc backs out to the dashboard first.
+enum PopoverScreen: Hashable, Sendable {
+    case dashboard
+    case customize
+    case settings
+
+    /// Left-to-right order for the popover's horizontal screen-switch slide: the dashboard is home on
+    /// the left, with Customize and Settings to its right. The slide reads its direction from these
+    /// ranks — a higher-ranked target enters from the trailing edge, a lower one from the leading edge.
+    var slideRank: Int {
+        switch self {
+        case .dashboard: 0
+        case .customize: 1
+        case .settings: 2
+        }
+    }
+}
+
+/// In-popover navigation: which screen is showing, the master/detail route inside Customize, and the
+/// horizontal screen-switch slide bookkeeping. Split out of `LayoutStore` (which owns the *layout* —
+/// enabled widgets, order, pins) so screen routing is its own concern; `LayoutStore` forwards its
+/// existing `screen`/`isEditing`/`customizeProviderID`/`screenSlide*` surface to this store, so callers
+/// are unchanged.
+@MainActor
+@Observable
+final class PopoverNavigationStore {
+    /// Which in-popover screen is showing. Drives the footer buttons, the Esc handler, and the
+    /// popover-closed reset alike.
+    var screen = PopoverScreen.dashboard {
+        didSet {
+            guard screen != oldValue else { return }
+            // Recorded synchronously with the change — not via SwiftUI's `onChange`, which fires a
+            // frame later and would let the popover paint the destination before the slide begins.
+            // DashboardView reads these on its very next render to slide in from the screen being left.
+            screenSlideFrom = oldValue
+            screenSlideID += 1
+            // Leaving Customize drops the L2 detail selection so reopening Customize shows the list,
+            // never a stranded detail screen. The popover-closed reset sets `screen = .dashboard`, so
+            // this also covers close/reopen.
+            if screen != .customize { customizeProviderID = nil }
+        }
+    }
+    /// Supports DashboardView's horizontal screen-switch slide: the screen being left, plus a counter
+    /// that ticks on every switch so the view can detect and animate each transition. UI-only; not persisted.
+    private(set) var screenSlideFrom = PopoverScreen.dashboard
+    private(set) var screenSlideID = 0
+    /// Whether the Customize screen is showing — a bridge over `screen` for the many call sites that
+    /// think in terms of edit mode.
+    var isEditing: Bool {
+        get { screen == .customize }
+        set { screen = newValue ? .customize : .dashboard }
+    }
+    /// The provider whose Customize detail (L2) is showing. nil shows the provider list (L1); a set id
+    /// shows that provider's metric sections and API key. UI-only (not persisted): cleared when leaving
+    /// Customize (see `screen`'s didSet) and on popover close.
+    var customizeProviderID: String?
+}

--- a/Sources/OpenUsage/Stores/TransientNotice.swift
+++ b/Sources/OpenUsage/Stores/TransientNotice.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Observation
 
 /// A small auto-clearing UI notice — the "shown for a couple of seconds, then it clears itself" pill.
@@ -17,8 +16,9 @@ final class TransientNotice<Value> {
     /// Bumped on every `present` so a `.id(trigger)`-keyed view replays its transition each time.
     private(set) var trigger = 0
 
-    @ObservationIgnored private let clearedValue: Value
-    @ObservationIgnored private let timeout: Duration
+    // `let`s are never observation-tracked; only the mutable task needs the annotation.
+    private let clearedValue: Value
+    private let timeout: Duration
     @ObservationIgnored private var clearTask: Task<Void, Never>?
 
     /// - Parameters:

--- a/Sources/OpenUsage/Stores/TransientNotice.swift
+++ b/Sources/OpenUsage/Stores/TransientNotice.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Observation
+
+/// A small auto-clearing UI notice — the "shown for a couple of seconds, then it clears itself" pill.
+/// One reusable box for what used to be three copy-pasted machines in `LayoutStore` (the pin-denial
+/// notice, the "Copied to clipboard" share confirmation, and the Customize action notice), each of which
+/// was a value + a replay-trigger counter + a clear `Task`.
+///
+/// `present(_:)` sets the value, bumps `trigger` (so a view keyed on it replays its pop-in even when the
+/// value is unchanged — e.g. the same denial twice in a row), and (re)starts the auto-clear timer.
+/// `clear()` resets immediately and cancels the timer — call it on popover close so a pill mid-countdown
+/// can't reappear stale on the next open (the store outlives the popover).
+@MainActor
+@Observable
+final class TransientNotice<Value> {
+    private(set) var value: Value
+    /// Bumped on every `present` so a `.id(trigger)`-keyed view replays its transition each time.
+    private(set) var trigger = 0
+
+    @ObservationIgnored private let clearedValue: Value
+    @ObservationIgnored private let timeout: Duration
+    @ObservationIgnored private var clearTask: Task<Void, Never>?
+
+    /// - Parameters:
+    ///   - clearedValue: the resting value shown when nothing is presented (e.g. `nil` / `false`).
+    ///   - timeout: how long a presented value stays before it auto-clears.
+    init(clearedValue: Value, timeout: Duration) {
+        self.value = clearedValue
+        self.clearedValue = clearedValue
+        self.timeout = timeout
+    }
+
+    func present(_ newValue: Value) {
+        value = newValue
+        trigger += 1
+        clearTask?.cancel()
+        let timeout = self.timeout
+        clearTask = Task { [weak self] in
+            try? await Task.sleep(for: timeout)
+            guard let self, !Task.isCancelled else { return }
+            value = clearedValue
+        }
+    }
+
+    func clear() {
+        value = clearedValue
+        clearTask?.cancel()
+        clearTask = nil
+    }
+}

--- a/Tests/OpenUsageTests/TransientNoticeTests.swift
+++ b/Tests/OpenUsageTests/TransientNoticeTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import OpenUsage
+
+/// Pins the timer semantics all three popover pills now share (pin-denial, share confirmation,
+/// Customize notice): present bumps the replay trigger and re-arms the auto-clear; a re-present
+/// cancels the earlier timer so the newer value gets its full stay; `clear()` resets immediately.
+/// Margins are generous (sleeps only ever run long) to stay calm on a loaded CI machine.
+@MainActor
+final class TransientNoticeTests: XCTestCase {
+    func testPresentBumpsTriggerAndAutoClears() async throws {
+        let notice = TransientNotice<String?>(clearedValue: nil, timeout: .milliseconds(100))
+        notice.present("Starred for menu bar")
+        XCTAssertEqual(notice.value, "Starred for menu bar")
+        XCTAssertEqual(notice.trigger, 1)
+        try await Task.sleep(for: .milliseconds(500))
+        XCTAssertNil(notice.value)
+    }
+
+    func testRePresentRestartsTheClearTimer() async throws {
+        let notice = TransientNotice<String?>(clearedValue: nil, timeout: .milliseconds(800))
+        notice.present("first")
+        try await Task.sleep(for: .milliseconds(400))
+        notice.present("second")
+        // Nominal 1000ms: past the first present's 800ms deadline, well before the second's 1200ms.
+        // If the first timer weren't cancelled, it would have wiped "second" here.
+        try await Task.sleep(for: .milliseconds(600))
+        XCTAssertEqual(notice.value, "second")
+        XCTAssertEqual(notice.trigger, 2)
+        try await Task.sleep(for: .milliseconds(800))
+        XCTAssertNil(notice.value)
+    }
+
+    func testClearResetsImmediatelyAndCancelsTheTimer() async throws {
+        let notice = TransientNotice<Bool>(clearedValue: false, timeout: .milliseconds(100))
+        notice.present(true)
+        notice.clear()
+        XCTAssertFalse(notice.value)
+        // The trigger only moves on present — clear must not replay the pill.
+        XCTAssertEqual(notice.trigger, 1)
+        try await Task.sleep(for: .milliseconds(300))
+        XCTAssertFalse(notice.value)
+    }
+}


### PR DESCRIPTION
**TL;DR** — First of four god-object-split follow-ups. Pulls in-popover navigation and the three transient-notice machines out of `LayoutStore` into focused sub-stores, **preserving its public API** so no call sites change. Stacked on #868.

> Base is the cleanup branch (#868), so this PR's diff shows only the split. GitHub CI ("Build and Test") runs on base=main PRs; it'll run here once #868 merges and this retargets to main. Verified locally in the meantime (build + 883 tests + app launch). Cursor Bugbot runs regardless.

## What was happening
`LayoutStore` (1200+ LOC) mixed layout state with (a) popover screen routing + slide bookkeeping and (b) three copy-pasted transient-pill state machines (pin-denial, "Copied to clipboard", Customize notice), each a value + replay-trigger + clear `Task`.

## What this changes
- **`PopoverNavigationStore`** — owns `screen` (+ its slide-bookkeeping `didSet`), `isEditing`, `customizeProviderID`, `screenSlideFrom/ID`. `LayoutStore` forwards its existing surface to it, so the ~59 call sites across 8 files are unchanged.
- **`TransientNotice<Value>`** — one reusable auto-clearing pill; the three machines collapse to three instances. Public `pinLimitNotice` / `shareConfirmation` / `customizationNotice`(+`Tone`) / `*Trigger` forward to these. The clear `Task`s are now encapsulated in the notice type.

## Heads-up
- API-preserving by design: navigation state is exposed through `LayoutStore`'s existing properties (forwarding to the sub-store) rather than a renamed `layout.navigation.screen` path — a 59-site rename of SwiftUI observation wasn't worth the regression risk for an organizational change. The state genuinely lives in the sub-stores.
- SwiftUI observation is preserved via the standard nested-`@Observable` access-tracking pattern; validated by the `PopoverScreen`/navigation forwarding tests + an app run (screen state, slide counter, Customize L2 reset all exercised).

## Tests
- `swift test` — 883 tests, 0 failures. Release build launches; providers refresh cleanly; no crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API-preserving refactor of UI-only navigation and transient notices; no persistence or layout mutation logic changes, with new unit tests for timer behavior.
> 
> **Overview**
> **`LayoutStore` shrinks** by moving two concerns into focused types while **call sites stay on the same properties** (`screen`, `isEditing`, pin/share/customize notices, triggers).
> 
> **`PopoverNavigationStore`** now owns `PopoverScreen`, screen-switch slide bookkeeping (`screenSlideFrom` / `screenSlideID`), Customize L2 (`customizeProviderID`), and `isEditing`. `LayoutStore` holds a private `navigation` instance and forwards getters/setters so SwiftUI observation and ~59 existing references do not need renames.
> 
> **`TransientNotice<Value>`** replaces three identical patterns (value + replay `trigger` + auto-clear `Task`) with one generic helper. Pin denial, share confirmation, and Customize pills use separate instances; `present` / `clear` replace inline timer code. Customize message and **tone** are bundled in **`CustomizationNoticeContent`** so they clear atomically.
> 
> **`TransientNoticeTests`** add async coverage for auto-clear, re-present timer restart, and immediate `clear()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1af892eab1f001ea72e82dec9825cc558e8b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->