### PR TITLE
Stop tests leaking UserDefaults suite domains

### DIFF
--- a/Tests/OpenUsageTests/AntigravityLayoutTests.swift
+++ b/Tests/OpenUsageTests/AntigravityLayoutTests.swift
@@ -101,10 +101,7 @@ final class AntigravityLayoutTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.AntigravityLayout.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.AntigravityLayout.\(name).\(UUID().uuidString)")
     }
 
     private func saveStored<T: Encodable>(_ value: T, forKey key: String, in defaults: UserDefaults) {

--- a/Tests/OpenUsageTests/CopilotProviderTests.swift
+++ b/Tests/OpenUsageTests/CopilotProviderTests.swift
@@ -567,10 +567,7 @@ final class CopilotProviderTests: XCTestCase {
     }
 
     private func freshDefaults() -> UserDefaults {
-        let suiteName = "CopilotProviderTests-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "CopilotProviderTests-\(UUID().uuidString)")
     }
 
     private func editorTokenStore() -> CopilotAuthStore {

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -413,10 +413,7 @@ final class CursorSpendProviderTests: XCTestCase {
     // MARK: helpers
 
     private func isolatedDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.CursorSpend.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.CursorSpend.\(name).\(UUID().uuidString)")
     }
 
     private func isolatedCache(_ defaults: UserDefaults) -> ProviderSnapshotCache {

--- a/Tests/OpenUsageTests/FailureBackoffTests.swift
+++ b/Tests/OpenUsageTests/FailureBackoffTests.swift
@@ -138,10 +138,7 @@ final class FailureBackoffTests: XCTestCase {
     }
 
     private func makeUserDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.Backoff.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.Backoff.\(name).\(UUID().uuidString)")
     }
 }
 

--- a/Tests/OpenUsageTests/FirstRunSeederTests.swift
+++ b/Tests/OpenUsageTests/FirstRunSeederTests.swift
@@ -181,10 +181,7 @@ final class FirstRunSeederTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.FirstRunSeeder.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.FirstRunSeeder.\(name).\(UUID().uuidString)")
     }
 }
 

--- a/Tests/OpenUsageTests/LayoutBootstrapTests.swift
+++ b/Tests/OpenUsageTests/LayoutBootstrapTests.swift
@@ -66,8 +66,7 @@ final class LayoutBootstrapTests: XCTestCase {
 
     private func makePersistence(_ name: String) -> (LayoutPersistence, UserDefaults) {
         let suite = "OpenUsageTests.LayoutBootstrap.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        let defaults = makeScratchDefaults(suiteName: suite)
         return (LayoutPersistence(defaults: defaults, storageKey: "layout"), defaults)
     }
 }

--- a/Tests/OpenUsageTests/LayoutPersistenceTests.swift
+++ b/Tests/OpenUsageTests/LayoutPersistenceTests.swift
@@ -67,9 +67,6 @@ final class LayoutPersistenceTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suite = "OpenUsageTests.LayoutPersistence.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.LayoutPersistence.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -1276,10 +1276,7 @@ final class LayoutStoreTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.LayoutStore.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.LayoutStore.\(name).\(UUID().uuidString)")
     }
 
     private func saveStored<T: Encodable>(_ value: T, forKey key: String, in defaults: UserDefaults) {

--- a/Tests/OpenUsageTests/LogLevelSettingTests.swift
+++ b/Tests/OpenUsageTests/LogLevelSettingTests.swift
@@ -57,9 +57,6 @@ final class LogLevelSettingTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.LogLevel.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.LogLevel.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/MenuBarPinTests.swift
+++ b/Tests/OpenUsageTests/MenuBarPinTests.swift
@@ -167,9 +167,6 @@ final class MenuBarPinTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.MenuBarPin.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.MenuBarPin.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/ModelUsageHoverTests.swift
+++ b/Tests/OpenUsageTests/ModelUsageHoverTests.swift
@@ -181,9 +181,6 @@ final class ModelUsageHoverTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.ModelUsageHover.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.ModelUsageHover.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/NewProviderSeederTests.swift
+++ b/Tests/OpenUsageTests/NewProviderSeederTests.swift
@@ -116,10 +116,7 @@ final class NewProviderSeederTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.NewProviderSeeder.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.NewProviderSeeder.\(name).\(UUID().uuidString)")
     }
 }
 

--- a/Tests/OpenUsageTests/PopoverScreenTests.swift
+++ b/Tests/OpenUsageTests/PopoverScreenTests.swift
@@ -41,9 +41,7 @@ final class PopoverScreenTests: XCTestCase {
     }
 
     private func makeStore(_ name: String) -> LayoutStore {
-        let suiteName = "OpenUsageTests.PopoverScreen.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
+        let defaults = makeScratchDefaults(suiteName: "OpenUsageTests.PopoverScreen.\(name).\(UUID().uuidString)")
         return LayoutStore(registry: .mock, defaults: defaults, storageKey: "layout")
     }
 }

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -5,10 +5,7 @@ import XCTest
 final class PopoverTransparencyStoreTests: XCTestCase {
     /// Isolated, throwaway defaults per test (pattern from `RefreshSettingTests`).
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.Transparency.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.Transparency.\(name).\(UUID().uuidString)")
     }
 
     /// A store on throwaway defaults with the accessibility flags pinned (both off by default), so the

--- a/Tests/OpenUsageTests/ProviderEnablementEnforcementTests.swift
+++ b/Tests/OpenUsageTests/ProviderEnablementEnforcementTests.swift
@@ -106,9 +106,6 @@ final class ProviderEnablementEnforcementTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.EnablementEnforce.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.EnablementEnforce.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
+++ b/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
@@ -178,9 +178,6 @@ final class ProviderEnablementStoreTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.Enablement.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.Enablement.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/RefreshSettingTests.swift
+++ b/Tests/OpenUsageTests/RefreshSettingTests.swift
@@ -121,9 +121,6 @@ final class RefreshSettingTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.RefreshSetting.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.RefreshSetting.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/StaleWhileRevalidateTests.swift
+++ b/Tests/OpenUsageTests/StaleWhileRevalidateTests.swift
@@ -199,10 +199,7 @@ final class StaleWhileRevalidateTests: XCTestCase {
     }
 
     private func makeUserDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.StaleWhileRevalidate.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.StaleWhileRevalidate.\(name).\(UUID().uuidString)")
     }
 }
 

--- a/Tests/OpenUsageTests/StalenessLabelTests.swift
+++ b/Tests/OpenUsageTests/StalenessLabelTests.swift
@@ -121,9 +121,7 @@ final class StalenessLabelTests: XCTestCase {
         descriptor: WidgetDescriptor,
         runtime: some ProviderRuntime
     ) -> WidgetDataStore {
-        let suiteName = "OpenUsageTests.Staleness.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
+        let defaults = makeScratchDefaults(suiteName: "OpenUsageTests.Staleness.\(UUID().uuidString)")
         return WidgetDataStore(
             registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
             providers: [runtime],

--- a/Tests/OpenUsageTests/TelemetryRecorderTests.swift
+++ b/Tests/OpenUsageTests/TelemetryRecorderTests.swift
@@ -151,9 +151,6 @@ final class TelemetryRecorderTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.Telemetry.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.Telemetry.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/TestSupport.swift
+++ b/Tests/OpenUsageTests/TestSupport.swift
@@ -1,6 +1,20 @@
 import XCTest
 @testable import OpenUsage
 
+extension XCTestCase {
+    /// A `UserDefaults` backed by a throwaway suite that is cleared *now* (so the test starts from a
+    /// clean slate) and whose persistent domain is removed again in this test's teardown. Use this for
+    /// any test needing an isolated defaults store: it prevents test data from lingering after the
+    /// run. Pass a unique `suiteName` (embed a `UUID()`) so parallel or repeated tests don't collide.
+    /// macOS 27 may still recreate an empty plist shell for a suite when the test process exits.
+    func makeScratchDefaults(suiteName: String) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName) // clean slate at start
+        addTeardownBlock { UserDefaults().removePersistentDomain(forName: suiteName) }
+        return defaults
+    }
+}
+
 /// The shipped pricing resources (supplement + LiteLLM/models.dev snapshots) as a ready-to-use
 /// `ModelPricing` — loaded once, entirely offline (no store, no network, no disk cache). Tests that
 /// price real model names use this the way production code uses `ModelPricingStore.current()`.

--- a/Tests/OpenUsageTests/UsageTrendTests.swift
+++ b/Tests/OpenUsageTests/UsageTrendTests.swift
@@ -210,9 +210,6 @@ final class UsageTrendTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.Trend.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.Trend.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/WidgetDataStoreNotificationTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreNotificationTests.swift
@@ -39,10 +39,7 @@ final class WidgetDataStoreNotificationTests: XCTestCase {
     }
 
     private func makeUserDefaults(_ name: String) -> UserDefaults {
-        let suite = "WidgetDataStoreNotificationTests.\(name)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        return defaults
+        makeScratchDefaults(suiteName: "WidgetDataStoreNotificationTests.\(name)")
     }
 
     private static let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("cursor"))

--- a/Tests/OpenUsageTests/WidgetDataStorePlanTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStorePlanTests.swift
@@ -101,9 +101,6 @@ final class WidgetDataStorePlanTests: XCTestCase {
     }
 
     private func makeDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.Plan.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.Plan.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -739,9 +739,6 @@ final class WidgetDataStoreTests: XCTestCase {
     }
 
     private func makeUserDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/WidgetMeterStyleTests.swift
+++ b/Tests/OpenUsageTests/WidgetMeterStyleTests.swift
@@ -179,10 +179,7 @@ final class WidgetMeterStyleTests: XCTestCase {
     }
 
     func testMeterStylePersistsAcrossStoreInstances() {
-        let suiteName = "OpenUsageTests.MeterStyle.persist.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let defaults = makeScratchDefaults(suiteName: "OpenUsageTests.MeterStyle.persist.\(UUID().uuidString)")
 
         let store = makeEmptyStore(defaults)
         XCTAssertEqual(store.meterStyle, .remaining)
@@ -268,9 +265,6 @@ final class WidgetMeterStyleTests: XCTestCase {
     }
 
     private func makeUserDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.MeterStyle.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.MeterStyle.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/WidgetNoDataTests.swift
+++ b/Tests/OpenUsageTests/WidgetNoDataTests.swift
@@ -93,9 +93,6 @@ final class WidgetNoDataTests: XCTestCase {
     }
 
     private func makeUserDefaults(_ name: String) -> UserDefaults {
-        let suiteName = "OpenUsageTests.NoData.\(name).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
+        makeScratchDefaults(suiteName: "OpenUsageTests.NoData.\(name).\(UUID().uuidString)")
     }
 }

--- a/Tests/OpenUsageTests/WidgetPercentClampTests.swift
+++ b/Tests/OpenUsageTests/WidgetPercentClampTests.swift
@@ -69,9 +69,7 @@ final class WidgetPercentClampTests: XCTestCase {
                 lines: [.progress(label: "Metric", used: used, limit: 100, format: .percent)]
             )
         )
-        let suiteName = "OpenUsageTests.PercentClamp.\(suite).\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
+        let defaults = makeScratchDefaults(suiteName: "OpenUsageTests.PercentClamp.\(suite).\(UUID().uuidString)")
         let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: { Date() })
         let store = WidgetDataStore(
             registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),


### PR DESCRIPTION
## TL;DR

The test suite created unique `UserDefaults(suiteName:)` domains but usually cleared them only before a test, never afterward, so repeated `swift test` runs accumulated thousands of test preference plists in `~/Library/Preferences`. This routes every leaking scratch suite through one shared helper that removes its data in teardown. Test infrastructure only — no app behavior change.

## What was happening

- Test helpers built suites with fresh UUIDs, called `removePersistentDomain` once at the top for a clean slate, and returned them.
- Nothing removed those domains when the test finished, so each run left newly written preferences behind.
- A few files already used a correct `defer { removePersistentDomain }` pattern; those remain unchanged.

## What this changes

- Adds `XCTestCase.makeScratchDefaults(suiteName:)` in `TestSupport.swift`. It pre-clears the suite and registers an `addTeardownBlock` that removes its persistent domain after the test.
- Routes all 28 leaking call sites across 27 test files through that helper, including the newer `LayoutBootstrapTests` and `LayoutPersistenceTests` added after this branch was first created.
- Keeps the existing XCTest class hierarchy unchanged and continues returning plain `UserDefaults` instances to test bodies.

## Heads-up

- **macOS 27 caveat:** on macOS ≤ 26 (including the `macos-26` CI runner), `removePersistentDomain` removes the suite plist. On macOS 27 beta, `cfprefsd` recreates an empty 42-byte dictionary for touched suites when the test process exits. The teardown still removes all test data, but a post-run filesystem cleanup is required to remove those empty shells.
- A complete one-time cleanup must include the non-`OpenUsageTests` prefixes used by Copilot, notification, and snapshot-cache tests:

```sh
find "$HOME/Library/Preferences" -maxdepth 1 -type f \( \
  -name 'OpenUsageTests*.plist' -o \
  -name 'CopilotProviderTests-*.plist' -o \
  -name 'WidgetDataStoreNotificationTests*.plist' -o \
  -name 'providerSnapshotCache.test.*.plist' \
\) -delete
```

## Tests

- `swift test --filter 'Layout(Bootstrap|Persistence)Tests'` — 5 passed.
- `swift test` — 953 passed, 3 skipped, 0 failures.
- Verified from a purged clean slate on macOS 27: the full suite created 216 plist shells, all 42-byte empty dictionaries; zero matching files retained test data.
- Removed the pre-existing 5,623-file local backlog and the post-verification empty shells; both matching filesystem files and `defaults domains` were zero afterward.
