### PR TITLE
Add hover affordance to Usage Trend chart

### DIFF
--- a/Sources/OpenUsage/Views/UsageSparkline.swift
+++ b/Sources/OpenUsage/Views/UsageSparkline.swift
@@ -34,6 +34,17 @@ struct UsageSparkline: View {
             // Anchor the popover to the bar strip (not the whole row), so its arrow points straight up
             // at the chart rather than at the row's center, off to the left of the bars.
             bars
+                // Match the spend/reset value affordance: light the sparkline as soon as the pointer
+                // arrives, then hold the highlight while its detail popover is open so the chart still
+                // reads as the popover's source. `hover.dismiss()` clears both flags on panel close.
+                .background {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(.quaternary)
+                        .padding(.horizontal, -7)
+                        .padding(.vertical, -4)
+                        .opacity(showChartHighlight ? 1 : 0)
+                }
+                .animation(.easeOut(duration: 0.12), value: showChartHighlight)
                 // Only the bar strip is hoverable — hovering the title must not reveal the detail.
                 .contentShape(Rectangle())
                 .onContinuousHover { phase in
@@ -52,6 +63,11 @@ struct UsageSparkline: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .onDisappear { hover.dismiss() }
+    }
+
+    /// Immediate pointer affordance plus a persistent source highlight while the popover is visible.
+    private var showChartHighlight: Bool {
+        hover.overInline || hover.isPresented
     }
 
     private var bars: some View {


### PR DESCRIPTION
## TL;DR

Adds the same immediate hover highlight used by spend and reset values to the Usage Trend sparkline, making the chart’s existing detail popover discoverable before its reveal delay completes.

## What was happening

- Hovering the Usage Trend chart opened its detail popover after a short dwell.
- The inline sparkline had no immediate visual response, so it looked inert until the popover appeared.
- Spend and Rate Limit Resets values already used a subtle highlight to signal the same interaction.

## What this changes

- Adds the shared `.quaternary` rounded highlight behind the Usage Trend sparkline.
- Lights the chart as soon as the pointer enters and keeps it highlighted while the detail popover is open, so the chart reads as the popover’s source.
- Reuses `HoverPopoverState.overInline` and `isPresented`, so the highlight clears with the existing panel-close dismissal path.
- Preserves the chart’s size and row rhythm with the same negative inset and 0.12-second fade as the existing value affordance.

## Heads-up

- This is a visual-only extension of the existing hover interaction; chart data, popover timing, and popover content are unchanged.
- Owner UI verification passed on the `0.7.0-dev` development build.

## Tests

- `./script/build_and_run.sh` — production build, signed bundle staging, restart, and launch passed.
- Owner verification — the hover highlight and existing detail popover work correctly in `OpenUsage 0.7.0-dev`.
- `swift test --filter UsageTrendTests` — test target compiled, but local execution was blocked before tests ran because the worktree test bundle could not load `@rpath/Sparkle.framework`.
- `git diff --check` — passed.

## Screenshots

Pending an owner-provided capture from the development build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only SwiftUI affordance in `UsageSparkline`; no changes to metrics, popover logic, or data handling.
> 
> **Overview**
> The Usage Trend sparkline now uses the same **immediate hover chip** as spend and rate-limit reset values, so the chart feels interactive before the detail popover’s dwell delay finishes.
> 
> A `.quaternary` rounded background on the bar strip fades in on pointer entry and **stays on while the popover is open** (`hover.overInline || hover.isPresented`), matching `WidgetRowView`’s insets and 0.12s animation. Popover timing, data, and hover dismissal behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c766c2727677cd8650bbc46b99124e937d415f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->