### PR TITLE
Preserve Cursor token refresh failure semantics

### DIFF
--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -88,6 +88,10 @@ final class CursorProvider: ProviderRuntime {
                 if accessToken == nil {
                     throw error
                 }
+                // A near-expiry JWT may still be accepted by the usage endpoint, so retain the existing
+                // fallback. Keep the swallowed refresh failure diagnosable without interpolating an
+                // error that could contain request details or credentials.
+                AppLog.warn(LogTag.auth("cursor"), "proactive token refresh failed; trying the existing access token")
             }
         }
 
@@ -192,24 +196,33 @@ final class CursorProvider: ProviderRuntime {
             return nil
         }
 
-        let response = try await usageClient.refreshToken(refreshToken)
+        let response: HTTPResponse
+        do {
+            response = try await usageClient.refreshToken(refreshToken)
+        } catch {
+            throw CursorUsageError.connectionFailed
+        }
         if response.statusCode == 400 || response.statusCode == 401 {
-            let body = ProviderParse.jsonObject(response.body)
-            if body?["shouldLogout"] as? Bool == true {
+            guard let body = ProviderParse.jsonObject(response.body),
+                  let shouldLogout = body["shouldLogout"] as? Bool else {
+                throw CursorUsageError.invalidResponse
+            }
+            if shouldLogout {
                 throw CursorAuthError.sessionExpired
             }
             throw CursorAuthError.tokenExpired
         }
-        guard (200..<300).contains(response.statusCode),
-              let body = ProviderParse.jsonObject(response.body)
-        else {
-            return nil
+        guard (200..<300).contains(response.statusCode) else {
+            throw CursorUsageError.requestFailed(response.statusCode)
+        }
+        guard let body = ProviderParse.jsonObject(response.body) else {
+            throw CursorUsageError.invalidResponse
         }
         if body["shouldLogout"] as? Bool == true {
             throw CursorAuthError.sessionExpired
         }
         guard let accessToken = (body["access_token"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
-            return nil
+            throw CursorUsageError.invalidResponse
         }
         // Fail loudly, but do NOT interpolate the error: the Cursor token is persisted via a SQL
         // statement that embeds the token, and a sqlite3 failure surfaces as stderr that could echo a
@@ -218,7 +231,7 @@ final class CursorProvider: ProviderRuntime {
         do {
             try authStore.saveAccessToken(accessToken, source: authState.source)
         } catch {
-            AppLog.error(LogTag.auth("cursor"), "failed to persist rotated access token to the Cursor state DB; using it for this session only")
+            AppLog.error(LogTag.auth("cursor"), "failed to persist rotated access token to the Cursor credential store; using it for this session only")
         }
         return accessToken
     }

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -102,11 +102,10 @@ extension CursorAuthError: CategorizedError {
 extension CursorUsageError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {
-        case .connectionFailed: .network
+        case .connectionFailed, .usageAfterRefreshFailed: .network
         case .invalidResponse, .totalUsageLimitMissing: .decoding
         case .requestFailed(let status): ErrorCategory.http(status)
         case .requestBasedUnavailable, .noActiveSubscription: .notAvailable
-        case .usageAfterRefreshFailed: .other
         }
     }
 }

--- a/Tests/OpenUsageTests/CursorProviderTests.swift
+++ b/Tests/OpenUsageTests/CursorProviderTests.swift
@@ -222,6 +222,191 @@ final class CursorProviderTests: XCTestCase {
         XCTAssertEqual(progress(snapshot.lines, "API usage")?.used, 7.5)
         XCTAssertEqual(progress(snapshot.lines, "On-demand")?.used, 40)
     }
+
+    func testRefreshOnlyCredentialsSurfaceRefreshConnectionFailure() async {
+        let provider = makeProvider(accessToken: nil, refreshToken: "refresh-token") { request in
+            if request.url == CursorUsageClient.refreshURL {
+                throw URLError(.cannotConnectToHost)
+            }
+            return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(badge(snapshot.lines, "Error"), ProviderUsageErrorText.connectionFailed)
+        XCTAssertEqual(snapshot.errorCategory, .network)
+    }
+
+    func testUsage401PreservesRefreshResponseFailureSemantics() async {
+        let cases: [(name: String, response: HTTPResponse, message: String, category: ErrorCategory)] = [
+            (
+                "server failure",
+                HTTPResponse(statusCode: 503, headers: [:], body: Data()),
+                ProviderUsageErrorText.requestFailed(statusCode: 503),
+                .http5xx
+            ),
+            (
+                "rate limit",
+                HTTPResponse(statusCode: 429, headers: [:], body: Data()),
+                ProviderUsageErrorText.requestFailed(statusCode: 429),
+                .rateLimited
+            ),
+            (
+                "malformed JSON",
+                HTTPResponse(statusCode: 200, headers: [:], body: Data("not-json".utf8)),
+                ProviderUsageErrorText.invalidResponse,
+                .decoding
+            ),
+            (
+                "missing access token",
+                HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"shouldLogout":false}"#.utf8)),
+                ProviderUsageErrorText.invalidResponse,
+                .decoding
+            ),
+            (
+                "malformed unauthorized response",
+                HTTPResponse(statusCode: 401, headers: [:], body: Data("not-json".utf8)),
+                ProviderUsageErrorText.invalidResponse,
+                .decoding
+            )
+        ]
+
+        for testCase in cases {
+            let provider = makeProvider(
+                accessToken: makeCursorJWT(),
+                refreshToken: "refresh-token"
+            ) { request in
+                if request.url == CursorUsageClient.refreshURL {
+                    return testCase.response
+                }
+                if request.url == CursorUsageClient.usageURL {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+
+            let snapshot = await provider.refresh()
+
+            XCTAssertEqual(badge(snapshot.lines, "Error"), testCase.message, testCase.name)
+            XCTAssertEqual(snapshot.errorCategory, testCase.category, testCase.name)
+            XCTAssertNotEqual(snapshot.errorCategory, .authExpired, testCase.name)
+        }
+    }
+
+    func testRefreshUsesAuthErrorsOnlyForExplicitExpirySemantics() async {
+        let cases: [(name: String, response: HTTPResponse, error: CursorAuthError)] = [
+            (
+                "logout response",
+                HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"shouldLogout":true}"#.utf8)),
+                .sessionExpired
+            ),
+            (
+                "unauthorized logout response",
+                HTTPResponse(statusCode: 401, headers: [:], body: Data(#"{"shouldLogout":true}"#.utf8)),
+                .sessionExpired
+            ),
+            (
+                "unauthorized token response",
+                HTTPResponse(statusCode: 401, headers: [:], body: Data(#"{"shouldLogout":false}"#.utf8)),
+                .tokenExpired
+            )
+        ]
+
+        for testCase in cases {
+            let provider = makeProvider(
+                accessToken: makeCursorJWT(),
+                refreshToken: "refresh-token"
+            ) { request in
+                if request.url == CursorUsageClient.refreshURL {
+                    return testCase.response
+                }
+                if request.url == CursorUsageClient.usageURL {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+
+            let snapshot = await provider.refresh()
+
+            XCTAssertEqual(badge(snapshot.lines, "Error"), testCase.error.localizedDescription, testCase.name)
+            XCTAssertEqual(snapshot.errorCategory, .authExpired, testCase.name)
+        }
+    }
+
+    func testProactiveRefreshFailureStillTriesUsableExistingToken() async {
+        let expiredAccessToken = makeCursorJWT(exp: 1)
+        let provider = makeProvider(
+            accessToken: expiredAccessToken,
+            refreshToken: "refresh-token"
+        ) { request in
+            if request.url == CursorUsageClient.refreshURL {
+                throw URLError(.cannotConnectToHost)
+            }
+            if request.url == CursorUsageClient.usageURL {
+                XCTAssertEqual(request.headers["Authorization"], "Bearer \(expiredAccessToken)")
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"enabled":true,"planUsage":{"limit":10000,"remaining":8000,"totalPercentUsed":20}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+        XCTAssertEqual(progress(snapshot.lines, "Total usage")?.used, 20)
+    }
+
+    func testUsageTransportFailureAfterSuccessfulRefreshStaysNetworkClassified() async {
+        let refreshedToken = makeCursorJWT(sub: "google-oauth2|refreshed-user")
+        let usageCalls = CursorCallCounter()
+        let provider = makeProvider(
+            accessToken: makeCursorJWT(),
+            refreshToken: "refresh-token"
+        ) { request in
+            if request.url == CursorUsageClient.refreshURL {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"access_token":"\#(refreshedToken)","shouldLogout":false}"#.utf8)
+                )
+            }
+            if request.url == CursorUsageClient.usageURL {
+                if usageCalls.next() == 1 {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                throw URLError(.networkConnectionLost)
+            }
+            return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(badge(snapshot.lines, "Error"), CursorUsageError.usageAfterRefreshFailed.localizedDescription)
+        XCTAssertEqual(snapshot.errorCategory, .network)
+    }
+
+    private func makeProvider(
+        accessToken: String?,
+        refreshToken: String?,
+        handler: @escaping @Sendable (HTTPRequest) async throws -> HTTPResponse
+    ) -> CursorProvider {
+        var values: [String: String] = [:]
+        values[CursorAuthStore.accessTokenKey] = accessToken
+        values[CursorAuthStore.refreshTokenKey] = refreshToken
+        return CursorProvider(
+            authStore: CursorAuthStore(
+                sqlite: FakeSQLite(values: values),
+                keychain: FakeKeychain(),
+                now: { Date(timeIntervalSince1970: 1_800_000_000) }
+            ),
+            usageClient: CursorUsageClient(http: RoutingHTTPClient(handler: handler)),
+            now: { Date(timeIntervalSince1970: 1_800_000_000) },
+            pricing: { TestPricing.bundled }
+        )
+    }
 }
 
 private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
@@ -236,6 +421,13 @@ private func dollarValue(_ lines: [MetricLine], _ label: String) -> Double? {
         return nil
     }
     return values.first { $0.kind == .dollars }?.number
+}
+
+private func badge(_ lines: [MetricLine], _ label: String) -> String? {
+    guard case .badge(_, let value, _, _) = lines.first(where: { $0.label == label }) else {
+        return nil
+    }
+    return value
 }
 
 private func makeCursorJWT(sub: String = "google-oauth2|user", exp: Double = 9_999_999_999) -> String {
@@ -278,6 +470,18 @@ private final class FakeSQLite: SQLiteAccessing, @unchecked Sendable {
             return nil
         }
         return String(sql[start..<end]).replacingOccurrences(of: "''", with: "'")
+    }
+}
+
+private final class CursorCallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func next() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+        return value
     }
 }
 

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -24,7 +24,7 @@ Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export.
 
 ## Troubleshooting
 
-- **"Not logged in" / token errors** — open Cursor and make sure you're signed in, then refresh.
+- **"Not logged in" / "Session expired" / "Token expired"** — open Cursor and make sure you're signed in, then refresh. Network, server, rate-limit, and malformed token-refresh responses are reported separately because signing in again cannot fix those failures.
 - **Some metrics missing** — Cursor omits fields depending on plan type (e.g. Requests only exists on request-based accounts); missing metrics simply show "No data".
 
 ## Under the hood


### PR DESCRIPTION
## TL;DR

Stops Cursor token-refresh network, server, rate-limit, and malformed-response failures from being mislabeled as an expired login, while preserving the existing safe fallback to an access token the usage endpoint may still accept.

## What was happening

- Refresh transport failures were untyped, while refresh 5xx, 429, malformed JSON, and missing-token responses collapsed to `nil`.
- During 401 recovery, that `nil` became “Token expired,” encouraging a re-login that cannot fix infrastructure or response-schema failures.
- A transport failure on the retried usage request had a distinct friendly message but was counted as telemetry category “other” instead of “network.”
- Proactive refresh failures with an existing access token were swallowed without a diagnostic.
- The token-persistence failure log named SQLite even when the selected credential source was Keychain.

## What this changes

- Maps refresh transport failures to the network category and preserves HTTP status semantics for 429, 4xx, and 5xx responses.
- Treats malformed JSON, malformed 400/401 bodies, and successful responses without a usable access token as invalid responses.
- Reserves session/token-expired errors for Cursor explicit `shouldLogout` boolean semantics.
- Keeps the existing proactive fallback to an access token that may remain server-usable, but logs that fallback without tokens or raw errors.
- Classifies transport failure after a successful refresh/retry as network while retaining its specific user-facing message.
- Makes the persistence diagnostic accurate for either SQLite or Keychain without exposing the credential or underlying SQL error.
- Updates Cursor troubleshooting guidance for the distinct token-refresh failure classes.

## Heads-up

- PR #914 independently corrects the pre-existing stale sentence about whether Cursor CSV export is fetched.
- PR #929 owns CSV export validation and fail-loud diagnostics; other optional endpoint diagnostics are intentionally kept out of this token-refresh PR.

## Tests

- Cursor provider suite: 6 tests passed; all Cursor-focused tests passed during independent review.
- Added coverage for refresh-only network failure; 429, 503, malformed/missing-token responses; explicit logout/token expiry; proactive fallback; and 401 → refresh → retried transport failure.
- Full suite: 967 XCTest cases passed, 3 expected skips; 3 Swift Testing cases passed.
- Release build packaged, code-signed, and launched with `script/build_and_run.sh verify`.
- `git diff --check` passed and two independent review passes found no remaining token-refresh issue.

## Screenshots

Refresh infrastructure failures now retain actionable guidance instead of appearing as expired authentication.

![Cursor refresh failure notice](https://gist.githubusercontent.com/robinebers/5d45266150cbbe876cc388c639ffa66e/raw/6186552a2673d2c3440306cf5dc69104938feb60/cursor-refresh-failure-notice.png)