### PR TITLE
Add GPT-5.6 pricing aliases and coverage

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within a day - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
-  "updated_at": "2026-07-03",
+  "updated_at": "2026-07-08",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -70,6 +70,25 @@
       "cache_write_per_million": 7.5,
       "cache_read_per_million": 0.6,
       "output_per_million": 22.5
+    },
+    "gpt-5.6-sol": {
+      "$comment": "OpenAI's GPT-5.6 preview pricing. Its public catalogs have not added these models yet.",
+      "input_per_million": 5.0,
+      "cache_write_per_million": 6.25,
+      "cache_read_per_million": 0.5,
+      "output_per_million": 30.0
+    },
+    "gpt-5.6-terra": {
+      "input_per_million": 2.5,
+      "cache_write_per_million": 3.125,
+      "cache_read_per_million": 0.25,
+      "output_per_million": 15.0
+    },
+    "gpt-5.6-luna": {
+      "input_per_million": 1.0,
+      "cache_write_per_million": 1.25,
+      "cache_read_per_million": 0.1,
+      "output_per_million": 6.0
     }
   },
   "fast_multipliers": {
@@ -143,6 +162,9 @@
     { "pattern": "^gpt-5\\.4-(?:low|medium|high|xhigh)$", "canonical": "gpt-5.4" },
     { "pattern": "^gpt-5\\.5(?:-(?:low|medium|high|xhigh|extra-high))?-fast$", "canonical": "gpt-5.5-fast" },
     { "pattern": "^gpt-5\\.5(?:-(?:low|medium|high|xhigh|extra-high))?$", "canonical": "gpt-5.5" },
+    { "pattern": "^gpt-5\\.6-sol(?:-(?:none|low|medium|high|xhigh|max|ultra))?$", "canonical": "gpt-5.6-sol" },
+    { "pattern": "^gpt-5\\.6-terra(?:-(?:none|low|medium|high|xhigh|max))?$", "canonical": "gpt-5.6-terra" },
+    { "pattern": "^gpt-5\\.6-luna(?:-(?:none|low|medium|high|xhigh|max))?$", "canonical": "gpt-5.6-luna" },
     { "pattern": "^kimi-k2\\.5$", "canonical": "moonshot/kimi-k2.5" },
     { "pattern": "^kimi-k2p5$", "canonical": "moonshot/kimi-k2.5" },
     { "pattern": "^glm-5\\.2(?:-(?:high|max))?$", "canonical": "glm-5.2" },

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -41,6 +41,9 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "claude-4.6-opus-max-thinking")?.inputPerMillion, 5)
         XCTAssertEqual(pricing.resolve(model: "claude-4.6-opus-max-thinking-fast")?.inputPerMillion, 30)
         XCTAssertEqual(pricing.resolve(model: "gpt-5.5-xhigh-fast")?.inputPerMillion, 12.5)
+        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-sol-ultra")?.inputPerMillion, 5)
+        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-terra-high")?.inputPerMillion, 2.5)
+        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-luna")?.inputPerMillion, 1)
         XCTAssertEqual(pricing.resolve(model: "grok-4-20-thinking")?.inputPerMillion, 2)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2p5")?.inputPerMillion, 0.6)
         XCTAssertEqual(pricing.resolve(model: "glm-5.2-max")?.inputPerMillion, 1.4)
@@ -85,6 +88,27 @@ final class PricingBundledResourceTests: XCTestCase {
         let sonnet46 = try XCTUnwrap(pricing.resolve(model: "claude-4.6-sonnet"))
         XCTAssertEqual(sonnet5.inputPerMillion, sonnet46.inputPerMillion)
         XCTAssertEqual(sonnet5.outputPerMillion, sonnet46.outputPerMillion)
+    }
+
+    func testGPT56PricingAndAliases() throws {
+        let pricing = Self.pricing
+        let sol = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-sol-ultra"))
+        XCTAssertEqual(sol.inputPerMillion, 5.0)
+        XCTAssertEqual(sol.cacheWritePerMillion, 6.25)
+        XCTAssertEqual(sol.cacheReadPerMillion, 0.5)
+        XCTAssertEqual(sol.outputPerMillion, 30.0)
+
+        let terra = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-terra-high"))
+        XCTAssertEqual(terra.inputPerMillion, 2.5)
+        XCTAssertEqual(terra.cacheWritePerMillion, 3.125)
+        XCTAssertEqual(terra.cacheReadPerMillion, 0.25)
+        XCTAssertEqual(terra.outputPerMillion, 15.0)
+
+        let luna = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-luna"))
+        XCTAssertEqual(luna.inputPerMillion, 1.0)
+        XCTAssertEqual(luna.cacheWritePerMillion, 1.25)
+        XCTAssertEqual(luna.cacheReadPerMillion, 0.1)
+        XCTAssertEqual(luna.outputPerMillion, 6.0)
     }
 
     /// Opus 4.7/4.8 fast modes: Cursor's published rates (supplement overrides) win over the


### PR DESCRIPTION
## TL;DR

Adds fallback pricing for GPT-5.6 Sol, Terra, and Luna so OpenUsage can price their Codex usage before the public catalog feeds include them.

## What was happening

- The live OpenUsage supplement, LiteLLM, and models.dev feeds did not include the GPT-5.6 model IDs.
- Usage recorded with those IDs was therefore unpriced and marked incomplete.

## What this changes

- Adds the official GPT-5.6 Sol, Terra, and Luna input, cache-write, cache-read, and output rates to the pricing supplement.
- Adds aliases for supported reasoning-effort suffixes, including Sol Ultra.
- Adds regression coverage for all three model variants and their rates.

## Heads-up

- The supplement is intentionally a temporary authoritative override until the public feeds add these preview model IDs. OpenAI pricing source: https://help.openai.com/en/articles/20001325-a-preview-of-gpt-56-sol-terra-and-luna
- Merging to `main` publishes the manifest to GitHub Pages; installed apps pick it up on their daily pricing refresh, without an app release.

## Tests

- `swift test --filter "ModelPricing|PricingBundledResource"` (compiled locally; local execution is blocked by a missing Sparkle framework in the worktree).
- GitHub Actions `Build and Test` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only pricing manifest and test updates; incorrect rates could misreport costs but no runtime logic changes.
> 
> **Overview**
> Adds **temporary authoritative pricing** for OpenAI’s GPT-5.6 preview models (**Sol**, **Terra**, **Luna**) in `pricing_supplement.json`, including full input/cache-write/cache-read/output rates and bumps `updated_at` to **2026-07-08**.
> 
> New **`alias_rules`** map Codex-style slugs (reasoning-effort suffixes such as `ultra`, `high`, `max`, etc.) to those canonical keys so usage logged before LiteLLM/models.dev list the IDs is no longer marked incomplete.
> 
> **Tests** extend Cursor slug spot-checks and add `testGPT56PricingAndAliases` to lock in all three tiers and token-bucket rates end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8ea33c3e690da980b2832fa1c151330784608d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->