### PR TITLE
Encode OAuth refresh form values correctly

### DIFF
--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityUsageClient.swift
@@ -100,9 +100,9 @@ struct AntigravityUsageClient: Sendable {
     func refreshGoogleToken(_ refreshToken: String) async -> TokenRefreshOutcome {
         guard let url = URL(string: Self.googleOAuthURL) else { return .unavailable }
         let form = [
-            "client_id=\(Self.formEncoded(Self.googleClientID))",
-            "client_secret=\(Self.formEncoded(Self.googleClientSecret))",
-            "refresh_token=\(Self.formEncoded(refreshToken))",
+            "client_id=\(Self.googleClientID.urlFormEncoded)",
+            "client_secret=\(Self.googleClientSecret.urlFormEncoded)",
+            "refresh_token=\(refreshToken.urlFormEncoded)",
             "grant_type=refresh_token"
         ].joined(separator: "&")
         let request = HTTPRequest(
@@ -128,11 +128,6 @@ struct AntigravityUsageClient: Sendable {
         default:
             return .unavailable // 5xx and anything else — transient
         }
-    }
-
-    private static func formEncoded(_ value: String) -> String {
-        // Conservative: refresh tokens contain `/`, so encode everything but alphanumerics.
-        value.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? value
     }
 }
 

--- a/Sources/OpenUsage/Support/ProviderParse.swift
+++ b/Sources/OpenUsage/Support/ProviderParse.swift
@@ -129,9 +129,22 @@ enum ProviderParse {
 }
 
 extension String {
-    /// Percent-encode for use as an `application/x-www-form-urlencoded` value.
+    /// Percent-encode one `application/x-www-form-urlencoded` value. Only the ASCII characters
+    /// RFC 3986 defines as unreserved pass through; spaces use `%20` so a literal `+` remains
+    /// distinguishable from a form-space separator.
     var urlFormEncoded: String {
-        addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? self
+        var encoded = ""
+        encoded.reserveCapacity(utf8.count)
+
+        for byte in utf8 {
+            switch byte {
+            case 0x41...0x5A, 0x61...0x7A, 0x30...0x39, 0x2D, 0x2E, 0x5F, 0x7E:
+                encoded.append(Character(UnicodeScalar(byte)))
+            default:
+                encoded.append(String(format: "%%%02X", byte))
+            }
+        }
+        return encoded
     }
 
     /// `nil` when the string is empty, otherwise the string itself — for treating "" as "missing".

--- a/Tests/OpenUsageTests/AntigravityProviderTests.swift
+++ b/Tests/OpenUsageTests/AntigravityProviderTests.swift
@@ -15,6 +15,28 @@ final class AntigravityProviderTests: XCTestCase {
         return resetsAt
     }
 
+    func testGoogleRefreshFormEncodesReservedCharactersInRequestBody() async throws {
+        let http = FakeHTTPClient(response: HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data(#"{"access_token":"new-token","expires_in":3600}"#.utf8)
+        ))
+        let client = AntigravityUsageClient(lsHTTP: http, http: http)
+
+        _ = await client.refreshGoogleToken("refresh token&=+/?%")
+
+        let request = try XCTUnwrap(http.requests.first)
+        XCTAssertEqual(request.method, "POST")
+        XCTAssertEqual(request.headers["Content-Type"], "application/x-www-form-urlencoded")
+        XCTAssertEqual(
+            String(data: try XCTUnwrap(request.body), encoding: .utf8),
+            "client_id=\(AntigravityUsageClient.googleClientID)" +
+                "&client_secret=\(AntigravityUsageClient.googleClientSecret)" +
+                "&refresh_token=refresh%20token%26%3D%2B%2F%3F%25" +
+                "&grant_type=refresh_token"
+        )
+    }
+
     // MARK: - Mapper: pooling
 
     func testBuildLinesPoolsAndOrders() {

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -646,6 +646,26 @@ final class CodexProviderTests: XCTestCase {
 }
 
 final class CodexUsageClientRefreshTests: XCTestCase {
+    func testRefreshFormEncodesReservedCharactersInRequestBody() async throws {
+        let http = FakeHTTPClient(response: HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data(#"{"access_token":"new-token"}"#.utf8)
+        ))
+        let client = CodexUsageClient(http: http)
+
+        _ = try await client.refreshToken("refresh token&=+/?%")
+
+        let request = try XCTUnwrap(http.requests.first)
+        XCTAssertEqual(request.method, "POST")
+        XCTAssertEqual(request.headers["Content-Type"], "application/x-www-form-urlencoded")
+        XCTAssertEqual(
+            String(data: try XCTUnwrap(request.body), encoding: .utf8),
+            "grant_type=refresh_token&client_id=app_EMoamEEZ73f0CkXaXp7hrann" +
+                "&refresh_token=refresh%20token%26%3D%2B%2F%3F%25"
+        )
+    }
+
     func testRefreshReportsRequestFailureForUnrecognizedErrorBody() async {
         // A 400 carrying a non-OAuth body (an HTML proxy/WAF page) must surface as a request failure,
         // not "Token expired. Run `codex` to log in again." — re-login can't fix a transport/infra error.

--- a/Tests/OpenUsageTests/GrokProviderTests.swift
+++ b/Tests/OpenUsageTests/GrokProviderTests.swift
@@ -3,6 +3,24 @@ import XCTest
 
 @MainActor
 final class GrokProviderTests: XCTestCase {
+    func testRefreshFormEncodesReservedCharactersInRequestBody() async throws {
+        let httpClient = RecordingHTTPClient { _ in
+            HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+        let client = GrokUsageClient(httpClient: httpClient)
+
+        _ = try await client.refreshToken("refresh token&=+/?%", clientID: "client id&=+/?%")
+
+        let request = try XCTUnwrap(httpClient.requests.first)
+        XCTAssertEqual(request.method, "POST")
+        XCTAssertEqual(request.headers["Content-Type"], "application/x-www-form-urlencoded")
+        XCTAssertEqual(
+            String(data: try XCTUnwrap(request.body), encoding: .utf8),
+            "grant_type=refresh_token&client_id=client%20id%26%3D%2B%2F%3F%25" +
+                "&refresh_token=refresh%20token%26%3D%2B%2F%3F%25"
+        )
+    }
+
     func testRefreshesExpiredTokenPersistsAuthAndFetchesUsage() async {
         let now = OpenUsageISO8601.date(from: "2026-02-02T00:00:00.000Z")!
         let files = FakeFiles([

--- a/Tests/OpenUsageTests/ProviderParseTests.swift
+++ b/Tests/OpenUsageTests/ProviderParseTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import OpenUsage
+
+final class ProviderParseTests: XCTestCase {
+    func testURLFormEncodingPreservesOnlyRFC3986UnreservedASCII() {
+        XCTAssertEqual("AZaz09-._~".urlFormEncoded, "AZaz09-._~")
+        XCTAssertEqual(
+            "space & equals= plus+ slash/ question? percent%".urlFormEncoded,
+            "space%20%26%20equals%3D%20plus%2B%20slash%2F%20question%3F%20percent%25"
+        )
+        XCTAssertEqual("café".urlFormEncoded, "caf%C3%A9")
+    }
+}


### PR DESCRIPTION
## TL;DR

OAuth refresh tokens and client identifiers are now encoded as true form values, so reserved characters cannot split or alter refresh requests. Antigravity, Codex, and Grok now share the same tested encoder.

## What was happening

- The shared form helper used `urlQueryAllowed`, which intentionally leaves query separators such as `&`, `=`, and `+` unescaped.
- A valid refresh token containing one of those characters could be parsed as additional fields or changed in transit.
- Antigravity carried a separate, stricter implementation instead of using the shared boundary helper.

## What this changes

- Encodes UTF-8 bytes while preserving only RFC 3986 unreserved ASCII characters.
- Uses `%20` for spaces and `%2B` for literal plus signs so the two remain distinct.
- Migrates Antigravity to the shared encoder and removes the duplicate implementation.
- Adds exact request-body regressions for Antigravity, Codex, and Grok, plus direct ASCII and Unicode encoder coverage.

## Heads-up

- This changes only token-refresh request serialization; provider auth selection and retry policy are unchanged.

## Tests

- Focused form/request tests — 4 passed
- `swift test` — 966 XCTest tests passed, 3 skipped; 3 Swift Testing tests passed
- `./script/build_and_run.sh verify` — release build, signing, launch, and process verification passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth refresh request serialization across multiple providers; incorrect encoding could break sign-in refresh, though scope is limited to form body building and is heavily regression-tested.
> 
> **Overview**
> OAuth token refresh bodies now serialize **client IDs, secrets, and refresh tokens** with a stricter shared `urlFormEncoded` helper so reserved characters (`&`, `=`, `+`, `/`, spaces, etc.) cannot be parsed as extra form fields or altered in transit.
> 
> The shared encoder no longer uses `urlQueryAllowed`; it percent-encodes UTF-8 bytes while leaving only **RFC 3986 unreserved ASCII** unescaped, uses **`%20` for spaces** and **`%2B` for literal plus signs**, and **Antigravity** drops its duplicate `formEncoded` in favor of this helper.
> 
> **Regression tests** assert exact `application/x-www-form-urlencoded` bodies for Antigravity, Codex, and Grok refresh calls, plus direct encoder coverage for ASCII and Unicode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4816fbfb297eb148b055cfd8bf21f20103367d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->