### PR TITLE
Separate panel height handling from status-item lifecycle

### DIFF
--- a/Sources/OpenUsage/App/PanelHeightController.swift
+++ b/Sources/OpenUsage/App/PanelHeightController.swift
@@ -1,0 +1,172 @@
+import AppKit
+
+/// Owns the menu-bar panel's placement and content-driven height changes. The status-item controller
+/// still owns panel creation and show/hide; this type owns only the height boundary between SwiftUI and
+/// AppKit.
+@MainActor
+final class PanelHeightController {
+    static let panelWidth: CGFloat = 320
+    static let defaultHeight: CGFloat = 800
+
+    private let panel: MenuBarPanel
+    private let currentScreen: () -> PopoverScreen
+    private let defaults: UserDefaults
+
+    private var anchorScreen: NSScreen?
+    private var anchorTopLeft: NSPoint?
+    private var morphSettleTask: Task<Void, Never>?
+    private(set) var isMorphing = false
+
+    init(
+        panel: MenuBarPanel,
+        defaults: UserDefaults = .standard,
+        currentScreen: @escaping () -> PopoverScreen
+    ) {
+        self.panel = panel
+        self.defaults = defaults
+        self.currentScreen = currentScreen
+    }
+
+    /// Installs the two narrow callbacks SwiftUI uses: apply one animated frame and clamp a target to
+    /// the available display height.
+    func installBridge() {
+        MenuBarPopover.applyHeight = { [weak self] height in
+            self?.applyMorphHeight(height)
+        }
+        MenuBarPopover.clampHeight = { [weak self] rawHeight in
+            self?.clampedHeight(rawHeight) ?? rawHeight
+        }
+    }
+
+    /// Invalidates height frames left over from the previous open before SwiftUI lays out this one.
+    func beginOpening() {
+        morphSettleTask?.cancel()
+        isMorphing = false
+        PanelHeightBridge.invalidate()
+    }
+
+    /// Captures the display and top-left anchor, then opens at the remembered height for this screen.
+    func positionForOpening(below buttonRect: NSRect) {
+        let screen = NSScreen.screens.first { $0.frame.intersects(buttonRect) } ?? NSScreen.main
+        anchorScreen = screen
+        let topLeft = PanelGeometry.clampedTopLeft(
+            below: buttonRect,
+            width: Self.panelWidth,
+            visibleFrame: screen?.visibleFrame
+        )
+        anchorTopLeft = topLeft
+
+        let remembered = loadHeight(for: currentScreen()) ?? Self.defaultHeight
+        let height = clampedHeight(remembered)
+        panel.setFrame(
+            PanelGeometry.frame(topLeft: topLeft, width: Self.panelWidth, height: height),
+            display: false
+        )
+        panel.invalidateShadow()
+    }
+
+    /// Saves before the caller changes screens or orders the panel out.
+    func saveBeforeClosing() {
+        guard panel.isVisible else { return }
+        saveHeight(panel.frame.height, for: currentScreen())
+    }
+
+    /// Clears all opening-session state after the panel is ordered out.
+    func finishClosing() {
+        anchorTopLeft = nil
+        anchorScreen = nil
+        morphSettleTask?.cancel()
+        isMorphing = false
+        PanelHeightBridge.invalidate()
+    }
+
+    private func applyMorphHeight(_ rawHeight: CGFloat) {
+        guard rawHeight > 1, panel.isVisible else { return }
+        guard let anchorTopLeft else {
+            AppLog.error(.statusItem, "Morph height while visible but no anchor; frame not applied")
+            return
+        }
+        let height = clampedHeight(rawHeight)
+        guard abs(panel.frame.height - height) > 1 else { return }
+        panel.setFrame(
+            PanelGeometry.frame(topLeft: anchorTopLeft, width: Self.panelWidth, height: height),
+            display: false
+        )
+        panel.invalidateShadow()
+        isMorphing = true
+        scheduleMorphSettle()
+    }
+
+    private func scheduleMorphSettle() {
+        morphSettleTask?.cancel()
+        morphSettleTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(120))
+            guard !Task.isCancelled, let self, self.panel.isVisible else { return }
+            self.isMorphing = false
+            self.saveHeight(self.panel.frame.height, for: self.currentScreen())
+        }
+    }
+
+    private func clampedHeight(_ rawHeight: CGFloat) -> CGFloat {
+        PanelGeometry.clampedHeight(rawHeight, maximum: maximumHeight())
+    }
+
+    private func maximumHeight() -> CGFloat {
+        guard let anchorTopLeft, let visibleFrame = (anchorScreen ?? NSScreen.main)?.visibleFrame else {
+            return Self.defaultHeight
+        }
+        return PanelGeometry.maximumHeight(topLeft: anchorTopLeft, visibleFrame: visibleFrame)
+    }
+
+    private func loadHeight(for screen: PopoverScreen) -> CGFloat? {
+        let value = defaults.double(forKey: Self.heightKey(for: screen))
+        return value > 0 ? CGFloat(value) : nil
+    }
+
+    private func saveHeight(_ height: CGFloat, for screen: PopoverScreen) {
+        defaults.set(Double(height), forKey: Self.heightKey(for: screen))
+    }
+
+    private static func heightKey(for screen: PopoverScreen) -> String {
+        switch screen {
+        case .dashboard: "openusage.panel.height.dashboard"
+        case .customize: "openusage.panel.height.customize"
+        case .settings: "openusage.panel.height.settings"
+        }
+    }
+}
+
+/// Pure panel geometry, kept separate so display clamping can be tested without opening a window.
+enum PanelGeometry {
+    static let topGap: CGFloat = 4
+    static let screenMargin: CGFloat = 8
+    static let minimumHeight: CGFloat = 200
+
+    static func clampedTopLeft(below buttonRect: NSRect, width: CGFloat, visibleFrame: NSRect?) -> NSPoint {
+        var x = buttonRect.minX
+        if let visibleFrame {
+            x = min(
+                max(x, visibleFrame.minX + screenMargin),
+                visibleFrame.maxX - width - screenMargin
+            )
+        }
+        return NSPoint(x: x, y: buttonRect.minY - topGap)
+    }
+
+    static func maximumHeight(topLeft: NSPoint, visibleFrame: NSRect) -> CGFloat {
+        let roomBelowAnchor = topLeft.y - visibleFrame.minY - screenMargin
+        let aestheticCap = floor(visibleFrame.height * 0.85)
+        return max(1, min(roomBelowAnchor, aestheticCap))
+    }
+
+    static func clampedHeight(_ rawHeight: CGFloat, maximum: CGFloat) -> CGFloat {
+        min(max(rawHeight, minimumHeight), maximum)
+    }
+
+    static func frame(topLeft: NSPoint, width: CGFloat, height: CGFloat) -> NSRect {
+        NSRect(
+            origin: NSPoint(x: topLeft.x, y: topLeft.y - height),
+            size: NSSize(width: width, height: height)
+        )
+    }
+}

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -32,42 +32,18 @@ final class StatusItemController: NSObject {
     /// (which never retains the controller), so this can be a plain non-optional `let`.
     private let imageUpdater: StatusItemImageUpdater
     private let panel: MenuBarPanel
+    private let heightController: PanelHeightController
     private let hostingController: NSHostingController<AnyView>
     /// The panel's backdrop: an opaque tray by default, swapped to a behind-window vibrancy view when
     /// the transparency style is non-opaque. Built once and toggled, so it can't race the style observer.
     private let backdrop = PopoverBackdropView(cornerRadius: StatusItemController.cornerRadius)
-    /// The screen the status-item button is on, captured on show — used to clamp the saved panel size
-    /// to whatever display the panel is currently opening on.
-    private var anchorScreen: NSScreen?
     /// Closes the panel on clicks outside it (the panel is non-activating and dismissal is ours to
     /// implement, the same model the old `.applicationDefined` popover used).
     private var outsideClickMonitors: [Any] = []
     /// Token for the appearance-change observer; held to follow the documented removal pattern.
     private var appearanceObserver: NSObjectProtocol?
-    /// Panel top-left in screen coords, captured on show. The panel grows downward from here, so the
-    /// top edge stays pinned just under the status-item button as its content changes height.
-    private var anchorTopLeft: NSPoint?
-
-    /// One width across both densities (matches `DashboardView.popoverWidth`). The panel is a single
-    /// column of metrics, so width is fixed and height follows the content.
-    private static let panelWidth: CGFloat = 320
-    /// Gap between the menu bar and the panel's top edge.
-    private static let topGap: CGFloat = 4
     /// Corner radius of the panel surface; tuned to read like a system menu-bar popover.
     private static let cornerRadius: CGFloat = 13
-    /// Smallest the panel can be — room for the footer plus a single provider card. Kept low so the
-    /// auto-fit morph can shrink the panel to match its content instead of showing blank space when
-    /// only one or two providers are enabled (#800).
-    private static let minPanelHeight: CGFloat = 200
-    /// Opening height before a measured or remembered screen height is available.
-    private static let defaultPanelHeight: CGFloat = 800
-    /// True while a SwiftUI-driven height morph is in flight. Outside-click dismissal is suspended for
-    /// its duration so the panel growing/shrinking under a stationary cursor can't be misread as an
-    /// outside click. Cleared by `scheduleMorphSettle` shortly after the per-frame height stream stops.
-    private var isMorphing = false
-    /// Fires once the per-frame height stream goes quiet: clears `isMorphing` and persists the settled
-    /// per-screen height (the next open's flash-free starting guess).
-    private var morphSettleTask: Task<Void, Never>?
 
     init(container: AppContainer, updater: UpdaterController) {
         self.container = container
@@ -95,12 +71,19 @@ final class StatusItemController: NSObject {
         // content scrolls only when that height reaches the available-screen limit.
         self.hostingController = hosting
 
-        self.panel = MenuBarPanel(
-            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.defaultPanelHeight),
+        let panel = MenuBarPanel(
+            contentRect: NSRect(
+                x: 0,
+                y: 0,
+                width: PanelHeightController.panelWidth,
+                height: PanelHeightController.defaultHeight
+            ),
             styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
+        self.panel = panel
+        self.heightController = PanelHeightController(panel: panel) { container.layout.screen }
 
         super.init()
 
@@ -134,14 +117,7 @@ final class StatusItemController: NSObject {
             self?.showPopover()
         }
 
-        // The panel auto-fits its content: SwiftUI owns one animated height (the single animation
-        // clock) and the panel just follows it. `applyHeight` is the per-frame follower; `clampHeight`
-        // shares the panel's [min, screen-max] clamp so SwiftUI's target matches where the frame lands.
-        MenuBarPopover.applyHeight = { [weak self] height in self?.applyMorphHeight(height) }
-        MenuBarPopover.clampHeight = { [weak self] raw in
-            guard let self else { return raw }
-            return min(max(raw, Self.minPanelHeight), self.maxPanelHeight())
-        }
+        heightController.installBridge()
 
         AppLog.info(.statusItem, "Status item ready (button: \(self.statusItem.button != nil), shortcut: \(KeyboardShortcuts.getShortcut(for: .togglePopover)?.description ?? "none"))")
     }
@@ -196,7 +172,7 @@ final class StatusItemController: NSObject {
         ])
 
         // A plain container VC owns the backdrop; the hosting controller is its child so SwiftUI gets
-        // a proper view-controller hierarchy. The panel itself is sized by `applyPanelSize`.
+        // a proper view-controller hierarchy. Panel placement and height live in `heightController`.
         let rootVC = NSViewController()
         rootVC.view = container
         rootVC.addChild(hostingController)
@@ -329,16 +305,12 @@ final class StatusItemController: NSObject {
         // `\.popoverIsVisible`; a closed popover keeps the loops unmounted, so a left-on egg costs no CPU.
         container.transparency.setPopoverShown(true)
 
-        // Drop any morph heights still queued from a previous session so a quick reopen during an old
-        // spring can't apply a stale height to this fresh open.
-        PanelHeightBridge.invalidate()
+        heightController.beginOpening()
         // Lay the content out first so the panel opens at the right size (no first-frame flash).
         hostingController.view.layoutSubtreeIfNeeded()
 
         let buttonRectOnScreen = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
-        anchorScreen = NSScreen.screens.first { $0.frame.intersects(buttonRectOnScreen) } ?? NSScreen.main
-        anchorTopLeft = clampedTopLeft(below: buttonRectOnScreen, width: Self.panelWidth)
-        applyPanelSize()
+        heightController.positionForOpening(below: buttonRectOnScreen)
 
         // `canBecomeKey` + `.nonactivatingPanel` makes this key without activating the app — no
         // activation race, so the dashboard receives keys on the first try.
@@ -362,14 +334,9 @@ final class StatusItemController: NSObject {
         // or reset toggle) stays first responder, so its focus ring would reopen with the popover as a
         // stray blue outline. Drop it on close so every reopen starts unfocused.
         clearStrayFocus()
-        // Persist the closing screen's height NOW, while `container.layout.screen` is still the screen
-        // being shown. The authoritative visibility signal below then tells SwiftUI to reset it to the
-        // dashboard. `scheduleMorphSettle` only persists after 120ms of quiet and bails once the panel is
-        // hidden, so without this a close during a height change or screen switch would never save the new
-        // height and the next open of that screen would use a stale flash-free guess.
-        if panel.isVisible {
-            PanelHeightStore.save(panel.frame.height, for: container.layout.screen)
-        }
+        // Save while the closing screen is still current; the authoritative SwiftUI close reset runs
+        // afterward.
+        heightController.saveBeforeClosing()
         // Closing: drop the on-screen flag so the egg's animation loops unmount their `TimelineView`
         // clocks and stop ticking — the whole point of the gate (no CPU while the egg is left on but the
         // popover is hidden). This is the authoritative hide signal, flipped synchronously with `orderOut`.
@@ -377,14 +344,7 @@ final class StatusItemController: NSObject {
         panel.orderOut(nil)
         stopOutsideClickMonitors()
         statusItem.button?.highlight(false)
-        anchorTopLeft = nil
-        anchorScreen = nil
-        // Settle any in-flight morph so a reopen doesn't inherit a stale flag, and invalidate heights
-        // already queued through PanelHeightBridge so a spring morph caught mid-flight by the close
-        // can't resize the panel after orderOut (or after a quick reopen).
-        morphSettleTask?.cancel()
-        isMorphing = false
-        PanelHeightBridge.invalidate()
+        heightController.finishClosing()
     }
 
     /// Drops keyboard focus inside the panel so a clicked plain-styled control (a metric row's
@@ -396,94 +356,6 @@ final class StatusItemController: NSObject {
         guard !ShortcutRecorderField.isRecordingActive,
               !(panel.firstResponder is NSText) else { return }
         panel.makeFirstResponder(nil)
-    }
-
-    /// Sizes the panel on show to a **flash-free opening guess** — the last settled height for the
-    /// screen being opened (or a default) — clamped to fit the current screen, top-left pinned under
-    /// the status item. Width is fixed (single-column list).
-    ///
-    /// The panel auto-fits its content via the SwiftUI morph (`applyMorphHeight`), but that measured
-    /// height only lands a runloop turn after the content lays out — too late for the first frame. So
-    /// we open at the persisted per-screen guess (kept current by `scheduleMorphSettle`), and SwiftUI
-    /// snaps to the exact measured height on appear; when the guess is close the snap is invisible.
-    /// Per-screen because `openSettings` opens straight onto Settings, which is a different height than
-    /// the dashboard. The clamp keeps a height saved on a big display from running off a short one.
-    private func applyPanelSize() {
-        guard let anchorTopLeft else { return }
-        let saved = PanelHeightStore.load(for: container.layout.screen) ?? Self.defaultPanelHeight
-        let height = min(max(saved, Self.minPanelHeight), maxPanelHeight())
-        let origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - height)
-        panel.setFrame(NSRect(origin: origin, size: NSSize(width: Self.panelWidth, height: height)), display: false)
-        panel.invalidateShadow()
-    }
-
-    // MARK: - Content-driven morph
-
-    /// Per-frame follower for the SwiftUI-driven height morph (the single animation clock). Called once
-    /// per animation frame with the interpolated height — already hopped onto the main queue and out of
-    /// SwiftUI's layout pass by `PanelHeightBridge`, so this runs synchronously and safely (a synchronous
-    /// `setFrame` from inside that pass would re-enter AppKit layout and trip `_NSDetectedLayoutRecursion`).
-    /// Single clock: only `setFrame(display:false)`, never `animate:true` / `panel.animator()`, so AppKit
-    /// adds no second animation to fight SwiftUI's spring.
-    private func applyMorphHeight(_ rawHeight: CGFloat) {
-        guard rawHeight > 1 else { return }   // 0 = "not established yet"; ignore the sentinel.
-        // Drop heights that arrive after a close. `PanelHeightBridge` hops each frame through
-        // `DispatchQueue.main.async`, so a spring morph in flight when the panel closes leaves queued
-        // callbacks behind; `orderOut` flips `isVisible` synchronously, so they're rejected here while
-        // closed (before any reopen) instead of resizing a hidden — or freshly reopened — panel.
-        guard panel.isVisible else { return }
-        guard let anchorTopLeft else {
-            AppLog.error(.statusItem, "Morph height while visible but no anchor; frame not applied")
-            return
-        }
-        let height = min(max(rawHeight, Self.minPanelHeight), maxPanelHeight())
-        // The live frame is the ground truth: apply only when it would actually move (>1pt). This both
-        // dedupes redundant per-render pushes and guarantees the frame never stops short of the driven
-        // height — there's no separate "last requested" tracking that a skipped apply could desync.
-        guard abs(panel.frame.height - height) > 1 else { return }
-        let origin = NSPoint(x: anchorTopLeft.x, y: anchorTopLeft.y - height)
-        panel.setFrame(NSRect(origin: origin, size: NSSize(width: Self.panelWidth, height: height)), display: false)
-        panel.invalidateShadow()
-        isMorphing = true
-        scheduleMorphSettle()
-    }
-
-    /// Clears `isMorphing` and persists the settled height once the per-frame stream goes quiet (a
-    /// spring keeps changing the height every frame until it settles, so this only fires at rest).
-    private func scheduleMorphSettle() {
-        morphSettleTask?.cancel()
-        morphSettleTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(120))
-            guard !Task.isCancelled, let self, self.panel.isVisible else { return }
-            self.isMorphing = false
-            PanelHeightStore.save(self.panel.frame.height, for: self.container.layout.screen)
-        }
-    }
-
-    /// The tallest the panel may be on the current screen: the room below its pinned top edge, capped at
-    /// 85% of the screen's usable height so it never dominates a large display.
-    private func maxPanelHeight() -> CGFloat {
-        guard let anchorTopLeft, let visible = (anchorScreen ?? NSScreen.main)?.visibleFrame else {
-            return Self.defaultPanelHeight
-        }
-        let roomBelowAnchor = anchorTopLeft.y - visible.minY - 8
-        let aestheticCap = floor(visible.height * 0.85)
-        // The ceiling is the room below the pinned top edge (capped at 85% for aesthetics). It is NOT
-        // floored at `minPanelHeight`: on a screen too short for the minimum, fitting on-screen wins —
-        // the panel becomes smaller than the min rather than running off the bottom edge. `max(1, …)`
-        // only guards a degenerate non-positive frame.
-        return max(1, min(roomBelowAnchor, aestheticCap))
-    }
-
-    /// Places the panel's top-left just below the button, clamped to the button's screen.
-    private func clampedTopLeft(below buttonRect: NSRect, width: CGFloat) -> NSPoint {
-        var x = buttonRect.minX
-        let topY = buttonRect.minY - Self.topGap
-        let screen = NSScreen.screens.first { $0.frame.intersects(buttonRect) } ?? NSScreen.main
-        if let visible = screen?.visibleFrame {
-            x = min(max(x, visible.minX + 8), visible.maxX - width - 8)
-        }
-        return NSPoint(x: x, y: topY)
     }
 
     // MARK: - Outside-click dismissal
@@ -549,7 +421,7 @@ final class StatusItemController: NSObject {
     /// Server), so the button is also matched by screen position.
     private func shouldKeepPanelOpen(windowID: ObjectIdentifier?, windowTypeName: String?, screenPoint: NSPoint) -> Bool {
         // The frame is moving mid-morph; a hit-test against it would be racy, so keep the panel open.
-        if isMorphing { return true }
+        if heightController.isMorphing { return true }
         // A sheet is attached to the panel (e.g. the Customize "Reset All Customization" confirmation
         // alert). Its buttons live in a child window whose own `event.window` is the sheet, not the
         // panel — without this guard a click on "Reset All" / "Cancel" reads as an outside click and
@@ -569,29 +441,5 @@ final class StatusItemController: NSObject {
         guard let button = statusItem.button, let buttonWindow = button.window else { return false }
         let buttonFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
         return buttonFrame.contains(screenPoint)
-    }
-}
-
-/// Persists the last settled panel height **per screen**, so the next open starts at a flash-free
-/// guess close to what the content will measure (the panel auto-fits, but the measurement lands a tick
-/// after the first frame — see `applyPanelSize`). Width is fixed (single-column list), so only height
-/// is stored; it's clamped to the current screen on each open. Per-screen because the dashboard,
-/// Customize, and Settings are genuinely different heights and `openSettings` opens straight onto one.
-private enum PanelHeightStore {
-    private static func key(for screen: PopoverScreen) -> String {
-        switch screen {
-        case .dashboard: "openusage.panel.height.dashboard"
-        case .customize: "openusage.panel.height.customize"
-        case .settings: "openusage.panel.height.settings"
-        }
-    }
-
-    static func load(for screen: PopoverScreen) -> CGFloat? {
-        let value = UserDefaults.standard.double(forKey: key(for: screen))
-        return value > 0 ? CGFloat(value) : nil
-    }
-
-    static func save(_ height: CGFloat, for screen: PopoverScreen) {
-        UserDefaults.standard.set(Double(height), forKey: key(for: screen))
     }
 }

--- a/Tests/OpenUsageTests/PanelGeometryTests.swift
+++ b/Tests/OpenUsageTests/PanelGeometryTests.swift
@@ -1,0 +1,60 @@
+import AppKit
+import XCTest
+@testable import OpenUsage
+
+final class PanelGeometryTests: XCTestCase {
+    func testHorizontalPlacementStaysInsideVisibleFrame() {
+        let visible = NSRect(x: 0, y: 0, width: 500, height: 900)
+        let left = PanelGeometry.clampedTopLeft(
+            below: NSRect(x: -40, y: 850, width: 20, height: 20),
+            width: 320,
+            visibleFrame: visible
+        )
+        let right = PanelGeometry.clampedTopLeft(
+            below: NSRect(x: 490, y: 850, width: 20, height: 20),
+            width: 320,
+            visibleFrame: visible
+        )
+
+        XCTAssertEqual(left.x, 8)
+        XCTAssertEqual(right.x, 172)
+        XCTAssertEqual(left.y, 846)
+    }
+
+    func testMaximumHeightUsesAvailableRoomAndDisplayCap() {
+        let visible = NSRect(x: 0, y: 0, width: 1200, height: 1000)
+
+        XCTAssertEqual(
+            PanelGeometry.maximumHeight(topLeft: NSPoint(x: 100, y: 900), visibleFrame: visible),
+            850
+        )
+    }
+
+    func testShortDisplayMayShrinkBelowNormalMinimum() {
+        let visible = NSRect(x: 0, y: 0, width: 500, height: 200)
+        let maximum = PanelGeometry.maximumHeight(
+            topLeft: NSPoint(x: 100, y: 190),
+            visibleFrame: visible
+        )
+
+        XCTAssertEqual(maximum, 170)
+        XCTAssertEqual(PanelGeometry.clampedHeight(600, maximum: maximum), 170)
+    }
+
+    func testHeightClampsToNormalMinimumAndDisplayMaximum() {
+        XCTAssertEqual(PanelGeometry.clampedHeight(50, maximum: 700), 200)
+        XCTAssertEqual(PanelGeometry.clampedHeight(900, maximum: 700), 700)
+        XCTAssertEqual(PanelGeometry.clampedHeight(520, maximum: 700), 520)
+    }
+
+    func testChangingHeightKeepsTopEdgeFixed() {
+        let topLeft = NSPoint(x: 120, y: 800)
+        let short = PanelGeometry.frame(topLeft: topLeft, width: 320, height: 300)
+        let tall = PanelGeometry.frame(topLeft: topLeft, width: 320, height: 650)
+
+        XCTAssertEqual(short.maxY, topLeft.y)
+        XCTAssertEqual(tall.maxY, topLeft.y)
+        XCTAssertEqual(short.minX, tall.minX)
+        XCTAssertEqual(short.width, tall.width)
+    }
+}


### PR DESCRIPTION
## TL;DR

Moves panel sizing, placement, and remembered heights into a small dedicated controller. The menu-bar controller still owns showing and hiding the panel, so this is a behavior-preserving cleanup.

## What was happening

- One controller handled status-item clicks, panel lifecycle, outside clicks, backdrop setup, panel sizing, display clamping, animations, and saved heights.
- Height behavior was hard to review or test without reading the entire menu-bar lifecycle.

## What this changes

- Gives panel height and placement one clear owner.
- Keeps the existing per-screen remembered heights and opening behavior.
- Keeps checking the current usable display area while the panel is open.
- Adds direct tests for screen limits, minimum height, and keeping the top edge fixed.

## Tests

- `swift test --filter PanelHeightBridgeTests`
- `swift test --filter PanelGeometryTests`
- `swift test` — 937 passed, 3 skipped
- `./script/build_and_run.sh verify`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Panel frame and dismissal behavior during height morphs are easy to regress, though the change is intended to be behavior-preserving and geometry is now unit-tested.
> 
> **Overview**
> **Refactors menu-bar popover sizing** by moving placement, SwiftUI-driven height morphs, per-screen `UserDefaults` persistence, and morph-settle timing out of `StatusItemController` into a new **`PanelHeightController`**, which still wires `MenuBarPopover.applyHeight` / `clampHeight` and exposes `isMorphing` for outside-click dismissal.
> 
> **Pure layout math** is pulled into a testable **`PanelGeometry`** helper (horizontal clamp under the status button, max height vs visible frame, min height, top-anchored frames). The old private **`PanelHeightStore`** enum is removed in favor of equivalent keys inside the controller.
> 
> **`StatusItemController`** now only orchestrates show/hide: it calls `beginOpening`, `positionForOpening`, `saveBeforeClosing`, and `finishClosing` on the height controller while keeping panel creation and lifecycle unchanged.
> 
> **Adds `PanelGeometryTests`** covering screen margins, height caps on short displays, and fixed top edge during resizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a35bd7b82ebdd63a3257828f1f8622d1dbde79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->