### PR TITLE
Separate layout startup rules from live actions

### DIFF
--- a/Sources/OpenUsage/Stores/LayoutBootstrap.swift
+++ b/Sources/OpenUsage/Stores/LayoutBootstrap.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+/// The owner-approved defaults and the legacy baseline used when an existing user has no seed marker.
+struct LayoutDefaultSet {
+    let metricIDs: [String]
+    let migrationBaselineMetricIDs: [String]
+    let pinnedMetricIDs: [String]
+    let expandedMetricIDs: [String]
+}
+
+/// Everything `LayoutStore` needs at the end of startup, plus the small set of migration writes that
+/// should be made after its stored properties are initialized.
+struct LayoutInitialState {
+    let placed: [PlacedWidget]
+    let providerOrder: [String]
+    let metricOrderByProvider: [String: [String]]
+    let pinnedMetricIDs: Set<String>
+    let expandedMetricIDs: Set<String>
+    let expandedProviderIDs: Set<String>
+    let defaultExpandedOnEnableIDs: Set<String>
+    let menuBarStyle: MenuBarStyle
+
+    let shouldPersistPlaced: Bool
+    let shouldPersistExpanded: Bool
+    let shouldPersistExpandOnEnable: Bool
+    let seededDefaultsToPersist: Set<String>?
+}
+
+/// Loads a layout for a fresh install or an existing user. This keeps startup/default-upgrade policy in
+/// one place and leaves `LayoutStore` responsible for live actions after initialization.
+@MainActor
+enum LayoutBootstrap {
+    static func load(
+        registry: WidgetRegistry,
+        persistence: LayoutPersistence,
+        defaults: LayoutDefaultSet
+    ) -> LayoutInitialState {
+        let hasStoredLayout = persistence.hasStoredLayout
+        let savedPlaced = persistence.loadPlaced()?.filter { registry.descriptor(id: $0.descriptorID) != nil }
+        let startingPlaced = savedPlaced ?? defaults.metricIDs
+            .filter { registry.descriptor(id: $0) != nil }
+            .map { PlacedWidget(descriptorID: $0) }
+        let seededResult = seedNewDefaultMetrics(
+            into: startingPlaced,
+            persistence: persistence,
+            hasStoredLayout: hasStoredLayout,
+            registry: registry,
+            defaults: defaults
+        )
+
+        let providerOrder = persistence.loadProviderOrder() ?? registry.providers.map(\.id)
+        let metricOrderByProvider = persistence.loadMetricOrder().map {
+            LayoutOrdering.normalizedMetricOrder($0, registry: registry)
+        } ?? LayoutOrdering.defaultMetricOrder(registry: registry)
+
+        // An existing value — including an empty array from a user who unpinned everything — wins.
+        let pinnedMetricIDs = Set(
+            (persistence.loadPins() ?? defaults.pinnedMetricIDs)
+                .filter { registry.descriptor(id: $0) != nil }
+        )
+
+        // Expanded membership is a fresh-install default only. Existing layouts that predate the feature
+        // keep every familiar metric above the caret unless the user later moves one.
+        var shouldPersistExpanded = false
+        var expandedMetricIDs: Set<String>
+        if let savedExpanded = persistence.loadExpandedMetrics() {
+            expandedMetricIDs = Set(savedExpanded.filter { registry.descriptor(id: $0) != nil })
+        } else if hasStoredLayout {
+            expandedMetricIDs = []
+        } else {
+            expandedMetricIDs = Set(defaults.expandedMetricIDs.filter { registry.descriptor(id: $0) != nil })
+            shouldPersistExpanded = true
+        }
+
+        let expandedProviderIDs = Set(
+            (persistence.loadExpandedProviders() ?? []).filter { registry.provider(id: $0) != nil }
+        )
+
+        // A newly-shipped default metric is new to an existing user, so it may safely start below the
+        // caret when that is its declared default. Metrics they already had are never silently hidden.
+        let newlyExpanded = Set(seededResult.newlyPlaced)
+            .intersection(defaults.expandedMetricIDs)
+            .filter { registry.descriptor(id: $0) != nil }
+        if !newlyExpanded.isSubset(of: expandedMetricIDs) {
+            expandedMetricIDs.formUnion(newlyExpanded)
+            shouldPersistExpanded = true
+        }
+
+        // Optional default-expanded metrics enter below the caret the first time they are enabled. The
+        // saved queue wins so an explicit user move is not recreated on the next launch.
+        let placedIDs = Set(seededResult.placed.map(\.descriptorID))
+        let expandedNow = expandedMetricIDs
+        let isExpandOnEnableCandidate: (String) -> Bool = { [registry] id in
+            registry.descriptor(id: id) != nil && !expandedNow.contains(id) && !placedIDs.contains(id)
+        }
+        let savedOnEnable = persistence.loadExpandOnEnable()
+        let defaultExpandedOnEnableIDs = Set(
+            (savedOnEnable ?? defaults.expandedMetricIDs).filter(isExpandOnEnableCandidate)
+        )
+
+        return LayoutInitialState(
+            placed: seededResult.placed,
+            providerOrder: providerOrder,
+            metricOrderByProvider: metricOrderByProvider,
+            pinnedMetricIDs: pinnedMetricIDs,
+            expandedMetricIDs: expandedMetricIDs,
+            expandedProviderIDs: expandedProviderIDs,
+            defaultExpandedOnEnableIDs: defaultExpandedOnEnableIDs,
+            menuBarStyle: persistence.loadMenuBarStyle(),
+            shouldPersistPlaced: seededResult.shouldPersistPlaced,
+            shouldPersistExpanded: shouldPersistExpanded,
+            shouldPersistExpandOnEnable: savedOnEnable == nil,
+            seededDefaultsToPersist: seededResult.shouldPersistSeededDefaults
+                ? seededResult.seededDefaults
+                : nil
+        )
+    }
+
+    private struct SeededDefaultsResult {
+        let placed: [PlacedWidget]
+        let seededDefaults: Set<String>
+        let shouldPersistPlaced: Bool
+        let shouldPersistSeededDefaults: Bool
+        let newlyPlaced: [String]
+    }
+
+    private static func seedNewDefaultMetrics(
+        into placed: [PlacedWidget],
+        persistence: LayoutPersistence,
+        hasStoredLayout: Bool,
+        registry: WidgetRegistry,
+        defaults: LayoutDefaultSet
+    ) -> SeededDefaultsResult {
+        let knownDefaults = LayoutOrdering.knownMetricIDs(defaults.metricIDs, registry: registry)
+        let knownDefaultSet = Set(knownDefaults)
+        let hasStoredSeededDefaults = persistence.hasStoredSeededDefaults
+
+        let seededDefaults: Set<String>
+        var shouldPersistSeededDefaults = false
+        if let saved = persistence.loadSeededDefaults() {
+            seededDefaults = Set(LayoutOrdering.knownMetricIDs(saved, registry: registry))
+            shouldPersistSeededDefaults = seededDefaults != Set(saved)
+        } else if hasStoredLayout {
+            seededDefaults = Set(LayoutOrdering.knownMetricIDs(defaults.migrationBaselineMetricIDs, registry: registry))
+            shouldPersistSeededDefaults = true
+        } else {
+            seededDefaults = knownDefaultSet
+            shouldPersistSeededDefaults = true
+        }
+
+        let placedIDs = Set(placed.map(\.descriptorID))
+        let toAdd = knownDefaults.filter { !seededDefaults.contains($0) && !placedIDs.contains($0) }
+        let nextSeededDefaults = seededDefaults.union(knownDefaultSet)
+        shouldPersistSeededDefaults = shouldPersistSeededDefaults
+            || !hasStoredSeededDefaults
+            || nextSeededDefaults != seededDefaults
+
+        return SeededDefaultsResult(
+            placed: placed + toAdd.map { PlacedWidget(descriptorID: $0) },
+            seededDefaults: nextSeededDefaults,
+            shouldPersistPlaced: !toAdd.isEmpty,
+            shouldPersistSeededDefaults: shouldPersistSeededDefaults,
+            newlyPlaced: toAdd
+        )
+    }
+}
+
+/// Pure ordering/default helpers shared by startup and live layout mutations.
+enum LayoutOrdering {
+    static func knownMetricIDs(_ ids: [String], registry: WidgetRegistry) -> [String] {
+        var seen = Set<String>()
+        return ids.filter { id in
+            guard registry.descriptor(id: id) != nil, !seen.contains(id) else { return false }
+            seen.insert(id)
+            return true
+        }
+    }
+
+    static func defaultMetricOrder(registry: WidgetRegistry) -> [String: [String]] {
+        var result: [String: [String]] = [:]
+        for provider in registry.providers {
+            result[provider.id] = registry.descriptors(for: provider.id).map(\.id)
+        }
+        return result
+    }
+
+    static func normalizedMetricOrder(
+        _ saved: [String: [String]],
+        registry: WidgetRegistry
+    ) -> [String: [String]] {
+        var fallback = defaultMetricOrder(registry: registry)
+        for provider in registry.providers {
+            let valid = registry.descriptors(for: provider.id).map(\.id)
+            if let savedIDs = saved[provider.id] {
+                fallback[provider.id] = normalizedMetricIDs(savedIDs, validIDs: valid)
+            }
+        }
+        return fallback
+    }
+
+    static func normalizedMetricIDs(_ saved: [String], validIDs: [String]) -> [String] {
+        let validSet = Set(validIDs)
+        var seen = Set<String>()
+        var ordered = saved.filter { id in
+            guard validSet.contains(id), !seen.contains(id) else { return false }
+            seen.insert(id)
+            return true
+        }
+        ordered.append(contentsOf: validIDs.filter { !seen.contains($0) })
+        return ordered
+    }
+}

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -103,7 +103,6 @@ final class LayoutStore {
     private let registry: WidgetRegistry
     private let persistence: LayoutPersistence
     private let defaultMetricIDs: [String]
-    private let migrationBaselineMetricIDs: [String]
     private let defaultPinnedMetricIDs: [String]
     private let defaultExpandedMetricIDs: [String]
     private var defaultExpandedOnEnableIDs: Set<String>
@@ -123,115 +122,33 @@ final class LayoutStore {
         let persistence = LayoutPersistence(defaults: defaults, storageKey: storageKey)
         self.persistence = persistence
         self.defaultMetricIDs = defaultMetricIDs
-        self.migrationBaselineMetricIDs = migrationBaselineMetricIDs
         self.defaultPinnedMetricIDs = defaultPinnedMetricIDs
         self.defaultExpandedMetricIDs = defaultExpandedMetricIDs
         self.isProviderEnabled = isProviderEnabled
 
-        let hasStoredLayout = persistence.hasStoredLayout
-        var initialPlaced: [PlacedWidget]
-        if let saved = persistence.loadPlaced() {
-            initialPlaced = saved.filter { registry.descriptor(id: $0.descriptorID) != nil }
-        } else {
-            initialPlaced = defaultMetricIDs
-                .filter { registry.descriptor(id: $0) != nil }
-                .map { PlacedWidget(descriptorID: $0) }
-        }
-        let seededResult = Self.seedNewDefaultMetrics(
-            into: initialPlaced,
-            persistence: persistence,
-            hasStoredLayout: hasStoredLayout,
+        let initial = LayoutBootstrap.load(
             registry: registry,
-            defaultMetricIDs: defaultMetricIDs,
-            migrationBaselineMetricIDs: migrationBaselineMetricIDs
+            persistence: persistence,
+            defaults: LayoutDefaultSet(
+                metricIDs: defaultMetricIDs,
+                migrationBaselineMetricIDs: migrationBaselineMetricIDs,
+                pinnedMetricIDs: defaultPinnedMetricIDs,
+                expandedMetricIDs: defaultExpandedMetricIDs
+            )
         )
-        initialPlaced = seededResult.placed
-        placed = initialPlaced
+        placed = initial.placed
+        providerOrder = initial.providerOrder
+        metricOrderByProvider = initial.metricOrderByProvider
+        pinnedMetricIDs = initial.pinnedMetricIDs
+        expandedMetricIDs = initial.expandedMetricIDs
+        expandedProviderIDs = initial.expandedProviderIDs
+        defaultExpandedOnEnableIDs = initial.defaultExpandedOnEnableIDs
+        menuBarStyle = initial.menuBarStyle
 
-        let initialProviderOrder: [String]
-        if let saved = persistence.loadProviderOrder() {
-            initialProviderOrder = saved
-        } else {
-            initialProviderOrder = registry.providers.map(\.id)
-        }
-        providerOrder = initialProviderOrder
-
-        let initialMetricOrder: [String: [String]]
-        if let saved = persistence.loadMetricOrder() {
-            initialMetricOrder = Self.normalizedMetricOrder(saved, registry: registry)
-        } else {
-            initialMetricOrder = Self.defaultMetricOrder(registry: registry)
-        }
-        metricOrderByProvider = initialMetricOrder
-
-        // Seed default pins on first launch (no saved value) so the menu bar shows real numbers out of
-        // the box; a saved value — including an empty one the user produced by unpinning — is respected.
-        if let savedPins = persistence.loadPins() {
-            pinnedMetricIDs = Set(savedPins.filter { registry.descriptor(id: $0) != nil })
-        } else {
-            pinnedMetricIDs = Set(defaultPinnedMetricIDs.filter { registry.descriptor(id: $0) != nil })
-        }
-
-        // Seed default expanded membership only on a genuinely fresh launch. An existing layout with no
-        // saved value predates this feature, so its metrics stay always-shown — never silently tuck a
-        // metric the user already lived with behind a new caret.
-        var shouldPersistExpanded = false
-        if let savedExpanded = persistence.loadExpandedMetrics() {
-            expandedMetricIDs = Set(savedExpanded.filter { registry.descriptor(id: $0) != nil })
-        } else if hasStoredLayout {
-            expandedMetricIDs = []
-        } else {
-            expandedMetricIDs = Set(defaultExpandedMetricIDs.filter { registry.descriptor(id: $0) != nil })
-            shouldPersistExpanded = true
-        }
-        // Finalized below once `expandedMetricIDs` is settled; seeded here so every stored property is
-        // initialized before the reads that compute the real value.
-        defaultExpandedOnEnableIDs = []
-        menuBarStyle = persistence.loadMenuBarStyle()
-
-        if let savedExpandedProviders = persistence.loadExpandedProviders() {
-            expandedProviderIDs = Set(savedExpandedProviders.filter { registry.provider(id: $0) != nil })
-        } else {
-            expandedProviderIDs = []
-        }
-        // A metric added to the defaults since the user's last layout (auto-enabled above by
-        // `seedNewDefaultMetrics`) is brand new to them — so when it's a default-expanded metric, tuck it
-        // below the caret now instead of surfacing it above the fold. Without this, an existing layout's
-        // saved (or empty) expanded set never learns about the new metric and it lands always-shown. Only
-        // newly-placed ids qualify, so a metric the user already lived with is never silently hidden.
-        let newlyExpanded = Set(seededResult.newlyPlaced)
-            .intersection(defaultExpandedMetricIDs)
-            .filter { registry.descriptor(id: $0) != nil }
-        if !newlyExpanded.isSubset(of: expandedMetricIDs) {
-            expandedMetricIDs.formUnion(newlyExpanded)
-            shouldPersistExpanded = true
-        }
-
-        // A default-expanded metric that is neither already an expanded member nor placed enters below
-        // the caret the first time the user enables it. This queue is *persisted*, not recomputed each
-        // launch: a saved set is loaded as-is (only re-filtered for metrics that have since been placed
-        // or expanded), so a metric the user explicitly moved above the fold while disabled — which
-        // consumes its queue entry — stays above the fold after a relaunch instead of being resurrected.
-        // It's seeded once (no saved value yet) from the default-expanded metrics not already shown, which
-        // is what carries a legacy layout's optional metrics (e.g. `cursor.requests`) below the caret.
-        let placedIDs = Set(placed.map(\.descriptorID))
-        let expandedNow = expandedMetricIDs
-        let isExpandOnEnableCandidate: (String) -> Bool = { [registry] id in
-            registry.descriptor(id: id) != nil && !expandedNow.contains(id) && !placedIDs.contains(id)
-        }
-        if let savedOnEnable = persistence.loadExpandOnEnable() {
-            defaultExpandedOnEnableIDs = Set(savedOnEnable.filter(isExpandOnEnableCandidate))
-        } else {
-            defaultExpandedOnEnableIDs = Set(defaultExpandedMetricIDs.filter(isExpandOnEnableCandidate))
-            persistExpandOnEnable()
-        }
-
-        if shouldPersistExpanded { persistExpanded() }
-
-        if seededResult.shouldPersistSeededDefaults {
-            persistSeededDefaults(seededResult.seededDefaults)
-        }
-        syncPlacedOrder(persistChanges: seededResult.shouldPersistPlaced)
+        if initial.shouldPersistExpandOnEnable { persistExpandOnEnable() }
+        if initial.shouldPersistExpanded { persistExpanded() }
+        if let seededDefaults = initial.seededDefaultsToPersist { persistSeededDefaults(seededDefaults) }
+        syncPlacedOrder(persistChanges: initial.shouldPersistPlaced)
     }
 
     func provider(id: String) -> Provider? { registry.provider(id: id) }
@@ -819,7 +736,7 @@ final class LayoutStore {
             .map { PlacedWidget(descriptorID: $0) }
         providerOrder = registry.providers.map(\.id)
         persistProviderOrder()
-        metricOrderByProvider = Self.defaultMetricOrder(registry: registry)
+        metricOrderByProvider = LayoutOrdering.defaultMetricOrder(registry: registry)
         persistMetricOrder()
         pinnedMetricIDs = Set(defaultPinnedMetricIDs.filter { registry.descriptor(id: $0) != nil })
         persistPins()
@@ -829,7 +746,7 @@ final class LayoutStore {
         persistExpandOnEnable()
         expandedProviderIDs = []
         persistExpandedProviders()
-        persistSeededDefaults(Set(Self.knownMetricIDs(defaultMetricIDs, registry: registry)))
+        persistSeededDefaults(Set(LayoutOrdering.knownMetricIDs(defaultMetricIDs, registry: registry)))
         persist()
     }
 
@@ -901,72 +818,10 @@ final class LayoutStore {
         persistence.saveSeededDefaults(ids)
     }
 
-    private struct SeededDefaultsResult {
-        let placed: [PlacedWidget]
-        let seededDefaults: Set<String>
-        let shouldPersistPlaced: Bool
-        let shouldPersistSeededDefaults: Bool
-        /// Metric ids newly auto-enabled this launch (a default added since the user's last layout).
-        /// Brand-new metrics the user never lived with, so a default-expanded one among them can be
-        /// tucked below the caret without the "don't silently hide a metric they already saw" concern.
-        let newlyPlaced: [String]
-    }
-
-    private static func seedNewDefaultMetrics(
-        into placed: [PlacedWidget],
-        persistence: LayoutPersistence,
-        hasStoredLayout: Bool,
-        registry: WidgetRegistry,
-        defaultMetricIDs: [String],
-        migrationBaselineMetricIDs: [String]
-    ) -> SeededDefaultsResult {
-        let knownDefaults = knownMetricIDs(defaultMetricIDs, registry: registry)
-        let knownDefaultSet = Set(knownDefaults)
-        let hasStoredSeededDefaults = persistence.hasStoredSeededDefaults
-
-        let seededDefaults: Set<String>
-        var shouldPersistSeededDefaults = false
-        if let saved = persistence.loadSeededDefaults() {
-            seededDefaults = Set(knownMetricIDs(saved, registry: registry))
-            shouldPersistSeededDefaults = seededDefaults != Set(saved)
-        } else if hasStoredLayout {
-            seededDefaults = Set(knownMetricIDs(migrationBaselineMetricIDs, registry: registry))
-            shouldPersistSeededDefaults = true
-        } else {
-            seededDefaults = knownDefaultSet
-            shouldPersistSeededDefaults = true
-        }
-
-        let placedIDs = Set(placed.map(\.descriptorID))
-        let toAdd = knownDefaults.filter { !seededDefaults.contains($0) && !placedIDs.contains($0) }
-        let nextPlaced = placed + toAdd.map { PlacedWidget(descriptorID: $0) }
-        let nextSeededDefaults = seededDefaults.union(knownDefaultSet)
-        shouldPersistSeededDefaults = shouldPersistSeededDefaults
-            || !hasStoredSeededDefaults
-            || nextSeededDefaults != seededDefaults
-
-        return SeededDefaultsResult(
-            placed: nextPlaced,
-            seededDefaults: nextSeededDefaults,
-            shouldPersistPlaced: !toAdd.isEmpty,
-            shouldPersistSeededDefaults: shouldPersistSeededDefaults,
-            newlyPlaced: toAdd
-        )
-    }
-
-    private static func knownMetricIDs(_ ids: [String], registry: WidgetRegistry) -> [String] {
-        var seen = Set<String>()
-        return ids.filter { id in
-            guard registry.descriptor(id: id) != nil, !seen.contains(id) else { return false }
-            seen.insert(id)
-            return true
-        }
-    }
-
     private func metricOrder(for providerID: String) -> [String] {
         let valid = registry.descriptors(for: providerID).map(\.id)
         let saved = metricOrderByProvider[providerID] ?? []
-        return Self.normalizedMetricIDs(saved, validIDs: valid)
+        return LayoutOrdering.normalizedMetricIDs(saved, validIDs: valid)
     }
 
     private func syncPlacedOrder(persistChanges: Bool = true) {
@@ -984,40 +839,6 @@ final class LayoutStore {
         if persistChanges { persist() }
     }
 
-    private static func defaultMetricOrder(registry: WidgetRegistry) -> [String: [String]] {
-        var result: [String: [String]] = [:]
-        for provider in registry.providers {
-            let valid = registry.descriptors(for: provider.id).map(\.id)
-            result[provider.id] = valid
-        }
-        return result
-    }
-
-    private static func normalizedMetricOrder(
-        _ saved: [String: [String]],
-        registry: WidgetRegistry
-    ) -> [String: [String]] {
-        var fallback = defaultMetricOrder(registry: registry)
-        for provider in registry.providers {
-            let valid = registry.descriptors(for: provider.id).map(\.id)
-            if let savedIDs = saved[provider.id] {
-                fallback[provider.id] = normalizedMetricIDs(savedIDs, validIDs: valid)
-            }
-        }
-        return fallback
-    }
-
-    private static func normalizedMetricIDs(_ saved: [String], validIDs: [String]) -> [String] {
-        let validSet = Set(validIDs)
-        var seen = Set<String>()
-        var ordered = saved.filter { id in
-            guard validSet.contains(id), !seen.contains(id) else { return false }
-            seen.insert(id)
-            return true
-        }
-        ordered.append(contentsOf: validIDs.filter { !seen.contains($0) })
-        return ordered
-    }
 }
 
 /// A provider and its placed (visible) widgets, split into the always-shown rows and the ones tucked

--- a/Tests/OpenUsageTests/LayoutBootstrapTests.swift
+++ b/Tests/OpenUsageTests/LayoutBootstrapTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class LayoutBootstrapTests: XCTestCase {
+    func testFreshInstallUsesCurrentDefaults() {
+        let (persistence, _) = makePersistence("Fresh")
+
+        let state = LayoutBootstrap.load(
+            registry: .mock,
+            persistence: persistence,
+            defaults: makeDefaultSet()
+        )
+
+        XCTAssertEqual(state.placed.map(\.descriptorID), ["claude.session", "claude.weekly"])
+        XCTAssertEqual(state.pinnedMetricIDs, ["claude.session"])
+        XCTAssertEqual(state.expandedMetricIDs, ["claude.weekly"])
+        XCTAssertEqual(state.seededDefaultsToPersist, ["claude.session", "claude.weekly"])
+        XCTAssertTrue(state.shouldPersistExpanded)
+        XCTAssertTrue(state.shouldPersistExpandOnEnable)
+        XCTAssertFalse(state.shouldPersistPlaced)
+    }
+
+    func testExistingLayoutUsesLegacyBaselineWithoutRestoringRemovedMetric() {
+        let (persistence, _) = makePersistence("ExistingBaseline")
+        persistence.savePlaced([PlacedWidget(descriptorID: "claude.session")])
+
+        let state = LayoutBootstrap.load(
+            registry: .mock,
+            persistence: persistence,
+            defaults: makeDefaultSet()
+        )
+
+        XCTAssertEqual(state.placed.map(\.descriptorID), ["claude.session"])
+        XCTAssertFalse(state.expandedMetricIDs.contains("claude.weekly"))
+        XCTAssertFalse(state.shouldPersistExpanded)
+        XCTAssertTrue(state.shouldPersistExpandOnEnable)
+        XCTAssertFalse(state.shouldPersistPlaced)
+        XCTAssertEqual(state.seededDefaultsToPersist, ["claude.session", "claude.weekly"])
+    }
+
+    func testPreviouslySeededMetricStaysOffWhenUserDisabledIt() {
+        let (persistence, _) = makePersistence("UserDisabled")
+        persistence.savePlaced([PlacedWidget(descriptorID: "claude.session")])
+        persistence.saveSeededDefaults(["claude.session", "claude.weekly"])
+
+        let state = LayoutBootstrap.load(
+            registry: .mock,
+            persistence: persistence,
+            defaults: makeDefaultSet()
+        )
+
+        XCTAssertEqual(state.placed.map(\.descriptorID), ["claude.session"])
+        XCTAssertFalse(state.shouldPersistPlaced)
+        XCTAssertNil(state.seededDefaultsToPersist)
+    }
+
+    private func makeDefaultSet() -> LayoutDefaultSet {
+        LayoutDefaultSet(
+            metricIDs: ["claude.session", "claude.weekly"],
+            migrationBaselineMetricIDs: ["claude.session", "claude.weekly"],
+            pinnedMetricIDs: ["claude.session"],
+            expandedMetricIDs: ["claude.weekly"]
+        )
+    }
+
+    private func makePersistence(_ name: String) -> (LayoutPersistence, UserDefaults) {
+        let suite = "OpenUsageTests.LayoutBootstrap.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return (LayoutPersistence(defaults: defaults, storageKey: "layout"), defaults)
+    }
+}


### PR DESCRIPTION
## TL;DR

Fresh-install and upgrade rules now live in one focused startup helper. The live layout store keeps the same behavior but is much easier to follow.

## What was happening

- The live layout store also contained a long startup routine for fresh installs, old installs, newly added defaults, pins, and expanded rows.
- Ordering cleanup and default-upgrade rules were mixed into user actions.
- It was difficult to tell which code ran once at launch and which code ran during normal use.

## What this changes

- Moves startup and default-upgrade decisions into a dedicated loader.
- Moves pure ordering cleanup into a shared helper used by startup and live actions.
- Removes startup-only state from the live store.
- Keeps all saved keys, write conditions, and user-choice rules unchanged.
- Adds direct tests for fresh installs, existing installs, and metrics a user previously turned off.

## Heads-up

- This is intentionally based on the saved-layout helper PR. It will be retargeted to `main` as soon as that foundation lands, which will trigger the normal CI run.

## Tests

- `swift test --filter LayoutBootstrapTests`
- `swift test --filter LayoutStoreTests`
- `swift test --filter AntigravityLayoutTests`
- `swift test --filter MenuBarPinTests`
- `./script/build_and_run.sh verify`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup code decides persisted layout and migration writes on every launch; behavior is meant to be unchanged but regressions could alter pins, expanded rows, or auto-enabled metrics for existing users.
> 
> **Overview**
> **Moves launch-time layout policy out of `LayoutStore`** into a new `LayoutBootstrap.load` path that returns `LayoutInitialState` (placed widgets, order, pins, expanded state, and which one-time persistence writes to run). Fresh install vs existing user rules—default metric seeding, migration baseline, expand-on-enable queue, and “don’t re-enable metrics the user turned off”—now live in one module instead of a long `init`.
> 
> **Extracts shared ordering helpers** into `LayoutOrdering` (`knownMetricIDs`, default/normalized metric order). `LayoutStore` still handles live mutations; it only calls bootstrap on startup and uses `LayoutOrdering` from `resetToDefault` and metric-order sync.
> 
> **Adds `LayoutBootstrapTests`** covering fresh install defaults, legacy layouts without forcing new expanded metrics, and seeded metrics staying disabled after the user removed them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35842a99b18c1364f31cf47780cb752556e1662a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->