### PR TITLE
Log Cursor optional endpoint failures

### DIFF
--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -123,18 +123,20 @@ final class CursorProvider: ProviderRuntime {
         }
 
         if shouldTryGenericRequestFallback(usage: usage) {
-            if let mapped = try? await requestBasedResult(
-                accessToken: currentToken,
-                planName: planName,
-                unavailableMessage: "Cursor request-based usage data unavailable. Try again later."
-            ) {
+            do {
+                let mapped = try await requestBasedResult(
+                    accessToken: currentToken,
+                    planName: planName,
+                    unavailableMessage: "Cursor request-based usage data unavailable. Try again later."
+                )
                 return snapshot(mapped)
+            } catch {
+                AppLog.warn(LogTag.plugin("cursor"), "optional request-based usage fallback failed")
             }
         }
 
         let creditGrants = await fetchCreditGrants(accessToken: currentToken)
-        let stripeResponse = try? await usageClient.fetchStripeBalance(accessToken: currentToken)
-        let stripeBalanceCents = CursorUsageMapper.stripeBalanceCents(from: stripeResponse ?? nil)
+        let stripeBalanceCents = await fetchStripeBalanceCents(accessToken: currentToken)
         var mapped = try CursorUsageMapper.mapUsage(
             usage: usage,
             planName: planName,
@@ -224,27 +226,82 @@ final class CursorProvider: ProviderRuntime {
     }
 
     private func fetchPlanName(accessToken: String) async -> (String?, Bool) {
-        do {
-            let response = try await usageClient.fetchPlan(accessToken: accessToken)
-            guard (200..<300).contains(response.statusCode),
-                  let body = ProviderParse.jsonObject(response.body),
-                  let planInfo = body["planInfo"] as? [String: Any]
-            else {
-                return (nil, true)
-            }
-            return (planInfo["planName"] as? String, false)
-        } catch {
+        guard let body = await fetchOptionalJSONObject(label: "plan", request: {
+            try await self.usageClient.fetchPlan(accessToken: accessToken)
+        }) else {
             return (nil, true)
         }
+        guard let planInfo = body["planInfo"] as? [String: Any],
+              let planName = (planInfo["planName"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .nilIfEmpty
+        else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional plan response contained invalid plan metadata")
+            return (nil, true)
+        }
+        return (planName, false)
     }
 
     private func fetchCreditGrants(accessToken: String) async -> [String: Any]? {
-        guard let response = try? await usageClient.fetchCredits(accessToken: accessToken),
-              (200..<300).contains(response.statusCode)
-        else {
+        guard let body = await fetchOptionalJSONObject(label: "credit-grants", request: {
+            try await self.usageClient.fetchCredits(accessToken: accessToken)
+        }) else {
             return nil
         }
-        return ProviderParse.jsonObject(response.body)
+        guard let hasCreditGrants = body["hasCreditGrants"] as? Bool else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional credit-grants response contained invalid grant metadata")
+            return nil
+        }
+        if hasCreditGrants {
+            guard let totalCents = ProviderParse.number(body["totalCents"]), totalCents > 0,
+                  let usedCents = ProviderParse.number(body["usedCents"]), usedCents >= 0 else {
+                AppLog.warn(LogTag.plugin("cursor"), "optional credit-grants response contained invalid grant metadata")
+                return nil
+            }
+        }
+        return body
+    }
+
+    private func fetchStripeBalanceCents(accessToken: String) async -> Double {
+        guard let body = await fetchOptionalJSONObject(label: "prepaid-balance", request: {
+            try await self.usageClient.fetchStripeBalance(accessToken: accessToken)
+        }) else {
+            return 0
+        }
+        guard ProviderParse.number(body["customerBalance"]) != nil else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional prepaid-balance response contained invalid balance metadata")
+            return 0
+        }
+        return CursorUsageMapper.stripeBalanceCents(from: body)
+    }
+
+    /// Optional endpoints enrich a usable primary snapshot; they never fail the whole provider. Keep
+    /// their boundary handling in one place so transport, preparation, status, and schema failures are
+    /// all visible with fixed, credential-free diagnostics.
+    private func fetchOptionalJSONObject(
+        label: String,
+        request: () async throws -> HTTPResponse?
+    ) async -> [String: Any]? {
+        let response: HTTPResponse?
+        do {
+            response = try await request()
+        } catch {
+            AppLog.warn(LogTag.plugin("cursor"), "optional \(label) request failed")
+            return nil
+        }
+        guard let response else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional \(label) request could not be prepared from the current session")
+            return nil
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional \(label) request returned HTTP \(response.statusCode)")
+            return nil
+        }
+        guard let body = ProviderParse.jsonObject(response.body) else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional \(label) response was invalid")
+            return nil
+        }
+        return body
     }
 
     private func requestBasedResult(accessToken: String, planName: String?, unavailableMessage: String) async throws -> CursorMappedUsage {

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -360,11 +360,9 @@ enum CursorUsageMapper {
         }
     }
 
-    static func stripeBalanceCents(from response: HTTPResponse?) -> Double {
-        guard let response,
-              (200..<300).contains(response.statusCode),
-              let stripe = ProviderParse.jsonObject(response.body),
-              let balance = ProviderParse.number(stripe["customerBalance"]),
+    static func stripeBalanceCents(from body: [String: Any]?) -> Double {
+        guard let body,
+              let balance = ProviderParse.number(body["customerBalance"]),
               balance < 0
         else {
             return 0

--- a/Tests/OpenUsageTests/CursorOptionalEndpointTests.swift
+++ b/Tests/OpenUsageTests/CursorOptionalEndpointTests.swift
@@ -1,0 +1,251 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class CursorOptionalEndpointTests: XCTestCase {
+    func testOptionalSchemaAndHTTPFailuresAreLoggedWithoutDiscardingPrimaryUsage() async throws {
+        let accessToken = makeCursorJWT(includeSubject: true)
+        let provider = makeProvider(accessToken: accessToken) { request in
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return Self.primaryUsageResponse
+            case CursorUsageClient.planURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"planInfo":{"planName":42}}"#.utf8))
+            case CursorUsageClient.creditsURL:
+                return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            case CursorUsageClient.stripeURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data("not-json".utf8))
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertEqual(progress(snapshot.lines, "Total usage")?.used, 20)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional plan response contained invalid plan metadata"), logs)
+        XCTAssertTrue(logs.contains("optional credit-grants request returned HTTP 503"), logs)
+        XCTAssertTrue(logs.contains("optional prepaid-balance response was invalid"), logs)
+        XCTAssertFalse(logs.contains(accessToken), logs)
+    }
+
+    func testOptionalTransportAndSessionPreparationFailuresAreLogged() async throws {
+        let provider = makeProvider(accessToken: makeCursorJWT(includeSubject: false)) { request in
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return Self.primaryUsageResponse
+            case CursorUsageClient.planURL, CursorUsageClient.creditsURL:
+                throw URLError(.cannotConnectToHost)
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertEqual(progress(snapshot.lines, "Total usage")?.used, 20)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional plan request failed"), logs)
+        XCTAssertTrue(logs.contains("optional credit-grants request failed"), logs)
+        XCTAssertTrue(logs.contains("optional prepaid-balance request could not be prepared from the current session"), logs)
+    }
+
+    func testInvalidPlanMetadataStillEnablesRequestBasedFallback() async throws {
+        let provider = makeProvider { request in
+            if request.url.absoluteString.hasPrefix(CursorUsageClient.restUsageURL.absoluteString) {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"gpt-4":{"maxRequestUsage":500,"numRequests":100}}"#.utf8)
+                )
+            }
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"enabled":true}"#.utf8))
+            case CursorUsageClient.planURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"planInfo":{"planName":42}}"#.utf8))
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertEqual(progress(snapshot.lines, "Requests")?.used, 100)
+        XCTAssertEqual(progress(snapshot.lines, "Requests")?.limit, 500)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional plan response contained invalid plan metadata"), logs)
+    }
+
+    func testMissingPrepaidBalanceMetadataIsLoggedWithoutDiscardingPrimaryUsage() async throws {
+        let provider = makeProvider { request in
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return Self.primaryUsageResponse
+            case CursorUsageClient.planURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"planInfo":{"planName":"pro"}}"#.utf8)
+                )
+            case CursorUsageClient.creditsURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"hasCreditGrants":false}"#.utf8))
+            case CursorUsageClient.stripeURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"unexpected":true}"#.utf8))
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertEqual(progress(snapshot.lines, "Total usage")?.used, 20)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional prepaid-balance response contained invalid balance metadata"), logs)
+    }
+
+    func testMalformedCreditMetadataIsLoggedWithoutBogusBalance() async throws {
+        let provider = makeProvider { request in
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return Self.primaryUsageResponse
+            case CursorUsageClient.planURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"planInfo":{"planName":"pro"}}"#.utf8)
+                )
+            case CursorUsageClient.creditsURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"hasCreditGrants":true,"totalCents":"10000","usedCents":"broken"}"#.utf8)
+                )
+            case CursorUsageClient.stripeURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"customerBalance":0}"#.utf8))
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertNil(snapshot.lines.first { $0.label == "Credits" })
+        XCTAssertTrue(logs.contains("optional credit-grants response contained invalid grant metadata"), logs)
+    }
+
+    func testFailedGenericRequestFallbackIsLoggedBeforePrimaryMappingError() async throws {
+        let provider = makeProvider { request in
+            if request.url.absoluteString.hasPrefix(CursorUsageClient.restUsageURL.absoluteString) {
+                return HTTPResponse(statusCode: 502, headers: [:], body: Data())
+            }
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"enabled":true,"planUsage":{}}"#.utf8)
+                )
+            case CursorUsageClient.planURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"planInfo":{"planName":"pro"}}"#.utf8)
+                )
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertNotNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional request-based usage fallback failed"), logs)
+    }
+
+    private nonisolated static var primaryUsageResponse: HTTPResponse {
+        HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data(
+                #"{"enabled":true,"billingCycleEnd":1772592000000,"planUsage":{"limit":40000,"remaining":32000,"totalPercentUsed":20}}"#.utf8
+            )
+        )
+    }
+
+    private func makeProvider(
+        accessToken: String = makeCursorJWT(includeSubject: true),
+        handler: @escaping @Sendable (HTTPRequest) async throws -> HTTPResponse
+    ) -> CursorProvider {
+        CursorProvider(
+            authStore: CursorAuthStore(
+                sqlite: OptionalCursorSQLite(values: [CursorAuthStore.accessTokenKey: accessToken]),
+                keychain: FakeKeychain()
+            ),
+            usageClient: CursorUsageClient(http: RoutingHTTPClient(handler: handler)),
+            now: { Date(timeIntervalSince1970: 1_800_000_000) },
+            pricing: { TestPricing.bundled }
+        )
+    }
+
+    private func captureLogs(
+        _ operation: () async -> ProviderSnapshot
+    ) async throws -> (ProviderSnapshot, String) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.CursorOptional.\(UUID().uuidString)", isDirectory: true)
+        let sink = LogFile(directory: directory, fileName: "OpenUsage.log")
+        sink.open()
+        let originalSink = AppLog.sink
+        AppLog.sink = sink
+        AppLog.reloadLevel(.warn)
+        defer {
+            AppLog.sink = originalSink
+            AppLog.reloadLevel()
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let snapshot = await operation()
+        let logs = try String(contentsOf: directory.appendingPathComponent("OpenUsage.log"), encoding: .utf8)
+        return (snapshot, logs)
+    }
+
+    private func progress(
+        _ lines: [MetricLine],
+        _ label: String
+    ) -> (used: Double, limit: Double)? {
+        guard case .progress(_, let used, let limit, _, _, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return (used, limit)
+    }
+}
+
+private func makeCursorJWT(includeSubject: Bool) -> String {
+    let payload = includeSubject
+        ? #"{"exp":9999999999,"sub":"google-oauth2|user"}"#
+        : #"{"exp":9999999999}"#
+    let encoded = Data(payload.utf8).base64EncodedString()
+        .replacingOccurrences(of: "=", with: "")
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+    return "a.\(encoded).c"
+}
+
+private final class OptionalCursorSQLite: SQLiteAccessing, @unchecked Sendable {
+    private let values: [String: String]
+
+    init(values: [String: String]) {
+        self.values = values
+    }
+
+    func queryValue(path: String, sql: String) throws -> String? {
+        for (key, value) in values where sql.contains(key) {
+            return value
+        }
+        return nil
+    }
+
+    func execute(path: String, sql: String) throws {}
+}

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -26,6 +26,7 @@ Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export.
 
 - **"Not logged in" / token errors** — open Cursor and make sure you're signed in, then refresh.
 - **Some metrics missing** — Cursor omits fields depending on plan type (e.g. Requests only exists on request-based accounts); missing metrics simply show "No data".
+- **Optional lookup failed** — plan, credit-grant, prepaid-balance, and request-fallback failures stay nonfatal when primary usage is available. OpenUsage records fixed, credential-free reasons in the diagnostic log.
 
 ## Under the hood
 


### PR DESCRIPTION
## TL;DR

Makes Cursor optional enrichment failures visible without letting nonessential plan, credit, prepaid-balance, or request-fallback endpoints discard usable primary usage, and rejects malformed financial metadata before it can produce an incorrect balance.

## What was happening

- Several Cursor enrichment calls used `try?` or returned `nil` for every failure shape.
- Transport, request preparation, non-success status, invalid JSON, and malformed metadata were indistinguishable from absent optional data.
- The request-based compatibility fallback could fail silently before the primary mapping error surfaced.
- Credit-grant fields defaulted malformed totals or usage to zero, which could overstate remaining credit.
- Prepaid-balance HTTP parsing lived in the mapper instead of at the provider boundary.

## What this changes

- Adds one provider helper for optional JSON boundaries, removing repeated transport, status, and schema handling.
- Records fixed, credential-free reasons for plan, credit-grant, and prepaid-balance failures.
- Validates and trims plan metadata while preserving request-based fallback when metadata is unusable.
- Requires a real credit-grant flag and, for active grants, finite positive totals plus nonnegative usage before mapping financial data.
- Logs generic request-fallback failure before continuing to the primary mapping result.
- Passes already-decoded prepaid data into the mapper, keeping I/O validation at the provider boundary.
- Keeps optional failures nonfatal when primary Cursor usage is usable.
- Updates Cursor troubleshooting with a dedicated optional-lookup entry.

## Tests

- Six boundary tests cover transport, request preparation, HTTP status, invalid JSON, plan/prepaid/credit metadata, fallback behavior, log visibility, token privacy, and primary-usage preservation.
- Includes a regression proving malformed used-credit metadata cannot create a bogus Credits row.
- Full suite: 968 XCTest cases passed with 3 expected skips, plus 3 Swift Testing cases.
- `git diff --check` passed.
- `script/build_and_run.sh verify` completed the release build, signed app staging, launch, and process verification.

No visual layout changes; screenshots are not applicable.