### PR TITLE
Keep launch-at-login errors visible

### DIFF
--- a/Sources/OpenUsage/Stores/LaunchAtLoginSetting.swift
+++ b/Sources/OpenUsage/Stores/LaunchAtLoginSetting.swift
@@ -1,0 +1,47 @@
+import Observation
+import ServiceManagement
+
+/// Keeps the Launch at Login switch aligned with macOS without treating a failed rollback as a
+/// second user action.
+@MainActor
+@Observable
+final class LaunchAtLoginSetting {
+    static let failureMessage = "macOS wouldn't update Launch at Login. Check System Settings → Login Items."
+
+    private(set) var isEnabled: Bool
+    private(set) var errorMessage: String?
+
+    private let currentStatus: () -> Bool
+    private let setSystemEnabled: (Bool) throws -> Void
+
+    init(
+        currentStatus: @escaping () -> Bool = { SMAppService.mainApp.status == .enabled },
+        setEnabled: @escaping (Bool) throws -> Void = { enabled in
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+        }
+    ) {
+        self.currentStatus = currentStatus
+        self.setSystemEnabled = setEnabled
+        self.isEnabled = currentStatus()
+    }
+
+    func update(to enabled: Bool) {
+        guard enabled != isEnabled else { return }
+        do {
+            try setSystemEnabled(enabled)
+            isEnabled = currentStatus()
+            errorMessage = nil
+        } catch {
+            AppLog.error(
+                .config,
+                "Launch at Login \(enabled ? "register" : "unregister") failed: \(error.localizedDescription)"
+            )
+            isEnabled = currentStatus()
+            errorMessage = Self.failureMessage
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -1,7 +1,6 @@
 import AppKit
 import Combine
 import KeyboardShortcuts
-import ServiceManagement
 import SwiftUI
 import UserNotifications
 
@@ -15,12 +14,7 @@ struct SettingsScreen: View {
     @Environment(AppContainer.self) private var container
     @Environment(UpdaterController.self) private var updater
 
-    /// Launch at login goes through the system login-item registry (`SMAppService`), which is the
-    /// source of truth — no shadow preference key. Registration can fail (e.g. unbundled `swift run`),
-    /// so a failed flip resyncs the toggle from the actual status, logs the error, and surfaces a
-    /// friendly line under the row.
-    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
-    @State private var launchAtLoginError: String?
+    @State private var launchAtLogin = LaunchAtLoginSetting()
     @AppStorage(TotalSpendSetting.key) private var showTotalSpend = true
     @AppStorage(AppearanceSetting.key) private var appearance = AppearanceSetting.system
     @AppStorage(TimeFormatSetting.key) private var timeFormat = TimeFormatSetting.auto
@@ -59,24 +53,13 @@ struct SettingsScreen: View {
                         .settingsSwitchStyle()
                 }
                 row("Launch at Login") {
-                    Toggle("", isOn: $launchAtLogin)
+                    Toggle("", isOn: Binding(
+                        get: { launchAtLogin.isEnabled },
+                        set: { launchAtLogin.update(to: $0) }
+                    ))
                         .settingsSwitchStyle()
-                        .onChange(of: launchAtLogin) { _, enabled in
-                            do {
-                                if enabled {
-                                    try SMAppService.mainApp.register()
-                                } else {
-                                    try SMAppService.mainApp.unregister()
-                                }
-                                launchAtLoginError = nil
-                            } catch {
-                                AppLog.error(.config, "Launch at Login \(enabled ? "register" : "unregister") failed: \(error.localizedDescription)")
-                                launchAtLoginError = "macOS wouldn't update Launch at Login. Check System Settings → Login Items."
-                                launchAtLogin = SMAppService.mainApp.status == .enabled
-                            }
-                        }
                 }
-                if let launchAtLoginError {
+                if let launchAtLoginError = launchAtLogin.errorMessage {
                     inlineNotice(launchAtLoginError)
                 }
                 // Click-to-record field; its ⓧ clears the combo and disables the shortcut.

--- a/Tests/OpenUsageTests/LaunchAtLoginSettingTests.swift
+++ b/Tests/OpenUsageTests/LaunchAtLoginSettingTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class LaunchAtLoginSettingTests: XCTestCase {
+    func testFailedChangeRollsBackWithoutMakingASecondSystemCall() {
+        let systemEnabled = false
+        var requestedValues: [Bool] = []
+        let setting = LaunchAtLoginSetting(
+            currentStatus: { systemEnabled },
+            setEnabled: { enabled in
+                requestedValues.append(enabled)
+                throw TestError.rejected
+            }
+        )
+
+        setting.update(to: true)
+
+        XCTAssertEqual(requestedValues, [true])
+        XCTAssertFalse(setting.isEnabled)
+        XCTAssertEqual(setting.errorMessage, LaunchAtLoginSetting.failureMessage)
+    }
+
+    func testLaterSuccessUpdatesTheSwitchAndClearsTheError() {
+        var systemEnabled = false
+        var shouldFail = true
+        let setting = LaunchAtLoginSetting(
+            currentStatus: { systemEnabled },
+            setEnabled: { enabled in
+                if shouldFail { throw TestError.rejected }
+                systemEnabled = enabled
+            }
+        )
+        setting.update(to: true)
+        shouldFail = false
+
+        setting.update(to: true)
+
+        XCTAssertTrue(setting.isEnabled)
+        XCTAssertNil(setting.errorMessage)
+    }
+
+    private enum TestError: Error {
+        case rejected
+    }
+}


### PR DESCRIPTION
## TL;DR

Make a failed Launch at Login change call macOS only once, return the switch to the real value, and keep the helpful error visible.

## What was happening

- A failed change moved the switch back programmatically.
- That rollback looked like another user click and called macOS a second time.
- A successful second call could erase the original error.

## What this changes

- Route only real switch changes through a small setting controller.
- Update the displayed switch directly after success or failure without making another system call.
- Preserve the error until a later real change succeeds.

## Tests

- swift test --filter LaunchAtLoginSettingTests
- Full release build, signing, launch, and running-process verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized settings behavior around login-item registration, with injectable dependencies and unit tests; no broader auth or data-path changes.
> 
> **Overview**
> Fixes a bug where a failed **Launch at Login** toggle could call `SMAppService` twice and hide the error: rolling the switch back via `@State` used to fire `.onChange` again, so a successful retry cleared the message.
> 
> Launch-at-login is now handled by **`LaunchAtLoginSetting`**, an `@Observable` controller that only calls register/unregister when the requested value differs from the displayed state, then syncs `isEnabled` from the real macOS status and sets or clears **`errorMessage`** without a second system round-trip. **Settings** binds the toggle through a custom `Binding` to `update(to:)` instead of inline `SMAppService` logic.
> 
> **`LaunchAtLoginSettingTests`** cover one system call on failure and error clearing after a later success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27bd492ee1e907c0143d76bea8d8c030417f8516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->