### PR TITLE
Mark Cursor spend as estimated

### DIFF
--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -33,9 +33,9 @@ final class CursorProvider: ProviderRuntime {
     /// time by ~12h+ in June 2026, so spend tracking was disabled for a stretch (issue #758). It is back
     /// on: the spend tiles (Today / Yesterday / Last 30 Days) and the token trend are imputed from the CSV
     /// via `CursorUsageCSV`, the shared `ModelPricingStore`, and `CursorUsageMapper.appendSpendLines`,
-    /// and the `cursor.today/yesterday/last30/trend` descriptors surface in the layout again. Spend that
-    /// uses a model no pricing source knows prices to $0, so each affected period's tile carries the
-    /// unknown model names for the warning triangle (see `appendSpendLines`).
+    /// and the `cursor.today/yesterday/last30/trend` descriptors surface in the layout again. Usage from
+    /// a model no pricing source knows is left out, and the affected period carries the model name for
+    /// the warning triangle (see `appendSpendLines`).
     static let spendTrackingEnabled = true
 
     var widgetDescriptors: [WidgetDescriptor] {

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -254,9 +254,9 @@ enum CursorUsageMapper {
     /// Append the shared Today / Yesterday / Last 30 Days spend tiles from Cursor's CSV rows. The rows
     /// are aggregated into one local-calendar-day `DailyUsageSeries` and handed to `SpendTileMapper`
     /// — the same builder the Claude/Codex/Grok tiles use — so the output is identical apart from the
-    /// `estimated: false` flag (Cursor spend is server-priced, so its dollars are not marked estimated). Callers only
-    /// invoke this when the CSV fetched and parsed, so a failure appends nothing and the tiles read
-    /// "No data".
+    /// source note. Cursor's costs are calculated locally from the exported token counts, so the dollar
+    /// values carry the estimate icon. Callers only invoke this when the CSV fetched and parsed, so a
+    /// failure appends nothing and the tiles read "No data".
     ///
     /// Model breakdown rows group by base model, not raw CSV slug: Cursor exports one slug per thinking
     /// effort / fast combination (`claude-opus-4-8-thinking-max`, `gpt-5.5-extra-high-fast`, …), and a
@@ -315,11 +315,11 @@ enum CursorUsageMapper {
                 }
             )
         })
-        SpendTileMapper.appendTokenUsage(series, to: &lines, now: now, estimated: false,
+        SpendTileMapper.appendTokenUsage(series, to: &lines, now: now, estimated: true,
                                          unknownModelsByDay: unknownModelsByDay,
                                          modelUsage: modelUsage,
                                          modelSourceNote: "From your Cursor usage export")
-        // Cursor's tokens come from the server-priced usage CSV, not a local CLI log, so the trend
+        // Cursor's tokens come from the server-exported usage CSV, not a local CLI log, so the trend
         // note names that source rather than the "estimated from local logs" line the log-scanning
         // providers use. Tokens are measured either way.
         SpendTileMapper.appendUsageTrend(series, to: &lines, now: now, note: "From your Cursor usage export")

--- a/Sources/OpenUsage/Providers/SpendTileMapper.swift
+++ b/Sources/OpenUsage/Providers/SpendTileMapper.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Turns local daily token/cost data into the shared Today / Yesterday / Last 30 Days spend tiles.
 /// Every spend-tracking provider funnels through here so the tiles render identically regardless of
-/// source: Claude / Codex / Grok feed token/cost from their CLI logs (estimated dollars),
-/// Cursor feeds server-priced dollars from its CSV export (`estimated: false`). The data shape
+/// source: Claude / Codex / Grok feed token/cost from their CLI logs, while Cursor feeds token/cost
+/// derived from its CSV export. The data shape
 /// (`DailyUsageSeries`) is a provider-neutral per-day carrier shared by every source.
 enum SpendTileMapper {
     /// Append the three spend tiles (Today / Yesterday / Last 30 Days). A period with no usage is left
@@ -12,8 +12,7 @@ enum SpendTileMapper {
     /// that proves otherwise. This holds for every source (the Claude/Codex/Grok log scanners,
     /// Cursor's CSV export); there's no per-source branching. "No data" is also what a tile shows when
     /// the source couldn't be read at all (missing log, failed API/CSV), where the caller appends
-    /// nothing. `estimated` flags the dollar value as a local estimate (drives the ⓘ); pass `false` for
-    /// server-priced sources like Cursor.
+    /// nothing. `estimated` controls whether the dollar value carries the local-estimate marker (ⓘ).
     /// `unknownModelsByDay` maps a `yyyy-MM-dd` day key to the set of model names used that day that no
     /// pricing source can price. Today / Yesterday pick up their own day's set; Last 30 Days carries the
     /// union across the whole window. Empty (the default) for sources without unknown-model detection, so
@@ -178,10 +177,9 @@ enum SpendTileMapper {
     /// rendered combined as "$4.08 · 1.2M tokens". The token value carries the "tokens" unit (the same
     /// way Codex credits carry "credits"), so the three spend tiles read consistently.
     ///
-    /// Only called for a period with real usage (see `hasUsage`), so the dollar is omitted only for an
-    /// unpriced day that still used tokens (e.g. an unknown model) — that row shows just the token count,
-    /// since its cost is genuinely unknown rather than zero. `estimated` flags the dollars as a local
-    /// estimate (the ⓘ); token counts are always measured, never flagged.
+    /// Only called for a period with real usage (see `hasUsage`). Some token-only callers may not provide
+    /// a dollar value. `estimated` flags locally calculated dollars with the ⓘ; token counts are always
+    /// measured, never flagged.
     private static func spendValues(tokens: Int, costUSD: Double?, estimated: Bool) -> [MetricValue] {
         var values: [MetricValue] = []
         if let costUSD {

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -69,11 +69,11 @@ final class CursorSpendRangeTests: XCTestCase {
         var lines: [MetricLine] = []
         CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, to: &lines)
 
-        // Combined cost + tokens, server-priced so the dollar value is not marked estimated.
-        XCTAssertEqual(values(lines, "Today"), [MetricValue(number: 1.00, kind: .dollars), MetricValue(number: 100, kind: .count, label: "tokens")])
-        XCTAssertEqual(values(lines, "Yesterday"), [MetricValue(number: 2.00, kind: .dollars), MetricValue(number: 200, kind: .count, label: "tokens")])
+        // Tokens come from Cursor; dollars are calculated locally and marked as estimated.
+        XCTAssertEqual(values(lines, "Today"), [MetricValue(number: 1.00, kind: .dollars, estimated: true), MetricValue(number: 100, kind: .count, label: "tokens")])
+        XCTAssertEqual(values(lines, "Yesterday"), [MetricValue(number: 2.00, kind: .dollars, estimated: true), MetricValue(number: 200, kind: .count, label: "tokens")])
         // Last 30 Days sums every fetched day (the provider scopes the CSV to a 30-day window).
-        XCTAssertEqual(values(lines, "Last 30 Days"), [MetricValue(number: 8.50, kind: .dollars), MetricValue(number: 1349, kind: .count, label: "tokens")])
+        XCTAssertEqual(values(lines, "Last 30 Days"), [MetricValue(number: 8.50, kind: .dollars, estimated: true), MetricValue(number: 1349, kind: .count, label: "tokens")])
     }
 
     func testZeroActivityLeavesTilesUnbacked() {
@@ -103,7 +103,7 @@ final class CursorSpendRangeTests: XCTestCase {
             return XCTFail("expected a Usage Trend chart line")
         }
         XCTAssertEqual(label, "Usage Trend")
-        // Cursor's tokens come from the server-priced CSV, so the note names that source, not local logs.
+        // Cursor's tokens come from its server export, so the note names that source, not local logs.
         XCTAssertEqual(note, "From your Cursor usage export")
         XCTAssertEqual(points.count, 31, "one bar per calendar day across the 31-day window")
         XCTAssertEqual(points.last?.value, 100, "today's tokens land on the last bar")
@@ -170,7 +170,7 @@ final class CursorSpendRangeTests: XCTestCase {
         // The unpriced row is excluded from the tile's tokens and the breakdown alike — it surfaces
         // only through the unknown-model warning.
         XCTAssertEqual(values(lines, "Today"),
-                       [MetricValue(number: 3.01, kind: .dollars), MetricValue(number: 300, kind: .count, label: "tokens")])
+                       [MetricValue(number: 3.01, kind: .dollars, estimated: true), MetricValue(number: 300, kind: .count, label: "tokens")])
         XCTAssertEqual(unknown(lines, "Today"), ["unpriced-cursor-model"])
         let breakdown = try XCTUnwrap(modelBreakdown(lines, "Today"))
         XCTAssertEqual(breakdown.sourceNote, "From your Cursor usage export")
@@ -355,7 +355,7 @@ final class CursorSpendProviderTests: XCTestCase {
                     providerID: cursor.provider.id,
                     displayName: cursor.provider.displayName,
                     lines: [.values(label: "Today", values: [
-                        MetricValue(number: dollars, kind: .dollars),
+                        MetricValue(number: dollars, kind: .dollars, estimated: true),
                         MetricValue(number: Double(tokens), kind: .count, label: "tokens")
                     ])]
                 )
@@ -377,8 +377,7 @@ final class CursorSpendProviderTests: XCTestCase {
             XCTAssertTrue(remaining.hasData)
             XCTAssertEqual(remaining.valueText, expectedValue)
             XCTAssertEqual(remaining.unboundedDetail, expectedDetail)
-            // Cursor spend is server-priced, so the combined tile carries no local-estimate note.
-            XCTAssertNil(remaining.infoNote)
+            XCTAssertEqual(remaining.infoNote, WidgetData.localEstimateNote)
             // Unbounded: identical under both meter styles.
             XCTAssertEqual(used.valueText, remaining.valueText)
             XCTAssertEqual(used.unboundedDetail, remaining.unboundedDetail)

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -18,9 +18,9 @@ Tracks your Cursor plan usage using the login from the Cursor app.
 
 Just be signed into the Cursor app. OpenUsage reads Cursor's local state database (and its keychain entries) for the session tokens; refreshed tokens are persisted back. Nothing extra to install or configure.
 
-## Spend history (temporarily unavailable)
+## Spend history
 
-Cursor's per-day spend tiles (Today / Yesterday / Last 30 Days) and the Usage Trend chart are **turned off for now**. They were built from Cursor's server-side usage export, which has started reporting at least ~12 hours behind real time — so a day's cost and tokens would show up stale or empty (for example, a `$0.00` "Today" while you're actively using Cursor). Rather than show misleading numbers, OpenUsage hides these rows until Cursor's reporting catches up. Everything else (Total / Auto / API usage, Extra Usage, Credits) is live and unaffected.
+Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export. OpenUsage uses the exported token counts and shared model pricing to estimate the cost locally. Cursor's export may occasionally arrive late, so the newest figures can lag behind current activity.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## TL;DR

Label Cursor dollar totals as estimates because Cursor supplies token counts and OpenUsage calculates the dollars locally.

## What was happening

- Cursor spend looked like an exact billed amount.
- The app was actually applying shared model prices to exported token counts.

## What this changes

- Show the existing estimate indicator on Cursor spend totals.
- Keep token counts and source notes unchanged.
- Update the Cursor guide and stale pricing comments.

## Tests

- swift test --filter CursorSpend
- Full release build, signing, launch, and running-process verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and documentation only; spend math and data sources are unchanged aside from the estimate flag on dollar metrics.
> 
> **Overview**
> Cursor **Today / Yesterday / Last 30 Days** dollar totals were shown like exact billed amounts even though OpenUsage **prices exported token counts** with shared model pricing. This PR passes **`estimated: true`** into `SpendTileMapper` for Cursor CSV spend so dollar `MetricValue`s get the same **ⓘ local-estimate** treatment as Claude/Codex/Grok log-based spend; **token counts**, export source notes, and unknown-model warnings are unchanged.
> 
> Comments in `CursorProvider`, `CursorUsageMapper`, and `SpendTileMapper` are aligned with that model (no more “server-priced” wording). **`docs/providers/cursor.md`** now documents active spend history and that costs are **local estimates**, with a note that the export can lag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2669a7bbc6b1298c84d94e43b19fff93d4e1f40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->