### PR TITLE
Log unreadable usage files without repeating

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -45,7 +45,7 @@ actor ClaudeLogUsageScanner {
     }
 
     /// Off-main-actor incremental parse cache (keyed path + size + mtime), owned by the shared scanner.
-    private let scanner = IncrementalJSONLScanner<Entry>()
+    private let scanner = IncrementalJSONLScanner<Entry>(logTag: LogTag.plugin("claude"))
 
     /// Scan the last `daysBack` days of Claude logs. Returns `nil` when no Claude data directory or
     /// no log files exist (the spend tiles then render "No data"); returns an empty series when logs

--- a/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
@@ -48,7 +48,7 @@ actor CodexLogUsageScanner {
     }
 
     /// Off-main-actor incremental parse cache (keyed path + size + mtime), owned by the shared scanner.
-    private let scanner = IncrementalJSONLScanner<Event>()
+    private let scanner = IncrementalJSONLScanner<Event>(logTag: LogTag.plugin("codex"))
 
     /// Scan the last `daysBack` days of Codex rollouts. Returns `nil` when no Codex home or no
     /// session files exist (the spend tiles then render "No data").

--- a/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
@@ -47,15 +47,15 @@ struct GrokLogUsageScanner: Sendable {
     func scan(daysBack: Int = 30, now: Date = Date(), pricing: ModelPricing) async -> LogUsageScan? {
         let path = logPath
         guard files.exists(path) else {
-            await readFailureReporter.update(failingPaths: [])
+            await readFailureReporter.update(checkedPaths: [path], failingPaths: [])
             return nil
         }
         let text: String
         do {
             text = try files.readText(path)
-            await readFailureReporter.update(failingPaths: [])
+            await readFailureReporter.update(checkedPaths: [path], failingPaths: [])
         } catch {
-            await readFailureReporter.update(failingPaths: [path])
+            await readFailureReporter.update(checkedPaths: [path], failingPaths: [path])
             return nil
         }
         return Self.parse(text, since: JSONLScanning.sinceDate(daysBack: daysBack, now: now), pricing: pricing)

--- a/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
@@ -12,15 +12,21 @@ struct GrokLogUsageScanner: Sendable {
     var files: TextFileAccessing
     var environment: EnvironmentReading
     var homeDirectory: @Sendable () -> URL
+    private let readFailureReporter: UsageLogReadFailureReporter
 
     init(
         files: TextFileAccessing = LocalTextFileAccessor(),
         environment: EnvironmentReading = ProcessEnvironmentReader(),
-        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser }
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        readFailureWarning: UsageLogReadFailureReporter.Warning? = nil
     ) {
         self.files = files
         self.environment = environment
         self.homeDirectory = homeDirectory
+        self.readFailureReporter = UsageLogReadFailureReporter(
+            logTag: LogTag.plugin("grok"),
+            warning: readFailureWarning
+        )
     }
 
     /// `~/.grok/logs/unified.jsonl`, or `$GROK_HOME/logs/unified.jsonl` when that env var is set.
@@ -40,7 +46,16 @@ struct GrokLogUsageScanner: Sendable {
     /// read + parse runs off the main actor when a `@MainActor` provider `await`s it.
     func scan(daysBack: Int = 30, now: Date = Date(), pricing: ModelPricing) async -> LogUsageScan? {
         let path = logPath
-        guard files.exists(path), let text = try? files.readText(path) else {
+        guard files.exists(path) else {
+            await readFailureReporter.update(failingPaths: [])
+            return nil
+        }
+        let text: String
+        do {
+            text = try files.readText(path)
+            await readFailureReporter.update(failingPaths: [])
+        } catch {
+            await readFailureReporter.update(failingPaths: [path])
             return nil
         }
         return Self.parse(text, since: JSONLScanning.sinceDate(daysBack: daysBack, now: now), pricing: pricing)

--- a/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
+++ b/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
@@ -96,8 +96,9 @@ actor IncrementalJSONLScanner<Item: Sendable> {
             maxConcurrentParses: maxConcurrentParses,
             parse: parse
         )
+        let checkedPaths = Set(parseResults.lazy.map(\.file.path))
         let unreadablePaths = Set(parseResults.lazy.filter(\.readFailed).map(\.file.path))
-        await readFailureReporter.update(failingPaths: unreadablePaths)
+        await readFailureReporter.update(checkedPaths: checkedPaths, failingPaths: unreadablePaths)
         for result in parseResults {
             let (file, parsed) = (result.file, result.items)
             guard let parsed else { continue }

--- a/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
+++ b/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
@@ -59,10 +59,16 @@ actor IncrementalJSONLScanner<Item: Sendable> {
 
     private var cache: [String: CachedFile] = [:]
     private let maxConcurrentParses: Int
+    private let readFailureReporter: UsageLogReadFailureReporter
 
-    init(maxConcurrentParses: Int = 8) {
+    init(
+        maxConcurrentParses: Int = 8,
+        logTag: String = LogTag.refresh.rawValue,
+        readFailureWarning: UsageLogReadFailureReporter.Warning? = nil
+    ) {
         precondition(maxConcurrentParses > 0)
         self.maxConcurrentParses = maxConcurrentParses
+        self.readFailureReporter = UsageLogReadFailureReporter(logTag: logTag, warning: readFailureWarning)
     }
 
     /// Re-parse the in-window files (reusing the cache on an unchanged path + size + mtime), then return
@@ -85,11 +91,15 @@ actor IncrementalJSONLScanner<Item: Sendable> {
                 toParse.append(file)
             }
         }
-        for (file, parsed) in await Self.parseFiles(
+        let parseResults = await Self.parseFiles(
             toParse,
             maxConcurrentParses: maxConcurrentParses,
             parse: parse
-        ) {
+        )
+        let unreadablePaths = Set(parseResults.lazy.filter(\.readFailed).map(\.file.path))
+        await readFailureReporter.update(failingPaths: unreadablePaths)
+        for result in parseResults {
+            let (file, parsed) = (result.file, result.items)
             guard let parsed else { continue }
             nextCache[file.path] = CachedFile(size: file.size, mtime: file.mtime, items: parsed)
         }
@@ -109,15 +119,21 @@ actor IncrementalJSONLScanner<Item: Sendable> {
         _ files: [JSONLScanning.DiscoveredFile],
         maxConcurrentParses: Int,
         parse: @Sendable @escaping (Data) -> [Item]?
-    ) async -> [(JSONLScanning.DiscoveredFile, [Item]?)] {
-        await withTaskGroup(of: (Int, [Item]?).self, returning: [(JSONLScanning.DiscoveredFile, [Item]?)].self) { group in
+    ) async -> [(file: JSONLScanning.DiscoveredFile, items: [Item]?, readFailed: Bool)] {
+        await withTaskGroup(
+            of: (Int, [Item]?, Bool).self,
+            returning: [(file: JSONLScanning.DiscoveredFile, items: [Item]?, readFailed: Bool)].self
+        ) { group in
             func addTask(at index: Int) {
                 let file = files[index]
                 group.addTask {
-                    guard let data = FileManager.default.contents(atPath: file.path) else {
-                        return (index, nil)
+                    guard FileManager.default.fileExists(atPath: file.path) else {
+                        return (index, nil, false)
                     }
-                    return (index, parse(data))
+                    guard let data = FileManager.default.contents(atPath: file.path) else {
+                        return (index, nil, true)
+                    }
+                    return (index, parse(data), false)
                 }
             }
 
@@ -128,9 +144,9 @@ actor IncrementalJSONLScanner<Item: Sendable> {
                 nextIndex += 1
             }
 
-            var results: [(JSONLScanning.DiscoveredFile, [Item]?)] = files.map { ($0, nil) }
-            for await (index, items) in group {
-                results[index] = (files[index], items)
+            var results = files.map { (file: $0, items: Optional<[Item]>.none, readFailed: false) }
+            for await (index, items, readFailed) in group {
+                results[index] = (files[index], items, readFailed)
                 if nextIndex < files.count {
                     addTask(at: nextIndex)
                     nextIndex += 1

--- a/Sources/OpenUsage/Providers/UsageLogReadFailureReporter.swift
+++ b/Sources/OpenUsage/Providers/UsageLogReadFailureReporter.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Logs only when a local usage file newly becomes unreadable. Repeated refreshes stay quiet until
+/// the file recovers and fails again.
+actor UsageLogReadFailureReporter {
+    typealias Warning = @Sendable (Int) -> Void
+
+    private var failingPaths: Set<String> = []
+    private let warning: Warning
+
+    init(logTag: String, warning: Warning? = nil) {
+        self.warning = warning ?? { count in
+            let noun = count == 1 ? "file" : "files"
+            AppLog.warn(logTag, "Could not read \(count) local usage log \(noun); skipped for this refresh")
+        }
+    }
+
+    func update(failingPaths nextFailingPaths: Set<String>) {
+        let newlyFailing = nextFailingPaths.subtracting(failingPaths)
+        failingPaths = nextFailingPaths
+        guard !newlyFailing.isEmpty else { return }
+        warning(newlyFailing.count)
+    }
+}

--- a/Sources/OpenUsage/Providers/UsageLogReadFailureReporter.swift
+++ b/Sources/OpenUsage/Providers/UsageLogReadFailureReporter.swift
@@ -15,9 +15,12 @@ actor UsageLogReadFailureReporter {
         }
     }
 
-    func update(failingPaths nextFailingPaths: Set<String>) {
+    func update(checkedPaths: Set<String>, failingPaths nextFailingPaths: Set<String>) {
         let newlyFailing = nextFailingPaths.subtracting(failingPaths)
-        failingPaths = nextFailingPaths
+        // Only clear a remembered failure when that same path was checked again and no longer failed.
+        // A scan may look at a different batch of files, which says nothing about older failures.
+        failingPaths.subtract(checkedPaths)
+        failingPaths.formUnion(nextFailingPaths)
         guard !newlyFailing.isEmpty else { return }
         warning(newlyFailing.count)
     }

--- a/Tests/OpenUsageTests/GrokLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/GrokLogUsageScannerTests.swift
@@ -132,13 +132,72 @@ final class GrokLogUsageScannerTests: XCTestCase {
     }
 
     func testScanReturnsNilWhenLogMissing() async {
+        let warnings = GrokWarningRecorder()
         let scanner = GrokLogUsageScanner(
             files: FakeFiles(),
             environment: FakeEnvironment(),
-            homeDirectory: { URL(fileURLWithPath: "/home/none") }
+            homeDirectory: { URL(fileURLWithPath: "/home/none") },
+            readFailureWarning: warnings.record
         )
 
         let usage = await scanner.scan(pricing: TestPricing.bundled)
         XCTAssertNil(usage)
+        XCTAssertEqual(warnings.counts, [])
+    }
+
+    func testUnreadableLogWarnsOnceUntilItRecovers() async {
+        let path = "/custom/grok/logs/unified.jsonl"
+        let files = FailingTextFiles(path: path)
+        let warnings = GrokWarningRecorder()
+        let scanner = GrokLogUsageScanner(
+            files: files,
+            environment: FakeEnvironment(["GROK_HOME": "/custom/grok"]),
+            homeDirectory: { URL(fileURLWithPath: "/home/ignored") },
+            readFailureWarning: warnings.record
+        )
+
+        _ = await scanner.scan(pricing: TestPricing.bundled)
+        _ = await scanner.scan(pricing: TestPricing.bundled)
+        XCTAssertEqual(warnings.counts, [1])
+
+        files.shouldFail = false
+        _ = await scanner.scan(pricing: TestPricing.bundled)
+        files.shouldFail = true
+        _ = await scanner.scan(pricing: TestPricing.bundled)
+        XCTAssertEqual(warnings.counts, [1, 1])
+    }
+}
+
+private final class GrokWarningRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedCounts: [Int] = []
+
+    var counts: [Int] { lock.withLock { recordedCounts } }
+
+    func record(_ count: Int) {
+        lock.withLock { recordedCounts.append(count) }
+    }
+}
+
+private final class FailingTextFiles: TextFileAccessing, @unchecked Sendable {
+    let path: String
+    var shouldFail = true
+
+    init(path: String) {
+        self.path = path
+    }
+
+    func exists(_ path: String) -> Bool { path == self.path }
+
+    func readText(_ path: String) throws -> String {
+        if shouldFail { throw TestError.unreadable }
+        return ""
+    }
+
+    func writeText(_ path: String, _ text: String) throws {}
+    func remove(_ path: String) throws {}
+
+    private enum TestError: Error {
+        case unreadable
     }
 }

--- a/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
+++ b/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
@@ -70,6 +70,33 @@ final class IncrementalJSONLScannerTests: XCTestCase {
         XCTAssertEqual(warnings.counts, [1, 1])
     }
 
+    func testScanningAnotherBatchDoesNotForgetAnUnreadableFile() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageScannerWarningBatches-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let unreadableURL = directory.appendingPathComponent("a.jsonl")
+        try FileManager.default.createDirectory(at: unreadableURL, withIntermediateDirectories: true)
+        let readableURL = directory.appendingPathComponent("b.jsonl")
+        try Data("7".utf8).write(to: readableURL)
+
+        let now = Date()
+        let unreadable = JSONLScanning.DiscoveredFile(path: unreadableURL.path, size: 0, mtime: now)
+        let readable = JSONLScanning.DiscoveredFile(path: readableURL.path, size: 1, mtime: now)
+        let warnings = WarningRecorder()
+        let scanner = IncrementalJSONLScanner<Int>(readFailureWarning: warnings.record)
+        let parse: @Sendable (Data) -> [Int]? = { data in
+            String(data: data, encoding: .utf8).flatMap(Int.init).map { [$0] }
+        }
+
+        _ = await scanner.items(from: [unreadable], since: .distantPast, parse: parse)
+        _ = await scanner.items(from: [readable], since: .distantPast, parse: parse)
+        _ = await scanner.items(from: [unreadable], since: .distantPast, parse: parse)
+
+        XCTAssertEqual(warnings.counts, [1])
+    }
+
     func testMissingFileDoesNotWarn() async {
         let warnings = WarningRecorder()
         let scanner = IncrementalJSONLScanner<Int>(readFailureWarning: warnings.record)

--- a/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
+++ b/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
@@ -29,6 +29,60 @@ final class IncrementalJSONLScannerTests: XCTestCase {
         XCTAssertEqual(items, Array(0..<20))
         XCTAssertLessThanOrEqual(probe.maximumActive, 3)
     }
+
+    func testUnreadableFileWarnsOnceUntilItRecovers() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageScannerWarnings-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let path = directory.appendingPathComponent("unreadable.jsonl")
+        try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+        let file = JSONLScanning.DiscoveredFile(path: path.path, size: 0, mtime: Date())
+        let warnings = WarningRecorder()
+        let scanner = IncrementalJSONLScanner<Int>(readFailureWarning: warnings.record)
+        let parse: @Sendable (Data) -> [Int]? = { data in
+            String(data: data, encoding: .utf8).flatMap(Int.init).map { [$0] }
+        }
+
+        _ = await scanner.items(from: [file], since: .distantPast, parse: parse)
+        _ = await scanner.items(from: [file], since: .distantPast, parse: parse)
+        XCTAssertEqual(warnings.counts, [1])
+
+        try FileManager.default.removeItem(at: path)
+        try Data("7".utf8).write(to: path)
+        let recoveredFile = JSONLScanning.DiscoveredFile(
+            path: path.path,
+            size: 1,
+            mtime: file.mtime.addingTimeInterval(1)
+        )
+        let recovered = await scanner.items(from: [recoveredFile], since: .distantPast, parse: parse)
+        XCTAssertEqual(recovered, [7])
+
+        try FileManager.default.removeItem(at: path)
+        try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+        let failedAgainFile = JSONLScanning.DiscoveredFile(
+            path: path.path,
+            size: 0,
+            mtime: file.mtime.addingTimeInterval(2)
+        )
+        _ = await scanner.items(from: [failedAgainFile], since: .distantPast, parse: parse)
+        XCTAssertEqual(warnings.counts, [1, 1])
+    }
+
+    func testMissingFileDoesNotWarn() async {
+        let warnings = WarningRecorder()
+        let scanner = IncrementalJSONLScanner<Int>(readFailureWarning: warnings.record)
+        let file = JSONLScanning.DiscoveredFile(
+            path: "/tmp/openusage-missing-\(UUID().uuidString).jsonl",
+            size: 0,
+            mtime: Date()
+        )
+
+        _ = await scanner.items(from: [file], since: .distantPast) { _ in [] }
+
+        XCTAssertEqual(warnings.counts, [])
+    }
 }
 
 private final class ConcurrencyProbe: @unchecked Sendable {
@@ -50,6 +104,21 @@ private final class ConcurrencyProbe: @unchecked Sendable {
     func end() {
         lock.withLock {
             active -= 1
+        }
+    }
+}
+
+private final class WarningRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedCounts: [Int] = []
+
+    var counts: [Int] {
+        lock.withLock { recordedCounts }
+    }
+
+    func record(_ count: Int) {
+        lock.withLock {
+            recordedCounts.append(count)
         }
     }
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -29,6 +29,10 @@ takes effect immediately — no restart.
 The release default is **Info** — quiet but useful. **Debug** is opt-in; turn it on only while
 reproducing a problem, since it is much noisier.
 
+If a local usage log exists but cannot be read, OpenUsage writes one warning and skips it for that
+refresh. It does not repeat the warning every five minutes; it warns again only if the file recovers
+and later becomes unreadable again.
+
 ## Subsystem tags
 
 Every line is prefixed with a bracketed tag so the log is easy to grep:


### PR DESCRIPTION
## TL;DR

Write one warning when a Claude, Codex, or Grok usage log exists but cannot be read. Stay quiet on later refreshes unless the file recovers and fails again.

## What was happening

- Unreadable local usage logs were silently skipped.
- Missing logs and unreadable logs looked identical in diagnostics.

## What this changes

- Warn once when a file newly becomes unreadable.
- Group the warning by count and omit file paths.
- Do not warn for a normally missing log.
- Clear the remembered failure after recovery so a later failure can warn again.
- Keep the UI behavior unchanged: unreadable logs still show No data, not a warning triangle.

## Tests

- swift test --filter IncrementalJSONLScannerTests
- swift test --filter GrokLogUsageScannerTests
- Full release build, signing, launch, and running-process verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: same skip/No-data behavior as before, with deduplicated warnings and new unit tests.
> 
> **Overview**
> Adds **`UsageLogReadFailureReporter`**, which emits a single grouped **`AppLog.warn`** (count only, no paths) the first time a usage log path becomes unreadable, stays quiet on later refreshes, and can warn again only after that path is re-checked successfully and then fails again.
> 
> **`IncrementalJSONLScanner`** (Claude/Codex) now tags reads with per-plugin **`logTag`** values, distinguishes missing files from read failures via a **`readFailed`** flag, and feeds checked/failing paths into the reporter. **`GrokLogUsageScanner`** reports read failures the same way when **`unified.jsonl`** exists but **`readText`** throws; missing logs still produce no warning.
> 
> Spend tiles are unchanged (unreadable logs still show **No data**). **`docs/logging.md`** documents the behavior; tests cover once-until-recovery, batch scans not clearing unrelated failures, and no warn on missing files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8750e70b785cf00ee118cb813b2b168f5c62d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->