### PR TITLE
Keep no-reset balances out of pace alerts

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -16,7 +16,7 @@ final class AppContainer {
     /// Settings ▸ API Keys lists these and writes key changes through the capability. Empty when no
     /// installed provider needs a user key, in which case the section hides itself.
     let apiKeyProviders: [any APIKeyManaging]
-    /// Quota pace notification preferences (master + three triggers). Drives the Settings section and is
+    /// Quota notification preferences (three triggers, with no master switch). Drives Settings and is
     /// read by `WidgetDataStore.evaluateNotifications`.
     let notificationSettings: NotificationSettingsStore
     /// Anonymous, opt-out usage telemetry (daily rollups). Exposed so Settings can toggle it and the

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -476,6 +476,11 @@ extension WidgetData {
         return (limit, resetsAt, TimeInterval(periodDurationMs) / 1000)
     }
 
+    /// Whether this metric has the limit, reset, and period context required for pace alerts. `.spent`
+    /// is visually identical with or without a reset, so notification logic uses this explicit bit to
+    /// avoid treating a plain exhausted balance as projected to run out before a reset.
+    var hasPaceContext: Bool { paceContext != nil }
+
     /// The meter's full visual state for `now` — the single source the row's color, amber tick,
     /// and warning copy all read from, so they can't drift apart. Precedence, highest first:
     ///

--- a/Sources/OpenUsage/Stores/NotificationSettingsStore.swift
+++ b/Sources/OpenUsage/Stores/NotificationSettingsStore.swift
@@ -5,9 +5,8 @@ import Observation
 /// turn all three off to silence). All default OFF; the app requests notification authorization the
 /// first time a trigger is turned on, so a fresh install stays quiet until the user opts in.
 ///
-/// Persisted in `UserDefaults` (each key independently, so an unset key reads its `true` default and a
-/// future-added trigger defaults on without migration). `@Observable` so the Settings toggles and the
-/// evaluation in `WidgetDataStore` read live values.
+/// Persisted in `UserDefaults` (each key independently, with an unset key reading the off default).
+/// `@Observable` so the Settings toggles and `WidgetDataStore` evaluation read live values.
 @MainActor
 @Observable
 final class NotificationSettingsStore {
@@ -17,7 +16,7 @@ final class NotificationSettingsStore {
     private static let healthyToCloseKey = "openusage.notifications.healthyToClose"
     private static let closeToRunningOutKey = "openusage.notifications.closeToRunningOut"
 
-    /// Alert the first time a metric drops under 10% remaining for the period.
+    /// Alert when a metric crosses under 10% remaining, with or without a reset window.
     var underTenPercent: Bool {
         didSet { defaults.set(underTenPercent, forKey: Self.underTenKey) }
     }

--- a/Sources/OpenUsage/Stores/QuotaNotificationEvaluator.swift
+++ b/Sources/OpenUsage/Stores/QuotaNotificationEvaluator.swift
@@ -6,9 +6,10 @@ import Foundation
 /// bounded, visible metrics and calls `evaluate`; delivery + the provider display name come in as
 /// closures so this type stays independent of the store's providers.
 ///
-/// Deduped per metric per reset window; the no-trustworthy-pace states (no data, fresh session, level
-/// bands) never fire. State for metrics not passed this pass is pruned, so re-enabling/re-adding a
-/// metric starts fresh rather than carrying a stale "already fired" flag.
+/// Deduped per metric while a condition remains unchanged. No-data metrics never fire; level-band and
+/// non-paced spent metrics skip pace alerts but can still fire the remaining-based Almost Out alert.
+/// State for metrics not passed this pass is pruned, so re-enabling/re-adding a metric starts fresh
+/// rather than carrying a stale "already fired" flag.
 @MainActor
 final class QuotaNotificationEvaluator {
     /// One enabled, bounded, visible metric for this pass, already resolved by the store.
@@ -35,8 +36,12 @@ final class QuotaNotificationEvaluator {
             let key = metric.key
             let data = metric.data
             let state = data.meterState(now: now)
+            let hasPaceContext = data.hasPaceContext
             let previous = notificationState[key] ?? NotificationState()
-            let currentBucket = PaceNotificationLogic.bucket(for: state)
+            let currentBucket = PaceNotificationLogic.bucket(
+                for: state,
+                hasPaceContext: hasPaceContext
+            )
             let resetDelta = Self.resetDelta(current: data.resetsAt, previous: previous.resetsAt)
             let resetAdvanced = PaceNotificationLogic.resetWindowAdvanced(
                 resetsAt: data.resetsAt,
@@ -46,11 +51,12 @@ final class QuotaNotificationEvaluator {
                 state: state,
                 fraction: data.remainingFraction,
                 resetsAt: data.resetsAt,
+                hasPaceContext: hasPaceContext,
                 previous: previous,
                 toggles: toggles
             )
             if !result.fire.isEmpty || resetAdvanced || Self.isPositiveResetMovement(resetDelta) {
-                AppLog.debug(.notifications, "decision \(key): metric=\(data.title) state=\(Self.notificationStateDescription(state)) bucket=\(Self.bucketDescription(currentBucket)) previousBucket=\(Self.bucketDescription(previous.previousBucket)) remaining=\(Self.percentDescription(data.remainingFraction)) reset=\(Self.dateDescription(data.resetsAt)) previousReset=\(Self.dateDescription(previous.resetsAt)) resetDelta=\(Self.resetDeltaDescription(resetDelta)) resetReason=\(Self.resetReasonDescription(delta: resetDelta, advanced: resetAdvanced)) primed=\(previous.primed) wasUnderTen=\(previous.wasUnderTenPercent) firedBefore=\(Self.milestoneDescription(previous.firedMilestones)) fire=\(Self.milestoneDescription(result.fire)) newBucket=\(Self.bucketDescription(result.newState.previousBucket)) newFired=\(Self.milestoneDescription(result.newState.firedMilestones)) toggles=\(Self.toggleDescription(toggles))")
+                AppLog.debug(.notifications, "decision \(key): metric=\(data.title) state=\(Self.notificationStateDescription(state)) paceContext=\(hasPaceContext ? "available" : "unavailable") bucket=\(Self.bucketDescription(currentBucket)) previousBucket=\(Self.bucketDescription(previous.previousBucket)) remaining=\(Self.percentDescription(data.remainingFraction)) reset=\(Self.dateDescription(data.resetsAt)) previousReset=\(Self.dateDescription(previous.resetsAt)) resetDelta=\(Self.resetDeltaDescription(resetDelta)) resetReason=\(Self.resetReasonDescription(delta: resetDelta, advanced: resetAdvanced)) primed=\(previous.primed) wasUnderTen=\(previous.wasUnderTenPercent) firedBefore=\(Self.milestoneDescription(previous.firedMilestones)) fire=\(Self.milestoneDescription(result.fire)) newBucket=\(Self.bucketDescription(result.newState.previousBucket)) newFired=\(Self.milestoneDescription(result.newState.firedMilestones)) toggles=\(Self.toggleDescription(toggles))")
             }
             // Deliver each fired milestone, then commit dedup state only for the ones that actually
             // delivered. The logic doesn't mark milestones fired — that's done here, after delivery

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -24,7 +24,7 @@ final class WidgetDataStore {
     private let orderedDescriptors: @MainActor () -> [WidgetDescriptor]
     /// Clock for the failure-backoff window. Injected so tests can advance time deterministically.
     private let now: () -> Date
-    /// Quota-notification preferences (master + per-trigger). Injected; `nil` disables notifications
+    /// Quota-notification preferences for the three triggers. Injected; `nil` disables notifications
     /// entirely (tests and previews that don't wire it).
     private let notificationSettings: (@MainActor () -> NotificationSettingsStore)?
     /// Where a fired milestone is delivered: `(idPrefix, title, subtitle, body) -> Bool`. The Bool is
@@ -157,10 +157,10 @@ final class WidgetDataStore {
 
     /// Evaluate every visible, enabled metric for a quota pace milestone and post a notification for any
     /// that just crossed one. Driven from the periodic loop *after* `refreshAll`, so it catches pace
-    /// worsening from time passing (not only from a fresh fetch). Deduped per metric per reset window by
-    /// the evaluator's per-key state; the no-trustworthy-pace states (no data, fresh session, level
-    /// bands) never fire. A no-op when notifications are unconfigured (tests/previews) or all triggers
-    /// are off.
+    /// worsening from time passing (not only from a fresh fetch). Deduped per metric by the evaluator's
+    /// per-key state. No-data metrics never fire; states without pace projection skip pace alerts but can
+    /// still fire the remaining-based Almost Out alert. A no-op when notifications are unconfigured
+    /// (tests/previews) or all triggers are off.
     ///
     /// State for metrics not visited this pass (e.g. a provider the user just disabled, or a metric
     /// removed from the layout) is pruned, so re-enabling/re-adding starts fresh rather than carrying a
@@ -503,4 +503,3 @@ final class WidgetDataStore {
         return Double(value[match].replacingOccurrences(of: ",", with: ""))
     }
 }
-

--- a/Sources/OpenUsage/Support/AppNotifications.swift
+++ b/Sources/OpenUsage/Support/AppNotifications.swift
@@ -3,8 +3,8 @@ import Foundation
 import UserNotifications
 
 /// The single entry point for posting macOS user notifications. Quota pace alerts go through `post`;
-/// authorization is requested at launch when at least one trigger is on (all default ON, so the prompt
-/// is expected on a fresh install).
+/// authorization is requested when the first Settings trigger is turned on. All triggers default off,
+/// so a fresh install remains quiet until the user opts in.
 ///
 /// Authorization is memoized in one `Task<Bool, Never>`: the first caller reads the current settings,
 /// short-circuits an already-authorized or already-denied state, and otherwise requests it; every later
@@ -33,8 +33,8 @@ final class AppNotifications: NSObject, UNUserNotificationCenterDelegate {
         NSClassFromString("XCTestCase") != nil
     }
 
-    /// Make this object the delegate and kick off the authorization request once at launch. Safe to call
-    /// from app launch; a no-op under tests.
+    /// Make this object the delegate. Authorization is requested separately when a trigger is enabled.
+    /// Safe to call from app launch; a no-op under tests.
     func registerAsDelegate() {
         guard !Self.isRunningUnderTests else { return }
         centerProvider().delegate = self

--- a/Sources/OpenUsage/Support/PaceNotificationLogic.swift
+++ b/Sources/OpenUsage/Support/PaceNotificationLogic.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// One of the three quota milestones a user can be alerted about. Each maps to a single per-trigger
-/// toggle in Settings and is deduped independently within a reset window.
+/// toggle in Settings and is deduped independently while its condition remains unchanged.
 enum PaceMilestone: String, CaseIterable, Hashable, Sendable {
-    /// First time the remaining share of the quota drops under 10% for the period.
+    /// First time the remaining share of the quota drops under 10%.
     case underTenPercent
     /// Pace verdict worsened from healthy (blue) to close-to-limit (yellow).
     case healthyToClose
@@ -28,7 +28,7 @@ extension PaceMilestone {
     /// body stays generic and reads well for any metric (sessions, rate-limit resets, spend tiles).
     var body: String {
         switch self {
-        case .underTenPercent: return "Under 10% usage remaining for this window."
+        case .underTenPercent: return "Under 10% of this limit remains."
         case .healthyToClose: return "Projected to finish close to your limit."
         case .closeToRunningOut: return "Projected to finish before the limit resets."
         }
@@ -44,28 +44,27 @@ extension PaceMilestone {
     }
 }
 
-/// The pace-severity bucket a metric is in, derived from its `MeterState`. Only the three live-pace
-/// verdicts (and the terminal `spent`) carry a comparable severity; states with no trustworthy pace
-/// (`noData`, absolute-band `level`, and a fresh session window) are `untracked` — they neither fire a
-/// milestone nor count as an improvement, so they can't reset a fired flag either.
+/// The pace-severity bucket a metric is in, derived from its `MeterState`. Only live-pace verdicts carry
+/// comparable severity. States without trustworthy pace are `untracked` for pace transitions, while
+/// their independent remaining share can still trigger Almost Out when real bounded data exists.
 enum PaceBucket: Hashable, Sendable {
-    /// No pace story to act on (no data, plain level band, or a not-yet-started session window).
+    /// No pace story to act on (plain level band, non-paced spent state, or no usable projection).
     case untracked
     /// Blue: on course to finish with ≥10% to spare.
     case healthy
     /// Yellow: projected inside the last 10%, cutting it close.
     case close
-    /// Red: projected to run out before the reset, or already spent to nothing.
+    /// Red: projected to run out before the reset, including a spent metric with active pace context.
     case runningOut
 }
 
 /// Deduplication state for one metric (provider + descriptor), persisted across refresh passes so a
-/// milestone fires once per reset window rather than on every tick. Lives in `WidgetDataStore`.
+/// milestone does not fire on every tick. A new reset window clears the reset-based history.
 struct NotificationState: Equatable, Sendable {
-    /// The reset instant of the window the fired flags belong to. When this advances (a new window),
-    /// the fired set clears so the same milestones can fire again next period.
+    /// The reset instant when this metric has a reset window; nil for non-reset balances. When it
+    /// advances, the fired set clears so the same milestones can fire again in the new period.
     var resetsAt: Date?
-    /// Milestones already alerted in the current window.
+    /// Milestones already alerted while their current condition remains unchanged.
     var firedMilestones: Set<PaceMilestone> = []
     /// The bucket observed on the previous evaluation, so a worsening transition can be detected.
     var previousBucket: PaceBucket = .untracked
@@ -77,8 +76,8 @@ struct NotificationState: Equatable, Sendable {
     var primed: Bool = false
 }
 
-/// Which per-milestone toggles are currently on. The master toggle is applied by the caller before
-/// this runs; this struct only carries the three individual switches.
+/// Which per-milestone toggles are currently on. There is no master switch; turning all three off
+/// silences notifications.
 struct PaceNotificationToggles: Sendable {
     var underTenPercent: Bool
     var healthyToClose: Bool
@@ -96,8 +95,8 @@ struct PaceNotificationToggles: Sendable {
 }
 
 /// Pure milestone logic — no SwiftUI, no UserNotifications — so the firing rules stay unit-testable.
-/// `WidgetDataStore.evaluateNotifications` feeds it the current `MeterState` + `fraction` + `resetsAt`
-/// for each metric and posts a notification for every returned milestone.
+/// `WidgetDataStore.evaluateNotifications` feeds it the current meter state, remaining fraction, reset,
+/// and whether reset-window pace context exists, then posts every returned milestone.
 enum PaceNotificationLogic {
     /// Result of one evaluation: the milestones to fire now, and the state to persist for next time.
     struct Transition: Equatable {
@@ -105,14 +104,19 @@ enum PaceNotificationLogic {
         var newState: NotificationState
     }
 
-    /// Maps a meter state to its pace bucket. The "no trustworthy pace" states (no data, fresh
-    /// session, absolute level bands) are `untracked` — they never fire and never reset flags.
-    static func bucket(for state: WidgetData.MeterState) -> PaceBucket {
+    /// Maps a meter state to its pace bucket. `.spent` is ambiguous by itself: it represents both an
+    /// exhausted reset-based quota and an exhausted balance with no reset. Only the former participates
+    /// in pace transitions; both remain eligible for the independent Almost Out threshold.
+    static func bucket(
+        for state: WidgetData.MeterState,
+        hasPaceContext: Bool
+    ) -> PaceBucket {
         switch state {
         case .noData, .level: return .untracked
         case .healthy: return .healthy
         case .closeToLimit: return .close
-        case .runningOut, .spent: return .runningOut
+        case .runningOut: return .runningOut
+        case .spent: return hasPaceContext ? .runningOut : .untracked
         }
     }
 
@@ -124,11 +128,11 @@ enum PaceNotificationLogic {
     ///   treated as the same reset window for notification dedupe.
     /// - `healthyToClose` / `closeToRunningOut` fire only on a worsening *edge* between adjacent
     ///   buckets, only if not already fired this window, and only if their toggle is on.
-    /// - `underTenPercent` fires the first time remaining crosses under 10% this window; recovering
-    ///   above 10% re-arms it so a later dip re-fires.
-    /// - `untracked` states (no data, fresh session, level bands) suppress everything — they carry no
-    ///   trustworthy pace — and don't disturb the recorded "previous" signals, so a momentary gap
-    ///   (e.g. a failed refresh) doesn't spuriously re-fire when real data returns.
+    /// - `underTenPercent` fires when remaining crosses under 10%; recovering above 10% re-arms it so a
+    ///   later dip re-fires, including for balances without reset windows.
+    /// - `noData` suppresses everything. Other pace-untracked states skip pace edges but can still cross
+    ///   the independent under-10% threshold. Untracked states don't disturb the recorded pace signal,
+    ///   so a momentary gap doesn't spuriously re-fire when real data returns.
     /// - Improving pace clears the relevant fired flags so a later worsening re-fires.
     static func transitions(
         state: WidgetData.MeterState,
@@ -136,6 +140,7 @@ enum PaceNotificationLogic {
         /// (callers pass `WidgetData.remainingFraction`, not the display-mode-dependent `fraction`).
         fraction: Double,
         resetsAt: Date?,
+        hasPaceContext: Bool,
         previous: NotificationState,
         toggles: PaceNotificationToggles
     ) -> Transition {
@@ -150,7 +155,7 @@ enum PaceNotificationLogic {
         }
         next.resetsAt = resetsAt ?? previous.resetsAt
 
-        let currentBucket = bucket(for: state)
+        let currentBucket = bucket(for: state, hasPaceContext: hasPaceContext)
 
         // No real data backing the tile: skip entirely without disturbing recorded signals — a
         // transient no-data tick shouldn't look like an improvement that re-arms milestones, nor a
@@ -174,8 +179,9 @@ enum PaceNotificationLogic {
 
         var fire: [PaceMilestone] = []
 
-        // Pace-verdict edges — only for live-pace states (`.level` has no pace projection, so no pace
-        // milestones for it). Severity order: untracked(-1) < healthy(0) < close(1) < runningOut(2).
+        // Pace-verdict edges — only for live-pace states (`.level` and non-paced `.spent` have no pace
+        // projection, so no pace milestones for them). Severity order:
+        // untracked(-1) < healthy(0) < close(1) < runningOut(2).
         // "Cutting It Close" is the yellow state itself: it fires only when the metric is *currently*
         // in `.close` having been below it. "Will Run Out" fires when severity reaches `.runningOut`
         // having been below it. A jump straight from blue to red fires *Will Run Out only* — the metric

--- a/Tests/OpenUsageTests/PaceNotificationLogicTests.swift
+++ b/Tests/OpenUsageTests/PaceNotificationLogicTests.swift
@@ -3,10 +3,10 @@ import XCTest
 
 /// Covers the pure milestone logic that decides when a quota notification fires: worsening pace edges
 /// (blue→yellow, yellow→red), the under-10%-remaining crossing, per-window dedup, reset rollover,
-/// recovery re-arming, the no-trustworthy-pace suppression, and the toggle gates. Mirrors CodexBar's
-/// QuotaWarningNotificationLogicTests.
+/// recovery re-arming, suppression of pace edges without a projection, and the toggle gates. Mirrors
+/// CodexBar's QuotaWarningNotificationLogicTests.
 final class PaceNotificationLogicTests: XCTestCase {
-    private let reset = Date(timeIntervalSince1970: 1_700_000_000)
+    private static let reset = Date(timeIntervalSince1970: 1_700_000_000)
 
     // Meter states with a comfortable fraction so the under-10% rule doesn't co-fire unless intended.
     private let healthy = WidgetData.MeterState.healthy(projectedFraction: 0.5)
@@ -17,12 +17,14 @@ final class PaceNotificationLogicTests: XCTestCase {
     private func step(
         _ state: WidgetData.MeterState,
         fraction: Double = 0.5,
-        resetsAt: Date? = nil,
+        resetsAt: Date? = PaceNotificationLogicTests.reset,
+        hasPaceContext: Bool = true,
         from previous: NotificationState = NotificationState(),
         toggles: PaceNotificationToggles = .allOn
     ) -> PaceNotificationLogic.Transition {
         PaceNotificationLogic.transitions(
-            state: state, fraction: fraction, resetsAt: resetsAt ?? reset,
+            state: state, fraction: fraction, resetsAt: resetsAt,
+            hasPaceContext: hasPaceContext,
             previous: previous, toggles: toggles
         )
     }
@@ -88,7 +90,7 @@ final class PaceNotificationLogicTests: XCTestCase {
         XCTAssertTrue(step(close, from: state).fire.isEmpty)   // deduped within the window
         // A later reset window: same worsening should fire again. Re-enter healthy then close in the
         // new window so the edge is present.
-        let newReset = reset.addingTimeInterval(3600)
+        let newReset = Self.reset.addingTimeInterval(3600)
         let rolled = step(healthy, resetsAt: newReset, from: state).newState
         let refired = step(close, resetsAt: newReset, from: rolled)
         XCTAssertEqual(refired.fire, [.healthyToClose])
@@ -98,7 +100,7 @@ final class PaceNotificationLogicTests: XCTestCase {
         var state = step(healthy).newState
         state = step(running, from: state).newState   // fires closeToRunningOut this window
 
-        let jitteredReset = reset.addingTimeInterval(0.09)
+        let jitteredReset = Self.reset.addingTimeInterval(0.09)
         let stillRunningOut = step(running, resetsAt: jitteredReset, from: state)
 
         XCTAssertTrue(stillRunningOut.fire.isEmpty)
@@ -110,7 +112,7 @@ final class PaceNotificationLogicTests: XCTestCase {
         var state = step(healthy).newState
         state = step(close, from: state).newState   // fires healthyToClose this window
 
-        let jitteredReset = reset.addingTimeInterval(0.09)
+        let jitteredReset = Self.reset.addingTimeInterval(0.09)
         let stillClose = step(close, resetsAt: jitteredReset, from: state)
 
         XCTAssertTrue(stillClose.fire.isEmpty)
@@ -150,21 +152,64 @@ final class PaceNotificationLogicTests: XCTestCase {
         XCTAssertTrue(result.fire.isEmpty)
     }
 
-    func testLevelPrimesWithoutFiringOnFirstObservation() {
+    func testNoResetLevelPrimesWithoutFiringOnFirstObservation() {
         // `.level` has used/limit data but no pace projection. The first observation primes (records the
         // under-10% baseline) without firing — like any other first observation.
-        let result = step(.level(.critical), fraction: 0.01)
+        let result = step(
+            .level(.critical),
+            fraction: 0.01,
+            resetsAt: nil,
+            hasPaceContext: false
+        )
         XCTAssertTrue(result.fire.isEmpty)
     }
 
-    func testLevelFiresAlmostOutUnderTenPercent() {
+    func testNoResetLevelFiresAlmostOutUnderTenPercent() {
         // `.level` metrics still fire "Almost Out" on the under-10% edge — it's a remaining-based
         // trigger, not a pace one. No pace milestone fires for `.level`.
-        let primed = step(.level(.critical), fraction: 0.20).newState
-        let first = step(.level(.critical), fraction: 0.08, from: primed)
+        let primed = step(
+            .level(.warning),
+            fraction: 0.20,
+            resetsAt: nil,
+            hasPaceContext: false
+        ).newState
+        let first = step(
+            .level(.critical),
+            fraction: 0.08,
+            resetsAt: nil,
+            hasPaceContext: false,
+            from: primed
+        )
         XCTAssertTrue(first.fire.contains(.underTenPercent))
         XCTAssertFalse(first.fire.contains(.healthyToClose))
         XCTAssertFalse(first.fire.contains(.closeToRunningOut))
+    }
+
+    func testNoResetSpentFiresOnlyAlmostOut() {
+        let primed = step(
+            .level(.warning),
+            fraction: 0.20,
+            resetsAt: nil,
+            hasPaceContext: false
+        ).newState
+        let spent = step(
+            .spent,
+            fraction: 0,
+            resetsAt: nil,
+            hasPaceContext: false,
+            from: primed
+        )
+
+        XCTAssertEqual(spent.fire, [.underTenPercent])
+        XCTAssertEqual(spent.newState.previousBucket, .untracked)
+    }
+
+    func testPacedSpentStillFiresRunningOutAndAlmostOut() {
+        let primed = step(healthy, fraction: 0.20).newState
+        let spent = step(.spent, fraction: 0, from: primed)
+
+        XCTAssertEqual(spent.fire, [.closeToRunningOut, .underTenPercent])
+        XCTAssertEqual(spent.newState.previousBucket, .runningOut)
     }
 
     func testUntrackedDoesNotDisturbPreviousSignals() {
@@ -178,9 +223,8 @@ final class PaceNotificationLogicTests: XCTestCase {
 
     // MARK: - Toggle gates
 
-    func testMasterOffSuppressionIsCallerSide() {
-        // The pure logic has no master flag; the caller gates it. With all per-triggers off, nothing
-        // fires even on a clear worsening — this stands in for the per-trigger-off path.
+    func testAllTogglesOffSuppressesAllMilestones() {
+        // There is no master flag. With all three triggers off, nothing fires on a clear worsening.
         let off = PaceNotificationToggles(underTenPercent: false, healthyToClose: false, closeToRunningOut: false)
         let state = step(healthy, toggles: off).newState
         let close = step(self.close, fraction: 0.05, from: state, toggles: off)
@@ -217,7 +261,7 @@ final class PaceNotificationLogicTests: XCTestCase {
     func testFreshSessionLevelPrimesWithoutFiring() {
         // A fresh session window resolves to an absolute-level state (`.level`) with plenty of quota
         // left, so it primes without firing. (A `.level` metric can still fire "Almost Out" later if it
-        // drops under 10% — see testLevelFiresAlmostOutUnderTenPercent.)
+        // drops under 10% — see testNoResetLevelFiresAlmostOutUnderTenPercent.)
         let result = step(.level(.normal), fraction: 0.99)
         XCTAssertTrue(result.fire.isEmpty)
     }

--- a/Tests/OpenUsageTests/WidgetDataStoreNotificationTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreNotificationTests.swift
@@ -56,12 +56,17 @@ final class WidgetDataStoreNotificationTests: XCTestCase {
         )
     }
 
-    private func snapshot(used: Double, resetsAt: Date? = nil) -> ProviderSnapshot {
+    private func snapshot(
+        used: Double,
+        resetsAt: Date? = nil,
+        hasPaceWindow: Bool = true
+    ) -> ProviderSnapshot {
         ProviderSnapshot(
             providerID: Self.provider.id,
             displayName: Self.provider.displayName,
             lines: [.progress(label: "Session", used: used, limit: 100, format: .percent,
-                              resetsAt: resetsAt ?? self.resetsAt, periodDurationMs: Int(week * 1000))]
+                              resetsAt: hasPaceWindow ? (resetsAt ?? self.resetsAt) : nil,
+                              periodDurationMs: hasPaceWindow ? Int(week * 1000) : nil)]
         )
     }
 
@@ -70,11 +75,16 @@ final class WidgetDataStoreNotificationTests: XCTestCase {
         settings: NotificationSettingsStore,
         recorder: Recorder,
         defaultsName: String,
+        hasPaceWindow: Bool = true,
         isEnabled: @escaping @MainActor (String) -> Bool = { _ in true },
         delivered: @escaping @MainActor () -> Bool = { true }
     ) -> (WidgetDataStore, MutableRuntime, WidgetDescriptor) {
         let descriptor = Self.descriptor()
-        let runtime = MutableRuntime(provider: Self.provider, descriptors: [descriptor], snapshot: snapshot(used: used))
+        let runtime = MutableRuntime(
+            provider: Self.provider,
+            descriptors: [descriptor],
+            snapshot: snapshot(used: used, hasPaceWindow: hasPaceWindow)
+        )
         let defaults = makeUserDefaults(defaultsName)
         let store = WidgetDataStore(
             registry: WidgetRegistry(providers: [Self.provider], descriptors: [descriptor]),
@@ -139,6 +149,81 @@ final class WidgetDataStoreNotificationTests: XCTestCase {
         XCTAssertTrue(recorder.posts.contains { $0.0 == "test.closeToRunningOut" })
         XCTAssertTrue(recorder.posts.contains { $0.3 == "Projected to finish before the limit resets." })
         XCTAssertTrue(recorder.posts.contains { $0.2 == "Test Session" })
+    }
+
+    func testNoResetSpentFiresAlmostOutWithoutPaceAlerts() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("no-reset-spent-settings"))
+        allOn(settings)
+        let recorder = Recorder()
+        let (store, runtime, _) = makeStore(
+            used: 80,
+            settings: settings,
+            recorder: recorder,
+            defaultsName: "no-reset-spent",
+            hasPaceWindow: false
+        )
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base) // level-band baseline
+
+        runtime.snapshot = snapshot(used: 100, hasPaceWindow: false)
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base)
+
+        XCTAssertEqual(recorder.posts.map { $0.0 }, ["test.underTenPercent"])
+        XCTAssertEqual(recorder.posts.first?.1, "Almost Out")
+        XCTAssertEqual(recorder.posts.first?.3, "Under 10% of this limit remains.")
+
+        // Staying spent is deduped; it must not discover a pace edge on a later tick.
+        await store.evaluateNotifications(now: base)
+        XCTAssertEqual(recorder.posts.count, 1)
+    }
+
+    func testNoResetLevelCrossingUnderTenFiresAlmostOut() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("no-reset-under-ten-settings"))
+        allOn(settings)
+        let recorder = Recorder()
+        let (store, runtime, _) = makeStore(
+            used: 80,
+            settings: settings,
+            recorder: recorder,
+            defaultsName: "no-reset-under-ten",
+            hasPaceWindow: false
+        )
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base) // 20% remaining, primes
+
+        runtime.snapshot = snapshot(used: 92, hasPaceWindow: false)
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base)
+
+        XCTAssertEqual(recorder.posts.map { $0.0 }, ["test.underTenPercent"])
+    }
+
+    func testPacedSpentStillFiresWillRunOutAndDedups() async {
+        let settings = NotificationSettingsStore(defaults: makeUserDefaults("paced-spent-settings"))
+        allOn(settings)
+        let recorder = Recorder()
+        let (store, runtime, _) = makeStore(
+            used: 80,
+            settings: settings,
+            recorder: recorder,
+            defaultsName: "paced-spent"
+        )
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base) // healthy pace baseline
+
+        runtime.snapshot = snapshot(used: 100)
+        await store.refreshAll(force: true)
+        await store.evaluateNotifications(now: base)
+
+        XCTAssertEqual(
+            recorder.posts.map { $0.0 },
+            ["test.closeToRunningOut", "test.underTenPercent"]
+        )
+        XCTAssertTrue(recorder.posts.contains { $0.3 == "Projected to finish before the limit resets." })
+
+        await store.evaluateNotifications(now: base)
+        XCTAssertEqual(recorder.posts.count, 2)
     }
 
     func testResetJitterDoesNotRefireRunningOutThroughTheStore() async {

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -32,15 +32,15 @@ Settings lives inside the popover — there is no separate window. Open it from 
 
 ## Notifications
 
-OpenUsage can alert you with a macOS notification when a metric's pace gets worse, so you don't have to keep the popover open to catch a quota creeping toward its limit. Alerts work while the app runs in the menu bar, even with the popover closed.
+OpenUsage can alert you with a macOS notification when a metric runs low or its pace gets worse, so you don't have to keep the popover open to catch a quota creeping toward its limit. Alerts work while the app runs in the menu bar, even with the popover closed.
 
 | Setting | Options | What it does |
 |---|---|---|
-| Almost Out | On / Off | Alerts the first time a metric drops under 10% remaining for the period. |
+| Almost Out | On / Off | Alerts when a metric crosses under 10% remaining, including balances without a reset window. |
 | Cutting It Close | On / Off | Alerts when a metric is projected to finish the period with little left — close to its limit. |
 | Will Run Out | On / Off | Alerts when a metric is projected to run out before it resets. |
 
-Each alert fires **once per metric per reset period**, so you get a heads-up without repeats on every refresh. Alerts fire only when a quota *worsens* while OpenUsage is running — a quota that's already in a bad state when you launch won't alert until it recovers and worsens again, or a new period begins. If a metric recovers (its pace eases back) and later worsens again, it can alert again. When a new period begins, the slate is wiped clean. Metrics without a reset window, or while their data can't be read, don't pace and never alert. Turn all three off to silence everything. When several alerts fire at once, they stack into a single grouped banner.
+Alerts fire on a new crossing or pace worsening, then stay deduplicated while that condition is unchanged, so you do not get repeats on every refresh. A quota already in a bad state when OpenUsage launches establishes the baseline without alerting. If it recovers and later worsens again, the alert re-arms; a new reset period also clears the reset-based history. **Almost Out** is based only on the remaining share, so it also works for bounded balances without a reset window. **Cutting It Close** and **Will Run Out** require reset-window pace context. Metrics whose data cannot be read never alert. Turn all three triggers off to silence everything. When several alerts fire at once, they stack into a single grouped banner.
 
 All three alerts default off. The first time you turn one on, OpenUsage asks for notification permission; if you decline (or turn notifications off for OpenUsage in System Settings later), a warning mark appears on the Notifications header and an "Open System Settings" button shows under the toggles so you can re-enable them. A notification's title is the alert name, its subtitle names the provider and metric, and its body is the plain-language verdict. Tapping an alert opens the popover on the dashboard.
 


### PR DESCRIPTION
## TL;DR

Prevents an exhausted balance with no reset window from firing the misleading "Will Run Out" pace alert, while preserving the remaining-based "Almost Out" alert.

## What was happening

- The visual `.spent` state represented both exhausted reset quotas and exhausted no-reset balances.
- Notification bucketing treated every `.spent` state as a pace failure.
- A balance with no reset could therefore claim it was projected to finish before a reset that did not exist.

## What this changes

- Carries explicit pace-context availability into notification bucketing.
- Keeps no-reset spent metrics pace-untracked while allowing their independent under-10% crossing.
- Preserves Will Run Out plus Almost Out for genuinely reset-based exhausted quotas.
- Clarifies notification copy, comments, and the Settings guide.

## Heads-up

- If PR #919 lands first, rebase this branch once: the only overlap is `AppNotifications`' authorization comments. Preserve #919's deferred, memoized authorization behavior; the combined implementation is verified.

## Tests

- Focused notification logic: 21 tests passed.
- Combined with PR #919 under the warning gate: 44 notification-focused tests and 974 XCTest cases passed (3 expected skips), plus 3 Swift Testing cases.
- WidgetDataStore notification integration: 11 tests passed.
- Full suite: 967 XCTest cases passed, 3 expected skips; 3 Swift Testing cases passed.
- `swift build` and `git diff --check` passed.
- `./script/build_and_run.sh verify` completed a release build, signed staging, and full app restart.

## Screenshots

No app layout or control appearance changes. This native content preview shows the corrected Almost Out banner fields; live banners are suppressed in the automated desktop session.

![Almost Out notification content preview](https://gist.githubusercontent.com/robinebers/5d45266150cbbe876cc388c639ffa66e/raw/ac6c644f75d2741aa01803adb3f581d706e19622/almost-out-notification-preview.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when macOS quota notifications fire for spent and no-reset metrics; behavior is covered by new logic and integration tests but affects user-visible alerts.
> 
> **Overview**
> Quota notifications no longer treat every **spent** meter as a pace failure. The PR adds **`hasPaceContext`** on `WidgetData` (limit + reset + period) and threads it through **`PaceNotificationLogic.bucket`** and the evaluator so **Will Run Out** / **Cutting It Close** only apply when there is a real reset-window projection.
> 
> Exhausted **no-reset** balances stay pace-untracked: they will not get a misleading “projected to finish before it resets” banner, but **Almost Out** still fires on the under-10% remaining crossing. Reset-based quotas that hit **spent** still get pace alerts as before.
> 
> Copy and docs are aligned with current behavior (three opt-in triggers, no master switch, updated Almost Out body). Unit and store integration tests cover no-reset spent, no-reset level, and paced spent paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b4d821a01facf65f119484383d497ed9e84858c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->