### PR TITLE
Compute model shares once per render

### DIFF
--- a/Sources/OpenUsage/Views/ModelUsageDetail.swift
+++ b/Sources/OpenUsage/Views/ModelUsageDetail.swift
@@ -16,12 +16,13 @@ struct ModelUsageDetail: View {
     private static let width: CGFloat = 280
 
     var body: some View {
-        let percents = Self.wholePercents(breakdown.models.map(share(for:)))
+        let shares = Self.shares(for: breakdown.models)
+        let percents = Self.wholePercents(shares)
         VStack(alignment: .leading, spacing: 8) {
             header
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(breakdown.models.indices, id: \.self) { index in
-                    modelRow(breakdown.models[index], percent: percents[index])
+                    modelRow(breakdown.models[index], share: shares[index], percent: percents[index])
                 }
             }
             PopoverSourceNote(text: breakdown.sourceNote)
@@ -47,7 +48,7 @@ struct ModelUsageDetail: View {
     /// Two text lines and the bar: model name / cost on top, share percent / tokens beneath. The name
     /// only competes with the short cost figure, so it almost never truncates; the percent line answers
     /// what the bar can't say precisely.
-    private func modelRow(_ model: ModelUsageEntry, percent: Int) -> some View {
+    private func modelRow(_ model: ModelUsageEntry, share: Double, percent: Int) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(model.model)
@@ -85,7 +86,7 @@ struct ModelUsageDetail: View {
                     .overlay(alignment: .leading) {
                         Capsule()
                             .fill(Theme.meterFill(.normal))
-                            .frame(width: proxy.size.width * share(for: model))
+                            .frame(width: proxy.size.width * share)
                     }
             }
             .frame(height: density.meterHeight)
@@ -101,17 +102,21 @@ struct ModelUsageDetail: View {
     /// One basis for the whole list: cost shares only when every listed model is priced — otherwise a
     /// column mixing cost shares (priced rows) with token shares (unpriced rows) would sum past 100%.
     /// With any unpriced model present, every row falls back to its token share.
-    private func share(for model: ModelUsageEntry) -> Double {
-        let allPriced = breakdown.models.allSatisfy { $0.costUSD != nil }
+    static func shares(for models: [ModelUsageEntry]) -> [Double] {
+        let allPriced = models.allSatisfy { $0.costUSD != nil }
         if allPriced {
-            let costTotal = breakdown.models.reduce(0.0) { $0 + ($1.costUSD ?? 0) }
-            if costTotal > 0, let cost = model.costUSD {
-                return min(max(cost / costTotal, 0), 1)
+            let costTotal = models.reduce(0.0) { $0 + ($1.costUSD ?? 0) }
+            if costTotal > 0 {
+                return models.map { model in
+                    min(max((model.costUSD ?? 0) / costTotal, 0), 1)
+                }
             }
         }
-        let tokenTotal = breakdown.models.reduce(0) { $0 + $1.totalTokens }
-        guard tokenTotal > 0 else { return 0 }
-        return min(max(Double(model.totalTokens) / Double(tokenTotal), 0), 1)
+        let tokenTotal = models.reduce(0) { $0 + $1.totalTokens }
+        guard tokenTotal > 0 else { return models.map { _ in 0 } }
+        return models.map { model in
+            min(max(Double(model.totalTokens) / Double(tokenTotal), 0), 1)
+        }
     }
 
     /// Integer percentages that always total exactly 100 (largest-remainder rounding): rounding each
@@ -137,4 +142,3 @@ struct ModelUsageDetail: View {
         return percents
     }
 }
-

--- a/Tests/OpenUsageTests/ModelUsageHoverTests.swift
+++ b/Tests/OpenUsageTests/ModelUsageHoverTests.swift
@@ -105,6 +105,33 @@ final class ModelUsageHoverTests: XCTestCase {
         }
     }
 
+    func testSharesUseCostWhenEveryModelIsPriced() {
+        let models = [
+            ModelUsageEntry(model: "alpha", totalTokens: 10, costUSD: 3),
+            ModelUsageEntry(model: "beta", totalTokens: 90, costUSD: 1)
+        ]
+
+        XCTAssertEqual(ModelUsageDetail.shares(for: models), [0.75, 0.25])
+    }
+
+    func testSharesUseTokensForEveryModelWhenOneIsUnpriced() {
+        let models = [
+            ModelUsageEntry(model: "alpha", totalTokens: 25, costUSD: 9),
+            ModelUsageEntry(model: "beta", totalTokens: 75, costUSD: nil)
+        ]
+
+        XCTAssertEqual(ModelUsageDetail.shares(for: models), [0.25, 0.75])
+    }
+
+    func testSharesAreZeroWhenThereIsNoCostOrTokenTotal() {
+        let models = [
+            ModelUsageEntry(model: "alpha", totalTokens: 0, costUSD: nil),
+            ModelUsageEntry(model: "beta", totalTokens: 0, costUSD: nil)
+        ]
+
+        XCTAssertEqual(ModelUsageDetail.shares(for: models), [0, 0])
+    }
+
     func testHoverPopoverStateOpensThenClosesAroundBothRegions() async {
         let state = HoverPopoverState(revealDelay: .milliseconds(1), hideGrace: .milliseconds(1))
         XCTAssertFalse(state.isPresented)


### PR DESCRIPTION
## TL;DR

Calculate each model’s share once and reuse it for both the printed percentage and the bar.

## What was happening

- The view recalculated the same totals separately for percentages and bars.
- That created two paths for one displayed value.

## What this changes

- Calculate the complete share list once per render.
- Reuse each share for the percentage and matching bar.
- Preserve cost-based shares when every model has a price and token-based shares otherwise.

## Tests

- swift test --filter ModelUsageHoverTests
- Full release build, signing, launch, and running-process verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI refactor with explicit tests; display logic is unchanged aside from eliminating duplicate share calculations.
> 
> **Overview**
> **Model usage hover detail** now derives each model’s share in one pass per render instead of recalculating totals separately for integer percentages and bar widths.
> 
> `share(for:)` becomes static **`shares(for:)`**, returning a `[Double]` for the full model list with the same rules as before: cost-based shares when every row has a price, otherwise token shares for all rows; zeros when there’s nothing to divide. Each row receives its precomputed share for the meter and the matching **`wholePercents`** value for the label.
> 
> **`ModelUsageHoverTests`** adds coverage for priced-only cost shares, mixed unpriced → token shares, and empty totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ddc401ee97c6b740c5a65e17dec33630533cba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->