### PR TITLE
Split Devin provider tests by responsibility

### DIFF
--- a/Tests/OpenUsageTests/DevinAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/DevinAuthStoreTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import OpenUsage
+
+final class DevinAuthStoreTests: XCTestCase {
+    func testParsesCredentialsTomlAndCleansServerURL() throws {
+        let store = DevinAuthStore(
+            files: FakeFiles([
+                DevinAuthStore.credentialsPath: """
+                windsurf_api_key = "devin-session-token$cli"
+                api_server_url = "https://server.codeium.test/"
+                """
+            ]),
+            sqlite: DevinFakeSQLite()
+        )
+
+        let auth = try store.loadCredentialsFile()
+
+        XCTAssertEqual(auth?.apiKey, "devin-session-token$cli")
+        XCTAssertEqual(auth?.apiServerUrl, "https://server.codeium.test")
+    }
+
+    func testRejectsPlaintextServerURLInsteadOfFallingBackToProduction() {
+        let store = DevinAuthStore(
+            files: FakeFiles([
+                DevinAuthStore.credentialsPath: """
+                windsurf_api_key = "devin-session-token$cli"
+                api_server_url = "http://server.codeium.test"
+                """
+            ]),
+            sqlite: DevinFakeSQLite()
+        )
+
+        XCTAssertThrowsError(try store.loadCredentialsFile()) { error in
+            XCTAssertEqual(error as? DevinAuthError, .invalidCredentialData)
+        }
+    }
+
+    func testReadsAppAuthFromSQLiteState() throws {
+        let sqlite = DevinFakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
+        let store = DevinAuthStore(files: FakeFiles(), sqlite: sqlite)
+
+        let auth = try store.loadAppAuth()
+
+        XCTAssertEqual(auth?.apiKey, "devin-session-token$app")
+        XCTAssertEqual(sqlite.lastPath, DevinAuthStore.stateDBPath)
+        XCTAssertEqual(sqlite.lastSQL?.contains("windsurfAuthStatus"), true)
+    }
+
+    func testMissingCredentialSourcesAreProvenAbsent() throws {
+        let store = DevinAuthStore(files: FakeFiles(), sqlite: DevinFakeSQLite())
+
+        XCTAssertNil(try store.loadCredentialsFile())
+        XCTAssertNil(try store.loadAppAuth())
+    }
+
+    func testUnreadableCredentialFileThrowsCredentialStoreUnreadable() {
+        let store = DevinAuthStore(files: DevinUnreadableFiles(), sqlite: DevinFakeSQLite())
+
+        XCTAssertThrowsError(try store.loadCredentialsFile()) { error in
+            XCTAssertEqual(error as? DevinAuthError, .credentialStoreUnreadable)
+        }
+    }
+
+    func testMalformedCredentialFileThrowsInvalidCredentialData() {
+        let store = DevinAuthStore(
+            files: FakeFiles([DevinAuthStore.credentialsPath: "windsurf_api_key = \"unterminated"]),
+            sqlite: DevinFakeSQLite()
+        )
+
+        XCTAssertThrowsError(try store.loadCredentialsFile()) { error in
+            XCTAssertEqual(error as? DevinAuthError, .invalidCredentialData)
+        }
+    }
+
+    func testUnreadableAppDatabaseThrowsCredentialStoreUnreadable() {
+        let store = DevinAuthStore(
+            files: FakeFiles(),
+            sqlite: DevinFakeSQLite(queryError: DevinCredentialBoundaryTestError.unreadable)
+        )
+
+        XCTAssertThrowsError(try store.loadAppAuth()) { error in
+            XCTAssertEqual(error as? DevinAuthError, .credentialStoreUnreadable)
+        }
+    }
+
+    func testMalformedAppDatabaseValueThrowsInvalidCredentialData() {
+        let store = DevinAuthStore(files: FakeFiles(), sqlite: DevinFakeSQLite(value: "{ not-json"))
+
+        XCTAssertThrowsError(try store.loadAppAuth()) { error in
+            XCTAssertEqual(error as? DevinAuthError, .invalidCredentialData)
+        }
+    }
+
+    func testSignedOutAppDatabaseValueIsAbsent() throws {
+        let store = DevinAuthStore(files: FakeFiles(), sqlite: DevinFakeSQLite(value: #"{"signedIn":false}"#))
+
+        XCTAssertNil(try store.loadAppAuth())
+    }
+}

--- a/Tests/OpenUsageTests/DevinProviderTests.swift
+++ b/Tests/OpenUsageTests/DevinProviderTests.swift
@@ -1,181 +1,11 @@
 import XCTest
 @testable import OpenUsage
 
-final class DevinAuthStoreTests: XCTestCase {
-    func testParsesCredentialsTomlAndCleansServerURL() throws {
-        let store = DevinAuthStore(
-            files: FakeFiles([
-                DevinAuthStore.credentialsPath: """
-                windsurf_api_key = "devin-session-token$cli"
-                api_server_url = "https://server.codeium.test/"
-                """
-            ]),
-            sqlite: FakeSQLite()
-        )
-
-        let auth = try store.loadCredentialsFile()
-
-        XCTAssertEqual(auth?.apiKey, "devin-session-token$cli")
-        XCTAssertEqual(auth?.apiServerUrl, "https://server.codeium.test")
-    }
-
-    func testRejectsPlaintextServerURLInsteadOfFallingBackToProduction() {
-        let store = DevinAuthStore(
-            files: FakeFiles([
-                DevinAuthStore.credentialsPath: """
-                windsurf_api_key = "devin-session-token$cli"
-                api_server_url = "http://server.codeium.test"
-                """
-            ]),
-            sqlite: FakeSQLite()
-        )
-
-        XCTAssertThrowsError(try store.loadCredentialsFile()) { error in
-            XCTAssertEqual(error as? DevinAuthError, .invalidCredentialData)
-        }
-    }
-
-    func testReadsAppAuthFromSQLiteState() throws {
-        let sqlite = FakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
-        let store = DevinAuthStore(files: FakeFiles(), sqlite: sqlite)
-
-        let auth = try store.loadAppAuth()
-
-        XCTAssertEqual(auth?.apiKey, "devin-session-token$app")
-        XCTAssertEqual(sqlite.lastPath, DevinAuthStore.stateDBPath)
-        XCTAssertEqual(sqlite.lastSQL?.contains("windsurfAuthStatus"), true)
-    }
-
-    func testMissingCredentialSourcesAreProvenAbsent() throws {
-        let store = DevinAuthStore(files: FakeFiles(), sqlite: FakeSQLite())
-
-        XCTAssertNil(try store.loadCredentialsFile())
-        XCTAssertNil(try store.loadAppAuth())
-    }
-
-    func testUnreadableCredentialFileThrowsCredentialStoreUnreadable() {
-        let store = DevinAuthStore(files: DevinUnreadableFiles(), sqlite: FakeSQLite())
-
-        XCTAssertThrowsError(try store.loadCredentialsFile()) { error in
-            XCTAssertEqual(error as? DevinAuthError, .credentialStoreUnreadable)
-        }
-    }
-
-    func testMalformedCredentialFileThrowsInvalidCredentialData() {
-        let store = DevinAuthStore(
-            files: FakeFiles([DevinAuthStore.credentialsPath: "windsurf_api_key = \"unterminated"]),
-            sqlite: FakeSQLite()
-        )
-
-        XCTAssertThrowsError(try store.loadCredentialsFile()) { error in
-            XCTAssertEqual(error as? DevinAuthError, .invalidCredentialData)
-        }
-    }
-
-    func testUnreadableAppDatabaseThrowsCredentialStoreUnreadable() {
-        let store = DevinAuthStore(
-            files: FakeFiles(),
-            sqlite: FakeSQLite(queryError: CredentialBoundaryTestError.unreadable)
-        )
-
-        XCTAssertThrowsError(try store.loadAppAuth()) { error in
-            XCTAssertEqual(error as? DevinAuthError, .credentialStoreUnreadable)
-        }
-    }
-
-    func testMalformedAppDatabaseValueThrowsInvalidCredentialData() {
-        let store = DevinAuthStore(files: FakeFiles(), sqlite: FakeSQLite(value: "{ not-json"))
-
-        XCTAssertThrowsError(try store.loadAppAuth()) { error in
-            XCTAssertEqual(error as? DevinAuthError, .invalidCredentialData)
-        }
-    }
-
-    func testSignedOutAppDatabaseValueIsAbsent() throws {
-        let store = DevinAuthStore(files: FakeFiles(), sqlite: FakeSQLite(value: #"{"signedIn":false}"#))
-
-        XCTAssertNil(try store.loadAppAuth())
-    }
-}
-
-final class DevinUsageMapperTests: XCTestCase {
-    func testMapsQuotaLinesAndExtraUsageBalance() throws {
-        let mapped = try DevinUsageMapper.mapUserStatus(makeUserStatus())
-
-        XCTAssertEqual(mapped.plan, "Max")
-        XCTAssertEqual(progress(mapped.lines, "Daily quota")?.used, 0)
-        XCTAssertEqual(progress(mapped.lines, "Daily quota")?.periodDurationMs, DevinUsageMapper.dayPeriodMs)
-        XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.used, 60)
-        XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.periodDurationMs, DevinUsageMapper.weekPeriodMs)
-        XCTAssertEqual(try XCTUnwrap(dollars(mapped.lines, "Extra usage balance")), 964.22, accuracy: 0.0001)
-        XCTAssertNotNil(progress(mapped.lines, "Weekly quota")?.resetsAt)
-    }
-
-    func testZeroOverageBalanceReadsZeroDollarsNotNoData() throws {
-        var userStatus = makeUserStatus()
-        var planStatus = userStatus["planStatus"] as! [String: Any]
-        planStatus["overageBalanceMicros"] = "0"
-        userStatus["planStatus"] = planStatus
-
-        let mapped = try DevinUsageMapper.mapUserStatus(userStatus)
-
-        // A present balance of zero is a real, measured value → 0, not "No data" (that's reserved
-        // for the field being absent entirely).
-        XCTAssertEqual(dollars(mapped.lines, "Extra usage balance"), 0)
-    }
-
-    func testUsesHiddenDailyQuotaAsWeeklyUsageWhenWeeklyIsAbsent() throws {
-        var userStatus = makeUserStatus()
-        var planStatus = userStatus["planStatus"] as! [String: Any]
-        var planInfo = planStatus["planInfo"] as! [String: Any]
-        planInfo["hideDailyQuota"] = true
-        planStatus["planInfo"] = planInfo
-        planStatus["dailyQuotaRemainingPercent"] = 30
-        planStatus.removeValue(forKey: "weeklyQuotaRemainingPercent")
-        userStatus["planStatus"] = planStatus
-
-        let mapped = try DevinUsageMapper.mapUserStatus(userStatus)
-
-        XCTAssertNil(progress(mapped.lines, "Daily quota"))
-        // The hidden daily quota fills the missing Weekly row and is still flipped from "remaining"
-        // to "used": 30% remaining -> 70% used (not passed through raw as 30).
-        XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.used, 70)
-        XCTAssertEqual(try XCTUnwrap(dollars(mapped.lines, "Extra usage balance")), 964.22, accuracy: 0.0001)
-    }
-
-    func testThrowsQuotaUnavailableWhenNoDisplayableFieldsExist() {
-        let userStatus: [String: Any] = [
-            "planStatus": [
-                "planInfo": ["planName": "Max"]
-            ]
-        ]
-
-        XCTAssertThrowsError(try DevinUsageMapper.mapUserStatus(userStatus)) { error in
-            XCTAssertEqual(error as? DevinUsageError, .quotaUnavailable)
-        }
-    }
-
-    private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
-        guard case .progress(_, let used, let limit, _, let resetsAt, let periodDurationMs, _) = lines.first(where: { $0.label == label }) else {
-            return nil
-        }
-        return (used, limit, resetsAt, periodDurationMs)
-    }
-
-    /// The first dollar value's raw number on a `.values` line (the shape extra-usage balance now uses).
-    private func dollars(_ lines: [MetricLine], _ label: String) -> Double? {
-        guard case .values(_, let values, _, _, _, _) = lines.first(where: { $0.label == label }) else {
-            return nil
-        }
-        return values.first(where: { $0.kind == .dollars })?.number
-    }
-}
-
 @MainActor
 final class DevinProviderTests: XCTestCase {
     func testRefreshUsesCredentialsFileBeforeAppState() async throws {
-        let httpClient = QueueHTTPClient(responses: [
-            HTTPResponse(statusCode: 200, headers: [:], body: try makeUserStatusBody())
+        let httpClient = DevinQueueHTTPClient(responses: [
+            HTTPResponse(statusCode: 200, headers: [:], body: try makeDevinUserStatusBody())
         ])
         let provider = DevinProvider(
             authStore: DevinAuthStore(
@@ -185,7 +15,7 @@ final class DevinProviderTests: XCTestCase {
                     api_server_url = "https://server.codeium.test"
                     """
                 ]),
-                sqlite: FakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
+                sqlite: DevinFakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
             ),
             usageClient: DevinUsageClient(http: httpClient),
             now: { Date(timeIntervalSince1970: 1_800_000_000) }
@@ -197,7 +27,7 @@ final class DevinProviderTests: XCTestCase {
         XCTAssertEqual(snapshot.lines.count, 3)
         XCTAssertEqual(httpClient.requests.count, 1)
         XCTAssertEqual(httpClient.requests.first?.url.absoluteString, "https://server.codeium.test/exa.seat_management_pb.SeatManagementService/GetUserStatus")
-        let body = try requestBody(httpClient.requests.first)
+        let body = try devinRequestBody(httpClient.requests.first)
         let metadata = body["metadata"] as? [String: Any]
         XCTAssertEqual(metadata?["apiKey"] as? String, "devin-session-token$cli")
         XCTAssertEqual(metadata?["ideName"] as? String, "devin")
@@ -205,9 +35,9 @@ final class DevinProviderTests: XCTestCase {
     }
 
     func testRefreshFallsBackToAppStateAfterExpiredCredentials() async throws {
-        let httpClient = QueueHTTPClient(responses: [
+        let httpClient = DevinQueueHTTPClient(responses: [
             HTTPResponse(statusCode: 401, headers: [:], body: Data("{}".utf8)),
-            HTTPResponse(statusCode: 200, headers: [:], body: try makeUserStatusBody(planName: "Teams"))
+            HTTPResponse(statusCode: 200, headers: [:], body: try makeDevinUserStatusBody(planName: "Teams"))
         ])
         let provider = DevinProvider(
             authStore: DevinAuthStore(
@@ -217,7 +47,7 @@ final class DevinProviderTests: XCTestCase {
                     api_server_url = "https://server.codeium.test"
                     """
                 ]),
-                sqlite: FakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
+                sqlite: DevinFakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
             ),
             usageClient: DevinUsageClient(http: httpClient)
         )
@@ -233,8 +63,8 @@ final class DevinProviderTests: XCTestCase {
 
     func testRefreshReturnsLoginHintWithoutAuth() async {
         let provider = DevinProvider(
-            authStore: DevinAuthStore(files: FakeFiles(), sqlite: FakeSQLite()),
-            usageClient: DevinUsageClient(http: QueueHTTPClient())
+            authStore: DevinAuthStore(files: FakeFiles(), sqlite: DevinFakeSQLite()),
+            usageClient: DevinUsageClient(http: DevinQueueHTTPClient())
         )
 
         let snapshot = await provider.refresh()
@@ -248,19 +78,19 @@ final class DevinProviderTests: XCTestCase {
 
     func testCredentialProbeIsFalseOnlyForProvenAbsence() async {
         let absent = DevinProvider(
-            authStore: DevinAuthStore(files: FakeFiles(), sqlite: FakeSQLite()),
-            usageClient: DevinUsageClient(http: QueueHTTPClient())
+            authStore: DevinAuthStore(files: FakeFiles(), sqlite: DevinFakeSQLite()),
+            usageClient: DevinUsageClient(http: DevinQueueHTTPClient())
         )
         let unreadableFile = DevinProvider(
-            authStore: DevinAuthStore(files: DevinUnreadableFiles(), sqlite: FakeSQLite()),
-            usageClient: DevinUsageClient(http: QueueHTTPClient())
+            authStore: DevinAuthStore(files: DevinUnreadableFiles(), sqlite: DevinFakeSQLite()),
+            usageClient: DevinUsageClient(http: DevinQueueHTTPClient())
         )
         let unreadableDatabase = DevinProvider(
             authStore: DevinAuthStore(
                 files: FakeFiles(),
-                sqlite: FakeSQLite(queryError: CredentialBoundaryTestError.unreadable)
+                sqlite: DevinFakeSQLite(queryError: DevinCredentialBoundaryTestError.unreadable)
             ),
-            usageClient: DevinUsageClient(http: QueueHTTPClient())
+            usageClient: DevinUsageClient(http: DevinQueueHTTPClient())
         )
 
         let absentDetected = await absent.hasLocalCredentials()
@@ -273,8 +103,8 @@ final class DevinProviderTests: XCTestCase {
 
     func testRefreshSurfacesUnreadableCredentialStoreWhenNoFallbackLoads() async {
         let provider = DevinProvider(
-            authStore: DevinAuthStore(files: DevinUnreadableFiles(), sqlite: FakeSQLite()),
-            usageClient: DevinUsageClient(http: QueueHTTPClient())
+            authStore: DevinAuthStore(files: DevinUnreadableFiles(), sqlite: DevinFakeSQLite()),
+            usageClient: DevinUsageClient(http: DevinQueueHTTPClient())
         )
 
         let snapshot = await provider.refresh()
@@ -287,9 +117,9 @@ final class DevinProviderTests: XCTestCase {
         let provider = DevinProvider(
             authStore: DevinAuthStore(
                 files: FakeFiles([DevinAuthStore.credentialsPath: "windsurf_api_key = \"unterminated"]),
-                sqlite: FakeSQLite()
+                sqlite: DevinFakeSQLite()
             ),
-            usageClient: DevinUsageClient(http: QueueHTTPClient())
+            usageClient: DevinUsageClient(http: DevinQueueHTTPClient())
         )
 
         let snapshot = await provider.refresh()
@@ -299,8 +129,8 @@ final class DevinProviderTests: XCTestCase {
     }
 
     func testRefreshFallsBackToAppStateAfterMalformedCLIFile() async throws {
-        let httpClient = QueueHTTPClient(responses: [
-            HTTPResponse(statusCode: 200, headers: [:], body: try makeUserStatusBody(planName: "Teams"))
+        let httpClient = DevinQueueHTTPClient(responses: [
+            HTTPResponse(statusCode: 200, headers: [:], body: try makeDevinUserStatusBody(planName: "Teams"))
         ])
         let provider = DevinProvider(
             authStore: DevinAuthStore(
@@ -310,7 +140,7 @@ final class DevinProviderTests: XCTestCase {
                     api_server_url = "http://unsafe.example"
                     """
                 ]),
-                sqlite: FakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
+                sqlite: DevinFakeSQLite(value: #"{"apiKey":"devin-session-token$app"}"#)
             ),
             usageClient: DevinUsageClient(http: httpClient)
         )
@@ -329,79 +159,5 @@ final class DevinProviderTests: XCTestCase {
             return nil
         }
         return text
-    }
-}
-
-private func makeUserStatus(planName: String = "Max") -> [String: Any] {
-    [
-        "planStatus": [
-            "planInfo": [
-                "planName": planName,
-                "billingStrategy": "BILLING_STRATEGY_QUOTA"
-            ],
-            "dailyQuotaRemainingPercent": 100,
-            "weeklyQuotaRemainingPercent": 40,
-            "overageBalanceMicros": "964220000",
-            "dailyQuotaResetAtUnix": "1774080000",
-            "weeklyQuotaResetAtUnix": "1774166400"
-        ]
-    ]
-}
-
-private func makeUserStatusBody(planName: String = "Max") throws -> Data {
-    try JSONSerialization.data(withJSONObject: ["userStatus": makeUserStatus(planName: planName)])
-}
-
-private func requestBody(_ request: HTTPRequest?) throws -> [String: Any] {
-    let data = try XCTUnwrap(request?.body)
-    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
-}
-
-private final class FakeSQLite: SQLiteAccessing, @unchecked Sendable {
-    var value: String?
-    var queryError: Error?
-    var lastPath: String?
-    var lastSQL: String?
-
-    init(value: String? = nil, queryError: Error? = nil) {
-        self.value = value
-        self.queryError = queryError
-    }
-
-    func queryValue(path: String, sql: String) throws -> String? {
-        lastPath = path
-        lastSQL = sql
-        if let queryError { throw queryError }
-        return value
-    }
-
-    func execute(path: String, sql: String) throws {}
-}
-
-private struct DevinUnreadableFiles: TextFileAccessing {
-    func exists(_ path: String) -> Bool { true }
-    func readText(_ path: String) throws -> String { throw CredentialBoundaryTestError.unreadable }
-    func writeText(_ path: String, _ text: String) throws {}
-    func remove(_ path: String) throws {}
-}
-
-private enum CredentialBoundaryTestError: Error {
-    case unreadable
-}
-
-private final class QueueHTTPClient: HTTPClient, @unchecked Sendable {
-    var responses: [HTTPResponse]
-    var requests: [HTTPRequest] = []
-
-    init(responses: [HTTPResponse] = []) {
-        self.responses = responses
-    }
-
-    func send(_ request: HTTPRequest) async throws -> HTTPResponse {
-        requests.append(request)
-        guard !responses.isEmpty else {
-            return HTTPResponse(statusCode: 500, headers: [:], body: Data("{}".utf8))
-        }
-        return responses.removeFirst()
     }
 }

--- a/Tests/OpenUsageTests/DevinTestSupport.swift
+++ b/Tests/OpenUsageTests/DevinTestSupport.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import OpenUsage
+
+func makeDevinUserStatus(planName: String = "Max") -> [String: Any] {
+    [
+        "planStatus": [
+            "planInfo": [
+                "planName": planName,
+                "billingStrategy": "BILLING_STRATEGY_QUOTA"
+            ],
+            "dailyQuotaRemainingPercent": 100,
+            "weeklyQuotaRemainingPercent": 40,
+            "overageBalanceMicros": "964220000",
+            "dailyQuotaResetAtUnix": "1774080000",
+            "weeklyQuotaResetAtUnix": "1774166400"
+        ]
+    ]
+}
+
+func makeDevinUserStatusBody(planName: String = "Max") throws -> Data {
+    try JSONSerialization.data(withJSONObject: ["userStatus": makeDevinUserStatus(planName: planName)])
+}
+
+func devinRequestBody(_ request: HTTPRequest?) throws -> [String: Any] {
+    let data = try XCTUnwrap(request?.body)
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+final class DevinFakeSQLite: SQLiteAccessing, @unchecked Sendable {
+    var value: String?
+    var queryError: Error?
+    var lastPath: String?
+    var lastSQL: String?
+
+    init(value: String? = nil, queryError: Error? = nil) {
+        self.value = value
+        self.queryError = queryError
+    }
+
+    func queryValue(path: String, sql: String) throws -> String? {
+        lastPath = path
+        lastSQL = sql
+        if let queryError { throw queryError }
+        return value
+    }
+
+    func execute(path: String, sql: String) throws {}
+}
+
+struct DevinUnreadableFiles: TextFileAccessing {
+    func exists(_ path: String) -> Bool { true }
+    func readText(_ path: String) throws -> String { throw DevinCredentialBoundaryTestError.unreadable }
+    func writeText(_ path: String, _ text: String) throws {}
+    func remove(_ path: String) throws {}
+}
+
+enum DevinCredentialBoundaryTestError: Error {
+    case unreadable
+}
+
+final class DevinQueueHTTPClient: HTTPClient, @unchecked Sendable {
+    var responses: [HTTPResponse]
+    var requests: [HTTPRequest] = []
+
+    init(responses: [HTTPResponse] = []) {
+        self.responses = responses
+    }
+
+    func send(_ request: HTTPRequest) async throws -> HTTPResponse {
+        requests.append(request)
+        guard !responses.isEmpty else {
+            return HTTPResponse(statusCode: 500, headers: [:], body: Data("{}".utf8))
+        }
+        return responses.removeFirst()
+    }
+}

--- a/Tests/OpenUsageTests/DevinUsageMapperTests.swift
+++ b/Tests/OpenUsageTests/DevinUsageMapperTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import OpenUsage
+
+final class DevinUsageMapperTests: XCTestCase {
+    func testMapsQuotaLinesAndExtraUsageBalance() throws {
+        let mapped = try DevinUsageMapper.mapUserStatus(makeDevinUserStatus())
+
+        XCTAssertEqual(mapped.plan, "Max")
+        XCTAssertEqual(progress(mapped.lines, "Daily quota")?.used, 0)
+        XCTAssertEqual(progress(mapped.lines, "Daily quota")?.periodDurationMs, DevinUsageMapper.dayPeriodMs)
+        XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.used, 60)
+        XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.periodDurationMs, DevinUsageMapper.weekPeriodMs)
+        XCTAssertEqual(try XCTUnwrap(dollars(mapped.lines, "Extra usage balance")), 964.22, accuracy: 0.0001)
+        XCTAssertNotNil(progress(mapped.lines, "Weekly quota")?.resetsAt)
+    }
+
+    func testZeroOverageBalanceReadsZeroDollarsNotNoData() throws {
+        var userStatus = makeDevinUserStatus()
+        var planStatus = userStatus["planStatus"] as! [String: Any]
+        planStatus["overageBalanceMicros"] = "0"
+        userStatus["planStatus"] = planStatus
+
+        let mapped = try DevinUsageMapper.mapUserStatus(userStatus)
+
+        // A present balance of zero is a real, measured value → 0, not "No data" (that's reserved
+        // for the field being absent entirely).
+        XCTAssertEqual(dollars(mapped.lines, "Extra usage balance"), 0)
+    }
+
+    func testUsesHiddenDailyQuotaAsWeeklyUsageWhenWeeklyIsAbsent() throws {
+        var userStatus = makeDevinUserStatus()
+        var planStatus = userStatus["planStatus"] as! [String: Any]
+        var planInfo = planStatus["planInfo"] as! [String: Any]
+        planInfo["hideDailyQuota"] = true
+        planStatus["planInfo"] = planInfo
+        planStatus["dailyQuotaRemainingPercent"] = 30
+        planStatus.removeValue(forKey: "weeklyQuotaRemainingPercent")
+        userStatus["planStatus"] = planStatus
+
+        let mapped = try DevinUsageMapper.mapUserStatus(userStatus)
+
+        XCTAssertNil(progress(mapped.lines, "Daily quota"))
+        // The hidden daily quota fills the missing Weekly row and is still flipped from "remaining"
+        // to "used": 30% remaining -> 70% used (not passed through raw as 30).
+        XCTAssertEqual(progress(mapped.lines, "Weekly quota")?.used, 70)
+        XCTAssertEqual(try XCTUnwrap(dollars(mapped.lines, "Extra usage balance")), 964.22, accuracy: 0.0001)
+    }
+
+    func testThrowsQuotaUnavailableWhenNoDisplayableFieldsExist() {
+        let userStatus: [String: Any] = [
+            "planStatus": [
+                "planInfo": ["planName": "Max"]
+            ]
+        ]
+
+        XCTAssertThrowsError(try DevinUsageMapper.mapUserStatus(userStatus)) { error in
+            XCTAssertEqual(error as? DevinUsageError, .quotaUnavailable)
+        }
+    }
+
+    private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, resetsAt: Date?, periodDurationMs: Int?)? {
+        guard case .progress(_, let used, let limit, _, let resetsAt, let periodDurationMs, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return (used, limit, resetsAt, periodDurationMs)
+    }
+
+    /// The first dollar value's raw number on a `.values` line (the shape extra-usage balance now uses).
+    private func dollars(_ lines: [MetricLine], _ label: String) -> Double? {
+        guard case .values(_, let values, _, _, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return values.first(where: { $0.kind == .dollars })?.number
+    }
+}


### PR DESCRIPTION
## TL;DR

Split the combined Devin test file into focused auth-store, usage-mapper, provider, and shared-support files. This is a test-only organization change with the same test coverage and fixtures.

## What was happening

- Devin auth, mapping, provider behavior, and shared fakes lived in one file.
- The combined integration branch pushes that file beyond the repository guideline of roughly 500 lines.
- Adding credential-boundary regression cases would keep growing an already mixed-responsibility test file.

## What this changes

- Moves auth-store coverage into DevinAuthStoreTests.swift.
- Moves usage mapping coverage into DevinUsageMapperTests.swift.
- Keeps provider refresh and fallback coverage in DevinProviderTests.swift.
- Moves reused payload builders and fakes into DevinTestSupport.swift with Devin-specific names to avoid module-wide fixture collisions.
- Keeps every resulting file below 200 lines without changing production code, test behavior, or fixture payloads.

## Tests

- swift test --filter Devin (24 tests passed)
- swift test (979 XCTest tests passed, 3 skipped; 3 Swift Testing tests passed)
- git diff --check
- Confirmed the set of Devin test method names is identical before and after the split.
- Confirmed all four Devin test files are below 500 lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only file moves and renames; production code and test assertions are unchanged.
> 
> **Overview**
> Splits the monolithic **Devin** test file into four focused files so each stays under the repo’s ~500-line guideline and new credential tests can land without mixing concerns.
> 
> **`DevinAuthStoreTests.swift`** holds credential TOML/SQLite auth-store cases. **`DevinUsageMapperTests.swift`** holds quota mapping cases. **`DevinProviderTests.swift`** keeps refresh, fallback, and credential-probe integration tests only.
> 
> Shared fixtures move to **`DevinTestSupport.swift`**, with Devin-prefixed names (`DevinFakeSQLite`, `DevinQueueHTTPClient`, `makeDevinUserStatus`, etc.) so they don’t collide with other providers’ `FakeSQLite` / `QueueHTTPClient` helpers. **No production code or test behavior changes**—same test method set and payloads, reorganized only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c50317eb4fa2c578320dddbde40e1688e59e781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->