### PR TITLE
refactor(StatusItemController): extract StatusItemImageUpdater

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -28,6 +28,8 @@ final class StatusItemController: NSObject {
     private let container: AppContainer
     private let updater: UpdaterController
     private let statusItem: NSStatusItem
+    /// Owns the menu-bar strip render loop (created in `init` once the status button exists).
+    private var imageUpdater: StatusItemImageUpdater?
     private let panel: MenuBarPanel
     private let hostingController: NSHostingController<AnyView>
     /// The panel's backdrop: an opaque tray by default, swapped to a behind-window vibrancy view when
@@ -97,7 +99,10 @@ final class StatusItemController: NSObject {
 
         configurePanel()
         configureStatusItem()
-        updateButtonImage()
+        imageUpdater = StatusItemImageUpdater(container: container) { [weak self] image in
+            self?.statusItem.button?.image = image
+        }
+        imageUpdater?.update()
         applyTransparency()
 
         appearanceObserver = NotificationCenter.default.addObserver(
@@ -202,49 +207,6 @@ final class StatusItemController: NSObject {
         // Left-click toggles the popover; right-click (or control-click) drops the context menu.
         // Both arrive through `statusButtonClicked`, which branches on the triggering event.
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])
-    }
-
-    // MARK: - Status item image
-
-    /// Coalesces re-render requests: a burst of snapshot writes (a multi-provider refresh pass) must
-    /// produce ~one re-render, not O(writes) MainActor Task hops + ImageRenderer passes. `nil` when idle.
-    private var pendingRenderTask: Task<Void, Never>?
-
-    /// Re-renders the menu-bar strip whenever anything it reads changes (pins, live data, meter
-    /// style, menu-bar style). `withObservationTracking`'s `onChange` is one-shot, so each render
-    /// re-arms it. The re-arm is debounced (see `scheduleButtonImageUpdate`).
-    private func updateButtonImage() {
-        let image = withObservationTracking {
-            renderButtonImage()
-        } onChange: { [weak self] in
-            Task { @MainActor [weak self] in
-                self?.scheduleButtonImageUpdate()
-            }
-        }
-        statusItem.button?.image = image
-    }
-
-    /// Debounce the re-render so a refresh-storm burst of snapshot writes collapses into a single
-    /// render once the burst settles, instead of one render per write — the feedback loop that can
-    /// starve the MainActor and drop the status item (the "menu bar disappears" failure mode).
-    private func scheduleButtonImageUpdate() {
-        pendingRenderTask?.cancel()
-        pendingRenderTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(50))
-            guard !Task.isCancelled else { return }
-            self?.updateButtonImage()
-        }
-    }
-
-    /// The pinned-metrics strip in the chosen style, or the app icon when nothing is pinned.
-    private func renderButtonImage() -> NSImage {
-        let content = MenuBarContentBuilder.build(
-            groups: container.layout.pinnedGroups,
-            data: { container.dataStore.data(for: $0) }
-        )
-        return MenuBarStripRenderer.image(for: content, style: container.layout.menuBarStyle)
-            ?? MenuBarIcon.image
-            ?? MenuBarStripRenderer.fallbackIcon
     }
 
     // MARK: - Transparency

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -28,8 +28,9 @@ final class StatusItemController: NSObject {
     private let container: AppContainer
     private let updater: UpdaterController
     private let statusItem: NSStatusItem
-    /// Owns the menu-bar strip render loop (created in `init` once the status button exists).
-    private var imageUpdater: StatusItemImageUpdater?
+    /// Owns the menu-bar strip render loop. Its apply closure captures the `NSStatusItem` directly
+    /// (which never retains the controller), so this can be a plain non-optional `let`.
+    private let imageUpdater: StatusItemImageUpdater
     private let panel: MenuBarPanel
     private let hostingController: NSHostingController<AnyView>
     /// The panel's backdrop: an opaque tray by default, swapped to a behind-window vibrancy view when
@@ -71,7 +72,14 @@ final class StatusItemController: NSObject {
     init(container: AppContainer, updater: UpdaterController) {
         self.container = container
         self.updater = updater
-        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        self.statusItem = statusItem
+        // Captures the status item, not `self` — no retain cycle, and no optional property just to
+        // work around `[weak self]` being unavailable before `super.init()`. The button is resolved
+        // lazily at each apply, so a not-yet-configured button is harmless (same as before the split).
+        self.imageUpdater = StatusItemImageUpdater(container: container) { image in
+            statusItem.button?.image = image
+        }
 
         let hosting = NSHostingController(
             rootView: AnyView(
@@ -99,10 +107,7 @@ final class StatusItemController: NSObject {
 
         configurePanel()
         configureStatusItem()
-        imageUpdater = StatusItemImageUpdater(container: container) { [weak self] image in
-            self?.statusItem.button?.image = image
-        }
-        imageUpdater?.update()
+        imageUpdater.update()
         applyTransparency()
 
         appearanceObserver = NotificationCenter.default.addObserver(
@@ -216,7 +221,8 @@ final class StatusItemController: NSObject {
     private var hasAppliedTransparency = false
 
     /// Applies the resolved transparency style to the panel and re-arms on the next change. Mirrors
-    /// `updateButtonImage`'s `withObservationTracking` re-arm (its `onChange` is one-shot). Reads the
+    /// `StatusItemImageUpdater.update()`'s `withObservationTracking` re-arm (its `onChange` is
+    /// one-shot). Reads the
     /// store's `effectiveStyle`, which folds in the persisted toggle, the egg state, and the system
     /// accessibility flags — so this fires whenever any of them changes. Backdrop already exists (it's a
     /// stored property), so the first call from `init` safely sets the initial look.

--- a/Sources/OpenUsage/App/StatusItemImageUpdater.swift
+++ b/Sources/OpenUsage/App/StatusItemImageUpdater.swift
@@ -1,0 +1,56 @@
+import AppKit
+import Observation
+
+/// Owns the menu-bar strip's render loop, split out of `StatusItemController`: render the pinned-metrics
+/// strip and re-render whenever anything it reads changes (pins, live data, meter style, menu-bar style).
+///
+/// `withObservationTracking`'s `onChange` is one-shot, so each render re-arms it. Re-arms are debounced
+/// so a refresh-storm burst of snapshot writes collapses into ~one render — the feedback loop that could
+/// otherwise starve the MainActor and drop the status item (the "menu bar disappears" failure mode).
+@MainActor
+final class StatusItemImageUpdater {
+    private let container: AppContainer
+    private let apply: (NSImage) -> Void
+    /// Coalesces re-render requests: a burst of snapshot writes must produce ~one re-render, not
+    /// O(writes) MainActor Task hops + ImageRenderer passes. `nil` when idle.
+    private var pendingRenderTask: Task<Void, Never>?
+
+    /// - Parameter apply: sets the rendered image onto the status-item button.
+    init(container: AppContainer, apply: @escaping (NSImage) -> Void) {
+        self.container = container
+        self.apply = apply
+    }
+
+    /// Render now and re-arm on the next observable change.
+    func update() {
+        let image = withObservationTracking {
+            renderButtonImage()
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.schedule()
+            }
+        }
+        apply(image)
+    }
+
+    /// Debounce the re-render so a burst settles into one render instead of one render per write.
+    private func schedule() {
+        pendingRenderTask?.cancel()
+        pendingRenderTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled else { return }
+            self?.update()
+        }
+    }
+
+    /// The pinned-metrics strip in the chosen style, or the app icon when nothing is pinned.
+    private func renderButtonImage() -> NSImage {
+        let content = MenuBarContentBuilder.build(
+            groups: container.layout.pinnedGroups,
+            data: { container.dataStore.data(for: $0) }
+        )
+        return MenuBarStripRenderer.image(for: content, style: container.layout.menuBarStyle)
+            ?? MenuBarIcon.image
+            ?? MenuBarStripRenderer.fallbackIcon
+    }
+}


### PR DESCRIPTION
**TL;DR** — Third god-object split. Pulls the menu-bar strip render loop out of `StatusItemController` into a focused `StatusItemImageUpdater`. Behavior-preserving (logic relocated verbatim). Stacked on #870.

> Stacked (#870 → #869 → #868). GitHub CI runs once the stack retargets to main; verified locally (build + 883 tests + **app launch**). Bugbot runs regardless.

## What was happening
`StatusItemController` bundled several concerns; one was the menu-bar strip render pipeline: `updateButtonImage` / `scheduleButtonImageUpdate` / `renderButtonImage`, the `pendingRenderTask` debounce, and the one-shot `withObservationTracking` re-arm.

## What this changes
- **`StatusItemImageUpdater`** owns that render loop. It needs only the `AppContainer` (layout `pinnedGroups` + `menuBarStyle`, `dataStore`) and an `apply: (NSImage) -> Void` closure to set the button image.
- `StatusItemController.init` creates it once the status button exists (`apply` = `self.statusItem.button?.image = …`) and calls `update()`; the pipeline methods + `pendingRenderTask` are gone from the controller.
- The debounce + `withObservationTracking` re-arm (the guard against the "menu bar disappears" refresh-storm) move intact — `withObservationTracking` is self-contained, so ownership doesn't change its semantics.

## Heads-up
- Not unit-testable (AppKit menu-bar rendering), so verified with an app run: the log reports `Status item ready (button: true)`, the strip renders on launch, providers refresh, no crash.
- The controller is still ~590 LOC; the residual is its genuine job (panel construction, status item + context menu, transparency, outside-click monitors, show/hide). The outside-click-guard dedup was already done in #868.

## Tests
- `swift test` — 883 tests, 0 failures. App launches and renders the strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving structural refactor of menu-bar rendering; no changes to panel, dismissal, or transparency logic.
> 
> **Overview**
> Moves the menu-bar strip render pipeline out of **`StatusItemController`** into a new **`StatusItemImageUpdater`** type. The controller no longer owns `updateButtonImage`, `scheduleButtonImageUpdate`, `renderButtonImage`, or `pendingRenderTask`; it holds an `imageUpdater` and kicks off rendering with `imageUpdater.update()` after setup.
> 
> **`StatusItemImageUpdater`** takes `AppContainer` plus an `apply: (NSImage) -> Void` closure. Init wires `apply` to `statusItem.button?.image = image` by capturing the local `NSStatusItem` (not `self`), avoiding retain cycles and optional workarounds before `super.init()`. Observation tracking, 50ms debounce, and `MenuBarContentBuilder` / `MenuBarStripRenderer` logic are unchanged—only relocated. A comment on `applyTransparency()` now points at `StatusItemImageUpdater.update()` for the one-shot re-arm pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84879dd4704e2974b2cbf4e1aa44f1f6e77afe5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->