### PR TITLE
refactor(DashboardView): extract PanelHeightCoordinator (auto-fit computation)

### DIFF
--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -190,7 +190,7 @@ struct DashboardView: View {
                     // destination is usually mounted+measured by now (it mounted on the slideProgress=0
                     // render), so we morph to its ideal. If it ISN'T measured yet and the height was
                     // never established (animatedHeight still the 0 sentinel — e.g. opening Settings
-                    // straight from the status-item menu), we must NOT morph to clampedTarget(0), which
+                    // straight from the status-item menu), we must NOT morph to a clamped zero, which
                     // floors to minPanelHeight and wrongly shrinks the panel: leave the height alone and
                     // let the completion / measurement establish it once a real ideal lands.
                     let coTarget: CGFloat? = heightCoordinator.target(for: destination)

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -31,12 +31,11 @@ struct DashboardView: View {
     /// Whether `animatedHeight` has been seeded for this open. Until then the first measurement (or a
     /// reopen) establishes it without animation; afterwards, changes spring.
     @State private var didEstablishHeight = false
-    /// Per-screen intrinsic heights, summed into `measuredIdeal`. Written only from geometry/preference
-    /// actions (which run after `body`), so they never trip "Modifying state during view update".
-    @State private var measuredScrollContent: [PopoverScreen: CGFloat] = [:]
-    @State private var measuredFooter: [PopoverScreen: CGFloat] = [:]
-    /// The window height each screen wants — top bar + footer + scroll content. The morph target.
-    @State private var measuredIdeal: [PopoverScreen: CGFloat] = [:]
+    /// Popover auto-fit height computation: per-screen measured pieces summed into each screen's clamped
+    /// morph target (`heightCoordinator.measuredIdeal` / `.target(for:)`). Written from the geometry
+    /// actions below. The animation itself — `animatedHeight`, the slide, the `withAnimation` spring —
+    /// stays in this view; the coordinator holds only the deterministic measurement.
+    @State private var heightCoordinator = PanelHeightCoordinator(topBarHeight: Self.topBarHeight)
     /// Horizontal screen-switch slide: 0 shows the outgoing screen, 1 the incoming one. Drives the
     /// page offset so the screens slide between modes on one spring.
     @State private var slideProgress: CGFloat = 1
@@ -152,7 +151,7 @@ struct DashboardView: View {
                         // Reopen: the SwiftUI tree survives a close, so re-seed the height for whatever
                         // screen we're opening on. Un-animated, and ≈ the controller's opening guess, so
                         // there's no visible jump. If not yet measured, the measurement onChange seeds it.
-                        if let target = targetHeight() {
+                        if let target = heightCoordinator.target(for: layout.screen) {
                             didEstablishHeight = true
                             animatedHeight = target
                         }
@@ -194,14 +193,14 @@ struct DashboardView: View {
                     // straight from the status-item menu), we must NOT morph to clampedTarget(0), which
                     // floors to minPanelHeight and wrongly shrinks the panel: leave the height alone and
                     // let the completion / measurement establish it once a real ideal lands.
-                    let coTarget: CGFloat? = measuredIdeal[destination].map { clampedTarget($0) }
+                    let coTarget: CGFloat? = heightCoordinator.target(for: destination)
                         ?? (animatedHeight > 0 ? animatedHeight : nil)
                     if coTarget != nil { didEstablishHeight = true }
                     withAnimation(Motion.spring, completionCriteria: .logicallyComplete) {
                         slideProgress = 1
                         if let coTarget { animatedHeight = coTarget }
                     } completion: {
-                        guard let target = targetHeight() else { return }
+                        guard let target = heightCoordinator.target(for: layout.screen) else { return }
                         if !didEstablishHeight {
                             didEstablishHeight = true
                             animatedHeight = target            // un-animated establish — never grow from 0
@@ -215,8 +214,8 @@ struct DashboardView: View {
             // loads rows): re-target the height on the same spring. Establishment is allowed even mid-
             // slide (a measurement that lands during a switch must seed the height — there's nothing to
             // fight yet); the animated *re-target* defers to the switch path while a slide is in flight.
-            .onChange(of: measuredIdeal[layout.screen]) { _, _ in
-                guard let target = targetHeight() else { return }
+            .onChange(of: heightCoordinator.measuredIdeal[layout.screen]) { _, _ in
+                guard let target = heightCoordinator.target(for: layout.screen) else { return }
                 if !didEstablishHeight {
                     didEstablishHeight = true
                     animatedHeight = target
@@ -344,36 +343,12 @@ struct DashboardView: View {
             // which we sum with the chrome into this screen's ideal window height. Keyed by the per-page
             // `screen`, so during a slide each mounted page measures its own content.
             .onPreferenceChange(ScrollContentHeightKey.self) { height in
-                measuredScrollContent[screen] = height
-                recomposeIdeal(for: screen)
+                heightCoordinator.setScrollContent(height, for: screen)
             }
             .softTopScrollEdge()
             .softBottomScrollEdge()
             .pinnedTopBar(spacing: 0) { fixedTopBar }
             .pinnedFooter(spacing: 0) { footerBar(for: layout.screen) }
-    }
-
-    // MARK: - Auto-fit height
-
-    /// Sum a screen's measured parts into its ideal window height. Top bar is the fixed `topBarHeight`
-    /// on Customize/Settings and 0 on the dashboard (it pins itself to that exact height); the footer is
-    /// measured because it varies (the Customize pin summary, the denied-pin notice line).
-    private func recomposeIdeal(for screen: PopoverScreen) {
-        guard let content = measuredScrollContent[screen], content > 0 else { return }
-        let topBar: CGFloat = screen == .dashboard ? 0 : Self.topBarHeight
-        let footer = measuredFooter[screen] ?? 0
-        measuredIdeal[screen] = topBar + footer + content
-    }
-
-    /// This screen's ideal height clamped to where the panel can actually sit (the controller owns the
-    /// [min, screen-max] clamp); `nil` until the screen has been measured.
-    private func targetHeight() -> CGFloat? {
-        guard let ideal = measuredIdeal[layout.screen] else { return nil }
-        return clampedTarget(ideal)
-    }
-
-    private func clampedTarget(_ ideal: CGFloat) -> CGFloat {
-        MenuBarPopover.clampHeight?(ideal) ?? ideal
     }
 
     /// The scrolling content for a screen, without chrome — this is the part that slides during a
@@ -634,12 +609,11 @@ struct DashboardView: View {
         // (not the desktop), so it stays consistent regardless of what's behind the window. Renders on
         // macOS 26+, including the macOS 27 (Golden Gate) beta; macOS 15 falls back to a frosted material.
         .barGlass()
-        // The footer's height feeds the auto-fit sum (`recomposeIdeal`); it varies — the Customize
-        // summary line vs the dashboard identity row vs the denied-pin notice — so measure it rather
-        // than assume a constant. Keyed by the destination `screen` (footer is keyed off `layout.screen`).
+        // The footer's height feeds the auto-fit sum (see `PanelHeightCoordinator`); it varies — the
+        // Customize summary line vs the dashboard identity row vs the denied-pin notice — so measure it
+        // rather than assume a constant. Keyed by the destination `screen` (footer is keyed off `layout.screen`).
         .onGeometryChange(for: CGFloat.self) { proxy in proxy.size.height } action: { height in
-            measuredFooter[screen] = height
-            recomposeIdeal(for: screen)
+            heightCoordinator.setFooter(height, for: screen)
         }
         // A successful "Share Screenshot" springs a small "Copied ✓" pill up just above the footer —
         // a floating success toast that's more glanceable than the in-footer text line, and separate

--- a/Sources/OpenUsage/Views/PanelHeightCoordinator.swift
+++ b/Sources/OpenUsage/Views/PanelHeightCoordinator.swift
@@ -1,4 +1,4 @@
-import SwiftUI
+import CoreGraphics
 import Observation
 
 /// The popover's auto-fit height *computation*, split out of `DashboardView`: per-screen measured
@@ -52,8 +52,8 @@ final class PanelHeightCoordinator {
         measuredIdeal[screen].map(clamped)
     }
 
-    /// Clamp an ideal to the panel's [min, screen-max] via the shared hook (identity when unset, e.g. tests).
-    func clamped(_ ideal: CGFloat) -> CGFloat {
+    /// Clamp an ideal to the panel's [min, screen-max] via the shared hook (identity when unset).
+    private func clamped(_ ideal: CGFloat) -> CGFloat {
         MenuBarPopover.clampHeight?(ideal) ?? ideal
     }
 }

--- a/Sources/OpenUsage/Views/PanelHeightCoordinator.swift
+++ b/Sources/OpenUsage/Views/PanelHeightCoordinator.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import Observation
+
+/// The popover's auto-fit height *computation*, split out of `DashboardView`: per-screen measured
+/// pieces summed into each screen's ideal window height (the morph target), clamped to the panel's
+/// allowed range. The view keeps the animation itself — `animatedHeight`, the screen-switch slide, and
+/// the `withAnimation` spring — so this holds only the deterministic measurement/target logic (which is
+/// now unit-testable), not the timing-sensitive animation clock.
+///
+/// Held as `@State` by the view; `@Observable` so `measuredIdeal` changes drive the view's morph
+/// `onChange`. The measured parts are written from the view's geometry callbacks via the setters.
+@MainActor
+@Observable
+final class PanelHeightCoordinator {
+    /// The window height each screen wants (top bar + footer + scroll content) — the morph target the
+    /// view animates toward. `private(set)`: written only through the measurement setters below.
+    private(set) var measuredIdeal: [PopoverScreen: CGFloat] = [:]
+
+    @ObservationIgnored private var measuredScrollContent: [PopoverScreen: CGFloat] = [:]
+    @ObservationIgnored private var measuredFooter: [PopoverScreen: CGFloat] = [:]
+    @ObservationIgnored private let topBarHeight: CGFloat
+
+    init(topBarHeight: CGFloat) {
+        self.topBarHeight = topBarHeight
+    }
+
+    /// Record a screen's measured scroll-content height (from the view's geometry action) and recompose
+    /// its ideal.
+    func setScrollContent(_ height: CGFloat, for screen: PopoverScreen) {
+        measuredScrollContent[screen] = height
+        recomposeIdeal(for: screen)
+    }
+
+    /// Record a screen's measured footer height (it varies — e.g. the Customize footer) and recompose.
+    func setFooter(_ height: CGFloat, for screen: PopoverScreen) {
+        measuredFooter[screen] = height
+        recomposeIdeal(for: screen)
+    }
+
+    /// Sum a screen's measured parts into its ideal window height. The dashboard shows no top bar; other
+    /// screens pin it to `topBarHeight`. A zero/absent scroll content leaves the ideal unset (not yet
+    /// measured), so the view keeps the size the controller opened at until a real measurement lands.
+    private func recomposeIdeal(for screen: PopoverScreen) {
+        guard let content = measuredScrollContent[screen], content > 0 else { return }
+        let topBar: CGFloat = screen == .dashboard ? 0 : topBarHeight
+        let footer = measuredFooter[screen] ?? 0
+        measuredIdeal[screen] = topBar + footer + content
+    }
+
+    /// The clamped target height for a screen, or `nil` until it's been measured.
+    func target(for screen: PopoverScreen) -> CGFloat? {
+        measuredIdeal[screen].map(clamped)
+    }
+
+    /// Clamp an ideal to the panel's [min, screen-max] via the shared hook (identity when unset, e.g. tests).
+    func clamped(_ ideal: CGFloat) -> CGFloat {
+        MenuBarPopover.clampHeight?(ideal) ?? ideal
+    }
+}

--- a/Tests/OpenUsageTests/PanelHeightCoordinatorTests.swift
+++ b/Tests/OpenUsageTests/PanelHeightCoordinatorTests.swift
@@ -41,11 +41,26 @@ final class PanelHeightCoordinatorTests: XCTestCase {
     }
 
     func testTargetIsNilUntilMeasuredThenClamps() {
+        // The clamp hook is a process global (see PanelHeightBridgeTests for the same reset pattern):
+        // pin it explicitly on both branches so this test can't depend on suite order.
+        let previousClamp = MenuBarPopover.clampHeight
+        defer { MenuBarPopover.clampHeight = previousClamp }
+
         let c = PanelHeightCoordinator(topBarHeight: topBar)
         XCTAssertNil(c.target(for: .dashboard))
+
+        MenuBarPopover.clampHeight = nil
         c.setScrollContent(300, for: .dashboard)
-        // No clamp hook installed in tests → target is the raw ideal.
+        // No clamp hook installed → target is the raw ideal.
         XCTAssertEqual(c.target(for: .dashboard), 300)
+
+        // With the panel's hook installed, the target is floored and capped at both edges.
+        MenuBarPopover.clampHeight = { min(max($0, 400), 600) }
+        XCTAssertEqual(c.target(for: .dashboard), 400)  // 300 floored to the panel minimum
+        c.setScrollContent(900, for: .dashboard)
+        XCTAssertEqual(c.target(for: .dashboard), 600)  // 900 capped at the screen max
+        c.setScrollContent(500, for: .dashboard)
+        XCTAssertEqual(c.target(for: .dashboard), 500)  // in-range ideals pass through
     }
 
     func testLaterMeasurementRecomposesIdeal() {

--- a/Tests/OpenUsageTests/PanelHeightCoordinatorTests.swift
+++ b/Tests/OpenUsageTests/PanelHeightCoordinatorTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import OpenUsage
+
+/// The popover auto-fit height computation, now unit-testable after being split out of DashboardView:
+/// each screen's ideal = (top bar unless dashboard) + footer + scroll content, and `target` clamps it.
+@MainActor
+final class PanelHeightCoordinatorTests: XCTestCase {
+    private let topBar: CGFloat = 44
+
+    func testDashboardIdealOmitsTopBar() {
+        let c = PanelHeightCoordinator(topBarHeight: topBar)
+        c.setScrollContent(300, for: .dashboard)
+        c.setFooter(40, for: .dashboard)
+        // Dashboard has no top bar: ideal = content + footer.
+        XCTAssertEqual(c.measuredIdeal[.dashboard], 340)
+    }
+
+    func testOtherScreensIncludeTopBar() {
+        let c = PanelHeightCoordinator(topBarHeight: topBar)
+        c.setScrollContent(300, for: .customize)
+        c.setFooter(40, for: .customize)
+        // Customize/Settings pin the fixed top bar: ideal = topBar + footer + content.
+        XCTAssertEqual(c.measuredIdeal[.customize], 44 + 40 + 300)
+    }
+
+    func testFooterDefaultsToZeroUntilMeasured() {
+        let c = PanelHeightCoordinator(topBarHeight: topBar)
+        c.setScrollContent(300, for: .settings)
+        XCTAssertEqual(c.measuredIdeal[.settings], 44 + 300)
+    }
+
+    func testIdealUnsetUntilScrollContentMeasured() {
+        let c = PanelHeightCoordinator(topBarHeight: topBar)
+        // A footer measurement alone (no scroll content yet) leaves the ideal unset — the view keeps the
+        // controller's opening size until real content lands.
+        c.setFooter(40, for: .dashboard)
+        XCTAssertNil(c.measuredIdeal[.dashboard])
+        // A zero-height content measurement is also ignored.
+        c.setScrollContent(0, for: .dashboard)
+        XCTAssertNil(c.measuredIdeal[.dashboard])
+    }
+
+    func testTargetIsNilUntilMeasuredThenClamps() {
+        let c = PanelHeightCoordinator(topBarHeight: topBar)
+        XCTAssertNil(c.target(for: .dashboard))
+        c.setScrollContent(300, for: .dashboard)
+        // No clamp hook installed in tests → target is the raw ideal.
+        XCTAssertEqual(c.target(for: .dashboard), 300)
+    }
+
+    func testLaterMeasurementRecomposesIdeal() {
+        let c = PanelHeightCoordinator(topBarHeight: topBar)
+        c.setScrollContent(300, for: .dashboard)
+        XCTAssertEqual(c.measuredIdeal[.dashboard], 300)
+        c.setScrollContent(500, for: .dashboard)   // content grew (rows loaded)
+        XCTAssertEqual(c.measuredIdeal[.dashboard], 500)
+    }
+}


### PR DESCRIPTION
**TL;DR** — Fourth and final god-object split. Pulls the popover auto-fit **height computation** out of `DashboardView` into a `PanelHeightCoordinator`, leaving the timing-sensitive animation mechanism untouched. Newly unit-tested. Stacked on #871.

> Top of the stack (#871 → #870 → #869 → #868). GitHub CI runs once the stack retargets to main; verified locally (build + 889 tests + **app launch**). Bugbot runs regardless.

## What was happening
`DashboardView` (~770 LOC) tangled the auto-fit/slide engine with the screen content. The auto-fit had two parts: the *measurement/target computation* (per-screen measured pieces → clamped ideal height) and the *animation* (`animatedHeight`, the slide, the `withAnimation` spring). The measurement was buried in the view and not unit-testable.

## What this changes
- **`PanelHeightCoordinator`** (`@Observable`, held as `@State`) owns the measured scroll-content/footer dictionaries, `recomposeIdeal`, and `target(for:)`/`clamped(_:)`. Geometry callbacks call `setScrollContent`/`setFooter`; the morph `onChange` reads `coordinator.measuredIdeal[…]`.
- The **animation stays in the view**: `animatedHeight`, `slideProgress`, `animatedSlideID`, `slideOffset`, and every `withAnimation` are unchanged — deliberately, so there's no risk to the delicate slide/morph timing. Only the deterministic measurement moved.

## Heads-up
- Scoped on purpose: I extracted the computation (safe, and now testable) rather than the animation clock. Lifting the `withAnimation`/`@State` timing into a separate object was the risky part with no way to verify slide/morph timing programmatically here — not worth it for an organizational change.
- The measurement is now covered by **6 new unit tests** it never had. App run confirms the popover still sizes correctly with no "Modifying state during view update".
- Nice pre-merge smoke test (not automatable from CI): open the popover and switch Dashboard ↔ Customize ↔ Settings to eyeball the slide+height morph. The animation code is unchanged, so this is a sanity check rather than a likely regression.

## Tests
- `swift test` — 889 tests (6 new `PanelHeightCoordinatorTests`), 0 failures. App launches, popover sizes correctly, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live popover sizing and screen-switch morph targets; behavior is intended to be a pure move but regressions would show as wrong panel height during Dashboard ↔ Customize ↔ Settings transitions.
> 
> **Overview**
> Moves popover **auto-fit height math** out of `DashboardView` into a new `@Observable` **`PanelHeightCoordinator`**, held as `@State`. Per-screen scroll and footer measurements now flow through `setScrollContent` / `setFooter`; morph targets come from `measuredIdeal` and `target(for:)` instead of view-local dictionaries and helpers (`recomposeIdeal`, `targetHeight`, `clampedTarget`).
> 
> **Animation is unchanged in the view**: `animatedHeight`, slide progress, and all `withAnimation` springs still live in `DashboardView`—only the deterministic measurement and clamping moved.
> 
> Adds **`PanelHeightCoordinatorTests`** (six cases) for ideal composition (dashboard vs other screens, footer defaults, unset until content), clamp behavior via `MenuBarPopover.clampHeight`, and remeasurement when content grows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf0c62de4396c3bab2ce23ccb35062b796afd08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->