### PR TITLE
Split widget store presentation accessors

### DIFF
--- a/Sources/OpenUsage/Stores/WidgetDataStore+Presentation.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore+Presentation.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+extension WidgetDataStore {
+    /// The provider's latest refresh error, or `nil` when its last refresh succeeded.
+    func errorMessage(for providerID: String) -> String? {
+        providerErrors[providerID]
+    }
+
+    /// A soft, non-blocking notice from the provider's latest *successful* snapshot (e.g. Claude's
+    /// "Re-login for live usage" when the login lacks the `user:profile` scope). `nil` when there's no
+    /// warning. After a *failed* refresh the store keeps the last good snapshot (so this warning can
+    /// linger) while setting `providerErrors` — use `headerNotice(for:)` for the rendered triangle so a
+    /// current hard error isn't masked by a stale soft warning.
+    func warningMessage(for providerID: String) -> String? {
+        snapshots[providerID]?.warning
+    }
+
+    /// The provider header's amber-triangle notice: a hard refresh error takes precedence over a stale
+    /// soft warning from the last successful snapshot. After a failed refresh the store keeps the last
+    /// good snapshot (so `warningMessage` still returns its warning) while `errorMessage` holds the
+    /// current failure — the error must win, or a stale "Re-login for live usage" warning would hide a
+    /// real "Token expired" failure. When there's no error, the soft warning (if any) shows.
+    func headerNotice(for providerID: String) -> String? {
+        errorMessage(for: providerID) ?? warningMessage(for: providerID)
+    }
+
+    func data(for descriptor: WidgetDescriptor) -> WidgetData {
+        if PlanWidget.isPlan(descriptor) {
+            var result = descriptor.sample
+            if let plan = plan(for: descriptor.providerID) {
+                result.valueTextOverride = plan
+                result.hasData = true
+            } else {
+                result.hasData = false
+            }
+            return result
+        }
+
+        var result: WidgetData
+        if let snapshot = snapshots[descriptor.providerID],
+           let line = snapshot.line(label: descriptor.metricLabel),
+           let data = resolve(line, descriptor: descriptor) {
+            result = data
+        } else {
+            // No real metric line backs this placed tile, so the sample's numbers are placeholders.
+            // Flag it as no-data; the tile renders "No data" instead of inventing usage.
+            result = descriptor.sample
+            result.hasData = false
+        }
+
+        // Single global choke point: tiles, the Add-Widget gallery, and the menu-bar value all funnel
+        // through here, so stamping the mode once makes them follow the global setting. Inert for
+        // unbounded tiles (limit == nil), whose displayed value ignores displayMode.
+        result.displayMode = meterStyle
+        result.resetDisplayMode = resetDisplayMode
+        result.alwaysShowPacing = alwaysShowPacing
+        result.widgetID = descriptor.id
+        return result
+    }
+
+    /// The plan label for a provider's latest snapshot (also feeds the optional Plan widget). `nil` until a
+    /// snapshot exists or when the provider doesn't expose a plan.
+    func plan(for providerID: String) -> String? {
+        snapshots[providerID]?.plan
+    }
+
+    /// How long a displayed snapshot may age before the header calls it out. A healthy provider's
+    /// snapshot resets to ~0 on every successful pass and only brushes one interval just before the next
+    /// one, so the threshold sits at two intervals: it fires only when a refresh has actually been missed
+    /// — a refresh loop that keeps failing, or a long-suspended background timer — never on the normal
+    /// per-cycle aging, which would flicker a hint on healthy providers.
+    static let stalenessThreshold = RefreshSetting.interval * 2
+
+    /// A compact "Outdated" hint for the provider's on-screen snapshot, surfaced only once that snapshot
+    /// has aged past `stalenessThreshold`; `nil` while the data is still current (the common case), so the
+    /// header stays clean until staleness is real. The label is short on purpose — a long plan name plus a
+    /// full "Updated 3h ago" string would overflow the header — so the precise age rides in the tooltip.
+    /// This is the visible counterpart to the silent fossilized-cache problem (#582): a failing-refresh
+    /// loop keeps the last good plan/limits on screen, and without this nothing told the user that data was
+    /// stale. Reads the store's injected clock, which tests pin to a fixed value.
+    func stalenessHint(for providerID: String) -> StalenessHint? {
+        guard let refreshedAt = snapshots[providerID]?.refreshedAt else { return nil }
+        let age = now().timeIntervalSince(refreshedAt)
+        guard age >= Self.stalenessThreshold, let duration = Formatters.compactDuration(age) else {
+            return nil
+        }
+        return StalenessHint(label: "Outdated", tooltip: "Last updated \(duration) ago")
+    }
+
+}

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -15,7 +15,7 @@ final class WidgetDataStore {
     /// so the store reads `LayoutStore.visiblePlaced` without owning it; defaults to registry order.
     private let orderedDescriptors: @MainActor () -> [WidgetDescriptor]
     /// Clock for the failure-backoff window. Injected so tests can advance time deterministically.
-    private let now: () -> Date
+    let now: () -> Date
     /// Quota-notification preferences (master + per-trigger). Injected; `nil` disables notifications
     /// entirely (tests and previews that don't wire it).
     private let notificationSettings: (@MainActor () -> NotificationSettingsStore)?
@@ -441,29 +441,6 @@ final class WidgetDataStore {
         }
     }
 
-    /// The provider's latest refresh error, or `nil` when its last refresh succeeded.
-    func errorMessage(for providerID: String) -> String? {
-        providerErrors[providerID]
-    }
-
-    /// A soft, non-blocking notice from the provider's latest *successful* snapshot (e.g. Claude's
-    /// "Re-login for live usage" when the login lacks the `user:profile` scope). `nil` when there's no
-    /// warning. After a *failed* refresh the store keeps the last good snapshot (so this warning can
-    /// linger) while setting `providerErrors` — use `headerNotice(for:)` for the rendered triangle so a
-    /// current hard error isn't masked by a stale soft warning.
-    func warningMessage(for providerID: String) -> String? {
-        snapshots[providerID]?.warning
-    }
-
-    /// The provider header's amber-triangle notice: a hard refresh error takes precedence over a stale
-    /// soft warning from the last successful snapshot. After a failed refresh the store keeps the last
-    /// good snapshot (so `warningMessage` still returns its warning) while `errorMessage` holds the
-    /// current failure — the error must win, or a stale "Re-login for live usage" warning would hide a
-    /// real "Token expired" failure. When there's no error, the soft warning (if any) shows.
-    func headerNotice(for providerID: String) -> String? {
-        errorMessage(for: providerID) ?? warningMessage(for: providerID)
-    }
-
     /// A snapshot that carries only error lines is a failed refresh; its message comes from the badge.
     private static func errorMessage(in snapshot: ProviderSnapshot) -> String? {
         guard !snapshot.lines.isEmpty, snapshot.lines.allSatisfy(\.isError) else { return nil }
@@ -471,70 +448,7 @@ final class WidgetDataStore {
         return "Refresh failed"
     }
 
-    func data(for descriptor: WidgetDescriptor) -> WidgetData {
-        if PlanWidget.isPlan(descriptor) {
-            var result = descriptor.sample
-            if let plan = plan(for: descriptor.providerID) {
-                result.valueTextOverride = plan
-                result.hasData = true
-            } else {
-                result.hasData = false
-            }
-            return result
-        }
-
-        var result: WidgetData
-        if let snapshot = snapshots[descriptor.providerID],
-           let line = snapshot.line(label: descriptor.metricLabel),
-           let data = resolve(line, descriptor: descriptor) {
-            result = data
-        } else {
-            // No real metric line backs this placed tile, so the sample's numbers are placeholders.
-            // Flag it as no-data; the tile renders "No data" instead of inventing usage.
-            result = descriptor.sample
-            result.hasData = false
-        }
-
-        // Single global choke point: tiles, the Add-Widget gallery, and the menu-bar value all funnel
-        // through here, so stamping the mode once makes them follow the global setting. Inert for
-        // unbounded tiles (limit == nil), whose displayed value ignores displayMode.
-        result.displayMode = meterStyle
-        result.resetDisplayMode = resetDisplayMode
-        result.alwaysShowPacing = alwaysShowPacing
-        result.widgetID = descriptor.id
-        return result
-    }
-
-    /// The plan label for a provider's latest snapshot (also feeds the optional Plan widget). `nil` until a
-    /// snapshot exists or when the provider doesn't expose a plan.
-    func plan(for providerID: String) -> String? {
-        snapshots[providerID]?.plan
-    }
-
-    /// How long a displayed snapshot may age before the header calls it out. A healthy provider's
-    /// snapshot resets to ~0 on every successful pass and only brushes one interval just before the next
-    /// one, so the threshold sits at two intervals: it fires only when a refresh has actually been missed
-    /// — a refresh loop that keeps failing, or a long-suspended background timer — never on the normal
-    /// per-cycle aging, which would flicker a hint on healthy providers.
-    static let stalenessThreshold = RefreshSetting.interval * 2
-
-    /// A compact "Outdated" hint for the provider's on-screen snapshot, surfaced only once that snapshot
-    /// has aged past `stalenessThreshold`; `nil` while the data is still current (the common case), so the
-    /// header stays clean until staleness is real. The label is short on purpose — a long plan name plus a
-    /// full "Updated 3h ago" string would overflow the header — so the precise age rides in the tooltip.
-    /// This is the visible counterpart to the silent fossilized-cache problem (#582): a failing-refresh
-    /// loop keeps the last good plan/limits on screen, and without this nothing told the user that data was
-    /// stale. Reads the store's injected clock, which tests pin to a fixed value.
-    func stalenessHint(for providerID: String) -> StalenessHint? {
-        guard let refreshedAt = snapshots[providerID]?.refreshedAt else { return nil }
-        let age = now().timeIntervalSince(refreshedAt)
-        guard age >= Self.stalenessThreshold, let duration = Formatters.compactDuration(age) else {
-            return nil
-        }
-        return StalenessHint(label: "Outdated", tooltip: "Last updated \(duration) ago")
-    }
-
-    private func resolve(_ line: MetricLine, descriptor: WidgetDescriptor) -> WidgetData? {
+    func resolve(_ line: MetricLine, descriptor: WidgetDescriptor) -> WidgetData? {
         switch line {
         case .progress(_, let used, let limit, let format, let resetsAt, let periodDurationMs, _):
             // A percent meter is a bounded 0...100 domain; sanitize an out-of-range sample (a provider


### PR DESCRIPTION
## TL;DR

Move WidgetDataStore read-only presentation accessors into a focused extension, keeping behavior byte-for-byte while making the store responsibilities easier to navigate. In the intended stack with #913, the main store falls to 478 lines.

## What was happening

- Refresh orchestration, persistence state, metric resolution, and read-only UI accessors all lived in one large store file.
- The refresh coalescing work in #928 brought the standalone file to 683 lines, well beyond the repository guideline.

## What this changes

- Moves error/warning/header access, widget-data projection, plan access, and staleness presentation into `WidgetDataStore+Presentation.swift`.
- Leaves the private snapshot error classifier with refresh ingestion in the main store.
- Preserves the moved declarations, comments, and bodies exactly; only cross-file visibility for the injected clock and legacy resolver changes temporarily.

## Heads-up

- This is stacked on `codex/coalesce-forced-refresh` (#928).
- #913 should land before this stack is finalized. A synthetic merge reproduced one expected conflict in `WidgetDataStore.swift`; the mechanical resolution is to keep #913’s private `reportMalformedTextMetrics` validator, remove the obsolete legacy resolver/parser chain, and call `WidgetDataResolver.resolve` from the presentation extension.
- That resolved stack has a 478-line main store, 90-line presentation extension, and 139-line resolver. Only the injected clock remains widened; the temporary legacy `resolve` widening disappears.
- Before #913 is applied, this isolated PR reduces the main file from 683 to 597 lines but cannot reach the 500-line guideline because the legacy resolver remains.

## Tests

- Standalone: 50/50 focused WidgetDataStore tests passed; full suite passed with 977 XCTest tests, 3 skipped, plus 3 Swift Testing tests; release build staged, signed, restarted, and confirmed from this worktree.
- Synthetic #913 stack: exact one-file conflict resolved as documented; 51/51 focused tests passed; full suite passed with 978 XCTest tests, 3 skipped, plus 3 Swift Testing tests.
- Moved-block SHA-256 parity and `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical file split with moved code parity; no logic changes beyond access control for cross-file calls.
> 
> **Overview**
> Splits **read-only UI projection** out of `WidgetDataStore` into a new **`WidgetDataStore+Presentation.swift`** extension so refresh orchestration and metric resolution stay in the main file.
> 
> The moved surface is unchanged in behavior: provider **error/warning/header notices**, **`data(for:)`** (plan tiles, snapshot lines, global display-mode stamping), **`plan(for:)`**, and **staleness** (`stalenessThreshold` / `stalenessHint`). Refresh ingestion keeps the private **`errorMessage(in:)`** classifier on the main type.
> 
> **Visibility tweaks** only: the injected **`now`** clock is no longer `private` (staleness reads it from the extension), and **`resolve`** is temporarily internal so **`data(for:)`** can still call the legacy resolver until a stacked refactor (#913) moves resolution elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4445302ed8d12df2f5678c81842024173be68e65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->