### PR TITLE
Harden local usage API request and encoding failures

### DIFF
--- a/Sources/OpenUsage/Services/LocalUsageAPI.swift
+++ b/Sources/OpenUsage/Services/LocalUsageAPI.swift
@@ -20,12 +20,25 @@ enum LocalUsageAPI {
     }
 
     static func respond(method: String, path: String, state: State) -> Response {
+        respond(method: method, path: path, state: state) { value in
+            try JSONEncoder().encode(value)
+        }
+    }
+
+    /// Encoding seam used by tests to prove failures stay inside the HTTP error contract. Production
+    /// uses the overload above, which always supplies Foundation's `JSONEncoder`.
+    static func respond(
+        method: String,
+        path: String,
+        state: State,
+        encodeJSON: (any Encodable) throws -> Data
+    ) -> Response {
         // Preflight support: OPTIONS anywhere is 204 + the CORS headers the server always sends.
         if method == "OPTIONS" {
             return Response(status: 204, body: nil)
         }
 
-        let segments = path.split(separator: "?", maxSplits: 1)[0]
+        let segments = path.prefix { $0 != "?" }
             .split(separator: "/")
             .map(String.init)
 
@@ -33,14 +46,14 @@ enum LocalUsageAPI {
         case (2, "v1", "usage"):
             guard method == "GET" else { return error(405, "method_not_allowed") }
             let snapshots = state.enabledOrderedIDs.compactMap { state.snapshots[$0] }
-            return Response(status: 200, body: encode(snapshots.map(WireSnapshot.init)))
+            return encodedResponse(snapshots.map(WireSnapshot.init), using: encodeJSON)
 
         case (3, "v1", "usage"):
             guard method == "GET" else { return error(405, "method_not_allowed") }
             let providerID = segments[2]
             guard state.knownIDs.contains(providerID) else { return error(404, "provider_not_found") }
             guard let snapshot = state.snapshots[providerID] else { return Response(status: 204, body: nil) }
-            return Response(status: 200, body: encode(WireSnapshot(snapshot)))
+            return encodedResponse(WireSnapshot(snapshot), using: encodeJSON)
 
         default:
             return error(404, "not_found")
@@ -53,8 +66,16 @@ enum LocalUsageAPI {
         Response(status: status, body: Data(#"{"error":"\#(code)"}"#.utf8))
     }
 
-    private static func encode(_ value: some Encodable) -> Data {
-        (try? JSONEncoder().encode(value)) ?? Data("[]".utf8)
+    private static func encodedResponse(
+        _ value: some Encodable,
+        using encodeJSON: (any Encodable) throws -> Data
+    ) -> Response {
+        do {
+            return Response(status: 200, body: try encodeJSON(value))
+        } catch let encodingError {
+            AppLog.error(.localAPI, "response encoding failed: \(encodingError.localizedDescription)")
+            return error(500, "encoding_failed")
+        }
     }
 
     // MARK: - Wire types (the documented public shape, distinct from the internal cache Codable)

--- a/Sources/OpenUsage/Services/LocalUsageServer.swift
+++ b/Sources/OpenUsage/Services/LocalUsageServer.swift
@@ -122,6 +122,7 @@ final class LocalUsageServer {
         case 204: "No Content"
         case 404: "Not Found"
         case 405: "Method Not Allowed"
+        case 500: "Internal Server Error"
         case 503: "Service Unavailable"
         default: "OK"
         }

--- a/Tests/OpenUsageTests/LocalUsageAPITests.swift
+++ b/Tests/OpenUsageTests/LocalUsageAPITests.swift
@@ -106,6 +106,53 @@ final class LocalUsageAPITests: XCTestCase {
         XCTAssertEqual(unknownRoute.status, 404)
         XCTAssertEqual((try json(unknownRoute.body) as? [String: Any])?["error"] as? String, "not_found")
     }
+
+    func testEmptyAndQueryOnlyPathsReturnNotFound() throws {
+        for path in ["", "?", "?source=test", "/?source=test"] {
+            let response = LocalUsageAPI.respond(method: "GET", path: path, state: makeState())
+
+            XCTAssertEqual(response.status, 404, path)
+            XCTAssertEqual(
+                (try json(response.body) as? [String: Any])?["error"] as? String,
+                "not_found",
+                path
+            )
+        }
+    }
+
+    func testQueryStringDoesNotChangeKnownRoute() throws {
+        let response = LocalUsageAPI.respond(
+            method: "GET",
+            path: "/v1/usage/claude?source=test",
+            state: makeState()
+        )
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual((try json(response.body) as? [String: Any])?["providerId"] as? String, "claude")
+    }
+
+    func testEncodingFailuresReturnInternalServerErrorObject() throws {
+        enum IntentionalEncodingFailure: Error { case expected }
+        let failEncoding: (any Encodable) throws -> Data = { _ in
+            throw IntentionalEncodingFailure.expected
+        }
+
+        for path in ["/v1/usage", "/v1/usage/claude"] {
+            let response = LocalUsageAPI.respond(
+                method: "GET",
+                path: path,
+                state: makeState(),
+                encodeJSON: failEncoding
+            )
+
+            XCTAssertEqual(response.status, 500, path)
+            XCTAssertEqual(
+                (try json(response.body) as? [String: Any])?["error"] as? String,
+                "encoding_failed",
+                path
+            )
+        }
+    }
 }
 
 final class LocalUsageServerRequestLineTests: XCTestCase {
@@ -128,5 +175,16 @@ final class LocalUsageServerRequestLineTests: XCTestCase {
         let (method, path) = LocalUsageServer.parseRequestLine("GET\r\n")
         XCTAssertEqual(method, "GET")
         XCTAssertEqual(path, "/")
+    }
+
+    func testMalformedRequestLinesRouteToNotFoundWithoutCrashing() {
+        let state = LocalUsageAPI.State(enabledOrderedIDs: [], knownIDs: [], snapshots: [:])
+
+        for head in ["", "GET\r\n", "GET ? HTTP/1.1\r\n", "not-http\r\n"] {
+            let request = LocalUsageServer.parseRequestLine(head)
+            let response = LocalUsageAPI.respond(method: request.method, path: request.path, state: state)
+
+            XCTAssertEqual(response.status, 404, head)
+        }
     }
 }

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -24,7 +24,7 @@ Returns the latest snapshot for one provider. Works for disabled providers too.
 
 ### Everything else
 
-Methods other than `GET`/`OPTIONS` return **405**; unknown routes return **404**. When the server is already handling its maximum of 16 concurrent connections, requests get **503** — back off and retry.
+Known routes reject methods other than `GET` with **405**; unknown routes return **404**. `OPTIONS` returns **204** on every route. A response serialization failure returns **500** instead of serving an invalid success body. When the server is already handling its maximum of 16 concurrent connections, requests get **503** — back off and retry.
 
 ## Response shape
 
@@ -83,7 +83,7 @@ The in-app model breakdown shown when hovering spend rows is not included in thi
 { "error": "provider_not_found" }
 ```
 
-Codes: `provider_not_found`, `not_found`, `method_not_allowed`, `server_busy`.
+Codes: `provider_not_found`, `not_found`, `method_not_allowed`, `encoding_failed`, `server_busy`.
 
 ## CORS and privacy
 


### PR DESCRIPTION
## TL;DR

Malformed local HTTP paths can no longer crash route parsing, and JSON serialization failures now fail loudly with HTTP 500 instead of returning a schema-invalid `[]` under HTTP 200. Successful endpoint wire shapes remain unchanged.

## What was happening

- Route parsing indexed the first result of a split without checking whether empty or query-only paths produced any segment.
- Encoding used `try?` and substituted `[]` for every failure, including single-provider endpoints that promise an object.
- That hid the real error and violated the documented response schema.

## What this changes

- Strips query text with an empty-safe prefix operation and routes malformed, empty, and query-only paths to the normal 404 contract.
- Adds a narrow encoding seam so both collection and single-object failure paths are deterministic in tests.
- Logs serialization failures and returns `500 {"error":"encoding_failed"}`.
- Adds the proper 500 reason phrase to the server response builder.
- Documents 404, 405, OPTIONS, 500, and the new error code.

## Heads-up

- No successful local API payload or CORS behavior changes.
- The encoding seam is internal and exists only to exercise an otherwise difficult failure boundary.

## Tests

- Focused local API/request-line tests — 12 passed
- `swift test` — 966 XCTest tests passed, 3 skipped; 3 Swift Testing tests passed
- `swift build`
- `./script/build_and_run.sh verify` — release build, signing, launch, and process verification passed
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Loopback-only API with unchanged successful payloads; failure paths now return explicit 500 instead of invalid 200 bodies, which is a contract fix rather than a broad behavioral shift.
> 
> **Overview**
> The loopback usage API now handles **malformed and query-only paths** without unsafe splitting: query strings are stripped with an empty-safe prefix, so `""`, `?…`, and similar requests get a normal **404** `not_found` instead of risking bad routing.
> 
> **JSON serialization** no longer swallows errors with `try?` and a fake **`[]` under 200**. Failures are logged and returned as **500** with `{"error":"encoding_failed"}`. Production still uses `JSONEncoder`; an internal **`encodeJSON` overload** exists so tests can force encoding errors on both list and single-provider routes.
> 
> `LocalUsageServer` maps **500** to the correct reason phrase. Tests cover empty/query paths, query strings on known routes, encoding failures, and malformed request lines end-to-end. **`docs/local-http-api.md`** documents the **500** / `encoding_failed` behavior alongside existing status codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e273df42d12a4842d1415ecfcbdb13ed07744c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->