### PR TITLE
Preserve Grok token refresh error semantics

### DIFF
--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -131,6 +131,16 @@ extension GrokUsageError: CategorizedError {
     }
 }
 
+extension GrokRefreshError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .connectionFailed: .network
+        case .invalidResponse: .decoding
+        case .requestFailed(let status): ErrorCategory.http(status)
+        }
+    }
+}
+
 extension DevinAuthError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {

--- a/Sources/OpenUsage/Providers/Grok/GrokAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokAuthStore.swift
@@ -68,7 +68,10 @@ struct GrokAuthStore: Sendable {
             throw GrokAuthError.notLoggedIn
         }
 
-        let candidates = auth.compactMap { entryKey, entry -> GrokAuthState? in
+        // JSON object and Swift Dictionary order are not contracts. A stable key order makes
+        // multi-account fallback deterministic across launches and gives tests a real preference rule.
+        let candidates = auth.keys.sorted().compactMap { entryKey -> GrokAuthState? in
+            guard let entry = auth[entryKey] else { return nil }
             guard let token = trimmed(entry.key) else { return nil }
             return GrokAuthState(auth: auth, entryKey: entryKey, entry: entry, token: token)
         }

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -58,24 +58,63 @@ final class GrokProvider: ProviderRuntime {
     private func loadAndProbe() async throws -> ProviderSnapshot {
         let candidates = try authStore.loadAuthCandidates()
         var sawExpiredCandidate = false
+        var refreshFailure: Error?
 
         for var state in candidates {
             if authStore.needsRefresh(entry: state.entry, token: state.token) {
-                if let refreshed = await refreshAccessToken(state: &state) {
-                    return try await probe(state: &state, accessToken: refreshed)
+                let isExpired = authStore.isExpired(entry: state.entry, token: state.token)
+                let refreshed: String?
+                do {
+                    refreshed = try await refreshAccessToken(state: &state)
+                } catch {
+                    if isExpired {
+                        sawExpiredCandidate = true
+                        if !(error is GrokAuthError), refreshFailure == nil {
+                            refreshFailure = error
+                        }
+                        continue
+                    }
+                    // A token inside the refresh buffer is still usable. Preserve that resilience, but
+                    // record why the proactive refresh failed before trying the current token.
+                    AppLog.warn(LogTag.auth("grok"), "proactive token refresh failed; trying the current unexpired token: \(error.localizedDescription)")
+                    refreshed = nil
                 }
-                if authStore.isExpired(entry: state.entry, token: state.token) {
+                if let refreshed {
+                    if let snapshot = try await probeCandidate(state: &state, accessToken: refreshed) {
+                        return snapshot
+                    }
+                    sawExpiredCandidate = true
+                    continue
+                }
+                if isExpired {
                     sawExpiredCandidate = true
                     continue
                 }
             }
-            return try await probe(state: &state, accessToken: state.token)
+            if let snapshot = try await probeCandidate(state: &state, accessToken: state.token) {
+                return snapshot
+            }
+            sawExpiredCandidate = true
         }
 
+        if let refreshFailure {
+            throw refreshFailure
+        }
         if sawExpiredCandidate {
             throw GrokAuthError.expired
         }
         throw GrokAuthError.invalidAuth
+    }
+
+    /// A rejected token invalidates only this stored account. Keep probing later accounts, while every
+    /// non-authentication failure still escapes immediately with its precise network/HTTP/decoding type.
+    private func probeCandidate(state: inout GrokAuthState, accessToken: String) async throws -> ProviderSnapshot? {
+        do {
+            return try await probe(state: &state, accessToken: accessToken)
+        } catch is GrokAuthError {
+            AppLog.warn(LogTag.auth("grok"), "stored account was rejected; trying the next account if available")
+            return nil
+        }
     }
 
     private func probe(state: inout GrokAuthState, accessToken: String) async throws -> ProviderSnapshot {
@@ -112,7 +151,7 @@ final class GrokProvider: ProviderRuntime {
             token: accessToken,
             attempt: { try await self.usageClient.fetchCreditsConfig(accessToken: $0) },
             refreshAccessToken: {
-                guard let refreshed = await self.refreshAccessToken(state: &working) else {
+                guard let refreshed = try await self.refreshAccessToken(state: &working) else {
                     throw GrokAuthError.expired
                 }
                 return refreshed
@@ -122,7 +161,7 @@ final class GrokProvider: ProviderRuntime {
         )
     }
 
-    private func refreshAccessToken(state: inout GrokAuthState) async -> String? {
+    private func refreshAccessToken(state: inout GrokAuthState) async throws -> String? {
         guard let refreshToken = authStore.refreshToken(for: state.entry) else {
             return nil
         }
@@ -134,27 +173,41 @@ final class GrokProvider: ProviderRuntime {
                 clientID: authStore.clientID(entryKey: state.entryKey, entry: state.entry)
             )
         } catch {
-            // Log the real cause: a transport failure here is currently surfaced to the user as
-            // "auth expired" (loadAndProbe / the retry closure both map a nil refresh to .expired), so
-            // without this line the actual reason (network/DNS/timeout) is lost. (Refining the
-            // user-facing message to a request-failure is deferred — it needs a careful rework of the
-            // candidate-loop + retry-closure semantics.)
             AppLog.warn(LogTag.auth("grok"), "token refresh request failed (transport): \(error.localizedDescription)")
-            return nil
+            throw GrokRefreshError.connectionFailed
         }
 
+        if refreshTokenWasRejected(response) {
+            AppLog.warn(LogTag.auth("grok"), "token refresh failed (HTTP \(response.statusCode))")
+            throw GrokAuthError.expired
+        }
         guard (200..<300).contains(response.statusCode) else {
             AppLog.warn(LogTag.auth("grok"), "token refresh failed (HTTP \(response.statusCode))")
-            return nil
+            throw GrokRefreshError.requestFailed(response.statusCode)
         }
-        guard let decoded = usageClient.decodeRefreshResponse(response),
-              !decoded.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
+
+        let decoded: GrokRefreshResponse
+        do {
+            decoded = try usageClient.decodeRefreshResponse(response)
+        } catch {
             AppLog.warn(LogTag.auth("grok"), "token refresh returned an undecodable or empty access token")
-            return nil
+            throw GrokRefreshError.invalidResponse
+        }
+        guard !decoded.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            AppLog.warn(LogTag.auth("grok"), "token refresh returned an undecodable or empty access token")
+            throw GrokRefreshError.invalidResponse
         }
 
         let accessToken = decoded.accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        let expiresAt: Date
+        do {
+            expiresAt = try refreshExpiryDate(response: decoded, accessToken: accessToken)
+        } catch {
+            AppLog.warn(LogTag.auth("grok"), "token refresh returned invalid expiry metadata")
+            throw error
+        }
+
+        // Validate the complete refresh payload before mutating in-memory or persisted auth state.
         state.token = accessToken
         state.entry.key = accessToken
         if let refreshToken = decoded.refreshToken?.trimmingCharacters(in: .whitespacesAndNewlines), !refreshToken.isEmpty {
@@ -164,7 +217,6 @@ final class GrokProvider: ProviderRuntime {
             state.entry.idToken = idToken
         }
 
-        let expiresAt = refreshExpiryDate(response: decoded, accessToken: accessToken)
         state.entry.expiresAt = OpenUsageISO8601.string(from: expiresAt)
         // Fail loudly: a swallowed save strands the rotated token on disk (next launch re-refreshes /
         // can surface a false "auth expired"). The refreshed token works for this session, so log and
@@ -177,8 +229,21 @@ final class GrokProvider: ProviderRuntime {
         return accessToken
     }
 
-    private func refreshExpiryDate(response: GrokRefreshResponse, accessToken: String) -> Date {
-        if let expiresIn = response.expiresIn, expiresIn.isFinite, expiresIn > 0 {
+    private func refreshTokenWasRejected(_ response: HTTPResponse) -> Bool {
+        guard (400..<500).contains(response.statusCode),
+              let body = ProviderParse.jsonObject(response.body),
+              let errorCode = (body["error"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        else {
+            return false
+        }
+        return errorCode.caseInsensitiveCompare("invalid_grant") == .orderedSame
+    }
+
+    private func refreshExpiryDate(response: GrokRefreshResponse, accessToken: String) throws -> Date {
+        if let expiresIn = response.expiresIn {
+            guard expiresIn.isFinite, expiresIn > 0 else {
+                throw GrokRefreshError.invalidResponse
+            }
             return now().addingTimeInterval(expiresIn)
         }
         if let tokenExpiry = authStore.tokenExpiresAt(accessToken) {
@@ -188,10 +253,21 @@ final class GrokProvider: ProviderRuntime {
     }
 
     private func fetchPlanName(accessToken: String) async -> String? {
+        let response: HTTPResponse
         do {
-            return GrokUsageMapper.planName(from: try await usageClient.fetchSettings(accessToken: accessToken))
+            response = try await usageClient.fetchSettings(accessToken: accessToken)
         } catch {
+            AppLog.warn(LogTag.plugin("grok"), "optional plan request failed")
             return nil
         }
+        guard (200..<300).contains(response.statusCode) else {
+            AppLog.warn(LogTag.plugin("grok"), "optional plan request returned HTTP \(response.statusCode)")
+            return nil
+        }
+        guard let plan = GrokUsageMapper.planName(from: response) else {
+            AppLog.warn(LogTag.plugin("grok"), "optional plan response contained invalid plan metadata")
+            return nil
+        }
+        return plan
     }
 }

--- a/Sources/OpenUsage/Providers/Grok/GrokUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokUsageClient.swift
@@ -31,6 +31,25 @@ enum GrokUsageError: Error, LocalizedError, Equatable {
     }
 }
 
+/// Failures from the OAuth token endpoint are separate from billing failures so a temporary refresh
+/// outage never masquerades as an expired Grok login.
+enum GrokRefreshError: Error, LocalizedError, Equatable {
+    case connectionFailed
+    case invalidResponse
+    case requestFailed(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .connectionFailed:
+            return "Grok token refresh failed. Check your connection."
+        case .invalidResponse:
+            return "Grok token refresh response changed."
+        case .requestFailed(let statusCode):
+            return "Grok token refresh failed (HTTP \(statusCode)). Try again later."
+        }
+    }
+}
+
 struct GrokUsageClient: Sendable {
     static let settingsURL = URL(string: "https://cli-chat-proxy.grok.com/v1/settings")!
     static let refreshURL = URL(string: "https://auth.x.ai/oauth2/token")!
@@ -81,8 +100,8 @@ struct GrokUsageClient: Sendable {
         ))
     }
 
-    func decodeRefreshResponse(_ response: HTTPResponse) -> GrokRefreshResponse? {
-        try? JSONDecoder().decode(GrokRefreshResponse.self, from: response.body)
+    func decodeRefreshResponse(_ response: HTTPResponse) throws -> GrokRefreshResponse {
+        try JSONDecoder().decode(GrokRefreshResponse.self, from: response.body)
     }
 
     private func authHeaders(accessToken: String) -> [String: String] {
@@ -94,4 +113,3 @@ struct GrokUsageClient: Sendable {
         ]
     }
 }
-

--- a/Tests/OpenUsageTests/GrokProviderTests.swift
+++ b/Tests/OpenUsageTests/GrokProviderTests.swift
@@ -173,6 +173,38 @@ final class GrokProviderTests: XCTestCase {
         XCTAssertNotNil(snapshot.errorCategory)
     }
 
+    func testPlanHTTPFailureIsLoggedWithoutDiscardingPrimaryUsage() async throws {
+        let provider = makeProvider(httpClient: RecordingHTTPClient { request in
+            if request.url == GrokUsageClient.settingsURL {
+                return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            }
+            return Self.defaultRoutes(request)
+        })
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertNil(snapshot.plan)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertNotNil(progress(snapshot.lines, "Weekly limit"))
+        XCTAssertTrue(logs.contains("optional plan request returned HTTP 503"), logs)
+    }
+
+    func testPlanTransportFailureIsLoggedWithoutDiscardingPrimaryUsage() async throws {
+        let provider = makeProvider(httpClient: RecordingHTTPClient { request in
+            if request.url == GrokUsageClient.settingsURL {
+                throw URLError(.cannotConnectToHost)
+            }
+            return Self.defaultRoutes(request)
+        })
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertNil(snapshot.plan)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertNotNil(progress(snapshot.lines, "Weekly limit"))
+        XCTAssertTrue(logs.contains("optional plan request failed"), logs)
+    }
+
     func testNonWeeklyPeriodShowsNoWeeklyLineAndNoWarning() async {
         // A not-yet-migrated (monthly-period) account is a valid state, not a failure: the Weekly
         // tile reads "No data" without the amber triangle, and the badge still renders.
@@ -311,6 +343,27 @@ final class GrokProviderTests: XCTestCase {
 
     private func noLogScanner() -> GrokLogUsageScanner {
         GrokLogUsageScanner(files: FakeFiles(), environment: FakeEnvironment(), homeDirectory: { URL(fileURLWithPath: "/home/none") })
+    }
+
+    private func captureLogs(
+        _ operation: () async -> ProviderSnapshot
+    ) async throws -> (ProviderSnapshot, String) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.GrokPlan.\(UUID().uuidString)", isDirectory: true)
+        let sink = LogFile(directory: directory, fileName: "OpenUsage.log")
+        sink.open()
+        let originalSink = AppLog.sink
+        AppLog.sink = sink
+        AppLog.reloadLevel(.warn)
+        defer {
+            AppLog.sink = originalSink
+            AppLog.reloadLevel()
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let snapshot = await operation()
+        let logs = try String(contentsOf: directory.appendingPathComponent("OpenUsage.log"), encoding: .utf8)
+        return (snapshot, logs)
     }
 
     private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {

--- a/Tests/OpenUsageTests/GrokRefreshErrorTests.swift
+++ b/Tests/OpenUsageTests/GrokRefreshErrorTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class GrokRefreshErrorTests: XCTestCase {
+    private let now = OpenUsageISO8601.date(from: "2026-02-02T00:00:00.000Z")!
+    private let expiredAuth = #"{"https://auth.x.ai::client":{"key":"expired-token","refresh_token":"refresh","expires_at":"2026-01-01T00:00:00.000Z"}}"#
+
+    func testExpiredTokenRefreshTransportFailureReportsNetworkError() async {
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.refreshURL {
+                throw URLError(.notConnectedToInternet)
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, authJSON: expiredAuth).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .network)
+        XCTAssertEqual(errorText(snapshot), "Grok token refresh failed. Check your connection.")
+        XCTAssertFalse(http.requests.contains { $0.url == GrokUsageClient.creditsConfigURL })
+    }
+
+    func testAuthRetryRefreshServerFailureReportsHTTPError() async {
+        var creditsCalls = 0
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.creditsConfigURL {
+                creditsCalls += 1
+                return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+            }
+            if request.url == GrokUsageClient.refreshURL {
+                return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .http5xx)
+        XCTAssertEqual(errorText(snapshot), "Grok token refresh failed (HTTP 503). Try again later.")
+        XCTAssertEqual(creditsCalls, 1, "a failed refresh must not retry billing with the rejected token")
+    }
+
+    func testMalformedSuccessfulRefreshReportsDecodingError() async {
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.refreshURL {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"unexpected":true}"#.utf8))
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, authJSON: expiredAuth).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .decoding)
+        XCTAssertEqual(errorText(snapshot), "Grok token refresh response changed.")
+    }
+
+    func testInvalidExplicitExpiryReportsDecodingWithoutRewritingAuthFile() async {
+        let jwtAccessToken = "a.eyJleHAiOjE3NzAwMDM2MDB9.c"
+        XCTAssertNotNil(GrokAuthStore().tokenExpiresAt(jwtAccessToken))
+        let cases = [
+            (expiresIn: "0", accessToken: jwtAccessToken),
+            (expiresIn: "-60", accessToken: "new-token"),
+            (expiresIn: "1e400", accessToken: "new-token")
+        ]
+        for testCase in cases {
+            let originalAuth = expiredAuth
+            let files = FakeFiles([GrokAuthStore.authPath: originalAuth])
+            let http = RefreshHTTPClient { request in
+                if request.url == GrokUsageClient.refreshURL {
+                    let body = #"{"access_token":"\#(testCase.accessToken)","refresh_token":"new-refresh","expires_in":\#(testCase.expiresIn)}"#
+                    return HTTPResponse(statusCode: 200, headers: [:], body: Data(body.utf8))
+                }
+                return Self.defaultRoute(request)
+            }
+
+            let snapshot = await makeProvider(http: http, files: files).refresh()
+
+            XCTAssertEqual(snapshot.errorCategory, .decoding, "expires_in=\(testCase.expiresIn)")
+            XCTAssertEqual(errorText(snapshot), "Grok token refresh response changed.")
+            XCTAssertEqual(files.files[GrokAuthStore.authPath], originalAuth, "expires_in=\(testCase.expiresIn)")
+        }
+    }
+
+    func testWhitespaceOnlyAccessTokenReportsDecodingWithoutRewritingAuthFile() async {
+        let originalAuth = expiredAuth
+        let files = FakeFiles([GrokAuthStore.authPath: originalAuth])
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.refreshURL {
+                let body = #"{"access_token":"   ","refresh_token":"new-refresh","expires_in":3600}"#
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(body.utf8))
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, files: files).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .decoding)
+        XCTAssertEqual(files.files[GrokAuthStore.authPath], originalAuth)
+    }
+
+    func testRateLimitedRefreshKeepsRateLimitClassification() async {
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.refreshURL {
+                return HTTPResponse(statusCode: 429, headers: [:], body: Data())
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, authJSON: expiredAuth).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .rateLimited)
+        XCTAssertEqual(errorText(snapshot), "Grok token refresh failed (HTTP 429). Try again later.")
+    }
+
+    func testRejectedRefreshTokenStillReportsExpiredAuth() async {
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.refreshURL {
+                return HTTPResponse(statusCode: 400, headers: [:], body: Data(#"{"error":"invalid_grant"}"#.utf8))
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, authJSON: expiredAuth).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authExpired)
+        XCTAssertEqual(errorText(snapshot), GrokAuthError.expired.localizedDescription)
+    }
+
+    func testUnrecognizedRefreshRejectionDoesNotClaimTheLoginExpired() async {
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.refreshURL {
+                return HTTPResponse(statusCode: 400, headers: [:], body: Data(#"{"error":"invalid_request"}"#.utf8))
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, authJSON: expiredAuth).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .http4xx)
+        XCTAssertEqual(errorText(snapshot), "Grok token refresh failed (HTTP 400). Try again later.")
+    }
+
+    func testFailedProactiveRefreshStillTriesCurrentUnexpiredToken() async {
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.refreshURL {
+                return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            }
+            return Self.defaultRoute(request)
+        }
+        let currentAuth = #"{"https://auth.x.ai::client":{"key":"current-token","refresh_token":"refresh","expires_at":"2026-02-02T00:02:00.000Z"}}"#
+
+        let snapshot = await makeProvider(http: http, authJSON: currentAuth).refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertNotNil(snapshot.lines.first { $0.label == "Weekly limit" })
+        XCTAssertTrue(http.requests.contains { request in
+            request.url == GrokUsageClient.creditsConfigURL
+                && request.headers["Authorization"] == "Bearer current-token"
+        })
+    }
+
+    func testSuccessfulProactiveRefreshDoesNotRetryCurrentTokenAfterProbeFailure() async {
+        let currentAuth = #"{"https://auth.x.ai::client":{"key":"current-token","refresh_token":"refresh","expires_at":"2026-02-02T00:02:00.000Z"}}"#
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.refreshURL {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"access_token":"new-token","refresh_token":"new-refresh","expires_in":3600}"#.utf8)
+                )
+            }
+            if request.url == GrokUsageClient.creditsConfigURL {
+                throw URLError(.notConnectedToInternet)
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, authJSON: currentAuth).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .network)
+        XCTAssertEqual(
+            http.requests
+                .filter { $0.url == GrokUsageClient.creditsConfigURL }
+                .compactMap { $0.headers["Authorization"] },
+            ["Bearer new-token"],
+            "a successful refresh must not turn a probe failure into a retry with the replaced token"
+        )
+    }
+
+    func testRejectedUnexpiredAccountFallsThroughToNextStoredAccount() async {
+        let auth = twoAccountAuth
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.creditsConfigURL,
+               request.headers["Authorization"] == "Bearer stale-token" {
+                return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, authJSON: auth).refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertNotNil(snapshot.lines.first { $0.label == "Weekly limit" })
+        XCTAssertEqual(
+            http.requests
+                .filter { $0.url == GrokUsageClient.creditsConfigURL }
+                .compactMap { $0.headers["Authorization"] },
+            ["Bearer stale-token", "Bearer valid-token"]
+        )
+        XCTAssertFalse(http.requests.contains { $0.url == GrokUsageClient.refreshURL })
+    }
+
+    func testEveryRejectedAccountReportsExpiredAfterTryingAllAccounts() async {
+        let http = RefreshHTTPClient { request in
+            if request.url == GrokUsageClient.creditsConfigURL {
+                return HTTPResponse(statusCode: 403, headers: [:], body: Data())
+            }
+            return Self.defaultRoute(request)
+        }
+
+        let snapshot = await makeProvider(http: http, authJSON: twoAccountAuth).refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authExpired)
+        XCTAssertEqual(errorText(snapshot), GrokAuthError.expired.localizedDescription)
+        XCTAssertEqual(
+            http.requests
+                .filter { $0.url == GrokUsageClient.creditsConfigURL }
+                .compactMap { $0.headers["Authorization"] },
+            ["Bearer stale-token", "Bearer valid-token"]
+        )
+    }
+
+    private var twoAccountAuth: String {
+        """
+        {
+          "a-stale": {
+            "key": "stale-token",
+            "expires_at": "2026-07-01T00:00:00.000Z"
+          },
+          "b-valid": {
+            "key": "valid-token",
+            "expires_at": "2026-07-01T00:00:00.000Z"
+          }
+        }
+        """
+    }
+
+    private func makeProvider(
+        http: RefreshHTTPClient,
+        authJSON: String = #"{"https://auth.x.ai::client":{"key":"token","refresh_token":"refresh","expires_at":"2026-07-01T00:00:00.000Z"}}"#
+    ) -> GrokProvider {
+        makeProvider(http: http, files: FakeFiles([GrokAuthStore.authPath: authJSON]))
+    }
+
+    private func makeProvider(http: RefreshHTTPClient, files: FakeFiles) -> GrokProvider {
+        let fixedNow = now
+        return GrokProvider(
+            authStore: GrokAuthStore(files: files, now: { fixedNow }),
+            usageClient: GrokUsageClient(httpClient: http),
+            logUsageScanner: GrokLogUsageScanner(
+                files: FakeFiles(),
+                environment: FakeEnvironment(),
+                homeDirectory: { URL(fileURLWithPath: "/home/none") }
+            ),
+            now: { fixedNow },
+            pricing: { TestPricing.bundled }
+        )
+    }
+
+    private static func defaultRoute(_ request: HTTPRequest) -> HTTPResponse {
+        if request.url == GrokUsageClient.creditsConfigURL {
+            return HTTPResponse(statusCode: 200, headers: [:], body: GrokCreditsFixtures.capturedResponseBody)
+        }
+        if request.url == GrokUsageClient.settingsURL {
+            return HTTPResponse(
+                statusCode: 200,
+                headers: [:],
+                body: Data(#"{"subscription_tier_display":"SuperGrok Heavy"}"#.utf8)
+            )
+        }
+        return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+    }
+
+    private func errorText(_ snapshot: ProviderSnapshot) -> String? {
+        guard case .badge(let label, let text, _, _) = snapshot.lines.first,
+              label == MetricLine.errorBadgeLabel
+        else {
+            return nil
+        }
+        return text
+    }
+}
+
+private final class RefreshHTTPClient: HTTPClient, @unchecked Sendable {
+    var requests: [HTTPRequest] = []
+    private let handler: (HTTPRequest) throws -> HTTPResponse
+
+    init(handler: @escaping (HTTPRequest) throws -> HTTPResponse) {
+        self.handler = handler
+    }
+
+    func send(_ request: HTTPRequest) async throws -> HTTPResponse {
+        requests.append(request)
+        return try handler(request)
+    }
+}

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -15,7 +15,7 @@ The weekly shared pool is the limit Grok enforces for unified-billing accounts (
 
 ## Where credentials come from
 
-Sign in once with the Grok CLI (`grok login`); OpenUsage reads the same `~/.grok/auth.json`. Access tokens refresh automatically before expiry, and rotated tokens are written back to the file.
+Sign in once with the Grok CLI (`grok login`); OpenUsage reads the same `~/.grok/auth.json`. Access tokens refresh automatically before expiry, and rotated tokens are written back to the file. If the file contains multiple stored accounts, OpenUsage tries them in stable key order and continues after one account is rejected. It asks you to sign in again only when every saved login is expired or rejected; network, server, and malformed-response failures are reported separately and leave the saved login alone.
 
 ## The spend tiles
 
@@ -24,9 +24,11 @@ Today / Yesterday / Last 30 Days are computed **locally** from the Grok CLI's lo
 ## Troubleshooting
 
 - **"Session expired" / auth errors** — run `grok login` again, then refresh.
+- **Token refresh request errors** — these are temporary network or Grok service failures, not proof that your login expired. Check your connection and retry before signing in again.
+- **Plan name missing** — plan lookup is optional, so weekly usage still appears; transport, HTTP, and malformed-response failures are recorded with credential-free reasons in the diagnostic log.
 - **Weekly shows "No data"** — your account still reports a monthly (non-weekly) period, meaning it hasn't been migrated to Grok's unified weekly billing yet.
 - **Spend tiles show "No data"** — they need the Grok CLI's log at `~/.grok/logs/unified.jsonl`; older CLI versions logged no token counts. Run a Grok CLI session to populate it, then refresh.
 
 ## Under the hood
 
-`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` for the weekly pool and pay-as-you-go cap — the exact call the Grok CLI itself makes — and `…/v1/settings` for the plan name; token refresh via `auth.x.ai`. A 401/403 triggers one token refresh and retry.
+`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` for the weekly pool and pay-as-you-go cap — the exact call the Grok CLI itself makes — and `…/v1/settings` for the plan name; token refresh via `auth.x.ai`. A 401/403 triggers one token refresh and retry for that account, then falls through to the next stored account if authentication is still rejected.


### PR DESCRIPTION
## TL;DR

Preserves precise Grok token-refresh failures, probes stored accounts deterministically, prevents duplicate billing requests after proactive refresh, and makes optional plan lookup failures visible without discarding usable quota data.

## What was happening

- Refresh failures collapsed to `nil` and ultimately surfaced as Session expired.
- Invalid refresh payload lifetimes could fall through to a fabricated one-hour expiry.
- A rejected first account could prevent later valid accounts in the same auth file from being tried, and dictionary iteration made preference nondeterministic.
- Proactive refresh and the subsequent usage probe shared one catch block, so a successful refresh followed by probe failure was mislabeled and retried with the replaced token.
- Optional plan transport, HTTP, and malformed-response failures silently removed the plan name.

## What this changes

- Introduces typed refresh errors with accurate network, decoding, HTTP, and rate-limit categories.
- Treats only structured OAuth `invalid_grant` as terminal expired authentication.
- Separates refresh and probe boundaries so probe failures propagate once with no stale-token retry.
- Validates the full refresh payload, including finite positive `expires_in`, before mutating or saving credentials.
- Preserves the original auth file on validation failures.
- Sorts stored account keys and continues after account-specific authentication rejection.
- Logs fixed, credential-free reasons for nonfatal optional plan failures while retaining primary usage.
- Updates Grok credential, multi-account, retry, plan, and troubleshooting documentation.

## Heads-up

- Stable key order is the explicit preference rule because JSON object and Swift dictionary order are not contracts.
- Plan lookup remains nonfatal because the weekly quota endpoint is authoritative.

## Tests

- Twelve refresh-boundary tests passed, including proactive refresh plus probe failure, stale-first/valid-second, and all-accounts-rejected regressions.
- Added two optional-plan regressions for transport and HTTP failures, log visibility, and primary-usage preservation.
- All 54 Grok-focused tests passed.
- Full suite: 976 XCTest cases passed with 3 expected skips, plus 3 Swift Testing cases.
- `git diff --check` passed.
- `script/build_and_run.sh verify` completed the release build, signed app staging, launch, and process verification.

## Screenshots

A transient token-refresh failure retains its precise status instead of being mislabeled as expired authentication.

![Grok refresh failure notice](https://gist.githubusercontent.com/robinebers/5d45266150cbbe876cc388c639ffa66e/raw/6186552a2673d2c3440306cf5dc69104938feb60/grok-refresh-failure-notice.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grok authentication, token persistence, and error surfacing—security-sensitive paths—but behavior is heavily regression-tested and narrows false auth-expired outcomes.
> 
> **Overview**
> Grok token refresh failures no longer collapse into **session expired**. A new **`GrokRefreshError`** type surfaces network, HTTP, rate-limit, and malformed-response failures with matching telemetry categories, while only OAuth **`invalid_grant`** is treated as terminal auth expiry.
> 
> The refresh/probe flow is split so billing probe failures propagate once (no duplicate credits calls after a successful proactive refresh), proactive refresh failures on still-valid tokens fall back to the current token with a warning, and refresh payloads are validated (including finite positive **`expires_in`**) before mutating or saving **`auth.json`**.
> 
> Multi-account **`auth.json`** probing is **deterministic** (sorted keys) and **continues** after per-account auth rejection via **`probeCandidate`**. Optional plan lookup now logs transport/HTTP/decoding failures without failing the snapshot. Docs and broad XCTest coverage document the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70288417ae61f4947c753b64ff5bbc69053fc1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->