### PR TITLE
Validate Cursor usage exports at the boundary

### DIFF
--- a/Sources/OpenUsage/Providers/Cursor/CursorCSVParser.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorCSVParser.swift
@@ -1,35 +1,68 @@
 import Foundation
 
 /// Minimal CSV parser supporting quoted fields with embedded commas, newlines, and escaped quotes
-/// (`""` → `"`). Streams records keyed by the header row. Ported verbatim from
+/// (`""` → `"`). Streams records keyed by the header row. Adapted from
 /// `../cursorcat/Sources/CursorCat/API/CSVParser.swift`.
 enum CursorCSVParser {
-    static func forEachRecord(in text: String, _ body: ([String: String]) -> Void) {
+    struct Summary: Equatable {
+        var isStructurallyComplete: Bool
+        var rejectedRecordCount: Int
+    }
+
+    /// Streams records and reports structural failures plus rows whose width differs from the header.
+    /// `header` exposes the normalized header once so boundary mappers can validate their required
+    /// schema without parsing the whole export a second time.
+    @discardableResult
+    static func forEachRecord(
+        in text: String,
+        header onHeader: (([String]) -> Void)? = nil,
+        _ body: ([String: String]) -> Void
+    ) -> Summary {
         var header: [String]?
-        forEachRow(in: text) { row in
+        var rejectedRecordCount = 0
+        let isStructurallyComplete = forEachRow(in: text) { row in
             guard let keys = header else {
-                header = row
+                let normalized = row.map {
+                    $0.trimmingCharacters(in: .whitespacesAndNewlines.union(CharacterSet(charactersIn: "\u{FEFF}")))
+                }
+                header = normalized
+                onHeader?(normalized)
                 return
             }
 
+            guard row.count == keys.count else {
+                rejectedRecordCount += 1
+                return
+            }
             var dict: [String: String] = [:]
-            for (i, key) in keys.enumerated() where i < row.count {
+            for (i, key) in keys.enumerated() {
                 dict[key] = row[i]
             }
             body(dict)
         }
+        return Summary(
+            isStructurallyComplete: isStructurallyComplete,
+            rejectedRecordCount: rejectedRecordCount
+        )
     }
 
-    private static func forEachRow(in text: String, _ body: ([String]) -> Void) {
+    private static func forEachRow(in text: String, _ body: ([String]) -> Void) -> Bool {
+        enum FieldState: Equatable {
+            case start
+            case unquoted
+            case quoted
+            case quoteClosed
+        }
+
         var field = ""
         var row: [String] = []
-        var inQuotes = false
+        var state = FieldState.start
         var i = text.startIndex
 
         while i < text.endIndex {
             let c = text[i]
 
-            if inQuotes {
+            if state == .quoted {
                 if c == "\"" {
                     let next = text.index(after: i)
                     if next < text.endIndex && text[next] == "\"" {
@@ -37,7 +70,7 @@ enum CursorCSVParser {
                         i = text.index(after: next)
                         continue
                     } else {
-                        inQuotes = false
+                        state = .quoteClosed
                         i = next
                         continue
                     }
@@ -48,30 +81,68 @@ enum CursorCSVParser {
                 }
             }
 
-            switch c {
-            case "\"":
-                inQuotes = true
-            case ",":
-                row.append(field)
-                field = ""
-            case "\r":
-                break
-            case "\n":
-                row.append(field)
-                emit(row, body)
-                row = []
-                field = ""
-            default:
-                field.append(c)
+            switch state {
+            case .start:
+                switch c {
+                case "\"":
+                    state = .quoted
+                case ",":
+                    row.append(field)
+                    field = ""
+                case "\r", "\n", "\r\n":
+                    row.append(field)
+                    emit(row, body)
+                    row = []
+                    field = ""
+                default:
+                    field.append(c)
+                    state = .unquoted
+                }
+            case .unquoted:
+                switch c {
+                case "\"":
+                    return false
+                case ",":
+                    row.append(field)
+                    field = ""
+                    state = .start
+                case "\r", "\n", "\r\n":
+                    row.append(field)
+                    emit(row, body)
+                    row = []
+                    field = ""
+                    state = .start
+                default:
+                    field.append(c)
+                }
+            case .quoteClosed:
+                switch c {
+                case ",":
+                    row.append(field)
+                    field = ""
+                    state = .start
+                case "\r", "\n", "\r\n":
+                    row.append(field)
+                    emit(row, body)
+                    row = []
+                    field = ""
+                    state = .start
+                default:
+                    return false
+                }
+            case .quoted:
+                preconditionFailure("quoted fields are handled before the state switch")
             }
             i = text.index(after: i)
         }
 
+        guard state != .quoted else { return false }
         // Trailing partial row.
-        if !field.isEmpty || !row.isEmpty {
+        if !field.isEmpty || !row.isEmpty || state == .quoteClosed {
             row.append(field)
             emit(row, body)
         }
+        return true
     }
 
     private static func emit(_ row: [String], _ body: ([String]) -> Void) {

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -157,15 +157,45 @@ final class CursorProvider: ProviderRuntime {
         let startOfToday = calendar.startOfDay(for: end)
         let start = calendar.date(byAdding: .day, value: -29, to: startOfToday) ?? startOfToday
 
-        guard let response = try? await usageClient.fetchUsageCSV(accessToken: accessToken, start: start, end: end),
-              (200..<300).contains(response.statusCode),
-              let csv = String(data: response.body, encoding: .utf8)
-        else {
+        let response: HTTPResponse?
+        do {
+            response = try await usageClient.fetchUsageCSV(accessToken: accessToken, start: start, end: end)
+        } catch {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV request failed")
+            return
+        }
+        guard let response else {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV request could not be prepared from the current session")
+            return
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV request returned HTTP \(response.statusCode)")
+            return
+        }
+        guard let csv = String(data: response.body, encoding: .utf8) else {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV response was not valid UTF-8")
             return
         }
         let pricing = await pricing()
-        let rows = CursorUsageCSV.parse(csv: csv, pricing: pricing)
-        CursorUsageMapper.appendSpendLines(rows: rows, now: end, pricing: pricing, to: &lines)
+        do {
+            let parsed = try CursorUsageCSV.parse(csv: csv, pricing: pricing)
+            if parsed.rejectedRowCount > 0 {
+                AppLog.warn(
+                    LogTag.plugin("cursor"),
+                    "usage CSV ignored \(parsed.rejectedRowCount) malformed row\(parsed.rejectedRowCount == 1 ? "" : "s")"
+                )
+            }
+            CursorUsageMapper.appendSpendLines(rows: parsed.rows, now: end, pricing: pricing, to: &lines)
+        } catch let error as CursorUsageCSVError {
+            switch error {
+            case .missingColumns(let columns):
+                AppLog.warn(LogTag.plugin("cursor"), "usage CSV missing required columns: \(columns.joined(separator: ", "))")
+            case .malformedCSV:
+                AppLog.warn(LogTag.plugin("cursor"), "usage CSV is structurally malformed")
+            }
+        } catch {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV could not be parsed")
+        }
     }
 
     private func fetchUsageWithRetry(accessToken: String, authState: inout CursorAuthState) async throws -> HTTPResponse {

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
@@ -11,7 +11,27 @@ struct CursorUsageCSVRow: Sendable, Equatable {
     var imputedCostDollars: Double?
 }
 
+struct CursorUsageCSVParseResult: Sendable, Equatable {
+    var rows: [CursorUsageCSVRow]
+    var rejectedRowCount: Int
+}
+
+enum CursorUsageCSVError: Error, Equatable {
+    case missingColumns([String])
+    case malformedCSV
+}
+
 enum CursorUsageCSV {
+    private enum Column {
+        static let date = "Date"
+        static let model = "Model"
+        static let cacheWrite = "Input (w/ Cache Write)"
+        static let input = "Input (w/o Cache Write)"
+        static let cacheRead = "Cache Read"
+        static let output = "Output Tokens"
+        static let required = [date, model, cacheWrite, input, cacheRead, output]
+    }
+
     // Date parsing runs once per row of a potentially large export; the three fixed-format parsers are
     // stateless after configuration, so they're built once instead of per call. DateFormatter and
     // ISO8601DateFormatter are thread-safe for parsing; `nonisolated(unsafe)` shares the immutable
@@ -33,28 +53,52 @@ enum CursorUsageCSV {
         return f
     }()
 
-    /// Pure parser: maps Cursor's exported CSV text into priced rows. Rows with an unparseable date or
-    /// header are skipped.
+    /// Pure boundary parser: maps Cursor's exported CSV text into priced rows, rejects malformed rows,
+    /// and fails when the export schema itself is unusable. Empty numeric cells are valid zeroes; a
+    /// non-empty non-integer or negative token count rejects that row instead of silently becoming zero.
     ///
     /// Cursor's CSV rows are aggregates, not individual requests, so long-context thresholds and Max
     /// Mode uplift cannot be applied reliably from row totals; rows bill at the base model API rate.
-    static func parse(csv: String, pricing: ModelPricing) -> [CursorUsageCSVRow] {
+    static func parse(csv: String, pricing: ModelPricing) throws -> CursorUsageCSVParseResult {
         var rows: [CursorUsageCSVRow] = []
-        CursorCSVParser.forEachRecord(in: csv) { r in
-            guard let dateStr = r["Date"]?.trimmingCharacters(in: .whitespaces),
+        var rejectedRowCount = 0
+        var acceptedTokenCount = 0
+        var missingColumns = Column.required
+        var hasDuplicateColumns = false
+        let summary = CursorCSVParser.forEachRecord(in: csv, header: { header in
+            let available = Set(header)
+            missingColumns = Column.required.filter { !available.contains($0) }
+            hasDuplicateColumns = available.count != header.count
+        }) { r in
+            guard let dateStr = r[Column.date]?.trimmingCharacters(in: .whitespaces),
                   !dateStr.isEmpty,
-                  let date = parseDate(dateStr)
-            else { return }
+                  let date = parseDate(dateStr),
+                  let model = r[Column.model]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !model.isEmpty,
+                  let cacheWrite = parseIntValue(r[Column.cacheWrite]),
+                  let input = parseIntValue(r[Column.input]),
+                  let cacheRead = parseIntValue(r[Column.cacheRead]),
+                  let output = parseIntValue(r[Column.output]),
+                  let rowTokenCount = addingWithoutOverflow([cacheWrite, input, cacheRead, output])
+            else {
+                rejectedRowCount += 1
+                return
+            }
+            let aggregate = acceptedTokenCount.addingReportingOverflow(rowTokenCount)
+            guard !aggregate.overflow else {
+                rejectedRowCount += 1
+                return
+            }
+            acceptedTokenCount = aggregate.partialValue
 
-            let model = (r["Model"] ?? "").trimmingCharacters(in: .whitespaces)
             // The CSV's "Input (w/ Cache Write)" tokens were written to the prompt cache; Anthropic
             // bills those at the 5-minute cache-write rate, other providers at the input rate (their
             // pricing entries carry cacheWrite == input).
             let tokens = TokenBreakdown(
-                input: parseIntValue(r["Input (w/o Cache Write)"] ?? ""),
-                cacheWrite5m: parseIntValue(r["Input (w/ Cache Write)"] ?? ""),
-                cacheRead: parseIntValue(r["Cache Read"] ?? ""),
-                output: parseIntValue(r["Output Tokens"] ?? "")
+                input: input,
+                cacheWrite5m: cacheWrite,
+                cacheRead: cacheRead,
+                output: output
             )
 
             rows.append(CursorUsageCSVRow(
@@ -68,7 +112,12 @@ enum CursorUsageCSV {
                 )
             ))
         }
-        return rows
+        guard summary.isStructurallyComplete, !hasDuplicateColumns else {
+            throw CursorUsageCSVError.malformedCSV
+        }
+        guard missingColumns.isEmpty else { throw CursorUsageCSVError.missingColumns(missingColumns) }
+        rejectedRowCount += summary.rejectedRecordCount
+        return CursorUsageCSVParseResult(rows: rows, rejectedRowCount: rejectedRowCount)
     }
 
     private static func parseDate(_ raw: String) -> Date? {
@@ -77,10 +126,37 @@ enum CursorUsageCSV {
         return plainDateTime.date(from: raw)
     }
 
-    private static func parseIntValue(_ raw: String) -> Int {
-        let normalized = raw.replacingOccurrences(of: ",", with: "")
-            .trimmingCharacters(in: .whitespaces)
+    private static func parseIntValue(_ raw: String?) -> Int? {
+        guard let raw else { return nil }
+        let normalized = raw.trimmingCharacters(in: .whitespaces)
         if normalized.isEmpty { return 0 }
-        return Int(normalized) ?? 0
+
+        let groups = normalized.split(separator: ",", omittingEmptySubsequences: false)
+        if groups.count > 1 {
+            guard let first = groups.first,
+                  (1...3).contains(first.utf8.count),
+                  isASCIIDigits(first),
+                  groups.dropFirst().allSatisfy({ $0.utf8.count == 3 && isASCIIDigits($0) })
+            else {
+                return nil
+            }
+        } else if !isASCIIDigits(normalized[...]) {
+            return nil
+        }
+        return Int(groups.joined())
+    }
+
+    private static func isASCIIDigits(_ value: Substring) -> Bool {
+        !value.isEmpty && value.utf8.allSatisfy { (48...57).contains($0) }
+    }
+
+    private static func addingWithoutOverflow(_ values: [Int]) -> Int? {
+        var total = 0
+        for value in values {
+            let addition = total.addingReportingOverflow(value)
+            guard !addition.overflow else { return nil }
+            total = addition.partialValue
+        }
+        return total
     }
 }

--- a/Tests/OpenUsageTests/CursorCSVBoundaryTests.swift
+++ b/Tests/OpenUsageTests/CursorCSVBoundaryTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+@testable import OpenUsage
+
+final class CursorCSVBoundaryTests: XCTestCase {
+    private let header = "Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens"
+
+    func testParserPreservesQuotedFieldsEscapesEmbeddedNewlinesAndCRLF() {
+        let csv = "Date,Model,Note\r\n"
+            + "2026-01-01T00:00:00Z,\"composer-1\",\"a, b \"\"quoted\"\" c\"\r\n"
+            + "2026-01-02T00:00:00Z,composer-1,\"line one\r\nline two\"\r\n"
+        var records: [[String: String]] = []
+
+        let summary = CursorCSVParser.forEachRecord(in: csv) { records.append($0) }
+
+        XCTAssertTrue(summary.isStructurallyComplete)
+        XCTAssertEqual(summary.rejectedRecordCount, 0)
+        XCTAssertEqual(records.count, 2)
+        guard records.count == 2 else { return }
+        XCTAssertEqual(records[0]["Note"], #"a, b "quoted" c"#)
+        XCTAssertEqual(records[1]["Note"], "line one\r\nline two")
+        XCTAssertEqual(records[1]["Model"], "composer-1")
+    }
+
+    func testParserParsesTrailingPartialRowWithoutNewline() {
+        let csv = "Date,Model\n2026-01-01T00:00:00Z,composer-1"
+        var records: [[String: String]] = []
+
+        let summary = CursorCSVParser.forEachRecord(in: csv) { records.append($0) }
+
+        XCTAssertTrue(summary.isStructurallyComplete)
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0]["Date"], "2026-01-01T00:00:00Z")
+        XCTAssertEqual(records[0]["Model"], "composer-1")
+    }
+
+    func testParserRejectsIllegalQuotePlacement() {
+        let malformed = [
+            "Date,Model\n2026-01-01T00:00:00Z,\"composer-1\"suffix",
+            "Date,Model\n2026-01-01T00:00:00Z,com\"poser-1"
+        ]
+
+        for csv in malformed {
+            let summary = CursorCSVParser.forEachRecord(in: csv) { _ in
+                XCTFail("a structurally malformed record must not be emitted")
+            }
+            XCTAssertFalse(summary.isStructurallyComplete, csv)
+        }
+    }
+
+    func testUsageCSVMapsColumnsToPricedRows() throws {
+        let csv = """
+        Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Cost
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,1000000,Included
+        2026-01-01T00:00:00Z,totally-unknown-model-xyz,No,0,100,0,0,Included
+        ,skipped-no-date,No,0,0,0,0,Included
+        """
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+        let rows = parsed.rows
+
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(parsed.rejectedRowCount, 1)
+        XCTAssertEqual(rows[0].model, "composer-1")
+        XCTAssertEqual(rows[0].tokens.output, 1_000_000)
+        XCTAssertEqual(rows[0].imputedCostDollars!, 10.0, accuracy: 1e-9)
+        XCTAssertEqual(rows[1].tokens.totalTokens, 100)
+        XCTAssertNil(rows[1].imputedCostDollars)
+    }
+
+    func testUsageCSVDoesNotTreatAggregatedRowsAsSingleLongContextRequests() throws {
+        var rates = ModelRates(
+            inputPerMillion: 3,
+            outputPerMillion: 15,
+            cacheWritePerMillion: 3.75,
+            cacheReadPerMillion: 0.3
+        )
+        rates.inputAbove200kPerMillion = 6
+        rates.outputAbove200kPerMillion = 22.5
+        let pricing = ModelPricing(
+            supplement: PricingSupplement(),
+            primary: PricingCatalog(entries: ["test-model": rates]),
+            secondary: PricingCatalog()
+        )
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,test-model,0,300000,0,100000
+        """
+
+        let row = try XCTUnwrap(CursorUsageCSV.parse(csv: csv, pricing: pricing).rows.first)
+
+        XCTAssertEqual(row.imputedCostDollars!, 2.4, accuracy: 0.0001)
+    }
+
+    func testUsageCSVValidatesGroupedAndUngroupedIntegers() throws {
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,,,,
+        2026-01-01T00:00:00Z,composer-1,0,"1,234",0,0
+        2026-01-01T00:00:00Z,composer-1,0,",",0,0
+        2026-01-01T00:00:00Z,composer-1,0,"1,2",0,0
+        2026-01-01T00:00:00Z,composer-1,0,"1,,2",0,0
+        2026-01-01T00:00:00Z,composer-1,0,"12,34",0,0
+        2026-01-01T00:00:00Z,composer-1,0,-1,0,0
+        2026-01-01T00:00:00Z,composer-1,0,1.5,0,0
+        2026-01-01T00:00:00Z,composer-1,0,1e3,0,0
+        2026-01-01T00:00:00Z,composer-1,0,9223372036854775808,0,0
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.tokens.totalTokens), [0, 1_234])
+        XCTAssertEqual(parsed.rejectedRowCount, 8)
+    }
+
+    func testUsageCSVRejectsRowsWhoseTokenBucketsOverflow() throws {
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,\(Int.max),1,0,0
+        2026-01-01T00:00:00Z,composer-1,0,100,0,0
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.tokens.totalTokens), [100])
+        XCTAssertEqual(parsed.rejectedRowCount, 1)
+    }
+
+    func testUsageCSVRejectsAggregateOverflowWithoutDiscardingSafeRows() throws {
+        let firstRowTokens = Int.max - 1
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,0,\(firstRowTokens),0,0
+        2026-01-02T00:00:00Z,composer-1,0,2,0,0
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.tokens.totalTokens), [firstRowTokens])
+        XCTAssertEqual(parsed.rejectedRowCount, 1)
+    }
+
+    func testUsageCSVAcceptsLargeNonOverflowingValues() throws {
+        let large = Int.max / 2
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,0,\(large),0,1
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.first?.tokens.totalTokens, large + 1)
+        XCTAssertEqual(parsed.rejectedRowCount, 0)
+    }
+
+    func testUsageCSVRejectsMismatchedRecordWidths() throws {
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,0,10,0,20
+        2026-01-01T00:00:00Z,composer-1,0,10,0,20,
+        2026-01-01T00:00:00Z,composer-1,0,10,0
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.tokens.totalTokens), [30])
+        XCTAssertEqual(parsed.rejectedRowCount, 2)
+    }
+
+    func testUsageCSVAcceptsBOMQuotedHeadersAndOptionalColumns() throws {
+        let csv = """
+        "﻿Date","Model","Input (w/ Cache Write)","Input (w/o Cache Write)","Cache Read","Output Tokens",Cost
+        2026-01-01T00:00:00Z,composer-1,,,,,Included
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.first?.tokens.totalTokens, 0)
+        XCTAssertEqual(parsed.rejectedRowCount, 0)
+    }
+
+    func testUsageCSVRejectsMissingDuplicateAndStructurallyMalformedColumns() {
+        let missingOutput = """
+        Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read
+        2026-01-01T00:00:00Z,composer-1,0,10,0
+        """
+        XCTAssertThrowsError(try CursorUsageCSV.parse(csv: missingOutput, pricing: TestPricing.bundled)) { error in
+            XCTAssertEqual(error as? CursorUsageCSVError, .missingColumns(["Output Tokens"]))
+        }
+
+        let duplicateDate = """
+        Date,Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens
+        2026-01-01T00:00:00Z,2026-01-01T00:00:00Z,composer-1,0,10,0,20
+        """
+        XCTAssertThrowsError(try CursorUsageCSV.parse(csv: duplicateDate, pricing: TestPricing.bundled)) { error in
+            XCTAssertEqual(error as? CursorUsageCSVError, .malformedCSV)
+        }
+
+        let unterminated = """
+        \(header)
+        2026-01-01T00:00:00Z,"composer-1,0,10,0,20
+        """
+        XCTAssertThrowsError(try CursorUsageCSV.parse(csv: unterminated, pricing: TestPricing.bundled)) { error in
+            XCTAssertEqual(error as? CursorUsageCSVError, .malformedCSV)
+        }
+    }
+}

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -1,80 +1,6 @@
 import XCTest
 @testable import OpenUsage
 
-// MARK: - CSV parser
-
-final class CursorCSVParserTests: XCTestCase {
-    func testParsesQuotedCommasEscapedQuotesAndEmbeddedNewlines() {
-        let csv = """
-        Date,Model,Note
-        2026-01-01T00:00:00Z,"composer-1","a, b ""quoted"" c"
-        2026-01-02T00:00:00Z,composer-1,"line one
-        line two"
-        """
-        var records: [[String: String]] = []
-        CursorCSVParser.forEachRecord(in: csv) { records.append($0) }
-
-        XCTAssertEqual(records.count, 2)
-        XCTAssertEqual(records[0]["Note"], #"a, b "quoted" c"#)
-        XCTAssertEqual(records[1]["Note"], "line one\nline two")
-        XCTAssertEqual(records[1]["Model"], "composer-1")
-    }
-
-    func testParsesTrailingPartialRowWithoutNewline() {
-        let csv = "Date,Model\n2026-01-01T00:00:00Z,composer-1"
-        var records: [[String: String]] = []
-        CursorCSVParser.forEachRecord(in: csv) { records.append($0) }
-
-        XCTAssertEqual(records.count, 1)
-        XCTAssertEqual(records[0]["Date"], "2026-01-01T00:00:00Z")
-        XCTAssertEqual(records[0]["Model"], "composer-1")
-    }
-
-    func testUsageCSVMapsColumnsToPricedRows() {
-        let csv = """
-        Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Cost
-        2026-01-01T00:00:00Z,composer-1,No,0,0,0,1000000,Included
-        2026-01-01T00:00:00Z,totally-unknown-model-xyz,No,0,100,0,0,Included
-        ,skipped-no-date,No,0,0,0,0,Included
-        """
-        let rows = CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
-
-        XCTAssertEqual(rows.count, 2) // the dateless row is skipped
-        XCTAssertEqual(rows[0].model, "composer-1")
-        XCTAssertEqual(rows[0].tokens.output, 1_000_000)
-        // composer-1 output is $10/M → 1M output = $10.
-        XCTAssertEqual(rows[0].imputedCostDollars!, 10.0, accuracy: 1e-9)
-        // No pricing source knows the second model: tokens counted, cost nil (flags the day incomplete).
-        XCTAssertEqual(rows[1].tokens.totalTokens, 100)
-        XCTAssertNil(rows[1].imputedCostDollars)
-    }
-
-    func testUsageCSVDoesNotTreatAggregatedRowsAsSingleLongContextRequests() throws {
-        var rates = ModelRates(
-            inputPerMillion: 3,
-            outputPerMillion: 15,
-            cacheWritePerMillion: 3.75,
-            cacheReadPerMillion: 0.3
-        )
-        rates.inputAbove200kPerMillion = 6
-        rates.outputAbove200kPerMillion = 22.5
-        let pricing = ModelPricing(
-            supplement: PricingSupplement(),
-            primary: PricingCatalog(entries: ["test-model": rates]),
-            secondary: PricingCatalog()
-        )
-        let csv = """
-        Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Cost
-        2026-01-01T00:00:00Z,test-model,No,0,300000,0,100000,Included
-        """
-
-        let row = try XCTUnwrap(CursorUsageCSV.parse(csv: csv, pricing: pricing).first)
-
-        // A CSV row combines many requests, so its total cannot prove that any one request crossed 200k.
-        XCTAssertEqual(row.imputedCostDollars!, 2.4, accuracy: 0.0001)
-    }
-}
-
 // MARK: - Range aggregation
 
 final class CursorSpendRangeTests: XCTestCase {
@@ -360,8 +286,8 @@ final class CursorSpendProviderTests: XCTestCase {
 
     func testSpendTileRendersCombinedCostAndTokensWithValueTooltip() async {
         let cursor = CursorProvider()
-        // Spend tiles are gated off the live provider (issue #758), so source the descriptor from the
-        // shared factory — this keeps the combined "cost · tokens" render shape covered for re-enable.
+        // Source the descriptor from the shared factory so this test can isolate the combined
+        // "cost · tokens" render shape from the provider's network refresh behavior.
         let descriptor = try! XCTUnwrap(WidgetDescriptor.spendTiles(provider: cursor.provider).first { $0.id == "cursor.today" })
 
         // The combined tile joins the dollar and the labeled token count. The render shape for a zero
@@ -427,11 +353,9 @@ final class CursorSpendProviderTests: XCTestCase {
 // MARK: - Client request contract
 
 final class CursorUsageClientRequestTests: XCTestCase {
-    // The provider-level CSV integration tests were removed when spend tracking was disabled (issue
-    // #758), but `CursorUsageClient.fetchUsageCSV` is kept intact for re-enable. Pin its request contract
-    // directly at the client level — endpoint, epoch-ms range, `strategy=tokens`, the session cookie, and
-    // `Accept: text/csv` — so a silent regression in URL/header construction can't slip through while the
-    // feature is off (this test runs regardless of `CursorProvider.spendTrackingEnabled`).
+    // Pin the request contract directly at the client level — endpoint, epoch-ms range,
+    // `strategy=tokens`, the session cookie, and `Accept: text/csv` — so a silent regression in
+    // URL/header construction cannot slip through.
     func testFetchUsageCSVBuildsTokenStrategyRequestWithSessionCookie() async throws {
         let accessToken = makeCursorJWT(sub: "google-oauth2|user_abc123")
         let http = RoutingHTTPClient { _ in

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -20,7 +20,7 @@ Just be signed into the Cursor app. OpenUsage reads Cursor's local state databas
 
 ## Spend history
 
-Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export. OpenUsage uses the exported token counts and shared model pricing to estimate the cost locally. Cursor's export may occasionally arrive late, so the newest figures can lag behind current activity.
+Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export. OpenUsage uses the exported token counts and shared model pricing to estimate the cost locally. Cursor's export may occasionally arrive late, so the newest figures can lag behind current activity. OpenUsage leaves isolated malformed rows out instead of silently counting broken values as zero. A failed download, invalid export schema, or broken CSV structure leaves spend history unavailable for that refresh. Each failure is recorded in the diagnostic log without including the exported usage data.
 
 ## Troubleshooting
 
@@ -29,4 +29,4 @@ Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export.
 
 ## Under the hood
 
-Connect RPC on `api2.cursor.sh` (dashboard usage), REST fallback at `cursor.com/api/usage` for request-based accounts, and Stripe balance at `cursor.com/api/auth/stripe`. A 401/403 triggers one token refresh and retry. Per-day spend imputation uses token counts priced through the shared [model pricing](../pricing.md); Cursor-native models (`auto`, `composer-*`, …) come from its supplement layer, which maintainers sync from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md). (The usage-events CSV export at `cursor.com/api/dashboard/export-usage-events-csv` previously fed the spend history; it's not currently fetched — see above.)
+Connect RPC on `api2.cursor.sh` (dashboard usage), REST fallback at `cursor.com/api/usage` for request-based accounts, Stripe balance at `cursor.com/api/auth/stripe`, and the usage-events CSV export at `cursor.com/api/dashboard/export-usage-events-csv`. The primary dashboard usage request refreshes the token and retries once after a 401/403; optional endpoint failures stay nonfatal and are recorded in the diagnostic log. Per-day spend imputation uses exported token counts priced through the shared [model pricing](../pricing.md); Cursor-native models (`auto`, `composer-*`, …) come from its supplement layer, which maintainers sync from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md).


### PR DESCRIPTION
## TL;DR

Validates Cursor usage CSV structure and token values before pricing them, so malformed exports are logged and excluded instead of silently changing spend or crashing on integer overflow. Optional CSV fetch failures remain nonfatal but are now diagnosable.

## What was happening

- The streaming parser treated only an unterminated final quote as malformed; illegal quote placement and surplus cells could shift or join values.
- Missing or duplicate required headers and mismatched row widths could produce partial dictionaries.
- Numeric parsing removed every comma, turning malformed values such as `1,2` into `12`, while invalid cells otherwise collapsed to zero.
- External values up to `Int.max` could overflow token-bucket or aggregate additions and terminate refresh.
- CSV transport, status, and UTF-8 failures returned silently, and the Cursor provider documentation contradicted the enabled export behavior.

## What this changes

- Uses a strict single-pass quote-state parser that preserves valid quoted commas, escaped quotes, embedded newlines, CRLF, BOM headers, and optional columns.
- Rejects illegal quote placement and malformed CSV structure; counts isolated record-width and field-validation failures without discarding good rows.
- Validates required and duplicate headers before mapping.
- Accepts empty numeric cells as zero and canonical comma grouping such as `1,234`, while rejecting malformed grouping, negatives, decimals, scientific notation, and out-of-range integers.
- Prevents both per-row and whole-export aggregate token overflow before constructing or pricing token breakdowns.
- Logs transport, status, UTF-8, schema, structure, and rejected-row failures using fixed messages and counts without exported rows, models, tokens, bodies, or credentials.
- Splits CSV boundary tests into a dedicated file, bringing `CursorSpendTests.swift` back below the repository size guideline.
- Updates Cursor spend-history, endpoint, failure, and retry documentation.

## Heads-up

- Structurally invalid CSV or an unusable header leaves spend history unavailable for that refresh; isolated invalid rows are skipped while valid rows remain usable.
- The primary dashboard usage request still has token-refresh retry semantics. The optional CSV request is nonfatal and logged without retry.
- If PRs #917 and #925 land first, rebase this branch once: their combined history overlaps one descriptor setup line in `CursorSpendTests`. Keep the shared `WidgetDescriptor.spendTiles` fixture used here; the resolved four-PR tree is verified.
- There is no visual design change, so screenshots are not applicable.

## Tests

- Added 12 focused boundary regressions covering CRLF/quoting, widths, optional columns, BOM/quoted headers, duplicate/missing headers, grouping, large values, and row/aggregate overflow.
- All Cursor-focused tests passed: 35 cases on the amended implementation; the 12 boundary tests passed again after the documentation correction.
- Full Swift suite: 970 XCTest cases passed, 3 expected skips; 3 Swift Testing cases passed.
- Release build packaged, code-signed, and launched with `script/build_and_run.sh verify`.
- Combined PRs #917, #925, #929, and #930 under the warning gate: 46 Cursor-focused tests and 981 XCTest cases passed (3 expected skips), plus 3 Swift Testing cases; release build/sign/launch verification passed.
- Two independent reviews completed; all functional findings were fixed, and the final pass found only the now-corrected retry wording.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spend imputation inputs and can drop spend tiles on schema/structure failures or skip bad rows, but live dashboard usage is unchanged and failures remain nonfatal with logging only.
> 
> **Overview**
> Hardens Cursor **spend history** by validating the usage-events CSV before token counts are priced, instead of silently coercing bad data or risking integer overflow during refresh.
> 
> **`CursorCSVParser`** now uses a strict quote-state machine, returns a **`Summary`** (structural completeness + width-mismatch rejections), normalizes BOM headers, and exposes the header row for schema checks. **`CursorUsageCSV.parse`** is now **`throws`** and returns **`CursorUsageCSVParseResult`** with **`rejectedRowCount`**; it enforces required/duplicate columns, rejects malformed structure, validates token integers (canonical `1,234` only), and skips rows on per-row or export-wide token overflow. **`CursorProvider.appendSpendLines`** replaces silent `try?` with explicit logging for fetch, HTTP, UTF-8, schema, structure, and rejected-row cases while keeping CSV failure nonfatal to live metrics.
> 
> Boundary coverage moves to **`CursorCSVBoundaryTests.swift`**; **`docs/providers/cursor.md`** documents malformed-row handling, spend unavailability on hard failures, and the active CSV export path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c66b4424e723971b29e49048e76cbeaad1fa172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->