### PR TITLE
Use the correct panel height on first open

### DIFF
--- a/Sources/OpenUsage/App/PanelHeightController.swift
+++ b/Sources/OpenUsage/App/PanelHeightController.swift
@@ -38,15 +38,14 @@ final class PanelHeightController {
         }
     }
 
-    /// Invalidates height frames left over from the previous open before SwiftUI lays out this one.
-    func beginOpening() {
+    /// Clears the previous session, captures the display, and opens at the remembered guess. This must
+    /// happen before SwiftUI sees the popover as shown, because that signal immediately asks the clamp
+    /// hook for this display's real maximum height.
+    func prepareForOpening(below buttonRect: NSRect) {
         morphSettleTask?.cancel()
         isMorphing = false
         PanelHeightBridge.invalidate()
-    }
 
-    /// Captures the display and top-left anchor, then opens at the remembered height for this screen.
-    func positionForOpening(below buttonRect: NSRect) {
         let screen = NSScreen.screens.first { $0.frame.intersects(buttonRect) } ?? NSScreen.main
         anchorScreen = screen
         let topLeft = PanelGeometry.clampedTopLeft(

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -304,12 +304,15 @@ final class StatusItemController: NSObject {
             AppLog.error(.statusItem, "Cannot show panel: status item has no button")
             return
         }
+        // Drop height frames left over from the previous open before changing the visibility signal.
+        // That signal makes SwiftUI immediately queue this open's measured height; invalidating after
+        // it would discard the correct per-display target and leave the panel at its remembered guess.
+        heightController.beginOpening()
         // Mark the popover on-screen before laying out, so the egg's animation loops mount their
         // `TimelineView` clocks in time for the first displayed frame. Read by the SwiftUI egg via
         // `\.popoverIsVisible`; a closed popover keeps the loops unmounted, so a left-on egg costs no CPU.
         container.transparency.setPopoverShown(true)
 
-        heightController.beginOpening()
         // Lay the content out first so the panel opens at the right size (no first-frame flash).
         hostingController.view.layoutSubtreeIfNeeded()
 

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -304,10 +304,11 @@ final class StatusItemController: NSObject {
             AppLog.error(.statusItem, "Cannot show panel: status item has no button")
             return
         }
-        // Drop height frames left over from the previous open before changing the visibility signal.
-        // That signal makes SwiftUI immediately queue this open's measured height; invalidating after
-        // it would discard the correct per-display target and leave the panel at its remembered guess.
-        heightController.beginOpening()
+        let buttonRectOnScreen = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
+        // Record the display before changing the visibility signal. That signal makes SwiftUI
+        // immediately clamp the measured height; without the display anchor the clamp falls back to
+        // the fixed opening guess, making large and small displays open at the same height.
+        heightController.prepareForOpening(below: buttonRectOnScreen)
         // Mark the popover on-screen before laying out, so the egg's animation loops mount their
         // `TimelineView` clocks in time for the first displayed frame. Read by the SwiftUI egg via
         // `\.popoverIsVisible`; a closed popover keeps the loops unmounted, so a left-on egg costs no CPU.
@@ -315,9 +316,6 @@ final class StatusItemController: NSObject {
 
         // Lay the content out first so the panel opens at the right size (no first-frame flash).
         hostingController.view.layoutSubtreeIfNeeded()
-
-        let buttonRectOnScreen = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
-        heightController.positionForOpening(below: buttonRectOnScreen)
 
         // `canBecomeKey` + `.nonactivatingPanel` makes this key without activating the app — no
         // activation race, so the dashboard receives keys on the first try.

--- a/Tests/OpenUsageTests/PanelHeightBridgeTests.swift
+++ b/Tests/OpenUsageTests/PanelHeightBridgeTests.swift
@@ -44,6 +44,25 @@ final class PanelHeightBridgeTests: XCTestCase {
         await fulfillment(of: [droppedApply], timeout: 0.05)
     }
 
+    func testOpeningAcceptsNewHeightAfterDroppingPreviousSession() async {
+        resetBridge()
+        defer { resetBridge() }
+
+        var applied: [CGFloat] = []
+        let openingApply = expectation(description: "applies this opening's height")
+        MenuBarPopover.applyHeight = { height in
+            applied.append(height)
+            openingApply.fulfill()
+        }
+
+        PanelHeightBridge.push(480) // queued by the previous session
+        PanelHeightBridge.invalidate()
+        PanelHeightBridge.push(760) // measured for the display being opened on now
+
+        await fulfillment(of: [openingApply], timeout: 1)
+        XCTAssertEqual(applied, [760])
+    }
+
     func testEffectValuePushesEstablishedHeight() async {
         resetBridge()
         defer { resetBridge() }


### PR DESCRIPTION
## TL;DR

Fixes the popover opening at the same height on different displays. The app now identifies the current display before calculating the opening height.

## What was happening

- The app began laying out the popover before recording which display it was opening on.
- Without a display, the height calculation used the same fixed fallback on every screen.
- Changing a metric later appeared to fix it because the display had been recorded by then.

## What this changes

- Clears measurements left over from the previous opening.
- Records the current display before the popover becomes visible and starts layout.
- Uses the remembered height only as a quick starting point, then applies the correct display-aware height.
- Keeps the existing height limits and sizing rules unchanged.
- Includes a regression test for accepting the new opening height after discarding stale work.

## Tests

- `swift test --filter PanelHeightBridgeTests` — 4 passed
- `swift test --filter PanelGeometryTests` — 5 passed
- `./script/build_and_run.sh verify`
- Manually confirmed on the built-in MacBook display and a larger external display: open, close, and reopen now use the correct height without toggling any metrics.

## Screenshots

No design change. Manual visual verification confirmed the intended display-aware height on both tested displays.
