### PR TITLE
Fix request-wide long-context pricing

### DIFF
--- a/Sources/OpenUsage/Pricing/ModelPricing.swift
+++ b/Sources/OpenUsage/Pricing/ModelPricing.swift
@@ -48,10 +48,15 @@ final class ModelPricing: Sendable {
         resolve(model: model) != nil
     }
 
-    /// Dollar cost of `tokens` for `model`, or nil when the model can't be priced.
-    func estimatedCostDollars(model: String, tokens: TokenBreakdown) -> Double? {
+    /// Dollar cost of `tokens` for `model`, or nil when the model can't be priced. Aggregated sources
+    /// can disable long-context tiers when they do not preserve individual request boundaries.
+    func estimatedCostDollars(
+        model: String,
+        tokens: TokenBreakdown,
+        applyLongContextRates: Bool = true
+    ) -> Double? {
         guard let rates = resolve(model: model) else { return nil }
-        return rates.costDollars(for: tokens)
+        return rates.costDollars(for: tokens, applyLongContextRates: applyLongContextRates)
     }
 
     private func resolveUncached(model: String) -> ModelRates? {

--- a/Sources/OpenUsage/Pricing/ModelRates.swift
+++ b/Sources/OpenUsage/Pricing/ModelRates.swift
@@ -10,7 +10,8 @@ struct ModelRates: Sendable, Equatable {
     var cacheWritePerMillion: Double
     var cacheReadPerMillion: Double
 
-    /// Rates for the token share above 200k tokens, where the provider prices long context higher.
+    /// Rates for requests whose prompt exceeds 200k tokens, where the provider prices the whole
+    /// request at the higher long-context tier.
     var inputAbove200kPerMillion: Double?
     var outputAbove200kPerMillion: Double?
     var cacheWriteAbove200kPerMillion: Double?
@@ -49,6 +50,9 @@ struct TokenBreakdown: Sendable, Equatable {
     /// The request ran the model's "fast" variant (Claude logs carry a `speed` field).
     var isFast: Bool = false
 
+    /// Input that determines whether the request crosses the long-context threshold. Output does not
+    /// select the tier, but it is billed at the selected tier once the prompt crosses the threshold.
+    var promptTokens: Int { input + cacheWrite5m + cacheWrite1h + cacheRead }
     var totalTokens: Int { input + cacheWrite5m + cacheWrite1h + cacheRead + output }
 }
 
@@ -57,27 +61,38 @@ extension ModelRates {
     /// explicit `above_1hr` fields where present).
     private static let cacheWrite1hInputMultiplier = 2.0
 
-    /// Dollar cost of `tokens` at these rates, applying >200k tiers and the fast multiplier.
-    func costDollars(for tokens: TokenBreakdown) -> Double {
+    /// Dollar cost of one request at these rates, applying the request-wide >200k tier and the fast
+    /// multiplier. Aggregated sources can opt out when their totals do not preserve request boundaries.
+    func costDollars(for tokens: TokenBreakdown, applyLongContextRates: Bool = true) -> Double {
         let multiplier = tokens.isFast ? fastMultiplier : 1
-        let cost = tieredCost(tokens.input, inputPerMillion, inputAbove200kPerMillion)
-            + tieredCost(tokens.output, outputPerMillion, outputAbove200kPerMillion)
-            + tieredCost(tokens.cacheWrite5m, cacheWritePerMillion, cacheWriteAbove200kPerMillion)
-            + tieredCost(
-                tokens.cacheWrite1h,
-                inputPerMillion * Self.cacheWrite1hInputMultiplier,
-                inputAbove200kPerMillion.map { $0 * Self.cacheWrite1hInputMultiplier }
-            )
-            + tieredCost(tokens.cacheRead, cacheReadPerMillion, cacheReadAbove200kPerMillion)
+        let useLongContextRates = applyLongContextRates && tokens.promptTokens > 200_000
+        let inputRate = selectedRate(base: inputPerMillion, longContext: inputAbove200kPerMillion,
+                                     useLongContextRates: useLongContextRates)
+        let outputRate = selectedRate(base: outputPerMillion, longContext: outputAbove200kPerMillion,
+                                      useLongContextRates: useLongContextRates)
+        let cacheWriteRate = selectedRate(base: cacheWritePerMillion, longContext: cacheWriteAbove200kPerMillion,
+                                          useLongContextRates: useLongContextRates)
+        let cacheReadRate = selectedRate(base: cacheReadPerMillion, longContext: cacheReadAbove200kPerMillion,
+                                         useLongContextRates: useLongContextRates)
+        let cacheWrite1hRate = selectedRate(
+            base: inputPerMillion,
+            longContext: inputAbove200kPerMillion,
+            useLongContextRates: useLongContextRates
+        ) * Self.cacheWrite1hInputMultiplier
+
+        let cost = cost(tokens.input, at: inputRate)
+            + cost(tokens.output, at: outputRate)
+            + cost(tokens.cacheWrite5m, at: cacheWriteRate)
+            + cost(tokens.cacheWrite1h, at: cacheWrite1hRate)
+            + cost(tokens.cacheRead, at: cacheReadRate)
         return cost * multiplier
     }
 
-    private func tieredCost(_ tokens: Int, _ basePerMillion: Double, _ abovePerMillion: Double?) -> Double {
-        let threshold = 200_000
-        guard tokens > 0 else { return 0 }
-        if let abovePerMillion, tokens > threshold {
-            return (Double(threshold) * basePerMillion + Double(tokens - threshold) * abovePerMillion) / 1_000_000
-        }
-        return Double(tokens) * basePerMillion / 1_000_000
+    private func selectedRate(base: Double, longContext: Double?, useLongContextRates: Bool) -> Double {
+        useLongContextRates ? (longContext ?? base) : base
+    }
+
+    private func cost(_ tokens: Int, at ratePerMillion: Double) -> Double {
+        Double(tokens) * ratePerMillion / 1_000_000
     }
 }

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
@@ -61,7 +61,11 @@ enum CursorUsageCSV {
                 date: date,
                 model: model,
                 tokens: tokens,
-                imputedCostDollars: pricing.estimatedCostDollars(model: model, tokens: tokens)
+                imputedCostDollars: pricing.estimatedCostDollars(
+                    model: model,
+                    tokens: tokens,
+                    applyLongContextRates: false
+                )
             ))
         }
         return rows

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -48,6 +48,31 @@ final class CursorCSVParserTests: XCTestCase {
         XCTAssertEqual(rows[1].tokens.totalTokens, 100)
         XCTAssertNil(rows[1].imputedCostDollars)
     }
+
+    func testUsageCSVDoesNotTreatAggregatedRowsAsSingleLongContextRequests() throws {
+        var rates = ModelRates(
+            inputPerMillion: 3,
+            outputPerMillion: 15,
+            cacheWritePerMillion: 3.75,
+            cacheReadPerMillion: 0.3
+        )
+        rates.inputAbove200kPerMillion = 6
+        rates.outputAbove200kPerMillion = 22.5
+        let pricing = ModelPricing(
+            supplement: PricingSupplement(),
+            primary: PricingCatalog(entries: ["test-model": rates]),
+            secondary: PricingCatalog()
+        )
+        let csv = """
+        Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Cost
+        2026-01-01T00:00:00Z,test-model,No,0,300000,0,100000,Included
+        """
+
+        let row = try XCTUnwrap(CursorUsageCSV.parse(csv: csv, pricing: pricing).first)
+
+        // A CSV row combines many requests, so its total cannot prove that any one request crossed 200k.
+        XCTAssertEqual(row.imputedCostDollars!, 2.4, accuracy: 0.0001)
+    }
 }
 
 // MARK: - Range aggregation

--- a/Tests/OpenUsageTests/ModelPricingTests.swift
+++ b/Tests/OpenUsageTests/ModelPricingTests.swift
@@ -166,13 +166,46 @@ final class ModelPricingTests: XCTestCase {
         XCTAssertEqual(pricing.estimatedCostDollars(model: "claude-sonnet-4-5", tokens: tokens)!, 28.05, accuracy: 0.0001)
     }
 
-    func testCostAbove200kUsesTieredRates() throws {
+    func testCostAbove200kUsesHigherRateForWholeRequest() throws {
         var entry = ModelRates(inputPerMillion: 3, outputPerMillion: 15, cacheWritePerMillion: 3.75, cacheReadPerMillion: 0.3)
         entry.inputAbove200kPerMillion = 6
         let pricing = try makePricing(primary: ["claude-sonnet-4-5": entry])
         let tokens = TokenBreakdown(input: 300_000)
-        // 200k at $3/M + 100k at $6/M = 0.6 + 0.6 = 1.2
-        XCTAssertEqual(pricing.estimatedCostDollars(model: "claude-sonnet-4-5", tokens: tokens)!, 1.2, accuracy: 0.0001)
+        XCTAssertEqual(pricing.estimatedCostDollars(model: "claude-sonnet-4-5", tokens: tokens)!, 1.8, accuracy: 0.0001)
+    }
+
+    func testCombinedPromptBucketsSelectLongContextRatesForEveryBucket() throws {
+        var entry = ModelRates(inputPerMillion: 3, outputPerMillion: 15, cacheWritePerMillion: 3.75, cacheReadPerMillion: 0.3)
+        entry.inputAbove200kPerMillion = 6
+        entry.outputAbove200kPerMillion = 22.5
+        entry.cacheWriteAbove200kPerMillion = 7.5
+        entry.cacheReadAbove200kPerMillion = 0.6
+        let pricing = try makePricing(primary: ["claude-sonnet-4-5": entry])
+        let tokens = TokenBreakdown(input: 100_000, cacheWrite5m: 60_000, cacheRead: 50_000, output: 20_000)
+
+        // The 210k prompt selects the higher tier for input, cache, and output alike.
+        let expected = 0.6 + 0.45 + 0.03 + 0.45
+        XCTAssertEqual(pricing.estimatedCostDollars(model: "claude-sonnet-4-5", tokens: tokens)!, expected, accuracy: 0.0001)
+    }
+
+    func testLargeOutputAloneDoesNotSelectLongContextRates() throws {
+        var entry = ModelRates(inputPerMillion: 3, outputPerMillion: 15, cacheWritePerMillion: 3.75, cacheReadPerMillion: 0.3)
+        entry.inputAbove200kPerMillion = 6
+        entry.outputAbove200kPerMillion = 22.5
+        let pricing = try makePricing(primary: ["claude-sonnet-4-5": entry])
+        let tokens = TokenBreakdown(input: 10_000, output: 300_000)
+
+        XCTAssertEqual(pricing.estimatedCostDollars(model: "claude-sonnet-4-5", tokens: tokens)!, 4.53, accuracy: 0.0001)
+    }
+
+    func testExactly200kPromptKeepsBaseRates() throws {
+        var entry = ModelRates(inputPerMillion: 3, outputPerMillion: 15, cacheWritePerMillion: 3.75, cacheReadPerMillion: 0.3)
+        entry.inputAbove200kPerMillion = 6
+        entry.outputAbove200kPerMillion = 22.5
+        let pricing = try makePricing(primary: ["claude-sonnet-4-5": entry])
+        let tokens = TokenBreakdown(input: 200_000, output: 10_000)
+
+        XCTAssertEqual(pricing.estimatedCostDollars(model: "claude-sonnet-4-5", tokens: tokens)!, 0.75, accuracy: 0.0001)
     }
 
     func testCostWithoutTierRatesUsesBaseRateThroughout() throws {

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -22,7 +22,7 @@ A model no source can price is left out of the spend figures entirely — its to
 
 ## What the estimate includes
 
-Costs are computed per usage event from four token buckets — plain input, cache writes, cache reads, and output — at the model's per-million-token rates, including 1-hour cache-write pricing, the >200k-token long-context tiers where a provider has them, and fast-variant multipliers. When a Claude log line carries an explicit `costUSD`, that value is used as-is. The result is an estimate of API-rate value, not a bill: subscription plans don't charge per token.
+Costs are computed per usage event from four token buckets — plain input, cache writes, cache reads, and output — at the model's per-million-token rates, including 1-hour cache-write pricing, the >200k-token long-context tiers where a provider has them, and fast-variant multipliers. When one request's prompt passes 200k tokens, the higher rate applies to the whole request. Cursor's export combines many requests into each row, so OpenUsage uses the normal rate there rather than guessing that one request crossed the limit. When a Claude log line carries an explicit `costUSD`, that value is used as-is. The result is an estimate of API-rate value, not a bill: subscription plans don't charge per token.
 
 ## Privacy
 


### PR DESCRIPTION
## TL;DR

Apply long-context pricing to the whole request once its prompt crosses 200k tokens. Keep Cursor on normal rates because its export combines many requests and cannot prove that any single request crossed the limit.

## What was happening

- The first 200k tokens were priced normally and only the remainder used the higher rate.
- Each token bucket chose its tier separately.
- A large Cursor aggregate could be mistaken for one oversized request.

## What this changes

- Choose one price tier from the request’s total prompt size.
- Apply that tier to input, cache, and output for the entire request.
- Keep exactly 200k at the normal rate.
- Disable long-context guessing for Cursor’s aggregated rows.
- Explain the behavior in the pricing guide.

## Tests

- swift test --filter ModelPricingTests
- swift test --filter CursorCSVParserTests
- Full release build, signing, launch, and running-process verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spend imputation for all per-request sources (Claude, Codex, Grok); dollar estimates can shift materially for long-context usage, while Cursor is deliberately conservative.
> 
> **Overview**
> **Long-context pricing** no longer splits each token bucket at 200k. When a single request’s **prompt** (input + cache buckets) exceeds 200k, the higher tier applies to **all** buckets for that request—including output. Exactly 200k prompt stays on base rates; output alone does not trigger the tier.
> 
> `ModelPricing.estimatedCostDollars` and `ModelRates.costDollars` gain `applyLongContextRates` (default `true`). **Cursor usage CSV** passes `false` because each row aggregates many requests, so row totals must not be treated as one oversized request.
> 
> Tests cover the new tier rules and Cursor base-rate imputation; `docs/pricing.md` documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e881be608c07c9f544b5e6eab5e10e0eeaa55334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->