### PR TITLE
Reject malformed Z.ai quota responses

### DIFF
--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -204,6 +204,9 @@ extension ZAIUsageError: CategorizedError {
         case .connectionFailed: .network
         case .invalidResponse: .decoding
         case .requestFailed(let status): ErrorCategory.http(status)
+        // The associated value is an application-envelope code from a successful HTTP response, so
+        // don't misclassify it as an HTTP status in telemetry.
+        case .businessFailure: .other
         case .noCodingPlan: .notAvailable
         }
     }

--- a/Sources/OpenUsage/Providers/ZAI/ZAIProvider.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIProvider.swift
@@ -56,14 +56,12 @@ final class ZAIProvider: ProviderRuntime {
 
         switch quota {
         case .success(let body):
-            // A valid key whose account has no GLM Coding Plan gets a 2xx with `success:false`. Surface
-            // that as a clear provider warning (the header's amber notice) rather than three blank "No
-            // data" meters that don't explain why nothing's there.
-            if ZAIUsageMapper.isNoCodingPlan(body) {
-                return ProviderSnapshot.error(provider: provider, error: ZAIUsageError.noCodingPlan)
+            do {
+                let mapped = try ZAIUsageMapper.map(quotaBody: body, subscriptionBody: subscription)
+                return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
+            } catch {
+                return ProviderSnapshot.error(provider: provider, error: error)
             }
-            let mapped = ZAIUsageMapper.map(quotaBody: body, subscriptionBody: subscription)
-            return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
         case .authFailure:
             return ProviderSnapshot.error(provider: provider, error: ZAIAuthError.invalidKey)
         case .failed(let error):
@@ -72,7 +70,8 @@ final class ZAIProvider: ProviderRuntime {
     }
 
     /// Run the required quota call and classify the outcome: the body on 2xx, an auth failure on
-    /// 401/403, or a typed failure for any other non-2xx, transport error, or empty body.
+    /// 401/403, or a typed failure for any other non-2xx or transport error. The mapper validates the
+    /// successful response body so malformed 2xx payloads retain their decoding/business distinction.
     private func load(_ call: () async throws -> HTTPResponse) async -> QuotaResult {
         do {
             let response = try await call()

--- a/Sources/OpenUsage/Providers/ZAI/ZAIUsageClient.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIUsageClient.swift
@@ -38,6 +38,9 @@ enum ZAIUsageError: Error, LocalizedError, Equatable {
     case connectionFailed
     case invalidResponse
     case requestFailed(Int)
+    /// The HTTP request succeeded, but Z.ai's JSON envelope reported `success:false` for a reason
+    /// other than the known no-plan state. The optional code is the business-envelope code, not HTTP.
+    case businessFailure(code: Int?)
     /// The key is valid but the account has no GLM Coding Plan (the quota endpoint answers a 2xx with
     /// `success:false`). Distinct from a malformed/failed request — there is simply nothing to meter.
     case noCodingPlan
@@ -50,6 +53,11 @@ enum ZAIUsageError: Error, LocalizedError, Equatable {
             return ProviderUsageErrorText.invalidResponse
         case .requestFailed(let status):
             return ProviderUsageErrorText.requestFailed(statusCode: status)
+        case .businessFailure(let code):
+            if let code {
+                return "Z.ai usage request failed (code \(code)). Try again later."
+            }
+            return "Z.ai usage request failed. Try again later."
         case .noCodingPlan:
             return "No active GLM Coding Plan. Subscribe at z.ai/subscribe to see usage."
         }

--- a/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
@@ -19,31 +19,48 @@ enum ZAIUsageMapper {
     /// `(plan, lines)` from the quota + subscription payloads. `subscription` may be `nil` (the
     /// request is best-effort) and the quota's `limits` array may carry one to three entries — only
     /// what's present is mapped, so a plan without web searches still shows the session meter.
-    static func map(quotaBody: Data, subscriptionBody: Data?) -> (plan: String?, lines: [MetricLine]) {
+    static func map(quotaBody: Data, subscriptionBody: Data?) throws -> (plan: String?, lines: [MetricLine]) {
         let plan = subscriptionBody.flatMap { planName(from: $0) }
-        let lines = mapQuota(quotaBody)
+        let lines = try mapQuota(quotaBody)
         return (plan, lines)
     }
 
-    /// True when a 2xx quota body is the "valid key, but no GLM Coding Plan" signal: Z.ai answers
-    /// `{"success":false,"code":500,"msg":"…coding plan"}` with no `data`. The provider turns this into a
-    /// clear `.notAvailable` error (a header warning) instead of three blank "No data" meters that don't
-    /// say why. Matched on the structured `success:false` plus the "coding plan" phrase the message
-    /// carries (ASCII even in the localized string), so an unrelated business failure doesn't trip it.
-    static func isNoCodingPlan(_ body: Data) -> Bool {
-        guard let root = ProviderParse.jsonObject(body),
-              (root["success"] as? Bool) == false else { return false }
-        return ((root["msg"] as? String) ?? "").lowercased().contains("coding plan")
-    }
+    /// Session + weekly + web-search meters from the quota payload. Only an explicit, correctly-shaped
+    /// empty `limits` array means "No usage data"; malformed envelopes, business failures, and nonempty
+    /// arrays that cannot produce a valid meter are errors rather than silent empty-state fallbacks.
+    static func mapQuota(_ body: Data) throws -> [MetricLine] {
+        guard let root = ProviderParse.jsonObject(body) else {
+            throw ZAIUsageError.invalidResponse
+        }
 
-    /// Session + weekly + web-search meters from the quota payload. Emits the "No usage data"
-    /// placeholder when the payload carries no usable limits, matching the legacy plugin.
-    static func mapQuota(_ body: Data) -> [MetricLine] {
-        guard let root = ProviderParse.jsonObject(body) else { return [.noUsageData] }
+        if let successValue = root["success"] {
+            guard let success = jsonBoolean(successValue) else {
+                throw ZAIUsageError.invalidResponse
+            }
+            if !success {
+                if isNoCodingPlan(root) {
+                    throw ZAIUsageError.noCodingPlan
+                }
+                throw ZAIUsageError.businessFailure(code: businessCode(root))
+            }
+        }
+
         // The limits array lives under `data.limits`; the legacy plugin also tolerated the root object
         // being the container directly (no `data` wrapper), so honor both.
-        let container = root["data"] as? [String: Any] ?? root
-        guard let limits = container["limits"] as? [[String: Any]], !limits.isEmpty else {
+        let container: [String: Any]
+        if let data = root["data"] {
+            guard let data = data as? [String: Any] else {
+                throw ZAIUsageError.invalidResponse
+            }
+            container = data
+        } else {
+            container = root
+        }
+        guard let rawLimits = container["limits"],
+              let limits = rawLimits as? [[String: Any]] else {
+            throw ZAIUsageError.invalidResponse
+        }
+        guard !limits.isEmpty else {
             return [.noUsageData]
         }
 
@@ -53,20 +70,20 @@ enum ZAIUsageMapper {
         // a multi-day window is the weekly meter. Z.ai reports both, and both are percentage meters.
         let tokenLimits = limits.filter { ($0["type"] as? String) == "TOKENS_LIMIT" || ($0["name"] as? String) == "TOKENS_LIMIT" }
         for entry in tokenLimits {
-            switch classifyTokenWindow(entry) {
+            switch try classifyTokenWindow(entry) {
             case .session(let periodMs):
-                lines.append(percentLine(entry, label: "Session", periodMs: periodMs))
+                lines.append(try percentLine(entry, label: "Session", periodMs: periodMs))
             case .weekly(let periodMs):
-                lines.append(percentLine(entry, label: "Weekly", periodMs: periodMs))
-            case .unknown:
-                continue
+                lines.append(try percentLine(entry, label: "Weekly", periodMs: periodMs))
             }
         }
         if let web = findLimit(limits, type: "TIME_LIMIT") {
-            lines.append(webSearchLine(from: web))
+            lines.append(try webSearchLine(from: web))
         }
 
-        MetricLine.appendNoDataIfNeeded(&lines)
+        guard !lines.isEmpty else {
+            throw ZAIUsageError.invalidResponse
+        }
         return lines
     }
 
@@ -86,16 +103,15 @@ enum ZAIUsageMapper {
 
     /// How a `TOKENS_LIMIT` entry's window maps to a meter. Z.ai encodes the window as a `(unit, number)`
     /// pair: `unit: 3` is hours (session), `unit: 6` is weeks (weekly), `unit: 5` is months. A sub-daily
-    /// window is the session meter; a multi-day window is the weekly meter; anything unrecognized is
-    /// skipped so a future unit value can't silently overwrite a known meter.
+    /// window is the session meter and a multi-day window is the weekly meter. A recognized token-limit
+    /// entry with an unknown/missing window is invalid schema, not an empty quota.
     private enum TokenWindow {
         case session(periodMs: Int)
         case weekly(periodMs: Int)
-        case unknown
     }
 
-    private static func classifyTokenWindow(_ entry: [String: Any]) -> TokenWindow {
-        guard let periodMs = periodDurationMs(for: entry) else { return .unknown }
+    private static func classifyTokenWindow(_ entry: [String: Any]) throws -> TokenWindow {
+        let periodMs = try periodDurationMs(for: entry)
         // Sub-daily → session; multi-day → weekly. The computed window rides along so the meter's
         // cadence reflects the payload instead of a hardcoded constant.
         if periodMs < 24 * 60 * 60 * 1000 {
@@ -105,10 +121,11 @@ enum ZAIUsageMapper {
     }
 
     /// Resolve a `(unit, number)` window to milliseconds. `unit` is Z.ai's internal time-unit code.
-    private static func periodDurationMs(for entry: [String: Any]) -> Int? {
-        guard let unit = ProviderParse.number(entry["unit"]),
-              let number = ProviderParse.number(entry["number"]) else {
-            return nil
+    private static func periodDurationMs(for entry: [String: Any]) throws -> Int {
+        guard let unit = quotaNumber(entry["unit"]),
+              let number = quotaNumber(entry["number"]),
+              number > 0 else {
+            throw ZAIUsageError.invalidResponse
         }
         let unitMs: Double
         switch unit {
@@ -116,15 +133,22 @@ enum ZAIUsageMapper {
         case 4: unitMs = 24 * 60 * 60 * 1000      // days
         case 6: unitMs = 7 * 24 * 60 * 60 * 1000  // weeks
         case 5: unitMs = 30 * 24 * 60 * 60 * 1000 // months
-        default: return nil
+        default: throw ZAIUsageError.invalidResponse
         }
-        return Int(unitMs * number)
+        let periodMs = unitMs * number
+        guard periodMs >= 1, periodMs < Double(Int.max) else {
+            throw ZAIUsageError.invalidResponse
+        }
+        return Int(periodMs)
     }
 
     /// A percentage meter (Session or Weekly) from a `TOKENS_LIMIT` entry.
-    private static func percentLine(_ entry: [String: Any], label: String, periodMs: Int) -> MetricLine {
-        let percentage = ProviderParse.clampPercent(ProviderParse.number(entry["percentage"]) ?? 0)
-        let resetsAt = ProviderParse.number(entry["nextResetTime"]).map { epochMsToDate($0) }
+    private static func percentLine(_ entry: [String: Any], label: String, periodMs: Int) throws -> MetricLine {
+        guard let rawPercentage = quotaNumber(entry["percentage"]) else {
+            throw ZAIUsageError.invalidResponse
+        }
+        let percentage = ProviderParse.clampPercent(rawPercentage)
+        let resetsAt = try optionalNumber(entry["nextResetTime"]).map { epochMsToDate($0) }
         return .progress(
             label: label,
             used: percentage,
@@ -136,16 +160,20 @@ enum ZAIUsageMapper {
     }
 
     /// TIME_LIMIT → a count meter (used / limit) for monthly web-search/reader calls.
-    private static func webSearchLine(from entry: [String: Any]) -> MetricLine {
-        let used = max(0, ProviderParse.number(entry["currentValue"]) ?? 0)
-        let limit = max(0, ProviderParse.number(entry["usage"]) ?? 0)
+    private static func webSearchLine(from entry: [String: Any]) throws -> MetricLine {
+        guard let rawUsed = quotaNumber(entry["currentValue"]),
+              let rawLimit = quotaNumber(entry["usage"]),
+              rawUsed >= 0,
+              rawLimit >= 0 else {
+            throw ZAIUsageError.invalidResponse
+        }
         // TIME_LIMIT carries a nextResetTime in current payloads (monthly renewal); honor it when
         // present so the countdown shows the real reset, otherwise the period cadence reads "monthly".
-        let resetsAt = ProviderParse.number(entry["nextResetTime"]).map { epochMsToDate($0) }
+        let resetsAt = try optionalNumber(entry["nextResetTime"]).map { epochMsToDate($0) }
         return .progress(
             label: "Web Searches",
-            used: used,
-            limit: limit,
+            used: rawUsed,
+            limit: rawLimit,
             format: .count(suffix: "searches"),
             resetsAt: resetsAt,
             periodDurationMs: monthlyPeriodMs
@@ -161,6 +189,55 @@ enum ZAIUsageMapper {
             }
         }
         return nil
+    }
+
+    /// The known "valid key, no GLM Coding Plan" business response includes `success:false` and an
+    /// absence phrase around "coding plan" inside its otherwise-localized message. A generic service
+    /// failure that merely mentions coding plans must remain a business error.
+    private static func isNoCodingPlan(_ root: [String: Any]) -> Bool {
+        let message = ((root["msg"] as? String) ?? "").lowercased()
+        return message.contains("不存在coding plan")
+            || message.contains("no coding plan")
+            || message.contains("coding plan does not exist")
+            || message.contains("coding plan not found")
+    }
+
+    private static func businessCode(_ root: [String: Any]) -> Int? {
+        guard let number = quotaNumber(root["code"]),
+              number.rounded() == number,
+              number >= Double(Int.min),
+              number < Double(Int.max) else {
+            return nil
+        }
+        return Int(number)
+    }
+
+    /// Optional numeric fields may be absent/null, but a present value with the wrong type is a schema
+    /// error. This keeps a malformed reset timestamp from being silently treated as "no reset".
+    private static func optionalNumber(_ value: Any?) throws -> Double? {
+        guard let value, !(value is NSNull) else { return nil }
+        guard let number = quotaNumber(value) else {
+            throw ZAIUsageError.invalidResponse
+        }
+        return number
+    }
+
+    /// `JSONSerialization` bridges both JSON booleans and numbers through `NSNumber`; reject the
+    /// boolean subtype before using the shared permissive numeric parser.
+    private static func quotaNumber(_ value: Any?) -> Double? {
+        if let number = value as? NSNumber,
+           CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return nil
+        }
+        return ProviderParse.number(value)
+    }
+
+    private static func jsonBoolean(_ value: Any) -> Bool? {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) == CFBooleanGetTypeID() else {
+            return nil
+        }
+        return number.boolValue
     }
 
     /// `nextResetTime` arrives as epoch milliseconds (e.g. `1770648402389`).

--- a/Tests/OpenUsageTests/ZAILiveResponseMappingTests.swift
+++ b/Tests/OpenUsageTests/ZAILiveResponseMappingTests.swift
@@ -20,7 +20,7 @@ final class ZAILiveResponseMappingTests: XCTestCase {
     """#
 
     func testMapsLiveResponseToSessionWeeklyAndWebSearches() throws {
-        let mapped = ZAIUsageMapper.map(
+        let mapped = try ZAIUsageMapper.map(
             quotaBody: Data(liveQuota.utf8),
             subscriptionBody: Data(liveSubscription.utf8)
         )

--- a/Tests/OpenUsageTests/ZAIProviderTests.swift
+++ b/Tests/OpenUsageTests/ZAIProviderTests.swift
@@ -250,7 +250,7 @@ final class ZAIAuthStoreTests: XCTestCase {
 
 final class ZAIUsageMapperTests: XCTestCase {
     func testMapsBothLimitsToSessionAndWebSearches() throws {
-        let mapped = ZAIUsageMapper.map(quotaBody: data(quotaBothLimitsJSON), subscriptionBody: data(subscriptionJSON))
+        let mapped = try ZAIUsageMapper.map(quotaBody: data(quotaBothLimitsJSON), subscriptionBody: data(subscriptionJSON))
 
         XCTAssertEqual(mapped.plan, "GLM Coding Max")
 
@@ -292,7 +292,7 @@ final class ZAIUsageMapperTests: XCTestCase {
           "success": true
         }
         """#
-        let mapped = ZAIUsageMapper.map(quotaBody: data(divergentJSON), subscriptionBody: nil)
+        let mapped = try ZAIUsageMapper.map(quotaBody: data(divergentJSON), subscriptionBody: nil)
         XCTAssertEqual(try XCTUnwrap(progress(mapped.lines, "Session")).periodDurationMs,
                        3 * 60 * 60 * 1000)
         XCTAssertEqual(try XCTUnwrap(progress(mapped.lines, "Weekly")).periodDurationMs,
@@ -300,7 +300,7 @@ final class ZAIUsageMapperTests: XCTestCase {
     }
 
     func testMapsSessionOnlyWhenNoTimeLimit() throws {
-        let mapped = ZAIUsageMapper.map(quotaBody: data(quotaSessionOnlyJSON), subscriptionBody: nil)
+        let mapped = try ZAIUsageMapper.map(quotaBody: data(quotaSessionOnlyJSON), subscriptionBody: nil)
 
         XCTAssertNil(mapped.plan)
         XCTAssertNotNil(progress(mapped.lines, "Session"))
@@ -315,29 +315,40 @@ final class ZAIUsageMapperTests: XCTestCase {
         XCTAssertNil(ZAIUsageMapper.planName(from: data(#"{"data":[]}"#)))
     }
 
-    func testEmptyLimitsYieldNoUsageData() {
-        let mapped = ZAIUsageMapper.map(quotaBody: data(#"{"data":{"limits":[]}}"#), subscriptionBody: nil)
-        // No usable limits → the shared "No usage data" placeholder, not a blank tile.
+    func testExplicitlyEmptyLimitsYieldNoUsageData() throws {
+        let mapped = try ZAIUsageMapper.map(
+            quotaBody: data(#"{"success":true,"data":{"limits":[]}}"#),
+            subscriptionBody: nil
+        )
+        // An explicitly empty, correctly-shaped array is a valid idle state.
         XCTAssertTrue(mapped.lines.contains { $0.label == "Status" })
     }
 
-    func testDetectsNoCodingPlanBody() {
+    func testKnownNoCodingPlanBodyThrowsDedicatedError() {
         // A valid key on an account with no GLM Coding Plan: the live quota endpoint answers 2xx with
         // `success:false` / "…coding plan" (captured verbatim from the real API).
-        XCTAssertTrue(ZAIUsageMapper.isNoCodingPlan(data(#"{"code":500,"msg":"当前用户不存在coding plan","success":false}"#)))
+        XCTAssertThrowsError(
+            try ZAIUsageMapper.mapQuota(data(#"{"code":500,"msg":"当前用户不存在coding plan","success":false}"#))
+        ) { error in
+            XCTAssertEqual(error as? ZAIUsageError, .noCodingPlan)
+        }
     }
 
-    func testIsNoCodingPlanFalseForUsableOrUnrelatedBodies() {
-        // A real quota payload and an unrelated business failure are both not "no coding plan".
-        XCTAssertFalse(ZAIUsageMapper.isNoCodingPlan(data(quotaBothLimitsJSON)))
-        XCTAssertFalse(ZAIUsageMapper.isNoCodingPlan(data(#"{"code":500,"msg":"internal error","success":false}"#)))
+    func testUnrelatedBusinessFailureThrowsBusinessError() {
+        let messages = ["internal error", "coding plan service unavailable"]
+        for message in messages {
+            let body = data(#"{"code":500,"msg":"\#(message)","success":false}"#)
+            XCTAssertThrowsError(try ZAIUsageMapper.mapQuota(body), message) { error in
+                XCTAssertEqual(error as? ZAIUsageError, .businessFailure(code: 500), message)
+            }
+        }
     }
 
     func testClampsAboveRangePercentage() throws {
         let body = data(#"""
         {"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":150,"currentValue":10,"usage":10}]}}
         """#)
-        let lines = ZAIUsageMapper.mapQuota(body)
+        let lines = try ZAIUsageMapper.mapQuota(body)
         let sessionUsed = try XCTUnwrap(progress(lines, "Session")?.used)
         XCTAssertEqual(sessionUsed, 100, accuracy: 0.001)
     }
@@ -347,7 +358,7 @@ final class ZAIUsageMapperTests: XCTestCase {
         let body = data(#"""
         {"data":{"limits":[{"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":25}]}}
         """#)
-        let lines = ZAIUsageMapper.mapQuota(body)
+        let lines = try ZAIUsageMapper.mapQuota(body)
         XCTAssertNil(progress(lines, "Session"))
         let weekly = try XCTUnwrap(progress(lines, "Weekly"))
         XCTAssertEqual(weekly.used, 25, accuracy: 0.001)

--- a/Tests/OpenUsageTests/ZAIResponseIntegrityTests.swift
+++ b/Tests/OpenUsageTests/ZAIResponseIntegrityTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import OpenUsage
+
+final class ZAIResponseIntegrityMapperTests: XCTestCase {
+    func testMalformedJSONThrowsInvalidResponse() {
+        assertInvalidQuota(Data("<html>gateway response</html>".utf8))
+    }
+
+    func testWrongTopLevelAndEnvelopeShapesThrowInvalidResponse() {
+        let wrongShapes = [
+            "[]",
+            #"{"success":1,"data":{"limits":[]}}"#,
+            #"{"success":true}"#,
+            #"{"success":true,"data":[]}"#,
+            #"{"success":true,"data":{}}"#,
+            #"{"success":true,"data":{"limits":{}}}"#,
+            #"{"success":true,"data":{"limits":[{"type":"UNKNOWN_LIMIT"}]}}"#
+        ]
+
+        for body in wrongShapes {
+            assertInvalidQuota(Data(body.utf8), context: body)
+        }
+    }
+
+    func testRecognizedLimitsMissingRequiredNumbersThrowInsteadOfFabricatingZero() {
+        let missingFields = [
+            #"{"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5}]}}"#,
+            #"{"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":true}]}}"#,
+            #"{"data":{"limits":[{"type":"TOKENS_LIMIT","number":5,"percentage":10}]}}"#,
+            #"{"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"percentage":10}]}}"#,
+            #"{"data":{"limits":[{"type":"TIME_LIMIT","usage":1000}]}}"#,
+            #"{"data":{"limits":[{"type":"TIME_LIMIT","currentValue":true,"usage":1000}]}}"#,
+            #"{"data":{"limits":[{"type":"TIME_LIMIT","currentValue":10}]}}"#,
+            #"{"data":{"limits":[{"type":"TIME_LIMIT","currentValue":-1,"usage":1000}]}}"#,
+            #"{"data":{"limits":[{"type":"TIME_LIMIT","currentValue":10,"usage":-1}]}}"#,
+            #"{"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":10,"nextResetTime":"later"}]}}"#
+        ]
+
+        for body in missingFields {
+            assertInvalidQuota(Data(body.utf8), context: body)
+        }
+    }
+
+    private func assertInvalidQuota(
+        _ body: Data,
+        context: String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try ZAIUsageMapper.mapQuota(body), context, file: file, line: line) { error in
+            XCTAssertEqual(error as? ZAIUsageError, .invalidResponse, context, file: file, line: line)
+        }
+    }
+}
+
+@MainActor
+final class ZAIResponseIntegrityProviderTests: XCTestCase {
+    func testMalformedQuotaJSONReportsDecodingFailure() async {
+        let snapshot = await makeProvider(quotaBody: Data("not-json".utf8)).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .decoding)
+        XCTAssertEqual(errorText(snapshot), "Usage response invalid. Try again later.")
+    }
+
+    func testWrongQuotaShapeReportsDecodingFailure() async {
+        let snapshot = await makeProvider(
+            quotaBody: Data(#"{"success":true,"data":[]}"#.utf8)
+        ).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .decoding)
+    }
+
+    func testBusinessFailurePreservesEnvelopeCodeAndCategory() async {
+        let snapshot = await makeProvider(
+            quotaBody: Data(#"{"success":false,"code":500,"msg":"internal error"}"#.utf8)
+        ).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .other)
+        XCTAssertEqual(errorText(snapshot), "Z.ai usage request failed (code 500). Try again later.")
+    }
+
+    func testMissingRequiredUsageNumberReportsDecodingInsteadOfZeroUsage() async {
+        let snapshot = await makeProvider(
+            quotaBody: Data(
+                #"{"success":true,"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5}]}}"#.utf8
+            )
+        ).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .decoding)
+        XCTAssertNil(snapshot.line(label: "Session"))
+    }
+
+    func testExplicitlyEmptyLimitsRemainAValidNoUsageDataSnapshot() async {
+        let snapshot = await makeProvider(
+            quotaBody: Data(#"{"success":true,"data":{"limits":[]}}"#.utf8)
+        ).refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertFalse(snapshot.lines.contains(where: \.isError))
+        XCTAssertNotNil(snapshot.line(label: "Status"))
+    }
+
+    private func makeProvider(quotaBody: Data) -> ZAIProvider {
+        ZAIProvider(
+            authStore: ZAIAuthStore(
+                files: FakeFiles(),
+                environment: FakeEnvironment(["ZAI_API_KEY": "zai-test"])
+            ),
+            usageClient: ZAIUsageClient(http: RoutingHTTPClient { request in
+                if request.url == ZAIUsageClient.quotaURL {
+                    return HTTPResponse(statusCode: 200, headers: [:], body: quotaBody)
+                }
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"success":true,"data":[]}"#.utf8)
+                )
+            }),
+            now: { Date(timeIntervalSince1970: 1_800_000_000) }
+        )
+    }
+
+    private func errorText(_ snapshot: ProviderSnapshot) -> String? {
+        guard case .badge(_, let text, _, _) = snapshot.lines.first else { return nil }
+        return text
+    }
+}

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -45,7 +45,10 @@ Two undocumented internal endpoints Z.ai's own subscription UI uses (stable in p
 - `GET https://api.z.ai/api/monitor/usage/quota/limit` — the quota meters.
 
 The quota response carries a `limits` array. Each `TOKENS_LIMIT` entry is a token window; its
-window length decides which meter it feeds (sub-daily → Session, multi-day → Weekly), so a `TIME_LIMIT` entry is the monthly web-search count. Reset times come back as epoch milliseconds.
+window length decides which meter it feeds (sub-daily → Session, multi-day → Weekly), while a
+`TIME_LIMIT` entry is the monthly web-search count. Reset times come back as epoch milliseconds.
+An explicitly empty `limits` array is a valid "No usage data" state. A failed or malformed response
+is shown as an error instead of being treated as zero usage.
 
 ## Troubleshooting
 
@@ -55,5 +58,9 @@ window length decides which meter it feeds (sub-daily → Session, multi-day →
 - **"No active GLM Coding Plan"** (amber notice by the name) — the key is valid, but the account has no
   GLM Coding Plan, so there's nothing to meter. Subscribe at [z.ai/subscribe](https://z.ai/subscribe);
   usage appears once your plan is active.
-- **Meters show "No usage data"** — you have a plan, but the quota endpoint returned no usable limits
-  yet. Check your [plan](https://z.ai/manage-apikey/coding-plan/personal/my-plan).
+- **"Z.ai usage request failed"** — Z.ai returned a structured failure even though the HTTP request
+  completed. Refresh later; the displayed code can help distinguish a provider outage.
+- **"Usage response invalid"** — the quota response was malformed or omitted fields needed to render
+  a meter. OpenUsage does not substitute zero for missing usage values.
+- **Meters show "No usage data"** — you have a plan, but the quota endpoint explicitly returned an
+  empty limits list. Check your [plan](https://z.ai/manage-apikey/coding-plan/personal/my-plan).


### PR DESCRIPTION
## TL;DR

Validates Z.ai quota envelopes and required meter fields so malformed or failed responses surface a useful error instead of fabricated zero usage or a misleading empty state.

## What was happening

- Malformed JSON, missing fields, and unknown non-empty quota shapes could collapse into "No usage data."
- Missing numeric values were silently substituted with zero.
- Every `success: false` response mentioning a coding plan could be classified as no active plan, even when it was a provider-side business failure.

## What this changes

- Treats only an explicit, correctly shaped empty `limits` array as a valid no-usage state.
- Rejects malformed required percentages, windows, counts, and present reset timestamps.
- Preserves the known no-plan state while giving other structured failures a typed error and retaining the Z.ai envelope code.
- Keeps envelope codes separate from HTTP status categories in telemetry.
- Updates the Z.ai provider guide and troubleshooting copy.

## Tests

- Focused Z.ai suite: 28 passed.
- Full suite: 970 XCTest cases passed, 3 expected skips; 3 Swift Testing cases passed.
- Captured live-response mapping fixture passed.
- `swift build` and `git diff --check` passed.
- `./script/build_and_run.sh verify` completed a release build, signed staging, and full app restart.

## Screenshots

Malformed quota responses now surface the provider notice instead of fabricated zero usage.

![Z.ai invalid-response notice](https://gist.githubusercontent.com/robinebers/5d45266150cbbe876cc388c639ffa66e/raw/6186552a2673d2c3440306cf5dc69104938feb60/zai-invalid-response-notice.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible Z.ai refresh behavior (errors vs empty meters) and parsing rules for an undocumented API; risk is mitigated by broad tests but could affect edge-case payloads that previously showed zeros or placeholders.
> 
> **Overview**
> Z.ai quota handling is **stricter**: malformed 2xx bodies, missing meter fields, and unrecognized limit shapes now surface **`invalidResponse`** or **`businessFailure`** instead of silent “No usage data” or **zero-filled** meters.
> 
> **`ZAIUsageMapper`** is now throwing end-to-end. Only a well-formed **`success:true`** payload with an explicitly empty **`limits`** array still maps to “No usage data.” **`success:false`** is split between the known **no GLM Coding Plan** phrases (→ **`noCodingPlan`**) and other envelope failures (→ **`businessFailure`** with optional Z.ai **`code`**, not HTTP). Required percentages, windows, counts, and present-but-wrong **`nextResetTime`** types are validated rather than defaulted.
> 
> **`ZAIProvider`** maps successful HTTP bodies through the throwing mapper so decoding vs business errors propagate to the snapshot. Telemetry maps **`businessFailure`** to **`.other`** so envelope codes are not mistaken for HTTP status codes. Docs and new integrity tests cover the error paths and user-facing copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca909a50fccdb3d756058f6fca71667f0bf4564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->