### PR TITLE
Separate panel click-away handling

### DIFF
--- a/Sources/OpenUsage/App/PanelOutsideClickMonitor.swift
+++ b/Sources/OpenUsage/App/PanelOutsideClickMonitor.swift
@@ -1,0 +1,115 @@
+import AppKit
+
+/// Owns the local and global mouse monitors that dismiss the menu-bar panel.
+@MainActor
+final class PanelOutsideClickMonitor {
+    private let panel: MenuBarPanel
+    private let statusItem: NSStatusItem
+    private let isMorphing: () -> Bool
+    private let onInsidePanelClick: () -> Void
+    private let onDismiss: () -> Void
+    private var monitors: [Any] = []
+
+    init(
+        panel: MenuBarPanel,
+        statusItem: NSStatusItem,
+        isMorphing: @escaping () -> Bool,
+        onInsidePanelClick: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.panel = panel
+        self.statusItem = statusItem
+        self.isMorphing = isMorphing
+        self.onInsidePanelClick = onInsidePanelClick
+        self.onDismiss = onDismiss
+    }
+
+    func start() {
+        stop()
+        let mask: NSEvent.EventTypeMask = [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        if let local = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { [weak self] event in
+            // NSEvent is not Sendable, so only copy these small values before returning to the main actor.
+            let windowID = event.window.map(ObjectIdentifier.init)
+            let windowTypeName = event.window.map { String(describing: type(of: $0)) }
+            MainActor.assumeIsolated {
+                self?.handleClick(
+                    windowID: windowID,
+                    windowTypeName: windowTypeName,
+                    screenPoint: NSEvent.mouseLocation
+                )
+            }
+            return event
+        }) {
+            monitors.append(local)
+        }
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: { [weak self] _ in
+            // Read the location now; the pointer may move before the main-actor task runs.
+            let screenPoint = NSEvent.mouseLocation
+            Task { @MainActor [weak self] in
+                self?.handleClick(windowID: nil, windowTypeName: nil, screenPoint: screenPoint)
+            }
+        }) {
+            monitors.append(global)
+        }
+    }
+
+    func stop() {
+        for monitor in monitors {
+            NSEvent.removeMonitor(monitor)
+        }
+        monitors = []
+    }
+
+    private func handleClick(
+        windowID: ObjectIdentifier?,
+        windowTypeName: String?,
+        screenPoint: NSPoint
+    ) {
+        let isInsidePanel = panel.frame.contains(screenPoint)
+        let hasWindowContext = windowID != nil && windowTypeName != nil
+        let buttonWindowID = statusItem.button?.window.map(ObjectIdentifier.init)
+        let context = PanelOutsideClickContext(
+            isMorphing: isMorphing(),
+            hasAttachedSheet: panel.attachedSheet != nil,
+            isOnStatusButton: isOnStatusButton(screenPoint),
+            isInsidePanel: isInsidePanel,
+            isPanelWindow: hasWindowContext && windowID == ObjectIdentifier(panel),
+            isStatusItemWindow: hasWindowContext && windowID == buttonWindowID,
+            eventWindowTypeName: hasWindowContext ? windowTypeName : nil
+        )
+
+        if PanelOutsideClickPolicy.shouldKeepOpen(context) {
+            if isInsidePanel { onInsidePanelClick() }
+            return
+        }
+        onDismiss()
+    }
+
+    private func isOnStatusButton(_ screenPoint: NSPoint) -> Bool {
+        guard let button = statusItem.button, let buttonWindow = button.window else { return false }
+        let buttonFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
+        return buttonFrame.contains(screenPoint)
+    }
+}
+
+struct PanelOutsideClickContext {
+    var isMorphing = false
+    var hasAttachedSheet = false
+    var isOnStatusButton = false
+    var isInsidePanel = false
+    var isPanelWindow = false
+    var isStatusItemWindow = false
+    var eventWindowTypeName: String?
+}
+
+enum PanelOutsideClickPolicy {
+    static func shouldKeepOpen(_ context: PanelOutsideClickContext) -> Bool {
+        context.isMorphing
+            || context.hasAttachedSheet
+            || context.isOnStatusButton
+            || context.isInsidePanel
+            || context.isPanelWindow
+            || context.isStatusItemWindow
+            || context.eventWindowTypeName?.localizedCaseInsensitiveContains("menu") == true
+    }
+}

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -33,13 +33,17 @@ final class StatusItemController: NSObject {
     private let imageUpdater: StatusItemImageUpdater
     private let panel: MenuBarPanel
     private let heightController: PanelHeightController
+    private lazy var outsideClickMonitor = PanelOutsideClickMonitor(
+        panel: panel,
+        statusItem: statusItem,
+        isMorphing: { [weak self] in self?.heightController.isMorphing ?? false },
+        onInsidePanelClick: { [weak self] in self?.clearStrayFocus() },
+        onDismiss: { [weak self] in self?.hidePanel() }
+    )
     private let hostingController: NSHostingController<AnyView>
     /// The panel's backdrop: an opaque tray by default, swapped to a behind-window vibrancy view when
     /// the transparency style is non-opaque. Built once and toggled, so it can't race the style observer.
     private let backdrop = PopoverBackdropView(cornerRadius: StatusItemController.cornerRadius)
-    /// Closes the panel on clicks outside it (the panel is non-activating and dismissal is ours to
-    /// implement, the same model the old `.applicationDefined` popover used).
-    private var outsideClickMonitors: [Any] = []
     /// Token for the appearance-change observer; held to follow the documented removal pattern.
     private var appearanceObserver: NSObjectProtocol?
     /// Corner radius of the panel surface; tuned to read like a system menu-bar popover.
@@ -321,7 +325,7 @@ final class StatusItemController: NSObject {
         // monitor, not first responder), and Tab from here focuses the first control as expected.
         clearStrayFocus()
         button.highlight(true)
-        startOutsideClickMonitors()
+        outsideClickMonitor.start()
     }
 
     private func hidePanel() {
@@ -342,7 +346,7 @@ final class StatusItemController: NSObject {
         // popover is hidden). This is the authoritative hide signal, flipped synchronously with `orderOut`.
         container.transparency.setPopoverShown(false)
         panel.orderOut(nil)
-        stopOutsideClickMonitors()
+        outsideClickMonitor.stop()
         statusItem.button?.highlight(false)
         heightController.finishClosing()
     }
@@ -358,88 +362,4 @@ final class StatusItemController: NSObject {
         panel.makeFirstResponder(nil)
     }
 
-    // MARK: - Outside-click dismissal
-
-    private func startOutsideClickMonitors() {
-        stopOutsideClickMonitors()
-        let mask: NSEvent.EventTypeMask = [.leftMouseDown, .rightMouseDown, .otherMouseDown]
-        if let local = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { [weak self] event in
-            // NSEvent is not Sendable: pull the window identity out before hopping to the actor.
-            let windowID = event.window.map(ObjectIdentifier.init)
-            let windowTypeName = event.window.map { String(describing: type(of: $0)) }
-            MainActor.assumeIsolated {
-                guard let self else { return }
-                // `NSEvent.mouseLocation` is the dependable screen-coordinate read (`locationInWindow`
-                // is unreliable for windowless / global events), so the status-button match is correct.
-                let screenPoint = NSEvent.mouseLocation
-                guard !self.shouldKeepPanelOpen(windowID: windowID, windowTypeName: windowTypeName, screenPoint: screenPoint)
-                else {
-                    // Click landed inside the panel: drop any stray focus ring a previously-clicked
-                    // toggle left behind, the way clicking empty space in a normal window does. The
-                    // monitor fires before the event reaches the view, so a click that lands on
-                    // another control just moves focus there next; empty space leaves it cleared.
-                    if self.panel.frame.contains(screenPoint) { self.clearStrayFocus() }
-                    return
-                }
-                self.hidePanel()
-            }
-            return event
-        }) {
-            outsideClickMonitors.append(local)
-        }
-        if let global = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: { [weak self] _ in
-            // Capture the click location NOW: `mouseLocation` read later (inside the Task) could be
-            // stale if the pointer moved before the hop, mis-deciding the status-button / in-panel
-            // checks. `NSPoint` is Sendable, so the captured value crosses into the Task safely.
-            let screenPoint = NSEvent.mouseLocation
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                // A global monitor only fires for clicks in OTHER apps, so there's no in-process window
-                // to identify — the shared keep-open policy decides on position alone (mid-morph frame,
-                // an attached sheet, the status button, or the panel frame). Passing nil window info is
-                // the accurate input, and reusing `shouldKeepPanelOpen` keeps the two monitors in step.
-                guard !self.shouldKeepPanelOpen(windowID: nil, windowTypeName: nil, screenPoint: screenPoint)
-                else { return }
-                self.hidePanel()
-            }
-        }) {
-            outsideClickMonitors.append(global)
-        }
-    }
-
-    private func stopOutsideClickMonitors() {
-        for monitor in outsideClickMonitors {
-            NSEvent.removeMonitor(monitor)
-        }
-        outsideClickMonitors = []
-    }
-
-    /// In-app clicks that must not dismiss: anything inside the panel itself, the status-item button
-    /// (its own handler toggles — closing here too would cancel it out and reopen), and menu windows
-    /// (the Settings pickers' popup menus and the footer's More menu render in separate `NSMenu`-backed
-    /// windows). Status-item clicks can arrive with no window (the menu bar is composited by the Window
-    /// Server), so the button is also matched by screen position.
-    private func shouldKeepPanelOpen(windowID: ObjectIdentifier?, windowTypeName: String?, screenPoint: NSPoint) -> Bool {
-        // The frame is moving mid-morph; a hit-test against it would be racy, so keep the panel open.
-        if heightController.isMorphing { return true }
-        // A sheet is attached to the panel (e.g. the Customize "Reset All Customization" confirmation
-        // alert). Its buttons live in a child window whose own `event.window` is the sheet, not the
-        // panel — without this guard a click on "Reset All" / "Cancel" reads as an outside click and
-        // dismisses the popover out from under the alert. Keep the panel open for the sheet's lifetime.
-        if panel.attachedSheet != nil { return true }
-        if isOnStatusButton(screenPoint: screenPoint) { return true }
-        if panel.frame.contains(screenPoint) { return true }
-        guard let windowID, let windowTypeName else { return false }
-        if windowID == ObjectIdentifier(panel) { return true }
-        if let buttonWindow = statusItem.button?.window, windowID == ObjectIdentifier(buttonWindow) {
-            return true
-        }
-        return windowTypeName.localizedCaseInsensitiveContains("menu")
-    }
-
-    private func isOnStatusButton(screenPoint: NSPoint) -> Bool {
-        guard let button = statusItem.button, let buttonWindow = button.window else { return false }
-        let buttonFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
-        return buttonFrame.contains(screenPoint)
-    }
 }

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// surface behind it — the system `.buttonStyle(.glass)` renders flat on a `Menu` (its own button
 /// chrome wins), so the glass goes on the container. It falls back to a frosted material capsule on
 /// macOS 15. The menu renders in its own `NSMenu`-backed window, which
-/// `StatusItemController.shouldKeepPanelOpen` keeps the popover open for.
+/// the panel's outside-click policy keeps the popover open for.
 ///
 /// Only the dashboard shows this; the Customize and Settings screens carry their own top-leading back
 /// button (`DashboardView.navBar`) to return home — the macOS-native place for it — so the footer

--- a/Tests/OpenUsageTests/PanelOutsideClickPolicyTests.swift
+++ b/Tests/OpenUsageTests/PanelOutsideClickPolicyTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import OpenUsage
+
+final class PanelOutsideClickPolicyTests: XCTestCase {
+    func testNormalOutsideClickDismisses() {
+        XCTAssertFalse(PanelOutsideClickPolicy.shouldKeepOpen(.init()))
+    }
+
+    func testEveryKeepOpenReasonKeepsPanelOpen() {
+        let contexts: [PanelOutsideClickContext] = [
+            .init(isMorphing: true),
+            .init(hasAttachedSheet: true),
+            .init(isOnStatusButton: true),
+            .init(isPanelWindow: true),
+            .init(isStatusItemWindow: true),
+            .init(eventWindowTypeName: "NSMenuWindow"),
+        ]
+
+        for context in contexts {
+            XCTAssertTrue(PanelOutsideClickPolicy.shouldKeepOpen(context))
+        }
+    }
+
+    func testInsidePanelKeepsOpenWithoutAnEventWindow() {
+        XCTAssertTrue(PanelOutsideClickPolicy.shouldKeepOpen(.init(isInsidePanel: true)))
+    }
+
+    func testInsidePanelStillKeepsOpenWhenAnotherReasonAlsoApplies() {
+        XCTAssertTrue(PanelOutsideClickPolicy.shouldKeepOpen(.init(isMorphing: true, isInsidePanel: true)))
+    }
+
+    func testMenuWindowMatchIsCaseInsensitive() {
+        XCTAssertTrue(
+            PanelOutsideClickPolicy.shouldKeepOpen(.init(eventWindowTypeName: "privateMENUwindow"))
+        )
+    }
+
+    func testUnrelatedWindowDismisses() {
+        XCTAssertFalse(PanelOutsideClickPolicy.shouldKeepOpen(.init(eventWindowTypeName: "NSWindow")))
+    }
+}


### PR DESCRIPTION
## TL;DR

Moves click-away listening and its keep-open rules into one small helper. The menu-bar controller now only starts and stops that helper when the panel opens and closes.

## What was happening

- The main menu-bar controller directly owned both mouse listeners and every exception to click-away closing.
- That made the controller harder to read and made the close rules difficult to test on their own.

## What this changes

- Gives the two mouse listeners one clear owner.
- Keeps the existing behavior for clicks inside the panel, on the status icon, in menus, on alerts, and while the panel is resizing.
- Adds direct tests for every keep-open reason and for a normal outside click.
- Updates one old comment that named the previous method.

## Tests

- `swift test --filter PanelOutsideClickPolicyTests`
- `swift test` — 943 passed, 3 skipped
- `./script/build_and_run.sh verify`

## Heads-up

This PR is stacked on the panel-height cleanup so each refactor stays small. It should be retargeted to `main` after that PR lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with preserved dismissal rules and new unit tests on the policy; no new user-facing flows, only re-homed event monitoring.
> 
> **Overview**
> **Extracts** menu-bar panel click-away logic out of `StatusItemController` into `PanelOutsideClickMonitor`, which owns local/global `NSEvent` monitors and delegates keep-vs-dismiss decisions to `PanelOutsideClickPolicy` via `PanelOutsideClickContext`.
> 
> The controller now only wires the monitor on show/hide (`start` / `stop`) with callbacks for morph state, clearing stray focus on in-panel clicks, and `hidePanel` on true outside clicks. **Behavior is intended to be unchanged**: same exceptions for morphing, attached sheets, status button hits, in-panel clicks, panel/status windows, and `NSMenu`-backed windows.
> 
> Adds **`PanelOutsideClickPolicyTests`** covering each keep-open reason, inside-panel without window context, case-insensitive menu window matching, and plain outside dismiss. Updates a **`HeaderView`** doc comment to reference the new policy name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6a3e3e12fe2fb1c7e0eceb098f1683ec1bac3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->