### PR TITLE
Separate saved layout data from live layout actions

### DIFF
--- a/Sources/OpenUsage/Stores/LayoutPersistence.swift
+++ b/Sources/OpenUsage/Stores/LayoutPersistence.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// The saved half of `LayoutStore`. It owns the key names, encoding, and UserDefaults access so the
+/// live store can focus on layout rules and user actions.
+@MainActor
+final class LayoutPersistence {
+    private let defaults: UserDefaults
+    private let keys: Keys
+
+    init(defaults: UserDefaults, storageKey: String) {
+        self.defaults = defaults
+        self.keys = Keys(storageKey: storageKey)
+    }
+
+    /// Presence is separate from successful decoding. Existing-but-unreadable data is still an existing
+    /// layout, so startup must not mistake corruption for a fresh install and apply fresh-only defaults.
+    var hasStoredLayout: Bool { defaults.data(forKey: keys.placed) != nil }
+    var hasStoredSeededDefaults: Bool { defaults.data(forKey: keys.seededDefaults) != nil }
+
+    func loadPlaced() -> [PlacedWidget]? { decode([PlacedWidget].self, forKey: keys.placed) }
+    func loadProviderOrder() -> [String]? { decode([String].self, forKey: keys.providerOrder) }
+    func loadMetricOrder() -> [String: [String]]? {
+        decode([String: [String]].self, forKey: keys.metricOrder)
+    }
+    func loadSeededDefaults() -> [String]? { decode([String].self, forKey: keys.seededDefaults) }
+
+    func loadPins() -> [String]? { defaults.stringArray(forKey: keys.pins) }
+    func loadExpandedMetrics() -> [String]? { defaults.stringArray(forKey: keys.expandedMetrics) }
+    func loadExpandOnEnable() -> [String]? { defaults.stringArray(forKey: keys.expandOnEnable) }
+    func loadExpandedProviders() -> [String]? { defaults.stringArray(forKey: keys.expandedProviders) }
+    func loadMenuBarStyle() -> MenuBarStyle { defaults.enumValue(forKey: keys.menuBarStyle, default: .text) }
+
+    func savePlaced(_ value: [PlacedWidget]) { encode(value, forKey: keys.placed) }
+    func saveProviderOrder(_ value: [String]) { encode(value, forKey: keys.providerOrder) }
+    func saveMetricOrder(_ value: [String: [String]]) { encode(value, forKey: keys.metricOrder) }
+    func saveSeededDefaults(_ value: Set<String>) {
+        encode(Array(value).sorted(), forKey: keys.seededDefaults)
+    }
+
+    func savePins(_ value: Set<String>) { defaults.set(Array(value), forKey: keys.pins) }
+    func saveExpandedMetrics(_ value: Set<String>) {
+        defaults.set(Array(value), forKey: keys.expandedMetrics)
+    }
+    func saveExpandOnEnable(_ value: Set<String>) {
+        defaults.set(Array(value), forKey: keys.expandOnEnable)
+    }
+    func saveExpandedProviders(_ value: Set<String>) {
+        defaults.set(Array(value), forKey: keys.expandedProviders)
+    }
+    func saveMenuBarStyle(_ value: MenuBarStyle) {
+        defaults.set(value.rawValue, forKey: keys.menuBarStyle)
+    }
+
+    /// Fail loudly: a swallowed encode would silently lose a layout change with no signal.
+    private func encode<T: Encodable>(_ value: T, forKey key: String) {
+        do {
+            defaults.set(try JSONEncoder().encode(value), forKey: key)
+        } catch {
+            AppLog.warn(.config, "failed to persist layout '\(key)': \(error.localizedDescription)")
+        }
+    }
+
+    /// Missing data is a normal first launch. Present-but-unreadable data is logged before startup uses
+    /// its normal fallback, so a damaged saved layout is never silently hidden.
+    private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            AppLog.warn(.config, "saved layout '\(key)' failed to decode; reseeding default: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private struct Keys {
+        let placed: String
+        let providerOrder: String
+        let metricOrder: String
+        let seededDefaults: String
+        let pins: String
+        let expandedMetrics: String
+        let expandOnEnable: String
+        let expandedProviders: String
+        let menuBarStyle: String
+
+        init(storageKey: String) {
+            placed = storageKey
+            providerOrder = "\(storageKey).providerOrder"
+            metricOrder = "\(storageKey).metricOrderByProvider"
+            seededDefaults = "\(storageKey).seededDefaults"
+            pins = "\(storageKey).menuBarPins"
+            expandedMetrics = "\(storageKey).expandedMetrics"
+            expandOnEnable = "\(storageKey).expandOnEnable"
+            expandedProviders = "\(storageKey).expandedProviders"
+            menuBarStyle = "\(storageKey).menuBarStyle"
+        }
+    }
+}

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -97,20 +97,11 @@ final class LayoutStore {
 
     /// Menu-bar display style (Text strip vs. compact Bars). Persisted; defaults to `.text`.
     var menuBarStyle: MenuBarStyle {
-        didSet { defaults.set(menuBarStyle.rawValue, forKey: menuBarStyleKey) }
+        didSet { persistence.saveMenuBarStyle(menuBarStyle) }
     }
 
     private let registry: WidgetRegistry
-    private let defaults: UserDefaults
-    private let storageKey: String
-    private let providerOrderKey: String
-    private let metricOrderKey: String
-    private let seededDefaultsKey: String
-    private let pinsKey: String
-    private let expandedMetricsKey: String
-    private let expandOnEnableKey: String
-    private let expandedProvidersKey: String
-    private let menuBarStyleKey: String
+    private let persistence: LayoutPersistence
     private let defaultMetricIDs: [String]
     private let migrationBaselineMetricIDs: [String]
     private let defaultPinnedMetricIDs: [String]
@@ -129,25 +120,17 @@ final class LayoutStore {
         isProviderEnabled: @escaping @MainActor (String) -> Bool = { _ in true }
     ) {
         self.registry = registry
-        self.defaults = defaults
-        self.storageKey = storageKey
-        self.providerOrderKey = "\(storageKey).providerOrder"
-        self.metricOrderKey = "\(storageKey).metricOrderByProvider"
-        self.seededDefaultsKey = "\(storageKey).seededDefaults"
-        self.pinsKey = "\(storageKey).menuBarPins"
-        self.expandedMetricsKey = "\(storageKey).expandedMetrics"
-        self.expandOnEnableKey = "\(storageKey).expandOnEnable"
-        self.expandedProvidersKey = "\(storageKey).expandedProviders"
-        self.menuBarStyleKey = "\(storageKey).menuBarStyle"
+        let persistence = LayoutPersistence(defaults: defaults, storageKey: storageKey)
+        self.persistence = persistence
         self.defaultMetricIDs = defaultMetricIDs
         self.migrationBaselineMetricIDs = migrationBaselineMetricIDs
         self.defaultPinnedMetricIDs = defaultPinnedMetricIDs
         self.defaultExpandedMetricIDs = defaultExpandedMetricIDs
         self.isProviderEnabled = isProviderEnabled
 
-        let hasStoredLayout = defaults.data(forKey: storageKey) != nil
+        let hasStoredLayout = persistence.hasStoredLayout
         var initialPlaced: [PlacedWidget]
-        if let saved = Self.decodeStored([PlacedWidget].self, from: defaults, forKey: storageKey) {
+        if let saved = persistence.loadPlaced() {
             initialPlaced = saved.filter { registry.descriptor(id: $0.descriptorID) != nil }
         } else {
             initialPlaced = defaultMetricIDs
@@ -156,8 +139,7 @@ final class LayoutStore {
         }
         let seededResult = Self.seedNewDefaultMetrics(
             into: initialPlaced,
-            defaults: defaults,
-            key: seededDefaultsKey,
+            persistence: persistence,
             hasStoredLayout: hasStoredLayout,
             registry: registry,
             defaultMetricIDs: defaultMetricIDs,
@@ -167,7 +149,7 @@ final class LayoutStore {
         placed = initialPlaced
 
         let initialProviderOrder: [String]
-        if let saved = Self.decodeStored([String].self, from: defaults, forKey: providerOrderKey) {
+        if let saved = persistence.loadProviderOrder() {
             initialProviderOrder = saved
         } else {
             initialProviderOrder = registry.providers.map(\.id)
@@ -175,7 +157,7 @@ final class LayoutStore {
         providerOrder = initialProviderOrder
 
         let initialMetricOrder: [String: [String]]
-        if let saved = Self.decodeStored([String: [String]].self, from: defaults, forKey: metricOrderKey) {
+        if let saved = persistence.loadMetricOrder() {
             initialMetricOrder = Self.normalizedMetricOrder(saved, registry: registry)
         } else {
             initialMetricOrder = Self.defaultMetricOrder(registry: registry)
@@ -184,7 +166,7 @@ final class LayoutStore {
 
         // Seed default pins on first launch (no saved value) so the menu bar shows real numbers out of
         // the box; a saved value — including an empty one the user produced by unpinning — is respected.
-        if let savedPins = defaults.stringArray(forKey: pinsKey) {
+        if let savedPins = persistence.loadPins() {
             pinnedMetricIDs = Set(savedPins.filter { registry.descriptor(id: $0) != nil })
         } else {
             pinnedMetricIDs = Set(defaultPinnedMetricIDs.filter { registry.descriptor(id: $0) != nil })
@@ -194,7 +176,7 @@ final class LayoutStore {
         // saved value predates this feature, so its metrics stay always-shown — never silently tuck a
         // metric the user already lived with behind a new caret.
         var shouldPersistExpanded = false
-        if let savedExpanded = defaults.stringArray(forKey: expandedMetricsKey) {
+        if let savedExpanded = persistence.loadExpandedMetrics() {
             expandedMetricIDs = Set(savedExpanded.filter { registry.descriptor(id: $0) != nil })
         } else if hasStoredLayout {
             expandedMetricIDs = []
@@ -205,9 +187,9 @@ final class LayoutStore {
         // Finalized below once `expandedMetricIDs` is settled; seeded here so every stored property is
         // initialized before the reads that compute the real value.
         defaultExpandedOnEnableIDs = []
-        menuBarStyle = defaults.enumValue(forKey: menuBarStyleKey, default: .text)
+        menuBarStyle = persistence.loadMenuBarStyle()
 
-        if let savedExpandedProviders = defaults.stringArray(forKey: expandedProvidersKey) {
+        if let savedExpandedProviders = persistence.loadExpandedProviders() {
             expandedProviderIDs = Set(savedExpandedProviders.filter { registry.provider(id: $0) != nil })
         } else {
             expandedProviderIDs = []
@@ -237,7 +219,7 @@ final class LayoutStore {
         let isExpandOnEnableCandidate: (String) -> Bool = { [registry] id in
             registry.descriptor(id: id) != nil && !expandedNow.contains(id) && !placedIDs.contains(id)
         }
-        if let savedOnEnable = defaults.stringArray(forKey: expandOnEnableKey) {
+        if let savedOnEnable = persistence.loadExpandOnEnable() {
             defaultExpandedOnEnableIDs = Set(savedOnEnable.filter(isExpandOnEnableCandidate))
         } else {
             defaultExpandedOnEnableIDs = Set(defaultExpandedMetricIDs.filter(isExpandOnEnableCandidate))
@@ -795,19 +777,19 @@ final class LayoutStore {
     }
 
     private func persistPins() {
-        defaults.set(Array(pinnedMetricIDs), forKey: pinsKey)
+        persistence.savePins(pinnedMetricIDs)
     }
 
     private func persistExpanded() {
-        defaults.set(Array(expandedMetricIDs), forKey: expandedMetricsKey)
+        persistence.saveExpandedMetrics(expandedMetricIDs)
     }
 
     private func persistExpandOnEnable() {
-        defaults.set(Array(defaultExpandedOnEnableIDs), forKey: expandOnEnableKey)
+        persistence.saveExpandOnEnable(defaultExpandedOnEnableIDs)
     }
 
     private func persistExpandedProviders() {
-        defaults.set(Array(expandedProviderIDs), forKey: expandedProvidersKey)
+        persistence.saveExpandedProviders(expandedProviderIDs)
     }
 
     // MARK: - Mutations
@@ -904,42 +886,19 @@ final class LayoutStore {
     }
 
     private func persist() {
-        persistEncodable(placed, forKey: storageKey)
+        persistence.savePlaced(placed)
     }
 
     private func persistProviderOrder() {
-        persistEncodable(providerOrder, forKey: providerOrderKey)
+        persistence.saveProviderOrder(providerOrder)
     }
 
     private func persistMetricOrder() {
-        persistEncodable(metricOrderByProvider, forKey: metricOrderKey)
+        persistence.saveMetricOrder(metricOrderByProvider)
     }
 
     private func persistSeededDefaults(_ ids: Set<String>) {
-        persistEncodable(Array(ids).sorted(), forKey: seededDefaultsKey)
-    }
-
-    /// Fail loudly: a swallowed encode would silently fail to persist a layout change with zero signal,
-    /// contradicting the project's loud-fail rule (and `ProviderSnapshotCache.save` one store over).
-    private func persistEncodable<T: Encodable>(_ value: T, forKey key: String) {
-        do {
-            defaults.set(try JSONEncoder().encode(value), forKey: key)
-        } catch {
-            AppLog.warn(.config, "failed to persist layout '\(key)': \(error.localizedDescription)")
-        }
-    }
-
-    /// Decode a persisted value, distinguishing "no data" (first launch — silent nil) from "present but
-    /// undecodable" (schema drift / corruption — warn loudly, then nil so init reseeds the default).
-    /// A silent reseed of the user's customized layout is exactly the invisible state loss the rule forbids.
-    private static func decodeStored<T: Decodable>(_ type: T.Type, from defaults: UserDefaults, forKey key: String) -> T? {
-        guard let data = defaults.data(forKey: key) else { return nil }
-        do {
-            return try JSONDecoder().decode(type, from: data)
-        } catch {
-            AppLog.warn(.config, "saved layout '\(key)' failed to decode; reseeding default: \(error.localizedDescription)")
-            return nil
-        }
+        persistence.saveSeededDefaults(ids)
     }
 
     private struct SeededDefaultsResult {
@@ -955,8 +914,7 @@ final class LayoutStore {
 
     private static func seedNewDefaultMetrics(
         into placed: [PlacedWidget],
-        defaults: UserDefaults,
-        key: String,
+        persistence: LayoutPersistence,
         hasStoredLayout: Bool,
         registry: WidgetRegistry,
         defaultMetricIDs: [String],
@@ -964,11 +922,11 @@ final class LayoutStore {
     ) -> SeededDefaultsResult {
         let knownDefaults = knownMetricIDs(defaultMetricIDs, registry: registry)
         let knownDefaultSet = Set(knownDefaults)
-        let hasStoredSeededDefaults = defaults.data(forKey: key) != nil
+        let hasStoredSeededDefaults = persistence.hasStoredSeededDefaults
 
         let seededDefaults: Set<String>
         var shouldPersistSeededDefaults = false
-        if let saved = decodeStored([String].self, from: defaults, forKey: key) {
+        if let saved = persistence.loadSeededDefaults() {
             seededDefaults = Set(knownMetricIDs(saved, registry: registry))
             shouldPersistSeededDefaults = seededDefaults != Set(saved)
         } else if hasStoredLayout {

--- a/Tests/OpenUsageTests/LayoutPersistenceTests.swift
+++ b/Tests/OpenUsageTests/LayoutPersistenceTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class LayoutPersistenceTests: XCTestCase {
+    func testLoadsEveryExistingKeyAndFormat() throws {
+        let defaults = makeDefaults("LoadsExistingKeys")
+        defaults.set(try JSONEncoder().encode([PlacedWidget(descriptorID: "claude.session")]), forKey: "layout")
+        defaults.set(try JSONEncoder().encode(["cursor", "claude"]), forKey: "layout.providerOrder")
+        defaults.set(
+            try JSONEncoder().encode(["claude": ["claude.weekly", "claude.session"]]),
+            forKey: "layout.metricOrderByProvider"
+        )
+        defaults.set(try JSONEncoder().encode(["claude.session"]), forKey: "layout.seededDefaults")
+        defaults.set(["claude.session"], forKey: "layout.menuBarPins")
+        defaults.set(["claude.weekly"], forKey: "layout.expandedMetrics")
+        defaults.set(["cursor.requests"], forKey: "layout.expandOnEnable")
+        defaults.set(["claude"], forKey: "layout.expandedProviders")
+        defaults.set(MenuBarStyle.bars.rawValue, forKey: "layout.menuBarStyle")
+
+        let persistence = LayoutPersistence(defaults: defaults, storageKey: "layout")
+
+        XCTAssertTrue(persistence.hasStoredLayout)
+        XCTAssertTrue(persistence.hasStoredSeededDefaults)
+        XCTAssertEqual(persistence.loadPlaced()?.map(\.descriptorID), ["claude.session"])
+        XCTAssertEqual(persistence.loadProviderOrder(), ["cursor", "claude"])
+        XCTAssertEqual(persistence.loadMetricOrder()?["claude"], ["claude.weekly", "claude.session"])
+        XCTAssertEqual(persistence.loadSeededDefaults(), ["claude.session"])
+        XCTAssertEqual(persistence.loadPins(), ["claude.session"])
+        XCTAssertEqual(persistence.loadExpandedMetrics(), ["claude.weekly"])
+        XCTAssertEqual(persistence.loadExpandOnEnable(), ["cursor.requests"])
+        XCTAssertEqual(persistence.loadExpandedProviders(), ["claude"])
+        XCTAssertEqual(persistence.loadMenuBarStyle(), .bars)
+    }
+
+    func testSavesEveryExistingKeyAndFormat() throws {
+        let defaults = makeDefaults("SavesExistingKeys")
+        let persistence = LayoutPersistence(defaults: defaults, storageKey: "layout")
+
+        persistence.savePlaced([PlacedWidget(descriptorID: "claude.session")])
+        persistence.saveProviderOrder(["cursor", "claude"])
+        persistence.saveMetricOrder(["claude": ["claude.weekly", "claude.session"]])
+        persistence.saveSeededDefaults(["claude.session"])
+        persistence.savePins(["claude.session"])
+        persistence.saveExpandedMetrics(["claude.weekly"])
+        persistence.saveExpandOnEnable(["cursor.requests"])
+        persistence.saveExpandedProviders(["claude"])
+        persistence.saveMenuBarStyle(.bars)
+
+        XCTAssertEqual(try decode([PlacedWidget].self, key: "layout", defaults: defaults).map(\.descriptorID), ["claude.session"])
+        XCTAssertEqual(try decode([String].self, key: "layout.providerOrder", defaults: defaults), ["cursor", "claude"])
+        XCTAssertEqual(
+            try decode([String: [String]].self, key: "layout.metricOrderByProvider", defaults: defaults)["claude"],
+            ["claude.weekly", "claude.session"]
+        )
+        XCTAssertEqual(try decode([String].self, key: "layout.seededDefaults", defaults: defaults), ["claude.session"])
+        XCTAssertEqual(Set(defaults.stringArray(forKey: "layout.menuBarPins") ?? []), ["claude.session"])
+        XCTAssertEqual(Set(defaults.stringArray(forKey: "layout.expandedMetrics") ?? []), ["claude.weekly"])
+        XCTAssertEqual(Set(defaults.stringArray(forKey: "layout.expandOnEnable") ?? []), ["cursor.requests"])
+        XCTAssertEqual(Set(defaults.stringArray(forKey: "layout.expandedProviders") ?? []), ["claude"])
+        XCTAssertEqual(defaults.string(forKey: "layout.menuBarStyle"), MenuBarStyle.bars.rawValue)
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, key: String, defaults: UserDefaults) throws -> T {
+        let data = try XCTUnwrap(defaults.data(forKey: key))
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suite = "OpenUsageTests.LayoutPersistence.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+}

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -262,6 +262,39 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertTrue(reloaded.placed.isEmpty)
     }
 
+    func testUnreadableStoredLayoutIsNotMistakenForFreshInstall() {
+        let defaults = makeDefaults("UnreadableExistingLayout")
+        defaults.set(Data("not valid layout data".utf8), forKey: "layout")
+
+        let store = LayoutStore(
+            registry: .mock,
+            defaults: defaults,
+            storageKey: "layout",
+            defaultExpandedMetricIDs: ["claude.weekly"]
+        )
+
+        XCTAssertFalse(
+            store.expandedMetricIDs.contains("claude.weekly"),
+            "present but damaged data is still an existing layout, so fresh-only defaults must stay off"
+        )
+    }
+
+    func testUnreadableSeedMarkerKeepsExistingUserBaseline() {
+        let defaults = makeDefaults("UnreadableSeedMarker")
+        saveStored([PlacedWidget(descriptorID: "claude.session")], forKey: "layout", in: defaults)
+        defaults.set(Data("not valid seeded-default data".utf8), forKey: "layout.seededDefaults")
+
+        let store = LayoutStore(
+            registry: .mock,
+            defaults: defaults,
+            storageKey: "layout",
+            defaultMetricIDs: ["claude.session", "claude.weekly"],
+            migrationBaselineMetricIDs: ["claude.session", "claude.weekly"]
+        )
+
+        XCTAssertEqual(store.placed.map(\.descriptorID), ["claude.session"])
+    }
+
     func testExistingLayoutAutoSeedsOnlyDefaultsAddedAfterBaseline() {
         let defaults = makeDefaults("SeedNewDefault")
         saveStored([PlacedWidget(descriptorID: "claude.session")], forKey: "layout", in: defaults)


### PR DESCRIPTION
## TL;DR

Saved layout reading and writing now lives in one small helper. The live layout store keeps the same public behavior but no longer owns key names, encoding, and storage details.

## What was happening

- One very large store handled both user actions and all saved-data plumbing.
- Saved key names, data formats, startup rules, and live mutations were mixed together.
- That made future changes harder to review safely.

## What this changes

- Moves all saved key names and read/write work into one focused helper.
- Keeps every existing key and saved format unchanged.
- Keeps missing data separate from damaged data, so a damaged layout is not mistaken for a fresh install.
- Adds direct compatibility tests for every saved key and format.
- Adds regression checks for damaged layout and default-marker data.

## Tests

- `swift test --filter LayoutStoreTests`
- `swift test --filter LayoutPersistenceTests`
- `swift test --filter AntigravityLayoutTests`
- `swift test --filter MenuBarPinTests`
- `./script/build_and_run.sh verify`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors layout startup and migration paths that gate user customization, but behavior is intended to be unchanged and is covered by new corruption and key-format tests.
> 
> **Overview**
> Introduces **`LayoutPersistence`** so **`LayoutStore`** no longer owns UserDefaults key names, JSON encode/decode, or direct reads/writes. All layout persistence (placed widgets, provider/metric order, pins, expanded state, menu bar style, seeded-default markers) goes through typed load/save APIs while **keeping the same keys and on-disk formats**.
> 
> **`hasStoredLayout`** / **`hasStoredSeededDefaults`** are based on **presence of data**, not successful decode, so corrupt blobs still count as an existing layout and **fresh-install-only defaults** (e.g. default expanded metrics) are not applied incorrectly.
> 
> Adds **`LayoutPersistenceTests`** for round-trip compatibility on every key, plus **`LayoutStore`** regressions for unreadable placed layout and seeded-defaults data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315e6b34749f64650186dee7bfe7a4ca921df3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->