### PR TITLE
Refactor dead provider contracts and Cursor gates

### DIFF
--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -99,31 +99,25 @@ extension WidgetDescriptor {
     /// The three local-spend tiles every spend-tracking provider exposes — Today / Yesterday / Last 30
     /// Days — each a combined "cost · tokens" row, backed by `SpendTileMapper`. Ids are
     /// `<provider>.today|yesterday|last30`, so the set is identical across Claude / Codex / Cursor / Grok.
-    static func spendTiles(provider: Provider) -> [WidgetDescriptor] {
-        var descriptors: [WidgetDescriptor] = [
+    static func spendTiles(provider: Provider, valueTooltipNote: String? = nil) -> [WidgetDescriptor] {
+        let descriptors: [WidgetDescriptor] = [
             .combined(id: "\(provider.id).today", provider: provider, title: "Today", isUsagePeriod: true),
             .combined(id: "\(provider.id).yesterday", provider: provider, title: "Yesterday", isUsagePeriod: true),
             .combined(id: "\(provider.id).last30", provider: provider, title: "Last 30 Days", isUsagePeriod: true)
         ]
-        if provider.id == "cursor" {
-            descriptors = descriptors.map { descriptor in
-                var sample = descriptor.sample
-                sample.valueTooltipNote = WidgetData.cursorUsageHistoryNote
-                return WidgetDescriptor(
-                    id: descriptor.id,
-                    providerID: descriptor.providerID,
-                    metricLabel: descriptor.metricLabel,
-                    sample: sample,
-                    pinnable: descriptor.pinnable
-                )
-            }
-        }
         // Mark the whole set as the local spend tiles — the Total Spend card's capability and
         // contribution signal.
         return descriptors.map { descriptor in
-            var marked = descriptor
-            marked.isSpendTile = true
-            return marked
+            var sample = descriptor.sample
+            sample.valueTooltipNote = valueTooltipNote
+            return WidgetDescriptor(
+                id: descriptor.id,
+                providerID: descriptor.providerID,
+                metricLabel: descriptor.metricLabel,
+                sample: sample,
+                pinnable: descriptor.pinnable,
+                isSpendTile: true
+            )
         }
     }
 

--- a/Sources/OpenUsage/Providers/APIKeyManagement.swift
+++ b/Sources/OpenUsage/Providers/APIKeyManagement.swift
@@ -23,8 +23,8 @@ enum APIKeyStatus: Sendable, Equatable {
 /// A `ProviderRuntime` that needs a user-supplied API key (OpenRouter today; future user-key
 /// providers conform later). Settings ▸ API Keys lists conformers, renders each one's
 /// `apiKeyStatus`, and writes changes through `saveAPIKey` / `deleteAPIKey`. The provider delegates
-/// to its auth store, so the UI stays provider-agnostic and the storage path each provider already
-/// reads is the one the UI writes — no new storage infra.
+/// to its auth store, so the UI stays provider-agnostic and writes through the same storage layer
+/// that authentication already reads — no new storage infra.
 @MainActor
 protocol APIKeyManaging: ProviderRuntime {
     /// The live key status, computed from the environment + the saved config file.
@@ -38,8 +38,4 @@ protocol APIKeyManaging: ProviderRuntime {
     /// Remove the saved key. If an env key is present the status falls back to `fromEnvironment`;
     /// otherwise `notSet`.
     func deleteAPIKey() throws
-    /// User-facing description of where the key is stored, shown under the input ("Stored in …").
-    var apiKeyStorageDescription: String { get }
-    /// The env-var name checked, shown in the "Using OPENROUTER_API_KEY from your environment" line.
-    var apiKeyEnvironmentName: String { get }
 }

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -29,30 +29,20 @@ final class CursorProvider: ProviderRuntime {
         self.pricing = pricing
     }
 
-    /// Cursor's usage-events CSV export (the source for the spend tiles + usage trend) had lagged real
-    /// time by ~12h+ in June 2026, so spend tracking was disabled for a stretch (issue #758). It is back
-    /// on: the spend tiles (Today / Yesterday / Last 30 Days) and the token trend are imputed from the CSV
-    /// via `CursorUsageCSV`, the shared `ModelPricingStore`, and `CursorUsageMapper.appendSpendLines`,
-    /// and the `cursor.today/yesterday/last30/trend` descriptors surface in the layout again. Usage from
-    /// a model no pricing source knows is left out, and the affected period carries the model name for
-    /// the warning triangle (see `appendSpendLines`).
-    static let spendTrackingEnabled = true
-
     var widgetDescriptors: [WidgetDescriptor] {
-        var descriptors: [WidgetDescriptor] = [
+        [
             .percent(id: "cursor.usage", provider: provider, title: "Total Usage", metricLabel: "Total usage"),
             .percent(id: "cursor.auto", provider: provider, title: "Auto Usage", metricLabel: "Auto usage"),
             .percent(id: "cursor.api", provider: provider, title: "API Usage", metricLabel: "API usage"),
             .boundedDollars(id: "cursor.onDemand", provider: provider, title: "Extra Usage", metricLabel: "On-demand", limit: 100, valueWord: "spent"),
             .boundedCount(id: "cursor.requests", provider: provider, title: "Requests", limit: 500,
                           suffix: "requests", periodDurationMs: CursorUsageMapper.billingPeriodMs),
-            .dollarBalance(id: "cursor.credits", provider: provider, title: "Credits", valueWord: "left")
-        ]
-        if Self.spendTrackingEnabled {
-            descriptors.append(.usageTrend(provider: provider))
-            descriptors.append(contentsOf: WidgetDescriptor.spendTiles(provider: provider))
-        }
-        return descriptors
+            .dollarBalance(id: "cursor.credits", provider: provider, title: "Credits", valueWord: "left"),
+            .usageTrend(provider: provider)
+        ] + WidgetDescriptor.spendTiles(
+            provider: provider,
+            valueTooltipNote: WidgetData.cursorUsageHistoryNote
+        )
     }
 
     func hasLocalCredentials() async -> Bool {
@@ -141,16 +131,13 @@ final class CursorProvider: ProviderRuntime {
             creditGrants: creditGrants,
             stripeBalanceCents: stripeBalanceCents
         )
-        if Self.spendTrackingEnabled {
-            await appendSpendLines(to: &mapped.lines, accessToken: currentToken)
-        }
+        await appendSpendLines(to: &mapped.lines, accessToken: currentToken)
         return snapshot(mapped)
     }
 
     /// Strictly additive: fetch the usage CSV and append the three per-day spend tiles. Any failure
     /// (no session, non-2xx, or undecodable body) appends nothing, so the live Cursor mapping is never
-    /// affected and the spend tiles fall back to "No data". Gated on `spendTrackingEnabled` (see there
-    /// for the on/off history).
+    /// affected and the spend tiles fall back to "No data".
     private func appendSpendLines(to lines: inout [MetricLine], accessToken: String) async {
         let calendar = Calendar.current
         let end = now()

--- a/Sources/OpenUsage/Providers/OpenRouter/OpenRouterProvider.swift
+++ b/Sources/OpenUsage/Providers/OpenRouter/OpenRouterProvider.swift
@@ -108,10 +108,6 @@ extension OpenRouterProvider: APIKeyManaging {
     func currentAPIKey() -> String? { authStore.currentAPIKey() }
     func saveAPIKey(_ key: String) throws { try authStore.saveAPIKey(key) }
     func deleteAPIKey() throws { try authStore.deleteAPIKey() }
-    /// Where the in-app editor writes — the primary config file the auth store reads first.
-    var apiKeyStorageDescription: String { OpenRouterAuthStore.configPaths[0] }
-    /// The env var shown in the "Using OPENROUTER_API_KEY from your environment" line.
-    var apiKeyEnvironmentName: String { OpenRouterAuthStore.environmentNames[0] }
 }
 
 private enum EndpointResult {

--- a/Sources/OpenUsage/Providers/ZAI/ZAIProvider.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIProvider.swift
@@ -105,10 +105,6 @@ extension ZAIProvider: APIKeyManaging {
     func currentAPIKey() -> String? { authStore.currentAPIKey() }
     func saveAPIKey(_ key: String) throws { try authStore.saveAPIKey(key) }
     func deleteAPIKey() throws { try authStore.deleteAPIKey() }
-    /// Where the in-app editor writes — the primary config file the auth store reads first.
-    var apiKeyStorageDescription: String { ZAIAuthStore.configPaths[0] }
-    /// The env var shown in the "Using ZAI_API_KEY from your environment" line.
-    var apiKeyEnvironmentName: String { ZAIAuthStore.environmentNames[0] }
 }
 
 private enum QuotaResult {

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -281,13 +281,11 @@ final class CursorSpendRangeTests: XCTestCase {
 
 @MainActor
 final class CursorSpendProviderTests: XCTestCase {
-    func testSpendTrackingEnabledDownloadsCSVExposesSpendTilesAndFlagsUnknownModels() async {
-        // Spend tracking is back on (issue #758): the provider downloads the usage CSV, exposes the
-        // spend-tile + trend descriptors, and emits Today / Yesterday / Last 30 Days / Usage Trend lines
+    func testSpendTrackingDownloadsCSVExposesSpendTilesAndFlagsUnknownModels() async {
+        // The provider downloads the usage CSV, exposes the spend-tile + trend descriptors, and emits
+        // Today / Yesterday / Last 30 Days / Usage Trend lines
         // alongside the live quota meters. A row that used a model no pricing source can price carries
         // that model's name so the tile can warn its cost is incomplete.
-        XCTAssertTrue(CursorProvider.spendTrackingEnabled, "this regression guards the enabled state")
-
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let iso = ISO8601DateFormatter()
         let todayStr = iso.string(from: now)
@@ -336,7 +334,7 @@ final class CursorSpendProviderTests: XCTestCase {
         let snapshot = await provider.refresh()
 
         XCTAssertTrue(http.requests.contains { $0.url.absoluteString.contains("export-usage-events-csv") },
-                      "spend tracking is enabled — Cursor must download the usage CSV")
+                      "Cursor refresh must download the usage CSV for spend metrics")
         // Live quota meter survives; spend tiles + trend are present.
         XCTAssertTrue(snapshot.lines.contains { $0.label == "Total usage" })
         for label in ["Today", "Yesterday", "Last 30 Days", "Usage Trend"] {
@@ -360,9 +358,7 @@ final class CursorSpendProviderTests: XCTestCase {
 
     func testSpendTileRendersCombinedCostAndTokensWithValueTooltip() async {
         let cursor = CursorProvider()
-        // Spend tiles are gated off the live provider (issue #758), so source the descriptor from the
-        // shared factory — this keeps the combined "cost · tokens" render shape covered for re-enable.
-        let descriptor = try! XCTUnwrap(WidgetDescriptor.spendTiles(provider: cursor.provider).first { $0.id == "cursor.today" })
+        let descriptor = try! XCTUnwrap(cursor.widgetDescriptors.first { $0.id == "cursor.today" })
 
         // The combined tile joins the dollar and the labeled token count. The render shape for a zero
         // line is still "$0.00 · 0 tokens" — the mapper no longer produces these (an idle period is left
@@ -427,11 +423,9 @@ final class CursorSpendProviderTests: XCTestCase {
 // MARK: - Client request contract
 
 final class CursorUsageClientRequestTests: XCTestCase {
-    // The provider-level CSV integration tests were removed when spend tracking was disabled (issue
-    // #758), but `CursorUsageClient.fetchUsageCSV` is kept intact for re-enable. Pin its request contract
-    // directly at the client level — endpoint, epoch-ms range, `strategy=tokens`, the session cookie, and
-    // `Accept: text/csv` — so a silent regression in URL/header construction can't slip through while the
-    // feature is off (this test runs regardless of `CursorProvider.spendTrackingEnabled`).
+    // Pin the request contract directly at the client level — endpoint, epoch-ms range,
+    // `strategy=tokens`, the session cookie, and `Accept: text/csv` — so a silent regression in
+    // URL/header construction cannot slip through.
     func testFetchUsageCSVBuildsTokenStrategyRequestWithSessionCookie() async throws {
         let accessToken = makeCursorJWT(sub: "google-oauth2|user_abc123")
         let http = RoutingHTTPClient { _ in

--- a/Tests/OpenUsageTests/OpenRouterProviderTests.swift
+++ b/Tests/OpenUsageTests/OpenRouterProviderTests.swift
@@ -362,8 +362,6 @@ final class OpenRouterProviderTests: XCTestCase {
 
         XCTAssertEqual(provider.apiKeyStatus, .fromEnvironment)
         XCTAssertEqual(provider.currentAPIKey(), "sk-or-env")
-        XCTAssertEqual(provider.apiKeyEnvironmentName, "OPENROUTER_API_KEY")
-        XCTAssertTrue(provider.apiKeyStorageDescription.contains("openrouter.json"))
 
         try provider.saveAPIKey("sk-or-saved")
         XCTAssertEqual(provider.apiKeyStatus, .overrideActive)
@@ -382,4 +380,3 @@ private func jsonResponse(_ object: [String: Any]) -> HTTPResponse {
     let body = (try? JSONSerialization.data(withJSONObject: object)) ?? Data("{}".utf8)
     return HTTPResponse(statusCode: 200, headers: [:], body: body)
 }
-

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -554,8 +554,9 @@ final class WidgetDataStoreTests: XCTestCase {
     }
 
     func testCursorSpendValueTooltipUsesUsageHistorySourceNote() async {
-        let provider = Provider(id: "cursor", displayName: "Cursor", icon: .providerMark("cursor"))
-        let combined = WidgetDescriptor.spendTiles(provider: provider).first { $0.id == "cursor.last30" }!
+        let cursor = CursorProvider()
+        let provider = cursor.provider
+        let combined = cursor.widgetDescriptors.first { $0.id == "cursor.last30" }!
         let runtime = TestProviderRuntime(
             provider: provider,
             descriptors: [combined],

--- a/Tests/OpenUsageTests/ZAIProviderTests.swift
+++ b/Tests/OpenUsageTests/ZAIProviderTests.swift
@@ -496,8 +496,6 @@ final class ZAIProviderTests: XCTestCase {
 
         XCTAssertEqual(provider.apiKeyStatus, .fromEnvironment)
         XCTAssertEqual(provider.currentAPIKey(), "zai-env")
-        XCTAssertEqual(provider.apiKeyEnvironmentName, "ZAI_API_KEY")
-        XCTAssertTrue(provider.apiKeyStorageDescription.contains("zai.json"))
 
         try provider.saveAPIKey("zai-saved")
         XCTAssertEqual(provider.apiKeyStatus, .overrideActive)

--- a/docs/research/model-hover/02-data-and-architecture.md
+++ b/docs/research/model-hover/02-data-and-architecture.md
@@ -266,7 +266,7 @@ Pricing refresh cadence:
 Provider scanner computation:
 
 - Claude and Codex scanners are actors with per-file parse caches keyed by path, size, and mtime. Every refresh reuses unchanged parsed entries/events and reruns dedup + aggregation.
-- Cursor fetches the CSV on each provider refresh when spend tracking is enabled and parses rows in memory.
+- Cursor fetches the CSV on each provider refresh and parses rows in memory.
 - Grok reads and parses the single unified log on each refresh; there is no per-file parse cache today.
 
 Would a model breakdown require extra computation?
@@ -374,7 +374,7 @@ Popover and hover behavior:
 
 Performance:
 
-- Cursor CSV parse cost already exists on every Cursor refresh when spend tracking is enabled. Model grouping is cheap relative to network fetch and parse.
+- Cursor CSV parse cost already exists on every Cursor refresh. Model grouping is cheap relative to network fetch and parse.
 - Claude/Codex per-file parse caches keep repeated refreshes cheap; model grouping reruns over cached entries/events each refresh, like current day aggregation.
 - Grok scans a single append-only file without a parse cache. A model panel increases only aggregation state, not file reads, but large logs could make Grok the highest-risk provider.
 


### PR DESCRIPTION
## TL;DR

Removes unused API-key protocol requirements and the permanently enabled Cursor spend flag, while making the shared spend-tile factory provider-agnostic.

## What was happening

- `APIKeyManaging` required two storage-label properties that production code never read.
- Cursor spend metrics were wrapped in a constant-true feature flag, leaving dead branches and stale disabled-feature comments.
- The generic spend-tile factory identified Cursor by a hardcoded provider ID to inject a Cursor-only tooltip note.

## What this changes

- Removes the unused API-key protocol surface and implementations.
- Makes Cursor spend descriptors and CSV enrichment unconditional, matching current behavior.
- Passes optional tooltip context explicitly from `CursorProvider` into the generic factory.
- Updates regression tests and the model-hover architecture notes to describe the live path.

## Tests

- `swift test` — 962 XCTest cases passed, 3 expected skips; 3 Swift Testing cases passed.
- Focused Cursor spend, WidgetDataStore, OpenRouter, and Z.ai API-key tests passed.
- `./script/build_and_run.sh verify` — release build, signed staging, full restart passed.
- `git diff --check` passed.

No visual behavior changes; screenshots are not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and comment/test cleanup only; Cursor spend and API-key flows behave the same as before the always-true flag.
> 
> **Overview**
> Removes **unused `APIKeyManaging` requirements** (`apiKeyStorageDescription`, `apiKeyEnvironmentName`) and their OpenRouter/Z.ai implementations, leaving save/delete/status delegation unchanged.
> 
> **Cursor spend tracking** is no longer behind `spendTrackingEnabled` (always on): widget descriptors always include usage trend + spend tiles, and `refresh()` always enriches metrics via the usage CSV. The shared **`WidgetDescriptor.spendTiles`** factory takes an optional `valueTooltipNote` instead of special-casing `provider.id == "cursor"`; Cursor passes `WidgetData.cursorUsageHistoryNote` at the call site.
> 
> Tests and **model-hover architecture docs** are updated to match the unconditional live path (no flag assertions, descriptors sourced from `CursorProvider`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e941fa41af28abca7fb452904e4cac5330e73bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->