### PR TITLE
Simplify menu-bar refresh coalescing

### DIFF
--- a/Sources/OpenUsage/App/StatusItemImageUpdater.swift
+++ b/Sources/OpenUsage/App/StatusItemImageUpdater.swift
@@ -4,16 +4,13 @@ import Observation
 /// Owns the menu-bar strip's render loop, split out of `StatusItemController`: render the pinned-metrics
 /// strip and re-render whenever anything it reads changes (pins, live data, meter style, menu-bar style).
 ///
-/// `withObservationTracking`'s `onChange` is one-shot, so each render re-arms it. Re-arms are debounced
-/// so a refresh-storm burst of snapshot writes collapses into ~one render — the feedback loop that could
-/// otherwise starve the MainActor and drop the status item (the "menu bar disappears" failure mode).
+/// `withObservationTracking`'s `onChange` is one-shot, so each render re-arms it. After the first change,
+/// the next render waits briefly so a burst of snapshot writes collapses into one render with the latest
+/// values — avoiding enough repeated work to make the menu-bar item disappear during a busy refresh.
 @MainActor
 final class StatusItemImageUpdater {
     private let container: AppContainer
     private let apply: (NSImage) -> Void
-    /// Coalesces re-render requests: a burst of snapshot writes must produce ~one re-render, not
-    /// O(writes) MainActor Task hops + ImageRenderer passes. `nil` when idle.
-    private var pendingRenderTask: Task<Void, Never>?
 
     /// - Parameter apply: sets the rendered image onto the status-item button.
     init(container: AppContainer, apply: @escaping (NSImage) -> Void) {
@@ -27,16 +24,16 @@ final class StatusItemImageUpdater {
             renderButtonImage()
         } onChange: { [weak self] in
             Task { @MainActor [weak self] in
-                self?.schedule()
+                self?.scheduleDelayedUpdate()
             }
         }
         apply(image)
     }
 
-    /// Debounce the re-render so a burst settles into one render instead of one render per write.
-    private func schedule() {
-        pendingRenderTask?.cancel()
-        pendingRenderTask = Task { @MainActor [weak self] in
+    /// The observation callback fires only once until `update()` reads and re-arms it. Waiting here lets
+    /// any immediately-following writes land first; the eventual render then reads their latest values.
+    private func scheduleDelayedUpdate() {
+        Task { @MainActor [weak self] in
             try? await Task.sleep(for: .milliseconds(50))
             guard !Task.isCancelled else { return }
             self?.update()


### PR DESCRIPTION
## TL;DR

The menu-bar image still waits briefly during a burst of updates, but no longer carries cancellation code that could never run.

## What was happening

- The observer reports only the first change, then waits to be set up again.
- The code claimed later changes cancelled and restarted that wait.
- Those later change reports cannot arrive until after the redraw, so the cancellation machinery was dead code.

## What this changes

- Keeps the same short wait after the first change.
- Redraws once using the newest values after that wait.
- Removes the unused saved task and cancellation path.
- Updates the explanation to match what the app really does.

## Tests

- `swift test --filter MenuBar`
- `./script/build_and_run.sh verify`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of menu-bar render scheduling with the same delay and redraw behavior; no auth, data, or API surface changes.
> 
> **Overview**
> **Simplifies how the menu-bar strip coalesces redraws** when observable data changes in bursts, without changing the visible behavior (still a ~50ms wait, then one redraw with the latest values).
> 
> `StatusItemImageUpdater` drops `pendingRenderTask` and the cancel-and-restart path that was meant to debounce multiple `onChange` callbacks. Because `withObservationTracking` only fires **once** until `update()` re-arms it, later changes cannot arrive during that wait—so the cancellation logic could never run.
> 
> The flow is now: first change → `scheduleDelayedUpdate()` sleeps briefly → `update()` renders and re-arms observation. Comments are updated to describe this one-shot observation model instead of debouncing overlapping callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4a5b42ac8bb7c786901faee8002d22934d4ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->