### PR TITLE
Keep local credential files private

### DIFF
--- a/Sources/OpenUsage/Services/SystemClients.swift
+++ b/Sources/OpenUsage/Services/SystemClients.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 protocol EnvironmentReading: Sendable {
@@ -26,6 +27,11 @@ protocol TextFileAccessing: Sendable {
 }
 
 struct LocalTextFileAccessor: TextFileAccessing {
+    /// Credential and token files must never be readable by another local account. Write through a
+    /// private temporary file in the destination directory, flush it, then rename it over the target:
+    /// the final replacement is atomic and has mode 0600 from the moment it becomes addressable.
+    private static let privateFileMode = mode_t(S_IRUSR | S_IWUSR)
+
     func exists(_ path: String) -> Bool {
         FileManager.default.fileExists(atPath: expandHome(path))
     }
@@ -38,13 +44,73 @@ struct LocalTextFileAccessor: TextFileAccessing {
         let expanded = expandHome(path)
         let parent = URL(fileURLWithPath: expanded).deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
-        try text.write(toFile: expanded, atomically: true, encoding: .utf8)
+
+        let destination = URL(fileURLWithPath: expanded)
+        let temporary = parent.appendingPathComponent(
+            ".\(destination.lastPathComponent).\(UUID().uuidString).tmp"
+        )
+        let descriptor = temporary.path.withCString {
+            Darwin.open($0, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW, Self.privateFileMode)
+        }
+        guard descriptor >= 0 else { throw Self.currentPOSIXError() }
+
+        var descriptorIsOpen = true
+        var temporaryExists = true
+        defer {
+            if descriptorIsOpen { _ = Darwin.close(descriptor) }
+            if temporaryExists {
+                temporary.path.withCString { _ = Darwin.unlink($0) }
+            }
+        }
+
+        // A process umask may only remove permissions at creation. Reassert the exact private mode on
+        // the still-unpublished inode before writing or renaming it into place.
+        guard Darwin.fchmod(descriptor, Self.privateFileMode) == 0 else {
+            throw Self.currentPOSIXError()
+        }
+        try Self.writeAll(Data(text.utf8), to: descriptor)
+        guard Darwin.fsync(descriptor) == 0 else { throw Self.currentPOSIXError() }
+        let closeResult = Darwin.close(descriptor)
+        descriptorIsOpen = false
+        guard closeResult == 0 else { throw Self.currentPOSIXError() }
+
+        let renameResult = temporary.path.withCString { source in
+            expanded.withCString { destination in
+                Darwin.rename(source, destination)
+            }
+        }
+        guard renameResult == 0 else { throw Self.currentPOSIXError() }
+        temporaryExists = false
     }
 
     func remove(_ path: String) throws {
         let expanded = expandHome(path)
         guard FileManager.default.fileExists(atPath: expanded) else { return }
         try FileManager.default.removeItem(atPath: expanded)
+    }
+
+    private static func writeAll(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var offset = 0
+            while offset < buffer.count {
+                let result = Darwin.write(
+                    descriptor,
+                    baseAddress.advanced(by: offset),
+                    buffer.count - offset
+                )
+                if result < 0 {
+                    if errno == EINTR { continue }
+                    throw currentPOSIXError()
+                }
+                guard result > 0 else { throw POSIXError(.EIO) }
+                offset += result
+            }
+        }
+    }
+
+    private static func currentPOSIXError() -> POSIXError {
+        POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
     }
 }
 
@@ -220,4 +286,3 @@ func expandHome(_ path: String) -> String {
     if path == "~" { return home }
     return home + String(path.dropFirst())
 }
-

--- a/Tests/OpenUsageTests/LocalTextFileAccessorTests.swift
+++ b/Tests/OpenUsageTests/LocalTextFileAccessorTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import XCTest
+@testable import OpenUsage
+
+/// Real-filesystem coverage for the credential writer. Every test stays inside a unique temporary
+/// directory and verifies both data integrity and the POSIX boundary that protects local secrets.
+final class LocalTextFileAccessorTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.LocalTextFileAccessor.\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryDirectory,
+           FileManager.default.fileExists(atPath: temporaryDirectory.path)
+        {
+            try FileManager.default.removeItem(at: temporaryDirectory)
+        }
+    }
+
+    func testFreshCredentialFileIsOwnerReadWriteOnly() throws {
+        let file = temporaryDirectory
+            .appendingPathComponent("nested", isDirectory: true)
+            .appendingPathComponent("credentials.json")
+
+        try LocalTextFileAccessor().writeText(file.path, #"{"token":"s3cr3t"}"#)
+
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), #"{"token":"s3cr3t"}"#)
+        XCTAssertEqual(try permissions(of: file), 0o600)
+        XCTAssertEqual(try siblingNames(of: file), ["credentials.json"])
+    }
+
+    func testOverwriteTightensExistingPermissiveFile() throws {
+        let file = temporaryDirectory.appendingPathComponent("api-key")
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        try "old-key".write(to: file, atomically: false, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
+        XCTAssertEqual(try permissions(of: file), 0o644)
+
+        try LocalTextFileAccessor().writeText(file.path, "new-key")
+
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), "new-key")
+        XCTAssertEqual(try permissions(of: file), 0o600)
+        XCTAssertEqual(try siblingNames(of: file), ["api-key"])
+    }
+
+    func testFailedReplacementRemovesPrivateTemporaryFile() throws {
+        let destinationDirectory = temporaryDirectory.appendingPathComponent("credential", isDirectory: true)
+        try FileManager.default.createDirectory(at: destinationDirectory, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try LocalTextFileAccessor().writeText(destinationDirectory.path, "secret"))
+
+        XCTAssertEqual(try siblingNames(of: destinationDirectory), ["credential"])
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destinationDirectory.path, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    private func permissions(of file: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+        return try XCTUnwrap(attributes[.posixPermissions] as? NSNumber).intValue & 0o777
+    }
+
+    private func siblingNames(of file: URL) throws -> [String] {
+        try FileManager.default.contentsOfDirectory(atPath: file.deletingLastPathComponent().path).sorted()
+    }
+}

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -20,6 +20,12 @@ It also reports **crashes**, so we can find and fix the bugs that make the app q
 - No error **messages** or file paths — only coarse error categories as counts.
 - Nothing while the toggle is off.
 
+## Credentials stored on this Mac
+
+OpenUsage primarily reads credentials that provider tools already keep on your Mac. When it writes a
+user-supplied API key or saves a refreshed credential, the file is replaced atomically and restricted to
+your macOS account (owner read and write only).
+
 ## Other network requests
 
 Besides the provider API calls the vendor's own tools would make, OpenUsage fetches public [model price lists](pricing.md) about once a day (from `raw.githubusercontent.com`, `models.dev`, and this project's GitHub Pages). These are plain downloads of public data — they carry no usage, log, or account information, and they run regardless of the Share Anonymous Usage setting. The spend tiles are computed from local CLI logs entirely on your Mac; no log data ever leaves it.


### PR DESCRIPTION
## TL;DR

OpenUsage now writes API keys and refreshed credentials through an atomic owner-only file replacement, preventing fresh secret files from inheriting world-readable default permissions.

## What was happening

- `LocalTextFileAccessor` relied on the default atomic string writer.
- On a normal `022` umask, a newly created credential file could be mode `0644`, readable by other local accounts.
- Existing private files often stayed private, which hid the fresh-install case.

## What this changes

- Creates a unique temporary file in the destination directory with owner read/write permissions only.
- Flushes and atomically renames the private inode into place, so the published file is never exposed with permissive permissions.
- Tightens an existing permissive credential file to `0600` on the next write.
- Cleans up the temporary file if publication fails.
- Documents how locally written credentials are protected.

## Heads-up

- This deliberately standardizes files written through `LocalTextFileAccessor` to `0600`; it does not change parent-directory permissions or provider-owned files that OpenUsage only reads.

## Tests

- `swift test --filter LocalTextFileAccessorTests`
- `swift test` — 965 XCTest tests passed, 3 skipped; 3 Swift Testing tests passed
- `./script/build_and_run.sh verify` — release build, signing, launch, and process verification passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared path used when persisting API keys and refreshed credentials; behavior is more correct for secrets but any POSIX edge-case regression could break credential saves.
> 
> **Overview**
> **`LocalTextFileAccessor.writeText`** no longer uses Foundation’s atomic string writer, which could create new credential files as **0644** under a typical umask. Writes now go through a **private temp file** in the destination directory (**`O_CREAT | O_EXCL`**, mode **0600**), **`fchmod`**, full write + **`fsync`**, then **`rename`** over the target so the published file is atomic and owner read/write only; overwrites also tighten an existing permissive file to **0600**. Failed publishes unlink the temp file via **`defer`**.
> 
> Adds **`LocalTextFileAccessorTests`** (permissions, overwrite tightening, cleanup on failed rename) and a **`docs/privacy.md`** note that locally written API keys/refreshed credentials are replaced atomically and restricted to the current macOS account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906d94fc7b0c27f69668dd11d0caa9952408b133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->