### PR TITLE
Preserve Devin failures across credential fallbacks

### DIFF
--- a/Sources/OpenUsage/Providers/Devin/DevinAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinAuthStore.swift
@@ -7,11 +7,14 @@ struct DevinAuth: Hashable, Sendable {
 
 enum DevinAuthError: Error, LocalizedError, Equatable {
     case notLoggedIn
+    case sessionExpired
 
     var errorDescription: String? {
         switch self {
         case .notLoggedIn:
             return "Run devin auth login or sign in to Devin and try again."
+        case .sessionExpired:
+            return "Devin session expired. Run `devin auth login` or sign in to Devin again."
         }
     }
 }

--- a/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
@@ -41,58 +41,76 @@ final class DevinProvider: ProviderRuntime {
     }
 
     func refresh() async -> ProviderSnapshot {
-        var sawAPIKey = false
         var sawAuthFailure = false
+        var firstUsageFailure: DevinUsageError?
         let credentials = await loadOffMainActor { [authStore] in authStore.loadCredentialsFile() }
 
         if let credentials {
-            sawAPIKey = true
-            switch await attempt(auth: credentials) {
+            switch await attempt(auth: credentials, sourceLabel: "CLI credentials") {
             case .success(let mapped):
                 return snapshot(from: mapped)
             case .authFailure:
                 sawAuthFailure = true
-            case .unavailable:
-                break
+            case .usageFailure(let error):
+                firstUsageFailure = error
             }
         }
 
         let appAuth = await loadOffMainActor({ [authStore] in authStore.loadAppAuth() })
         if let appAuth,
            credentials == nil || shouldAttemptAppAuth(appAuth, after: credentials) {
-            sawAPIKey = true
-            switch await attempt(auth: appAuth) {
+            switch await attempt(auth: appAuth, sourceLabel: "app credentials") {
             case .success(let mapped):
                 return snapshot(from: mapped)
             case .authFailure:
                 sawAuthFailure = true
-            case .unavailable:
-                break
+            case .usageFailure(let error):
+                firstUsageFailure = firstUsageFailure ?? error
             }
         }
 
-        if sawAuthFailure {
-            return ProviderSnapshot.error(provider: provider, error: DevinAuthError.notLoggedIn)
+        // An auth rejection only proves that one candidate is stale. If another candidate encountered a
+        // transport, HTTP, or decoding failure, preserve that actionable failure instead of replacing it
+        // with a misleading login fallback.
+        if let firstUsageFailure {
+            return ProviderSnapshot.error(provider: provider, error: firstUsageFailure)
         }
-        if sawAPIKey {
-            return ProviderSnapshot.error(provider: provider, error: DevinUsageError.quotaUnavailable)
+        if sawAuthFailure {
+            return ProviderSnapshot.error(provider: provider, error: DevinAuthError.sessionExpired)
         }
         return ProviderSnapshot.error(provider: provider, error: DevinAuthError.notLoggedIn)
     }
 
-    private func attempt(auth: DevinAuth) async -> DevinAuthAttempt {
+    private func attempt(auth: DevinAuth, sourceLabel: String) async -> DevinAuthAttempt {
         let apiServerURL = authStore.effectiveAPIServerURL(auth)
+        let response: HTTPResponse
         do {
-            let response = try await usageClient.fetchUserStatus(auth: auth, apiServerURL: apiServerURL)
-            if response.statusCode == 401 || response.statusCode == 403 {
-                return .authFailure
-            }
-            guard (200..<300).contains(response.statusCode) else {
-                return .unavailable
-            }
-            return .success(try DevinUsageMapper.mapUserStatusResponse(response))
+            response = try await usageClient.fetchUserStatus(auth: auth, apiServerURL: apiServerURL)
+        } catch let error as DevinUsageError {
+            AppLog.error(LogTag.plugin("devin"), "\(sourceLabel) quota request could not be created")
+            return .usageFailure(error)
         } catch {
-            return .unavailable
+            AppLog.error(LogTag.plugin("devin"), "\(sourceLabel) quota request failed to connect")
+            return .usageFailure(.connectionFailed)
+        }
+
+        if response.statusCode == 401 || response.statusCode == 403 {
+            AppLog.warn(LogTag.auth("devin"), "\(sourceLabel) rejected (HTTP \(response.statusCode)); trying the next source if available")
+            return .authFailure
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            AppLog.error(LogTag.plugin("devin"), "\(sourceLabel) quota request failed (HTTP \(response.statusCode))")
+            return .usageFailure(.requestFailed(response.statusCode))
+        }
+
+        do {
+            return .success(try DevinUsageMapper.mapUserStatusResponse(response))
+        } catch let error as DevinUsageError {
+            AppLog.error(LogTag.plugin("devin"), "\(sourceLabel) quota response was unusable")
+            return .usageFailure(error)
+        } catch {
+            AppLog.error(LogTag.plugin("devin"), "\(sourceLabel) quota response could not be decoded")
+            return .usageFailure(.invalidResponse)
         }
     }
 
@@ -110,5 +128,5 @@ final class DevinProvider: ProviderRuntime {
 private enum DevinAuthAttempt {
     case success(DevinMappedUsage)
     case authFailure
-    case unavailable
+    case usageFailure(DevinUsageError)
 }

--- a/Sources/OpenUsage/Providers/Devin/DevinUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinUsageMapper.swift
@@ -106,12 +106,20 @@ enum DevinUsageMapper {
 }
 
 enum DevinUsageError: Error, LocalizedError, Equatable {
+    case connectionFailed
     case invalidResponse
+    case requestFailed(Int)
     case quotaUnavailable
 
     var errorDescription: String? {
         switch self {
-        case .invalidResponse, .quotaUnavailable:
+        case .connectionFailed:
+            return ProviderUsageErrorText.connectionFailed
+        case .invalidResponse:
+            return ProviderUsageErrorText.invalidResponse
+        case .requestFailed(let statusCode):
+            return ProviderUsageErrorText.requestFailed(statusCode: statusCode)
+        case .quotaUnavailable:
             return "Devin quota data unavailable. Try again later."
         }
     }

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -135,6 +135,7 @@ extension DevinAuthError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {
         case .notLoggedIn: .notLoggedIn
+        case .sessionExpired: .authExpired
         }
     }
 }
@@ -142,7 +143,9 @@ extension DevinAuthError: CategorizedError {
 extension DevinUsageError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {
+        case .connectionFailed: .network
         case .invalidResponse: .decoding
+        case .requestFailed(let status): ErrorCategory.http(status)
         case .quotaUnavailable: .notAvailable
         }
     }

--- a/Tests/OpenUsageTests/DevinProviderTests.swift
+++ b/Tests/OpenUsageTests/DevinProviderTests.swift
@@ -181,6 +181,89 @@ final class DevinProviderTests: XCTestCase {
         ])
     }
 
+    func testRefreshFallsBackToAppStateAfterPrimaryServiceFailure() async throws {
+        let httpClient = QueueHTTPClient(responses: [
+            HTTPResponse(statusCode: 500, headers: [:], body: Data("{}".utf8)),
+            HTTPResponse(statusCode: 200, headers: [:], body: try makeUserStatusBody(planName: "Teams"))
+        ])
+
+        let snapshot = await makeProviderWithDistinctCredentials(http: httpClient).refresh()
+
+        XCTAssertEqual(snapshot.plan, "Teams")
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(httpClient.requests.count, 2)
+    }
+
+    func testRefreshKeepsNonAuthFailureWhenAnotherCredentialIsRejected() async {
+        struct Scenario {
+            var name: String
+            var results: [QueuedHTTPResult]
+            var expectedText: String
+            var expectedCategory: ErrorCategory
+        }
+
+        let scenarios = [
+            Scenario(
+                name: "primary server error then stale app credentials",
+                results: [
+                    .response(HTTPResponse(statusCode: 500, headers: [:], body: Data("{}".utf8))),
+                    .response(HTTPResponse(statusCode: 401, headers: [:], body: Data("{}".utf8)))
+                ],
+                expectedText: DevinUsageError.requestFailed(500).localizedDescription,
+                expectedCategory: .http5xx
+            ),
+            Scenario(
+                name: "stale primary credentials then malformed app response",
+                results: [
+                    .response(HTTPResponse(statusCode: 401, headers: [:], body: Data("{}".utf8))),
+                    .response(HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+                ],
+                expectedText: DevinUsageError.invalidResponse.localizedDescription,
+                expectedCategory: .decoding
+            ),
+            Scenario(
+                name: "primary connection failure then stale app credentials",
+                results: [
+                    .connectionFailure,
+                    .response(HTTPResponse(statusCode: 403, headers: [:], body: Data("{}".utf8)))
+                ],
+                expectedText: DevinUsageError.connectionFailed.localizedDescription,
+                expectedCategory: .network
+            ),
+            Scenario(
+                name: "two service failures keep the preferred credential's failure",
+                results: [
+                    .response(HTTPResponse(statusCode: 429, headers: [:], body: Data("{}".utf8))),
+                    .response(HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+                ],
+                expectedText: DevinUsageError.requestFailed(429).localizedDescription,
+                expectedCategory: .rateLimited
+            )
+        ]
+
+        for scenario in scenarios {
+            let httpClient = QueueHTTPClient(results: scenario.results)
+            let snapshot = await makeProviderWithDistinctCredentials(http: httpClient).refresh()
+
+            XCTAssertEqual(errorText(snapshot.lines), scenario.expectedText, scenario.name)
+            XCTAssertEqual(snapshot.errorCategory, scenario.expectedCategory, scenario.name)
+            XCTAssertEqual(httpClient.requests.count, 2, scenario.name)
+        }
+    }
+
+    func testRefreshReportsExpiredSessionWhenEveryCredentialIsRejected() async {
+        let httpClient = QueueHTTPClient(responses: [
+            HTTPResponse(statusCode: 401, headers: [:], body: Data("{}".utf8)),
+            HTTPResponse(statusCode: 403, headers: [:], body: Data("{}".utf8))
+        ])
+
+        let snapshot = await makeProviderWithDistinctCredentials(http: httpClient).refresh()
+
+        XCTAssertEqual(errorText(snapshot.lines), DevinAuthError.sessionExpired.localizedDescription)
+        XCTAssertEqual(snapshot.errorCategory, .authExpired)
+        XCTAssertEqual(httpClient.requests.count, 2)
+    }
+
     func testRefreshReturnsLoginHintWithoutAuth() async {
         let provider = DevinProvider(
             authStore: DevinAuthStore(files: FakeFiles(), sqlite: FakeSQLite()),
@@ -201,6 +284,21 @@ final class DevinProviderTests: XCTestCase {
             return nil
         }
         return text
+    }
+
+    private func makeProviderWithDistinctCredentials(http: QueueHTTPClient) -> DevinProvider {
+        DevinProvider(
+            authStore: DevinAuthStore(
+                files: FakeFiles([
+                    DevinAuthStore.credentialsPath: """
+                    windsurf_api_key = "devin-session-token$cli"
+                    api_server_url = "https://server.codeium.test"
+                    """
+                ]),
+                sqlite: FakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
+            ),
+            usageClient: DevinUsageClient(http: http)
+        )
     }
 }
 
@@ -248,18 +346,36 @@ private final class FakeSQLite: SQLiteAccessing, @unchecked Sendable {
 }
 
 private final class QueueHTTPClient: HTTPClient, @unchecked Sendable {
-    var responses: [HTTPResponse]
+    var results: [QueuedHTTPResult]
     var requests: [HTTPRequest] = []
 
     init(responses: [HTTPResponse] = []) {
-        self.responses = responses
+        self.results = responses.map(QueuedHTTPResult.response)
+    }
+
+    init(results: [QueuedHTTPResult]) {
+        self.results = results
     }
 
     func send(_ request: HTTPRequest) async throws -> HTTPResponse {
         requests.append(request)
-        guard !responses.isEmpty else {
+        guard !results.isEmpty else {
             return HTTPResponse(statusCode: 500, headers: [:], body: Data("{}".utf8))
         }
-        return responses.removeFirst()
+        switch results.removeFirst() {
+        case .response(let response):
+            return response
+        case .connectionFailure:
+            throw StubHTTPError.connectionFailure
+        }
     }
+}
+
+private enum QueuedHTTPResult {
+    case response(HTTPResponse)
+    case connectionFailure
+}
+
+private enum StubHTTPError: Error {
+    case connectionFailure
 }

--- a/docs/providers/devin.md
+++ b/docs/providers/devin.md
@@ -22,9 +22,11 @@ If the CLI credentials fail but the app is signed in with a different account, t
 
 ## Troubleshooting
 
-- **"Not logged in"** — run `devin auth login`, or sign into the Devin app, then refresh.
+- **"Not logged in"** — OpenUsage found no usable credential. Run `devin auth login`, or sign into the Devin app, then refresh.
+- **"Session expired"** — every available credential was rejected. Sign in again with the Devin CLI or app, then refresh.
+- **Connection, request, or response error** — at least one credential encountered a non-authentication failure. Check your connection and Devin's service, then try again; this failure is kept instead of being replaced by a misleading login prompt from another stale credential.
 - **Weekly shows the daily figure** — when Devin reports no separate weekly quota, the daily quota is shown in the Weekly row so it stays meaningful.
 
 ## Under the hood
 
-Connect RPC `GetUserStatus` on the configured API server (default `server.codeium.com`). Quota percentages arrive as "remaining" and are flipped to "used". No token refresh — a 401/403 switches to the next auth source instead.
+Connect RPC `GetUserStatus` on the configured API server (default `server.codeium.com`). Quota percentages arrive as "remaining" and are flipped to "used". There is no token refresh; a failed credential falls through to the next distinct auth source when one exists. If none succeed, a connection, HTTP, or response failure takes precedence over a 401/403 login hint.


### PR DESCRIPTION
## TL;DR

Makes Devin credential fallback preserve the real connection, HTTP, or decoding failure when another local credential is stale. A login error is now shown only when every attempted credential is rejected.

## What was happening

- Devin probes both CLI and app credentials when they represent different accounts or servers.
- One 401/403 set a shared flag that could replace a valid source failure with a misleading "Not logged in" result.
- Transport, non-2xx, and malformed response failures collapsed into one unavailable branch and were not logged.

## What this changes

- Keeps the first typed non-authentication failure while still allowing a later credential source to succeed.
- Distinguishes no credentials from credentials that were all rejected.
- Classifies network, HTTP, rate-limit, server, and decoding failures precisely.
- Logs each failed boundary with fixed source labels and status codes, without credentials, request bodies, or response bodies.
- Updates the Devin troubleshooting and implementation documentation.

## Heads-up

- Credential preference is unchanged: CLI credentials are tried first, followed by distinct Devin app credentials.

## Tests

- 17 focused Devin tests passed, including mixed auth/network/HTTP/decoding precedence and successful fallback cases.
- Full Swift suite: 965 XCTest cases passed, 3 skipped; 3 Swift Testing cases passed.
- Release build packaged, code-signed, and launched with `script/build_and_run.sh verify`.
- Independent review completed with no findings.

## Screenshots

Only all-credentials-rejected outcomes show the expired-session guidance; mixed failures retain their precise error.

![Devin expired-session notice](https://gist.githubusercontent.com/robinebers/5d45266150cbbe876cc388c639ffa66e/raw/6186552a2673d2c3440306cf5dc69104938feb60/devin-session-expired-notice.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Devin refresh error precedence and user-facing messages when multiple credentials exist; behavior is well covered by new tests but affects a real provider integration path.
> 
> **Overview**
> **Devin refresh** no longer turns mixed credential outcomes into a misleading “not logged in” when CLI and app auth are tried in sequence.
> 
> `refresh()` keeps the **first non-auth failure** (connection, HTTP status, or bad decode) if any credential hit that, even when another source returns 401/403. **Session expired** is shown only when every attempted credential is rejected; **not logged in** stays for missing credentials. `attempt()` replaces the old `unavailable` bucket with typed **`DevinUsageError`** cases, shared error copy via `ProviderUsageErrorText`, structured logging per source label, and **`sessionExpired`** on `DevinAuthError` with `authExpired` telemetry.
> 
> Tests add fallback-on-5xx, precedence scenarios, and all-auth-rejected behavior; docs describe the new troubleshooting messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c6d30effa92e7651b8549a3e91f65784a70ec26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->