### PR TITLE
Enforce warning-free Swift builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Conventions for the per-provider modules under `Sources/OpenUsage/Providers/<Nam
 ## Running / Testing Changes
 
 - There is no hot reload. The app is a long-lived menu-bar process, so **every code change requires a full rebuild and restart of the running app** to take effect — kill the running instance, rebuild, and relaunch before testing.
+- Swift warnings are build and CI errors for both the app and test targets; keep every build warning-free.
 
 ## Pull Requests
 

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,8 @@ let package = Package(
                 .copy("Resources/pricing_models_dev_snapshot.json")
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error)
             ]
         ),
         .testTarget(
@@ -42,7 +43,8 @@ let package = Package(
             dependencies: ["OpenUsage"],
             path: "Tests/OpenUsageTests",
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error)
             ]
         )
     ]

--- a/Sources/OpenUsage/Models/RateLimitResetsPresentation.swift
+++ b/Sources/OpenUsage/Models/RateLimitResetsPresentation.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Pure presentation data for the rate-limit-resets popover. Keeping this outside the SwiftUI view
+/// makes the count/expiry state machine and timeline formatting independently testable and nonisolated.
+enum RateLimitResetsPresentation {
+    /// What the popover body renders after resolving the available count and expiry list.
+    enum Content: Equatable {
+        case timeline([Entry])
+        case unknownExpiries(count: Int)
+        case empty
+    }
+
+    /// One timeline node's display strings, derived from a credit's expiry instant.
+    struct Entry: Identifiable, Equatable {
+        let id: Int          // 0-based row index (soonest first)
+        let number: Int      // 1-based reset number, shown inside the dot
+        let severity: WidgetData.MeterSeverity
+        let time: String       // exact expiry, e.g. "Jul 12 at 5:30 PM"; "Expiring soon" when imminent
+        let countdown: String? // "12d 18h"; nil when imminent (no useful countdown to show)
+
+        var accessibilityLabel: String {
+            "Reset \(number), \(time)" + (countdown.map { ", expires in \($0)" } ?? "")
+        }
+    }
+
+    /// Empty `expiries` is ambiguous: a genuinely empty balance (`count == 0`) shows the empty state,
+    /// but a positive `count` with no expiries means the dedicated expiry fetch was unavailable and the
+    /// row fell back to the usage-body count — show that count rather than "no resets".
+    static func content(count: Int, expiries: [Date], now: Date = Date()) -> Content {
+        let entries = entries(from: expiries, now: now)
+        if !entries.isEmpty { return .timeline(entries) }
+        if count > 0 { return .unknownExpiries(count: count) }
+        return .empty
+    }
+
+    /// Build the timeline entries from raw expiry instants: sort soonest-first, number from 1, and pair
+    /// each exact expiry time with its countdown. A past-due or ≤5-minute expiry can't print a useful
+    /// exact time or countdown, so it reads "Expiring soon" with no trailing countdown. Imminence keys
+    /// off the *relative* window — `Formatters.whenLabel(.relative)` collapses to `soon` at ≤5 minutes,
+    /// while `.absolute` only collapses once past-due — so both formats agree instead of the exact time
+    /// printing a wall-clock while the countdown reads "soon".
+    static func entries(from expiries: [Date], now: Date = Date()) -> [Entry] {
+        expiries.sorted().enumerated().map { index, date in
+            let relative = Formatters.whenLabel(at: date, mode: .relative, now: now)
+            let absolute = Formatters.whenLabel(at: date, mode: .absolute, now: now)
+            let imminent = (relative == nil || relative == Formatters.imminent)
+            return Entry(
+                id: index,
+                number: index + 1,
+                severity: WidgetData.expirySeverity(secondsRemaining: date.timeIntervalSince(now)),
+                time: (imminent || absolute == nil) ? "Expiring soon" : absolute!,
+                countdown: imminent ? nil : relative
+            )
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -32,7 +32,7 @@ final class ClaudeProvider: ProviderRuntime {
         usageClient: ClaudeUsageClient = ClaudeUsageClient(),
         logUsageScanner: ClaudeLogUsageScanner = ClaudeLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -23,7 +23,7 @@ final class CodexProvider: ProviderRuntime {
         usageClient: CodexUsageClient = CodexUsageClient(),
         logUsageScanner: CodexLogUsageScanner = CodexLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient

--- a/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
@@ -175,9 +175,9 @@ enum CopilotUsageMapper {
         return dayOnlyFormatter.date(from: raw)
     }
 
-    /// `nonisolated(unsafe)` is sound: `DateFormatter` is documented thread-safe on macOS 10.9+, and the
-    /// formatter is never mutated after creation (same pattern as `CursorUsageCSV`/`OpenUsageISO8601`).
-    private nonisolated(unsafe) static let dayOnlyFormatter: DateFormatter = {
+    /// Foundation marks `DateFormatter` as sendable on supported macOS versions. This formatter is
+    /// configured once during initialization and never mutated afterward.
+    private static let dayOnlyFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -21,7 +21,7 @@ final class CursorProvider: ProviderRuntime {
         authStore: CursorAuthStore = CursorAuthStore(),
         usageClient: CursorUsageClient = CursorUsageClient(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -22,7 +22,7 @@ final class GrokProvider: ProviderRuntime {
         usageClient: GrokUsageClient = GrokUsageClient(),
         logUsageScanner: GrokLogUsageScanner = GrokLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -99,7 +99,7 @@ struct ProviderSnapshotCache {
         AppLog.debug(.cache, "write \(snapshot.providerID)")
         // Mark this provider as written *this session* so its snapshot now satisfies the freshness gate
         // (a launch-loaded snapshot never does — see `sessionWrites`).
-        sessionWrites.withLock { $0.insert(snapshot.providerID) }
+        _ = sessionWrites.withLock { $0.insert(snapshot.providerID) }
         var payload = loadPayload()
         payload.snapshots[snapshot.providerID] = snapshot
         save(payload)

--- a/Sources/OpenUsage/Views/RateLimitResetsDetail.swift
+++ b/Sources/OpenUsage/Views/RateLimitResetsDetail.swift
@@ -8,6 +8,8 @@ import SwiftUI
 /// are available it shows a centered empty state. Mirrors `ModelUsageDetail` / `UsageTrendDetail`'s
 /// calm — header + flat body — presented via `.popover`.
 struct RateLimitResetsDetail: View {
+    private typealias Entry = RateLimitResetsPresentation.Entry
+
     let title: String
     /// The row's "N available" count. Only used to disambiguate an empty `expiries` list: 0 → genuinely
     /// no credits (empty state); > 0 → credits we have but whose expiry times weren't fetched.
@@ -24,7 +26,7 @@ struct RateLimitResetsDetail: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             header
-            switch Self.content(count: count, expiries: expiries) {
+            switch RateLimitResetsPresentation.content(count: count, expiries: expiries) {
             case .timeline(let entries): timeline(entries)
             case .unknownExpiries(let count): unknownExpiriesState(count)
             case .empty: emptyState
@@ -149,56 +151,4 @@ struct RateLimitResetsDetail: View {
         .accessibilityLabel(entry.accessibilityLabel)
     }
 
-    /// What the body renders, resolved once from the count and expiry list so the "empty vs. count-only
-    /// vs. timeline" choice is unit-testable and can't drift between the view and its tests.
-    enum Content: Equatable {
-        case timeline([Entry])
-        case unknownExpiries(count: Int)
-        case empty
-    }
-
-    /// Empty `expiries` is ambiguous: a genuinely empty balance (`count == 0`) shows the empty state,
-    /// but a positive `count` with no expiries means the dedicated expiry fetch was unavailable and the
-    /// row fell back to the usage-body count — show that count rather than "no resets".
-    static func content(count: Int, expiries: [Date], now: Date = Date()) -> Content {
-        let entries = entries(from: expiries, now: now)
-        if !entries.isEmpty { return .timeline(entries) }
-        if count > 0 { return .unknownExpiries(count: count) }
-        return .empty
-    }
-
-    /// One timeline node's display strings, derived from a credit's expiry instant. Pure and static so
-    /// the phrasing is unit-testable without a view.
-    struct Entry: Identifiable, Equatable {
-        let id: Int          // 0-based row index (soonest first)
-        let number: Int      // 1-based reset number, shown inside the dot
-        let severity: WidgetData.MeterSeverity
-        let time: String       // exact expiry, e.g. "Jul 12 at 5:30 PM"; "Expiring soon" when imminent
-        let countdown: String? // "12d 18h"; nil when imminent (no useful countdown to show)
-
-        var accessibilityLabel: String {
-            "Reset \(number), \(time)" + (countdown.map { ", expires in \($0)" } ?? "")
-        }
-    }
-
-    /// Build the timeline entries from raw expiry instants: sort soonest-first, number from 1, and pair
-    /// each exact expiry time with its countdown. A past-due or ≤5-minute expiry can't print a useful
-    /// exact time or countdown, so it reads "Expiring soon" with no trailing countdown. Imminence keys
-    /// off the *relative* window — `Formatters.whenLabel(.relative)` collapses to `soon` at ≤5 minutes,
-    /// while `.absolute` only collapses once past-due — so both formats agree instead of the exact time
-    /// printing a wall-clock while the countdown reads "soon".
-    static func entries(from expiries: [Date], now: Date = Date()) -> [Entry] {
-        expiries.sorted().enumerated().map { index, date in
-            let relative = Formatters.whenLabel(at: date, mode: .relative, now: now)
-            let absolute = Formatters.whenLabel(at: date, mode: .absolute, now: now)
-            let imminent = (relative == nil || relative == Formatters.imminent)
-            return Entry(
-                id: index,
-                number: index + 1,
-                severity: WidgetData.expirySeverity(secondsRemaining: date.timeIntervalSince(now)),
-                time: (imminent || absolute == nil) ? "Expiring soon" : absolute!,
-                countdown: imminent ? nil : relative
-            )
-        }
-    }
 }

--- a/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
+++ b/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
@@ -1,3 +1,4 @@
+import os
 import XCTest
 @testable import OpenUsage
 
@@ -35,13 +36,13 @@ final class LoginShellEnvironmentTests: XCTestCase {
         let runner = RecordingRunner(stdout: [begin, "OPENROUTER_API_KEY=sk-or-test", end].joined(separator: "\0"))
         let env = LoginShellEnvironment(runner: runner)
         let captured = expectation(description: "captured off-main")
-        var value: String?
+        let value = OSAllocatedUnfairLock<String?>(initialState: nil)
         DispatchQueue.global().async {
-            value = env.value(for: "OPENROUTER_API_KEY")
+            value.withLock { $0 = env.value(for: "OPENROUTER_API_KEY") }
             captured.fulfill()
         }
         wait(for: [captured], timeout: 5)
-        XCTAssertEqual(value, "sk-or-test")
+        XCTAssertEqual(value.withLock { $0 }, "sk-or-test")
         XCTAssertEqual(runner.callCount, 1)
     }
 

--- a/Tests/OpenUsageTests/ResetDisplayTests.swift
+++ b/Tests/OpenUsageTests/ResetDisplayTests.swift
@@ -186,7 +186,7 @@ final class ResetDisplayTests: XCTestCase {
         // The popover timeline sorts the credits soonest-first, numbers them from 1, and pairs each
         // exact expiry time with its countdown. Per-credit dot color reuses the row's severity bands.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let entries = RateLimitResetsDetail.entries(
+        let entries = RateLimitResetsPresentation.entries(
             from: [
                 // Deliberately out of order to prove the sort.
                 now.addingTimeInterval(12 * 24 * 3600 + 18 * 3600),          // ~12d18h -> blue
@@ -207,7 +207,7 @@ final class ResetDisplayTests: XCTestCase {
         // wall-clock time or countdown, so it collapses to "Expiring soon" with no trailing countdown —
         // matching Formatters.imminent. Its dot stays red.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let entries = RateLimitResetsDetail.entries(from: [now.addingTimeInterval(-60)], now: now)
+        let entries = RateLimitResetsPresentation.entries(from: [now.addingTimeInterval(-60)], now: now)
 
         XCTAssertEqual(entries.count, 1)
         XCTAssertEqual(entries[0].time, "Expiring soon")
@@ -220,7 +220,7 @@ final class ResetDisplayTests: XCTestCase {
         // exact time must not print a wall-clock while the countdown vanishes — both collapse to
         // "Expiring soon" with no countdown.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let entries = RateLimitResetsDetail.entries(from: [now.addingTimeInterval(180)], now: now)
+        let entries = RateLimitResetsPresentation.entries(from: [now.addingTimeInterval(180)], now: now)
 
         XCTAssertEqual(entries.count, 1)
         XCTAssertEqual(entries[0].time, "Expiring soon")
@@ -228,7 +228,7 @@ final class ResetDisplayTests: XCTestCase {
     }
 
     func testResetsPopoverEmptyWhenNoCredits() {
-        XCTAssertTrue(RateLimitResetsDetail.entries(from: [], now: Date()).isEmpty)
+        XCTAssertTrue(RateLimitResetsPresentation.entries(from: [], now: Date()).isEmpty)
     }
 
     func testCompactDurationAlwaysShowsHoursAtDayScale() {
@@ -245,18 +245,18 @@ final class ResetDisplayTests: XCTestCase {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
 
         // Zero credits -> the genuine empty state.
-        XCTAssertEqual(RateLimitResetsDetail.content(count: 0, expiries: [], now: now), .empty)
+        XCTAssertEqual(RateLimitResetsPresentation.content(count: 0, expiries: [], now: now), .empty)
 
         // Credits present but no expiry list (dedicated fetch unavailable -> usage-body count fallback):
         // must NOT read "no resets"; it states the count instead.
         XCTAssertEqual(
-            RateLimitResetsDetail.content(count: 3, expiries: [], now: now),
+            RateLimitResetsPresentation.content(count: 3, expiries: [], now: now),
             .unknownExpiries(count: 3)
         )
 
         // Expiries present -> the timeline.
         let expiries = [now.addingTimeInterval(4 * 24 * 3600)]
-        guard case .timeline(let entries) = RateLimitResetsDetail.content(count: 1, expiries: expiries, now: now) else {
+        guard case .timeline(let entries) = RateLimitResetsPresentation.content(count: 1, expiries: expiries, now: now) else {
             return XCTFail("expected timeline")
         }
         XCTAssertEqual(entries.count, 1)


### PR DESCRIPTION
## TL;DR

The app and test targets now treat every Swift warning as an error. All existing warnings are resolved, including actor-isolated reset presentation logic that has been moved out of the SwiftUI view into a pure model.

## What was happening

- SwiftPM builds completed with recurring compiler warnings in provider defaults, cache bookkeeping, a shared formatter, and concurrency-sensitive tests.
- Reset formatting lived inside a SwiftUI `View`, which implicitly isolated otherwise pure helpers to the main actor.
- Nothing prevented a new warning from accumulating unnoticed.

## What this changes

- Enables `.treatAllWarnings(as: .error)` for both the OpenUsage executable and test target.
- Documents the warning-free build and CI policy in `AGENTS.md`.
- Removes redundant pricing-closure awaits and the obsolete unsafe formatter annotation.
- Explicitly discards the cache set-insertion result.
- Makes the login-shell concurrency test synchronize its captured result.
- Extracts `RateLimitResetsPresentation` as a Foundation-only, independently tested model and keeps the view render-only.

## Heads-up

- This intentionally makes future warnings CI-blocking. Dependency targets are not changed by the package target settings.
- The reset-presentation extraction has no intended visual or copy change.

## Tests

- Focused warning and reset tests — 24 passed
- `swift test` — 962 XCTest tests passed, 3 skipped; 3 Swift Testing tests passed
- `swift build` — passed with warnings treated as errors
- `./script/build_and_run.sh verify` — warning-free release build, signing, launch, and process verification passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly build policy and warning fixes plus a refactor with existing tests; behavior should be unchanged aside from stricter future builds.
> 
> **Overview**
> **Swift warnings are now CI-blocking** for both the OpenUsage app and test targets via `.treatAllWarnings(as: .error)` in `Package.swift`, with `AGENTS.md` updated to match.
> 
> **Compiler hygiene:** default provider pricing closures drop redundant `await` on synchronous `ModelPricingStore.current()`; `CopilotUsageMapper` drops `nonisolated(unsafe)` on its static `DateFormatter`; `ProviderSnapshotCache` explicitly discards the set-insert result; and the login-shell off-main-thread test uses `OSAllocatedUnfairLock` instead of capturing a mutable `var` across concurrency boundaries.
> 
> **Rate-limit resets popover:** timeline formatting and the empty / count-only / timeline state machine move from `RateLimitResetsDetail` into **`RateLimitResetsPresentation`** (Foundation-only, independently unit-tested); the SwiftUI view only renders. No intended UI or copy change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ee7effa94304d716db06e1b7524051d7165b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->