### PR TITLE
Remove unused UI plumbing

### DIFF
--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -97,8 +97,6 @@ extension View {
 }
 
 private struct PartyPulseModifier: ViewModifier {
-    @Environment(\.popoverIsVisible) private var shown
-
     func body(content: Content) -> some View {
         // Clock mounts only while the popover is on-screen (see `VisibilityGatedTimeline`); the pulse
         // starts immediately on reopen / in-place activation and costs nothing when the popover is closed.

--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -70,18 +70,17 @@ extension View {
     /// The grouped-card surface used for provider/settings cards, in the shared rounded shape: the
     /// bright page base lifted by the system's `.fill.quaternary` (the System Settings grouped-box
     /// look), borderless — the subtle fill carries the grouping the way Settings does, in both light
-    /// and dark. Drawing the opaque page base first keeps a lifted drag preview solid while it floats.
-    /// `lifted` is accepted for call-site symmetry; live and lifted cards share one surface (the lift's
-    /// depth comes from `ReorderLiftPreview`'s shadow, not a different fill).
-    func cardSurface(lifted: Bool = false) -> some View {
-        modifier(CardSurfaceModifier(lifted: lifted))
+    /// and dark. Drawing the opaque page base first keeps a lifted drag preview solid while it floats;
+    /// the preview's depth comes from `ReorderLiftPreview`'s shadow, not a different card surface.
+    func cardSurface() -> some View {
+        modifier(CardSurfaceModifier())
     }
 
     /// A single-row lifted preview surface: the card surface plus a thin separator hairline that fences
     /// a free-floating one-row chip off from the rows beneath it (the multi-row provider previews don't
     /// take the hairline — their shadow alone reads as detached).
     func liftedRowSurface() -> some View {
-        cardSurface(lifted: true)
+        cardSurface()
             .overlay { Theme.cardShape.strokeBorder(.separator, lineWidth: 0.5) }
     }
 
@@ -98,13 +97,12 @@ extension View {
 /// system's `.fill.quaternary` composited on top — borderless, matching the macOS System Settings
 /// grouped box in both light and dark. The opaque base means a lifted drag preview stays solid while
 /// it floats; the page base under a live card is the same color as the tray behind it, so it's
-/// invisible there. `lifted` is unused — both paths share the one surface.
+/// invisible there. Live cards and drag previews share the same surface.
 ///
 /// Under the translucent surface treatment (Increase Transparency / the secret-code egg) the opaque page base
 /// is dropped so the behind-window vibrancy backdrop shows through, while the system grouped fill stays
 /// so cards still read as grouped boxes over the desktop.
 private struct CardSurfaceModifier: ViewModifier {
-    let lifted: Bool
     @Environment(\.popoverSurfaceTreatment) private var treatment
 
     func body(content: Content) -> some View {

--- a/Sources/OpenUsage/Views/ProviderCard.swift
+++ b/Sources/OpenUsage/Views/ProviderCard.swift
@@ -7,9 +7,8 @@ import SwiftUI
 /// spacing and even drew dividers the live list doesn't).
 ///
 /// The live list threads per-row gestures/opacity/frames through `rows`; the preview passes plain
-/// `WidgetRowView`s and flips `lifted` for the legible material backing.
+/// `WidgetRowView`s; the preview's shadow supplies its lifted depth.
 struct DashboardMetricCard<Rows: View>: View {
-    var lifted: Bool = false
     @ViewBuilder var rows: Rows
 
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
@@ -19,6 +18,6 @@ struct DashboardMetricCard<Rows: View>: View {
             rows
         }
         .padding(.vertical, density.cardGutter)
-        .cardSurface(lifted: lifted)
+        .cardSurface()
     }
 }

--- a/Sources/OpenUsage/Views/ReorderGeometry.swift
+++ b/Sources/OpenUsage/Views/ReorderGeometry.swift
@@ -79,7 +79,7 @@ struct ReorderLiftPreview: View {
             ProviderSectionHeader(provider: provider, plan: plan, showsDragHandle: true)
                 .padding(.horizontal, 8)
 
-            DashboardMetricCard(lifted: true) {
+            DashboardMetricCard {
                 ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                     WidgetRowView(data: row)
                 }


### PR DESCRIPTION
## TL;DR

Remove two UI inputs that were being passed or read but never changed the result.

## What was happening

- Card styling accepted a lifted option that it did not use.
- A party-mode effect read popover visibility but did not use the value.

## What this changes

- Remove the unused lifted option and simplify its call sites.
- Remove the unused visibility read.
- Keep the rendered appearance and animation behavior unchanged.

## Tests

- Full release build, signing, launch, and running-process verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and signature cleanup only; styling and animation paths are unchanged.
> 
> **Overview**
> Removes dead API surface that did not affect rendering: the **`lifted`** parameter on **`cardSurface()`**, **`CardSurfaceModifier`**, and **`DashboardMetricCard`**, plus call sites that passed **`lifted: true`** for drag previews. Live cards and lifted previews already shared one surface; depth during reorder comes from **`ReorderLiftPreview`**’s shadow.
> 
> **`PartyPulseModifier`** no longer reads **`\.popoverIsVisible`**; popover visibility still gates the animation clock via **`VisibilityGatedTimeline`**, which owns that environment value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b61302f1ff84d9747c9c398f1a59b8bfecff5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->