### PR TITLE
feat(pricing): Grok 4.5, Kimi K2.7 Code, Claude 4.7 Opus aliases

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -50,6 +50,26 @@
       "cache_read_per_million": 0.5,
       "output_per_million": 30.0
     },
+    "grok-4.5": {
+      "$comment": "Cursor + SpaceXAI first-party model. Cache write not published separately; defaults to input.",
+      "input_per_million": 2.0,
+      "cache_write_per_million": 2.0,
+      "cache_read_per_million": 0.5,
+      "output_per_million": 6.0
+    },
+    "grok-4.5-fast": {
+      "input_per_million": 4.0,
+      "cache_write_per_million": 4.0,
+      "cache_read_per_million": 1.0,
+      "output_per_million": 18.0
+    },
+    "kimi-k2.7-code": {
+      "$comment": "Cursor's published Kimi K2.7 Code rates. Public catalogs disagree (some bare keys are $0), so this override wins.",
+      "input_per_million": 0.95,
+      "cache_write_per_million": 0.95,
+      "cache_read_per_million": 0.19,
+      "output_per_million": 4.0
+    },
     "claude-opus-4-7-fast": {
       "$comment": "Cursor bills Opus 4.7 fast mode at these rates; the models.dev entry carries higher (stale) numbers, so this override wins.",
       "input_per_million": 30.0,
@@ -115,6 +135,10 @@
     { "pattern": "^composer-2\\.5$", "canonical": "composer-2.5" },
     { "pattern": "^composer-2\\.5-fast$", "canonical": "composer-2.5-fast" },
     { "pattern": "^github_bugbot$", "canonical": "github_bugbot" },
+    { "pattern": "^grok-4\\.5(?:-(?:low|medium|high))?-fast$", "canonical": "grok-4.5-fast" },
+    { "pattern": "^grok-4\\.5(?:-(?:low|medium|high))?$", "canonical": "grok-4.5" },
+    { "pattern": "^kimi-k2\\.7(?:-code)?$", "canonical": "kimi-k2.7-code" },
+    { "pattern": "^kimi-k2p7(?:-code)?$", "canonical": "kimi-k2.7-code" },
     { "pattern": "^claude-4\\.5-haiku(?:-thinking)?$", "canonical": "claude-haiku-4-5" },
     { "pattern": "^claude-4\\.5-opus-(?:low|medium|high)(?:-thinking)?$", "canonical": "claude-opus-4-5" },
     { "pattern": "^claude-4-sonnet-1m(?:-thinking)?$", "canonical": "claude-4-sonnet-1m" },
@@ -123,6 +147,8 @@
     { "pattern": "^claude-4\\.6-sonnet(?:-(?:low|medium|high|xhigh|max))?(?:-thinking)?$", "canonical": "claude-sonnet-4-6" },
     { "pattern": "^claude-4\\.6-opus-(?:low|medium|high|max)(?:-thinking)?-fast$", "canonical": "claude-opus-4-6-fast" },
     { "pattern": "^claude-4\\.6-opus-(?:low|medium|high|max)(?:-thinking)?$", "canonical": "claude-opus-4-6" },
+    { "pattern": "^claude-4\\.7-opus-(?:low|medium|high|max)(?:-thinking)?-fast$", "canonical": "claude-opus-4-7-fast" },
+    { "pattern": "^claude-4\\.7-opus-(?:low|medium|high|max)(?:-thinking)?$", "canonical": "claude-opus-4-7" },
     { "pattern": "^claude-opus-4-7(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-opus-4-7-fast" },
     { "pattern": "^claude-opus-4-7(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-4-7" },
     { "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-opus-4-8-fast" },

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -48,7 +48,13 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "gpt-5.6-luna")?.inputPerMillion, 1)
         XCTAssertEqual(pricing.resolve(model: "gpt-5.6-luna-fast")?.inputPerMillion, 2.5)
         XCTAssertEqual(pricing.resolve(model: "grok-4-20-thinking")?.inputPerMillion, 2)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5")?.inputPerMillion, 2)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-high-fast")?.inputPerMillion, 4)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2p5")?.inputPerMillion, 0.6)
+        XCTAssertEqual(pricing.resolve(model: "kimi-k2.7-code")?.inputPerMillion, 0.95)
+        XCTAssertEqual(pricing.resolve(model: "kimi-k2p7")?.inputPerMillion, 0.95)
+        XCTAssertEqual(pricing.resolve(model: "claude-4.7-opus-high-thinking")?.inputPerMillion, 5)
+        XCTAssertEqual(pricing.resolve(model: "claude-4.7-opus-max-thinking-fast")?.inputPerMillion, 30)
         XCTAssertEqual(pricing.resolve(model: "glm-5.2-max")?.inputPerMillion, 1.4)
         XCTAssertEqual(pricing.resolve(model: "github_bugbot")?.outputPerMillion, 30)
         XCTAssertEqual(pricing.resolve(model: "Premium (GPT-5.3-Codex)")?.inputPerMillion, 1.75)
@@ -165,6 +171,39 @@ final class PricingBundledResourceTests: XCTestCase {
         let pricing = Self.pricing
         XCTAssertEqual(pricing.resolve(model: "grok-build")?.inputPerMillion, 1)
         XCTAssertEqual(pricing.resolve(model: "grok-composer-2.5-fast")?.inputPerMillion, 3)
+    }
+
+    /// Grok 4.5 (Cursor + SpaceXAI first-party): standard and fast rates from Cursor docs, with
+    /// effort slugs collapsing to the same entries.
+    func testGrok45PricingAndAliases() throws {
+        let pricing = Self.pricing
+        let standard = try XCTUnwrap(pricing.resolve(model: "grok-4.5-high"))
+        XCTAssertEqual(standard.inputPerMillion, 2.0)
+        XCTAssertEqual(standard.cacheWritePerMillion, 2.0)
+        XCTAssertEqual(standard.cacheReadPerMillion, 0.5)
+        XCTAssertEqual(standard.outputPerMillion, 6.0)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5"), standard)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-low"), standard)
+
+        let fast = try XCTUnwrap(pricing.resolve(model: "grok-4.5-fast"))
+        XCTAssertEqual(fast.inputPerMillion, 4.0)
+        XCTAssertEqual(fast.cacheWritePerMillion, 4.0)
+        XCTAssertEqual(fast.cacheReadPerMillion, 1.0)
+        XCTAssertEqual(fast.outputPerMillion, 18.0)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-medium-fast"), fast)
+    }
+
+    /// Kimi K2.7 Code: Cursor's published rates override messy public-catalog entries.
+    func testKimiK27CodePricingAndAliases() throws {
+        let pricing = Self.pricing
+        let kimi = try XCTUnwrap(pricing.resolve(model: "kimi-k2.7-code"))
+        XCTAssertEqual(kimi.inputPerMillion, 0.95)
+        XCTAssertEqual(kimi.cacheWritePerMillion, 0.95)
+        XCTAssertEqual(kimi.cacheReadPerMillion, 0.19)
+        XCTAssertEqual(kimi.outputPerMillion, 4.0)
+        XCTAssertEqual(pricing.resolve(model: "kimi-k2.7"), kimi)
+        XCTAssertEqual(pricing.resolve(model: "kimi-k2p7"), kimi)
+        XCTAssertEqual(pricing.resolve(model: "kimi-k2p7-code"), kimi)
     }
 
     func testCostSumsAllBucketsAndUnpricedIsNil() throws {


### PR DESCRIPTION
## TL;DR
Syncs the pricing supplement with Cursor’s current models & pricing docs: Grok 4.5 (standard + fast), Kimi K2.7 Code, and Claude 4.7 Opus CSV-style aliases.

## What was happening
- Grok 4.5 is on Cursor’s first-party pool with published token rates, but the supplement had no entry, so usage would stay unpriced.
- Kimi K2.7 Code appears in Cursor’s API pricing table; public catalogs disagree (some bare keys are $0), so CSV slugs could resolve to the wrong dollars or nothing useful.
- Claude 4.7 Opus is listed, but only `claude-opus-4-7-*` aliases existed — not the `claude-4.7-opus-*` CSV shape used for 4.6.

## What this changes
Source: [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md) (+ [Grok 4.5](https://cursor.com/docs/models/grok-4-5.md) / [available models help](https://cursor.com/help/models-and-usage/available-models.md)).

**Pricing entries**
- `grok-4.5`: $2 / $2 / $0.50 / $6 (input / cache write / cache read / output per 1M)
- `grok-4.5-fast`: $4 / $4 / $1 / $18
- `kimi-k2.7-code`: $0.95 / $0.95 / $0.19 / $4 (Cursor table; cache write defaults to input)

**Alias rules**
- `grok-4.5` / `grok-4.5-{low,medium,high}` → `grok-4.5` (fast variants before base)
- `kimi-k2.7`, `kimi-k2.7-code`, `kimi-k2p7`, `kimi-k2p7-code` → `kimi-k2.7-code`
- `claude-4.7-opus-{low,medium,high,max}(-thinking)(-fast)?` → Opus 4.7 / fast override

Existing Composer / Auto / Bugbot / GPT-5.6 / Opus fast overrides unchanged. `updated_at` already `2026-07-08`.

## Tests
- Supplement JSON validation (CI-equivalent script)
- `swift test --filter "ModelPricing|PricingBundledResource"` — 46 tests, 0 failures


Made with [Cursor](https://cursor.com)