### PR TITLE
Preserve forced refreshes during in-flight requests

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -83,7 +83,9 @@ final class AppContainer {
         )
         // Re-enabling a provider should fetch it promptly, so clear any leftover failure backoff before
         // the enablement wake refreshes. `weak` breaks the cycle (dataStore already captures enablement).
-        enablement.onProviderEnabled = { [weak dataStore] id in dataStore?.clearFailureBackoff(for: id) }
+        enablement.onProviderEnabled = { [weak dataStore] id in
+            dataStore?.prepareProviderEnablementRefresh(for: id)
+        }
         // Fresh installs start minimal: seed the enabled-provider list (Claude/Codex/Cursor right away,
         // then the detected set once the local credential probe finishes). No-op on every later launch.
         let onboarding = OnboardingStore()

--- a/Sources/OpenUsage/Models/StalenessHint.swift
+++ b/Sources/OpenUsage/Models/StalenessHint.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// A compact staleness hint for a provider's on-screen snapshot. `label` is a short, fixed word
+/// ("Outdated") that stays narrow next to long plan names like "Super Grok Heavy", while the precise
+/// age lives in `tooltip` ("Last updated 3h 12m ago"), revealed on hover.
+struct StalenessHint: Equatable {
+    let label: String
+    let tooltip: String
+}

--- a/Sources/OpenUsage/Stores/ProviderRefreshCoalescer.swift
+++ b/Sources/OpenUsage/Stores/ProviderRefreshCoalescer.swift
@@ -8,9 +8,10 @@ extension WidgetDataStore {
     enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
 }
 
-/// Pending work behind `WidgetDataStore`'s per-provider in-flight guard. A forced request queues one
-/// post-flight probe; callers that reach the guard wait for the active request's final outcome.
-/// Keeping this bookkeeping separate leaves the store focused on fetch policy and snapshot updates.
+/// Pending work behind `WidgetDataStore`'s per-provider in-flight guard. An ordinary caller receives
+/// the active request's outcome; a forced caller queues a post-flight probe and waits until the forced
+/// chain settles. Keeping this bookkeeping separate leaves the store focused on fetch policy and
+/// snapshot updates.
 @MainActor
 final class ProviderRefreshCoalescer {
     /// `Task.cancel()` invokes its handler off-actor. This flag closes the interval before the cleanup
@@ -29,6 +30,7 @@ final class ProviderRefreshCoalescer {
 
     private struct Waiter {
         let id: UUID
+        let waitsForForcedRefresh: Bool
         var needsForcedRefresh: Bool
         let cancellation: WaiterCancellation
         let continuation: CheckedContinuation<WidgetDataStore.RefreshOutcome, Never>
@@ -87,6 +89,7 @@ final class ProviderRefreshCoalescer {
         }
         waiters[providerID, default: []].append(Waiter(
             id: waiterID,
+            waitsForForcedRefresh: force,
             needsForcedRefresh: force,
             cancellation: cancellation,
             continuation: continuation
@@ -176,6 +179,21 @@ final class ProviderRefreshCoalescer {
             || waiters[providerID]?.contains(where: {
                 claim.waiterIDs.contains($0.id) && !$0.cancellation.isCancelled
             }) == true
+    }
+
+    /// Complete callers that joined only the request that just finished. Forced callers stay queued
+    /// until the forced chain settles, including any newer force that arrived during a follow-up.
+    func resolveNonForcedWaiters(
+        providerID: String,
+        outcome: WidgetDataStore.RefreshOutcome
+    ) {
+        guard let providerWaiters = waiters[providerID] else { return }
+        let completed = providerWaiters.filter { !$0.waitsForForcedRefresh }
+        let remaining = providerWaiters.filter(\.waitsForForcedRefresh)
+        waiters[providerID] = remaining.isEmpty ? nil : remaining
+        for waiter in completed {
+            waiter.continuation.resume(returning: waiter.cancellation.isCancelled ? .skipped : outcome)
+        }
     }
 
     func resolveWaiters(

--- a/Sources/OpenUsage/Stores/ProviderRefreshCoalescer.swift
+++ b/Sources/OpenUsage/Stores/ProviderRefreshCoalescer.swift
@@ -2,16 +2,16 @@ import Foundation
 import os
 
 extension WidgetDataStore {
-    /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch
-    /// from real outcomes rather than cumulative error state. Concurrent calls receive the active
-    /// provider request's eventual outcome instead of being reported as skipped.
+    /// What a single provider request actually did, so `refreshAll` can summarize the batch from real
+    /// outcomes rather than cumulative error state. Ordinary joiners receive the active request's
+    /// outcome; forced joiners receive the follow-up that consumes their intent.
     enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
 }
 
 /// Pending work behind `WidgetDataStore`'s per-provider in-flight guard. An ordinary caller receives
-/// the active request's outcome; a forced caller queues a post-flight probe and waits until the forced
-/// chain settles. Keeping this bookkeeping separate leaves the store focused on fetch policy and
-/// snapshot updates.
+/// the active request's outcome; a forced caller queues a post-flight probe and receives the outcome
+/// of the probe that consumes its intent. Keeping this bookkeeping separate leaves the store focused
+/// on fetch policy and snapshot updates.
 @MainActor
 final class ProviderRefreshCoalescer {
     /// `Task.cancel()` invokes its handler off-actor. This flag closes the interval before the cleanup
@@ -50,7 +50,11 @@ final class ProviderRefreshCoalescer {
     private var queuedForcedProviderIDs: Set<String> = []
     private var waiters: [String: [Waiter]] = [:]
 
-    func join(providerID: String, force: Bool) async -> WidgetDataStore.RefreshOutcome {
+    func join(
+        providerID: String,
+        force: Bool,
+        onRegistered: @MainActor () -> Void = {}
+    ) async -> WidgetDataStore.RefreshOutcome {
         let waiterID = UUID()
         let cancellation = WaiterCancellation()
         return await withTaskCancellationHandler {
@@ -61,7 +65,8 @@ final class ProviderRefreshCoalescer {
                     waiterID: waiterID,
                     force: force,
                     cancellation: cancellation,
-                    continuation: continuation
+                    continuation: continuation,
+                    onRegistered: onRegistered
                 )
             }
         } onCancel: {
@@ -81,7 +86,8 @@ final class ProviderRefreshCoalescer {
         waiterID: UUID,
         force: Bool,
         cancellation: WaiterCancellation,
-        continuation: CheckedContinuation<WidgetDataStore.RefreshOutcome, Never>
+        continuation: CheckedContinuation<WidgetDataStore.RefreshOutcome, Never>,
+        onRegistered: @MainActor () -> Void
     ) {
         guard !cancellation.isCancelled else {
             continuation.resume(returning: .skipped)
@@ -94,6 +100,7 @@ final class ProviderRefreshCoalescer {
             cancellation: cancellation,
             continuation: continuation
         ))
+        onRegistered()
     }
 
     /// Remove and return one cancelled waiter so the store can resume it promptly as `.skipped`.
@@ -174,7 +181,7 @@ final class ProviderRefreshCoalescer {
         return hasQueuedForcedRefresh(providerID: providerID)
     }
 
-    private func isLive(_ claim: ForcedRefreshClaim, providerID: String) -> Bool {
+    func hasLiveIntent(_ claim: ForcedRefreshClaim, providerID: String) -> Bool {
         claim.includesEnablementIntent
             || waiters[providerID]?.contains(where: {
                 claim.waiterIDs.contains($0.id) && !$0.cancellation.isCancelled
@@ -182,7 +189,7 @@ final class ProviderRefreshCoalescer {
     }
 
     /// Complete callers that joined only the request that just finished. Forced callers stay queued
-    /// until the forced chain settles, including any newer force that arrived during a follow-up.
+    /// for the specific forced claim that consumes their intent.
     func resolveNonForcedWaiters(
         providerID: String,
         outcome: WidgetDataStore.RefreshOutcome
@@ -196,37 +203,20 @@ final class ProviderRefreshCoalescer {
         }
     }
 
-    func resolveWaiters(
+    /// Complete only the forced callers whose intent this claim consumed. Later forced callers belong
+    /// to a newer claim, so their cancellation or disablement can never rewrite this cohort's result.
+    func resolveClaimedWaiters(
+        _ claim: ForcedRefreshClaim,
         providerID: String,
         outcome: WidgetDataStore.RefreshOutcome
     ) {
-        for waiter in waiters.removeValue(forKey: providerID) ?? [] {
+        guard let providerWaiters = waiters[providerID] else { return }
+        let completed = providerWaiters.filter { claim.waiterIDs.contains($0.id) }
+        let remaining = providerWaiters.filter { !claim.waiterIDs.contains($0.id) }
+        waiters[providerID] = remaining.isEmpty ? nil : remaining
+        for waiter in completed {
             waiter.continuation.resume(returning: waiter.cancellation.isCancelled ? .skipped : outcome)
         }
     }
 
-    /// Move a claimed forced follow-up to an independent task when its original owner is cancelled.
-    /// `operation` returns `nil` when the provider can no longer run; otherwise its normal refresh
-    /// pipeline owns waiter resolution.
-    func handOffQueuedForcedRefresh(
-        providerID: String,
-        operation: @escaping @MainActor () async -> WidgetDataStore.RefreshOutcome?
-    ) {
-        Task.detached { [weak self] in
-            await self?.runHandedOffForcedRefresh(providerID: providerID, operation: operation)
-        }
-    }
-
-    private func runHandedOffForcedRefresh(
-        providerID: String,
-        operation: @escaping @MainActor () async -> WidgetDataStore.RefreshOutcome?
-    ) async {
-        guard let claim = takeQueuedForcedRefresh(providerID: providerID),
-              isLive(claim, providerID: providerID),
-              await operation() != nil
-        else {
-            resolveWaiters(providerID: providerID, outcome: .skipped)
-            return
-        }
-    }
 }

--- a/Sources/OpenUsage/Stores/ProviderRefreshCoalescer.swift
+++ b/Sources/OpenUsage/Stores/ProviderRefreshCoalescer.swift
@@ -1,0 +1,214 @@
+import Foundation
+import os
+
+extension WidgetDataStore {
+    /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch
+    /// from real outcomes rather than cumulative error state. Concurrent calls receive the active
+    /// provider request's eventual outcome instead of being reported as skipped.
+    enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
+}
+
+/// Pending work behind `WidgetDataStore`'s per-provider in-flight guard. A forced request queues one
+/// post-flight probe; callers that reach the guard wait for the active request's final outcome.
+/// Keeping this bookkeeping separate leaves the store focused on fetch policy and snapshot updates.
+@MainActor
+final class ProviderRefreshCoalescer {
+    /// `Task.cancel()` invokes its handler off-actor. This flag closes the interval before the cleanup
+    /// hop reaches MainActor, so an owner cannot claim a force from an already-cancelled waiter.
+    private final class WaiterCancellation: Sendable {
+        private let cancelled = OSAllocatedUnfairLock(initialState: false)
+
+        func cancel() {
+            cancelled.withLock { $0 = true }
+        }
+
+        var isCancelled: Bool {
+            cancelled.withLock { $0 }
+        }
+    }
+
+    private struct Waiter {
+        let id: UUID
+        var needsForcedRefresh: Bool
+        let cancellation: WaiterCancellation
+        let continuation: CheckedContinuation<WidgetDataStore.RefreshOutcome, Never>
+    }
+
+    /// Provenance for one claimed follow-up. Enablement intent exists independently of a caller;
+    /// waiter intent stays live only while at least one of the recorded callers remains uncancelled.
+    /// Keeping that distinction lets a cancelled owner restore only work somebody still wants.
+    struct ForcedRefreshClaim {
+        fileprivate let includesEnablementIntent: Bool
+        fileprivate let waiterIDs: Set<UUID>
+    }
+
+    /// Forced work requested without a waiting caller, currently provider re-enablement during an
+    /// active request. Waiting force callers carry their own pending flag in `waiters` so cancelling the
+    /// last such caller also withdraws work that nobody is waiting for.
+    private var queuedForcedProviderIDs: Set<String> = []
+    private var waiters: [String: [Waiter]] = [:]
+
+    func join(providerID: String, force: Bool) async -> WidgetDataStore.RefreshOutcome {
+        let waiterID = UUID()
+        let cancellation = WaiterCancellation()
+        return await withTaskCancellationHandler {
+            guard !Task.isCancelled else { return .skipped }
+            return await withCheckedContinuation { continuation in
+                register(
+                    providerID: providerID,
+                    waiterID: waiterID,
+                    force: force,
+                    cancellation: cancellation,
+                    continuation: continuation
+                )
+            }
+        } onCancel: {
+            // Mark synchronously before the actor hop. `has/takeQueuedForcedRefresh` consult this flag,
+            // so the owner cannot race ahead and claim work from the cancelled waiter.
+            cancellation.cancel()
+            // Cancellation handlers are nonisolated. Hop back to this actor to remove and release only
+            // the cancelled waiter; the active provider request belongs to another caller.
+            Task.detached { [weak self] in
+                await self?.cancelWaiter(providerID: providerID, waiterID: waiterID)
+            }
+        }
+    }
+
+    private func register(
+        providerID: String,
+        waiterID: UUID,
+        force: Bool,
+        cancellation: WaiterCancellation,
+        continuation: CheckedContinuation<WidgetDataStore.RefreshOutcome, Never>
+    ) {
+        guard !cancellation.isCancelled else {
+            continuation.resume(returning: .skipped)
+            return
+        }
+        waiters[providerID, default: []].append(Waiter(
+            id: waiterID,
+            needsForcedRefresh: force,
+            cancellation: cancellation,
+            continuation: continuation
+        ))
+    }
+
+    /// Remove and return one cancelled waiter so the store can resume it promptly as `.skipped`.
+    /// Its force request disappears with it unless another waiter or an explicit queue still needs one.
+    private func removeWaiter(
+        providerID: String,
+        waiterID: UUID
+    ) -> CheckedContinuation<WidgetDataStore.RefreshOutcome, Never>? {
+        guard var providerWaiters = waiters[providerID],
+              let index = providerWaiters.firstIndex(where: { $0.id == waiterID })
+        else { return nil }
+
+        let continuation = providerWaiters.remove(at: index).continuation
+        if providerWaiters.isEmpty {
+            waiters[providerID] = nil
+        } else {
+            waiters[providerID] = providerWaiters
+        }
+        return continuation
+    }
+
+    private func cancelWaiter(providerID: String, waiterID: UUID) {
+        removeWaiter(providerID: providerID, waiterID: waiterID)?
+            .resume(returning: .skipped)
+    }
+
+    func queueEnablementForcedRefresh(providerID: String) {
+        queuedForcedProviderIDs.insert(providerID)
+    }
+
+    func hasQueuedForcedRefresh(providerID: String) -> Bool {
+        queuedForcedProviderIDs.contains(providerID)
+            || waiters[providerID]?.contains(where: {
+                $0.needsForcedRefresh && !$0.cancellation.isCancelled
+            }) == true
+    }
+
+    func takeQueuedForcedRefresh(providerID: String) -> ForcedRefreshClaim? {
+        let includesEnablementIntent = queuedForcedProviderIDs.remove(providerID) != nil
+        var claimedWaiterIDs: Set<UUID> = []
+        guard var providerWaiters = waiters[providerID] else {
+            return includesEnablementIntent
+                ? ForcedRefreshClaim(includesEnablementIntent: true, waiterIDs: [])
+                : nil
+        }
+
+        for index in providerWaiters.indices
+        where providerWaiters[index].needsForcedRefresh && !providerWaiters[index].cancellation.isCancelled {
+            providerWaiters[index].needsForcedRefresh = false
+            claimedWaiterIDs.insert(providerWaiters[index].id)
+        }
+        waiters[providerID] = providerWaiters
+        guard includesEnablementIntent || !claimedWaiterIDs.isEmpty else { return nil }
+        return ForcedRefreshClaim(
+            includesEnablementIntent: includesEnablementIntent,
+            waiterIDs: claimedWaiterIDs
+        )
+    }
+
+    /// Restore a follow-up interrupted with its owner, retaining its original provenance. A cancelled
+    /// waiter is deliberately absent from the restored queue, while enablement intent survives without
+    /// a waiter because it represents a user action whose wake still needs a fresh request.
+    func restoreQueuedForcedRefresh(
+        _ claim: ForcedRefreshClaim,
+        providerID: String
+    ) -> Bool {
+        if claim.includesEnablementIntent {
+            queuedForcedProviderIDs.insert(providerID)
+        }
+        if var providerWaiters = waiters[providerID] {
+            for index in providerWaiters.indices
+            where claim.waiterIDs.contains(providerWaiters[index].id)
+                && !providerWaiters[index].cancellation.isCancelled {
+                providerWaiters[index].needsForcedRefresh = true
+            }
+            waiters[providerID] = providerWaiters
+        }
+        return hasQueuedForcedRefresh(providerID: providerID)
+    }
+
+    private func isLive(_ claim: ForcedRefreshClaim, providerID: String) -> Bool {
+        claim.includesEnablementIntent
+            || waiters[providerID]?.contains(where: {
+                claim.waiterIDs.contains($0.id) && !$0.cancellation.isCancelled
+            }) == true
+    }
+
+    func resolveWaiters(
+        providerID: String,
+        outcome: WidgetDataStore.RefreshOutcome
+    ) {
+        for waiter in waiters.removeValue(forKey: providerID) ?? [] {
+            waiter.continuation.resume(returning: waiter.cancellation.isCancelled ? .skipped : outcome)
+        }
+    }
+
+    /// Move a claimed forced follow-up to an independent task when its original owner is cancelled.
+    /// `operation` returns `nil` when the provider can no longer run; otherwise its normal refresh
+    /// pipeline owns waiter resolution.
+    func handOffQueuedForcedRefresh(
+        providerID: String,
+        operation: @escaping @MainActor () async -> WidgetDataStore.RefreshOutcome?
+    ) {
+        Task.detached { [weak self] in
+            await self?.runHandedOffForcedRefresh(providerID: providerID, operation: operation)
+        }
+    }
+
+    private func runHandedOffForcedRefresh(
+        providerID: String,
+        operation: @escaping @MainActor () async -> WidgetDataStore.RefreshOutcome?
+    ) async {
+        guard let claim = takeQueuedForcedRefresh(providerID: providerID),
+              isLive(claim, providerID: providerID),
+              await operation() != nil
+        else {
+            resolveWaiters(providerID: providerID, outcome: .skipped)
+            return
+        }
+    }
+}

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -229,6 +229,7 @@ final class WidgetDataStore {
         }
 
         var outcome = await performRefresh(providerID: providerID, provider: provider, force: force)
+        refreshCoalescer.resolveNonForcedWaiters(providerID: providerID, outcome: outcome)
         if Task.isCancelled {
             if refreshCoalescer.hasQueuedForcedRefresh(providerID: providerID) {
                 // The cancelled owner cannot satisfy a force requested by another live caller. Release
@@ -248,7 +249,11 @@ final class WidgetDataStore {
             // provenance instead of letting an already-cancelled owner enter provider work.
             if Task.isCancelled {
                 ownsProviderSlot = false
-                finishCancelledForcedRefreshClaim(forceClaim, providerID: providerID)
+                finishCancelledForcedRefreshClaim(
+                    forceClaim,
+                    providerID: providerID,
+                    outcome: .skipped
+                )
                 return .skipped
             }
             // A disable that lands during the active request wins; do not start a new request for a
@@ -260,9 +265,14 @@ final class WidgetDataStore {
             AppLog.debug(.refresh, "run queued forced refresh \(providerID)")
             outcome = await performRefresh(providerID: providerID, provider: provider, force: true)
             queuedOutcome = outcome
+            refreshCoalescer.resolveNonForcedWaiters(providerID: providerID, outcome: outcome)
             if Task.isCancelled {
                 ownsProviderSlot = false
-                finishCancelledForcedRefreshClaim(forceClaim, providerID: providerID)
+                finishCancelledForcedRefreshClaim(
+                    forceClaim,
+                    providerID: providerID,
+                    outcome: outcome
+                )
                 return .skipped
             }
         }
@@ -270,22 +280,24 @@ final class WidgetDataStore {
         return outcome
     }
 
-    /// Release a cancelled owner's slot and preserve only live intent from its claimed follow-up. A
-    /// cancelled waiter must not manufacture an ownerless request; enablement intent remains valid on
-    /// its own and is handed to a task with an independent cancellation lifetime.
+    /// Release a cancelled owner's slot. An interrupted follow-up restores only its still-live intent;
+    /// a follow-up that already produced a real outcome is complete and must never be replayed. Newer
+    /// forced work, if any, is handed to a task with an independent cancellation lifetime.
     private func finishCancelledForcedRefreshClaim(
         _ claim: ProviderRefreshCoalescer.ForcedRefreshClaim,
-        providerID: String
+        providerID: String,
+        outcome: RefreshOutcome
     ) {
-        let hasLiveForcedRefresh = refreshCoalescer.restoreQueuedForcedRefresh(
-            claim,
-            providerID: providerID
-        )
+        let hasLiveForcedRefresh = if outcome == .skipped {
+            refreshCoalescer.restoreQueuedForcedRefresh(claim, providerID: providerID)
+        } else {
+            refreshCoalescer.hasQueuedForcedRefresh(providerID: providerID)
+        }
         refreshingProviderIDs.remove(providerID)
         if hasLiveForcedRefresh {
             handOffQueuedForcedRefresh(providerID: providerID)
         } else {
-            refreshCoalescer.resolveWaiters(providerID: providerID, outcome: .skipped)
+            refreshCoalescer.resolveWaiters(providerID: providerID, outcome: outcome)
         }
     }
 

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -66,6 +66,14 @@ final class WidgetDataStore {
     /// day. `nil` (and so a no-op) in tests and previews. Not observable UI state.
     @ObservationIgnored var onRefreshOutcome: (@MainActor (String, RefreshOutcome, ErrorCategory?, Bool) -> Void)?
 
+    /// Deterministic concurrency-test seam invoked after a caller is actually registered behind an
+    /// active provider request. Nil in the app; unlike scheduler yields, this proves the waiter exists.
+    @ObservationIgnored var onRefreshJoined: (@MainActor (String, Bool) -> Void)?
+
+    /// Deterministic concurrency-test gate immediately before a reserved cancellation hand-off drains
+    /// its queue. Nil in the app; tests can pause here to prove the provider slot remains reserved.
+    @ObservationIgnored var beforeRefreshHandOff: (@MainActor () async -> Void)?
+
     /// Global meter style: whether every bounded tile (and the menu-bar value) renders as "used" or
     /// "left/remaining". Persisted so the choice survives relaunch; defaults to `.remaining`.
     var meterStyle: WidgetDisplayMode {
@@ -217,7 +225,11 @@ final class WidgetDataStore {
             // Wait for the owner's real outcome. A force also requests one fresh post-flight probe because
             // credentials may have changed after the owner loaded them.
             AppLog.debug(.refresh, "\(force ? "queue forced" : "join") refresh \(providerID) (already in flight)")
-            return await refreshCoalescer.join(providerID: providerID, force: force)
+            return await refreshCoalescer.join(
+                providerID: providerID,
+                force: force,
+                onRegistered: { [weak self] in self?.onRefreshJoined?(providerID, force) }
+            )
         }
 
         refreshingProviderIDs.insert(providerID)
@@ -228,61 +240,96 @@ final class WidgetDataStore {
             }
         }
 
-        var outcome = await performRefresh(providerID: providerID, provider: provider, force: force)
-        refreshCoalescer.resolveNonForcedWaiters(providerID: providerID, outcome: outcome)
+        let ownerOutcome = await performRefresh(providerID: providerID, provider: provider, force: force)
+        refreshCoalescer.resolveNonForcedWaiters(providerID: providerID, outcome: ownerOutcome)
         if Task.isCancelled {
             if refreshCoalescer.hasQueuedForcedRefresh(providerID: providerID) {
-                // The cancelled owner cannot satisfy a force requested by another live caller. Release
-                // the provider slot and move that work to a fresh, independent task.
+                // The cancelled owner cannot satisfy another caller's force. Transfer the still-held
+                // slot to an independent task so no newer owner can slip into the hand-off gap.
                 ownsProviderSlot = false
-                refreshingProviderIDs.remove(providerID)
                 handOffQueuedForcedRefresh(providerID: providerID)
-            } else {
-                refreshCoalescer.resolveWaiters(providerID: providerID, outcome: .skipped)
             }
             return .skipped
         }
 
-        var queuedOutcome = outcome
+        switch await drainQueuedForcedRefreshes(providerID: providerID, provider: provider) {
+        case .completed:
+            return ownerOutcome
+        case .slotTransferred:
+            ownsProviderSlot = false
+            return .skipped
+        }
+    }
+
+    private enum ForcedRefreshDrainResult {
+        case completed(performedRequest: Bool)
+        case slotTransferred
+    }
+
+    /// Drain each queued force as its own waiter cohort while the caller owns the provider slot.
+    /// Cancellation transfers that same reservation to a detached task; it never opens a gap where a
+    /// newer owner could start and acquire synthetic work on behalf of an older, cancelled cohort.
+    private func drainQueuedForcedRefreshes(
+        providerID: String,
+        provider: ProviderRuntime
+    ) async -> ForcedRefreshDrainResult {
+        var performedRequest = false
         while let forceClaim = refreshCoalescer.takeQueuedForcedRefresh(providerID: providerID) {
             // Cancellation can land after the check above but before this claim. Restore its original
             // provenance instead of letting an already-cancelled owner enter provider work.
             if Task.isCancelled {
-                ownsProviderSlot = false
                 finishCancelledForcedRefreshClaim(
                     forceClaim,
                     providerID: providerID,
                     outcome: .skipped
                 )
-                return .skipped
+                return .slotTransferred
+            }
+            // A force waiter can cancel concurrently just after its flag was claimed. Avoid starting
+            // provider work when that claim no longer contains any live caller or enablement intent.
+            guard refreshCoalescer.hasLiveIntent(forceClaim, providerID: providerID) else {
+                refreshCoalescer.resolveClaimedWaiters(
+                    forceClaim,
+                    providerID: providerID,
+                    outcome: .skipped
+                )
+                continue
             }
             // A disable that lands during the active request wins; do not start a new request for a
             // provider the user has since turned off.
             guard isProviderEnabled(providerID) else {
-                queuedOutcome = .skipped
+                refreshCoalescer.resolveClaimedWaiters(
+                    forceClaim,
+                    providerID: providerID,
+                    outcome: .skipped
+                )
                 break
             }
+            performedRequest = true
             AppLog.debug(.refresh, "run queued forced refresh \(providerID)")
-            outcome = await performRefresh(providerID: providerID, provider: provider, force: true)
-            queuedOutcome = outcome
+            let outcome = await performRefresh(providerID: providerID, provider: provider, force: true)
             refreshCoalescer.resolveNonForcedWaiters(providerID: providerID, outcome: outcome)
+            if outcome != .skipped {
+                refreshCoalescer.resolveClaimedWaiters(
+                    forceClaim,
+                    providerID: providerID,
+                    outcome: outcome
+                )
+            }
             if Task.isCancelled {
-                ownsProviderSlot = false
                 finishCancelledForcedRefreshClaim(
                     forceClaim,
                     providerID: providerID,
                     outcome: outcome
                 )
-                return .skipped
+                return .slotTransferred
             }
         }
-        refreshCoalescer.resolveWaiters(providerID: providerID, outcome: queuedOutcome)
-        return outcome
+        return .completed(performedRequest: performedRequest)
     }
 
-    /// Release a cancelled owner's slot. An interrupted follow-up restores only its still-live intent;
-    /// a follow-up that already produced a real outcome is complete and must never be replayed. Newer
-    /// forced work, if any, is handed to a task with an independent cancellation lifetime.
+    /// Transfer a cancelled owner's slot when live work remains, or release it when none does. An
+    /// interrupted follow-up restores only its still-live intent; a completed follow-up is never replayed.
     private func finishCancelledForcedRefreshClaim(
         _ claim: ProviderRefreshCoalescer.ForcedRefreshClaim,
         providerID: String,
@@ -293,22 +340,50 @@ final class WidgetDataStore {
         } else {
             refreshCoalescer.hasQueuedForcedRefresh(providerID: providerID)
         }
-        refreshingProviderIDs.remove(providerID)
         if hasLiveForcedRefresh {
             handOffQueuedForcedRefresh(providerID: providerID)
         } else {
-            refreshCoalescer.resolveWaiters(providerID: providerID, outcome: outcome)
+            refreshingProviderIDs.remove(providerID)
         }
     }
 
-    /// Let the coalescer continue forced work with an independent cancellation lifetime. Consuming the
-    /// queue before `refresh(force:)` makes that call the promised follow-up, not a third request.
+    /// Transfer the already-reserved provider slot to a task with an independent cancellation lifetime.
+    /// The task drains the original waiter provenance directly; it never manufactures a synthetic force.
     private func handOffQueuedForcedRefresh(providerID: String) {
-        refreshCoalescer.handOffQueuedForcedRefresh(providerID: providerID) { [weak self] in
-            guard let self, self.isProviderEnabled(providerID), self.providersByID[providerID] != nil else {
-                return nil
+        Task.detached { [weak self] in
+            await self?.runReservedForcedRefreshHandOff(providerID: providerID)
+        }
+    }
+
+    /// Continue a cancelled owner's queued work without releasing its provider slot. Ordinary callers
+    /// that arrive during the transfer join this reserved request; later forces become later claims.
+    private func runReservedForcedRefreshHandOff(providerID: String) async {
+        if let beforeRefreshHandOff {
+            self.beforeRefreshHandOff = nil
+            await beforeRefreshHandOff()
+        }
+        var ownsProviderSlot = true
+        defer {
+            if ownsProviderSlot {
+                refreshingProviderIDs.remove(providerID)
             }
-            return await self.refresh(providerID: providerID, force: true)
+        }
+        guard let provider = providersByID[providerID] else {
+            AppLog.error(.refresh, "reserved refresh hand-off lost provider \(providerID)")
+            while let claim = refreshCoalescer.takeQueuedForcedRefresh(providerID: providerID) {
+                refreshCoalescer.resolveClaimedWaiters(claim, providerID: providerID, outcome: .skipped)
+            }
+            refreshCoalescer.resolveNonForcedWaiters(providerID: providerID, outcome: .skipped)
+            return
+        }
+
+        switch await drainQueuedForcedRefreshes(providerID: providerID, provider: provider) {
+        case .completed(let performedRequest):
+            if !performedRequest {
+                refreshCoalescer.resolveNonForcedWaiters(providerID: providerID, outcome: .skipped)
+            }
+        case .slotTransferred:
+            ownsProviderSlot = false
         }
     }
 

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -1,14 +1,6 @@
 import Foundation
 import Observation
 
-/// A compact staleness hint for a provider's on-screen snapshot. `label` is a short, fixed word
-/// ("Outdated") that stays narrow next to long plan names like "Super Grok Heavy", while the precise
-/// age lives in `tooltip` ("Last updated 3h 12m ago"), revealed on hover.
-struct StalenessHint: Equatable {
-    let label: String
-    let tooltip: String
-}
-
 @MainActor
 @Observable
 final class WidgetDataStore {
@@ -60,6 +52,9 @@ final class WidgetDataStore {
     /// Per-provider earliest next-probe time after a failure (see `failureRetryBackoff`). Not part of
     /// observable UI state, so it's excluded from `@Observable` tracking.
     @ObservationIgnored private var failureRetryAfter: [String: Date] = [:]
+
+    /// Coalesces forced follow-ups and resumes callers that join an active provider request.
+    @ObservationIgnored private let refreshCoalescer = ProviderRefreshCoalescer()
 
     /// Owns the quota pace-notification subsystem (dedup state, fire/deliver decision, trace). This store
     /// just gathers each pass's enabled bounded metrics and delegates.
@@ -194,12 +189,6 @@ final class WidgetDataStore {
         )
     }
 
-    /// What a single provider's refresh actually did this pass, so `refreshAll` can summarize the batch
-    /// from real outcomes rather than cumulative error state. `.backedOff` is a probe deliberately skipped
-    /// because the provider failed within the last `failureRetryBackoff` — distinct from `.skipped`
-    /// (disabled / unknown / already in flight) so a wake-burst's suppression is visible in the logs.
-    enum RefreshOutcome: Sendable { case refreshed, failed, cacheHit, skipped, backedOff }
-
     @discardableResult
     func refresh(providerID: String, force: Bool = false) async -> RefreshOutcome {
         guard isProviderEnabled(providerID) else { return .skipped }
@@ -222,16 +211,115 @@ final class WidgetDataStore {
         }
 
         guard let provider = providersByID[providerID] else { return .skipped }
-        // Skip if an in-flight refresh already owns this provider (e.g. the background timer racing the
-        // first popover open), so we never fire duplicate network calls for the same provider.
+        // Skip if an in-flight refresh already owns this provider (e.g. a manual refresh racing the
+        // background timer), so we never fire duplicate network calls for the same provider.
         guard !refreshingProviderIDs.contains(providerID) else {
-            AppLog.debug(.refresh, "cache skip \(providerID) (already in flight)")
+            // Wait for the owner's real outcome. A force also requests one fresh post-flight probe because
+            // credentials may have changed after the owner loaded them.
+            AppLog.debug(.refresh, "\(force ? "queue forced" : "join") refresh \(providerID) (already in flight)")
+            return await refreshCoalescer.join(providerID: providerID, force: force)
+        }
+
+        refreshingProviderIDs.insert(providerID)
+        var ownsProviderSlot = true
+        defer {
+            if ownsProviderSlot {
+                refreshingProviderIDs.remove(providerID)
+            }
+        }
+
+        var outcome = await performRefresh(providerID: providerID, provider: provider, force: force)
+        if Task.isCancelled {
+            if refreshCoalescer.hasQueuedForcedRefresh(providerID: providerID) {
+                // The cancelled owner cannot satisfy a force requested by another live caller. Release
+                // the provider slot and move that work to a fresh, independent task.
+                ownsProviderSlot = false
+                refreshingProviderIDs.remove(providerID)
+                handOffQueuedForcedRefresh(providerID: providerID)
+            } else {
+                refreshCoalescer.resolveWaiters(providerID: providerID, outcome: .skipped)
+            }
             return .skipped
         }
-        refreshingProviderIDs.insert(providerID)
-        defer { refreshingProviderIDs.remove(providerID) }
+
+        var queuedOutcome = outcome
+        while let forceClaim = refreshCoalescer.takeQueuedForcedRefresh(providerID: providerID) {
+            // Cancellation can land after the check above but before this claim. Restore its original
+            // provenance instead of letting an already-cancelled owner enter provider work.
+            if Task.isCancelled {
+                ownsProviderSlot = false
+                finishCancelledForcedRefreshClaim(forceClaim, providerID: providerID)
+                return .skipped
+            }
+            // A disable that lands during the active request wins; do not start a new request for a
+            // provider the user has since turned off.
+            guard isProviderEnabled(providerID) else {
+                queuedOutcome = .skipped
+                break
+            }
+            AppLog.debug(.refresh, "run queued forced refresh \(providerID)")
+            outcome = await performRefresh(providerID: providerID, provider: provider, force: true)
+            queuedOutcome = outcome
+            if Task.isCancelled {
+                ownsProviderSlot = false
+                finishCancelledForcedRefreshClaim(forceClaim, providerID: providerID)
+                return .skipped
+            }
+        }
+        refreshCoalescer.resolveWaiters(providerID: providerID, outcome: queuedOutcome)
+        return outcome
+    }
+
+    /// Release a cancelled owner's slot and preserve only live intent from its claimed follow-up. A
+    /// cancelled waiter must not manufacture an ownerless request; enablement intent remains valid on
+    /// its own and is handed to a task with an independent cancellation lifetime.
+    private func finishCancelledForcedRefreshClaim(
+        _ claim: ProviderRefreshCoalescer.ForcedRefreshClaim,
+        providerID: String
+    ) {
+        let hasLiveForcedRefresh = refreshCoalescer.restoreQueuedForcedRefresh(
+            claim,
+            providerID: providerID
+        )
+        refreshingProviderIDs.remove(providerID)
+        if hasLiveForcedRefresh {
+            handOffQueuedForcedRefresh(providerID: providerID)
+        } else {
+            refreshCoalescer.resolveWaiters(providerID: providerID, outcome: .skipped)
+        }
+    }
+
+    /// Let the coalescer continue forced work with an independent cancellation lifetime. Consuming the
+    /// queue before `refresh(force:)` makes that call the promised follow-up, not a third request.
+    private func handOffQueuedForcedRefresh(providerID: String) {
+        refreshCoalescer.handOffQueuedForcedRefresh(providerID: providerID) { [weak self] in
+            guard let self, self.isProviderEnabled(providerID), self.providersByID[providerID] != nil else {
+                return nil
+            }
+            return await self.refresh(providerID: providerID, force: true)
+        }
+    }
+
+    private func performRefresh(
+        providerID: String,
+        provider: ProviderRuntime,
+        force: Bool
+    ) async -> RefreshOutcome {
+        // This is the final boundary before credential/network work. It also closes cancellation that
+        // lands immediately after a queued claim's explicit pre-flight check.
+        guard !Task.isCancelled else {
+            AppLog.debug(.refresh, "\(providerID) refresh cancelled before provider work")
+            return .skipped
+        }
         let start = Date()
         let snapshot = await provider.refresh()
+        // Providers return user-facing error snapshots rather than throwing. A cancelled network call
+        // can therefore arrive here looking like a normal failure; discard it before mutating errors,
+        // backoff, telemetry, snapshots, or cache so a later task can retry immediately.
+        guard !Task.isCancelled else {
+            AppLog.debug(.refresh, "\(providerID) refresh cancelled")
+            return .skipped
+        }
         let durationMs = Int(Date().timeIntervalSince(start) * 1000)
         if let message = Self.errorMessage(in: snapshot) {
             // Failed refresh: surface the error but keep the last good snapshot on screen rather than
@@ -255,12 +343,15 @@ final class WidgetDataStore {
         return .refreshed
     }
 
-    /// Clears a provider's failure backoff so the next pass probes it immediately. Called when the user
-    /// re-enables a provider: the enablement wake exists to fetch promptly, so a stale backoff from a
-    /// failure just before it was turned off must not suppress that fetch (the loop wouldn't otherwise
-    /// retry until the 5-minute heartbeat). The periodic loop never calls this — only the user action does.
-    func clearFailureBackoff(for providerID: String) {
+    /// Prepare the refresh wake emitted specifically when the user enables a provider. Clear any stale
+    /// failure backoff, and when an older request is still running preserve an independent forced
+    /// follow-up so that request cannot fail after this clear and silently restore the backoff.
+    /// Credential saves do not call this: their forced refresh already bypasses backoff and coalesces.
+    func prepareProviderEnablementRefresh(for providerID: String) {
         failureRetryAfter[providerID] = nil
+        if refreshingProviderIDs.contains(providerID) {
+            refreshCoalescer.queueEnablementForcedRefresh(providerID: providerID)
+        }
     }
 
     /// The provider's latest refresh error, or `nil` when its last refresh succeeded.
@@ -503,4 +594,3 @@ final class WidgetDataStore {
         return Double(value[match].replacingOccurrences(of: ",", with: ""))
     }
 }
-

--- a/Sources/OpenUsage/Views/APIKeysSection.swift
+++ b/Sources/OpenUsage/Views/APIKeysSection.swift
@@ -9,8 +9,7 @@ import AppKit
 ///
 /// A saved key writes to the config file the auth store already reads, and config > env — so "save" is
 /// also "override the env key", and clearing a saved override falls back to the env key or to none.
-/// After any change the card clears the provider's failure backoff and forces a refresh so the
-/// dashboard updates immediately.
+/// After any change the card forces a refresh so the dashboard updates immediately.
 struct APIKeysSection: View {
     let provider: any APIKeyManaging
     @Environment(WidgetDataStore.self) private var dataStore
@@ -241,12 +240,11 @@ struct APIKeysSection: View {
         }
     }
 
-    /// Clear any failure backoff so the wake refresh actually probes the provider, then force a
-    /// refresh so the dashboard shows the new key's data immediately instead of waiting for the next
-    /// 5-minute pass. No-op for the refresh if the provider is disabled — the key is still saved.
+    /// Force a refresh so the dashboard shows the new key's data immediately instead of waiting for
+    /// the next 5-minute pass. Force already bypasses failure backoff and joins an in-flight request as
+    /// one follow-up. No-op for the refresh if the provider is disabled — the key is still saved.
     private func triggerRefresh() {
         let id = provider.provider.id
-        dataStore.clearFailureBackoff(for: id)
         Task { await dataStore.refresh(providerID: id, force: true) }
     }
 }

--- a/Tests/OpenUsageTests/FailureBackoffTests.swift
+++ b/Tests/OpenUsageTests/FailureBackoffTests.swift
@@ -80,7 +80,7 @@ final class FailureBackoffTests: XCTestCase {
         XCTAssertEqual(runtime.refreshCount, 3)
     }
 
-    func testClearingBackoffAllowsImmediateReprobe() async {
+    func testPreparingProviderEnablementAllowsImmediateReprobe() async {
         // The re-enable path: clearing the backoff must let the very next pass probe, even inside the
         // window, so a just-re-enabled provider isn't stuck on stale data until the 5-minute heartbeat.
         var clock = Date(timeIntervalSince1970: 1_800_000_000)
@@ -94,7 +94,7 @@ final class FailureBackoffTests: XCTestCase {
         await store.refreshAll()                       // inside window → suppressed
         XCTAssertEqual(runtime.refreshCount, 1)
 
-        store.clearFailureBackoff(for: runtime.provider.id)
+        store.prepareProviderEnablementRefresh(for: runtime.provider.id)
         await store.refreshAll()                       // backoff cleared → probes immediately
         XCTAssertEqual(runtime.refreshCount, 2)
     }

--- a/Tests/OpenUsageTests/RefreshCoalescingTests.swift
+++ b/Tests/OpenUsageTests/RefreshCoalescingTests.swift
@@ -162,6 +162,57 @@ final class RefreshCoalescingTests: XCTestCase {
         XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
     }
 
+    func testCancellingOwnerAfterClaimedForceSucceedsDoesNotReplayCompletedClaim() async {
+        let fixture = makeFixture(
+            snapshots: [
+                successSnapshot(used: 20),
+                successSnapshot(used: 80),
+                successSnapshot(used: 95),
+            ]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let followUpStarted = expectation(description: "forced follow-up started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { followUpStarted.fulfill() }
+            if count == 3 {
+                // Keep a regressed implementation from hanging the test on its erroneous replay.
+                Task {
+                    await Task.yield()
+                    fixture.runtime.resumeNext()
+                }
+            }
+        }
+
+        var original: Task<WidgetDataStore.RefreshOutcome, Never>?
+        fixture.store.onRefreshOutcome = { _, outcome, _, force in
+            // Cancellation lands after the forced request committed its successful snapshot but before
+            // the owner resumes from performRefresh. The consumed claim is already satisfied.
+            if force, outcome == .refreshed, fixture.runtime.refreshCount == 2 {
+                original?.cancel()
+            }
+        }
+
+        original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let forced = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        await Task.yield()
+
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [followUpStarted], timeout: 1)
+        fixture.runtime.resumeNext()
+
+        let originalOutcome = await original?.value
+        let forcedOutcome = await forced.value
+        for _ in 0..<20 { await Task.yield() }
+
+        XCTAssertTrue(originalOutcome == .skipped)
+        XCTAssertTrue(forcedOutcome == .refreshed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2, "completed forced work must not be replayed")
+        XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 80))
+        XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+    }
+
     func testCancelledClaimedEnablementIntentIsHandedOff() async {
         let fixture = makeFixture(
             snapshots: [
@@ -426,15 +477,18 @@ final class RefreshCoalescingTests: XCTestCase {
 
         let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
         await fulfillment(of: [firstStarted], timeout: 1)
+        let joined = Task { await fixture.store.refresh(providerID: testProvider.id) }
         let forced = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
         await Task.yield()
 
         enabled.value = false
         fixture.runtime.resumeNext()
         let originalOutcome = await original.value
+        let joinedOutcome = await joined.value
         let forcedOutcome = await forced.value
 
         XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertTrue(joinedOutcome == .refreshed, "an ordinary joiner keeps the active request outcome")
         XCTAssertTrue(forcedOutcome == .skipped)
         XCTAssertEqual(fixture.runtime.refreshCount, 1)
         XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))

--- a/Tests/OpenUsageTests/RefreshCoalescingTests.swift
+++ b/Tests/OpenUsageTests/RefreshCoalescingTests.swift
@@ -1,0 +1,497 @@
+import XCTest
+@testable import OpenUsage
+
+/// Covers the per-provider refresh gate. Only one provider request may run at a time, but an explicit
+/// force that arrives after the active request loaded its credentials must survive as one fresh follow-up.
+@MainActor
+final class RefreshCoalescingTests: XCTestCase {
+    func testCancellingJoinedCallerReturnsPromptlyWithoutCancellingOwner() async {
+        let fixture = makeFixture(snapshots: [successSnapshot(used: 40)])
+        let firstStarted = expectation(description: "original refresh started")
+        let joinedFinished = expectation(description: "cancelled joined caller returned")
+        fixture.runtime.onStart = { _ in firstStarted.fulfill() }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        let joinedReturned = MutableFlag(value: false)
+        let joined = Task {
+            let outcome = await fixture.store.refresh(providerID: testProvider.id)
+            joinedReturned.value = true
+            joinedFinished.fulfill()
+            return outcome
+        }
+        await Task.yield()
+        await Task.yield()
+        XCTAssertFalse(joinedReturned.value, "the caller must be registered behind the active owner")
+
+        joined.cancel()
+        await fulfillment(of: [joinedFinished], timeout: 1)
+
+        let joinedOutcome = await joined.value
+        XCTAssertTrue(joinedOutcome == .skipped)
+        XCTAssertTrue(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+        XCTAssertEqual(fixture.runtime.refreshCount, 1)
+
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 1)
+    }
+
+    func testCancelledOwnerHandsQueuedForceToFreshTask() async {
+        let fixture = makeFixture(
+            snapshots: [
+                .error(provider: testProvider, message: "Cancelled owner result."),
+                successSnapshot(used: 80),
+            ]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let followUpStarted = expectation(description: "handed-off forced refresh started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { followUpStarted.fulfill() }
+        }
+        var telemetry: [(outcome: WidgetDataStore.RefreshOutcome, manual: Bool)] = []
+        fixture.store.onRefreshOutcome = { _, outcome, _, manual in
+            telemetry.append((outcome, manual))
+        }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        let forcedReturned = MutableFlag(value: false)
+        let forced = Task {
+            let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
+            forcedReturned.value = true
+            return outcome
+        }
+        await Task.yield()
+        await Task.yield()
+        XCTAssertFalse(forcedReturned.value)
+
+        original.cancel()
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [followUpStarted], timeout: 1)
+
+        let originalOutcome = await original.value
+        XCTAssertTrue(originalOutcome == .skipped)
+        XCTAssertFalse(forcedReturned.value)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2)
+        XCTAssertEqual(fixture.runtime.startedWhileCancelled, [false, false])
+
+        fixture.runtime.resumeNext()
+        let forcedOutcome = await forced.value
+        XCTAssertTrue(forcedOutcome == .refreshed)
+        XCTAssertNil(fixture.store.errorMessage(for: testProvider.id))
+        XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 80))
+        XCTAssertEqual(telemetry.count, 1)
+        XCTAssertTrue(telemetry.first?.outcome == .refreshed)
+        XCTAssertTrue(telemetry.first?.manual == true)
+    }
+
+    func testCancellingOnlyForcedWaiterWithdrawsItsFollowUp() async {
+        let fixture = makeFixture(snapshots: [successSnapshot(used: 40)])
+        let firstStarted = expectation(description: "original refresh started")
+        let forcedFinished = expectation(description: "cancelled force returned")
+        fixture.runtime.onStart = { _ in firstStarted.fulfill() }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        let forced = Task {
+            let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
+            forcedFinished.fulfill()
+            return outcome
+        }
+        await Task.yield()
+        await Task.yield()
+
+        forced.cancel()
+        // Resume the owner immediately, before the cancellation cleanup task can hop back to MainActor.
+        // The synchronous cancellation flag must still prevent this owner from claiming the force.
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        await fulfillment(of: [forcedFinished], timeout: 1)
+        let forcedOutcome = await forced.value
+
+        XCTAssertTrue(forcedOutcome == .skipped)
+        XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 1, "a cancelled sole force must not leave orphaned work")
+    }
+
+    func testCancellingClaimedForceAndOwnerDoesNotRestoreOwnerlessWork() async {
+        let fixture = makeFixture(
+            snapshots: [successSnapshot(used: 40), successSnapshot(used: 80)]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let followUpStarted = expectation(description: "forced follow-up started")
+        let forcedFinished = expectation(description: "cancelled force returned")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { followUpStarted.fulfill() }
+        }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let forced = Task {
+            let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
+            forcedFinished.fulfill()
+            return outcome
+        }
+        await Task.yield()
+        await Task.yield()
+
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [followUpStarted], timeout: 1)
+
+        // The follow-up already claimed this waiter's force. Cancelling the waiter must still revoke
+        // that provenance; cancelling the owner afterward cannot restore it as independent work.
+        forced.cancel()
+        await fulfillment(of: [forcedFinished], timeout: 1)
+        original.cancel()
+        fixture.runtime.resumeNext()
+
+        let forcedOutcome = await forced.value
+        let originalOutcome = await original.value
+        for _ in 0..<20 { await Task.yield() }
+
+        XCTAssertTrue(forcedOutcome == .skipped)
+        XCTAssertTrue(originalOutcome == .skipped)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2, "no live requester remains for a third fetch")
+        XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+    }
+
+    func testCancelledClaimedEnablementIntentIsHandedOff() async {
+        let fixture = makeFixture(
+            snapshots: [
+                successSnapshot(used: 20),
+                successSnapshot(used: 40),
+                successSnapshot(used: 90),
+            ]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let followUpStarted = expectation(description: "enablement follow-up started")
+        let handedOffStarted = expectation(description: "enablement intent handed off")
+        let handedOffFinished = expectation(description: "handed-off refresh finished")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { followUpStarted.fulfill() }
+            if count == 3 { handedOffStarted.fulfill() }
+        }
+        fixture.store.onRefreshOutcome = { _, outcome, _, force in
+            if outcome == .refreshed, force, fixture.runtime.refreshCount == 3 {
+                handedOffFinished.fulfill()
+            }
+        }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        fixture.store.prepareProviderEnablementRefresh(for: testProvider.id)
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [followUpStarted], timeout: 1)
+
+        // Unlike waiter-backed intent, an enablement action remains meaningful without a waiting task.
+        original.cancel()
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        XCTAssertTrue(originalOutcome == .skipped)
+
+        await fulfillment(of: [handedOffStarted], timeout: 1)
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [handedOffFinished], timeout: 1)
+
+        XCTAssertEqual(fixture.runtime.refreshCount, 3)
+        XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 90))
+        XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+    }
+
+    func testNonForcedCallerJoinsActiveRefreshBeforeReturning() async {
+        let fixture = makeFixture(snapshots: [successSnapshot(used: 40)])
+        let firstStarted = expectation(description: "original refresh started")
+        fixture.runtime.onStart = { _ in firstStarted.fulfill() }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        let joinedReturned = MutableFlag(value: false)
+        let joined = Task {
+            let outcome = await fixture.store.refresh(providerID: testProvider.id)
+            joinedReturned.value = true
+            return outcome
+        }
+        await Task.yield()
+        await Task.yield()
+        XCTAssertFalse(joinedReturned.value)
+        XCTAssertEqual(fixture.runtime.refreshCount, 1)
+
+        // The periodic-style caller was held until the active request produced current data; it did not
+        // start a duplicate and could not continue into notification evaluation against the old snapshot.
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        let joinedOutcome = await joined.value
+
+        XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertTrue(joinedOutcome == .refreshed)
+        XCTAssertTrue(joinedReturned.value)
+        XCTAssertEqual(fixture.runtime.refreshCount, 1)
+    }
+
+    func testConcurrentForcesCoalesceIntoOnePostFlightRefresh() async {
+        let fixture = makeFixture(
+            snapshots: [
+                .error(provider: testProvider, message: "The old key was rejected."),
+                successSnapshot(used: 80),
+            ]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let followUpStarted = expectation(description: "forced follow-up started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { followUpStarted.fulfill() }
+        }
+        var telemetry: [(outcome: WidgetDataStore.RefreshOutcome, manual: Bool)] = []
+        fixture.store.onRefreshOutcome = { _, outcome, _, manual in
+            telemetry.append((outcome, manual))
+        }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        // Model an API-key save and a second click while the request that loaded the old key is suspended.
+        // Both callers must join one queued follow-up rather than disappearing or starting overlapping I/O.
+        let forcedA = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        let forcedB = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(fixture.runtime.refreshCount, 1)
+
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [followUpStarted], timeout: 1)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2)
+        XCTAssertTrue(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        let forcedAOutcome = await forcedA.value
+        let forcedBOutcome = await forcedB.value
+
+        XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertTrue(forcedAOutcome == .refreshed)
+        XCTAssertTrue(forcedBOutcome == .refreshed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2, "a force burst must produce exactly one follow-up")
+        XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+        XCTAssertNil(fixture.store.errorMessage(for: testProvider.id))
+        XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 80))
+        XCTAssertEqual(telemetry.count, 2)
+        XCTAssertTrue(telemetry[0].outcome == .failed)
+        XCTAssertFalse(telemetry[0].manual)
+        XCTAssertTrue(telemetry[1].outcome == .refreshed)
+        XCTAssertTrue(telemetry[1].manual)
+    }
+
+    func testForceDuringForcedFollowUpQueuesOneSequentialThirdRefresh() async {
+        let fixture = makeFixture(
+            snapshots: [
+                successSnapshot(used: 20),
+                successSnapshot(used: 60),
+                .error(provider: testProvider, message: "Newest credential was rejected."),
+            ]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let secondStarted = expectation(description: "first forced follow-up started")
+        let thirdStarted = expectation(description: "second forced follow-up started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { secondStarted.fulfill() }
+            if count == 3 { thirdStarted.fulfill() }
+        }
+        var waiterReturnCount = 0
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let forcedA = Task {
+            let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
+            waiterReturnCount += 1
+            return outcome
+        }
+        await Task.yield()
+
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [secondStarted], timeout: 1)
+        let forcedB = Task {
+            let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
+            waiterReturnCount += 1
+            return outcome
+        }
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(fixture.runtime.refreshCount, 2)
+        XCTAssertEqual(waiterReturnCount, 0)
+
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [thirdStarted], timeout: 1)
+        XCTAssertEqual(fixture.runtime.refreshCount, 3)
+        XCTAssertEqual(fixture.runtime.maximumConcurrentRefreshCount, 1)
+        XCTAssertEqual(waiterReturnCount, 0, "both force callers wait for the newest queued outcome")
+
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        let forcedAOutcome = await forcedA.value
+        let forcedBOutcome = await forcedB.value
+
+        XCTAssertTrue(originalOutcome == .failed)
+        XCTAssertTrue(forcedAOutcome == .failed)
+        XCTAssertTrue(forcedBOutcome == .failed)
+        XCTAssertEqual(waiterReturnCount, 2)
+        XCTAssertEqual(fixture.runtime.refreshCount, 3, "the later force queues exactly one more request")
+        XCTAssertEqual(fixture.runtime.maximumConcurrentRefreshCount, 1, "provider requests never overlap")
+        XCTAssertEqual(fixture.store.errorMessage(for: testProvider.id), "Newest credential was rejected.")
+        XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 60))
+    }
+
+    func testDelayedCredentialForceDoesNotPrequeueOwnerlessFollowUp() async {
+        let fixture = makeFixture(
+            snapshots: [successSnapshot(used: 40), successSnapshot(used: 80)]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let credentialRefreshStarted = expectation(description: "credential refresh started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { credentialRefreshStarted.fulfill() }
+        }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        // API-key persistence is synchronous, but its forced refresh starts in a Task. Model the owner
+        // finishing before that Task registers: saving a key has no separate enablement prequeue, so the
+        // owner completes after one request and the delayed force becomes exactly the second request.
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 1)
+
+        let credentialRefresh = Task {
+            await fixture.store.refresh(providerID: testProvider.id, force: true)
+        }
+        await fulfillment(of: [credentialRefreshStarted], timeout: 1)
+        fixture.runtime.resumeNext()
+
+        let credentialOutcome = await credentialRefresh.value
+        XCTAssertTrue(credentialOutcome == .refreshed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2, "one credential save must issue one fresh request")
+    }
+
+    func testPreparingEnablementDuringRequestQueuesImmediateFollowUp() async {
+        let fixture = makeFixture(
+            snapshots: [
+                .error(provider: testProvider, message: "The old request failed."),
+                successSnapshot(used: 65),
+            ]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let followUpStarted = expectation(description: "enablement follow-up started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { followUpStarted.fulfill() }
+        }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        // Re-enabling a provider calls this before the wake-driven pass. If the old request later fails,
+        // it must not restore a backoff and swallow the user's request for an immediate probe.
+        fixture.store.prepareProviderEnablementRefresh(for: testProvider.id)
+        fixture.runtime.resumeNext()
+
+        await fulfillment(of: [followUpStarted], timeout: 1)
+        fixture.runtime.resumeNext()
+        let outcome = await original.value
+
+        XCTAssertTrue(outcome == .refreshed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2)
+        XCTAssertNil(fixture.store.errorMessage(for: testProvider.id))
+        XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 65))
+    }
+
+    func testDisableCancelsQueuedFollowUpAndReleasesWaitingCaller() async {
+        let enabled = MutableFlag()
+        let fixture = makeFixture(
+            snapshots: [successSnapshot(used: 25)],
+            isEnabled: { enabled.value }
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        fixture.runtime.onStart = { _ in firstStarted.fulfill() }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let forced = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        await Task.yield()
+
+        enabled.value = false
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        let forcedOutcome = await forced.value
+
+        XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertTrue(forcedOutcome == .skipped)
+        XCTAssertEqual(fixture.runtime.refreshCount, 1)
+        XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+    }
+
+    // MARK: - Fixtures
+
+    private struct Fixture {
+        let store: WidgetDataStore
+        let runtime: SuspendedSequenceProviderRuntime
+    }
+
+    private var testProvider: Provider {
+        Provider(id: "test", displayName: "Test", icon: .providerMark("codex"))
+    }
+
+    private func makeFixture(
+        snapshots: [ProviderSnapshot],
+        isEnabled: @escaping @MainActor () -> Bool = { true }
+    ) -> Fixture {
+        let descriptor = WidgetDescriptor(
+            id: "test.session",
+            providerID: testProvider.id,
+            metricLabel: "Session",
+            sample: WidgetData(
+                title: "Session",
+                icon: testProvider.icon,
+                kind: .percent,
+                used: 0,
+                limit: 100
+            )
+        )
+        let runtime = SuspendedSequenceProviderRuntime(
+            provider: testProvider,
+            descriptors: [descriptor],
+            snapshots: snapshots
+        )
+        let defaults = UserDefaults(suiteName: "RefreshCoalescingTests.\(UUID().uuidString)")!
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [testProvider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots"),
+            defaults: defaults,
+            isProviderEnabled: { _ in isEnabled() }
+        )
+        return Fixture(store: store, runtime: runtime)
+    }
+
+    private func successSnapshot(used: Double) -> ProviderSnapshot {
+        ProviderSnapshot(
+            providerID: testProvider.id,
+            displayName: testProvider.displayName,
+            lines: [sessionLine(used: used)]
+        )
+    }
+
+    private func sessionLine(used: Double) -> MetricLine {
+        .progress(label: "Session", used: used, limit: 100, format: .percent)
+    }
+}

--- a/Tests/OpenUsageTests/RefreshCoalescingTests.swift
+++ b/Tests/OpenUsageTests/RefreshCoalescingTests.swift
@@ -15,14 +15,17 @@ final class RefreshCoalescingTests: XCTestCase {
         await fulfillment(of: [firstStarted], timeout: 1)
 
         let joinedReturned = MutableFlag(value: false)
+        let joinedEntered = expectation(description: "ordinary caller entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if !force { joinedEntered.fulfill() }
+        }
         let joined = Task {
             let outcome = await fixture.store.refresh(providerID: testProvider.id)
             joinedReturned.value = true
             joinedFinished.fulfill()
             return outcome
         }
-        await Task.yield()
-        await Task.yield()
+        await fulfillment(of: [joinedEntered], timeout: 1)
         XCTAssertFalse(joinedReturned.value, "the caller must be registered behind the active owner")
 
         joined.cancel()
@@ -61,13 +64,16 @@ final class RefreshCoalescingTests: XCTestCase {
         await fulfillment(of: [firstStarted], timeout: 1)
 
         let forcedReturned = MutableFlag(value: false)
+        let forcedEntered = expectation(description: "force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedEntered.fulfill() }
+        }
         let forced = Task {
             let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
             forcedReturned.value = true
             return outcome
         }
-        await Task.yield()
-        await Task.yield()
+        await fulfillment(of: [forcedEntered], timeout: 1)
         XCTAssertFalse(forcedReturned.value)
 
         original.cancel()
@@ -90,6 +96,62 @@ final class RefreshCoalescingTests: XCTestCase {
         XCTAssertTrue(telemetry.first?.manual == true)
     }
 
+    func testHandedOffForceKeepsOwnOutcomeWhenLaterForceFails() async {
+        let fixture = makeFixture(
+            snapshots: [
+                .error(provider: testProvider, message: "Cancelled owner result."),
+                successSnapshot(used: 80),
+                .error(provider: testProvider, message: "Later force failed."),
+            ]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let handedOffStarted = expectation(description: "handed-off force started")
+        let laterForceStarted = expectation(description: "later force started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { handedOffStarted.fulfill() }
+            if count == 3 { laterForceStarted.fulfill() }
+        }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+
+        let forcedAEntered = expectation(description: "first force registered")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedAEntered.fulfill() }
+        }
+        let forcedA = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        await fulfillment(of: [forcedAEntered], timeout: 1)
+
+        original.cancel()
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [handedOffStarted], timeout: 1)
+
+        let forcedBEntered = expectation(description: "later force registered")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedBEntered.fulfill() }
+        }
+        let forcedB = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        await fulfillment(of: [forcedBEntered], timeout: 1)
+
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [laterForceStarted], timeout: 1)
+        fixture.runtime.resumeNext()
+
+        let originalOutcome = await original.value
+        let forcedAOutcome = await forcedA.value
+        let forcedBOutcome = await forcedB.value
+
+        XCTAssertTrue(originalOutcome == .skipped)
+        XCTAssertTrue(forcedAOutcome == .refreshed)
+        XCTAssertTrue(forcedBOutcome == .failed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 3)
+        XCTAssertEqual(fixture.runtime.maximumConcurrentRefreshCount, 1)
+        XCTAssertEqual(fixture.store.errorMessage(for: testProvider.id), "Later force failed.")
+        XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 80))
+        XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+    }
+
     func testCancellingOnlyForcedWaiterWithdrawsItsFollowUp() async {
         let fixture = makeFixture(snapshots: [successSnapshot(used: 40)])
         let firstStarted = expectation(description: "original refresh started")
@@ -99,13 +161,16 @@ final class RefreshCoalescingTests: XCTestCase {
         let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
         await fulfillment(of: [firstStarted], timeout: 1)
 
+        let forcedEntered = expectation(description: "force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedEntered.fulfill() }
+        }
         let forced = Task {
             let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
             forcedFinished.fulfill()
             return outcome
         }
-        await Task.yield()
-        await Task.yield()
+        await fulfillment(of: [forcedEntered], timeout: 1)
 
         forced.cancel()
         // Resume the owner immediately, before the cancellation cleanup task can hop back to MainActor.
@@ -134,13 +199,16 @@ final class RefreshCoalescingTests: XCTestCase {
 
         let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
         await fulfillment(of: [firstStarted], timeout: 1)
+        let forcedEntered = expectation(description: "force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedEntered.fulfill() }
+        }
         let forced = Task {
             let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
             forcedFinished.fulfill()
             return outcome
         }
-        await Task.yield()
-        await Task.yield()
+        await fulfillment(of: [forcedEntered], timeout: 1)
 
         fixture.runtime.resumeNext()
         await fulfillment(of: [followUpStarted], timeout: 1)
@@ -195,8 +263,14 @@ final class RefreshCoalescingTests: XCTestCase {
 
         original = Task { await fixture.store.refresh(providerID: testProvider.id) }
         await fulfillment(of: [firstStarted], timeout: 1)
-        let forced = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
-        await Task.yield()
+        let forcedEntered = expectation(description: "force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedEntered.fulfill() }
+        }
+        let forced = Task {
+            return await fixture.store.refresh(providerID: testProvider.id, force: true)
+        }
+        await fulfillment(of: [forcedEntered], timeout: 1)
 
         fixture.runtime.resumeNext()
         await fulfillment(of: [followUpStarted], timeout: 1)
@@ -210,6 +284,127 @@ final class RefreshCoalescingTests: XCTestCase {
         XCTAssertTrue(forcedOutcome == .refreshed)
         XCTAssertEqual(fixture.runtime.refreshCount, 2, "completed forced work must not be replayed")
         XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 80))
+        XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+    }
+
+    func testDisabledLaterForceDoesNotDowngradeCompletedForcedOutcome() async {
+        let enabled = MutableFlag()
+        let fixture = makeFixture(
+            snapshots: [successSnapshot(used: 20), successSnapshot(used: 80)],
+            isEnabled: { enabled.value }
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let followUpStarted = expectation(description: "first forced follow-up started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { followUpStarted.fulfill() }
+        }
+
+        var original: Task<WidgetDataStore.RefreshOutcome, Never>?
+        fixture.store.onRefreshOutcome = { _, outcome, _, force in
+            if force, outcome == .refreshed, fixture.runtime.refreshCount == 2 {
+                // A completed successfully. Cancel its owner and disable before queued B can run.
+                enabled.value = false
+                original?.cancel()
+            }
+        }
+
+        original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let forcedAEntered = expectation(description: "first force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedAEntered.fulfill() }
+        }
+        let forcedA = Task {
+            return await fixture.store.refresh(providerID: testProvider.id, force: true)
+        }
+        await fulfillment(of: [forcedAEntered], timeout: 1)
+
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [followUpStarted], timeout: 1)
+        let forcedBEntered = expectation(description: "later force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedBEntered.fulfill() }
+        }
+        let forcedB = Task {
+            return await fixture.store.refresh(providerID: testProvider.id, force: true)
+        }
+        await fulfillment(of: [forcedBEntered], timeout: 1)
+        fixture.runtime.resumeNext()
+
+        let originalOutcome = await original?.value
+        let forcedAOutcome = await forcedA.value
+        let forcedBOutcome = await forcedB.value
+
+        XCTAssertTrue(originalOutcome == .skipped)
+        XCTAssertTrue(forcedAOutcome == .refreshed, "later cleanup must preserve A's completed result")
+        XCTAssertTrue(forcedBOutcome == .skipped)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2)
+        XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 80))
+        XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+    }
+
+    func testReservedHandOffDoesNotCreateOwnerlessSyntheticForce() async {
+        let fixture = makeFixture(
+            snapshots: [
+                .error(provider: testProvider, message: "Cancelled owner result."),
+                successSnapshot(used: 80),
+            ]
+        )
+        let firstStarted = expectation(description: "original refresh started")
+        let handedOffStarted = expectation(description: "reserved hand-off refresh started")
+        fixture.runtime.onStart = { count in
+            if count == 1 { firstStarted.fulfill() }
+            if count == 2 { handedOffStarted.fulfill() }
+        }
+
+        let handOffPaused = expectation(description: "reserved hand-off paused")
+        var handOffContinuation: CheckedContinuation<Void, Never>?
+        fixture.store.beforeRefreshHandOff = {
+            handOffPaused.fulfill()
+            await withCheckedContinuation { handOffContinuation = $0 }
+        }
+
+        let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [firstStarted], timeout: 1)
+        let oldForceEntered = expectation(description: "old force registered")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { oldForceEntered.fulfill() }
+        }
+        let oldForce = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        await fulfillment(of: [oldForceEntered], timeout: 1)
+
+        original.cancel()
+        fixture.runtime.resumeNext()
+        await fulfillment(of: [handOffPaused], timeout: 1)
+        XCTAssertTrue(fixture.store.refreshingProviderIDs.contains(testProvider.id))
+
+        let newForceEntered = expectation(description: "new force registered behind reservation")
+        let ordinaryEntered = expectation(description: "ordinary caller registered behind reservation")
+        fixture.store.onRefreshJoined = { _, force in
+            (force ? newForceEntered : ordinaryEntered).fulfill()
+        }
+        let newForce = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
+        let ordinary = Task { await fixture.store.refresh(providerID: testProvider.id) }
+        await fulfillment(of: [newForceEntered, ordinaryEntered], timeout: 1)
+
+        oldForce.cancel()
+        let oldForceOutcome = await oldForce.value
+        handOffContinuation?.resume()
+        handOffContinuation = nil
+
+        await fulfillment(of: [handedOffStarted], timeout: 1)
+        fixture.runtime.resumeNext()
+        let originalOutcome = await original.value
+        let newForceOutcome = await newForce.value
+        let ordinaryOutcome = await ordinary.value
+
+        XCTAssertTrue(originalOutcome == .skipped)
+        XCTAssertTrue(oldForceOutcome == .skipped)
+        XCTAssertTrue(newForceOutcome == .refreshed)
+        XCTAssertTrue(ordinaryOutcome == .refreshed)
+        XCTAssertEqual(fixture.runtime.refreshCount, 2, "cancelled old intent must not create a third request")
+        XCTAssertEqual(fixture.runtime.maximumConcurrentRefreshCount, 1)
         XCTAssertFalse(fixture.store.refreshingProviderIDs.contains(testProvider.id))
     }
 
@@ -266,13 +461,16 @@ final class RefreshCoalescingTests: XCTestCase {
         await fulfillment(of: [firstStarted], timeout: 1)
 
         let joinedReturned = MutableFlag(value: false)
+        let joinedEntered = expectation(description: "ordinary caller entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if !force { joinedEntered.fulfill() }
+        }
         let joined = Task {
             let outcome = await fixture.store.refresh(providerID: testProvider.id)
             joinedReturned.value = true
             return outcome
         }
-        await Task.yield()
-        await Task.yield()
+        await fulfillment(of: [joinedEntered], timeout: 1)
         XCTAssertFalse(joinedReturned.value)
         XCTAssertEqual(fixture.runtime.refreshCount, 1)
 
@@ -311,10 +509,18 @@ final class RefreshCoalescingTests: XCTestCase {
 
         // Model an API-key save and a second click while the request that loaded the old key is suspended.
         // Both callers must join one queued follow-up rather than disappearing or starting overlapping I/O.
-        let forcedA = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
-        let forcedB = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
-        await Task.yield()
-        await Task.yield()
+        let forcesEntered = expectation(description: "both forces entered the join path")
+        forcesEntered.expectedFulfillmentCount = 2
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcesEntered.fulfill() }
+        }
+        let forcedA = Task {
+            return await fixture.store.refresh(providerID: testProvider.id, force: true)
+        }
+        let forcedB = Task {
+            return await fixture.store.refresh(providerID: testProvider.id, force: true)
+        }
+        await fulfillment(of: [forcesEntered], timeout: 1)
         XCTAssertEqual(fixture.runtime.refreshCount, 1)
 
         fixture.runtime.resumeNext()
@@ -327,7 +533,7 @@ final class RefreshCoalescingTests: XCTestCase {
         let forcedAOutcome = await forcedA.value
         let forcedBOutcome = await forcedB.value
 
-        XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertTrue(originalOutcome == .failed)
         XCTAssertTrue(forcedAOutcome == .refreshed)
         XCTAssertTrue(forcedBOutcome == .refreshed)
         XCTAssertEqual(fixture.runtime.refreshCount, 2, "a force burst must produce exactly one follow-up")
@@ -352,6 +558,7 @@ final class RefreshCoalescingTests: XCTestCase {
         let firstStarted = expectation(description: "original refresh started")
         let secondStarted = expectation(description: "first forced follow-up started")
         let thirdStarted = expectation(description: "second forced follow-up started")
+        let forcedAReturned = expectation(description: "first force received its follow-up outcome")
         fixture.runtime.onStart = { count in
             if count == 1 { firstStarted.fulfill() }
             if count == 2 { secondStarted.fulfill() }
@@ -361,38 +568,46 @@ final class RefreshCoalescingTests: XCTestCase {
 
         let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
         await fulfillment(of: [firstStarted], timeout: 1)
+        let forcedAEntered = expectation(description: "first force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedAEntered.fulfill() }
+        }
         let forcedA = Task {
             let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
             waiterReturnCount += 1
+            forcedAReturned.fulfill()
             return outcome
         }
-        await Task.yield()
+        await fulfillment(of: [forcedAEntered], timeout: 1)
 
         fixture.runtime.resumeNext()
         await fulfillment(of: [secondStarted], timeout: 1)
+        let forcedBEntered = expectation(description: "second force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            if force { forcedBEntered.fulfill() }
+        }
         let forcedB = Task {
             let outcome = await fixture.store.refresh(providerID: testProvider.id, force: true)
             waiterReturnCount += 1
             return outcome
         }
-        await Task.yield()
-        await Task.yield()
+        await fulfillment(of: [forcedBEntered], timeout: 1)
         XCTAssertEqual(fixture.runtime.refreshCount, 2)
         XCTAssertEqual(waiterReturnCount, 0)
 
         fixture.runtime.resumeNext()
-        await fulfillment(of: [thirdStarted], timeout: 1)
+        await fulfillment(of: [thirdStarted, forcedAReturned], timeout: 1)
         XCTAssertEqual(fixture.runtime.refreshCount, 3)
         XCTAssertEqual(fixture.runtime.maximumConcurrentRefreshCount, 1)
-        XCTAssertEqual(waiterReturnCount, 0, "both force callers wait for the newest queued outcome")
+        XCTAssertEqual(waiterReturnCount, 1, "force A receives the request that consumed A's intent")
 
         fixture.runtime.resumeNext()
         let originalOutcome = await original.value
         let forcedAOutcome = await forcedA.value
         let forcedBOutcome = await forcedB.value
 
-        XCTAssertTrue(originalOutcome == .failed)
-        XCTAssertTrue(forcedAOutcome == .failed)
+        XCTAssertTrue(originalOutcome == .refreshed)
+        XCTAssertTrue(forcedAOutcome == .refreshed)
         XCTAssertTrue(forcedBOutcome == .failed)
         XCTAssertEqual(waiterReturnCount, 2)
         XCTAssertEqual(fixture.runtime.refreshCount, 3, "the later force queues exactly one more request")
@@ -460,7 +675,7 @@ final class RefreshCoalescingTests: XCTestCase {
         fixture.runtime.resumeNext()
         let outcome = await original.value
 
-        XCTAssertTrue(outcome == .refreshed)
+        XCTAssertTrue(outcome == .failed)
         XCTAssertEqual(fixture.runtime.refreshCount, 2)
         XCTAssertNil(fixture.store.errorMessage(for: testProvider.id))
         XCTAssertEqual(fixture.store.snapshots[testProvider.id]?.line(label: "Session"), sessionLine(used: 65))
@@ -477,9 +692,18 @@ final class RefreshCoalescingTests: XCTestCase {
 
         let original = Task { await fixture.store.refresh(providerID: testProvider.id) }
         await fulfillment(of: [firstStarted], timeout: 1)
-        let joined = Task { await fixture.store.refresh(providerID: testProvider.id) }
-        let forced = Task { await fixture.store.refresh(providerID: testProvider.id, force: true) }
-        await Task.yield()
+        let joinedEntered = expectation(description: "ordinary joiner entered the join path")
+        let forcedEntered = expectation(description: "force entered the join path")
+        fixture.store.onRefreshJoined = { _, force in
+            (force ? forcedEntered : joinedEntered).fulfill()
+        }
+        let joined = Task {
+            return await fixture.store.refresh(providerID: testProvider.id)
+        }
+        let forced = Task {
+            return await fixture.store.refresh(providerID: testProvider.id, force: true)
+        }
+        await fulfillment(of: [joinedEntered, forcedEntered], timeout: 1)
 
         enabled.value = false
         fixture.runtime.resumeNext()

--- a/Tests/OpenUsageTests/TestSupport.swift
+++ b/Tests/OpenUsageTests/TestSupport.swift
@@ -331,6 +331,55 @@ final class CountingProviderRuntime: ProviderRuntime {
     }
 }
 
+@MainActor
+final class MutableFlag {
+    var value: Bool
+
+    init(value: Bool = true) {
+        self.value = value
+    }
+}
+
+/// A controllable provider sequence for refresh ownership/coalescing tests. Every request suspends until
+/// `resumeNext()` supplies its corresponding snapshot, making request order and overlap deterministic.
+@MainActor
+final class SuspendedSequenceProviderRuntime: ProviderRuntime {
+    let provider: Provider
+    let widgetDescriptors: [WidgetDescriptor]
+    var onStart: (Int) -> Void = { _ in }
+    private(set) var refreshCount = 0
+    private(set) var startedWhileCancelled: [Bool] = []
+    private(set) var maximumConcurrentRefreshCount = 0
+
+    private var activeRefreshCount = 0
+    private var snapshots: [ProviderSnapshot]
+    private var continuations: [CheckedContinuation<ProviderSnapshot, Never>] = []
+
+    init(provider: Provider, descriptors: [WidgetDescriptor], snapshots: [ProviderSnapshot]) {
+        self.provider = provider
+        self.widgetDescriptors = descriptors
+        self.snapshots = snapshots
+    }
+
+    func refresh() async -> ProviderSnapshot {
+        refreshCount += 1
+        activeRefreshCount += 1
+        maximumConcurrentRefreshCount = max(maximumConcurrentRefreshCount, activeRefreshCount)
+        defer { activeRefreshCount -= 1 }
+        startedWhileCancelled.append(Task.isCancelled)
+        onStart(refreshCount)
+        return await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func resumeNext() {
+        precondition(!snapshots.isEmpty, "test provided too few snapshots")
+        precondition(!continuations.isEmpty, "no suspended refresh to resume")
+        continuations.removeFirst().resume(returning: snapshots.removeFirst())
+    }
+}
+
 /// A runtime that returns `first` on the first refresh and `second` on every refresh after — for
 /// sequences like a success that later turns into a failure (e.g. testing that a hard error takes
 /// precedence over a stale soft warning from the prior success).

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -87,6 +87,10 @@ in-app **Settings → API Keys** card manages its key with no per-provider UI wo
   name for the card's copy.
 - `AppContainer` collects every `APIKeyManaging` provider into `apiKeyProviders`, which the card
   lists. Add the provider to the registry as usual and the card picks it up.
+- Saving or removing a key forces a live refresh, which already bypasses failure backoff. If an older
+  request is still running, the store coalesces the change into one post-request refresh so the newly
+  selected credential is the one that wins; credential-save code must not also prepare an enablement
+  refresh or it can queue the same work twice.
 
 Persist the key to a file the auth store already checks (don't introduce a parallel store), so the
 file remains the source of truth and a user can still edit it by hand.

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -5,7 +5,7 @@
 - All enabled providers refresh together: at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Providers fetch in parallel — one slow provider doesn't delay the others.
 - Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running.
 - The popover footer shows `Next update in Nm`. **Clicking it (or ⌘R)** refreshes immediately, skipping the cache.
-- Forced refreshes waiting behind the same active provider request coalesce into one fresh follow-up. A later force that arrives while that follow-up is already running queues one more sequential refresh, so a changed credential is not lost and provider calls never overlap.
+- Forced refreshes waiting behind the same active provider request coalesce into one fresh follow-up. A later force that arrives while that follow-up is already running queues one more sequential refresh, so a changed credential is not lost and provider calls never overlap. Ordinary refresh callers waiting on the active request receive that request's result; cancelling a later forced follow-up (for example, by turning the provider off) does not rewrite a completed result as skipped.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.
 
 ## Caching

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -5,7 +5,7 @@
 - All enabled providers refresh together: at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Providers fetch in parallel — one slow provider doesn't delay the others.
 - Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running.
 - The popover footer shows `Next update in Nm`. **Clicking it (or ⌘R)** refreshes immediately, skipping the cache.
-- Forced refreshes waiting behind the same active provider request coalesce into one fresh follow-up. A later force that arrives while that follow-up is already running queues one more sequential refresh, so a changed credential is not lost and provider calls never overlap. Ordinary refresh callers waiting on the active request receive that request's result; cancelling a later forced follow-up (for example, by turning the provider off) does not rewrite a completed result as skipped.
+- Forced refreshes waiting behind the same active provider request coalesce into one fresh follow-up. A later force that arrives while that follow-up is already running queues one more sequential refresh, so a changed credential is not lost and provider calls never overlap. Each waiting caller receives the result of the request that consumed its intent; cancelling a later forced follow-up (for example, by turning the provider off) does not rewrite an earlier completed result as skipped.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.
 
 ## Caching

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -5,6 +5,7 @@
 - All enabled providers refresh together: at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Providers fetch in parallel — one slow provider doesn't delay the others.
 - Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running.
 - The popover footer shows `Next update in Nm`. **Clicking it (or ⌘R)** refreshes immediately, skipping the cache.
+- Forced refreshes waiting behind the same active provider request coalesce into one fresh follow-up. A later force that arrives while that follow-up is already running queues one more sequential refresh, so a changed credential is not lost and provider calls never overlap.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.
 
 ## Caching


### PR DESCRIPTION
## TL;DR

Queues one fresh provider probe when a forced refresh arrives during an in-flight request, instead of discarding the user action. Concurrent callers receive the outcome of the request that consumed their intent; cancellation hand-offs keep the provider slot reserved, so calls never overlap or create ownerless work.

## What was happening

- The per-provider in-flight guard returned `skipped` to every concurrent caller.
- Saving or deleting an API key could request an immediate forced refresh after an older request had loaded the previous key; that force was lost.
- The old request could then fail and restore backoff, leaving the new credential untested until a later periodic pass.
- Re-enable actions and provider context-menu refreshes could hit the same lost-intent branch.
- Early coalescing drafts used provider-wide waiter cleanup, which let a later cancellation overwrite an earlier completed result or sweep callers from a newer request.

## What this changes

- Extracts a main-actor coalescer that records ordinary and forced waiters with exactly-once continuations.
- Resolves ordinary callers from the active request and each forced cohort from the follow-up that consumes its intent.
- Coalesces force bursts while preserving a later force that arrives during a follow-up itself.
- Keeps the provider slot reserved when a canceled owner hands queued work to an independent task; no newer owner can slip into a hand-off gap and no synthetic force is created.
- Lets canceled waiters withdraw promptly without canceling the active owner, replaying completed work, or leaving ownerless requests.
- Queues an immediate follow-up when re-enable clears backoff during an older request.
- Cancels only the affected forced cohort if the provider is disabled before that follow-up begins.
- Keeps automatic/manual telemetry attached only to requests that actually execute.
- Removes the API-key path redundant backoff prequeue; the forced refresh already bypasses backoff.
- Splits `StalenessHint` out of the store and updates the refresh contract documentation.

## Heads-up

- Provider requests remain serialized per provider; different providers still refresh in parallel.
- Independently verified with PRs #921 and #936 in every merge order; all reconstructed combined trees are identical.
- There is no visual design change, so screenshots are not applicable.

## Tests

- Fifteen deterministic suspension-based regressions cover ordinary joiners, force bursts, force-during-follow-up, re-enable/backoff, disable, waiter cancellation, owner cancellation, reserved hand-off, cohort isolation, and delayed API-key ordering.
- Focused coalescing suite: 15 passed; 50 consecutive local stress runs and 30 independent stress runs passed.
- Standalone full suite: 977 XCTest cases passed with 3 expected skips; 3 Swift Testing cases passed.
- Combined with #912, #913, #921, and #936: 989 XCTest cases passed with 3 expected skips; 3 Swift Testing cases passed.
- Release build packaged, code-signed, and launched with `script/build_and_run.sh verify`; a process-teardown race in the script itself was isolated separately from app startup.
- Independent concurrency review found no remaining functional, isolation, continuation, reservation, documentation, or KISS/DRY issue.
- `git diff --check` passed; the merge simulation with #913 is conflict-free.