### PR TITLE
fix: single-instance decisions must not trust the LaunchServices snapshot

### DIFF
--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -19,17 +19,37 @@ struct OpenUsageApp: App {
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var container: AppContainer?
     private var statusItemController: StatusItemController?
+    private var singleInstanceLock: SingleInstanceLock.Token?
     private let updater = UpdaterController()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Open/trim the file log, seed the cached level, and emit the startup line BEFORE anything
         // else logs, so the first lines of a session are captured.
         AppLog.bootstrap()
-        // Single-instance guard (#635): reject a duplicate before it grabs the local-API port
-        // (127.0.0.1:6736) or adds a second status item. `terminate(_:)` unwinds asynchronously and
-        // is cancellable, so we MUST return here — otherwise this method keeps running and creates
-        // the very duplicate it was meant to prevent.
-        if SingleInstanceGuard.deferToExistingInstance() {
+        // Kernel-level single-instance lock (#874): rejects a duplicate even when two copies launch
+        // so close together that the workspace guard's LaunchServices snapshot misses the peer.
+        var holdsLock = false
+        if let bundleID = Bundle.main.bundleIdentifier {
+            switch SingleInstanceLock.acquire(bundleIdentifier: bundleID) {
+            case .acquired(let token):
+                singleInstanceLock = token
+                holdsLock = true
+            case .alreadyRunning:
+                SingleInstanceGuard.activateExistingInstance()
+                AppLog.info(.lifecycle, "duplicate launch detected by process lock; terminating")
+                NSApp.terminate(nil)
+                return
+            case .failed(let message):
+                AppLog.error(.lifecycle, "single-instance lock unavailable: \(message)")
+            }
+        }
+        // The lock winner must NOT consult the workspace guard: its snapshot can still contain a
+        // lock loser that is mid-exit (alive, lower PID), and yielding to it leaves ZERO instances
+        // (reproduced in #874). The guard remains only as the fallback for unbundled launches
+        // (`swift run` has no bundle ID) or lock setup failure. `terminate(_:)` unwinds
+        // asynchronously and is cancellable, so we MUST return here — otherwise this method keeps
+        // running and creates the very duplicate it was meant to prevent.
+        if !holdsLock, SingleInstanceGuard.deferToExistingInstance() {
             AppLog.info(.lifecycle, "duplicate launch detected; handing off to the running instance and terminating")
             NSApp.terminate(nil)
             return
@@ -44,9 +64,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let isFreshInstall = SettingsMigrator.isFreshInstall()
         SettingsMigrator.migrate()
         // Let only the `SMAppService` login item drive startup: opt out of AppKit's reopen-on-login
-        // so a reboot doesn't also restore us and race the login item in the first place. The guard
-        // above already resolves the race deterministically (lowest PID survives) even if both fire;
-        // this just avoids the wasted second launch.
+        // so a reboot doesn't also restore us and race the login item in the first place. The lock
+        // above resolves same-bundle startup races even if both launch triggers fire; this just avoids
+        // the wasted second launch.
         NSApp.disableRelaunchOnLogin()
         // App-wide theme override (NSApp.appearance): the popover ignores SwiftUI's
         // preferredColorScheme, so the override is applied at the AppKit level once at launch;

--- a/Sources/OpenUsage/App/SingleInstanceGuard.swift
+++ b/Sources/OpenUsage/App/SingleInstanceGuard.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 
 /// Rejects a second copy of OpenUsage at launch (issue #635). macOS can fire two independent launch
 /// triggers on reboot — session restoration ("Reopen windows when logging back in") and the
@@ -30,7 +31,10 @@ enum SingleInstanceGuard {
     static func deferToExistingInstance() -> Bool {
         guard let bundleID = Bundle.main.bundleIdentifier else { return false }
         let me = NSRunningApplication.current
+        // Drop stale entries: yielding to a corpse can cascade into every copy terminating (the
+        // zero-survivor outcomes reproduced in #874).
         let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+            .filter(isAlive)
         guard let survivorPID = instanceToYieldTo(
             myPID: me.processIdentifier,
             runningPIDs: running.map(\.processIdentifier)
@@ -40,5 +44,25 @@ enum SingleInstanceGuard {
         // Resolved from the same snapshot the decision used, so the survivor is still present.
         running.first { $0.processIdentifier == survivorPID }?.activate()
         return true
+    }
+
+    /// Focus handoff without the lowest-PID decision: activates any other running copy with our
+    /// bundle identifier. Used when `SingleInstanceLock` already told us a peer owns the slot —
+    /// lock acquisition order is not PID order, so the peer may have a *higher* PID and
+    /// `deferToExistingInstance()` would skip the activation. Best-effort: in the snapshot-miss
+    /// race the peer may not be visible to LaunchServices yet, and that's fine — the lock, not
+    /// this handoff, is what decides who survives.
+    static func activateExistingInstance() {
+        guard let bundleID = Bundle.main.bundleIdentifier else { return }
+        let myPID = NSRunningApplication.current.processIdentifier
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+            .first { $0.processIdentifier != myPID && isAlive($0) }?
+            .activate()
+    }
+
+    /// LaunchServices can briefly keep a just-terminated copy in its snapshot under load (#874).
+    /// `isTerminated` catches what it already knows; `kill(pid, 0)` asks the kernel directly.
+    private static func isAlive(_ app: NSRunningApplication) -> Bool {
+        !app.isTerminated && kill(app.processIdentifier, 0) == 0
     }
 }

--- a/Sources/OpenUsage/App/SingleInstanceLock.swift
+++ b/Sources/OpenUsage/App/SingleInstanceLock.swift
@@ -1,0 +1,71 @@
+import Darwin
+import Foundation
+
+/// Kernel-backed single-instance lock, closing the startup race `SingleInstanceGuard` (#635/#637)
+/// can't: the guard decides from an `NSRunningApplication` snapshot, and when two copies launch
+/// near-simultaneously LaunchServices can hand each a snapshot containing only itself — both
+/// conclude "no older peer" and keep running. An exclusive `flock` on a per-bundle file is atomic
+/// in the kernel: exactly one process holds it no matter how the launches interleave. The kernel
+/// also releases it when the holder exits or crashes, so a stale lock can never block a relaunch.
+enum SingleInstanceLock {
+    enum Acquisition {
+        case acquired(Token)
+        case alreadyRunning
+        case failed(String)
+    }
+
+    /// Owns the lock for the process lifetime — keeps the descriptor open so the kernel keeps the
+    /// `flock` held. Dropping the token unlocks and closes the descriptor.
+    final class Token {
+        private let fd: CInt
+
+        fileprivate init(fd: CInt) {
+            self.fd = fd
+        }
+
+        deinit {
+            flock(fd, LOCK_UN)
+            Darwin.close(fd)
+        }
+    }
+
+    /// Locks `Application Support/OpenUsage/<bundle id>.lock` — a directory the app already uses
+    /// for its own state, and stable no matter where the app bundle itself lives.
+    static func acquire(bundleIdentifier: String) -> Acquisition {
+        guard let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return .failed("Application Support directory unavailable")
+        }
+        let lockURL = appSupport
+            .appendingPathComponent("OpenUsage", isDirectory: true)
+            .appendingPathComponent("\(bundleIdentifier).lock")
+        return acquire(at: lockURL)
+    }
+
+    /// Split out from the well-known-path entry point so tests can aim the lock at a temp file.
+    static func acquire(at lockURL: URL) -> Acquisition {
+        do {
+            try FileManager.default.createDirectory(
+                at: lockURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+
+        let fd = Darwin.open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC, mode_t(S_IRUSR | S_IWUSR))
+        guard fd >= 0 else {
+            return .failed(String(cString: strerror(errno)))
+        }
+
+        guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
+            let lockError = errno
+            Darwin.close(fd)
+            return lockError == EWOULDBLOCK ? .alreadyRunning : .failed(String(cString: strerror(lockError)))
+        }
+
+        return .acquired(Token(fd: fd))
+    }
+}

--- a/Tests/OpenUsageTests/SingleInstanceLockTests.swift
+++ b/Tests/OpenUsageTests/SingleInstanceLockTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class SingleInstanceLockTests: XCTestCase {
+    func testSecondAcquisitionIsRejectedUntilTheFirstTokenIsReleased() throws {
+        let lockURL = makeLockURL()
+        var token: SingleInstanceLock.Token?
+
+        switch SingleInstanceLock.acquire(at: lockURL) {
+        case .acquired(let acquired):
+            token = acquired
+        default:
+            XCTFail("first acquisition should own the lock")
+        }
+
+        XCTAssertNotNil(token)
+        assertAlreadyRunning(SingleInstanceLock.acquire(at: lockURL))
+        token = nil
+
+        switch SingleInstanceLock.acquire(at: lockURL) {
+        case .acquired:
+            break
+        default:
+            XCTFail("lock should be acquirable after the first token is released")
+        }
+    }
+
+    func testLockRejectsDuplicateWhenRunningApplicationSnapshotMissesThePeer() throws {
+        let lockURL = makeLockURL()
+        var token: SingleInstanceLock.Token?
+
+        switch SingleInstanceLock.acquire(at: lockURL) {
+        case .acquired(let acquired):
+            token = acquired
+        default:
+            XCTFail("first acquisition should own the lock")
+        }
+
+        XCTAssertNotNil(token)
+        XCTAssertNil(SingleInstanceGuard.instanceToYieldTo(myPID: 101, runningPIDs: [101]))
+        assertAlreadyRunning(SingleInstanceLock.acquire(at: lockURL))
+        token = nil
+    }
+
+    private func makeLockURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("openusage-lock-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("OpenUsage.lock")
+    }
+
+    private func assertAlreadyRunning(
+        _ acquisition: SingleInstanceLock.Acquisition,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .alreadyRunning = acquisition else {
+            XCTFail("second acquisition should be rejected", file: file, line: line)
+            return
+        }
+    }
+}


### PR DESCRIPTION
Fixes #874 (follow-up to #635 / #637).

**TL;DR**

The single-instance guard decides who survives from a LaunchServices snapshot, and under slow simultaneous startup that snapshot lies — reproducibly leaving **zero** running instances on stock v0.7.3 (every copy thinks it's the duplicate and quits), and leaving the duplicate-icons window #637 itself documented. This PR moves the decision to kernel truth: an exclusive `flock` picks exactly one winner.

**What was happening**

- #637's guard reads `NSRunningApplication.runningApplications(withBundleIdentifier:)` and yields to the lowest PID. Under slow startup the snapshot can **miss a live peer** (both copies keep running → two menu-bar icons) or **still contain a dead or dying one** (every copy yields to it and terminates → nothing left running — the "won't reopen" symptom from #635).
- The zero-instances mode reproduces on stock v0.7.3: 4 simultaneous slow launches (efficiency cores + CPU load), 40 iterations → 4 ended with **no OpenUsage running**, and the app log shows all four copies logging `duplicate launch detected; handing off…` in those windows. Full harness in #874.
- Real logins hit these conditions: #874's machine launches two copies at every login (a leftover Tauri autostart LaunchAgent races the `SMAppService` login item, and `disableRelaunchOnLogin()` can't suppress a launchd agent), and login is exactly when startup is slowest. Gentle warm-system launches never failed in 160 iterations — which is why this survived since #637.

**What this changes**

- New `SingleInstanceLock`: an exclusive `flock` on `Application Support/OpenUsage/<bundle id>.lock`, taken at the top of `applicationDidFinishLaunching`, before the local-API port grab and the status item. Kernel-atomic — exactly one winner no matter how launches interleave — and auto-released when the holder exits or crashes, so a stale lock can never block a relaunch.
- The winner keeps the lock token for the process lifetime and **does not consult the snapshot guard at all** — that's what makes the zero-instances mode impossible, not just unlikely. A loser activates the running instance (new `activateExistingInstance()`; lock order isn't PID order, so the lowest-PID handoff doesn't apply) and terminates.
- The workspace guard from #637 stays as the fallback for launches without a bundle ID (`swift run`) or lock setup failure, now filtering terminated processes out of its snapshot so it can't yield to a corpse.
- Regression tests: lock ownership and release, and the snapshot-miss case (guard sees only itself; the lock still rejects the duplicate).

**Heads-up**

- The lock is keyed by bundle identifier, so it also serializes the LaunchAgent-vs-login-item double launch from #874. Cleaning up that leftover agent itself is proposed there as a follow-up.
- A legacy Tauri *app* (different bundle ID) running beside the Swift app remains out of scope for any same-bundle guard.

**Tests**

- `swift test --filter 'SingleInstanceLockTests|SingleInstanceGuardTests'` — 8/8 pass.
- Stress harness from #874 against this build: 40/40 iterations settle at exactly one instance (stock v0.7.3 under the same harness: 4 zero-instance failures in 40). Kill-then-relaunch: 10/10 come back up.
- 100 iterations of paired `open -n` and 40 of mixed direct-exec + `open -n`: always exactly one survivor.
- `./script/build_and_run.sh verify` — app staged and runs.
- Full `swift test`: only pre-existing Codex pricing failures, unrelated (no Codex/pricing files touched).

Proudly generated using Fable5.
