### PR TITLE
Surface CLI provider credential storage failures

### DIFF
--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityAuthStore.swift
@@ -34,11 +34,18 @@ struct AntigravityAuthStore: Sendable {
     }
 
     /// Blocking keychain read — call off the main actor.
-    func loadKeychainToken() -> AntigravityKeychainToken? {
-        guard let raw = try? keychain.readGenericPassword(service: Self.keychainService, account: Self.keychainAccount),
-              let token = Self.extractToken(fromKeychainRaw: raw)
-        else {
-            return nil
+    func loadKeychainToken() throws -> AntigravityKeychainToken? {
+        let raw: String?
+        do {
+            raw = try keychain.readGenericPassword(service: Self.keychainService, account: Self.keychainAccount)
+        } catch {
+            AppLog.error(LogTag.auth("antigravity"), "keychain credential read failed")
+            throw AntigravityError.credentialStoreUnreadable
+        }
+        guard let raw else { return nil }
+        guard let token = Self.extractToken(fromKeychainRaw: raw) else {
+            AppLog.error(LogTag.auth("antigravity"), "keychain credential is malformed")
+            throw AntigravityError.invalidCredentialData
         }
         return token
     }
@@ -59,16 +66,28 @@ struct AntigravityAuthStore: Sendable {
     func loadCachedToken() -> String? {
         // Require at least `refreshBuffer` of life left, matching `isUsable(expiry:)` for the keychain
         // token — a near-expiry cached token would otherwise yield a near-certain 401 and a wasteful
-        // extra refresh.
-        guard files.exists(Self.cachePath),
-              let text = try? files.readText(Self.cachePath),
-              let data = text.data(using: .utf8),
-              let cached = try? JSONDecoder().decode(CachedToken.self, from: data),
-              cached.expiresAtMs > (now().timeIntervalSince1970 + Self.refreshBuffer) * 1000
-        else {
+        // extra refresh. This is OpenUsage's own best-effort cache, not the primary credential store:
+        // corruption is logged and ignored, while an expired entry is a normal silent cache miss.
+        let text: String
+        do {
+            guard let stored = try files.readTextIfPresent(Self.cachePath) else { return nil }
+            text = stored
+        } catch {
+            AppLog.warn(LogTag.auth("antigravity"), "refreshed-token cache read failed; ignoring it")
             return nil
         }
-        return cached.accessToken.nilIfEmpty
+        guard let cached = try? JSONDecoder().decode(CachedToken.self, from: Data(text.utf8)) else {
+            AppLog.warn(LogTag.auth("antigravity"), "refreshed-token cache is malformed; ignoring it")
+            return nil
+        }
+        guard cached.expiresAtMs > (now().timeIntervalSince1970 + Self.refreshBuffer) * 1000 else {
+            return nil
+        }
+        guard let token = cached.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty else {
+            AppLog.warn(LogTag.auth("antigravity"), "refreshed-token cache has no usable token; ignoring it")
+            return nil
+        }
+        return token
     }
 
     func cacheToken(_ accessToken: String, expiresIn: Double) {
@@ -92,14 +111,20 @@ struct AntigravityAuthStore: Sendable {
     static func extractToken(fromKeychainRaw raw: String) -> AntigravityKeychainToken? {
         guard let text = ProviderParse.unwrapGoKeyring(raw) else { return nil }
 
-        if let data = text.data(using: .utf8),
-           let json = try? JSONSerialization.jsonObject(with: data) {
+        if let json = try? JSONSerialization.jsonObject(with: Data(text.utf8)) {
             if let dict = json as? [String: Any] {
                 return tokenFromObject(dict)
             }
             if let string = (json as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
                 return AntigravityKeychainToken(accessToken: string, refreshToken: nil, expiry: nil)
             }
+            return nil
+        }
+
+        // A value that looks like JSON but failed to parse is broken structured credential material,
+        // not a raw bearer token.
+        if text.hasPrefix("{") || text.hasPrefix("[") {
+            return nil
         }
 
         if text.hasPrefix("Bearer ") {

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityErrors.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityErrors.swift
@@ -6,6 +6,10 @@ import Foundation
 enum AntigravityError: Error, LocalizedError, Equatable {
     /// No usable credentials anywhere (no LS running, no keychain token, nothing cached).
     case notSignedIn
+    /// The Antigravity keychain item exists or may exist, but macOS would not let us read it.
+    case credentialStoreUnreadable
+    /// The Antigravity keychain item was present but did not contain a usable token payload.
+    case invalidCredentialData
     /// A token was found but rejected (401/403) and a refresh couldn't recover it.
     case authExpired
     /// Credentials exist and look valid, but every endpoint was unreachable (network / server outage).
@@ -16,6 +20,10 @@ enum AntigravityError: Error, LocalizedError, Equatable {
         switch self {
         case .notSignedIn:
             return "Start Antigravity or run `agy` and try again."
+        case .credentialStoreUnreadable:
+            return "Couldn't read Antigravity credentials from Keychain. Unlock Keychain or sign in to Antigravity again."
+        case .invalidCredentialData:
+            return "Antigravity credentials are invalid. Open Antigravity or run `agy` to sign in again."
         case .authExpired:
             return "Antigravity sign-in expired. Open Antigravity or run `agy` to refresh."
         case .unavailable:

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
@@ -45,10 +45,18 @@ final class AntigravityProvider: ProviderRuntime {
     func hasLocalCredentials() async -> Bool {
         // The keychain token (or our refreshed-token cache) is the works-with-the-app-closed source
         // `refresh()` falls back to; a logged-in Antigravity install has it even when no language
-        // server is running, so process discovery isn't needed here.
-        await loadOffMainActor { [authStore] in
-            authStore.loadKeychainToken() != nil || authStore.loadCachedToken() != nil
+        // server is running, so process discovery isn't needed here. A keychain boundary failure is
+        // conservatively present; the app-owned refreshed-token cache remains best-effort.
+        var keychainToken: AntigravityKeychainToken?
+        var keychainFailed = false
+        do {
+            keychainToken = try await loadOffMainActor { [authStore] in try authStore.loadKeychainToken() }
+        } catch {
+            logUnexpectedBoundaryError(error, source: "keychain credential probe")
+            keychainFailed = true
         }
+        let cachedToken = await loadOffMainActor { [authStore] in authStore.loadCachedToken() }
+        return keychainToken != nil || cachedToken != nil || keychainFailed
     }
 
     func refresh() async -> ProviderSnapshot {
@@ -153,13 +161,20 @@ final class AntigravityProvider: ProviderRuntime {
 
     private func probeCloudCode() async throws -> StrategyResult {
         let authStore = self.authStore
-        let keychainToken = await loadOffMainActor({ authStore.loadKeychainToken() })
+        let keychainToken: AntigravityKeychainToken?
+        var loadError: AntigravityError?
+        do {
+            keychainToken = try await loadOffMainActor { try authStore.loadKeychainToken() }
+        } catch {
+            loadError = boundaryError(error, source: "keychain credential load")
+            keychainToken = nil
+        }
 
         var tokens: [String] = []
         if let keychainToken, let access = keychainToken.accessToken, authStore.isUsable(expiry: keychainToken.expiry) {
             tokens.append(access)
         }
-        if let cached = authStore.loadCachedToken(), !tokens.contains(cached) {
+        if let cached = await loadOffMainActor({ authStore.loadCachedToken() }), !tokens.contains(cached) {
             tokens.append(cached)
         }
 
@@ -202,7 +217,19 @@ final class AntigravityProvider: ProviderRuntime {
         if sawAuthFailure { throw AntigravityError.authExpired }
         // Signed in but every endpoint was unreachable — report a transient failure, not "not signed in".
         if hasCredentials { throw AntigravityError.unavailable }
+        if let loadError { throw loadError }
         throw AntigravityError.notSignedIn
+    }
+
+    private func boundaryError(_ error: Error, source: String) -> AntigravityError {
+        if let authError = error as? AntigravityError { return authError }
+        AppLog.error(LogTag.auth("antigravity"), "unexpected \(source) failure")
+        return .credentialStoreUnreadable
+    }
+
+    private func logUnexpectedBoundaryError(_ error: Error, source: String) {
+        guard !(error is AntigravityError) else { return }
+        AppLog.error(LogTag.auth("antigravity"), "unexpected \(source) failure")
     }
 
     private enum CloudCodeProbe {

--- a/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
@@ -39,8 +39,13 @@ struct CodexAuthState: Hashable, Sendable {
     /// probe requires before fetching usage (an API-key-only auth.json can't serve the usage API).
     /// `hasLocalCredentials()`'s first-run detection checks this, so the two can never drift.
     var hasUsableAccessToken: Bool {
-        auth.tokens?.accessToken?.isEmpty == false
+        auth.tokens?.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
+}
+
+struct CodexAuthLoadResult: Sendable {
+    var candidates: [CodexAuthState]
+    var firstError: CodexAuthError?
 }
 
 enum CodexAuthError: Error, LocalizedError, Equatable {
@@ -50,6 +55,7 @@ enum CodexAuthError: Error, LocalizedError, Equatable {
     case tokenRevoked
     case tokenExpired
     case usageAPIKey
+    case credentialStoreUnreadable
     case invalidAuthPayload
 
     var errorDescription: String? {
@@ -66,16 +72,21 @@ enum CodexAuthError: Error, LocalizedError, Equatable {
             return "Token expired. Run `codex` to log in again."
         case .usageAPIKey:
             return "Usage not available for API key."
+        case .credentialStoreUnreadable:
+            return "Couldn't read Codex credentials. Check access to the Codex auth files and Keychain, then try again."
         case .invalidAuthPayload:
-            return "Codex auth data is invalid."
+            return "Codex credentials are invalid. Run `codex` to authenticate again."
         }
     }
 
+    /// Whether this error invalidates only the current credential candidate. The provider retains the
+    /// last fallback error, so an API-key-only setup still ends with `usageAPIKey`; it just no longer
+    /// prevents a later OAuth file or keychain candidate from being tried.
     var allowsAuthFallback: Bool {
         switch self {
-        case .sessionExpired, .tokenConflict, .tokenRevoked, .tokenExpired:
+        case .sessionExpired, .tokenConflict, .tokenRevoked, .tokenExpired, .usageAPIKey:
             return true
-        case .notLoggedIn, .usageAPIKey, .invalidAuthPayload:
+        case .notLoggedIn, .credentialStoreUnreadable, .invalidAuthPayload:
             return false
         }
     }
@@ -106,31 +117,65 @@ struct CodexAuthStore: Sendable {
         self.now = now
     }
 
+    /// Load every ordered file source without letting one broken file hide a valid sibling. The first
+    /// boundary error is retained for the provider to surface only when no valid source can be used.
+    func loadAuthResult() -> CodexAuthLoadResult {
+        var candidates: [CodexAuthState] = []
+        var firstError: CodexAuthError?
+        for path in authPaths() {
+            do {
+                if let candidate = try loadAuth(at: path) {
+                    candidates.append(candidate)
+                }
+            } catch let error as CodexAuthError {
+                if firstError == nil { firstError = error }
+            } catch {
+                AppLog.error(LogTag.auth("codex"), "unexpected auth file load failure")
+                if firstError == nil { firstError = .credentialStoreUnreadable }
+            }
+        }
+        return CodexAuthLoadResult(candidates: candidates, firstError: firstError)
+    }
+
+    /// Compatibility view used by parsing tests and callers that only need successfully loaded
+    /// candidates. Provider refresh/probe paths use `loadAuthResult()` so boundary errors are retained.
     func loadAuthCandidates() -> [CodexAuthState] {
-        authPaths().compactMap { loadAuth(at: $0) }
+        loadAuthResult().candidates
     }
 
     /// Reads the credential from a single on-disk auth file — the targeted counterpart to
     /// `loadKeychainAuth()`, used when reloading the exact source we already loaded from so we don't
-    /// re-scan every candidate path. Returns `nil` when the file is missing, unreadable, or doesn't
-    /// carry token-like auth.
-    func loadAuth(at path: String) -> CodexAuthState? {
-        guard files.exists(path),
-              let text = try? files.readText(path),
-              let auth = Self.parseAuth(text),
-              Self.hasTokenLikeAuth(auth)
-        else {
-            return nil
+    /// re-scan every candidate path. `nil` is reserved for a genuinely missing file; unreadable or
+    /// malformed credential material logs and throws a typed boundary error.
+    func loadAuth(at path: String) throws -> CodexAuthState? {
+        let text: String
+        do {
+            guard let stored = try files.readTextIfPresent(path) else { return nil }
+            text = stored
+        } catch {
+            AppLog.error(LogTag.auth("codex"), "auth file read failed")
+            throw CodexAuthError.credentialStoreUnreadable
+        }
+
+        guard let auth = Self.parseAuth(text), Self.hasTokenLikeAuth(auth) else {
+            AppLog.error(LogTag.auth("codex"), "auth file is malformed")
+            throw CodexAuthError.invalidAuthPayload
         }
         return CodexAuthState(auth: auth, source: .file(path: path))
     }
 
-    func loadKeychainAuth() -> CodexAuthState? {
-        guard let value = try? keychain.readGenericPassword(service: Self.keychainService),
-              let auth = Self.parseAuth(value),
-              Self.hasTokenLikeAuth(auth)
-        else {
-            return nil
+    func loadKeychainAuth() throws -> CodexAuthState? {
+        let value: String?
+        do {
+            value = try keychain.readGenericPassword(service: Self.keychainService)
+        } catch {
+            AppLog.error(LogTag.auth("codex"), "keychain credential read failed")
+            throw CodexAuthError.credentialStoreUnreadable
+        }
+        guard let value else { return nil }
+        guard let auth = Self.parseAuth(value), Self.hasTokenLikeAuth(auth) else {
+            AppLog.error(LogTag.auth("codex"), "keychain credential is malformed")
+            throw CodexAuthError.invalidAuthPayload
         }
         return CodexAuthState(auth: auth, source: .keychain)
     }
@@ -201,8 +246,8 @@ struct CodexAuthStore: Sendable {
     }
 
     static func hasTokenLikeAuth(_ auth: CodexAuth) -> Bool {
-        if auth.tokens?.accessToken?.isEmpty == false { return true }
-        if auth.apiKey?.isEmpty == false { return true }
+        if auth.tokens?.accessToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false { return true }
+        if auth.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false { return true }
         return false
     }
 
@@ -217,4 +262,3 @@ private extension CodexAuthState.Source {
         return false
     }
 }
-

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -50,20 +50,27 @@ final class CodexProvider: ProviderRuntime {
     func hasLocalCredentials() async -> Bool {
         // Same sources as `refresh()`: auth.json candidates first, keychain as the fallback. Only a
         // usable access token counts (see `hasUsableAccessToken`) — an API-key-only auth.json can't
-        // serve the usage API, so seeding it on would just show an error row.
-        let fileCandidates = authStore.loadAuthCandidates()
-        if fileCandidates.contains(where: \.hasUsableAccessToken) {
+        // serve the usage API, so that valid syntax alone does not seed the provider. A boundary error
+        // is different: detection is one-shot, so an indeterminate present source counts conservatively.
+        let fileLoad = await loadOffMainActor { [authStore] in authStore.loadAuthResult() }
+        if fileLoad.candidates.contains(where: \.hasUsableAccessToken) {
             return true
         }
-        let keychain = await loadOffMainActor { [authStore] in authStore.loadKeychainAuth() }
-        return keychain?.hasUsableAccessToken == true
+        do {
+            let keychain = try await loadOffMainActor { [authStore] in try authStore.loadKeychainAuth() }
+            return keychain?.hasUsableAccessToken == true || fileLoad.firstError != nil
+        } catch {
+            logUnexpectedBoundaryError(error, source: "keychain credential probe")
+            return true
+        }
     }
 
     func refresh() async -> ProviderSnapshot {
-        let fileCandidates = authStore.loadAuthCandidates()
+        let fileLoad = await loadOffMainActor { [authStore] in authStore.loadAuthResult() }
         var lastFallbackError: Error?
+        var firstLoadError = fileLoad.firstError
 
-        for candidate in fileCandidates {
+        for candidate in fileLoad.candidates {
             do {
                 return try await probe(authState: candidate)
             } catch let error as CodexAuthError where error.allowsAuthFallback {
@@ -74,7 +81,16 @@ final class CodexProvider: ProviderRuntime {
             }
         }
 
-        if let keychainCandidate = await loadOffMainActor({ [authStore] in authStore.loadKeychainAuth() }) {
+        let keychainCandidate: CodexAuthState?
+        do {
+            keychainCandidate = try await loadOffMainActor { [authStore] in try authStore.loadKeychainAuth() }
+        } catch {
+            if firstLoadError == nil {
+                firstLoadError = boundaryError(error, source: "keychain credential load")
+            }
+            keychainCandidate = nil
+        }
+        if let keychainCandidate {
             do {
                 return try await probe(authState: keychainCandidate)
             } catch {
@@ -85,13 +101,18 @@ final class CodexProvider: ProviderRuntime {
         if let lastFallbackError {
             return ProviderSnapshot.error(provider: provider, error: lastFallbackError)
         }
+        if let firstLoadError {
+            return ProviderSnapshot.error(provider: provider, error: firstLoadError)
+        }
         return ProviderSnapshot.error(provider: provider, error: CodexAuthError.notLoggedIn)
     }
 
     private func probe(authState initialState: CodexAuthState) async throws -> ProviderSnapshot {
         var authState = initialState
-        guard var accessToken = authState.auth.tokens?.accessToken, !accessToken.isEmpty else {
-            if authState.auth.apiKey?.isEmpty == false {
+        guard var accessToken = authState.auth.tokens?.accessToken?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !accessToken.isEmpty else {
+            if authState.auth.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
                 throw CodexAuthError.usageAPIKey
             }
             throw CodexAuthError.notLoggedIn
@@ -101,10 +122,18 @@ final class CodexProvider: ProviderRuntime {
             // The `codex` CLI may have rotated the token on disk since we loaded it. Re-read the live
             // credential first and adopt its (newer) access token — refreshing our stale copy would send
             // an already-rotated refresh_token and trip `refresh_token_reused` (issue #516).
-            if let live = reloadLiveAuth(source: authState.source),
-               let liveToken = live.auth.tokens?.accessToken, !liveToken.isEmpty {
-                authState = live
-                accessToken = liveToken
+            do {
+                if let live = try await reloadLiveAuth(source: authState.source),
+                   let liveToken = live.auth.tokens?.accessToken?
+                       .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !liveToken.isEmpty {
+                    authState = live
+                    accessToken = liveToken
+                }
+            } catch {
+                // The candidate already loaded successfully, so this later re-read failure is not the
+                // terminal credential boundary. The auth store logged it; continue with the valid
+                // in-memory candidate and let refresh/usage return the actionable outcome.
             }
         }
 
@@ -183,13 +212,24 @@ final class CodexProvider: ProviderRuntime {
     /// token the `codex` CLI rotated out-of-band is picked up before we attempt our own refresh. Reads
     /// only that one source — matching how `codex` reads the single `auth.json` from `CODEX_HOME` —
     /// rather than re-scanning every candidate path.
-    private func reloadLiveAuth(source: CodexAuthState.Source) -> CodexAuthState? {
+    private func reloadLiveAuth(source: CodexAuthState.Source) async throws -> CodexAuthState? {
         switch source {
         case .file(let path):
-            return authStore.loadAuth(at: path)
+            return try await loadOffMainActor { [authStore] in try authStore.loadAuth(at: path) }
         case .keychain:
-            return authStore.loadKeychainAuth()
+            return try await loadOffMainActor { [authStore] in try authStore.loadKeychainAuth() }
         }
+    }
+
+    private func boundaryError(_ error: Error, source: String) -> CodexAuthError {
+        if let authError = error as? CodexAuthError { return authError }
+        AppLog.error(LogTag.auth("codex"), "unexpected \(source) failure")
+        return .credentialStoreUnreadable
+    }
+
+    private func logUnexpectedBoundaryError(_ error: Error, source: String) {
+        guard !(error is CodexAuthError) else { return }
+        AppLog.error(LogTag.auth("codex"), "unexpected \(source) failure")
     }
 
     private func refreshAccessToken(authState: inout CodexAuthState, refreshToken: String) async throws -> String {

--- a/Sources/OpenUsage/Providers/Copilot/CopilotAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotAuthStore.swift
@@ -5,9 +5,16 @@ struct CopilotToken: Hashable, Sendable {
     var value: String
 }
 
+struct CopilotAuthLoadResult: Sendable {
+    var token: CopilotToken?
+    var firstError: CopilotAuthError?
+}
+
 enum CopilotAuthError: Error, LocalizedError, Equatable {
     case notLoggedIn
     case tokenInvalid
+    case credentialStoreUnreadable
+    case invalidCredentialData
 
     var errorDescription: String? {
         switch self {
@@ -15,6 +22,10 @@ enum CopilotAuthError: Error, LocalizedError, Equatable {
             return "Sign in to GitHub Copilot in your editor, or run gh auth login, and try again."
         case .tokenInvalid:
             return "GitHub token invalid or expired. Re-authenticate (gh auth login) and try again."
+        case .credentialStoreUnreadable:
+            return "Couldn't read GitHub Copilot credentials. Check access to your editor and GitHub CLI credentials, then try again."
+        case .invalidCredentialData:
+            return "GitHub Copilot credentials are invalid. Sign in to Copilot in your editor or run `gh auth login` again."
         }
     }
 }
@@ -43,62 +54,146 @@ struct CopilotAuthStore: Sendable {
         self.keychain = keychain
     }
 
-    /// First non-empty source wins. Blocking (Keychain) — call off the main actor.
+    /// First non-empty source wins. Broken sources are retained as a deferred error while later
+    /// siblings are tried; the provider surfaces that error only when no valid token loads.
+    /// Blocking (files + Keychain) — call off the main actor.
+    func loadTokenResult() -> CopilotAuthLoadResult {
+        var firstError: CopilotAuthError?
+
+        do {
+            if let token = try loadFromEditorConfig() {
+                return CopilotAuthLoadResult(token: token, firstError: nil)
+            }
+        } catch let error as CopilotAuthError {
+            firstError = error
+        } catch {
+            AppLog.error(LogTag.auth("copilot"), "unexpected editor credential load failure")
+            firstError = .credentialStoreUnreadable
+        }
+
+        var ghConfig: GhConfig?
+        do {
+            ghConfig = try loadGhConfig()
+            if let token = ghConfig?.token {
+                return CopilotAuthLoadResult(token: token, firstError: nil)
+            }
+        } catch let error as CopilotAuthError {
+            if firstError == nil { firstError = error }
+        } catch {
+            AppLog.error(LogTag.auth("copilot"), "unexpected GitHub CLI credential load failure")
+            if firstError == nil { firstError = .credentialStoreUnreadable }
+        }
+
+        do {
+            if let token = try loadFromGhKeychain(account: ghConfig?.username) {
+                return CopilotAuthLoadResult(token: token, firstError: nil)
+            }
+        } catch let error as CopilotAuthError {
+            if firstError == nil { firstError = error }
+        } catch {
+            AppLog.error(LogTag.auth("copilot"), "unexpected keychain credential load failure")
+            if firstError == nil { firstError = .credentialStoreUnreadable }
+        }
+
+        return CopilotAuthLoadResult(token: nil, firstError: firstError)
+    }
+
+    /// Compatibility view for callers/tests that only need a successfully loaded token.
     func loadToken() -> CopilotToken? {
-        loadFromEditorConfig() ?? loadFromGhConfig() ?? loadFromGhKeychain()
+        loadTokenResult().token
     }
 
     // MARK: - Sources
 
-    func loadFromEditorConfig() -> CopilotToken? {
+    func loadFromEditorConfig() throws -> CopilotToken? {
+        var firstError: CopilotAuthError?
         for path in [Self.editorAppsPath, Self.editorHostsPath] {
-            guard files.exists(path),
-                  let text = try? files.readText(path),
-                  let token = Self.oauthToken(fromEditorJSON: text)
-            else {
+            let text: String
+            do {
+                guard let stored = try files.readTextIfPresent(path) else { continue }
+                text = stored
+            } catch {
+                AppLog.error(LogTag.auth("copilot"), "editor credential file read failed")
+                if firstError == nil { firstError = .credentialStoreUnreadable }
                 continue
             }
-            return CopilotToken(value: token)
+
+            switch Self.editorToken(fromJSON: text) {
+            case .token(let token):
+                return CopilotToken(value: token)
+            case .compatibleAccountAbsent:
+                // Enterprise-only files are valid but cannot authenticate api.github.com. Keep
+                // walking to the older editor file, gh config, and Keychain.
+                continue
+            case .invalid:
+                AppLog.error(LogTag.auth("copilot"), "editor credential file is malformed")
+                if firstError == nil { firstError = .invalidCredentialData }
+            }
         }
+        if let firstError { throw firstError }
         return nil
     }
 
-    func loadFromGhConfig() -> CopilotToken? {
-        guard files.exists(Self.ghHostsPath),
-              let text = try? files.readText(Self.ghHostsPath),
-              let token = Self.yamlValue(text, key: "oauth_token")
-        else {
-            return nil
-        }
-        return CopilotToken(value: token)
+    private struct GhConfig {
+        var token: CopilotToken?
+        var username: String?
     }
 
-    func loadFromGhKeychain() -> CopilotToken? {
-        guard let raw = readGhKeychainRaw(),
-              let token = ProviderParse.unwrapGoKeyring(raw)
-        else {
-            return nil
+    private func loadGhConfig() throws -> GhConfig? {
+        let text: String
+        do {
+            guard let stored = try files.readTextIfPresent(Self.ghHostsPath) else { return nil }
+            text = stored
+        } catch {
+            AppLog.error(LogTag.auth("copilot"), "GitHub CLI credential file read failed")
+            throw CopilotAuthError.credentialStoreUnreadable
         }
-        return CopilotToken(value: token)
+
+        guard Self.isPlausibleHostsYAML(text) else {
+            AppLog.error(LogTag.auth("copilot"), "GitHub CLI credential file is malformed")
+            throw CopilotAuthError.invalidCredentialData
+        }
+
+        let token = Self.yamlValue(text, key: "oauth_token").map(CopilotToken.init(value:))
+        let username = Self.yamlValue(text, key: "user")
+        return GhConfig(token: token, username: username)
     }
 
-    private func readGhKeychainRaw() -> String? {
-        // `gh` stores its Keychain item under the GitHub username as the account. Read it scoped to that
-        // account when we can recover it from hosts.yml; otherwise fall back to a service-only lookup.
-        if let account = ghUsername(),
-           let raw = try? keychain.readGenericPassword(service: Self.ghKeychainService, account: account) {
-            return raw
-        }
-        return try? keychain.readGenericPassword(service: Self.ghKeychainService)
-    }
+    private func loadFromGhKeychain(account: String?) throws -> CopilotToken? {
+        var firstError: CopilotAuthError?
 
-    private func ghUsername() -> String? {
-        guard files.exists(Self.ghHostsPath),
-              let text = try? files.readText(Self.ghHostsPath)
-        else {
-            return nil
+        if let account {
+            do {
+                if let raw = try keychain.readGenericPassword(service: Self.ghKeychainService, account: account) {
+                    if let token = ProviderParse.unwrapGoKeyring(raw) {
+                        return CopilotToken(value: token)
+                    }
+                    AppLog.error(LogTag.auth("copilot"), "account-scoped keychain credential is malformed")
+                    firstError = .invalidCredentialData
+                }
+            } catch {
+                AppLog.error(LogTag.auth("copilot"), "account-scoped keychain credential read failed")
+                firstError = .credentialStoreUnreadable
+            }
         }
-        return Self.yamlValue(text, key: "user")
+
+        do {
+            if let raw = try keychain.readGenericPassword(service: Self.ghKeychainService) {
+                guard let token = ProviderParse.unwrapGoKeyring(raw) else {
+                    AppLog.error(LogTag.auth("copilot"), "keychain credential is malformed")
+                    throw CopilotAuthError.invalidCredentialData
+                }
+                return CopilotToken(value: token)
+            }
+        } catch let error as CopilotAuthError {
+            if firstError == nil { firstError = error }
+        } catch {
+            AppLog.error(LogTag.auth("copilot"), "keychain credential read failed")
+            if firstError == nil { firstError = .credentialStoreUnreadable }
+        }
+
+        if let firstError { throw firstError }
+        return nil
     }
 
     // MARK: - Parsing (pure)
@@ -109,10 +204,20 @@ struct CopilotAuthStore: Sendable {
     /// (e.g. GitHub Enterprise) must not be sent to api.github.com, and returning `nil` lets the chain
     /// fall through to gh config / keychain, which may hold a valid github.com token.
     static func oauthToken(fromEditorJSON text: String) -> String? {
+        guard case .token(let token) = editorToken(fromJSON: text) else { return nil }
+        return token
+    }
+
+    private enum EditorTokenParse {
+        case token(String)
+        case compatibleAccountAbsent
+        case invalid
+    }
+
+    private static func editorToken(fromJSON text: String) -> EditorTokenParse {
         guard let data = text.data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return nil
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .invalid
         }
 
         func token(in value: Any?) -> String? {
@@ -125,10 +230,31 @@ struct CopilotAuthStore: Sendable {
             return token
         }
 
-        for (key, value) in object where key == "github.com" || key.hasPrefix("github.com:") {
-            if let token = token(in: value) { return token }
+        let compatible = object.filter { key, _ in key == "github.com" || key.hasPrefix("github.com:") }
+        guard !compatible.isEmpty else { return .compatibleAccountAbsent }
+        for (_, value) in compatible {
+            if let token = token(in: value) { return .token(token) }
         }
-        return nil
+        return .invalid
+    }
+
+    /// Narrow validation for the simple host map `gh` writes. Enterprise-only files remain valid and
+    /// simply produce no github.com token; empty/garbled lines are treated as malformed credentials.
+    private static func isPlausibleHostsYAML(_ text: String) -> Bool {
+        let lines = text.split(whereSeparator: \.isNewline)
+        guard !lines.isEmpty else { return false }
+        var sawRootHeader = false
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            if line.first?.isWhitespace == true {
+                guard trimmed.contains(":") else { return false }
+            } else {
+                guard trimmed.hasSuffix(":"), !trimmed.dropLast().isEmpty else { return false }
+                sawRootHeader = true
+            }
+        }
+        return sawRootHeader
     }
 
     /// Read an indented `key: value` from within a specific host block of the `hosts.yml` GitHub CLI
@@ -144,7 +270,7 @@ struct CopilotAuthStore: Sendable {
             // An unindented line starts a new top-level block (a host header or other root key); only
             // the github.com block's children should be read.
             if let first = line.first, !first.isWhitespace {
-                inHost = line.trimmingCharacters(in: .whitespaces).hasPrefix(hostHeader)
+                inHost = line.trimmingCharacters(in: .whitespaces) == hostHeader
                 continue
             }
             guard inHost else { continue }

--- a/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
@@ -49,13 +49,18 @@ final class CopilotProvider: ProviderRuntime {
 
     func hasLocalCredentials() async -> Bool {
         // Same source as `refresh()`: editor config, gh config, or the gh keychain entry.
-        await loadOffMainActor { [authStore] in authStore.loadToken() } != nil
+        let load = await loadOffMainActor { [authStore] in authStore.loadTokenResult() }
+        return load.token != nil || load.firstError != nil
     }
 
     func refresh() async -> ProviderSnapshot {
-        let token = await loadOffMainActor { [authStore] in authStore.loadToken() }
+        let load = await loadOffMainActor { [authStore] in authStore.loadTokenResult() }
+        let token = load.token
         guard let token else {
-            return ProviderSnapshot.error(provider: provider, error: CopilotAuthError.notLoggedIn)
+            return ProviderSnapshot.error(
+                provider: provider,
+                error: load.firstError ?? CopilotAuthError.notLoggedIn
+            )
         }
 
         do {

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -77,6 +77,7 @@ extension CodexAuthError: CategorizedError {
         case .notLoggedIn: .notLoggedIn
         case .sessionExpired, .tokenConflict, .tokenRevoked, .tokenExpired: .authExpired
         case .usageAPIKey: .notAvailable
+        case .credentialStoreUnreadable: .credentialAccess
         case .invalidAuthPayload: .authInvalid
         }
     }
@@ -158,6 +159,8 @@ extension CopilotAuthError: CategorizedError {
         switch self {
         case .notLoggedIn: .notLoggedIn
         case .tokenInvalid: .authExpired
+        case .credentialStoreUnreadable: .credentialAccess
+        case .invalidCredentialData: .authInvalid
         }
     }
 }
@@ -226,6 +229,8 @@ extension AntigravityError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {
         case .notSignedIn: .notLoggedIn
+        case .credentialStoreUnreadable: .credentialAccess
+        case .invalidCredentialData: .authInvalid
         case .authExpired: .authExpired
         case .unavailable: .network
         }

--- a/Tests/OpenUsageTests/AntigravityCredentialBoundaryTests.swift
+++ b/Tests/OpenUsageTests/AntigravityCredentialBoundaryTests.swift
@@ -1,0 +1,215 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class AntigravityCredentialBoundaryTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testMissingSourcesRemainAbsent() async {
+        let provider = makeProvider(keychain: FakeKeychain(), files: FakeFiles())
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+        XCTAssertEqual(errorText(snapshot), AntigravityError.notSignedIn.localizedDescription)
+    }
+
+    func testUnreadableKeychainIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(
+            keychain: AntigravityBoundaryKeychain(readFails: true),
+            files: FakeFiles()
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .credentialAccess)
+        XCTAssertEqual(errorText(snapshot), AntigravityError.credentialStoreUnreadable.localizedDescription)
+    }
+
+    func testMalformedWrappedKeychainIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(
+            keychain: FakeKeychain("go-keyring-base64:not-base64"),
+            files: FakeFiles()
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertEqual(errorText(snapshot), AntigravityError.invalidCredentialData.localizedDescription)
+    }
+
+    func testJSONKeychainWithoutTokensIsMalformedNotARawBearerToken() async {
+        let provider = makeProvider(
+            keychain: FakeKeychain(#"{"account":"present-but-tokenless"}"#),
+            files: FakeFiles()
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertEqual(errorText(snapshot), AntigravityError.invalidCredentialData.localizedDescription)
+    }
+
+    func testValidCacheWinsAfterKeychainReadFailure() async {
+        let routing = RoutingHTTPClient { request in
+            if request.url.path.contains("retrieveUserQuotaSummary") {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"groups":[]}"#.utf8))
+            }
+            return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+        }
+        let provider = makeProvider(
+            keychain: AntigravityBoundaryKeychain(readFails: true),
+            files: FakeFiles([AntigravityAuthStore.cachePath: cachedToken(expiresIn: 3_600)]),
+            http: routing
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(routing.requests.contains { $0.url.path.contains("retrieveUserQuotaSummary") })
+    }
+
+    func testCorruptAppOwnedCacheIsIgnoredRatherThanSurfacedAsPrimaryCredentialFailure() async {
+        let provider = makeProvider(
+            keychain: FakeKeychain(),
+            files: FakeFiles([AntigravityAuthStore.cachePath: "{ not-json"])
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+        XCTAssertEqual(errorText(snapshot), AntigravityError.notSignedIn.localizedDescription)
+    }
+
+    func testUnreadableAppOwnedCacheIsIgnoredRatherThanSurfacedAsPrimaryCredentialFailure() async {
+        let provider = makeProvider(
+            keychain: FakeKeychain(),
+            files: AntigravityBoundaryFiles([AntigravityAuthStore.cachePath: .unreadable])
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+    }
+
+    func testExpiredAppOwnedCacheIsANormalMiss() async {
+        let provider = makeProvider(
+            keychain: FakeKeychain(),
+            files: FakeFiles([AntigravityAuthStore.cachePath: cachedToken(expiresIn: 30)])
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+    }
+
+    private func makeProvider(
+        keychain: KeychainAccessing,
+        files: TextFileAccessing,
+        http: HTTPClient = FakeHTTPClient(response: HTTPResponse(statusCode: 500, headers: [:], body: Data()))
+    ) -> AntigravityProvider {
+        let fixedNow = now
+        return AntigravityProvider(
+            authStore: AntigravityAuthStore(keychain: keychain, files: files, now: { fixedNow }),
+            usageClient: AntigravityUsageClient(lsHTTP: http, http: http),
+            discovery: LanguageServerDiscovery(processRunner: AntigravityNoProcessRunner()),
+            now: { fixedNow }
+        )
+    }
+
+    private func cachedToken(expiresIn: TimeInterval) -> String {
+        let expiresAtMs = (now.timeIntervalSince1970 + expiresIn) * 1_000
+        return #"{"accessToken":"cached-access-token","expiresAtMs":\#(expiresAtMs)}"#
+    }
+
+    private func errorText(_ snapshot: ProviderSnapshot) -> String? {
+        guard case .badge(_, let text, _, _) = snapshot.lines.first else { return nil }
+        return text
+    }
+}
+
+private struct AntigravityBoundaryKeychain: KeychainAccessing {
+    var value: String?
+    var readFails: Bool
+
+    init(value: String? = nil, readFails: Bool = false) {
+        self.value = value
+        self.readFails = readFails
+    }
+
+    func readGenericPassword(service: String) throws -> String? {
+        if readFails { throw AntigravityBoundaryTestError.unreadable }
+        return value
+    }
+
+    func readGenericPassword(service: String, account: String) throws -> String? {
+        if readFails { throw AntigravityBoundaryTestError.unreadable }
+        return value
+    }
+
+    func writeGenericPassword(service: String, value: String) throws {}
+}
+
+private final class AntigravityBoundaryFiles: TextFileAccessing, @unchecked Sendable {
+    enum Entry {
+        case text(String)
+        case unreadable
+    }
+
+    private var entries: [String: Entry]
+
+    init(_ entries: [String: Entry]) {
+        self.entries = entries
+    }
+
+    func exists(_ path: String) -> Bool {
+        entries[path] != nil
+    }
+
+    func readText(_ path: String) throws -> String {
+        switch entries[path] {
+        case .text(let text): return text
+        case .unreadable: throw AntigravityBoundaryTestError.unreadable
+        case nil: return ""
+        }
+    }
+
+    func writeText(_ path: String, _ text: String) throws {
+        entries[path] = .text(text)
+    }
+
+    func remove(_ path: String) throws {
+        entries.removeValue(forKey: path)
+    }
+}
+
+private struct AntigravityNoProcessRunner: ProcessRunning {
+    func run(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) throws -> ProcessResult {
+        ProcessResult(exitCode: 0, stdout: "", stderr: "")
+    }
+}
+
+private enum AntigravityBoundaryTestError: Error {
+    case unreadable
+}

--- a/Tests/OpenUsageTests/AntigravityProviderTests.swift
+++ b/Tests/OpenUsageTests/AntigravityProviderTests.swift
@@ -252,11 +252,11 @@ final class AntigravityProviderTests: XCTestCase {
         XCTAssertEqual(store(expiresInSeconds: 7200).loadCachedToken(), "ya29.cached")
     }
 
-    func testLoadKeychainTokenThroughStore() {
+    func testLoadKeychainTokenThroughStore() throws {
         let inner = #"{"token":{"access_token":"ya29.kc","refresh_token":"1//r"}}"#
         let wrapped = "go-keyring-base64:" + Data(inner.utf8).base64EncodedString()
         let store = AntigravityAuthStore(keychain: FakeKeychain(wrapped), files: FakeFiles())
-        let token = store.loadKeychainToken()
+        let token = try store.loadKeychainToken()
         XCTAssertEqual(token?.accessToken, "ya29.kc")
         XCTAssertEqual(token?.refreshToken, "1//r")
     }

--- a/Tests/OpenUsageTests/CodexCredentialBoundaryTests.swift
+++ b/Tests/OpenUsageTests/CodexCredentialBoundaryTests.swift
@@ -1,0 +1,226 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class CodexCredentialBoundaryTests: XCTestCase {
+    func testMissingSourcesRemainAbsent() async {
+        let provider = makeProvider(files: FakeFiles(), keychain: FakeKeychain())
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+        XCTAssertEqual(errorText(snapshot), CodexAuthError.notLoggedIn.localizedDescription)
+    }
+
+    func testUnreadableFileIsConservativelyDetectedAndSurfaced() async {
+        let files = CodexBoundaryFiles([
+            "~/.config/codex/auth.json": .unreadable
+        ])
+        let provider = makeProvider(files: files, keychain: FakeKeychain())
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .credentialAccess)
+        XCTAssertEqual(errorText(snapshot), CodexAuthError.credentialStoreUnreadable.localizedDescription)
+    }
+
+    func testMalformedFileIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(
+            files: FakeFiles(["~/.config/codex/auth.json": "{ not-json"]),
+            keychain: FakeKeychain()
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertEqual(errorText(snapshot), CodexAuthError.invalidAuthPayload.localizedDescription)
+    }
+
+    func testMalformedKeychainIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(files: FakeFiles(), keychain: FakeKeychain("{ not-json"))
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertEqual(errorText(snapshot), CodexAuthError.invalidAuthPayload.localizedDescription)
+    }
+
+    func testUnreadableKeychainIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(files: FakeFiles(), keychain: CodexBoundaryKeychain(readFails: true))
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .credentialAccess)
+        XCTAssertEqual(errorText(snapshot), CodexAuthError.credentialStoreUnreadable.localizedDescription)
+    }
+
+    func testLaterOAuthFileWinsAfterMalformedSibling() async {
+        let http = successfulHTTP()
+        let provider = makeProvider(
+            files: FakeFiles([
+                "~/.config/codex/auth.json": "{ not-json",
+                "~/.codex/auth.json": #"{"tokens":{"access_token":"oauth-file-token"}}"#
+            ]),
+            keychain: FakeKeychain(),
+            http: http
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(usageAuthorizations(in: http), ["Bearer oauth-file-token"])
+    }
+
+    func testKeychainOAuthWinsAfterUnreadableFile() async {
+        let http = successfulHTTP()
+        let provider = makeProvider(
+            files: CodexBoundaryFiles(["~/.config/codex/auth.json": .unreadable]),
+            keychain: FakeKeychain(#"{"tokens":{"access_token":"keychain-token"}}"#),
+            http: http
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(usageAuthorizations(in: http), ["Bearer keychain-token"])
+    }
+
+    func testAPIKeyOnlyAuthIsSupportedButDoesNotSeedSubscriptionUsage() async {
+        let provider = makeProvider(
+            files: FakeFiles(["~/.config/codex/auth.json": #"{"OPENAI_API_KEY":"sk-api-only"}"#]),
+            keychain: FakeKeychain()
+        )
+
+        let load = provider.authStore.loadAuthResult()
+        XCTAssertNil(load.firstError, "API-key-only auth is valid syntax, not malformed")
+        XCTAssertEqual(load.candidates.first?.auth.apiKey, "sk-api-only")
+        XCTAssertFalse(load.candidates.first?.hasUsableAccessToken == true)
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .notAvailable)
+        XCTAssertEqual(errorText(snapshot), CodexAuthError.usageAPIKey.localizedDescription)
+    }
+
+    func testValidAPIKeyGuidanceTakesPrecedenceOverBrokenSibling() async {
+        let provider = makeProvider(
+            files: FakeFiles([
+                "~/.config/codex/auth.json": #"{"OPENAI_API_KEY":"sk-api-only"}"#,
+                "~/.codex/auth.json": "{ not-json"
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected, "the broken sibling makes one-shot detection conservative")
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notAvailable)
+        XCTAssertEqual(errorText(snapshot), CodexAuthError.usageAPIKey.localizedDescription)
+    }
+
+    private func makeProvider(
+        files: TextFileAccessing,
+        keychain: KeychainAccessing,
+        http: FakeHTTPClient = FakeHTTPClient(response: HTTPResponse(statusCode: 500, headers: [:], body: Data()))
+    ) -> CodexProvider {
+        CodexProvider(
+            authStore: CodexAuthStore(
+                environment: FakeEnvironment(),
+                files: files,
+                keychain: keychain
+            ),
+            usageClient: CodexUsageClient(http: http),
+            logUsageScanner: CodexLogFixture.scanner(home: nil),
+            now: { Date(timeIntervalSince1970: 1_800_000_000) },
+            pricing: { TestPricing.bundled }
+        )
+    }
+
+    private func successfulHTTP() -> FakeHTTPClient {
+        FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+    }
+
+    private func usageAuthorizations(in http: FakeHTTPClient) -> [String?] {
+        http.requests
+            .filter { $0.url == CodexUsageClient.usageURL }
+            .map { $0.headers["Authorization"] }
+    }
+
+    private func errorText(_ snapshot: ProviderSnapshot) -> String? {
+        guard case .badge(_, let text, _, _) = snapshot.lines.first else { return nil }
+        return text
+    }
+}
+
+private final class CodexBoundaryFiles: TextFileAccessing, @unchecked Sendable {
+    enum Entry {
+        case text(String)
+        case unreadable
+    }
+
+    private var entries: [String: Entry]
+
+    init(_ entries: [String: Entry]) {
+        self.entries = entries
+    }
+
+    func exists(_ path: String) -> Bool {
+        entries[path] != nil
+    }
+
+    func readText(_ path: String) throws -> String {
+        switch entries[path] {
+        case .text(let text): return text
+        case .unreadable: throw CodexBoundaryTestError.unreadable
+        case nil: return ""
+        }
+    }
+
+    func writeText(_ path: String, _ text: String) throws {
+        entries[path] = .text(text)
+    }
+
+    func remove(_ path: String) throws {
+        entries.removeValue(forKey: path)
+    }
+}
+
+private enum CodexBoundaryTestError: Error {
+    case unreadable
+}
+
+private struct CodexBoundaryKeychain: KeychainAccessing {
+    var value: String?
+    var readFails: Bool
+
+    init(value: String? = nil, readFails: Bool = false) {
+        self.value = value
+        self.readFails = readFails
+    }
+
+    func readGenericPassword(service: String) throws -> String? {
+        if readFails { throw CodexBoundaryTestError.unreadable }
+        return value
+    }
+
+    func readGenericPassword(service: String, account: String) throws -> String? {
+        if readFails { throw CodexBoundaryTestError.unreadable }
+        return value
+    }
+
+    func writeGenericPassword(service: String, value: String) throws {}
+}

--- a/Tests/OpenUsageTests/CopilotCredentialBoundaryTests.swift
+++ b/Tests/OpenUsageTests/CopilotCredentialBoundaryTests.swift
@@ -1,0 +1,297 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class CopilotCredentialBoundaryTests: XCTestCase {
+    func testMissingSourcesRemainAbsent() async {
+        let provider = makeProvider(files: FakeFiles(), keychain: FakeKeychain())
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+        XCTAssertEqual(errorText(snapshot), CopilotAuthError.notLoggedIn.localizedDescription)
+    }
+
+    func testUnreadableEditorFileIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(
+            files: CopilotBoundaryFiles([CopilotAuthStore.editorAppsPath: .unreadable]),
+            keychain: FakeKeychain()
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .credentialAccess)
+        XCTAssertEqual(errorText(snapshot), CopilotAuthError.credentialStoreUnreadable.localizedDescription)
+    }
+
+    func testMalformedEditorFileIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(
+            files: FakeFiles([CopilotAuthStore.editorAppsPath: "{ not-json"]),
+            keychain: FakeKeychain()
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertEqual(errorText(snapshot), CopilotAuthError.invalidCredentialData.localizedDescription)
+    }
+
+    func testMalformedAppsFileDoesNotHideValidOlderEditorFile() {
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.editorAppsPath: "{ not-json",
+                CopilotAuthStore.editorHostsPath: #"{"github.com":{"oauth_token":"editor-token"}}"#
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        let load = store.loadTokenResult()
+
+        XCTAssertEqual(load.token?.value, "editor-token")
+        XCTAssertNil(load.firstError)
+    }
+
+    func testMalformedEditorFileDoesNotHideValidGhConfig() {
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.editorAppsPath: "{ not-json",
+                CopilotAuthStore.ghHostsPath: """
+                github.com:
+                    user: octocat
+                    oauth_token: gh-config-token
+                """
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        let load = store.loadTokenResult()
+
+        XCTAssertEqual(load.token?.value, "gh-config-token")
+        XCTAssertNil(load.firstError)
+    }
+
+    func testUnreadableGhConfigDoesNotHideValidServiceKeychainToken() {
+        let wrapped = "go-keyring-base64:" + Data("keychain-token".utf8).base64EncodedString()
+        let store = CopilotAuthStore(
+            files: CopilotBoundaryFiles([CopilotAuthStore.ghHostsPath: .unreadable]),
+            keychain: FakeKeychain(wrapped)
+        )
+
+        let load = store.loadTokenResult()
+
+        XCTAssertEqual(load.token?.value, "keychain-token")
+        XCTAssertNil(load.firstError)
+    }
+
+    func testMalformedGhConfigIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(
+            files: FakeFiles([CopilotAuthStore.ghHostsPath: "not a host map"]),
+            keychain: FakeKeychain()
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertEqual(errorText(snapshot), CopilotAuthError.invalidCredentialData.localizedDescription)
+    }
+
+    func testMalformedAccountKeychainEntryDoesNotHideValidServiceEntry() {
+        let wrapped = "go-keyring-base64:" + Data("service-token".utf8).base64EncodedString()
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.ghHostsPath: """
+                github.com:
+                    user: octocat
+                """
+            ]),
+            keychain: CopilotBoundaryKeychain(
+                accountValue: "go-keyring-base64:not-base64",
+                serviceValue: wrapped
+            )
+        )
+
+        let load = store.loadTokenResult()
+
+        XCTAssertEqual(load.token?.value, "service-token")
+        XCTAssertNil(load.firstError)
+    }
+
+    func testEnterpriseOnlyFilesAreCompatibleAbsence() async {
+        let files = FakeFiles([
+            CopilotAuthStore.editorAppsPath:
+                #"{"ghe.corp.example:Iv1.enterprise":{"oauth_token":"enterprise-token"}}"#,
+            CopilotAuthStore.ghHostsPath: """
+            ghe.corp.example:
+                user: enterprise-user
+                oauth_token: enterprise-token
+            """
+        ])
+        let provider = makeProvider(files: files, keychain: FakeKeychain())
+
+        let load = provider.authStore.loadTokenResult()
+        XCTAssertNil(load.token)
+        XCTAssertNil(load.firstError, "Enterprise-only files are valid but cannot serve api.github.com")
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+    }
+
+    func testLookalikeGithubHostDoesNotLeakItsTokenToDotCom() {
+        let store = CopilotAuthStore(
+            files: FakeFiles([
+                CopilotAuthStore.ghHostsPath: """
+                github.com:enterprise:
+                    user: enterprise-user
+                    oauth_token: enterprise-token
+                """
+            ]),
+            keychain: FakeKeychain()
+        )
+
+        let load = store.loadTokenResult()
+
+        XCTAssertNil(load.token)
+        XCTAssertNil(load.firstError, "a valid non-dot-com host is compatible absence")
+    }
+
+    func testGithubConfigWithoutInlineTokenCanUseAnAbsentKeychain() async {
+        let files = FakeFiles([
+            CopilotAuthStore.ghHostsPath: """
+            github.com:
+                user: octocat
+                git_protocol: https
+            """
+        ])
+        let provider = makeProvider(files: files, keychain: FakeKeychain())
+
+        let load = provider.authStore.loadTokenResult()
+        XCTAssertNil(load.token)
+        XCTAssertNil(load.firstError, "gh can keep the token in Keychain instead of hosts.yml")
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+    }
+
+    func testMalformedKeychainIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(
+            files: FakeFiles(),
+            keychain: FakeKeychain("go-keyring-base64:not-base64")
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertEqual(errorText(snapshot), CopilotAuthError.invalidCredentialData.localizedDescription)
+    }
+
+    func testUnreadableKeychainIsConservativelyDetectedAndSurfaced() async {
+        let provider = makeProvider(
+            files: FakeFiles(),
+            keychain: CopilotBoundaryKeychain(serviceReadFails: true)
+        )
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .credentialAccess)
+        XCTAssertEqual(errorText(snapshot), CopilotAuthError.credentialStoreUnreadable.localizedDescription)
+    }
+
+    private func makeProvider(
+        files: TextFileAccessing,
+        keychain: KeychainAccessing
+    ) -> CopilotProvider {
+        CopilotProvider(
+            authStore: CopilotAuthStore(files: files, keychain: keychain),
+            usageClient: CopilotUsageClient(http: FakeHTTPClient(
+                response: HTTPResponse(statusCode: 500, headers: [:], body: Data())
+            )),
+            defaults: UserDefaults(suiteName: "CopilotCredentialBoundaryTests.\(UUID().uuidString)")!
+        )
+    }
+
+    private func errorText(_ snapshot: ProviderSnapshot) -> String? {
+        guard case .badge(_, let text, _, _) = snapshot.lines.first else { return nil }
+        return text
+    }
+}
+
+private final class CopilotBoundaryFiles: TextFileAccessing, @unchecked Sendable {
+    enum Entry {
+        case text(String)
+        case unreadable
+    }
+
+    private var entries: [String: Entry]
+
+    init(_ entries: [String: Entry]) {
+        self.entries = entries
+    }
+
+    func exists(_ path: String) -> Bool {
+        entries[path] != nil
+    }
+
+    func readText(_ path: String) throws -> String {
+        switch entries[path] {
+        case .text(let text): return text
+        case .unreadable: throw CopilotBoundaryTestError.unreadable
+        case nil: return ""
+        }
+    }
+
+    func writeText(_ path: String, _ text: String) throws {
+        entries[path] = .text(text)
+    }
+
+    func remove(_ path: String) throws {
+        entries.removeValue(forKey: path)
+    }
+}
+
+private struct CopilotBoundaryKeychain: KeychainAccessing {
+    var accountValue: String?
+    var serviceValue: String?
+    var accountReadFails: Bool
+    var serviceReadFails: Bool
+
+    init(
+        accountValue: String? = nil,
+        serviceValue: String? = nil,
+        accountReadFails: Bool = false,
+        serviceReadFails: Bool = false
+    ) {
+        self.accountValue = accountValue
+        self.serviceValue = serviceValue
+        self.accountReadFails = accountReadFails
+        self.serviceReadFails = serviceReadFails
+    }
+
+    func readGenericPassword(service: String) throws -> String? {
+        if serviceReadFails { throw CopilotBoundaryTestError.unreadable }
+        return serviceValue
+    }
+
+    func readGenericPassword(service: String, account: String) throws -> String? {
+        if accountReadFails { throw CopilotBoundaryTestError.unreadable }
+        return accountValue
+    }
+
+    func writeGenericPassword(service: String, value: String) throws {}
+}
+
+private enum CopilotBoundaryTestError: Error {
+    case unreadable
+}

--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -30,6 +30,8 @@ If neither is available you'll see *Start Antigravity or run `agy` and try again
 ## Troubleshooting
 
 - **"Start Antigravity or run `agy`…"** — sign in to the Antigravity app (or run `agy`) so a usable token exists, then refresh.
+- **"Couldn't read Antigravity credentials from Keychain"** — unlock Keychain or sign in to Antigravity again, then refresh.
+- **"Antigravity credentials are invalid"** — the Keychain item is present but malformed. Open Antigravity or run `agy` to replace it.
 - **The weekly meters show "No data"** — your Antigravity build doesn't expose the quota-summary endpoint yet (only newer builds do). The 5-hour meters still work from the older endpoints; updating Antigravity brings the weekly meters back.
 - **A meter shows "No data"** — that pool/window wasn't in the latest response (some tiers only report certain windows). The other meters still update.
 - **Where did the Gemini Pro and Flash meters go?** — merged: both models draw from the one shared Gemini pool, which is now the single Session meter.
@@ -37,6 +39,6 @@ If neither is available you'll see *Start Antigravity or run `agy` and try again
 
 ## Under the hood
 
-Best source first: the local language server discovered by scanning for the `language_server` / `agy` process and reading its CSRF token and listening ports; then Google Cloud Code using the Keychain token, refreshed via Google OAuth when needed. On each source OpenUsage asks the quota-summary endpoint first (`RetrieveUserQuotaSummary` on the language server, `v1internal:retrieveUserQuotaSummary` on Cloud Code) — the only endpoint that reports the merged pools and the weekly windows. Builds without it fall back to the legacy per-model endpoints (`GetUserStatus` / `GetCommandModelConfigs` locally, `fetchAvailableModels` / `retrieveUserQuota` remotely), whose per-model quotas are merged into the two pools by keeping each pool's worst remaining fraction; those endpoints only know the 5-hour windows. The plan name prefers Antigravity's own `userTier` over the inherited Windsurf plan field.
+Best source first: the local language server discovered by scanning for the `language_server` / `agy` process and reading its CSRF token and listening ports; then Google Cloud Code using the Keychain token, refreshed via Google OAuth when needed. OpenUsage keeps a short-lived cache of its own refreshed access token; an expired cache is a normal miss, while a corrupt cache is logged and ignored rather than treated as broken Antigravity credentials. On each source OpenUsage asks the quota-summary endpoint first (`RetrieveUserQuotaSummary` on the language server, `v1internal:retrieveUserQuotaSummary` on Cloud Code) — the only endpoint that reports the merged pools and the weekly windows. Builds without it fall back to the legacy per-model endpoints (`GetUserStatus` / `GetCommandModelConfigs` locally, `fetchAvailableModels` / `retrieveUserQuota` remotely), whose per-model quotas are merged into the two pools by keeping each pool's worst remaining fraction; those endpoints only know the 5-hour windows. The plan name prefers Antigravity's own `userTier` over the inherited Windsurf plan field.
 
 > Reverse-engineered from the app and language-server binary; endpoints and storage may change without notice.

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -25,6 +25,8 @@ Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the C
 ## Troubleshooting
 
 - **"Not logged in"** — run `codex` and sign in, then refresh.
+- **"Couldn't read Codex credentials"** — OpenUsage found an auth file or Keychain source but macOS could not read it. Check the file permissions and that Keychain is unlocked, then refresh.
+- **"Codex credentials are invalid"** — an auth file or Keychain value is present but malformed. Run `codex` and sign in again to replace it.
 - **API-key-only setups** can't read subscription usage — sign in with your ChatGPT account instead.
 - **Spend tiles show "No data"** — OpenUsage found no Codex session logs in the last 30 days. If your Codex home lives somewhere custom, set `CODEX_HOME` so both the Codex CLI and OpenUsage look in the same place.
 

--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -49,6 +49,9 @@ Using Copilot in a supported editor is enough on its own — the editor writes t
 
 - **"Sign in to GitHub Copilot…"** — no token was found. Sign in to Copilot in your editor, or run `gh auth login`.
 - **"GitHub token invalid or expired"** — the token was rejected (401/403). Re-authenticate with `gh auth login`.
+- **"Couldn't read GitHub Copilot credentials"** — an editor or GitHub CLI credential source exists but cannot be read. Check its file permissions and that Keychain is unlocked.
+- **"GitHub Copilot credentials are invalid"** — a compatible GitHub.com credential source is malformed. Sign in again through your editor or run `gh auth login` to replace it.
+- A valid config containing only GitHub Enterprise hosts is ignored for the GitHub.com usage API; OpenUsage continues to the next editor file, GitHub CLI config, and Keychain source.
 - **Meters show "No data" but the plan is shown** — expected on an org-managed Copilot Business/Enterprise seat when you aren't an owner or billing manager of the org (GitHub doesn't expose per-seat quota, and org billing is admin-only). If you *are* an org admin and still see no Org Credits, make sure your token can list your orgs — the GitHub CLI token from `gh auth login` can; some editor-plugin tokens can't.
 
 ## Under the hood


### PR DESCRIPTION
## TL;DR

Distinguish genuinely missing credentials from unreadable or malformed local credential stores for Codex, Copilot, and Antigravity. Valid later sources still win, while a real boundary failure now reaches the user with actionable guidance instead of being mislabeled as “not logged in.”

## What was happening

- Codex auth files and Keychain reads collapsed missing, unreadable, malformed, and tokenless data into the same empty result.
- Copilot editor, GitHub CLI, and Keychain failures could disappear as “not logged in,” and one broken higher-priority file could hide a valid later source.
- Antigravity Keychain failures were treated as missing credentials; malformed structured values could fall through as raw bearer tokens.
- One-shot provider detection could leave a provider disabled when credentials probably existed but could not be inspected.
- Troubleshooting docs did not explain these repairable credential-store failures or the intentional best-effort exceptions.

## What this changes

- Adds typed unreadable/malformed credential outcomes and telemetry categories for all three providers.
- Makes provider detection conservative for indeterminate credential boundaries while keeping proven absence disabled.
- Preserves ordered fallback: a valid later Codex file, Copilot source, Keychain entry, or Antigravity refreshed-token cache can recover from an earlier broken source.
- Keeps valid Codex API-key-only guidance ahead of a broken sibling while still allowing later OAuth candidates to serve subscription usage.
- Restricts Copilot parsing to GitHub.com credentials; valid GitHub Enterprise-only configuration remains compatible absence and falls through safely.
- Treats Antigravity’s app-owned refreshed-token cache as best effort: expired entries are normal misses and corrupt/unreadable entries are logged and ignored.
- Documents the new errors, recovery steps, fallback behavior, and cache/enterprise exceptions.

## Heads-up

- This PR is stacked on #941; review the commit on top of `codex/surface-grok-devin-credential-errors`, and rebase it after #941 lands.
- #915 overlaps the Codex fallback switch. When rebasing, preserve `credentialStoreUnreadable` as a terminal load error while retaining API-key fallback.
- No visual changes.

## Tests

- `swift test --filter 'CredentialBoundaryTests'` — 30 tests passed.
- `swift test` — 1,009 XCTest tests passed (3 skipped), plus 3 Swift Testing tests.
- `script/build_and_run.sh verify` — release build, signed bundle staging, launch verification, and post-verification process cleanup passed.
- Synthetic interaction stack with #911, #915, #931, and #935 — 30 focused tests and 1,018 XCTest tests passed (3 skipped), plus 3 Swift Testing tests; preserve #911’s form-encoding regression when #935 splits the Codex test file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and Keychain/file reads across three providers with changed error and fallback semantics; behavior is heavily tested but wrong classification could still mislead users or telemetry.
> 
> **Overview**
> **Codex, Copilot, and Antigravity** no longer collapse unreadable Keychain/files, malformed payloads, and true “not signed in” into the same empty outcome. Each provider gains **`credentialStoreUnreadable`** and **invalid credential** errors with user-facing copy, **`ErrorCategory`** mapping (`.credentialAccess` / `.authInvalid`), and load paths that **keep the first boundary error** while still trying later sources.
> 
> **Fallback and detection behavior** changes: ordered sources still win when a sibling is broken (e.g. later Codex `auth.json` or Keychain OAuth after a bad file). **`hasLocalCredentials()`** treats indeterminate read/parse failures as **present** so one-shot provider enablement does not hide a likely install. Codex treats **`usageAPIKey`** as candidate-level fallback so API-key guidance does not block a valid OAuth sibling; Antigravity’s **app-owned refresh cache** stays best-effort (expired = miss, corrupt/unreadable = log and ignore). Copilot tightens **github.com-only** token selection (enterprise-only configs fall through; stricter `hosts.yml` host matching).
> 
> Provider docs add troubleshooting for the new errors; **30 boundary tests** cover detection, surfacing, and fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5778424bb08ef18e2334a5ecdb86ed867edba606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->