### PR TITLE
fix(pricing): match Cursor's grok-4.5-fast-high slug order

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -135,6 +135,7 @@
     { "pattern": "^composer-2\\.5$", "canonical": "composer-2.5" },
     { "pattern": "^composer-2\\.5-fast$", "canonical": "composer-2.5-fast" },
     { "pattern": "^github_bugbot$", "canonical": "github_bugbot" },
+    { "pattern": "^grok-4\\.5-fast(?:-(?:low|medium|high))?$", "canonical": "grok-4.5-fast" },
     { "pattern": "^grok-4\\.5(?:-(?:low|medium|high))?-fast$", "canonical": "grok-4.5-fast" },
     { "pattern": "^grok-4\\.5(?:-(?:low|medium|high))?$", "canonical": "grok-4.5" },
     { "pattern": "^kimi-k2\\.7(?:-code)?$", "canonical": "kimi-k2.7-code" },

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -49,6 +49,7 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "gpt-5.6-luna-fast")?.inputPerMillion, 2.5)
         XCTAssertEqual(pricing.resolve(model: "grok-4-20-thinking")?.inputPerMillion, 2)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5")?.inputPerMillion, 2)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-high")?.inputPerMillion, 4)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-high-fast")?.inputPerMillion, 4)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2p5")?.inputPerMillion, 0.6)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2.7-code")?.inputPerMillion, 0.95)
@@ -190,6 +191,9 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(fast.cacheWritePerMillion, 4.0)
         XCTAssertEqual(fast.cacheReadPerMillion, 1.0)
         XCTAssertEqual(fast.outputPerMillion, 18.0)
+        // Cursor CSV uses fast-before-effort (`grok-4.5-fast-high`); also accept effort-before-fast.
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-high"), fast)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-medium"), fast)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-medium-fast"), fast)
     }
 


### PR DESCRIPTION
## TL;DR
Prices Cursor’s real Grok 4.5 fast slug `grok-4.5-fast-high` (fast before effort), which the previous alias missed.

## What was happening
- After #907, OpenUsage still warned **Unknown model found — grok-4.5-fast-high**.
- The alias only matched `grok-4.5-{effort}-fast`, not Cursor’s `grok-4.5-fast-{effort}` order.

## What this changes
- Adds `^grok-4\\.5-fast(?:-(?:low|medium|high))?$` → `grok-4.5-fast` (before the effort-then-fast rule).
- Keeps the previous effort-then-fast pattern for safety.
- Regression coverage for `grok-4.5-fast-high` / `grok-4.5-fast-medium`.

## Tests
- `swift test --filter PricingBundledResourceTests/testGrok45|testKnownCursor|testEveryAlias`


Made with [Cursor](https://cursor.com)