### PR TITLE
Split Copilot provider tests by responsibility

### DIFF
--- a/Tests/OpenUsageTests/CopilotAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/CopilotAuthStoreTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import OpenUsage
+
+final class CopilotAuthStoreTests: XCTestCase {
+    func testReadsEditorAppsJSON() {
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.editorAppsPath: """
+                { "github.com:Iv1.abc123": { "user": "octocat", "oauth_token": "gho_editor" } }
+                """
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        let token = store.loadToken()
+
+        XCTAssertEqual(token?.value, "gho_editor")
+    }
+
+    func testReadsGhHostsOAuthToken() {
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.ghHostsPath: """
+                github.com:
+                    git_protocol: https
+                    user: octocat
+                    oauth_token: gho_ghconfig
+                """
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        let token = store.loadToken()
+
+        XCTAssertEqual(token?.value, "gho_ghconfig")
+    }
+
+    func testDecodesGoKeyringWrappedGhKeychainToken() {
+        let wrapped = "go-keyring-base64:" + Data("gho_keychain".utf8).base64EncodedString()
+        let store = CopilotAuthStore(files: FakeFiles(), keychain: FakeKeychain(wrapped))
+
+        let token = store.loadToken()
+
+        XCTAssertEqual(token?.value, "gho_keychain")
+    }
+
+    func testEditorConfigWinsOverKeychain() {
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.editorAppsPath: #"{ "github.com": { "oauth_token": "gho_editor" } }"#
+            ]),
+            keychain: FakeKeychain("go-keyring-base64:" + Data("gho_keychain".utf8).base64EncodedString())
+        )
+
+        // Editor config wins over the keychain: the editor token is returned, not the keychain one.
+        XCTAssertEqual(store.loadToken()?.value, "gho_editor")
+    }
+
+    func testReturnsNilWhenNoCredentials() {
+        let store = CopilotAuthStore(files: FakeFiles(), keychain: FakeKeychain())
+        XCTAssertNil(store.loadToken())
+    }
+
+    func testEditorConfigIgnoresNonGithubDotComHost() {
+        // An Enterprise-only editor config must not yield a token for api.github.com; the chain should
+        // fall through to the gh keychain (which here holds the real github.com token).
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.editorAppsPath: #"{ "ghe.corp.example:Iv1.x": { "oauth_token": "gho_enterprise" } }"#
+            ]),
+            keychain: FakeKeychain("go-keyring-base64:" + Data("gho_dotcom".utf8).base64EncodedString())
+        )
+
+        let token = store.loadToken()
+
+        XCTAssertEqual(token?.value, "gho_dotcom")
+    }
+
+    func testEditorConfigPicksGithubDotComAmongHosts() {
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.editorAppsPath: #"{ "ghe.corp.example:Iv1.x": { "oauth_token": "gho_ent" }, "github.com:Iv1.y": { "oauth_token": "gho_dotcom" } }"#
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        XCTAssertEqual(store.loadToken()?.value, "gho_dotcom")
+    }
+
+    func testYamlValueIgnoresNestedUsersMap() {
+        let hosts = """
+        github.com:
+            users:
+                octocat:
+            user: octocat
+        """
+        XCTAssertEqual(CopilotAuthStore.yamlValue(hosts, key: "user"), "octocat")
+    }
+
+    func testYamlValueScopesToGithubDotComHost() {
+        // A GitHub Enterprise block precedes github.com; the github.com token must win.
+        let hosts = """
+        ghe.corp.example:
+            oauth_token: gho_enterprise
+            user: ent
+        github.com:
+            oauth_token: gho_dotcom
+            user: octocat
+        """
+        XCTAssertEqual(CopilotAuthStore.yamlValue(hosts, key: "oauth_token"), "gho_dotcom")
+        XCTAssertEqual(CopilotAuthStore.yamlValue(hosts, key: "user"), "octocat")
+    }
+
+    func testGhConfigPrefersGithubDotComTokenOverEnterprise() {
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.ghHostsPath: """
+                ghe.corp.example:
+                    oauth_token: gho_enterprise
+                github.com:
+                    oauth_token: gho_dotcom
+                """
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        XCTAssertEqual(store.loadToken()?.value, "gho_dotcom")
+    }
+}

--- a/Tests/OpenUsageTests/CopilotOrgBillingMapperTests.swift
+++ b/Tests/OpenUsageTests/CopilotOrgBillingMapperTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import OpenUsage
+
+final class CopilotOrgBillingMapperTests: XCTestCase {
+    func testParsesOrgLogins() {
+        let body: [[String: Any]] = [["login": "acme", "id": 1], ["login": "globex"], ["id": 3]]
+        let response = HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: try! JSONSerialization.data(withJSONObject: body)
+        )
+
+        XCTAssertEqual(CopilotOrgBillingMapper.orgLogins(response), ["acme", "globex"])
+    }
+
+    func testOrgLoginsEmptyForGarbledBody() {
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: Data("<html>".utf8))
+        XCTAssertEqual(CopilotOrgBillingMapper.orgLogins(response), [])
+    }
+
+    func testMapsAICreditUsageFromSummary() throws {
+        // The exact shape reported in issue #839: one Copilot AI-unit item, fully covered by included
+        // credits (netAmount 0).
+        let lines = try XCTUnwrap(
+            CopilotOrgBillingMapper.usageLines(body: CopilotTestFixtures.orgSummaryBody())
+        )
+
+        XCTAssertEqual(CopilotTestFixtures.orgCount(lines, "Org Credits") ?? -1, 298.698546, accuracy: 0.0001)
+        XCTAssertEqual(CopilotTestFixtures.orgDollars(lines, "Org Spend"), 0)
+    }
+
+    func testSumsMultipleCreditItemsAndBilledSpend() throws {
+        var body = CopilotTestFixtures.orgSummaryBody()
+        body["usageItems"] = [
+            ["product": "Copilot", "sku": "copilot_ai_unit", "unitType": "ai-units", "grossQuantity": 100.5, "netAmount": 1.25],
+            ["product": "Copilot", "sku": "Copilot AI Credits", "unitType": "ai-credits", "grossQuantity": 50, "netAmount": 0.5]
+        ]
+
+        let lines = try XCTUnwrap(CopilotOrgBillingMapper.usageLines(body: body))
+
+        XCTAssertEqual(CopilotTestFixtures.orgCount(lines, "Org Credits") ?? -1, 150.5, accuracy: 0.0001)
+        XCTAssertEqual(CopilotTestFixtures.orgDollars(lines, "Org Spend") ?? -1, 1.75, accuracy: 0.0001)
+    }
+
+    func testNilWhenNoCopilotCreditItems() {
+        // Actions minutes and Copilot seat fees (non-credit units) must not produce org meters.
+        var body = CopilotTestFixtures.orgSummaryBody()
+        body["usageItems"] = [
+            ["product": "Actions", "sku": "actions_linux", "unitType": "minutes", "grossQuantity": 120, "netAmount": 0.96],
+            ["product": "Copilot", "sku": "copilot_business_seat", "unitType": "user-months", "grossQuantity": 10, "netAmount": 190]
+        ]
+
+        XCTAssertNil(CopilotOrgBillingMapper.usageLines(body: body))
+    }
+
+    func testNilWhenSummaryHasNoUsageItems() {
+        XCTAssertNil(CopilotOrgBillingMapper.usageLines(body: ["organization": "acme"]))
+    }
+}

--- a/Tests/OpenUsageTests/CopilotProviderTests.swift
+++ b/Tests/OpenUsageTests/CopilotProviderTests.swift
@@ -1,387 +1,16 @@
 import XCTest
 @testable import OpenUsage
 
-final class CopilotAuthStoreTests: XCTestCase {
-    func testReadsEditorAppsJSON() {
-        let store = CopilotAuthStore(
-            files: FakeFiles([
-                CopilotAuthStore.editorAppsPath: """
-                { "github.com:Iv1.abc123": { "user": "octocat", "oauth_token": "gho_editor" } }
-                """
-            ]),
-            keychain: FakeKeychain()
-        )
-
-        let token = store.loadToken()
-
-        XCTAssertEqual(token?.value, "gho_editor")
-    }
-
-    func testReadsGhHostsOAuthToken() {
-        let store = CopilotAuthStore(
-            files: FakeFiles([
-                CopilotAuthStore.ghHostsPath: """
-                github.com:
-                    git_protocol: https
-                    user: octocat
-                    oauth_token: gho_ghconfig
-                """
-            ]),
-            keychain: FakeKeychain()
-        )
-
-        let token = store.loadToken()
-
-        XCTAssertEqual(token?.value, "gho_ghconfig")
-    }
-
-    func testDecodesGoKeyringWrappedGhKeychainToken() {
-        let wrapped = "go-keyring-base64:" + Data("gho_keychain".utf8).base64EncodedString()
-        let store = CopilotAuthStore(files: FakeFiles(), keychain: FakeKeychain(wrapped))
-
-        let token = store.loadToken()
-
-        XCTAssertEqual(token?.value, "gho_keychain")
-    }
-
-    func testEditorConfigWinsOverKeychain() {
-        let store = CopilotAuthStore(
-            files: FakeFiles([
-                CopilotAuthStore.editorAppsPath: #"{ "github.com": { "oauth_token": "gho_editor" } }"#
-            ]),
-            keychain: FakeKeychain("go-keyring-base64:" + Data("gho_keychain".utf8).base64EncodedString())
-        )
-
-        // Editor config wins over the keychain: the editor token is returned, not the keychain one.
-        XCTAssertEqual(store.loadToken()?.value, "gho_editor")
-    }
-
-    func testReturnsNilWhenNoCredentials() {
-        let store = CopilotAuthStore(files: FakeFiles(), keychain: FakeKeychain())
-        XCTAssertNil(store.loadToken())
-    }
-
-    func testEditorConfigIgnoresNonGithubDotComHost() {
-        // An Enterprise-only editor config must not yield a token for api.github.com; the chain should
-        // fall through to the gh keychain (which here holds the real github.com token).
-        let store = CopilotAuthStore(
-            files: FakeFiles([
-                CopilotAuthStore.editorAppsPath: #"{ "ghe.corp.example:Iv1.x": { "oauth_token": "gho_enterprise" } }"#
-            ]),
-            keychain: FakeKeychain("go-keyring-base64:" + Data("gho_dotcom".utf8).base64EncodedString())
-        )
-
-        let token = store.loadToken()
-
-        XCTAssertEqual(token?.value, "gho_dotcom")
-    }
-
-    func testEditorConfigPicksGithubDotComAmongHosts() {
-        let store = CopilotAuthStore(
-            files: FakeFiles([
-                CopilotAuthStore.editorAppsPath: #"{ "ghe.corp.example:Iv1.x": { "oauth_token": "gho_ent" }, "github.com:Iv1.y": { "oauth_token": "gho_dotcom" } }"#
-            ]),
-            keychain: FakeKeychain()
-        )
-
-        XCTAssertEqual(store.loadToken()?.value, "gho_dotcom")
-    }
-
-    func testYamlValueIgnoresNestedUsersMap() {
-        let hosts = """
-        github.com:
-            users:
-                octocat:
-            user: octocat
-        """
-        XCTAssertEqual(CopilotAuthStore.yamlValue(hosts, key: "user"), "octocat")
-    }
-
-    func testYamlValueScopesToGithubDotComHost() {
-        // A GitHub Enterprise block precedes github.com; the github.com token must win.
-        let hosts = """
-        ghe.corp.example:
-            oauth_token: gho_enterprise
-            user: ent
-        github.com:
-            oauth_token: gho_dotcom
-            user: octocat
-        """
-        XCTAssertEqual(CopilotAuthStore.yamlValue(hosts, key: "oauth_token"), "gho_dotcom")
-        XCTAssertEqual(CopilotAuthStore.yamlValue(hosts, key: "user"), "octocat")
-    }
-
-    func testGhConfigPrefersGithubDotComTokenOverEnterprise() {
-        let store = CopilotAuthStore(
-            files: FakeFiles([
-                CopilotAuthStore.ghHostsPath: """
-                ghe.corp.example:
-                    oauth_token: gho_enterprise
-                github.com:
-                    oauth_token: gho_dotcom
-                """
-            ]),
-            keychain: FakeKeychain()
-        )
-
-        XCTAssertEqual(store.loadToken()?.value, "gho_dotcom")
-    }
-}
-
-final class CopilotUsageMapperTests: XCTestCase {
-    func testMapsPaidCreditsAndChatAsPercentUsed() throws {
-        let mapped = try CopilotUsageMapper.map(body: makePaidBody())
-
-        XCTAssertEqual(mapped.plan, "Pro")
-        XCTAssertEqual(progress(mapped.lines, "Credits")?.used, 59)
-        XCTAssertEqual(progress(mapped.lines, "Chat")?.used, 5)
-        XCTAssertNotNil(progress(mapped.lines, "Credits")?.resetsAt)
-        XCTAssertEqual(progress(mapped.lines, "Credits")?.periodDurationMs, CopilotUsageMapper.periodMs)
-    }
-
-    func testSuppressesUnlimitedAndSentinelBuckets() throws {
-        // Paid plans report chat/completions as unlimited — both the explicit flag and the `-1`
-        // entitlement/remaining sentinel — which carry no real meter and must be suppressed, leaving
-        // just Credits.
-        var body = makePaidBody()
-        var quota = body["quota_snapshots"] as! [String: Any]
-        quota["chat"] = ["unlimited": true, "entitlement": 0, "remaining": 0, "quota_id": "chat"]
-        quota["completions"] = ["entitlement": -1, "remaining": -1, "quota_id": "completions"]
-        body["quota_snapshots"] = quota
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertNil(progress(mapped.lines, "Chat"))
-        XCTAssertNil(progress(mapped.lines, "Completions"))
-        XCTAssertEqual(progress(mapped.lines, "Credits")?.used, 59)
-    }
-
-    func testEmitsExtraUsageWhenOveragePermitted() throws {
-        var body = makePaidBody()
-        var quota = body["quota_snapshots"] as! [String: Any]
-        var premium = quota["premium_interactions"] as! [String: Any]
-        premium["overage_permitted"] = true
-        premium["overage_count"] = 36
-        quota["premium_interactions"] = premium
-        body["quota_snapshots"] = quota
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertEqual(countValue(mapped.lines, "Extra Usage"), 36)
-    }
-
-    func testShowsExtraUsageZeroWhenPermittedButUnused() throws {
-        var body = makePaidBody()
-        var quota = body["quota_snapshots"] as! [String: Any]
-        var premium = quota["premium_interactions"] as! [String: Any]
-        premium["overage_permitted"] = true
-        premium["overage_count"] = 0
-        quota["premium_interactions"] = premium
-        body["quota_snapshots"] = quota
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertEqual(countValue(mapped.lines, "Extra Usage"), 0)
-    }
-
-    func testSuppressesExtraUsageWhenNotPermitted() throws {
-        // makePaidBody's premium has no overage flag → extra usage is genuinely N/A.
-        let mapped = try CopilotUsageMapper.map(body: makePaidBody())
-        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
-    }
-
-    func testIgnoresLegacyLimitedQuotasWhenSnapshotsPresent() throws {
-        // A paid response with Credits present and chat/completions unlimited (-1) must NOT fall back to
-        // the legacy limited_user_quotas path, even if the payload still carries it — doing so would show
-        // free-tier Chat/Completions meters on a paid account alongside Credits.
-        var body = makePaidBody()
-        var quota = body["quota_snapshots"] as! [String: Any]
-        quota["chat"] = ["entitlement": -1, "remaining": -1, "quota_id": "chat"]
-        quota["completions"] = ["entitlement": -1, "remaining": -1, "quota_id": "completions"]
-        body["quota_snapshots"] = quota
-        body["limited_user_quotas"] = ["chat": 100, "completions": 1000]
-        body["monthly_quotas"] = ["chat": 500, "completions": 4000]
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertNotNil(progress(mapped.lines, "Credits"))
-        XCTAssertNil(progress(mapped.lines, "Chat"))
-        XCTAssertNil(progress(mapped.lines, "Completions"))
-    }
-
-    func testSuppressesZeroEntitlementPlaceholder() throws {
-        let body: [String: Any] = [
-            "copilot_plan": "business",
-            "quota_snapshots": [
-                "premium_interactions": ["entitlement": 0, "remaining": 0, "percent_remaining": 100, "quota_id": "premium"],
-                "chat": ["entitlement": 1000, "remaining": 800, "percent_remaining": 80, "quota_id": "chat"]
-            ]
-        ]
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertNil(progress(mapped.lines, "Credits"))
-        XCTAssertEqual(progress(mapped.lines, "Chat")?.used, 20)
-    }
-
-    func testMapsLiveFreeAccountSnapshots() throws {
-        // The exact shape a free `individual` account returns today: real chat/completions counts in
-        // `quota_snapshots`, a zero-entitlement premium bucket, and `token_based_billing` on every bucket.
-        // Credits + Extra Usage suppress (no allotment / overage off); Chat + Completions render.
-        let body: [String: Any] = [
-            "copilot_plan": "individual",
-            "access_type_sku": "free_limited_copilot",
-            "token_based_billing": true,
-            "quota_reset_date": "2099-07-01",
-            "quota_snapshots": [
-                "chat": ["entitlement": 200, "remaining": 182, "percent_remaining": 91.0, "overage_permitted": false, "token_based_billing": true],
-                "completions": ["entitlement": 2000, "remaining": 1989, "percent_remaining": 99.4, "overage_permitted": false, "token_based_billing": true],
-                "premium_interactions": ["entitlement": 0, "remaining": 0, "percent_remaining": 0.0, "overage_permitted": false, "token_based_billing": true]
-            ]
-        ]
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertEqual(mapped.plan, "Individual")
-        XCTAssertNil(progress(mapped.lines, "Credits"))
-        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
-        XCTAssertEqual(progress(mapped.lines, "Chat")?.used ?? -1, 9, accuracy: 0.0001)
-        XCTAssertEqual(progress(mapped.lines, "Completions")?.used ?? -1, 0.6, accuracy: 0.0001)
-    }
-
-    func testMapsFreeTierLimitedQuotas() throws {
-        let body: [String: Any] = [
-            "copilot_plan": "individual",
-            "limited_user_quotas": ["chat": 250, "completions": 2000],
-            "monthly_quotas": ["chat": 500, "completions": 4000],
-            "limited_user_reset_date": "2099-02-15"
-        ]
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertEqual(mapped.plan, "Individual")
-        XCTAssertEqual(progress(mapped.lines, "Chat")?.used, 50)
-        XCTAssertEqual(progress(mapped.lines, "Completions")?.used, 50)
-        XCTAssertNotNil(progress(mapped.lines, "Chat")?.resetsAt)
-    }
-
-    func testTokenBasedBillingReturnsPlanWithoutMeters() throws {
-        let body: [String: Any] = [
-            "copilot_plan": "business",
-            "token_based_billing": true,
-            "quota_snapshots": [
-                "premium_interactions": ["entitlement": 0, "remaining": 0, "quota_id": "premium"]
-            ]
-        ]
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertEqual(mapped.plan, "Business")
-        XCTAssertTrue(mapped.lines.isEmpty)
-        XCTAssertTrue(mapped.isOrgManagedSeat)
-    }
-
-    func testPlaceholderOveragePermittedDoesNotEmitExtraUsageOrBlockOrgFlag() throws {
-        // Regression for issue #839's second report: the org-managed placeholder carries
-        // `overage_permitted: true` on a zero-entitlement premium bucket. That must not render a
-        // meaningless "Extra Usage: 0" row — and must still flag the seat as org-managed so the
-        // provider runs the org-billing lookup.
-        var body: [String: Any] = [
-            "copilot_plan": "business",
-            "token_based_billing": true,
-            "quota_snapshots": [
-                "premium_interactions": [
-                    "entitlement": 0, "remaining": 0, "unlimited": true,
-                    "overage_permitted": true, "overage_count": 0, "token_based_billing": true
-                ]
-            ]
-        ]
-
-        let mapped = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
-        XCTAssertTrue(mapped.lines.isEmpty)
-        XCTAssertTrue(mapped.isOrgManagedSeat)
-
-        // A paid account with a real credit pool keeps its Extra Usage row.
-        body = makePaidBody()
-        var quota = body["quota_snapshots"] as! [String: Any]
-        var premium = quota["premium_interactions"] as! [String: Any]
-        premium["overage_permitted"] = true
-        premium["overage_count"] = 12
-        quota["premium_interactions"] = premium
-        body["quota_snapshots"] = quota
-
-        let paid = try CopilotUsageMapper.map(body: body)
-
-        XCTAssertEqual(countValue(paid.lines, "Extra Usage"), 12)
-        XCTAssertFalse(paid.isOrgManagedSeat)
-    }
-
-    func testThrowsQuotaUnavailableWhenEmpty() {
-        XCTAssertThrowsError(try CopilotUsageMapper.map(body: ["copilot_plan": "pro"])) { error in
-            XCTAssertEqual(error as? CopilotUsageError, .quotaUnavailable)
-        }
-    }
-}
-
-final class CopilotOrgBillingMapperTests: XCTestCase {
-    func testParsesOrgLogins() {
-        let body: [[String: Any]] = [["login": "acme", "id": 1], ["login": "globex"], ["id": 3]]
-        let response = HTTPResponse(statusCode: 200, headers: [:], body: try! JSONSerialization.data(withJSONObject: body))
-
-        XCTAssertEqual(CopilotOrgBillingMapper.orgLogins(response), ["acme", "globex"])
-    }
-
-    func testOrgLoginsEmptyForGarbledBody() {
-        let response = HTTPResponse(statusCode: 200, headers: [:], body: Data("<html>".utf8))
-        XCTAssertEqual(CopilotOrgBillingMapper.orgLogins(response), [])
-    }
-
-    func testMapsAICreditUsageFromSummary() throws {
-        // The exact shape reported in issue #839: one Copilot AI-unit item, fully covered by included
-        // credits (netAmount 0).
-        let lines = try XCTUnwrap(CopilotOrgBillingMapper.usageLines(body: makeOrgSummaryBody()))
-
-        XCTAssertEqual(orgCount(lines, "Org Credits") ?? -1, 298.698546, accuracy: 0.0001)
-        XCTAssertEqual(orgDollars(lines, "Org Spend"), 0)
-    }
-
-    func testSumsMultipleCreditItemsAndBilledSpend() throws {
-        var body = makeOrgSummaryBody()
-        body["usageItems"] = [
-            ["product": "Copilot", "sku": "copilot_ai_unit", "unitType": "ai-units", "grossQuantity": 100.5, "netAmount": 1.25],
-            ["product": "Copilot", "sku": "Copilot AI Credits", "unitType": "ai-credits", "grossQuantity": 50, "netAmount": 0.5]
-        ]
-
-        let lines = try XCTUnwrap(CopilotOrgBillingMapper.usageLines(body: body))
-
-        XCTAssertEqual(orgCount(lines, "Org Credits") ?? -1, 150.5, accuracy: 0.0001)
-        XCTAssertEqual(orgDollars(lines, "Org Spend") ?? -1, 1.75, accuracy: 0.0001)
-    }
-
-    func testNilWhenNoCopilotCreditItems() {
-        // Actions minutes and Copilot seat fees (non-credit units) must not produce org meters.
-        var body = makeOrgSummaryBody()
-        body["usageItems"] = [
-            ["product": "Actions", "sku": "actions_linux", "unitType": "minutes", "grossQuantity": 120, "netAmount": 0.96],
-            ["product": "Copilot", "sku": "copilot_business_seat", "unitType": "user-months", "grossQuantity": 10, "netAmount": 190]
-        ]
-
-        XCTAssertNil(CopilotOrgBillingMapper.usageLines(body: body))
-    }
-
-    func testNilWhenSummaryHasNoUsageItems() {
-        XCTAssertNil(CopilotOrgBillingMapper.usageLines(body: ["organization": "acme"]))
-    }
-}
-
 @MainActor
 final class CopilotProviderTests: XCTestCase {
     func testNotLoggedInWhenNoToken() async {
         let provider = CopilotProvider(
             authStore: CopilotAuthStore(files: FakeFiles(), keychain: FakeKeychain()),
-            usageClient: CopilotUsageClient(http: FakeHTTPClient(response: ok(makePaidBody())))
+            usageClient: CopilotUsageClient(
+                http: FakeHTTPClient(
+                    response: CopilotTestFixtures.ok(CopilotTestFixtures.paidBody())
+                )
+            )
         )
 
         let snapshot = await provider.refresh()
@@ -392,7 +21,11 @@ final class CopilotProviderTests: XCTestCase {
     func testTokenInvalidOn401() async {
         let provider = CopilotProvider(
             authStore: editorTokenStore(),
-            usageClient: CopilotUsageClient(http: FakeHTTPClient(response: HTTPResponse(statusCode: 401, headers: [:], body: Data())))
+            usageClient: CopilotUsageClient(
+                http: FakeHTTPClient(
+                    response: HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                )
+            )
         )
 
         let snapshot = await provider.refresh()
@@ -401,7 +34,9 @@ final class CopilotProviderTests: XCTestCase {
     }
 
     func testMapsLinesAndSendsTokenHeaderOnSuccess() async throws {
-        let http = FakeHTTPClient(response: ok(makePaidBody()))
+        let http = FakeHTTPClient(
+            response: CopilotTestFixtures.ok(CopilotTestFixtures.paidBody())
+        )
         let provider = CopilotProvider(
             authStore: editorTokenStore(),
             usageClient: CopilotUsageClient(http: http),
@@ -424,7 +59,9 @@ final class CopilotProviderTests: XCTestCase {
         ]
         let provider = CopilotProvider(
             authStore: editorTokenStore(),
-            usageClient: CopilotUsageClient(http: FakeHTTPClient(response: ok(body)))
+            usageClient: CopilotUsageClient(
+                http: FakeHTTPClient(response: CopilotTestFixtures.ok(body))
+            )
         )
 
         let snapshot = await provider.refresh()
@@ -435,10 +72,16 @@ final class CopilotProviderTests: XCTestCase {
     }
 
     func testOrgManagedSeatShowsOrgBillingLines() async {
-        let http = routedClient([
-            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
-            ("/user/orgs", okJSON([["login": "acme"]])),
-            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        let http = CopilotTestFixtures.routedClient([
+            (
+                "/copilot_internal/user",
+                CopilotTestFixtures.ok(CopilotTestFixtures.businessPlaceholderBody())
+            ),
+            ("/user/orgs", CopilotTestFixtures.okJSON([["login": "acme"]])),
+            (
+                "/orgs/acme/settings/billing/usage/summary",
+                CopilotTestFixtures.ok(CopilotTestFixtures.orgSummaryBody())
+            )
         ])
         let defaults = freshDefaults()
         let provider = makeOrgProvider(http: http, defaults: defaults)
@@ -447,9 +90,13 @@ final class CopilotProviderTests: XCTestCase {
 
         XCTAssertNil(snapshot.errorCategory)
         XCTAssertEqual(snapshot.plan, "Business")
-        XCTAssertEqual(orgCount(snapshot.lines, "Org Credits") ?? -1, 298.698546, accuracy: 0.0001)
-        XCTAssertEqual(orgDollars(snapshot.lines, "Org Spend"), 0)
-        // The placeholder's `overage_permitted: true` must not leave a meaningless Extra Usage row.
+        XCTAssertEqual(
+            CopilotTestFixtures.orgCount(snapshot.lines, "Org Credits") ?? -1,
+            298.698546,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(CopilotTestFixtures.orgDollars(snapshot.lines, "Org Spend"), 0)
+        // The placeholder's overage_permitted: true must not leave a meaningless Extra Usage row.
         XCTAssertNil(snapshot.lines.first(where: { $0.label == "Extra Usage" }))
         XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
     }
@@ -458,9 +105,12 @@ final class CopilotProviderTests: XCTestCase {
         // A plain org member (not owner/billing manager) gets 403 on org billing — the expected state,
         // which must keep today's plan-only card rather than erroring the provider.
         let forbidden = HTTPResponse(statusCode: 403, headers: [:], body: Data())
-        let http = routedClient([
-            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
-            ("/user/orgs", okJSON([["login": "acme"]])),
+        let http = CopilotTestFixtures.routedClient([
+            (
+                "/copilot_internal/user",
+                CopilotTestFixtures.ok(CopilotTestFixtures.businessPlaceholderBody())
+            ),
+            ("/user/orgs", CopilotTestFixtures.okJSON([["login": "acme"]])),
             ("/orgs/acme/settings/billing/usage/summary", forbidden)
         ])
         let defaults = freshDefaults()
@@ -475,9 +125,15 @@ final class CopilotProviderTests: XCTestCase {
     }
 
     func testUsesCachedOrgWithoutReprobing() async {
-        let http = routedClient([
-            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
-            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        let http = CopilotTestFixtures.routedClient([
+            (
+                "/copilot_internal/user",
+                CopilotTestFixtures.ok(CopilotTestFixtures.businessPlaceholderBody())
+            ),
+            (
+                "/orgs/acme/settings/billing/usage/summary",
+                CopilotTestFixtures.ok(CopilotTestFixtures.orgSummaryBody())
+            )
         ])
         let defaults = freshDefaults()
         defaults.set("acme", forKey: CopilotProvider.billingOrgDefaultsKey)
@@ -485,18 +141,27 @@ final class CopilotProviderTests: XCTestCase {
 
         let snapshot = await provider.refresh()
 
-        XCTAssertNotNil(orgCount(snapshot.lines, "Org Credits"))
+        XCTAssertNotNil(CopilotTestFixtures.orgCount(snapshot.lines, "Org Credits"))
         XCTAssertFalse(http.requests.contains { $0.url.absoluteString.contains("/user/orgs") })
     }
 
     func testEvictsStaleCachedOrgAndReprobes() async {
         // The cached org answers without Copilot usage (e.g. the user changed orgs) — it must be
         // forgotten and discovery re-run.
-        let http = routedClient([
-            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
-            ("/orgs/oldorg/settings/billing/usage/summary", HTTPResponse(statusCode: 404, headers: [:], body: Data())),
-            ("/user/orgs", okJSON([["login": "acme"]])),
-            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        let http = CopilotTestFixtures.routedClient([
+            (
+                "/copilot_internal/user",
+                CopilotTestFixtures.ok(CopilotTestFixtures.businessPlaceholderBody())
+            ),
+            (
+                "/orgs/oldorg/settings/billing/usage/summary",
+                HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            ),
+            ("/user/orgs", CopilotTestFixtures.okJSON([["login": "acme"]])),
+            (
+                "/orgs/acme/settings/billing/usage/summary",
+                CopilotTestFixtures.ok(CopilotTestFixtures.orgSummaryBody())
+            )
         ])
         let defaults = freshDefaults()
         defaults.set("oldorg", forKey: CopilotProvider.billingOrgDefaultsKey)
@@ -504,34 +169,52 @@ final class CopilotProviderTests: XCTestCase {
 
         let snapshot = await provider.refresh()
 
-        XCTAssertNotNil(orgCount(snapshot.lines, "Org Credits"))
+        XCTAssertNotNil(CopilotTestFixtures.orgCount(snapshot.lines, "Org Credits"))
         XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
     }
 
     func testDiscoveryKeepsProbingPastAFailingOrg() async {
         // One org's billing endpoint having an outage (5xx) must not abort discovery — the next org's
         // usage should still be found and cached.
-        let http = routedClient([
-            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
-            ("/user/orgs", okJSON([["login": "brokenorg"], ["login": "acme"]])),
-            ("/orgs/brokenorg/settings/billing/usage/summary", HTTPResponse(statusCode: 503, headers: [:], body: Data())),
-            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        let http = CopilotTestFixtures.routedClient([
+            (
+                "/copilot_internal/user",
+                CopilotTestFixtures.ok(CopilotTestFixtures.businessPlaceholderBody())
+            ),
+            (
+                "/user/orgs",
+                CopilotTestFixtures.okJSON([["login": "brokenorg"], ["login": "acme"]])
+            ),
+            (
+                "/orgs/brokenorg/settings/billing/usage/summary",
+                HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            ),
+            (
+                "/orgs/acme/settings/billing/usage/summary",
+                CopilotTestFixtures.ok(CopilotTestFixtures.orgSummaryBody())
+            )
         ])
         let defaults = freshDefaults()
         let provider = makeOrgProvider(http: http, defaults: defaults)
 
         let snapshot = await provider.refresh()
 
-        XCTAssertNotNil(orgCount(snapshot.lines, "Org Credits"))
+        XCTAssertNotNil(CopilotTestFixtures.orgCount(snapshot.lines, "Org Credits"))
         XCTAssertEqual(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey), "acme")
     }
 
     func testTransientBillingFailureKeepsCachedOrg() async {
         // A 5xx from the cached org's billing endpoint is a brief outage, not a stale org: the cache
         // must survive (no re-discovery), and the refresh degrades to the plan-only card.
-        let http = routedClient([
-            ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
-            ("/orgs/acme/settings/billing/usage/summary", HTTPResponse(statusCode: 503, headers: [:], body: Data()))
+        let http = CopilotTestFixtures.routedClient([
+            (
+                "/copilot_internal/user",
+                CopilotTestFixtures.ok(CopilotTestFixtures.businessPlaceholderBody())
+            ),
+            (
+                "/orgs/acme/settings/billing/usage/summary",
+                HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            )
         ])
         let defaults = freshDefaults()
         defaults.set("acme", forKey: CopilotProvider.billingOrgDefaultsKey)
@@ -546,8 +229,11 @@ final class CopilotProviderTests: XCTestCase {
     }
 
     func testPersonalPaidAccountMakesNoOrgCalls() async {
-        let http = routedClient([
-            ("/copilot_internal/user", ok(makePaidBody()))
+        let http = CopilotTestFixtures.routedClient([
+            (
+                "/copilot_internal/user",
+                CopilotTestFixtures.ok(CopilotTestFixtures.paidBody())
+            )
         ])
         let provider = makeOrgProvider(http: http, defaults: freshDefaults())
 
@@ -557,7 +243,10 @@ final class CopilotProviderTests: XCTestCase {
         XCTAssertEqual(http.requests.count, 1)
     }
 
-    private func makeOrgProvider(http: RoutingHTTPClient, defaults: UserDefaults) -> CopilotProvider {
+    private func makeOrgProvider(
+        http: RoutingHTTPClient,
+        defaults: UserDefaults
+    ) -> CopilotProvider {
         CopilotProvider(
             authStore: editorTokenStore(),
             usageClient: CopilotUsageClient(http: http),
@@ -575,114 +264,10 @@ final class CopilotProviderTests: XCTestCase {
 
     private func editorTokenStore() -> CopilotAuthStore {
         CopilotAuthStore(
-            files: FakeFiles([CopilotAuthStore.editorAppsPath: #"{ "github.com": { "oauth_token": "gho_editor" } }"#]),
+            files: FakeFiles([
+                CopilotAuthStore.editorAppsPath: #"{ "github.com": { "oauth_token": "gho_editor" } }"#
+            ]),
             keychain: FakeKeychain()
         )
     }
-}
-
-// MARK: - Helpers
-
-/// A `RoutingHTTPClient` answering with the first response whose URL-substring key matches; unmatched
-/// URLs 404.
-private func routedClient(_ routes: [(substring: String, response: HTTPResponse)]) -> RoutingHTTPClient {
-    RoutingHTTPClient { request in
-        routes.first(where: { request.url.absoluteString.contains($0.substring) })?.response
-            ?? HTTPResponse(statusCode: 404, headers: [:], body: Data())
-    }
-}
-
-/// The exact `/copilot_internal/user` shape of an org-managed Copilot Business seat from issue #839:
-/// plan is reported but every quota bucket is a zero-entitlement token-based-billing placeholder.
-/// Crucially, the premium bucket carries `overage_permitted: true` — the field that used to sneak an
-/// "Extra Usage: 0" row into the mapped lines and block the org-billing fallback.
-private func makeBusinessPlaceholderBody() -> [String: Any] {
-    func bucket(_ id: String, overagePermitted: Bool) -> [String: Any] {
-        [
-            "overage_count": 0, "overage_entitlement": 0, "overage_permitted": overagePermitted,
-            "percent_remaining": 100.0, "quota_id": id, "quota_remaining": 0.0, "unlimited": true,
-            "has_quota": true, "quota_reset_at": 0, "token_based_billing": true,
-            "remaining": 0, "entitlement": 0
-        ]
-    }
-    return [
-        "copilot_plan": "business",
-        "token_based_billing": true,
-        "quota_snapshots": [
-            "chat": bucket("chat", overagePermitted: false),
-            "completions": bucket("completions", overagePermitted: false),
-            "premium_interactions": bucket("premium_interactions", overagePermitted: true)
-        ]
-    ]
-}
-
-/// The org billing usage summary from issue #839: one Copilot AI-unit item, fully covered by the
-/// included credits.
-private func makeOrgSummaryBody() -> [String: Any] {
-    [
-        "timePeriod": ["year": 2026, "month": 7],
-        "organization": "acme",
-        "usageItems": [
-            [
-                "product": "Copilot",
-                "sku": "copilot_ai_unit",
-                "unitType": "ai-units",
-                "pricePerUnit": 0.01,
-                "grossQuantity": 298.698546,
-                "grossAmount": 2.98698546,
-                "discountQuantity": 298.698546,
-                "discountAmount": 2.98698546,
-                "netQuantity": 0.0,
-                "netAmount": 0.0
-            ]
-        ]
-    ]
-}
-
-private func okJSON(_ array: [[String: Any]]) -> HTTPResponse {
-    HTTPResponse(statusCode: 200, headers: [:], body: try! JSONSerialization.data(withJSONObject: array))
-}
-
-private func orgCount(_ lines: [MetricLine], _ label: String) -> Double? {
-    value(lines, label: label, kind: .count)
-}
-
-private func orgDollars(_ lines: [MetricLine], _ label: String) -> Double? {
-    value(lines, label: label, kind: .dollars)
-}
-
-private func value(_ lines: [MetricLine], label: String, kind: MetricKind) -> Double? {
-    guard case .values(_, let values, _, _, _, _) = lines.first(where: { $0.label == label }) else {
-        return nil
-    }
-    return values.first(where: { $0.kind == kind })?.number
-}
-
-private func makePaidBody() -> [String: Any] {
-    [
-        "copilot_plan": "pro",
-        "quota_reset_date": "2099-01-15T00:00:00Z",
-        "quota_snapshots": [
-            "premium_interactions": ["entitlement": 300, "remaining": 123, "percent_remaining": 41, "quota_id": "premium"],
-            "chat": ["entitlement": 1000, "remaining": 950, "percent_remaining": 95, "quota_id": "chat"]
-        ]
-    ]
-}
-
-private func ok(_ body: [String: Any]) -> HTTPResponse {
-    HTTPResponse(statusCode: 200, headers: [:], body: try! JSONSerialization.data(withJSONObject: body))
-}
-
-private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
-    guard case .progress(_, let used, let limit, _, let resetsAt, let periodDurationMs, _) = lines.first(where: { $0.label == label }) else {
-        return nil
-    }
-    return (used, limit, resetsAt, periodDurationMs)
-}
-
-private func countValue(_ lines: [MetricLine], _ label: String) -> Double? {
-    guard case .values(_, let values, _, _, _, _) = lines.first(where: { $0.label == label }) else {
-        return nil
-    }
-    return values.first?.number
 }

--- a/Tests/OpenUsageTests/CopilotTestFixtures.swift
+++ b/Tests/OpenUsageTests/CopilotTestFixtures.swift
@@ -1,0 +1,143 @@
+import Foundation
+@testable import OpenUsage
+
+enum CopilotTestFixtures {
+    /// A RoutingHTTPClient answering with the first response whose URL-substring key matches; unmatched
+    /// URLs 404.
+    static func routedClient(
+        _ routes: [(substring: String, response: HTTPResponse)]
+    ) -> RoutingHTTPClient {
+        RoutingHTTPClient { request in
+            routes.first(where: { request.url.absoluteString.contains($0.substring) })?.response
+                ?? HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+    }
+
+    /// The exact /copilot_internal/user shape of an org-managed Copilot Business seat from issue #839:
+    /// plan is reported but every quota bucket is a zero-entitlement token-based-billing placeholder.
+    /// Crucially, the premium bucket carries overage_permitted: true — the field that used to sneak an
+    /// "Extra Usage: 0" row into the mapped lines and block the org-billing fallback.
+    static func businessPlaceholderBody() -> [String: Any] {
+        func bucket(_ id: String, overagePermitted: Bool) -> [String: Any] {
+            [
+                "overage_count": 0, "overage_entitlement": 0, "overage_permitted": overagePermitted,
+                "percent_remaining": 100.0, "quota_id": id, "quota_remaining": 0.0, "unlimited": true,
+                "has_quota": true, "quota_reset_at": 0, "token_based_billing": true,
+                "remaining": 0, "entitlement": 0
+            ]
+        }
+        return [
+            "copilot_plan": "business",
+            "token_based_billing": true,
+            "quota_snapshots": [
+                "chat": bucket("chat", overagePermitted: false),
+                "completions": bucket("completions", overagePermitted: false),
+                "premium_interactions": bucket("premium_interactions", overagePermitted: true)
+            ]
+        ]
+    }
+
+    /// The org billing usage summary from issue #839: one Copilot AI-unit item, fully covered by the
+    /// included credits.
+    static func orgSummaryBody() -> [String: Any] {
+        [
+            "timePeriod": ["year": 2026, "month": 7],
+            "organization": "acme",
+            "usageItems": [
+                [
+                    "product": "Copilot",
+                    "sku": "copilot_ai_unit",
+                    "unitType": "ai-units",
+                    "pricePerUnit": 0.01,
+                    "grossQuantity": 298.698546,
+                    "grossAmount": 2.98698546,
+                    "discountQuantity": 298.698546,
+                    "discountAmount": 2.98698546,
+                    "netQuantity": 0.0,
+                    "netAmount": 0.0
+                ]
+            ]
+        ]
+    }
+
+    static func okJSON(_ array: [[String: Any]]) -> HTTPResponse {
+        HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: try! JSONSerialization.data(withJSONObject: array)
+        )
+    }
+
+    static func orgCount(_ lines: [MetricLine], _ label: String) -> Double? {
+        value(lines, label: label, kind: .count)
+    }
+
+    static func orgDollars(_ lines: [MetricLine], _ label: String) -> Double? {
+        value(lines, label: label, kind: .dollars)
+    }
+
+    static func paidBody() -> [String: Any] {
+        [
+            "copilot_plan": "pro",
+            "quota_reset_date": "2099-01-15T00:00:00Z",
+            "quota_snapshots": [
+                "premium_interactions": [
+                    "entitlement": 300,
+                    "remaining": 123,
+                    "percent_remaining": 41,
+                    "quota_id": "premium"
+                ],
+                "chat": [
+                    "entitlement": 1000,
+                    "remaining": 950,
+                    "percent_remaining": 95,
+                    "quota_id": "chat"
+                ]
+            ]
+        ]
+    }
+
+    static func ok(_ body: [String: Any]) -> HTTPResponse {
+        HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: try! JSONSerialization.data(withJSONObject: body)
+        )
+    }
+
+    static func progress(
+        _ lines: [MetricLine],
+        _ label: String
+    ) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
+        guard case .progress(
+            _,
+            let used,
+            let limit,
+            _,
+            let resetsAt,
+            let periodDurationMs,
+            _
+        ) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return (used, limit, resetsAt, periodDurationMs)
+    }
+
+    static func countValue(_ lines: [MetricLine], _ label: String) -> Double? {
+        guard case .values(_, let values, _, _, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return values.first?.number
+    }
+
+    private static func value(
+        _ lines: [MetricLine],
+        label: String,
+        kind: MetricKind
+    ) -> Double? {
+        guard case .values(_, let values, _, _, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return values.first(where: { $0.kind == kind })?.number
+    }
+}

--- a/Tests/OpenUsageTests/CopilotUsageMapperTests.swift
+++ b/Tests/OpenUsageTests/CopilotUsageMapperTests.swift
@@ -1,0 +1,206 @@
+import XCTest
+@testable import OpenUsage
+
+final class CopilotUsageMapperTests: XCTestCase {
+    func testMapsPaidCreditsAndChatAsPercentUsed() throws {
+        let mapped = try CopilotUsageMapper.map(body: CopilotTestFixtures.paidBody())
+
+        XCTAssertEqual(mapped.plan, "Pro")
+        XCTAssertEqual(CopilotTestFixtures.progress(mapped.lines, "Credits")?.used, 59)
+        XCTAssertEqual(CopilotTestFixtures.progress(mapped.lines, "Chat")?.used, 5)
+        XCTAssertNotNil(CopilotTestFixtures.progress(mapped.lines, "Credits")?.resetsAt)
+        XCTAssertEqual(
+            CopilotTestFixtures.progress(mapped.lines, "Credits")?.periodDurationMs,
+            CopilotUsageMapper.periodMs
+        )
+    }
+
+    func testSuppressesUnlimitedAndSentinelBuckets() throws {
+        // Paid plans report chat/completions as unlimited — both the explicit flag and the -1
+        // entitlement/remaining sentinel — which carry no real meter and must be suppressed, leaving
+        // just Credits.
+        var body = CopilotTestFixtures.paidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        quota["chat"] = ["unlimited": true, "entitlement": 0, "remaining": 0, "quota_id": "chat"]
+        quota["completions"] = ["entitlement": -1, "remaining": -1, "quota_id": "completions"]
+        body["quota_snapshots"] = quota
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertNil(CopilotTestFixtures.progress(mapped.lines, "Chat"))
+        XCTAssertNil(CopilotTestFixtures.progress(mapped.lines, "Completions"))
+        XCTAssertEqual(CopilotTestFixtures.progress(mapped.lines, "Credits")?.used, 59)
+    }
+
+    func testEmitsExtraUsageWhenOveragePermitted() throws {
+        var body = CopilotTestFixtures.paidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        var premium = quota["premium_interactions"] as! [String: Any]
+        premium["overage_permitted"] = true
+        premium["overage_count"] = 36
+        quota["premium_interactions"] = premium
+        body["quota_snapshots"] = quota
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(CopilotTestFixtures.countValue(mapped.lines, "Extra Usage"), 36)
+    }
+
+    func testShowsExtraUsageZeroWhenPermittedButUnused() throws {
+        var body = CopilotTestFixtures.paidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        var premium = quota["premium_interactions"] as! [String: Any]
+        premium["overage_permitted"] = true
+        premium["overage_count"] = 0
+        quota["premium_interactions"] = premium
+        body["quota_snapshots"] = quota
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(CopilotTestFixtures.countValue(mapped.lines, "Extra Usage"), 0)
+    }
+
+    func testSuppressesExtraUsageWhenNotPermitted() throws {
+        // paidBody's premium has no overage flag → extra usage is genuinely N/A.
+        let mapped = try CopilotUsageMapper.map(body: CopilotTestFixtures.paidBody())
+        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
+    }
+
+    func testIgnoresLegacyLimitedQuotasWhenSnapshotsPresent() throws {
+        // A paid response with Credits present and chat/completions unlimited (-1) must NOT fall back to
+        // the legacy limited_user_quotas path, even if the payload still carries it — doing so would show
+        // free-tier Chat/Completions meters on a paid account alongside Credits.
+        var body = CopilotTestFixtures.paidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        quota["chat"] = ["entitlement": -1, "remaining": -1, "quota_id": "chat"]
+        quota["completions"] = ["entitlement": -1, "remaining": -1, "quota_id": "completions"]
+        body["quota_snapshots"] = quota
+        body["limited_user_quotas"] = ["chat": 100, "completions": 1000]
+        body["monthly_quotas"] = ["chat": 500, "completions": 4000]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertNotNil(CopilotTestFixtures.progress(mapped.lines, "Credits"))
+        XCTAssertNil(CopilotTestFixtures.progress(mapped.lines, "Chat"))
+        XCTAssertNil(CopilotTestFixtures.progress(mapped.lines, "Completions"))
+    }
+
+    func testSuppressesZeroEntitlementPlaceholder() throws {
+        let body: [String: Any] = [
+            "copilot_plan": "business",
+            "quota_snapshots": [
+                "premium_interactions": ["entitlement": 0, "remaining": 0, "percent_remaining": 100, "quota_id": "premium"],
+                "chat": ["entitlement": 1000, "remaining": 800, "percent_remaining": 80, "quota_id": "chat"]
+            ]
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertNil(CopilotTestFixtures.progress(mapped.lines, "Credits"))
+        XCTAssertEqual(CopilotTestFixtures.progress(mapped.lines, "Chat")?.used, 20)
+    }
+
+    func testMapsLiveFreeAccountSnapshots() throws {
+        // The exact shape a free individual account returns today: real chat/completions counts in
+        // quota_snapshots, a zero-entitlement premium bucket, and token_based_billing on every bucket.
+        // Credits + Extra Usage suppress (no allotment / overage off); Chat + Completions render.
+        let body: [String: Any] = [
+            "copilot_plan": "individual",
+            "access_type_sku": "free_limited_copilot",
+            "token_based_billing": true,
+            "quota_reset_date": "2099-07-01",
+            "quota_snapshots": [
+                "chat": ["entitlement": 200, "remaining": 182, "percent_remaining": 91.0, "overage_permitted": false, "token_based_billing": true],
+                "completions": ["entitlement": 2000, "remaining": 1989, "percent_remaining": 99.4, "overage_permitted": false, "token_based_billing": true],
+                "premium_interactions": ["entitlement": 0, "remaining": 0, "percent_remaining": 0.0, "overage_permitted": false, "token_based_billing": true]
+            ]
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(mapped.plan, "Individual")
+        XCTAssertNil(CopilotTestFixtures.progress(mapped.lines, "Credits"))
+        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
+        XCTAssertEqual(CopilotTestFixtures.progress(mapped.lines, "Chat")?.used ?? -1, 9, accuracy: 0.0001)
+        XCTAssertEqual(
+            CopilotTestFixtures.progress(mapped.lines, "Completions")?.used ?? -1,
+            0.6,
+            accuracy: 0.0001
+        )
+    }
+
+    func testMapsFreeTierLimitedQuotas() throws {
+        let body: [String: Any] = [
+            "copilot_plan": "individual",
+            "limited_user_quotas": ["chat": 250, "completions": 2000],
+            "monthly_quotas": ["chat": 500, "completions": 4000],
+            "limited_user_reset_date": "2099-02-15"
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(mapped.plan, "Individual")
+        XCTAssertEqual(CopilotTestFixtures.progress(mapped.lines, "Chat")?.used, 50)
+        XCTAssertEqual(CopilotTestFixtures.progress(mapped.lines, "Completions")?.used, 50)
+        XCTAssertNotNil(CopilotTestFixtures.progress(mapped.lines, "Chat")?.resetsAt)
+    }
+
+    func testTokenBasedBillingReturnsPlanWithoutMeters() throws {
+        let body: [String: Any] = [
+            "copilot_plan": "business",
+            "token_based_billing": true,
+            "quota_snapshots": [
+                "premium_interactions": ["entitlement": 0, "remaining": 0, "quota_id": "premium"]
+            ]
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(mapped.plan, "Business")
+        XCTAssertTrue(mapped.lines.isEmpty)
+        XCTAssertTrue(mapped.isOrgManagedSeat)
+    }
+
+    func testPlaceholderOveragePermittedDoesNotEmitExtraUsageOrBlockOrgFlag() throws {
+        // Regression for issue #839's second report: the org-managed placeholder carries
+        // overage_permitted: true on a zero-entitlement premium bucket. That must not render a
+        // meaningless "Extra Usage: 0" row — and must still flag the seat as org-managed so the
+        // provider runs the org-billing lookup.
+        var body: [String: Any] = [
+            "copilot_plan": "business",
+            "token_based_billing": true,
+            "quota_snapshots": [
+                "premium_interactions": [
+                    "entitlement": 0, "remaining": 0, "unlimited": true,
+                    "overage_permitted": true, "overage_count": 0, "token_based_billing": true
+                ]
+            ]
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
+        XCTAssertTrue(mapped.lines.isEmpty)
+        XCTAssertTrue(mapped.isOrgManagedSeat)
+
+        // A paid account with a real credit pool keeps its Extra Usage row.
+        body = CopilotTestFixtures.paidBody()
+        var quota = body["quota_snapshots"] as! [String: Any]
+        var premium = quota["premium_interactions"] as! [String: Any]
+        premium["overage_permitted"] = true
+        premium["overage_count"] = 12
+        quota["premium_interactions"] = premium
+        body["quota_snapshots"] = quota
+
+        let paid = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(CopilotTestFixtures.countValue(paid.lines, "Extra Usage"), 12)
+        XCTAssertFalse(paid.isOrgManagedSeat)
+    }
+
+    func testThrowsQuotaUnavailableWhenEmpty() {
+        XCTAssertThrowsError(try CopilotUsageMapper.map(body: ["copilot_plan": "pro"])) { error in
+            XCTAssertEqual(error as? CopilotUsageError, .quotaUnavailable)
+        }
+    }
+}


### PR DESCRIPTION
## TL;DR

Splits the 688-line Copilot provider test file into focused authentication, usage-mapping, organization-billing, and provider-integration suites with shared fixtures. All 39 tests are preserved exactly; production behavior is unchanged.

## What was happening

- One test file mixed four independent responsibilities and exceeded the repository's ~500-line convention.
- Shared HTTP and response fixtures were file-level globals, making ownership and reuse harder to scan.
- Finding a regression test required navigating unrelated auth, mapper, billing, and integration coverage.

## What this changes

- Moves authentication coverage into `CopilotAuthStoreTests`.
- Moves quota mapping and organization billing mapping into their own suites.
- Keeps end-to-end provider behavior in the original provider test file.
- Namespaces shared response builders and assertions in `CopilotTestFixtures`.
- Preserves every test name and assertion while keeping every resulting file below 500 lines.

## Heads-up

- This is a test-only responsibility split: no app source, runtime behavior, documentation, or visual output changes.

## Tests

- Copilot-focused suite: 39 tests passed.
- Exact test-name and class-count parity with `origin/main`: 39 of 39 preserved.
- Full suite: 962 XCTest cases passed with 3 expected skips; 3 Swift Testing cases passed.
- `script/build_and_run.sh verify` completed the release build, signed app staging, launch, and process verification.
- `git diff --check` passed.
- Independent exact-commit review found no behavior or fixture drift.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only file moves and fixture extraction; no application source or runtime behavior changes.
> 
> **Overview**
> Splits the oversized **`CopilotProviderTests`** monolith into four focused suites and a shared fixture module so each file stays under the repo’s ~500-line guideline.
> 
> **`CopilotAuthStoreTests`**, **`CopilotUsageMapperTests`**, and **`CopilotOrgBillingMapperTests`** now own the auth, quota-mapping, and org-billing mapper cases that used to live in one file. **`CopilotProviderTests`** keeps only end-to-end **`CopilotProvider.refresh()`** integration tests (auth errors, org billing discovery/cache, HTTP routing).
> 
> Private file-level helpers (`routedClient`, `makePaidBody`, `progress`, etc.) move into **`CopilotTestFixtures`** as static members; call sites switch from those globals to `CopilotTestFixtures.*`. Test names and assertions are unchanged—no production code touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf1c789783dbb8b74f1bf6d27a3b0ff990bbfdbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->