### PR TITLE
Fix Codex authentication fallback and refresh errors

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
@@ -71,11 +71,14 @@ enum CodexAuthError: Error, LocalizedError, Equatable {
         }
     }
 
+    /// Whether this error invalidates only the current credential candidate. The provider retains the
+    /// last fallback error, so an API-key-only setup still ends with `usageAPIKey`; it just no longer
+    /// prevents a later OAuth file or keychain candidate from being tried.
     var allowsAuthFallback: Bool {
         switch self {
-        case .sessionExpired, .tokenConflict, .tokenRevoked, .tokenExpired:
+        case .sessionExpired, .tokenConflict, .tokenRevoked, .tokenExpired, .usageAPIKey:
             return true
-        case .notLoggedIn, .usageAPIKey, .invalidAuthPayload:
+        case .notLoggedIn, .invalidAuthPayload:
             return false
         }
     }
@@ -217,4 +220,3 @@ private extension CodexAuthState.Source {
         return false
     }
 }
-

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -170,7 +170,13 @@ final class CodexProvider: ProviderRuntime {
                     return try await self.refreshAccessToken(authState: &working, refreshToken: refreshToken)
                 } catch let error as CodexAuthError {
                     throw error
+                } catch let error as CodexUsageError {
+                    // The token endpoint returned a categorized HTTP/decode failure. Preserve it so
+                    // the user-facing error and telemetry don't misreport every refresh failure as a
+                    // transport outage.
+                    throw error
                 } catch {
+                    // URLSession transport failures are untyped at this boundary.
                     throw CodexUsageError.connectionFailed
                 }
             },

--- a/Tests/OpenUsageTests/CodexAuthenticationTests.swift
+++ b/Tests/OpenUsageTests/CodexAuthenticationTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import OpenUsage
+
+final class CodexAuthCandidateTests: XCTestCase {
+    func testDefaultAuthFilesPreserveAPIKeyThenOAuthFallbackOrder() {
+        let store = CodexAuthStore(
+            environment: FakeEnvironment(),
+            files: FakeFiles([
+                "~/.config/codex/auth.json": #"{"OPENAI_API_KEY":"sk-api-only"}"#,
+                "~/.codex/auth.json": #"{"tokens":{"access_token":"oauth-token"}}"#
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        let candidates = store.loadAuthCandidates()
+
+        XCTAssertEqual(candidates.map(\.source), [
+            .file(path: "~/.config/codex/auth.json"),
+            .file(path: "~/.codex/auth.json")
+        ])
+        XCTAssertEqual(candidates.first?.auth.apiKey, "sk-api-only")
+        XCTAssertFalse(candidates.first?.hasUsableAccessToken == true)
+        XCTAssertEqual(candidates.last?.auth.tokens?.accessToken, "oauth-token")
+        XCTAssertTrue(candidates.last?.hasUsableAccessToken == true)
+    }
+}
+
+@MainActor
+final class CodexAuthenticationFallbackTests: XCTestCase {
+    func testAPIKeyOnlyFileFallsThroughToLaterOAuthFile() async {
+        let http = successfulHTTPClient()
+        let provider = makeProvider(
+            files: FakeFiles([
+                "~/.config/codex/auth.json": #"{"OPENAI_API_KEY":"sk-api-only"}"#,
+                "~/.codex/auth.json": #"{"tokens":{"access_token":"oauth-file-token"}}"#
+            ]),
+            keychain: FakeKeychain(),
+            http: http
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(usageAuthorizations(in: http), ["Bearer oauth-file-token"])
+    }
+
+    func testAPIKeyOnlyFileStillReturnsExistingGuidanceWhenNoOAuthCandidateExists() async {
+        let http = successfulHTTPClient()
+        let provider = makeProvider(
+            files: FakeFiles([
+                "~/.config/codex/auth.json": #"{"OPENAI_API_KEY":"sk-api-only"}"#
+            ]),
+            keychain: FakeKeychain(),
+            http: http
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notAvailable)
+        guard case .badge(_, let text, _, _) = snapshot.lines.first else {
+            return XCTFail("expected the API-key guidance badge")
+        }
+        XCTAssertEqual(text, "Usage not available for API key.")
+        XCTAssertTrue(http.requests.isEmpty)
+    }
+
+    func testAPIKeyOnlyFileFallsThroughToKeychainOAuth() async {
+        let http = successfulHTTPClient()
+        let provider = makeProvider(
+            files: FakeFiles([
+                "~/.config/codex/auth.json": #"{"OPENAI_API_KEY":"sk-api-only"}"#
+            ]),
+            keychain: FakeKeychain(#"{"tokens":{"access_token":"keychain-oauth-token"}}"#),
+            http: http
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(usageAuthorizations(in: http), ["Bearer keychain-oauth-token"])
+    }
+
+    func testUsageUnauthorizedThenRefresh503PreservesHTTP5xxCategory() async {
+        let http = RoutingHTTPClient { request in
+            switch request.url {
+            case CodexUsageClient.usageURL:
+                return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+            case CodexUsageClient.refreshURL:
+                return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            default:
+                return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+            }
+        }
+        let provider = makeProvider(
+            files: FakeFiles([
+                "~/.config/codex/auth.json":
+                    #"{"tokens":{"access_token":"stale-token","refresh_token":"refresh-token"}}"#
+            ]),
+            keychain: FakeKeychain(),
+            http: http
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .http5xx)
+        guard case .badge(_, let text, _, _) = snapshot.lines.first else {
+            return XCTFail("expected the refresh failure badge")
+        }
+        XCTAssertEqual(text, "Usage request failed (HTTP 503). Try again later.")
+        XCTAssertEqual(http.requests.map(\.url), [
+            CodexUsageClient.usageURL,
+            CodexUsageClient.refreshURL
+        ])
+    }
+
+    private func makeProvider(
+        files: FakeFiles,
+        keychain: FakeKeychain,
+        http: any HTTPClient
+    ) -> CodexProvider {
+        CodexProvider(
+            authStore: CodexAuthStore(
+                environment: FakeEnvironment(),
+                files: files,
+                keychain: keychain
+            ),
+            usageClient: CodexUsageClient(http: http),
+            logUsageScanner: CodexLogFixture.scanner(home: nil),
+            now: { Date(timeIntervalSince1970: 1_800_000_000) },
+            pricing: { TestPricing.bundled }
+        )
+    }
+
+    private func successfulHTTPClient() -> RoutingHTTPClient {
+        RoutingHTTPClient { _ in
+            HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8))
+        }
+    }
+
+    private func usageAuthorizations(in http: RoutingHTTPClient) -> [String?] {
+        http.requests
+            .filter { $0.url == CodexUsageClient.usageURL }
+            .map { $0.headers["Authorization"] }
+    }
+}

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -16,7 +16,7 @@ Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI
 
 ## Where credentials come from
 
-Sign in once with the Codex CLI (`codex`); OpenUsage reads the same auth files (`$CODEX_HOME` respected) with a keychain fallback. Tokens refresh automatically and rotate back into the auth file.
+Sign in once with the Codex CLI (`codex`); OpenUsage reads the same auth files (`$CODEX_HOME` respected) with a keychain fallback. When multiple standard auth files exist, an API-key-only file doesn't hide a later ChatGPT OAuth login. Tokens refresh automatically and rotate back into the auth file.
 
 ## The spend tiles
 
@@ -26,6 +26,9 @@ Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the C
 
 - **"Not logged in"** — run `codex` and sign in, then refresh.
 - **API-key-only setups** can't read subscription usage — sign in with your ChatGPT account instead.
+- **"Usage request failed" or "Usage response invalid"** — OpenUsage found your login, but a token
+  refresh or usage request hit a temporary network, server, or response problem. Retry first; unlike a
+  token-expired message, this does not mean the local login is missing.
 - **Spend tiles show "No data"** — OpenUsage found no Codex session logs in the last 30 days. If your Codex home lives somewhere custom, set `CODEX_HOME` so both the Codex CLI and OpenUsage look in the same place.
 
 ## Under the hood


### PR DESCRIPTION
## TL;DR

Codex now skips an API-key-only credential candidate when a later ChatGPT OAuth login is available, while preserving the existing API-key guidance when it is the only credential. Token-refresh HTTP/decode failures also retain their real category instead of being reported as generic connection failures.

## What was happening

- The standard Codex auth-file search could find an API-key-only file before a valid OAuth file or Keychain entry.
- `usageAPIKey` stopped candidate fallback, so the valid OAuth login was never tried.
- A usage 401 followed by a refresh 503 was converted to `connectionFailed`, losing its HTTP 5xx telemetry and user guidance.

## What this changes

- Treats `usageAPIKey` as candidate-local and continues through later file/Keychain candidates.
- Retains the last candidate error, so an API-key-only installation still reads “Usage not available for API key.”
- Preserves typed Codex token-refresh HTTP and decode failures; only unknown transport errors normalize to connection failure.
- Documents multiple-file fallback behavior.
- Adds a dedicated authentication regression suite for source order, file and Keychain fallback, API-only guidance, and 401→refresh-503 classification.

## Heads-up

- Credential source preference is unchanged; this only allows candidate-specific unusable auth to fall through.
- The separate form-encoding PR is independent and does not need to land first.

## Tests

- Focused Codex authentication tests — 8 passed
- `swift test` — 967 XCTest tests passed, 3 skipped; 3 Swift Testing tests passed
- `swift build`
- `./script/build_and_run.sh verify` — release build, signing, launch, and process verification passed
- `git diff --check`

## Screenshots

API-key-only credentials retain the existing user guidance while fallback can continue to later OAuth candidates.

![Codex API-key usage notice](https://gist.githubusercontent.com/robinebers/5d45266150cbbe876cc388c639ffa66e/raw/6186552a2673d2c3440306cf5dc69104938feb60/codex-api-key-usage-notice.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential selection and error mapping on the Codex usage/refresh path, which affects which login is used and how failures are shown, but scope is limited to Codex with regression tests.
> 
> **Overview**
> **Codex auth** now treats an API-key-only credential as a per-candidate failure so refresh can try later OAuth files or keychain entries, while still surfacing “Usage not available for API key.” when no OAuth login exists.
> 
> **Token refresh** during usage retry no longer maps categorized `CodexUsageError` responses (e.g. HTTP 503) to generic connection failures, so user-facing badges and error telemetry keep the real HTTP/decode category.
> 
> Adds regression tests for candidate order, API-key fallthrough, and 401→refresh-503 handling; updates Codex provider docs for multi-file auth and transient usage/refresh failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3489e13da4f742e282baea4824bd7ee7ca80f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->