### PR TITLE
Bound concurrent log parsing

### DIFF
--- a/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
+++ b/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
@@ -58,6 +58,12 @@ actor IncrementalJSONLScanner<Item: Sendable> {
     }
 
     private var cache: [String: CachedFile] = [:]
+    private let maxConcurrentParses: Int
+
+    init(maxConcurrentParses: Int = 8) {
+        precondition(maxConcurrentParses > 0)
+        self.maxConcurrentParses = maxConcurrentParses
+    }
 
     /// Re-parse the in-window files (reusing the cache on an unchanged path + size + mtime), then return
     /// every file's items concatenated in the input order — callers pass a path-sorted list so a
@@ -79,7 +85,11 @@ actor IncrementalJSONLScanner<Item: Sendable> {
                 toParse.append(file)
             }
         }
-        for (file, parsed) in await Self.parseFiles(toParse, parse: parse) {
+        for (file, parsed) in await Self.parseFiles(
+            toParse,
+            maxConcurrentParses: maxConcurrentParses,
+            parse: parse
+        ) {
             guard let parsed else { continue }
             nextCache[file.path] = CachedFile(size: file.size, mtime: file.mtime, items: parsed)
         }
@@ -93,15 +103,16 @@ actor IncrementalJSONLScanner<Item: Sendable> {
         return items
     }
 
-    /// Read + parse the changed files in parallel (they're independent; the first scan of a heavy tree
-    /// is CPU-bound on JSON decoding). Results are keyed back to the input order; a `nil` item list
-    /// marks an unreadable file.
+    /// Read + parse a bounded number of changed files in parallel. Results are keyed back to the input
+    /// order; a `nil` item list marks an unreadable file.
     private static func parseFiles(
         _ files: [JSONLScanning.DiscoveredFile],
+        maxConcurrentParses: Int,
         parse: @Sendable @escaping (Data) -> [Item]?
     ) async -> [(JSONLScanning.DiscoveredFile, [Item]?)] {
         await withTaskGroup(of: (Int, [Item]?).self, returning: [(JSONLScanning.DiscoveredFile, [Item]?)].self) { group in
-            for (index, file) in files.enumerated() {
+            func addTask(at index: Int) {
+                let file = files[index]
                 group.addTask {
                     guard let data = FileManager.default.contents(atPath: file.path) else {
                         return (index, nil)
@@ -109,9 +120,21 @@ actor IncrementalJSONLScanner<Item: Sendable> {
                     return (index, parse(data))
                 }
             }
+
+            var nextIndex = 0
+            let initialCount = min(maxConcurrentParses, files.count)
+            for index in 0..<initialCount {
+                addTask(at: index)
+                nextIndex += 1
+            }
+
             var results: [(JSONLScanning.DiscoveredFile, [Item]?)] = files.map { ($0, nil) }
             for await (index, items) in group {
                 results[index] = (files[index], items)
+                if nextIndex < files.count {
+                    addTask(at: nextIndex)
+                    nextIndex += 1
+                }
             }
             return results
         }

--- a/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
+++ b/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import XCTest
+@testable import OpenUsage
+
+final class IncrementalJSONLScannerTests: XCTestCase {
+    func testLimitsConcurrentParsesAndKeepsFileOrder() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageScannerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let now = Date()
+        let files = try (0..<20).map { index in
+            let url = directory.appendingPathComponent(String(format: "%02d.jsonl", index))
+            let data = Data("\(index)".utf8)
+            try data.write(to: url)
+            return JSONLScanning.DiscoveredFile(path: url.path, size: data.count, mtime: now)
+        }
+        let probe = ConcurrencyProbe()
+        let scanner = IncrementalJSONLScanner<Int>(maxConcurrentParses: 3)
+
+        let items = await scanner.items(from: files, since: now.addingTimeInterval(-1)) { data in
+            probe.begin()
+            defer { probe.end() }
+            Thread.sleep(forTimeInterval: 0.01)
+            return String(data: data, encoding: .utf8).flatMap(Int.init).map { [$0] }
+        }
+
+        XCTAssertEqual(items, Array(0..<20))
+        XCTAssertLessThanOrEqual(probe.maximumActive, 3)
+    }
+}
+
+private final class ConcurrencyProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var active = 0
+    private var maximum = 0
+
+    var maximumActive: Int {
+        lock.withLock { maximum }
+    }
+
+    func begin() {
+        lock.withLock {
+            active += 1
+            maximum = max(maximum, active)
+        }
+    }
+
+    func end() {
+        lock.withLock {
+            active -= 1
+        }
+    }
+}


### PR DESCRIPTION
## TL;DR

Read at most eight changed usage logs at once instead of starting every file simultaneously. Normal refreshes stay effectively unchanged while large first scans use less memory and disk pressure.

## What was happening

- A first scan started one job for every changed log file.
- Large histories could create hundreds of jobs at once.

## What this changes

- Keep a rolling pool of at most eight file parses.
- Preserve deterministic file order and the existing cache behavior.
- Add a test that proves the limit and output order.

## Heads-up

- Normal cached refreshes usually parse zero to a few files, so they should not be slower.
- A huge first scan on a machine able to sustain more than eight heavy parses could take slightly longer, in exchange for predictable resource use.

## Tests

- swift test --filter IncrementalJSONLScannerTests
- Full release build, signing, launch, and running-process verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized concurrency tuning in shared log scanning; default behavior matches prior semantics for typical small refreshes, with only large first scans seeing different parallelism.
> 
> **Overview**
> **`IncrementalJSONLScanner`** no longer launches a parse task for every changed log file at once. It now keeps a rolling pool capped by **`maxConcurrentParses`** (default **8**), starting new work only as in-flight parses finish.
> 
> Cache behavior, mtime windowing, and concatenation order are unchanged. Claude and Codex scanners keep using the default limit via **`IncrementalJSONLScanner()`**.
> 
> A new unit test drives 20 files with **`maxConcurrentParses: 3`**, asserts output order **`0…19`**, and records peak overlap with a **`ConcurrencyProbe`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ebb0b9792579cd05ee13f4f6d743b9576a6ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->