### PR TITLE
chore(pricing): refresh price lists hourly instead of daily

### DIFF
--- a/.agents/skills/pricing-update/SKILL.md
+++ b/.agents/skills/pricing-update/SKILL.md
@@ -5,7 +5,7 @@ description: Sync OpenUsage's pricing supplement with Cursor's published model p
 
 # Pricing Update
 
-`Sources/OpenUsage/Resources/pricing_supplement.json` prices the models no public catalog carries (Cursor-native models like `auto`, `composer-*`, `github_bugbot`), supplies fast-variant multipliers, and maps provider log/CSV slugs to canonical pricing keys. On merge to `main`, `.github/workflows/pricing-supplement.yml` validates it and publishes it to GitHub Pages; installed apps pick it up within ~a day — no release needed. Full background: `docs/pricing.md`.
+`Sources/OpenUsage/Resources/pricing_supplement.json` prices the models no public catalog carries (Cursor-native models like `auto`, `composer-*`, `github_bugbot`), supplies fast-variant multipliers, and maps provider log/CSV slugs to canonical pricing keys. On merge to `main`, `.github/workflows/pricing-supplement.yml` validates it and publishes it to GitHub Pages; installed apps pick it up within about an hour — no release needed. Full background: `docs/pricing.md`.
 
 Only the supplement needs manual care. Normal API models (new Claude/GPT/Gemini/Grok releases) are priced automatically by the daily LiteLLM and models.dev fetches — do not add them to the supplement unless they need an alias rule or the catalogs are wrong.
 

--- a/Sources/OpenUsage/Pricing/ModelPricingStore.swift
+++ b/Sources/OpenUsage/Pricing/ModelPricingStore.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 /// Owns the app's model pricing data: bundled snapshots for offline first launch, on-disk caches in
-/// Application Support, and daily refreshes from the live feeds (LiteLLM, models.dev, and the
+/// Application Support, and hourly refreshes from the live feeds (LiteLLM, models.dev, and the
 /// OpenUsage pricing supplement on gh-pages). `current()` never blocks on the network — it serves
 /// the freshest data on hand and revalidates in the background (stale-while-revalidate).
 actor ModelPricingStore {
     static let shared = ModelPricingStore()
 
     /// Refetch a source this long after its last success.
-    private static let refreshInterval: TimeInterval = 24 * 60 * 60
+    private static let refreshInterval: TimeInterval = 60 * 60
     /// Retry a failed source after this long (keeps failure logs from repeating every provider pass).
     private static let failureRetryInterval: TimeInterval = 30 * 60
 

--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within a day - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
+  "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
   "updated_at": "2026-07-08",
   "pricing": {
     "auto": {

--- a/Tests/OpenUsageTests/ModelPricingStoreTests.swift
+++ b/Tests/OpenUsageTests/ModelPricingStoreTests.swift
@@ -112,7 +112,7 @@ final class ModelPricingStoreTests: XCTestCase {
         let (store, _) = makeStore(handler: { Self.respond(to: $0) })
         await store.refreshNow()
 
-        let later = Date().addingTimeInterval(25 * 60 * 60)
+        let later = Date().addingTimeInterval(2 * 60 * 60)
         let (aged, http) = makeStore(
             handler: { request in
                 XCTAssertEqual(request.headers["If-None-Match"], "\"v1\"")
@@ -131,7 +131,7 @@ final class ModelPricingStoreTests: XCTestCase {
         let (store, _) = makeStore(handler: { Self.respond(to: $0) })
         await store.refreshNow()
 
-        let later = Date().addingTimeInterval(25 * 60 * 60)
+        let later = Date().addingTimeInterval(2 * 60 * 60)
         let (aged, _) = makeStore(handler: { _ in
             HTTPResponse(statusCode: 500, headers: [:], body: Data())
         }, now: { later })
@@ -145,7 +145,7 @@ final class ModelPricingStoreTests: XCTestCase {
         let (store, _) = makeStore(handler: { Self.respond(to: $0) })
         await store.refreshNow()
 
-        let later = Date().addingTimeInterval(25 * 60 * 60)
+        let later = Date().addingTimeInterval(2 * 60 * 60)
         let (aged, _) = makeStore(handler: { _ in
             HTTPResponse(statusCode: 200, headers: [:], body: Data("not json".utf8))
         }, now: { later })

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -10,9 +10,9 @@ Prices are layered from three sources; when the same model appears in more than 
 2. **LiteLLM** — the community-maintained `model_prices_and_context_window.json`, covering the vast majority of API-priced models.
 3. **models.dev** — a gap-filler for models LiteLLM misses (e.g. some brand-new or niche models).
 
-The app ships with bundled snapshots of all three, so pricing works offline and on first launch. At runtime each source is refetched about once a day (with ETag revalidation) and cached in `~/Library/Application Support/OpenUsage/pricing/`. A refresh never blocks a usage scan — scans always price against the freshest data already on hand.
+The app ships with bundled snapshots of all three, so pricing works offline and on first launch. At runtime each source is refetched about once an hour (with ETag revalidation) and cached in `~/Library/Application Support/OpenUsage/pricing/`. A refresh never blocks a usage scan — scans always price against the freshest data already on hand.
 
-Because the supplement is published to GitHub Pages on merge, a pricing correction reaches installed apps within a day — no app update needed.
+Because the supplement is published to GitHub Pages on merge, a pricing correction reaches installed apps within about an hour — no app update needed.
 
 ## How a model name resolves
 
@@ -30,5 +30,5 @@ The pricing refresh fetches three public price lists (from `raw.githubuserconten
 
 ## Maintainer notes
 
-- **Supplement changes** (new Cursor-native model, price correction, new alias): edit `Sources/OpenUsage/Resources/pricing_supplement.json`, sync entries from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md), and update `updated_at`. On merge to `main`, `.github/workflows/pricing-supplement.yml` publishes it to gh-pages; installed apps pick it up within a day. The bundled copy ships with the next release for first launches. The **pricing-update skill** (`.agents/skills/pricing-update/`) walks an agent through the whole sync: pull the Cursor page, diff, edit, validate, and open a PR.
+- **Supplement changes** (new Cursor-native model, price correction, new alias): edit `Sources/OpenUsage/Resources/pricing_supplement.json`, sync entries from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md), and update `updated_at`. On merge to `main`, `.github/workflows/pricing-supplement.yml` publishes it to gh-pages; installed apps pick it up within about an hour. The bundled copy ships with the next release for first launches. The **pricing-update skill** (`.agents/skills/pricing-update/`) walks an agent through the whole sync: pull the Cursor page, diff, edit, validate, and open a PR.
 - **Bundled snapshots** (`pricing_litellm_snapshot.json`, `pricing_models_dev_snapshot.json`): regenerate occasionally (e.g. before a release) with `script/update_pricing_snapshots.sh`. Staleness is harmless — runtime fetches override them.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -22,7 +22,7 @@ It also reports **crashes**, so we can find and fix the bugs that make the app q
 
 ## Other network requests
 
-Besides the provider API calls the vendor's own tools would make, OpenUsage fetches public [model price lists](pricing.md) about once a day (from `raw.githubusercontent.com`, `models.dev`, and this project's GitHub Pages). These are plain downloads of public data — they carry no usage, log, or account information, and they run regardless of the Share Anonymous Usage setting. The spend tiles are computed from local CLI logs entirely on your Mac; no log data ever leaves it.
+Besides the provider API calls the vendor's own tools would make, OpenUsage fetches public [model price lists](pricing.md) about once an hour (from `raw.githubusercontent.com`, `models.dev`, and this project's GitHub Pages). These are plain downloads of public data — they carry no usage, log, or account information, and they run regardless of the Share Anonymous Usage setting. The spend tiles are computed from local CLI logs entirely on your Mac; no log data ever leaves it.
 
 ## How it works
 


### PR DESCRIPTION
## TL;DR
Pricing feeds (LiteLLM, models.dev, and the OpenUsage supplement) now refetch about once an hour instead of once a day.

## What was happening
- After a pricing supplement merge, installed apps could keep a stale cache for up to 24 hours.
- That left unknown-model warnings up long after GitHub Pages already had the fix.

## What this changes
- `ModelPricingStore.refreshInterval`: 24h → 1h (ETag revalidation and 30-minute failure backoff unchanged).
- Docs, privacy note, pricing-update skill, and supplement `$comment` updated to match.
- Store tests advance the clock by 2 hours past the new TTL.

## Tests
- `swift test --filter ModelPricingStoreTests` — 7 tests, 0 failures


Made with [Cursor](https://cursor.com)