### PR TITLE
Split Claude and Codex log scanner tests

### DIFF
--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerScanTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerScanTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import OpenUsage
+
+/// End-to-end file discovery, cache invalidation, and session-root coverage for the Claude log scanner.
+extension ClaudeLogUsageScannerTests {
+    // MARK: - End-to-end scan
+
+    func testScanReadsFixtureHomeAndRescanPicksUpNewLines() async throws {
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let home = try ClaudeLogFixture.makeHome(files: [
+            "project-a/session-1.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
+                messageID: "msg-1", requestID: "req-1"
+            )
+        ])
+        let scanner = ClaudeLogFixture.scanner(home: home)
+
+        let firstScan = await scanner.scan(now: now, pricing: pricing)
+        let first = try XCTUnwrap(firstScan)
+        XCTAssertEqual(first.series.daily.count, 1)
+        XCTAssertEqual(first.series.daily[0].totalTokens, 150)
+        XCTAssertEqual(first.series.daily[0].costUSD ?? 0, 0.25, accuracy: 1e-9)
+
+        // Append a second session file; the rescan must pick it up (per-file cache invalidation).
+        let newFile = home.appendingPathComponent("projects/project-a/session-2.jsonl")
+        try ClaudeLogFixture.usageLine(
+            timestamp: timestamp, input: 10, output: 5, costUSD: 0.05,
+            messageID: "msg-2", requestID: "req-2"
+        ).write(to: newFile, atomically: true, encoding: .utf8)
+
+        let secondScan = await scanner.scan(now: now, pricing: pricing)
+        let second = try XCTUnwrap(secondScan)
+        XCTAssertEqual(second.series.daily[0].totalTokens, 165)
+        XCTAssertEqual(second.series.daily[0].costUSD ?? 0, 0.30, accuracy: 1e-9)
+    }
+
+    func testScanDeduplicatesReplaysAcrossFiles() async throws {
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        // The same message replayed in a sidechain session file under a new request id: only the
+        // parent's tokens may count.
+        let home = try ClaudeLogFixture.makeHome(files: [
+            "project-a/parent.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
+                messageID: "msg-shared", requestID: "req-parent", isSidechain: false
+            ),
+            "project-a/sidechain.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: timestamp, input: 90_000, output: 10, costUSD: 9.99,
+                messageID: "msg-shared", requestID: "req-replay", isSidechain: true
+            )
+        ])
+        let scanner = ClaudeLogFixture.scanner(home: home)
+
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+        XCTAssertEqual(scan.series.daily.count, 1)
+        XCTAssertEqual(scan.series.daily[0].totalTokens, 150)
+        XCTAssertEqual(scan.series.daily[0].costUSD ?? 0, 0.25, accuracy: 1e-9)
+    }
+
+    func testScanSkipsFilesLastTouchedBeforeTheWindow() async throws {
+        let now = Date()
+        let home = try ClaudeLogFixture.makeHome(files: [
+            "project-a/old.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: OpenUsageISO8601.string(from: now.addingTimeInterval(-90 * 86_400)),
+                input: 100, output: 50, costUSD: 0.25
+            )
+        ])
+        let oldFile = home.appendingPathComponent("projects/project-a/old.jsonl")
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-90 * 86_400)], ofItemAtPath: oldFile.path
+        )
+        let scanner = ClaudeLogFixture.scanner(home: home)
+
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+        XCTAssertTrue(scan.series.daily.isEmpty)
+    }
+
+    func testScanReturnsNilWithoutClaudeHome() async {
+        let scanner = ClaudeLogFixture.scanner(home: nil)
+        let scan = await scanner.scan(now: Date(), pricing: pricing)
+        XCTAssertNil(scan)
+    }
+
+    /// Manual parity harness against the real logs on this machine: prints per-day totals to compare
+    /// with `ccusage daily --json --offline`. Gated like the other live tests.
+    func testParityAgainstRealLocalLogs() async throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment["OPENUSAGE_CLAUDE_PARITY"] == "1")
+        let scanner = ClaudeLogUsageScanner()
+        let result = await scanner.scan(now: Date(), pricing: TestPricing.bundled)
+        let scan = try XCTUnwrap(result)
+        for day in scan.series.daily.sorted(by: { $0.date < $1.date }) {
+            print("PARITY \(day.date) tokens=\(day.totalTokens) cost=\(day.costUSD.map { String(format: "%.4f", $0) } ?? "nil")")
+        }
+        if !scan.unknownModelsByDay.isEmpty {
+            print("PARITY unknown models: \(scan.unknownModelsByDay)")
+        }
+    }
+
+    // MARK: - Cowork session roots
+
+    func testScanSumsTerminalAndCoworkLogs() async throws {
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let home = try ClaudeLogFixture.makeUserHome(
+            claudeFiles: [
+                "project-a/terminal.jsonl": ClaudeLogFixture.usageLine(
+                    timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
+                    messageID: "msg-terminal", requestID: "req-terminal"
+                )
+            ],
+            coworkSessions: [
+                "group-1/sub-1/local_a": [
+                    "workspace/session.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 10, output: 5, costUSD: 0.05,
+                        messageID: "msg-cowork", requestID: "req-cowork"
+                    )
+                ],
+                "group-1/sub-1/agent/local_ditto_a": [
+                    "workspace/session.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 2, output: 3, costUSD: 0.01,
+                        messageID: "msg-ditto", requestID: "req-ditto"
+                    )
+                ]
+            ]
+        )
+        let scanner = ClaudeLogFixture.scanner(userHome: home)
+
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+        XCTAssertEqual(scan.series.daily.count, 1)
+        XCTAssertEqual(scan.series.daily[0].totalTokens, 170)
+        XCTAssertEqual(scan.series.daily[0].costUSD ?? 0, 0.31, accuracy: 1e-9)
+    }
+
+    func testScanFindsCoworkLogsWithoutTerminalClaudeHome() async throws {
+        let now = Date()
+        let home = try ClaudeLogFixture.makeUserHome(coworkSessions: [
+            "group-1/sub-1/local_a": [
+                "workspace/session.jsonl": ClaudeLogFixture.usageLine(
+                    timestamp: OpenUsageISO8601.string(from: now), input: 10, output: 5, costUSD: 0.05
+                )
+            ]
+        ])
+        let scanner = ClaudeLogFixture.scanner(userHome: home)
+
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+        XCTAssertEqual(scan.series.daily.count, 1)
+        XCTAssertEqual(scan.series.daily[0].totalTokens, 15)
+    }
+
+    func testScanDeduplicatesReplaysAcrossTerminalAndCoworkLogs() async throws {
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let home = try ClaudeLogFixture.makeUserHome(
+            claudeFiles: [
+                "project-a/parent.jsonl": ClaudeLogFixture.usageLine(
+                    timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
+                    messageID: "msg-shared", requestID: "req-parent", isSidechain: false
+                )
+            ],
+            coworkSessions: [
+                "group-1/sub-1/local_a": [
+                    "workspace/replay.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 90_000, output: 10, costUSD: 9.99,
+                        messageID: "msg-shared", requestID: "req-replay", isSidechain: true
+                    )
+                ]
+            ]
+        )
+        let scanner = ClaudeLogFixture.scanner(userHome: home)
+
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+        XCTAssertEqual(scan.series.daily.count, 1)
+        XCTAssertEqual(scan.series.daily[0].totalTokens, 150)
+        XCTAssertEqual(scan.series.daily[0].costUSD ?? 0, 0.25, accuracy: 1e-9)
+    }
+
+    func testScanAcceptsProjectsDirItselfInConfigDir() async throws {
+        let now = Date()
+        let home = try ClaudeLogFixture.makeHome(files: [
+            "project-a/session.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: OpenUsageISO8601.string(from: now), input: 10, output: 5, costUSD: 0.01
+            )
+        ])
+        // ccusage accepts `CLAUDE_CONFIG_DIR` pointing at the `projects/` dir itself.
+        let scanner = ClaudeLogUsageScanner(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": home.appendingPathComponent("projects").path]),
+            homeDirectory: { FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-claude-home") }
+        )
+
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+        XCTAssertEqual(scan.series.daily.count, 1)
+        XCTAssertEqual(scan.series.daily[0].totalTokens, 15)
+    }
+}

--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
@@ -1,30 +1,24 @@
 import XCTest
 @testable import OpenUsage
 
-enum ClaudeLogUsageScannerTestFixtures {
-    /// Deterministic fixture pricing: input $10/M, output $20/M, cache write $12.5/M, read $1/M.
-    static func pricing() -> ModelPricing {
-        ModelPricing(
-            supplement: PricingSupplement(),
-            primary: PricingCatalog(entries: [
-                "claude-test-model": ModelRates(
-                    inputPerMillion: 10, outputPerMillion: 20,
-                    cacheWritePerMillion: 12.5, cacheReadPerMillion: 1,
-                    fastMultiplier: 2
-                )
-            ]),
-            secondary: PricingCatalog(entries: [:])
-        )
-    }
-}
-
 /// Line parsing, deduplication, and day aggregation for the native Claude log scanner — the
 /// dedup/validity fixtures are ported from ccusage's Claude adapter tests so the two agree on
 /// what counts.
 final class ClaudeLogUsageScannerTests: XCTestCase {
     private typealias Entry = ClaudeLogUsageScanner.Entry
 
-    let pricing = ClaudeLogUsageScannerTestFixtures.pricing()
+    /// Deterministic fixture pricing: input $10/M, output $20/M, cache write $12.5/M, read $1/M.
+    let pricing = ModelPricing(
+        supplement: PricingSupplement(),
+        primary: PricingCatalog(entries: [
+            "claude-test-model": ModelRates(
+                inputPerMillion: 10, outputPerMillion: 20,
+                cacheWritePerMillion: 12.5, cacheReadPerMillion: 1,
+                fastMultiplier: 2
+            )
+        ]),
+        secondary: PricingCatalog(entries: [:])
+    )
 
     private func localDay(_ iso: String) -> String {
         let date = OpenUsageISO8601.date(from: iso)!

--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
@@ -1,24 +1,30 @@
 import XCTest
 @testable import OpenUsage
 
+enum ClaudeLogUsageScannerTestFixtures {
+    /// Deterministic fixture pricing: input $10/M, output $20/M, cache write $12.5/M, read $1/M.
+    static func pricing() -> ModelPricing {
+        ModelPricing(
+            supplement: PricingSupplement(),
+            primary: PricingCatalog(entries: [
+                "claude-test-model": ModelRates(
+                    inputPerMillion: 10, outputPerMillion: 20,
+                    cacheWritePerMillion: 12.5, cacheReadPerMillion: 1,
+                    fastMultiplier: 2
+                )
+            ]),
+            secondary: PricingCatalog(entries: [:])
+        )
+    }
+}
+
 /// Line parsing, deduplication, and day aggregation for the native Claude log scanner — the
 /// dedup/validity fixtures are ported from ccusage's Claude adapter tests so the two agree on
 /// what counts.
 final class ClaudeLogUsageScannerTests: XCTestCase {
     private typealias Entry = ClaudeLogUsageScanner.Entry
 
-    /// Deterministic fixture pricing: input $10/M, output $20/M, cache write $12.5/M, read $1/M.
-    private let pricing = ModelPricing(
-        supplement: PricingSupplement(),
-        primary: PricingCatalog(entries: [
-            "claude-test-model": ModelRates(
-                inputPerMillion: 10, outputPerMillion: 20,
-                cacheWritePerMillion: 12.5, cacheReadPerMillion: 1,
-                fastMultiplier: 2
-            )
-        ]),
-        secondary: PricingCatalog(entries: [:])
-    )
+    let pricing = ClaudeLogUsageScannerTestFixtures.pricing()
 
     private func localDay(_ iso: String) -> String {
         let date = OpenUsageISO8601.date(from: iso)!
@@ -319,199 +325,4 @@ final class ClaudeLogUsageScannerTests: XCTestCase {
         XCTAssertTrue(scan.series.daily.isEmpty)
     }
 
-    // MARK: - End-to-end scan
-
-    func testScanReadsFixtureHomeAndRescanPicksUpNewLines() async throws {
-        let now = Date()
-        let timestamp = OpenUsageISO8601.string(from: now)
-        let home = try ClaudeLogFixture.makeHome(files: [
-            "project-a/session-1.jsonl": ClaudeLogFixture.usageLine(
-                timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
-                messageID: "msg-1", requestID: "req-1"
-            )
-        ])
-        let scanner = ClaudeLogFixture.scanner(home: home)
-
-        let firstScan = await scanner.scan(now: now, pricing: pricing)
-        let first = try XCTUnwrap(firstScan)
-        XCTAssertEqual(first.series.daily.count, 1)
-        XCTAssertEqual(first.series.daily[0].totalTokens, 150)
-        XCTAssertEqual(first.series.daily[0].costUSD ?? 0, 0.25, accuracy: 1e-9)
-
-        // Append a second session file; the rescan must pick it up (per-file cache invalidation).
-        let newFile = home.appendingPathComponent("projects/project-a/session-2.jsonl")
-        try ClaudeLogFixture.usageLine(
-            timestamp: timestamp, input: 10, output: 5, costUSD: 0.05,
-            messageID: "msg-2", requestID: "req-2"
-        ).write(to: newFile, atomically: true, encoding: .utf8)
-
-        let secondScan = await scanner.scan(now: now, pricing: pricing)
-        let second = try XCTUnwrap(secondScan)
-        XCTAssertEqual(second.series.daily[0].totalTokens, 165)
-        XCTAssertEqual(second.series.daily[0].costUSD ?? 0, 0.30, accuracy: 1e-9)
-    }
-
-    func testScanDeduplicatesReplaysAcrossFiles() async throws {
-        let now = Date()
-        let timestamp = OpenUsageISO8601.string(from: now)
-        // The same message replayed in a sidechain session file under a new request id: only the
-        // parent's tokens may count.
-        let home = try ClaudeLogFixture.makeHome(files: [
-            "project-a/parent.jsonl": ClaudeLogFixture.usageLine(
-                timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
-                messageID: "msg-shared", requestID: "req-parent", isSidechain: false
-            ),
-            "project-a/sidechain.jsonl": ClaudeLogFixture.usageLine(
-                timestamp: timestamp, input: 90_000, output: 10, costUSD: 9.99,
-                messageID: "msg-shared", requestID: "req-replay", isSidechain: true
-            )
-        ])
-        let scanner = ClaudeLogFixture.scanner(home: home)
-
-        let result = await scanner.scan(now: now, pricing: pricing)
-        let scan = try XCTUnwrap(result)
-        XCTAssertEqual(scan.series.daily.count, 1)
-        XCTAssertEqual(scan.series.daily[0].totalTokens, 150)
-        XCTAssertEqual(scan.series.daily[0].costUSD ?? 0, 0.25, accuracy: 1e-9)
-    }
-
-    func testScanSkipsFilesLastTouchedBeforeTheWindow() async throws {
-        let now = Date()
-        let home = try ClaudeLogFixture.makeHome(files: [
-            "project-a/old.jsonl": ClaudeLogFixture.usageLine(
-                timestamp: OpenUsageISO8601.string(from: now.addingTimeInterval(-90 * 86_400)),
-                input: 100, output: 50, costUSD: 0.25
-            )
-        ])
-        let oldFile = home.appendingPathComponent("projects/project-a/old.jsonl")
-        try FileManager.default.setAttributes(
-            [.modificationDate: now.addingTimeInterval(-90 * 86_400)], ofItemAtPath: oldFile.path
-        )
-        let scanner = ClaudeLogFixture.scanner(home: home)
-
-        let result = await scanner.scan(now: now, pricing: pricing)
-        let scan = try XCTUnwrap(result)
-        XCTAssertTrue(scan.series.daily.isEmpty)
-    }
-
-    func testScanReturnsNilWithoutClaudeHome() async {
-        let scanner = ClaudeLogFixture.scanner(home: nil)
-        let scan = await scanner.scan(now: Date(), pricing: pricing)
-        XCTAssertNil(scan)
-    }
-
-    /// Manual parity harness against the real logs on this machine: prints per-day totals to compare
-    /// with `ccusage daily --json --offline`. Gated like the other live tests.
-    func testParityAgainstRealLocalLogs() async throws {
-        try XCTSkipUnless(ProcessInfo.processInfo.environment["OPENUSAGE_CLAUDE_PARITY"] == "1")
-        let scanner = ClaudeLogUsageScanner()
-        let result = await scanner.scan(now: Date(), pricing: TestPricing.bundled)
-        let scan = try XCTUnwrap(result)
-        for day in scan.series.daily.sorted(by: { $0.date < $1.date }) {
-            print("PARITY \(day.date) tokens=\(day.totalTokens) cost=\(day.costUSD.map { String(format: "%.4f", $0) } ?? "nil")")
-        }
-        if !scan.unknownModelsByDay.isEmpty {
-            print("PARITY unknown models: \(scan.unknownModelsByDay)")
-        }
-    }
-
-    // MARK: - Cowork session roots
-
-    func testScanSumsTerminalAndCoworkLogs() async throws {
-        let now = Date()
-        let timestamp = OpenUsageISO8601.string(from: now)
-        let home = try ClaudeLogFixture.makeUserHome(
-            claudeFiles: [
-                "project-a/terminal.jsonl": ClaudeLogFixture.usageLine(
-                    timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
-                    messageID: "msg-terminal", requestID: "req-terminal"
-                )
-            ],
-            coworkSessions: [
-                "group-1/sub-1/local_a": [
-                    "workspace/session.jsonl": ClaudeLogFixture.usageLine(
-                        timestamp: timestamp, input: 10, output: 5, costUSD: 0.05,
-                        messageID: "msg-cowork", requestID: "req-cowork"
-                    )
-                ],
-                "group-1/sub-1/agent/local_ditto_a": [
-                    "workspace/session.jsonl": ClaudeLogFixture.usageLine(
-                        timestamp: timestamp, input: 2, output: 3, costUSD: 0.01,
-                        messageID: "msg-ditto", requestID: "req-ditto"
-                    )
-                ]
-            ]
-        )
-        let scanner = ClaudeLogFixture.scanner(userHome: home)
-
-        let result = await scanner.scan(now: now, pricing: pricing)
-        let scan = try XCTUnwrap(result)
-        XCTAssertEqual(scan.series.daily.count, 1)
-        XCTAssertEqual(scan.series.daily[0].totalTokens, 170)
-        XCTAssertEqual(scan.series.daily[0].costUSD ?? 0, 0.31, accuracy: 1e-9)
-    }
-
-    func testScanFindsCoworkLogsWithoutTerminalClaudeHome() async throws {
-        let now = Date()
-        let home = try ClaudeLogFixture.makeUserHome(coworkSessions: [
-            "group-1/sub-1/local_a": [
-                "workspace/session.jsonl": ClaudeLogFixture.usageLine(
-                    timestamp: OpenUsageISO8601.string(from: now), input: 10, output: 5, costUSD: 0.05
-                )
-            ]
-        ])
-        let scanner = ClaudeLogFixture.scanner(userHome: home)
-
-        let result = await scanner.scan(now: now, pricing: pricing)
-        let scan = try XCTUnwrap(result)
-        XCTAssertEqual(scan.series.daily.count, 1)
-        XCTAssertEqual(scan.series.daily[0].totalTokens, 15)
-    }
-
-    func testScanDeduplicatesReplaysAcrossTerminalAndCoworkLogs() async throws {
-        let now = Date()
-        let timestamp = OpenUsageISO8601.string(from: now)
-        let home = try ClaudeLogFixture.makeUserHome(
-            claudeFiles: [
-                "project-a/parent.jsonl": ClaudeLogFixture.usageLine(
-                    timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
-                    messageID: "msg-shared", requestID: "req-parent", isSidechain: false
-                )
-            ],
-            coworkSessions: [
-                "group-1/sub-1/local_a": [
-                    "workspace/replay.jsonl": ClaudeLogFixture.usageLine(
-                        timestamp: timestamp, input: 90_000, output: 10, costUSD: 9.99,
-                        messageID: "msg-shared", requestID: "req-replay", isSidechain: true
-                    )
-                ]
-            ]
-        )
-        let scanner = ClaudeLogFixture.scanner(userHome: home)
-
-        let result = await scanner.scan(now: now, pricing: pricing)
-        let scan = try XCTUnwrap(result)
-        XCTAssertEqual(scan.series.daily.count, 1)
-        XCTAssertEqual(scan.series.daily[0].totalTokens, 150)
-        XCTAssertEqual(scan.series.daily[0].costUSD ?? 0, 0.25, accuracy: 1e-9)
-    }
-
-    func testScanAcceptsProjectsDirItselfInConfigDir() async throws {
-        let now = Date()
-        let home = try ClaudeLogFixture.makeHome(files: [
-            "project-a/session.jsonl": ClaudeLogFixture.usageLine(
-                timestamp: OpenUsageISO8601.string(from: now), input: 10, output: 5, costUSD: 0.01
-            )
-        ])
-        // ccusage accepts `CLAUDE_CONFIG_DIR` pointing at the `projects/` dir itself.
-        let scanner = ClaudeLogUsageScanner(
-            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": home.appendingPathComponent("projects").path]),
-            homeDirectory: { FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-claude-home") }
-        )
-
-        let result = await scanner.scan(now: now, pricing: pricing)
-        let scan = try XCTUnwrap(result)
-        XCTAssertEqual(scan.series.daily.count, 1)
-        XCTAssertEqual(scan.series.daily[0].totalTokens, 15)
-    }
 }

--- a/Tests/OpenUsageTests/CodexLogUsageScannerScanTests.swift
+++ b/Tests/OpenUsageTests/CodexLogUsageScannerScanTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import OpenUsage
+
+/// End-to-end session discovery, caching, and bundled-pricing coverage for the Codex log scanner.
+extension CodexLogUsageScannerTests {
+    // MARK: - End-to-end scan
+
+    func testScanReadsSessionsAndArchivedSessions() async throws {
+        let day = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
+        let home = try CodexLogFixture.makeHome(files: [
+            "sessions/2026/05/rollout-a.jsonl": [
+                CodexLogFixture.turnContext(timestamp: day, model: "gpt-5.2"),
+                CodexLogFixture.tokenCount(timestamp: day, last: CodexLogFixture.usage(input: 100, output: 50))
+            ].joined(separator: "\n"),
+            "archived_sessions/rollout-b.jsonl": CodexLogFixture.tokenCount(
+                timestamp: day, last: CodexLogFixture.usage(input: 30, output: 20), model: "gpt-5.2"
+            )
+        ])
+        let scanner = CodexLogFixture.scanner(home: home)
+
+        let scan = await scanner.scan(pricing: CodexLogUsageScannerTestFixtures.fixedRates())
+
+        XCTAssertEqual(scan?.series.daily.reduce(0) { $0 + $1.totalTokens }, 200)
+    }
+
+    func testScanPrefersActiveSessionsCopyOverArchivedDuplicate() async throws {
+        let day = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
+        let content = CodexLogFixture.tokenCount(
+            timestamp: day, last: CodexLogFixture.usage(input: 100, output: 50), model: "gpt-5.2"
+        )
+        let home = try CodexLogFixture.makeHome(files: [
+            "sessions/rollout-a.jsonl": content,
+            "archived_sessions/rollout-a.jsonl": content
+        ])
+        let scanner = CodexLogFixture.scanner(home: home)
+
+        let scan = await scanner.scan(pricing: CodexLogUsageScannerTestFixtures.fixedRates())
+
+        // Same relative path in both dirs = the same session archived; identical events dedupe
+        // anyway, but the discovery-level rule keeps it to one parse.
+        XCTAssertEqual(scan?.series.daily.reduce(0) { $0 + $1.totalTokens }, 150)
+    }
+
+    func testScanReturnsNilWithoutCodexHome() async {
+        let scanner = CodexLogFixture.scanner(home: nil)
+        let scan = await scanner.scan(pricing: CodexLogUsageScannerTestFixtures.fixedRates())
+        XCTAssertNil(scan)
+    }
+
+    func testScanCachesUnchangedFilesAndPicksUpNewOnes() async throws {
+        let day = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
+        let home = try CodexLogFixture.makeHome(files: [
+            "sessions/rollout-a.jsonl": CodexLogFixture.tokenCount(
+                timestamp: day, last: CodexLogFixture.usage(input: 100, output: 50), model: "gpt-5.2"
+            )
+        ])
+        let scanner = CodexLogFixture.scanner(home: home)
+
+        let first = await scanner.scan(pricing: CodexLogUsageScannerTestFixtures.fixedRates())
+        XCTAssertEqual(first?.series.daily.reduce(0) { $0 + $1.totalTokens }, 150)
+
+        try CodexLogFixture.tokenCount(
+            timestamp: day, last: CodexLogFixture.usage(input: 30, output: 20), model: "gpt-5.2"
+        ).write(to: home.appendingPathComponent("sessions/rollout-b.jsonl"), atomically: true, encoding: .utf8)
+
+        let second = await scanner.scan(pricing: CodexLogUsageScannerTestFixtures.fixedRates())
+        XCTAssertEqual(second?.series.daily.reduce(0) { $0 + $1.totalTokens }, 200)
+    }
+
+    /// Manual parity harness against the real logs on this machine: prints per-day totals to compare
+    /// with `ccusage codex daily --json --offline`. Gated like the other live tests.
+    func testParityAgainstRealLocalLogs() async throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment["OPENUSAGE_CODEX_PARITY"] == "1")
+        let scanner = CodexLogUsageScanner()
+        let result = await scanner.scan(pricing: TestPricing.bundled)
+        let scan = try XCTUnwrap(result)
+        for day in scan.series.daily.sorted(by: { $0.date < $1.date }) {
+            print("PARITY \(day.date) tokens=\(day.totalTokens) cost=\(day.costUSD.map { String(format: "%.4f", $0) } ?? "nil")")
+        }
+        if !scan.unknownModelsByDay.isEmpty {
+            print("PARITY unknown models: \(scan.unknownModelsByDay)")
+        }
+    }
+
+    func testScanPricesRealCodexModelsFromBundledSnapshots() async throws {
+        let day = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
+        let home = try CodexLogFixture.makeHome(files: [
+            "sessions/rollout-a.jsonl": [
+                CodexLogFixture.turnContext(timestamp: day, model: "gpt-5.3-codex"),
+                CodexLogFixture.tokenCount(
+                    timestamp: day,
+                    last: CodexLogFixture.usage(input: 1_000_000, output: 0)
+                )
+            ].joined(separator: "\n")
+        ])
+        let scanner = CodexLogFixture.scanner(home: home)
+
+        let scan = await scanner.scan(pricing: TestPricing.bundled)
+        let today = scan?.series.daily.first
+
+        // gpt-5.3-codex must resolve in the bundled LiteLLM snapshot and price > $0.
+        XCTAssertTrue(scan?.unknownModelsByDay.isEmpty ?? false)
+        XCTAssertGreaterThan(today?.costUSD ?? 0, 0)
+    }
+}

--- a/Tests/OpenUsageTests/CodexLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/CodexLogUsageScannerTests.swift
@@ -1,13 +1,8 @@
 import XCTest
 @testable import OpenUsage
 
-/// `CodexLogUsageScanner` against fixture rollout files — parsing, totals deltas, model tracking,
-/// subagent replay skipping, dedup, aggregation, and the end-to-end scan. Fixture semantics ported
-/// from ccusage's Codex adapter tests.
-final class CodexLogUsageScannerTests: XCTestCase {
-    private let pricing = TestPricing.bundled
-
-    private func fixedRates(_ input: Double = 1000, _ output: Double = 3000) -> ModelPricing {
+enum CodexLogUsageScannerTestFixtures {
+    static func fixedRates(_ input: Double = 1000, _ output: Double = 3000) -> ModelPricing {
         ModelPricing(
             supplement: PricingSupplement(),
             primary: PricingCatalog(entries: ["gpt-5.2": ModelRates(
@@ -17,7 +12,12 @@ final class CodexLogUsageScannerTests: XCTestCase {
             secondary: PricingCatalog(entries: [:])
         )
     }
+}
 
+/// `CodexLogUsageScanner` against fixture rollout files — parsing, totals deltas, model tracking,
+/// subagent replay skipping, dedup, and aggregation. Fixture semantics are ported
+/// from ccusage's Codex adapter tests.
+final class CodexLogUsageScannerTests: XCTestCase {
     // MARK: - Line parsing
 
     func testLastTokenUsageWinsOverTotalsDelta() {
@@ -274,7 +274,7 @@ final class CodexLogUsageScannerTests: XCTestCase {
                 makeEvent("2026-05-12T09:00:00.000Z"),
                 makeEvent("2026-05-13T08:00:00.000Z")
             ],
-            since: .distantPast, pricing: fixedRates(), fastTier: false
+            since: .distantPast, pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: false
         )
 
         XCTAssertEqual(scan.series.daily.count, 2)
@@ -299,7 +299,7 @@ final class CodexLogUsageScannerTests: XCTestCase {
             total: 150
         )
         let scan = CodexLogUsageScanner.aggregate(
-            events: [event], since: .distantPast, pricing: fixedRates(), fastTier: false
+            events: [event], since: .distantPast, pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: false
         )
 
         var lines: [MetricLine] = []
@@ -323,7 +323,7 @@ final class CodexLogUsageScannerTests: XCTestCase {
         // The same event parsed from a copied session file counts once.
         let event = makeEvent("2026-05-12T08:00:00.000Z")
         let scan = CodexLogUsageScanner.aggregate(
-            events: [event, event], since: .distantPast, pricing: fixedRates(), fastTier: false
+            events: [event, event], since: .distantPast, pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: false
         )
 
         XCTAssertEqual(scan.series.daily.first?.totalTokens, 150)
@@ -332,7 +332,7 @@ final class CodexLogUsageScannerTests: XCTestCase {
     func testAggregateCachedTokensPriceAtCacheReadRate() {
         let scan = CodexLogUsageScanner.aggregate(
             events: [makeEvent("2026-05-12T08:00:00.000Z", input: 1000, cached: 400, output: 0)],
-            since: .distantPast, pricing: fixedRates(), fastTier: false
+            since: .distantPast, pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: false
         )
 
         // 600 non-cached x $1000/M + 400 cached x $100/M = 0.6 + 0.04.
@@ -342,11 +342,11 @@ final class CodexLogUsageScannerTests: XCTestCase {
     func testAggregateFastTierDoublesWhenNoExplicitMultiplier() {
         let base = CodexLogUsageScanner.aggregate(
             events: [makeEvent("2026-05-12T08:00:00.000Z")],
-            since: .distantPast, pricing: fixedRates(), fastTier: false
+            since: .distantPast, pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: false
         )
         let fast = CodexLogUsageScanner.aggregate(
             events: [makeEvent("2026-05-12T08:00:00.000Z")],
-            since: .distantPast, pricing: fixedRates(), fastTier: true
+            since: .distantPast, pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: true
         )
 
         XCTAssertEqual(
@@ -367,7 +367,7 @@ final class CodexLogUsageScannerTests: XCTestCase {
                 makeEvent("2026-05-12T08:00:00.000Z", model: "mystery-model-9"),
                 makeEvent("2026-05-12T09:00:00.000Z")
             ],
-            since: .distantPast, pricing: fixedRates(), fastTier: false
+            since: .distantPast, pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: false
         )
 
         // Unpriceable tokens never enter the displayed totals — they surface only through the
@@ -381,7 +381,7 @@ final class CodexLogUsageScannerTests: XCTestCase {
     func testAggregateUnknownModelOnlyLeavesDayUnbacked() {
         let scan = CodexLogUsageScanner.aggregate(
             events: [makeEvent("2026-05-12T08:00:00.000Z", model: "mystery-model-9")],
-            since: .distantPast, pricing: fixedRates(), fastTier: false
+            since: .distantPast, pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: false
         )
 
         // A day with nothing priceable produces no series entry at all (→ "No data"), but the
@@ -395,109 +395,10 @@ final class CodexLogUsageScannerTests: XCTestCase {
         let scan = CodexLogUsageScanner.aggregate(
             events: [makeEvent("2026-01-01T08:00:00.000Z"), makeEvent("2026-05-12T08:00:00.000Z")],
             since: OpenUsageISO8601.date(from: "2026-05-01T00:00:00.000Z")!,
-            pricing: fixedRates(), fastTier: false
+            pricing: CodexLogUsageScannerTestFixtures.fixedRates(), fastTier: false
         )
 
         XCTAssertEqual(scan.series.daily.map(\.date), ["2026-05-12"])
     }
 
-    // MARK: - End-to-end scan
-
-    func testScanReadsSessionsAndArchivedSessions() async throws {
-        let day = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
-        let home = try CodexLogFixture.makeHome(files: [
-            "sessions/2026/05/rollout-a.jsonl": [
-                CodexLogFixture.turnContext(timestamp: day, model: "gpt-5.2"),
-                CodexLogFixture.tokenCount(timestamp: day, last: CodexLogFixture.usage(input: 100, output: 50))
-            ].joined(separator: "\n"),
-            "archived_sessions/rollout-b.jsonl": CodexLogFixture.tokenCount(
-                timestamp: day, last: CodexLogFixture.usage(input: 30, output: 20), model: "gpt-5.2"
-            )
-        ])
-        let scanner = CodexLogFixture.scanner(home: home)
-
-        let scan = await scanner.scan(pricing: fixedRates())
-
-        XCTAssertEqual(scan?.series.daily.reduce(0) { $0 + $1.totalTokens }, 200)
-    }
-
-    func testScanPrefersActiveSessionsCopyOverArchivedDuplicate() async throws {
-        let day = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
-        let content = CodexLogFixture.tokenCount(
-            timestamp: day, last: CodexLogFixture.usage(input: 100, output: 50), model: "gpt-5.2"
-        )
-        let home = try CodexLogFixture.makeHome(files: [
-            "sessions/rollout-a.jsonl": content,
-            "archived_sessions/rollout-a.jsonl": content
-        ])
-        let scanner = CodexLogFixture.scanner(home: home)
-
-        let scan = await scanner.scan(pricing: fixedRates())
-
-        // Same relative path in both dirs = the same session archived; identical events dedupe
-        // anyway, but the discovery-level rule keeps it to one parse.
-        XCTAssertEqual(scan?.series.daily.reduce(0) { $0 + $1.totalTokens }, 150)
-    }
-
-    func testScanReturnsNilWithoutCodexHome() async {
-        let scanner = CodexLogFixture.scanner(home: nil)
-        let scan = await scanner.scan(pricing: fixedRates())
-        XCTAssertNil(scan)
-    }
-
-    func testScanCachesUnchangedFilesAndPicksUpNewOnes() async throws {
-        let day = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
-        let home = try CodexLogFixture.makeHome(files: [
-            "sessions/rollout-a.jsonl": CodexLogFixture.tokenCount(
-                timestamp: day, last: CodexLogFixture.usage(input: 100, output: 50), model: "gpt-5.2"
-            )
-        ])
-        let scanner = CodexLogFixture.scanner(home: home)
-
-        let first = await scanner.scan(pricing: fixedRates())
-        XCTAssertEqual(first?.series.daily.reduce(0) { $0 + $1.totalTokens }, 150)
-
-        try CodexLogFixture.tokenCount(
-            timestamp: day, last: CodexLogFixture.usage(input: 30, output: 20), model: "gpt-5.2"
-        ).write(to: home.appendingPathComponent("sessions/rollout-b.jsonl"), atomically: true, encoding: .utf8)
-
-        let second = await scanner.scan(pricing: fixedRates())
-        XCTAssertEqual(second?.series.daily.reduce(0) { $0 + $1.totalTokens }, 200)
-    }
-
-    /// Manual parity harness against the real logs on this machine: prints per-day totals to compare
-    /// with `ccusage codex daily --json --offline`. Gated like the other live tests.
-    func testParityAgainstRealLocalLogs() async throws {
-        try XCTSkipUnless(ProcessInfo.processInfo.environment["OPENUSAGE_CODEX_PARITY"] == "1")
-        let scanner = CodexLogUsageScanner()
-        let result = await scanner.scan(pricing: TestPricing.bundled)
-        let scan = try XCTUnwrap(result)
-        for day in scan.series.daily.sorted(by: { $0.date < $1.date }) {
-            print("PARITY \(day.date) tokens=\(day.totalTokens) cost=\(day.costUSD.map { String(format: "%.4f", $0) } ?? "nil")")
-        }
-        if !scan.unknownModelsByDay.isEmpty {
-            print("PARITY unknown models: \(scan.unknownModelsByDay)")
-        }
-    }
-
-    func testScanPricesRealCodexModelsFromBundledSnapshots() async throws {
-        let day = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
-        let home = try CodexLogFixture.makeHome(files: [
-            "sessions/rollout-a.jsonl": [
-                CodexLogFixture.turnContext(timestamp: day, model: "gpt-5.3-codex"),
-                CodexLogFixture.tokenCount(
-                    timestamp: day,
-                    last: CodexLogFixture.usage(input: 1_000_000, output: 0)
-                )
-            ].joined(separator: "\n")
-        ])
-        let scanner = CodexLogFixture.scanner(home: home)
-
-        let scan = await scanner.scan(pricing: pricing)
-        let today = scan?.series.daily.first
-
-        // gpt-5.3-codex must resolve in the bundled LiteLLM snapshot and price > $0.
-        XCTAssertTrue(scan?.unknownModelsByDay.isEmpty ?? false)
-        XCTAssertGreaterThan(today?.costUSD ?? 0, 0)
-    }
 }


### PR DESCRIPTION
## TL;DR

Split the oversized Claude and Codex log-scanner test files into focused scanner and end-to-end scan files. Test behavior, fixtures, and XCTest identifiers stay unchanged.

## What was happening

- `ClaudeLogUsageScannerTests.swift` had grown to 517 lines.
- `CodexLogUsageScannerTests.swift` had grown to 503 lines.
- Parsing, aggregation, file discovery, cache invalidation, and live parity coverage were all mixed into two files.

## What this changes

- Moves Claude end-to-end file-discovery and Cowork-root tests into `ClaudeLogUsageScannerScanTests.swift`.
- Moves Codex end-to-end session-discovery and caching tests into `CodexLogUsageScannerScanTests.swift`.
- Keeps the new files as extensions of the original test classes so every XCTest identifier remains stable.
- Shares each pricing fixture from one definition instead of copying fixture setup.
- Leaves all four resulting files below the project 500-line guideline.

## Tests

- `swift test --filter "ClaudeLogUsageScannerTests|CodexLogUsageScannerTests"` — 54 tests, 2 opt-in parity skips, 0 failures.
- `swift test` — 962 XCTest cases, 3 opt-in skips, 0 failures; 3 Swift Testing cases passed.
- `git diff --cached --check`.
- Verified the complete Claude and Codex test-name sets match `origin/main`.

No production behavior or visual output changes, so documentation and screenshots are not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only file moves and fixture visibility tweaks; no app or scanner implementation changes.
> 
> **Overview**
> Splits **Claude** and **Codex** log-scanner tests that had grown past the ~500-line guideline into four smaller files without changing test behavior or names.
> 
> **Claude:** End-to-end coverage (fixture home scans, cache invalidation, sidechain dedup, Cowork session roots, `CLAUDE_CONFIG_DIR` parity, opt-in live parity) moves to `ClaudeLogUsageScannerScanTests.swift` as an **extension** of `ClaudeLogUsageScannerTests`. The base file keeps parsing, dedup, and aggregation tests; `pricing` is widened from `private` to `let` so the extension can reuse it.
> 
> **Codex:** Session discovery, archived vs active sessions, file caching, bundled pricing, and parity tests move to `CodexLogUsageScannerScanTests.swift` as an extension of `CodexLogUsageScannerTests`. `fixedRates` becomes `CodexLogUsageScannerTestFixtures.fixedRates()` so unit and scan tests share one pricing helper.
> 
> No production or scanner logic changes—layout and fixture sharing only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64a417fa4b130e4b6c1b5f46cc9419c49bbb882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->