### PR TITLE
Separate dashboard content from popover coordination

### DIFF
--- a/Sources/OpenUsage/Views/DashboardContentView.swift
+++ b/Sources/OpenUsage/Views/DashboardContentView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// The dashboard-only scrolling content. Screen switching, panel sizing, fixed bars, keyboard handling,
+/// and close/reset behavior stay with `DashboardView`.
+struct DashboardContentView: View {
+    let container: AppContainer
+    let layout: LayoutStore
+    let updater: UpdaterController
+    let reorderSpaceName: String
+    let horizontalPadding: CGFloat
+    let bottomGap: CGFloat
+
+    @Binding var reorderLift: ReorderLift?
+    @Binding var scrollPosition: ScrollPosition
+
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @AppStorage(TotalSpendSetting.key) private var showTotalSpend = true
+
+    var body: some View {
+        PopoverScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                // A pending update found by a scheduled Sparkle check tops everything — it's the
+                // reminder the buried Sparkle window can't deliver for a dockless app.
+                if let updateVersion = updater.availableUpdateVersion {
+                    UpdateBannerCard(version: updateVersion)
+                        .padding(.bottom, density.sectionSpacing)
+                        .transition(.scale(scale: 0.95).combined(with: .opacity))
+                }
+                // The one-time first-run hint sits above the provider sections (and above the
+                // empty-state line, which a fresh install can hit while nothing has data yet).
+                if container.onboarding.isCustomizeHintPending {
+                    CustomizeHintCard()
+                        .padding(.bottom, density.sectionSpacing)
+                        .transition(.scale(scale: 0.95).combined(with: .opacity))
+                }
+                widgetContent
+            }
+            .animation(Motion.spring, value: container.onboarding.isCustomizeHintPending)
+            .animation(Motion.spring, value: updater.availableUpdateVersion)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.top, density.contentTopPadding)
+            .padding(.bottom, bottomGap)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .scrollPosition($scrollPosition)
+    }
+
+    @ViewBuilder
+    private var widgetContent: some View {
+        // The cross-provider Total Spend ring stays visible whenever the user allows it and an enabled
+        // provider can track spend, even before fresh data arrives or when every metric row is hidden.
+        if showTotalSpend, layout.hasSpendCapableProvider {
+            TotalSpendCard()
+                .padding(.bottom, density.sectionSpacing)
+        }
+        if layout.displayGroups.isEmpty {
+            Text("Turn on Customize to choose what to show.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 24)
+                .padding(.horizontal, 16)
+        } else {
+            WidgetGroupedListView(
+                reorderSpaceName: reorderSpaceName,
+                reorderLift: $reorderLift
+            )
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -49,10 +49,7 @@ struct DashboardView: View {
     /// attaches to this panel as a sheet (see `StatusItemController`'s attached-sheet guard), so a
     /// click on its buttons can't be misread as an outside click that dismisses the popover.
     @State private var isPresentingResetAllConfirm = false
-    /// Row rhythm tracks the global density setting live.
-    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
-    @AppStorage(TotalSpendSetting.key) private var showTotalSpend = true
-
+    /// Shared horizontal inset for dashboard content and fixed chrome.
     private static let outerPadding: CGFloat = 14
     /// Breathing room between the bottom of the scrolling content and the pinned footer. Kept small
     /// because the native scroll edge effect — not whitespace — provides the visual separation.
@@ -356,7 +353,16 @@ struct DashboardView: View {
     private func scrollBody(for screen: PopoverScreen) -> some View {
         switch screen {
         case .dashboard:
-            scrollingDashboard
+            DashboardContentView(
+                container: container,
+                layout: layout,
+                updater: updater,
+                reorderSpaceName: Self.reorderSpace,
+                horizontalPadding: Self.outerPadding,
+                bottomGap: Self.contentBottomGap,
+                reorderLift: $reorderLift,
+                scrollPosition: $dashboardScrollPosition
+            )
         case .customize:
             CustomizeView(
                 reorderSpaceName: Self.reorderSpace,
@@ -419,67 +425,6 @@ struct DashboardView: View {
             withAnimation(Motion.spring) { layout.customizeProviderID = nil }
         } else {
             withAnimation(Motion.modeSwitch) { layout.screen = .dashboard }
-        }
-    }
-
-    /// The widget list as a scroll view that fills the region the footer leaves. The content scrolls
-    /// under the footer with the native soft scroll-edge fade (`softTopScrollEdge`/`softBottomScrollEdge`
-    /// are applied uniformly in `screenView`). Unlike Customize/Settings it tracks the dashboard's own
-    /// scroll position, so that modifier stays here on the scroll view.
-    private var scrollingDashboard: some View {
-        PopoverScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                // A pending update found by a scheduled Sparkle check tops everything — it's the
-                // reminder the buried Sparkle window can't deliver for a dockless app.
-                if let updateVersion = updater.availableUpdateVersion {
-                    UpdateBannerCard(version: updateVersion)
-                        .padding(.bottom, density.sectionSpacing)
-                        .transition(.scale(scale: 0.95).combined(with: .opacity))
-                }
-                // The one-time first-run hint sits above the provider sections (and above the
-                // empty-state line, which a fresh install can hit while nothing has data yet).
-                // It scrolls with the content — a grouped card, not chrome.
-                if container.onboarding.isCustomizeHintPending {
-                    CustomizeHintCard()
-                        .padding(.bottom, density.sectionSpacing)
-                        .transition(.scale(scale: 0.95).combined(with: .opacity))
-                }
-                widgetContent
-            }
-            .animation(Motion.spring, value: container.onboarding.isCustomizeHintPending)
-            .animation(Motion.spring, value: updater.availableUpdateVersion)
-            .padding(.horizontal, Self.outerPadding)
-            .padding(.top, density.contentTopPadding)
-            .padding(.bottom, Self.contentBottomGap)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .scrollPosition($dashboardScrollPosition)
-    }
-
-    @ViewBuilder
-    private var widgetContent: some View {
-        // The cross-provider Total Spend ring tops the provider sections whenever the user hasn't
-        // hidden it (Settings → General) and any enabled provider is capable of tracking spend.
-        // The gate is capability, not data — and independent of the provider sections below, so a
-        // fresh morning, a lone provider, or a dashboard with every metric hidden still shows the
-        // card (with its ring or "No spend data" state) rather than silently dropping it.
-        if showTotalSpend, layout.hasSpendCapableProvider {
-            TotalSpendCard()
-                .padding(.bottom, density.sectionSpacing)
-        }
-        if layout.displayGroups.isEmpty {
-            Text("Turn on Customize to choose what to show.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 24)
-                .padding(.horizontal, 16)
-        } else {
-            WidgetGroupedListView(
-                reorderSpaceName: Self.reorderSpace,
-                reorderLift: $reorderLift
-            )
         }
     }
 


### PR DESCRIPTION
## TL;DR

The dashboard’s scrolling cards and widget list now live in their own small view. Screen switching, panel sizing, keyboard handling, and close behavior remain with the popover coordinator.

## What was happening

- One large view drew the dashboard, switched screens, animated the panel, handled keyboard commands, and drew the fixed bars.
- The dashboard-only content was buried inside that coordinator.

## What this changes

- Moves the update card, first-run hint, total spend, empty state, widget list, and dashboard scrolling into a focused view.
- Passes the few required stores, bindings, and layout values explicitly.
- Keeps the same animation, scrolling, drag preview, spacing, and height measurement behavior.
- Keeps durable density and Total Spend settings next to the content that uses them.

## Tests

- `swift test --filter Dashboard`
- `swift test --filter PanelHeightCoordinatorTests`
- `./script/build_and_run.sh verify`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural SwiftUI split with moved code and explicit parameters; no new logic paths or security-sensitive changes.
> 
> **Overview**
> **Splits the dashboard scroll area out of `DashboardView` into a new `DashboardContentView`.**
> 
> The extracted view owns the update banner, customize hint, total spend card, empty state, and `WidgetGroupedListView` inside `PopoverScrollView`, with `@AppStorage` for density and total-spend visibility kept next to that content. `DashboardView` now wires the dashboard case in `scrollBody(for:)` with explicit `container`, `layout`, `updater`, padding constants, and bindings for reorder lift and scroll position; screen slides, pinned chrome, panel height, and keyboard handling stay in the coordinator.
> 
> The total-spend comment is tightened to emphasize showing the ring when spend-capable providers are enabled, independent of whether data has arrived yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0581cfc5f37c979d2d0d1fbfd3c601a37821cf6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->