### PR TITLE
Clear the update banner when an update session ends

### DIFF
--- a/Sources/OpenUsage/App/UpdaterController.swift
+++ b/Sources/OpenUsage/App/UpdaterController.swift
@@ -145,7 +145,7 @@ private final class UpdaterChannelDelegate: NSObject, SPUUpdaterDelegate {
 /// The accessory-app activation dance. `SPUStandardUserDriverDelegate` is nonisolated in Sparkle, so
 /// this delegate stays nonisolated; its callbacks run on the main thread, so they assume main-actor
 /// isolation to touch `NSApp`.
-private final class UpdaterUserDriverDelegate: NSObject, SPUStandardUserDriverDelegate {
+final class UpdaterUserDriverDelegate: NSObject, SPUStandardUserDriverDelegate {
     /// Publishes "a scheduled check found version X" back to `UpdaterController` (main actor), which
     /// renders it as the dashboard's update banner.
     var onUpdateFound: (@MainActor @Sendable (String) -> Void)?
@@ -203,10 +203,13 @@ private final class UpdaterUserDriverDelegate: NSObject, SPUStandardUserDriverDe
         }
     }
 
-    /// …then drop back to a pure menu-bar app once the update session ends.
+    /// …then drop back to a pure menu-bar app once the update session ends and clear any in-app
+    /// indicator still left behind by a dismissal, skip, install, or failure.
     func standardUserDriverWillFinishUpdateSession() {
+        let onUpdateResolved = onUpdateResolved
         MainActor.assumeIsolated { () -> Void in
             NSApp.setActivationPolicy(.accessory)
+            onUpdateResolved?()
         }
     }
 }

--- a/Tests/OpenUsageTests/UpdaterControllerTests.swift
+++ b/Tests/OpenUsageTests/UpdaterControllerTests.swift
@@ -1,0 +1,20 @@
+import AppKit
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class UpdaterUserDriverDelegateTests: XCTestCase {
+    func testFinishingUpdateSessionClearsInAppUpdateIndicator() {
+        let application = NSApplication.shared
+        let originalPolicy = application.activationPolicy()
+        defer { application.setActivationPolicy(originalPolicy) }
+
+        let delegate = UpdaterUserDriverDelegate()
+        var resolved = false
+        delegate.onUpdateResolved = { resolved = true }
+
+        delegate.standardUserDriverWillFinishUpdateSession()
+
+        XCTAssertTrue(resolved)
+    }
+}


### PR DESCRIPTION
## TL;DR

Clear the in-app update banner whenever Sparkle finishes an update session, so a dismissed, skipped, failed, or completed update does not leave a stale banner behind.

## What was happening

- The banner cleared when the user reached Sparkle’s update window.
- Some session-ending paths could finish without clearing the banner.

## What this changes

- Clear the banner from Sparkle’s final session callback.
- Keep the app’s menu-bar-only activation behavior unchanged.
- Add a regression test for the final callback.

## Tests

- swift test --filter UpdaterUserDriverDelegateTests
- Full release build, signing, launch, and running-process verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Sparkle delegate change plus test exposure; no auth or data handling, behavior is clearing UI state on session end.
> 
> **Overview**
> Clears the dashboard **update available** banner when Sparkle finishes an update session, not only when the user opens Sparkle’s update UI.
> 
> `UpdaterUserDriverDelegate.standardUserDriverWillFinishUpdateSession()` now invokes `onUpdateResolved` (which nils `availableUpdateVersion` on `UpdaterController`) after restoring the accessory activation policy, so dismiss, skip, install, or failure paths don’t leave a stale banner. **`UpdaterUserDriverDelegate`** is no longer `private` so tests can target it.
> 
> Adds **`UpdaterUserDriverDelegateTests`** to assert the finish-session callback fires `onUpdateResolved`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3194f3baf7c436309a0f1d5f86487bee85e6f764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->