### PR TITLE
fix: remove the legacy Tauri autostart LaunchAgent on launch

### DIFF
--- a/Sources/OpenUsage/App/LegacyLaunchAgentCleanup.swift
+++ b/Sources/OpenUsage/App/LegacyLaunchAgentCleanup.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Deletes the autostart LaunchAgent left behind by the legacy Tauri edition (issues #607/#874).
+///
+/// `tauri-plugin-autostart` (edition ≤ 0.6.28) wrote `~/Library/LaunchAgents/OpenUsage.plist` with
+/// `RunAtLoad = true`, pointing at the app binary by absolute path. Updating in place never removed
+/// it, and on a case-insensitive volume (the APFS default) its Tauri-era program path
+/// (`…/Contents/MacOS/openusage`, lowercase binary name) resolves to this edition's binary. Two
+/// consequences for upgraded machines:
+/// - the agent launches the app at every login *in addition to* the `SMAppService` login item —
+///   the double launch behind #874 (`disableRelaunchOnLogin()` is AppKit-level and cannot suppress
+///   a launchd agent), and
+/// - Login Items & Extensions attributes the agent to the signing team ("SUNSTORY LLC") instead of
+///   the app (#607): a bare LaunchAgent has no app identity, so macOS labels it by the code
+///   signature of the binary it points to.
+///
+/// The removal decision is pure and deliberately conservative: only an agent whose program resolves
+/// *inside this app's own bundle* is deleted. Anything else — a hand-rolled agent pointing at
+/// another location, some other tool's agent that happens to share the filename — is left alone
+/// (and logged, so a stray survivor is visible in the log file). Runs on every launch: the common
+/// case is a single file-existence probe, and re-running covers a user who reinstalls the legacy
+/// edition and upgrades again.
+///
+/// Deliberately file-only — no `launchctl bootout`. With `RunAtLoad`, the process the agent spawned
+/// IS the service process, and if the single-instance survivor is the agent-launched copy (it's
+/// whichever copy won the startup race), booting out the label would SIGTERM this very process.
+/// Deleting the plist is sufficient and self-safe: launchd loads agents from disk at login, so the
+/// next login has nothing to load, and the Login Items entry disappears once the file is gone.
+enum LegacyLaunchAgentCleanup {
+    /// What the legacy plist declares, as far as the removal decision cares. `programPath` is the
+    /// executable the agent launches: launchd's `Program` key when present, else the first
+    /// `ProgramArguments` element (`tauri-plugin-autostart` wrote only the latter).
+    struct Agent: Equatable {
+        var programPath: String?
+    }
+
+    /// `tauri-plugin-autostart` named the plist after the app's product name.
+    static var defaultAgentURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/OpenUsage.plist")
+    }
+
+    /// Live entry point, called once per launch. Parameters exist for tests only.
+    static func removeLeftoverAgent(
+        agentURL: URL = defaultAgentURL,
+        bundlePath: String = Bundle.main.bundlePath
+    ) {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: agentURL.path) else { return }
+
+        let agent: Agent
+        do {
+            agent = try parse(plistData: Data(contentsOf: agentURL))
+        } catch {
+            AppLog.error(.lifecycle, "found \(agentURL.path) but couldn't read it: \(error.localizedDescription)")
+            return
+        }
+
+        guard shouldRemove(programPath: agent.programPath, bundlePath: bundlePath) else {
+            AppLog.info(.lifecycle, "leaving \(agentURL.path) alone — its program (\(agent.programPath ?? "unset")) is outside this app bundle")
+            return
+        }
+
+        do {
+            try fileManager.removeItem(at: agentURL)
+            AppLog.info(.lifecycle, "removed legacy Tauri autostart agent \(agentURL.path) — it pointed into this app bundle and double-launched the app at login (#874)")
+        } catch {
+            AppLog.error(.lifecycle, "couldn't delete legacy autostart agent \(agentURL.path): \(error.localizedDescription) — will retry next launch")
+        }
+    }
+
+    /// Pure decision: remove only when the agent's program lives inside our own `.app` bundle.
+    /// The comparison is case-insensitive to mirror the APFS default — the whole reason the
+    /// lowercase Tauri path still launches this edition's binary. Requiring a `.app` bundle path
+    /// keeps unbundled runs (`swift run`, whose "bundle" is a build directory) from ever matching.
+    static func shouldRemove(programPath: String?, bundlePath: String) -> Bool {
+        guard let programPath else { return false }
+        let bundle = (bundlePath as NSString).standardizingPath
+        guard bundle.hasSuffix(".app") else { return false }
+        let program = (programPath as NSString).standardizingPath
+        return program.lowercased().hasPrefix(bundle.lowercased() + "/")
+    }
+
+    /// Extracts the launched executable from a launchd plist. Throws on non-plist data; unknown or
+    /// missing keys yield a nil `programPath` (which `shouldRemove` treats as "leave it alone").
+    static func parse(plistData: Data) throws -> Agent {
+        let plist = try PropertyListSerialization.propertyList(from: plistData, format: nil)
+        guard let dict = plist as? [String: Any] else {
+            return Agent(programPath: nil)
+        }
+        let program = dict["Program"] as? String
+            ?? (dict["ProgramArguments"] as? [String])?.first
+        return Agent(programPath: program)
+    }
+}

--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -48,6 +48,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // above already resolves the race deterministically (lowest PID survives) even if both fire;
         // this just avoids the wasted second launch.
         NSApp.disableRelaunchOnLogin()
+        // The legacy Tauri edition's autostart agent (~/Library/LaunchAgents/OpenUsage.plist)
+        // survives the upgrade and re-launches this binary at every login, racing the login item —
+        // the double launch behind #874 and the "SUNSTORY LLC" Login Items entry from #607.
+        // Deleting it (only when it provably points into our bundle) stops that race at the source;
+        // the instance guard above stays as the referee for the remaining triggers. Runs after the
+        // guard on purpose, so only the surviving copy touches the file.
+        LegacyLaunchAgentCleanup.removeLeftoverAgent()
         // App-wide theme override (NSApp.appearance): the popover ignores SwiftUI's
         // preferredColorScheme, so the override is applied at the AppKit level once at launch;
         // the Theme picker on the Settings screen re-applies it on change.

--- a/Tests/OpenUsageTests/LegacyLaunchAgentCleanupTests.swift
+++ b/Tests/OpenUsageTests/LegacyLaunchAgentCleanupTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import OpenUsage
+
+final class LegacyLaunchAgentCleanupTests: XCTestCase {
+    // MARK: - Removal decision (pure)
+
+    /// The real-world case from #874: the Tauri-era agent points at the lowercase binary name, which
+    /// case-insensitive APFS resolves into this edition's bundle.
+    func testTauriLowercaseProgramInsideBundleIsRemoved() {
+        XCTAssertTrue(LegacyLaunchAgentCleanup.shouldRemove(
+            programPath: "/Applications/OpenUsage.app/Contents/MacOS/openusage",
+            bundlePath: "/Applications/OpenUsage.app"
+        ))
+    }
+
+    func testExactCaseProgramInsideBundleIsRemoved() {
+        XCTAssertTrue(LegacyLaunchAgentCleanup.shouldRemove(
+            programPath: "/Applications/OpenUsage.app/Contents/MacOS/OpenUsage",
+            bundlePath: "/Applications/OpenUsage.app"
+        ))
+    }
+
+    /// A hand-rolled agent pointing anywhere else must be left alone.
+    func testProgramOutsideBundleIsKept() {
+        XCTAssertFalse(LegacyLaunchAgentCleanup.shouldRemove(
+            programPath: "/usr/local/bin/openusage",
+            bundlePath: "/Applications/OpenUsage.app"
+        ))
+    }
+
+    func testMissingProgramIsKept() {
+        XCTAssertFalse(LegacyLaunchAgentCleanup.shouldRemove(
+            programPath: nil,
+            bundlePath: "/Applications/OpenUsage.app"
+        ))
+    }
+
+    /// Unbundled runs (`swift run`) report a build directory as the bundle path; that must never
+    /// match, so a dev run can't delete a user's real agent by accident.
+    func testNonAppBundlePathNeverMatches() {
+        XCTAssertFalse(LegacyLaunchAgentCleanup.shouldRemove(
+            programPath: "/Users/dev/openusage/.build/debug/OpenUsage",
+            bundlePath: "/Users/dev/openusage/.build/debug"
+        ))
+    }
+
+    /// Prefix matching must be component-wise: a sibling like `OpenUsage.app2` shares the string
+    /// prefix but is a different bundle.
+    func testSiblingDirectorySharingPrefixIsKept() {
+        XCTAssertFalse(LegacyLaunchAgentCleanup.shouldRemove(
+            programPath: "/Applications/OpenUsage.app2/Contents/MacOS/openusage",
+            bundlePath: "/Applications/OpenUsage.app"
+        ))
+    }
+
+    /// The bundle path itself (no inner component) is not a program inside the bundle.
+    func testProgramEqualToBundlePathIsKept() {
+        XCTAssertFalse(LegacyLaunchAgentCleanup.shouldRemove(
+            programPath: "/Applications/OpenUsage.app",
+            bundlePath: "/Applications/OpenUsage.app"
+        ))
+    }
+
+    // MARK: - Plist parsing
+
+    func testParseReadsFirstProgramArgument() throws {
+        // Shape-faithful to what tauri-plugin-autostart wrote (see #874).
+        let agent = try LegacyLaunchAgentCleanup.parse(plistData: plist([
+            "Label": "OpenUsage",
+            "ProgramArguments": ["/Applications/OpenUsage.app/Contents/MacOS/openusage"],
+            "RunAtLoad": true
+        ]))
+        XCTAssertEqual(agent.programPath, "/Applications/OpenUsage.app/Contents/MacOS/openusage")
+    }
+
+    func testParsePrefersProgramKeyOverProgramArguments() throws {
+        let agent = try LegacyLaunchAgentCleanup.parse(plistData: plist([
+            "Program": "/Applications/OpenUsage.app/Contents/MacOS/OpenUsage",
+            "ProgramArguments": ["/somewhere/else"]
+        ]))
+        XCTAssertEqual(agent.programPath, "/Applications/OpenUsage.app/Contents/MacOS/OpenUsage")
+    }
+
+    func testParseWithoutProgramKeysYieldsNil() throws {
+        let agent = try LegacyLaunchAgentCleanup.parse(plistData: plist(["Label": "OpenUsage"]))
+        XCTAssertNil(agent.programPath)
+    }
+
+    func testParseRejectsNonPlistData() {
+        XCTAssertThrowsError(try LegacyLaunchAgentCleanup.parse(plistData: Data("not a plist".utf8)))
+    }
+
+    // MARK: - End to end (temp filesystem)
+
+    func testLeftoverTauriAgentFileIsDeleted() throws {
+        let agentURL = try writeAgent([
+            "Label": "OpenUsage",
+            "ProgramArguments": ["/Applications/OpenUsage.app/Contents/MacOS/openusage"],
+            "RunAtLoad": true
+        ])
+        defer { try? FileManager.default.removeItem(at: agentURL.deletingLastPathComponent()) }
+
+        LegacyLaunchAgentCleanup.removeLeftoverAgent(
+            agentURL: agentURL, bundlePath: "/Applications/OpenUsage.app"
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: agentURL.path))
+    }
+
+    func testForeignAgentFileIsKept() throws {
+        let agentURL = try writeAgent([
+            "Label": "OpenUsage",
+            "ProgramArguments": ["/usr/local/bin/something-else"]
+        ])
+        defer { try? FileManager.default.removeItem(at: agentURL.deletingLastPathComponent()) }
+
+        LegacyLaunchAgentCleanup.removeLeftoverAgent(
+            agentURL: agentURL, bundlePath: "/Applications/OpenUsage.app"
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: agentURL.path))
+    }
+
+    func testUnreadableAgentFileIsKept() throws {
+        let agentURL = try writeRaw(Data("not a plist".utf8))
+        defer { try? FileManager.default.removeItem(at: agentURL.deletingLastPathComponent()) }
+
+        LegacyLaunchAgentCleanup.removeLeftoverAgent(
+            agentURL: agentURL, bundlePath: "/Applications/OpenUsage.app"
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: agentURL.path))
+    }
+
+    func testMissingAgentFileIsANoOp() {
+        let agentURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openusage-agent-\(UUID().uuidString)")
+            .appendingPathComponent("OpenUsage.plist")
+
+        LegacyLaunchAgentCleanup.removeLeftoverAgent(
+            agentURL: agentURL, bundlePath: "/Applications/OpenUsage.app"
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: agentURL.path))
+    }
+
+    // MARK: - Helpers
+
+    private func plist(_ dict: [String: Any]) throws -> Data {
+        try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
+    }
+
+    private func writeAgent(_ dict: [String: Any]) throws -> URL {
+        try writeRaw(plist(dict))
+    }
+
+    private func writeRaw(_ data: Data) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openusage-agent-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("OpenUsage.plist")
+        try data.write(to: url)
+        return url
+    }
+}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -10,6 +10,8 @@ Settings lives inside the popover — there is no separate window. Open it from 
 | Launch at Login | on/off | Registers the app as a login item (the system's login-item registry is the source of truth). |
 | Global Shortcut | record a shortcut | Global shortcut that toggles the popover from anywhere. Click the field and press a combo; the ⓧ clears it and disables the shortcut. |
 
+**Upgrading from the legacy (pre-0.7) edition:** the old edition managed start-on-login with its own launcher file, which an in-place update left behind. That leftover could start the app a second time at every login and showed up in System Settings → Login Items under the signing company's name ("SUNSTORY LLC") instead of OpenUsage. The app now removes it automatically on launch — only when the file verifiably points at OpenUsage itself — so login starts exactly one copy, controlled by the Launch at Login toggle above.
+
 ## Appearance
 
 | Setting | Options | What it does |


### PR DESCRIPTION
## Approved issue

Fixes #607 (for upgraded machines); implements the leftover-agent follow-up proposed in #874.

## TL;DR

Machines upgraded from the Tauri edition still have its autostart file (`~/Library/LaunchAgents/OpenUsage.plist`), which launches the app a second time at every login and shows up in Login Items as "SUNSTORY LLC". The app now deletes that file on launch — but only when it verifiably points into our own app bundle.

## What was happening

- The Tauri edition (≤ 0.6.28) managed start-on-login via `tauri-plugin-autostart`, which wrote a LaunchAgent plist with `RunAtLoad = true`. Updating in place never removed it.
- The agent's program path (`…/Contents/MacOS/openusage`, Tauri's lowercase binary name) resolves to the Swift binary on case-insensitive APFS (the default), so the old agent launches the *current* app at every login — racing the `SMAppService` login item. `disableRelaunchOnLogin()` can't suppress a launchd agent, so this is the standing double-launch trigger behind #874's duplicate icons / zero-instances reports.
- A bare LaunchAgent has no app identity, so macOS attributes it to the signing team of the binary it points to — the "Software from SUNSTORY LLC can run in the background" alert and Login Items entry from #607, which the `SMAppService` switch only fixed for fresh installs.

## What this changes

- New `LegacyLaunchAgentCleanup`, called from `applicationDidFinishLaunching` right after the single-instance guard (so only the surviving copy touches the file). Common case is a single file-existence probe; it runs every launch so a reinstall-then-upgrade of the legacy edition is cleaned up again.
- The removal decision is pure and conservative: the plist is deleted only when its `Program`/`ProgramArguments` path resolves *inside our own `.app` bundle*, compared case-insensitively (mirroring the APFS behavior that makes the stale path work). Hand-rolled agents pointing elsewhere, foreign plists sharing the filename, and unbundled `swift run` (whose "bundle path" is a build directory) never match — they're left alone and logged.
- Failures log loudly via `AppLog`; a failed delete retries next launch.
- Docs: upgrade note added to the Startup section of `docs/settings.md`.

## Heads-up

- **Deliberately no `launchctl bootout`.** With `RunAtLoad`, the process the agent spawned *is* the launchd service — and the single-instance survivor may be exactly that copy, so booting out the label could SIGTERM the app mid-launch. Deleting the plist is sufficient (launchd loads agents from disk at login) and self-safe; the Login Items entry disappears once the file is gone.
- This complements PR #873 rather than replacing it: this change removes the guaranteed per-login double launch at the source, while the flock lock is still wanted for the remaining races (session restore, update relaunches, manual double-opens).

## Tests

- 15 regression tests in `LegacyLaunchAgentCleanupTests`: the removal decision (the real #874 lowercase path, exact case, outside-bundle, nil program, non-`.app` bundle path, the `OpenUsage.app2` prefix trap, program-equals-bundle-path), plist parsing (`ProgramArguments`, `Program` precedence, missing keys, garbage data), and end-to-end temp-filesystem runs (Tauri agent deleted; foreign, unreadable, and missing files untouched).
- Authored in a Linux container without a macOS toolchain — relying on CI's macOS `swift build` + `swift test` for the build check.

## Screenshots

Not applicable — no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEQ6tcdB1DytTBXmqjhUBq

---

> [!NOTE]
> **Medium Risk**
> Deletes a user LaunchAgents plist on launch when it matches OpenUsage's bundle; logic is conservative and well-tested, but mistaken deletion would affect login behavior.
>
> **Overview**
> Fixes **double launch at login** (#874) and the stray **"SUNSTORY LLC" Login Items** entry (#607) for users who upgraded from the pre-0.7 Tauri build without removing `~/Library/LaunchAgents/OpenUsage.plist`.
>
> On each launch, after the single-instance guard, the surviving process runs **`LegacyLaunchAgentCleanup`**: if that plist exists, it parses `Program` / `ProgramArguments` and **deletes the file only when the target executable resolves inside the current `.app` bundle** (case-insensitive, so the old lowercase `openusage` path still matches). Foreign or unreadable plists are left in place and logged. Removal is **file-only**—no `launchctl bootout`—so an agent-spawned survivor cannot terminate itself.
>
> Unit tests cover the removal predicate, plist parsing, and temp-filesystem delete/keep paths. **Settings** docs note automatic cleanup for legacy upgraders.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff6786e907b0f9d0d07101b339cb1899c6a728e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>