### PR TITLE
Keep automatic refresh cadence stable

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -168,10 +168,10 @@ final class AppContainer {
         FirstRunSeeder.reseed(providers: providers, enablement: enablement)
     }
 
-    /// Drives live updates: refresh on launch, then again every refresh interval. Each pass honors the
-    /// cache, so it only hits the network once a snapshot has actually expired. `@Observable` propagates
-    /// the resulting snapshot changes to the menu-bar label and any open widgets, so the UI refreshes on
-    /// its own instead of only when the popover opens.
+    /// Sole owner of automatic updates: refresh on launch, then again every refresh interval. Each pass
+    /// honors the cache, so it only hits the network once a snapshot has actually expired. `@Observable`
+    /// propagates the resulting snapshot changes to the menu-bar label and any open widgets; mounting or
+    /// opening the popover never starts a competing refresh pass.
     ///
     /// Between passes the loop sleeps via `RefreshWakeSignal`, which wakes it early when the user
     /// enables/disables a provider so a newly-enabled provider is fetched promptly instead of waiting out
@@ -179,7 +179,8 @@ final class AppContainer {
     /// landing while a pass is still running (first-run credential detection, `NewProviderSeeder`, the
     /// Customize "Reset All" reseed — all of which typically finish faster than the network fetches) is
     /// never lost. Each pass still honors the cache (and the per-provider failure backoff), so an early
-    /// wake only hits the network for a provider whose snapshot has actually expired.
+    /// wake only hits the network for a provider whose snapshot has actually expired. The wake preserves
+    /// the existing timer deadline, preventing a cache-hit pass from postponing the next live refresh.
     ///
     /// The wake is deliberately scoped to `ProviderEnablementStore.didChangeNotification` — NOT the
     /// firehose `UserDefaults.didChangeNotification`, which fires for the app's own snapshot-cache writes,
@@ -189,18 +190,25 @@ final class AppContainer {
     private static func startPeriodicRefresh(dataStore: WidgetDataStore, telemetry: TelemetryRecorder) -> Task<Void, Never> {
         Task {
             let wakeSignal = RefreshWakeSignal()
-            while !Task.isCancelled {
-                await dataStore.refreshAll()
+            await PeriodicRefreshLoop.run(
+                interval: .seconds(RefreshSetting.interval),
+                refreshAll: { await dataStore.refreshAll() },
                 // Re-evaluate quota pace milestones every tick — after the refresh so it sees fresh data,
                 // and on every loop (not just on a fetch) so pace worsening from elapsed time alone still
                 // alerts even with the popover closed.
-                await dataStore.evaluateNotifications()
+                evaluateNotifications: { await dataStore.evaluateNotifications() },
                 // Day-rollover beat: emits `app_daily_active` once per local day and flushes any
                 // prior-day provider rollups. Runs on launch and every interval, so always-running
                 // instances still produce a daily-active signal.
-                telemetry.tick()
-                await wakeSignal.waitForWake(timeout: RefreshSetting.interval)
-            }
+                tickTelemetry: { telemetry.tick() },
+                // Publish the wall-clock counterpart of the loop's monotonic deadline for the footer.
+                // This callback runs only when the scheduler advances the cadence, never after an early
+                // enablement wake or a manual refresh.
+                didScheduleNextPass: {
+                    dataStore.nextAutomaticRefreshAt = Date().addingTimeInterval(RefreshSetting.interval)
+                },
+                waitForNextPass: { await wakeSignal.wait(timeout: $0) }
+            )
         }
     }
 }

--- a/Sources/OpenUsage/App/PeriodicRefreshLoop.swift
+++ b/Sources/OpenUsage/App/PeriodicRefreshLoop.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The app's single automatic refresh pipeline. `AppContainer` owns its task for the whole process
+/// lifetime; views only observe the resulting store changes and never start an automatic pass.
+///
+/// Keeping the sequencing here makes the lifecycle explicit and testable: every launch/wake pass
+/// finishes refreshing before quota notifications and telemetry inspect the new state, then waits for
+/// the next timer or provider-enablement wake. An early enablement pass preserves the scheduled timer
+/// deadline, so cache hits cannot postpone the next live refresh by another full interval.
+@MainActor
+enum PeriodicRefreshLoop {
+    static func run(
+        interval: Duration,
+        clockNow: @MainActor () -> ContinuousClock.Instant = { ContinuousClock.now },
+        refreshAll: @MainActor () async -> Void,
+        evaluateNotifications: @MainActor () async -> Void,
+        tickTelemetry: @MainActor () -> Void,
+        didScheduleNextPass: @MainActor () -> Void,
+        waitForNextPass: @MainActor (Duration) async -> RefreshWakeSignal.Trigger?
+    ) async {
+        var deadline: ContinuousClock.Instant?
+        var trigger: RefreshWakeSignal.Trigger?
+
+        while !Task.isCancelled {
+            await refreshAll()
+            // Cancellation can land while providers are in flight. Once that pass unwinds, stop before
+            // treating it as a completed cycle through notifications, telemetry, or a new deadline.
+            guard !Task.isCancelled else { return }
+            await evaluateNotifications()
+            // Notification delivery also suspends. A cancellation there must not leak into telemetry or
+            // publish a deadline for a cycle that will never wait for that deadline.
+            guard !Task.isCancelled else { return }
+            tickTelemetry()
+
+            // Launch and scheduled-timer passes begin a new cadence interval. An early enablement pass
+            // deliberately leaves the deadline alone: otherwise a wake just before expiry could turn
+            // the five-minute cadence into almost ten minutes between live provider fetches.
+            if deadline == nil || trigger == .timer {
+                deadline = clockNow().advanced(by: interval)
+                didScheduleNextPass()
+            }
+            guard let deadline else { return }
+            let remaining = max(.zero, clockNow().duration(to: deadline))
+            guard let nextTrigger = await waitForNextPass(remaining) else { return }
+            trigger = nextTrigger
+        }
+    }
+}

--- a/Sources/OpenUsage/App/RefreshWakeSignal.swift
+++ b/Sources/OpenUsage/App/RefreshWakeSignal.swift
@@ -14,12 +14,17 @@ import Foundation
 ///
 /// Here the subscription is installed once, synchronously, in `init` — before the loop's first pass —
 /// feeding an `AsyncStream` with `.bufferingNewest(1)`: a wake posted while nobody is waiting is
-/// retained, and a burst coalesces into a single pending wake, so the next `waitForWake` returns
-/// immediately instead of sleeping out the interval.
+/// retained, and a burst coalesces into a single pending wake, so the next `wait` returns immediately
+/// instead of sleeping out the interval.
 @MainActor
 final class RefreshWakeSignal {
-    private let stream: AsyncStream<Void>
-    private let continuation: AsyncStream<Void>.Continuation
+    enum Trigger: Equatable, Sendable {
+        case enablementChange
+        case timer
+    }
+
+    private let stream: AsyncStream<Trigger>
+    private let continuation: AsyncStream<Trigger>.Continuation
     private let center: NotificationCenter
     /// `nonisolated(unsafe)` so the nonisolated `deinit` can unregister the observer; it is immutable
     /// after `init`, and `NotificationCenter` is documented thread-safe.
@@ -29,14 +34,17 @@ final class RefreshWakeSignal {
         name: Notification.Name = ProviderEnablementStore.didChangeNotification,
         center: NotificationCenter = .default
     ) {
-        let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: Trigger.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
         self.stream = stream
         self.continuation = continuation
         self.center = center
         // Registered synchronously, so no notification posted after `init` returns can be missed.
         // The continuation is `Sendable`; yielding from whatever context posts is safe.
         self.observer = center.addObserver(forName: name, object: nil, queue: nil) { _ in
-            continuation.yield()
+            continuation.yield(.enablementChange)
         }
     }
 
@@ -45,22 +53,28 @@ final class RefreshWakeSignal {
         continuation.finish()
     }
 
-    /// Returns when a wake has been posted — including one buffered while the caller was doing other
-    /// work — or when `timeout` elapses, whichever comes first (the timer feeds the same stream). Also
-    /// returns promptly when the surrounding task is cancelled. If the timeout and a wake race, the
-    /// loser stays buffered; the resulting extra pass is all cache hits, so it stays harmless.
+    /// Returns what ended the wait: a provider-enablement change (including one buffered while the
+    /// caller was doing other work), or the scheduled timer. Returns `nil` when the surrounding task is
+    /// cancelled. Keeping the two triggers distinct lets the refresh loop preserve its existing timer
+    /// deadline across an early enablement pass instead of starting a fresh full interval.
+    ///
+    /// If the timer and a wake race, the loser stays buffered. The resulting extra pass is harmless
+    /// because provider cache checks still gate network work.
     ///
     /// The refresh loop is the signal's only consumer, and only ever sequentially: each call makes a
     /// fresh iterator over the shared stream (fine sequentially — the buffer lives on the stream), so
     /// no actor-isolated iterator state has to survive a suspension.
-    func waitForWake(timeout: TimeInterval) async {
+    func wait(timeout: Duration) async -> Trigger? {
         let timer = Task { [continuation] in
-            try? await Task.sleep(for: .seconds(timeout))
-            guard !Task.isCancelled else { return }
-            continuation.yield()
+            do {
+                try await Task.sleep(for: max(.zero, timeout))
+            } catch {
+                return
+            }
+            continuation.yield(.timer)
         }
         defer { timer.cancel() }
         var iterator = stream.makeAsyncIterator()
-        _ = await iterator.next()
+        return await iterator.next()
     }
 }

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -47,10 +47,10 @@ final class WidgetDataStore {
 
     var snapshots: [String: ProviderSnapshot] = [:]
     var refreshingProviderIDs: Set<String> = []
-    /// Wall-clock time the most recent full refresh pass finished. Together with the chosen refresh
-    /// cadence it drives the dashboard footer's live "Next update in …" countdown, so the footer reflects
-    /// the real schedule instead of a hardcoded value. `nil` until the first pass completes.
-    var lastRefreshAt: Date?
+    /// Wall-clock deadline for the next automatic timer pass. `PeriodicRefreshLoop` updates it only when
+    /// that scheduler starts a new cadence interval, so manual refreshes and early provider-enablement
+    /// wakes cannot make the footer disagree with the timer. `nil` until the launch pass completes.
+    var nextAutomaticRefreshAt: Date?
     /// Latest refresh error per provider (e.g. "Not logged in. Run `codex` to authenticate."). Set when
     /// a refresh comes back as an error snapshot, cleared on the next successful one. The dashboard
     /// renders it as a warning indicator beside the provider name; the last good snapshot keeps
@@ -141,10 +141,6 @@ final class WidgetDataStore {
         for task in tasks {
             outcomes.append(await task.value)
         }
-        // Stamp the end of the pass so the footer countdown targets the next scheduled refresh
-        // (this time + one refresh interval), mirroring the periodic loop that sleeps one interval
-        // after each pass.
-        lastRefreshAt = Date()
         let durationMs = Int(Date().timeIntervalSince(start) * 1000)
         // Count THIS batch's actual outcomes, not the long-lived `providerErrors` map (which persists
         // across passes, so reading it would miscount cache hits and stale earlier failures).
@@ -222,8 +218,8 @@ final class WidgetDataStore {
         }
 
         guard let provider = providersByID[providerID] else { return .skipped }
-        // Skip if an in-flight refresh already owns this provider (e.g. the background timer racing the
-        // first popover open), so we never fire duplicate network calls for the same provider.
+        // Skip if an in-flight refresh already owns this provider (e.g. a manual refresh racing the
+        // background timer), so we never fire duplicate network calls for the same provider.
         guard !refreshingProviderIDs.contains(providerID) else {
             AppLog.debug(.refresh, "cache skip \(providerID) (already in flight)")
             return .skipped
@@ -503,4 +499,3 @@ final class WidgetDataStore {
         return Double(value[match].replacingOccurrences(of: ",", with: ""))
     }
 }
-

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -21,7 +21,6 @@ struct DashboardView: View {
     @Environment(WidgetDataStore.self) private var dataStore
     @Environment(PopoverTransparencyStore.self) private var transparency
     @Environment(UpdaterController.self) private var updater
-    @State private var didInitialRefresh = false
     @State private var reorderLift: ReorderLift?
     /// The panel height SwiftUI drives — the single animation clock. `PanelHeightModifier` follows it
     /// frame-by-frame onto the AppKit panel, so the window resize rides the same spring as the screen
@@ -218,11 +217,6 @@ struct DashboardView: View {
                 } else if !isSliding, abs(target - animatedHeight) > 1 {
                     withAnimation(Motion.spring) { animatedHeight = target }
                 }
-            }
-            .task {
-                guard !didInitialRefresh else { return }
-                didInitialRefresh = true
-                await dataStore.refreshAll()
             }
             // Watches for the secret transparency code while the panel is key and toggles the egg. A
             // sibling of `PopoverKeyReader` that only observes (never consumes), so it can't disturb

--- a/Sources/OpenUsage/Views/PopoverFooter.swift
+++ b/Sources/OpenUsage/Views/PopoverFooter.swift
@@ -98,8 +98,15 @@ struct PopoverFooter: View {
 
     private func updateStatusText(now: Date) -> String {
         if isUpdating { return "Updating…" }
-        let base = dataStore.lastRefreshAt ?? now
-        let remaining = max(0, base.addingTimeInterval(RefreshSetting.interval).timeIntervalSince(now))
+        return Self.countdownText(nextAutomaticRefreshAt: dataStore.nextAutomaticRefreshAt, now: now)
+    }
+
+    /// Pure formatting seam for the scheduler-owned deadline. Keeping the deadline (rather than a
+    /// loosely related batch-completion time) as the input makes early and manual refreshes unable to
+    /// reset the displayed cadence.
+    static func countdownText(nextAutomaticRefreshAt: Date?, now: Date) -> String {
+        let target = nextAutomaticRefreshAt ?? now.addingTimeInterval(RefreshSetting.interval)
+        let remaining = max(0, target.timeIntervalSince(now))
         let totalSeconds = Int(remaining.rounded(.up))
         if totalSeconds >= 60 {
             let minutes = Int((Double(totalSeconds) / 60).rounded(.up))

--- a/Tests/OpenUsageTests/PeriodicRefreshLoopTests.swift
+++ b/Tests/OpenUsageTests/PeriodicRefreshLoopTests.swift
@@ -1,0 +1,226 @@
+import XCTest
+@testable import OpenUsage
+
+/// Guards ordering within the automatic refresh loop. The duplicate dashboard-owned task was removed
+/// structurally; these tests verify that the remaining AppContainer-owned loop completes one refresh,
+/// notification, and telemetry pipeline before waiting or beginning another.
+@MainActor
+final class PeriodicRefreshLoopTests: XCTestCase {
+    func testCancellationDuringRefreshStopsBeforePostRefreshWork() async {
+        let refreshStarted = expectation(description: "refresh started")
+        var events: [String] = []
+
+        let task = Task {
+            await PeriodicRefreshLoop.run(
+                interval: .seconds(300),
+                refreshAll: {
+                    events.append("refresh")
+                    refreshStarted.fulfill()
+                    try? await Task.sleep(for: .seconds(60))
+                },
+                evaluateNotifications: { events.append("notifications") },
+                tickTelemetry: { events.append("telemetry") },
+                didScheduleNextPass: { events.append("deadline") },
+                waitForNextPass: { _ in
+                    events.append("wait")
+                    return nil
+                }
+            )
+        }
+        await fulfillment(of: [refreshStarted], timeout: 1)
+
+        task.cancel()
+        await task.value
+
+        XCTAssertEqual(events, ["refresh"])
+    }
+
+    func testCancellationDuringNotificationsStopsBeforeTelemetryAndDeadline() async {
+        let notificationsStarted = expectation(description: "notifications started")
+        var events: [String] = []
+
+        let task = Task {
+            await PeriodicRefreshLoop.run(
+                interval: .seconds(300),
+                refreshAll: { events.append("refresh") },
+                evaluateNotifications: {
+                    events.append("notifications")
+                    notificationsStarted.fulfill()
+                    try? await Task.sleep(for: .seconds(60))
+                },
+                tickTelemetry: { events.append("telemetry") },
+                didScheduleNextPass: { events.append("deadline") },
+                waitForNextPass: { _ in
+                    events.append("wait")
+                    return nil
+                }
+            )
+        }
+        await fulfillment(of: [notificationsStarted], timeout: 1)
+
+        task.cancel()
+        await task.value
+
+        XCTAssertEqual(events, ["refresh", "notifications"])
+    }
+
+    func testLaunchRunsOneCompletePassBeforeWaiting() async {
+        var events: [String] = []
+        let waiting = expectation(description: "first pass reached wait")
+
+        let task = Task {
+            await PeriodicRefreshLoop.run(
+                interval: .seconds(300),
+                refreshAll: { events.append("refresh") },
+                evaluateNotifications: { events.append("notifications") },
+                tickTelemetry: { events.append("telemetry") },
+                didScheduleNextPass: {},
+                waitForNextPass: { _ in
+                    events.append("wait")
+                    waiting.fulfill()
+                    try? await Task.sleep(for: .seconds(60))
+                    return nil
+                }
+            )
+        }
+        await fulfillment(of: [waiting], timeout: 1)
+
+        XCTAssertEqual(events, ["refresh", "notifications", "telemetry", "wait"])
+
+        task.cancel()
+        await task.value
+    }
+
+    func testOneWakeRunsExactlyOneMoreCompletePass() async {
+        let wakeName = Notification.Name("PeriodicRefreshLoopTests.wake")
+        let center = NotificationCenter()
+        let signal = RefreshWakeSignal(name: wakeName, center: center)
+        var events: [String] = []
+        let firstWait = expectation(description: "launch pass reached wait")
+        let secondWait = expectation(description: "wake pass reached wait")
+        var waitCount = 0
+
+        let task = Task {
+            await PeriodicRefreshLoop.run(
+                interval: .seconds(300),
+                refreshAll: { events.append("refresh") },
+                evaluateNotifications: { events.append("notifications") },
+                tickTelemetry: { events.append("telemetry") },
+                didScheduleNextPass: {},
+                waitForNextPass: { timeout in
+                    waitCount += 1
+                    events.append("wait")
+                    if waitCount == 1 {
+                        firstWait.fulfill()
+                    } else if waitCount == 2 {
+                        secondWait.fulfill()
+                    }
+                    return await signal.wait(timeout: timeout)
+                }
+            )
+        }
+        await fulfillment(of: [firstWait], timeout: 1)
+        center.post(name: wakeName, object: nil)
+        await fulfillment(of: [secondWait], timeout: 1)
+
+        XCTAssertEqual(
+            events,
+            [
+                "refresh", "notifications", "telemetry", "wait",
+                "refresh", "notifications", "telemetry", "wait",
+            ]
+        )
+
+        task.cancel()
+        await task.value
+    }
+
+    func testEarlyWakeKeepsTimeRemainingOnScheduledCadence() async {
+        var now = ContinuousClock.now
+        let wallStart = Date(timeIntervalSince1970: 1_800_000_000)
+        var wallNow = wallStart
+        var nextAutomaticRefreshAt: Date?
+        var passCount = 0
+        var timeouts: [Duration] = []
+
+        await PeriodicRefreshLoop.run(
+            interval: .seconds(300),
+            clockNow: { now },
+            refreshAll: { passCount += 1 },
+            evaluateNotifications: {},
+            tickTelemetry: {},
+            didScheduleNextPass: {
+                nextAutomaticRefreshAt = wallNow.addingTimeInterval(300)
+            },
+            waitForNextPass: { timeout in
+                timeouts.append(timeout)
+                if timeouts.count == 1 {
+                    // Enable a provider four minutes into the five-minute cadence. The wake pass must
+                    // leave one minute on the timer, not restart a fresh five-minute sleep.
+                    now = now.advanced(by: .seconds(240))
+                    wallNow = wallNow.addingTimeInterval(240)
+                    return .enablementChange
+                }
+                return nil
+            }
+        )
+
+        XCTAssertEqual(passCount, 2)
+        XCTAssertEqual(timeouts, [.seconds(300), .seconds(60)])
+        XCTAssertEqual(nextAutomaticRefreshAt, wallStart.addingTimeInterval(300))
+        XCTAssertEqual(
+            PopoverFooter.countdownText(nextAutomaticRefreshAt: nextAutomaticRefreshAt, now: wallNow),
+            "Next update in 1m"
+        )
+    }
+
+    func testWakePassCrossingDeadlineRunsScheduledPassImmediately() async {
+        var now = ContinuousClock.now
+        var passCount = 0
+        var timeouts: [Duration] = []
+
+        await PeriodicRefreshLoop.run(
+            interval: .seconds(300),
+            clockNow: { now },
+            refreshAll: {
+                passCount += 1
+                if passCount == 2 {
+                    // The early pass starts just before expiry but finishes just after it. Providers
+                    // that were cache hits at the start still need the now-due scheduled pass.
+                    now = now.advanced(by: .seconds(2))
+                }
+            },
+            evaluateNotifications: {},
+            tickTelemetry: {},
+            didScheduleNextPass: {},
+            waitForNextPass: { timeout in
+                timeouts.append(timeout)
+                switch timeouts.count {
+                case 1:
+                    now = now.advanced(by: .seconds(299))
+                    return .enablementChange
+                case 2:
+                    return .timer
+                default:
+                    return nil
+                }
+            }
+        )
+
+        XCTAssertEqual(passCount, 3)
+        XCTAssertEqual(timeouts, [.seconds(300), .zero, .seconds(300)])
+    }
+
+    func testManualRefreshDoesNotMoveAutomaticDeadline() async {
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [], descriptors: []),
+            providers: []
+        )
+        let deadline = Date(timeIntervalSince1970: 1_800_000_300)
+        store.nextAutomaticRefreshAt = deadline
+
+        await store.refreshAll(force: true)
+
+        XCTAssertEqual(store.nextAutomaticRefreshAt, deadline)
+    }
+}

--- a/Tests/OpenUsageTests/RefreshWakeSignalTests.swift
+++ b/Tests/OpenUsageTests/RefreshWakeSignalTests.swift
@@ -20,7 +20,8 @@ final class RefreshWakeSignalTests: XCTestCase {
         center.post(name: wakeName, object: nil)
 
         let start = Date()
-        await signal.waitForWake(timeout: 60)
+        let trigger = await signal.wait(timeout: .seconds(60))
+        XCTAssertEqual(trigger, .enablementChange)
         XCTAssertLessThan(
             Date().timeIntervalSince(start), 5,
             "a wake posted before the wait began must be buffered, not lost"
@@ -32,12 +33,13 @@ final class RefreshWakeSignalTests: XCTestCase {
         let signal = RefreshWakeSignal(name: wakeName, center: center)
 
         let start = Date()
-        let wait = Task { await signal.waitForWake(timeout: 60) }
+        let wait = Task { await signal.wait(timeout: .seconds(60)) }
         // Let the wait suspend before posting, so this exercises the live-wake path (not the buffer).
         await Task.yield()
         center.post(name: wakeName, object: nil)
 
-        await wait.value
+        let trigger = await wait.value
+        XCTAssertEqual(trigger, .enablementChange)
         XCTAssertLessThan(Date().timeIntervalSince(start), 5)
     }
 
@@ -46,7 +48,8 @@ final class RefreshWakeSignalTests: XCTestCase {
         let signal = RefreshWakeSignal(name: wakeName, center: center)
 
         let start = Date()
-        await signal.waitForWake(timeout: 0.1)
+        let trigger = await signal.wait(timeout: .milliseconds(100))
+        XCTAssertEqual(trigger, .timer)
         // `Task.sleep` never fires early; returning proves the timer path works without any wake.
         XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), 0.09)
     }
@@ -60,11 +63,13 @@ final class RefreshWakeSignalTests: XCTestCase {
         }
 
         // The burst collapses into one buffered wake: the first wait consumes it immediately...
-        await signal.waitForWake(timeout: 60)
+        let wakeTrigger = await signal.wait(timeout: .seconds(60))
+        XCTAssertEqual(wakeTrigger, .enablementChange)
 
         // ...and the second finds nothing buffered, so it sleeps out its full timeout.
         let start = Date()
-        await signal.waitForWake(timeout: 0.1)
+        let timerTrigger = await signal.wait(timeout: .milliseconds(100))
+        XCTAssertEqual(timerTrigger, .timer)
         XCTAssertGreaterThanOrEqual(
             Date().timeIntervalSince(start), 0.09,
             "a burst of wakes must coalesce into one, not queue up extra refresh passes"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,9 @@ The UI reads from a few observable stores:
 - `ProviderEnablementStore` — which providers the user has turned on or off.
 
 Refresh runs on a timer in `AppContainer`; each pass respects the cache, so the network is only hit once a
-snapshot has actually expired.
+snapshot has actually expired. That loop is the sole owner of automatic refreshes: SwiftUI views observe
+the store, but mounting or opening the popover never starts another pass. Provider-enablement changes can
+wake the loop early without moving its regular timer deadline.
 
 ## The AppKit bridge
 

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -2,8 +2,8 @@
 
 ## When data updates
 
-- All enabled providers refresh together: at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Providers fetch in parallel — one slow provider doesn't delay the others.
-- Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running.
+- All enabled providers refresh together: at launch, then every 5 minutes (a fixed cadence — there's no setting for it). The background loop is the one automatic refresh owner, so opening the popover doesn't start an extra pass. Providers fetch in parallel — one slow provider doesn't delay the others.
+- Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running. That early pass doesn't postpone the regular five-minute update.
 - The popover footer shows `Next update in Nm`. **Clicking it (or ⌘R)** refreshes immediately, skipping the cache.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.
 

--- a/docs/research/model-hover/02-data-and-architecture.md
+++ b/docs/research/model-hover/02-data-and-architecture.md
@@ -250,6 +250,8 @@ UI recommendation:
 Provider refresh cadence:
 
 - `AppContainer.startPeriodicRefresh` calls `WidgetDataStore.refreshAll()` on launch and every `RefreshSetting.interval`.
+- The `AppContainer` loop is the sole automatic refresh owner; `DashboardView` observes results and does not refresh when it mounts or the popover opens.
+- Provider-enablement wakes run promptly but preserve the existing scheduled deadline, so a cache-hit pass cannot postpone the next live fetch.
 - `RefreshSetting.interval` is fixed at 5 minutes.
 - Manual refresh uses `dataStore.refreshAll(force: true)`.
 - `WidgetDataStore.refresh(providerID:force:)` honors `ProviderSnapshotCache.snapshot(providerID:)` unless forced.


### PR DESCRIPTION
## TL;DR

Makes `AppContainer` the single automatic refresh owner, preserves the five-minute timer deadline across early provider-enablement wakes, and gives the footer the scheduler-owned deadline so manual or cache-hit refreshes cannot move the displayed countdown.

## What was happening

- `AppContainer` started the launch refresh while the eagerly hosted dashboard started another one-shot refresh.
- Provider guards prevented duplicate requests, but the losing batch could complete with skipped outcomes and let notification evaluation inspect stale state.
- Every early enablement wake restarted a full interval after its cache-aware pass, so a wake just before expiry could stretch live data updates toward ten minutes.
- The footer derived its countdown from the most recent batch completion, even when that batch was manual or an early cache hit and did not move the real timer.

## What this changes

- Removes the view-owned initial refresh and keeps one process-lifetime automatic loop in `AppContainer`.
- Extracts a small scheduler seam with explicit refresh, notification, telemetry, and wait ordering.
- Stops cancellation during refresh or notification delivery before telemetry, deadline publication, or another wait.
- Distinguishes enablement wakes from scheduled timer wakes.
- Preserves a monotonic deadline across early wakes and immediately runs the due scheduled pass if an early pass crosses that deadline.
- Publishes `nextAutomaticRefreshAt` from the scheduler only when cadence advances.
- Makes the footer read that deadline; manual refreshes and early wakes no longer reset its countdown.
- Updates architecture, refresh behavior, research notes, and in-flight ownership comments.

## Heads-up

- Manual and timer requests still use the existing per-provider in-flight guard. Whole-batch forced-refresh coalescing is isolated in PR #928.
- A merge-tree check with PR #928 is clean and the behaviors are compatible.
- No visual design change; screenshots are not applicable.

## Tests

- Eleven focused scheduler, wake-signal, countdown, cancellation, and manual-refresh lifecycle tests passed.
- Added deterministic regressions for a wake four minutes into cadence, a wake pass crossing expiry, and a manual refresh preserving the deadline.
- Full suite: 969 XCTest cases passed with 3 expected skips, plus 3 Swift Testing cases.
- `git diff --check` passed.
- `script/build_and_run.sh verify` completed the release build, signed app staging, launch, and process verification.
- Independent exact-commit and combined-tree review found no remaining lifecycle issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core refresh scheduling and timing behavior that affects all providers and the footer UX; changes are well-tested but incorrect deadline logic could delay live updates or confuse users.
> 
> **Overview**
> **Automatic refresh** is consolidated in `AppContainer` via a new **`PeriodicRefreshLoop`**: refresh → notifications → telemetry → wait, with cancellation guards so half-finished cycles do not publish deadlines or run post-refresh work.
> 
> **`DashboardView`** no longer runs a one-shot `refreshAll()` on mount, so opening the popover cannot compete with the background loop.
> 
> **`RefreshWakeSignal`** now returns **enablement vs timer** triggers (`wait(timeout:)`). Early provider-enablement passes **keep the existing monotonic deadline** instead of sleeping another full interval; if an early pass crosses expiry, the next wait uses **zero** so the scheduled pass runs immediately.
> 
> **`WidgetDataStore`** drops batch-end `lastRefreshAt` stamping and exposes **`nextAutomaticRefreshAt`**, set only when the scheduler starts a new cadence interval—manual ⌘R refreshes do not move it.
> 
> **`PopoverFooter`** formats “Next update in …” from that deadline via **`countdownText`**.
> 
> Docs and **unit tests** cover loop ordering, wake buffering, early-wake timing, deadline crossing, and manual refresh preserving the deadline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e4a788a9598f3975b1e54dc01ca697460ba84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->