### PR TITLE
Validate Cursor boundary data without losing primary usage

### DIFF
--- a/Sources/OpenUsage/Providers/Cursor/CursorCSVParser.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorCSVParser.swift
@@ -1,35 +1,68 @@
 import Foundation
 
 /// Minimal CSV parser supporting quoted fields with embedded commas, newlines, and escaped quotes
-/// (`""` → `"`). Streams records keyed by the header row. Ported verbatim from
+/// (`""` → `"`). Streams records keyed by the header row. Adapted from
 /// `../cursorcat/Sources/CursorCat/API/CSVParser.swift`.
 enum CursorCSVParser {
-    static func forEachRecord(in text: String, _ body: ([String: String]) -> Void) {
+    struct Summary: Equatable {
+        var isStructurallyComplete: Bool
+        var rejectedRecordCount: Int
+    }
+
+    /// Streams records and reports structural failures plus rows whose width differs from the header.
+    /// `header` exposes the normalized header once so boundary mappers can validate their required
+    /// schema without parsing the whole export a second time.
+    @discardableResult
+    static func forEachRecord(
+        in text: String,
+        header onHeader: (([String]) -> Void)? = nil,
+        _ body: ([String: String]) -> Void
+    ) -> Summary {
         var header: [String]?
-        forEachRow(in: text) { row in
+        var rejectedRecordCount = 0
+        let isStructurallyComplete = forEachRow(in: text) { row in
             guard let keys = header else {
-                header = row
+                let normalized = row.map {
+                    $0.trimmingCharacters(in: .whitespacesAndNewlines.union(CharacterSet(charactersIn: "\u{FEFF}")))
+                }
+                header = normalized
+                onHeader?(normalized)
                 return
             }
 
+            guard row.count == keys.count else {
+                rejectedRecordCount += 1
+                return
+            }
             var dict: [String: String] = [:]
-            for (i, key) in keys.enumerated() where i < row.count {
+            for (i, key) in keys.enumerated() {
                 dict[key] = row[i]
             }
             body(dict)
         }
+        return Summary(
+            isStructurallyComplete: isStructurallyComplete,
+            rejectedRecordCount: rejectedRecordCount
+        )
     }
 
-    private static func forEachRow(in text: String, _ body: ([String]) -> Void) {
+    private static func forEachRow(in text: String, _ body: ([String]) -> Void) -> Bool {
+        enum FieldState: Equatable {
+            case start
+            case unquoted
+            case quoted
+            case quoteClosed
+        }
+
         var field = ""
         var row: [String] = []
-        var inQuotes = false
+        var state = FieldState.start
         var i = text.startIndex
 
         while i < text.endIndex {
             let c = text[i]
 
-            if inQuotes {
+            if state == .quoted {
                 if c == "\"" {
                     let next = text.index(after: i)
                     if next < text.endIndex && text[next] == "\"" {
@@ -37,7 +70,7 @@ enum CursorCSVParser {
                         i = text.index(after: next)
                         continue
                     } else {
-                        inQuotes = false
+                        state = .quoteClosed
                         i = next
                         continue
                     }
@@ -48,30 +81,68 @@ enum CursorCSVParser {
                 }
             }
 
-            switch c {
-            case "\"":
-                inQuotes = true
-            case ",":
-                row.append(field)
-                field = ""
-            case "\r":
-                break
-            case "\n":
-                row.append(field)
-                emit(row, body)
-                row = []
-                field = ""
-            default:
-                field.append(c)
+            switch state {
+            case .start:
+                switch c {
+                case "\"":
+                    state = .quoted
+                case ",":
+                    row.append(field)
+                    field = ""
+                case "\r", "\n", "\r\n":
+                    row.append(field)
+                    emit(row, body)
+                    row = []
+                    field = ""
+                default:
+                    field.append(c)
+                    state = .unquoted
+                }
+            case .unquoted:
+                switch c {
+                case "\"":
+                    return false
+                case ",":
+                    row.append(field)
+                    field = ""
+                    state = .start
+                case "\r", "\n", "\r\n":
+                    row.append(field)
+                    emit(row, body)
+                    row = []
+                    field = ""
+                    state = .start
+                default:
+                    field.append(c)
+                }
+            case .quoteClosed:
+                switch c {
+                case ",":
+                    row.append(field)
+                    field = ""
+                    state = .start
+                case "\r", "\n", "\r\n":
+                    row.append(field)
+                    emit(row, body)
+                    row = []
+                    field = ""
+                    state = .start
+                default:
+                    return false
+                }
+            case .quoted:
+                preconditionFailure("quoted fields are handled before the state switch")
             }
             i = text.index(after: i)
         }
 
+        guard state != .quoted else { return false }
         // Trailing partial row.
-        if !field.isEmpty || !row.isEmpty {
+        if !field.isEmpty || !row.isEmpty || state == .quoteClosed {
             row.append(field)
             emit(row, body)
         }
+        return true
     }
 
     private static func emit(_ row: [String], _ body: ([String]) -> Void) {

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -157,15 +157,45 @@ final class CursorProvider: ProviderRuntime {
         let startOfToday = calendar.startOfDay(for: end)
         let start = calendar.date(byAdding: .day, value: -29, to: startOfToday) ?? startOfToday
 
-        guard let response = try? await usageClient.fetchUsageCSV(accessToken: accessToken, start: start, end: end),
-              (200..<300).contains(response.statusCode),
-              let csv = String(data: response.body, encoding: .utf8)
-        else {
+        let response: HTTPResponse?
+        do {
+            response = try await usageClient.fetchUsageCSV(accessToken: accessToken, start: start, end: end)
+        } catch {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV request failed")
+            return
+        }
+        guard let response else {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV request could not be prepared from the current session")
+            return
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV request returned HTTP \(response.statusCode)")
+            return
+        }
+        guard let csv = String(data: response.body, encoding: .utf8) else {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV response was not valid UTF-8")
             return
         }
         let pricing = await pricing()
-        let rows = CursorUsageCSV.parse(csv: csv, pricing: pricing)
-        CursorUsageMapper.appendSpendLines(rows: rows, now: end, pricing: pricing, to: &lines)
+        do {
+            let parsed = try CursorUsageCSV.parse(csv: csv, pricing: pricing)
+            if parsed.rejectedRowCount > 0 {
+                AppLog.warn(
+                    LogTag.plugin("cursor"),
+                    "usage CSV ignored \(parsed.rejectedRowCount) malformed row\(parsed.rejectedRowCount == 1 ? "" : "s")"
+                )
+            }
+            CursorUsageMapper.appendSpendLines(rows: parsed.rows, now: end, pricing: pricing, to: &lines)
+        } catch let error as CursorUsageCSVError {
+            switch error {
+            case .missingColumns(let columns):
+                AppLog.warn(LogTag.plugin("cursor"), "usage CSV missing required columns: \(columns.joined(separator: ", "))")
+            case .malformedCSV:
+                AppLog.warn(LogTag.plugin("cursor"), "usage CSV is structurally malformed")
+            }
+        } catch {
+            AppLog.warn(LogTag.plugin("cursor"), "usage CSV could not be parsed")
+        }
     }
 
     private func fetchUsageWithRetry(accessToken: String, authState: inout CursorAuthState) async throws -> HTTPResponse {

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -123,18 +123,20 @@ final class CursorProvider: ProviderRuntime {
         }
 
         if shouldTryGenericRequestFallback(usage: usage) {
-            if let mapped = try? await requestBasedResult(
-                accessToken: currentToken,
-                planName: planName,
-                unavailableMessage: "Cursor request-based usage data unavailable. Try again later."
-            ) {
+            do {
+                let mapped = try await requestBasedResult(
+                    accessToken: currentToken,
+                    planName: planName,
+                    unavailableMessage: "Cursor request-based usage data unavailable. Try again later."
+                )
                 return snapshot(mapped)
+            } catch {
+                AppLog.warn(LogTag.plugin("cursor"), "optional request-based usage fallback failed")
             }
         }
 
         let creditGrants = await fetchCreditGrants(accessToken: currentToken)
-        let stripeResponse = try? await usageClient.fetchStripeBalance(accessToken: currentToken)
-        let stripeBalanceCents = CursorUsageMapper.stripeBalanceCents(from: stripeResponse ?? nil)
+        let stripeBalanceCents = await fetchStripeBalanceCents(accessToken: currentToken)
         var mapped = try CursorUsageMapper.mapUsage(
             usage: usage,
             planName: planName,
@@ -254,27 +256,82 @@ final class CursorProvider: ProviderRuntime {
     }
 
     private func fetchPlanName(accessToken: String) async -> (String?, Bool) {
-        do {
-            let response = try await usageClient.fetchPlan(accessToken: accessToken)
-            guard (200..<300).contains(response.statusCode),
-                  let body = ProviderParse.jsonObject(response.body),
-                  let planInfo = body["planInfo"] as? [String: Any]
-            else {
-                return (nil, true)
-            }
-            return (planInfo["planName"] as? String, false)
-        } catch {
+        guard let body = await fetchOptionalJSONObject(label: "plan", request: {
+            try await self.usageClient.fetchPlan(accessToken: accessToken)
+        }) else {
             return (nil, true)
         }
+        guard let planInfo = body["planInfo"] as? [String: Any],
+              let planName = (planInfo["planName"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .nilIfEmpty
+        else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional plan response contained invalid plan metadata")
+            return (nil, true)
+        }
+        return (planName, false)
     }
 
     private func fetchCreditGrants(accessToken: String) async -> [String: Any]? {
-        guard let response = try? await usageClient.fetchCredits(accessToken: accessToken),
-              (200..<300).contains(response.statusCode)
-        else {
+        guard let body = await fetchOptionalJSONObject(label: "credit-grants", request: {
+            try await self.usageClient.fetchCredits(accessToken: accessToken)
+        }) else {
             return nil
         }
-        return ProviderParse.jsonObject(response.body)
+        guard let hasCreditGrants = body["hasCreditGrants"] as? Bool else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional credit-grants response contained invalid grant metadata")
+            return nil
+        }
+        if hasCreditGrants {
+            guard let totalCents = ProviderParse.number(body["totalCents"]), totalCents > 0,
+                  let usedCents = ProviderParse.number(body["usedCents"]), usedCents >= 0 else {
+                AppLog.warn(LogTag.plugin("cursor"), "optional credit-grants response contained invalid grant metadata")
+                return nil
+            }
+        }
+        return body
+    }
+
+    private func fetchStripeBalanceCents(accessToken: String) async -> Double {
+        guard let body = await fetchOptionalJSONObject(label: "prepaid-balance", request: {
+            try await self.usageClient.fetchStripeBalance(accessToken: accessToken)
+        }) else {
+            return 0
+        }
+        guard ProviderParse.number(body["customerBalance"]) != nil else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional prepaid-balance response contained invalid balance metadata")
+            return 0
+        }
+        return CursorUsageMapper.stripeBalanceCents(from: body)
+    }
+
+    /// Optional endpoints enrich a usable primary snapshot; they never fail the whole provider. Keep
+    /// their boundary handling in one place so transport, preparation, status, and schema failures are
+    /// all visible with fixed, credential-free diagnostics.
+    private func fetchOptionalJSONObject(
+        label: String,
+        request: () async throws -> HTTPResponse?
+    ) async -> [String: Any]? {
+        let response: HTTPResponse?
+        do {
+            response = try await request()
+        } catch {
+            AppLog.warn(LogTag.plugin("cursor"), "optional \(label) request failed")
+            return nil
+        }
+        guard let response else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional \(label) request could not be prepared from the current session")
+            return nil
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional \(label) request returned HTTP \(response.statusCode)")
+            return nil
+        }
+        guard let body = ProviderParse.jsonObject(response.body) else {
+            AppLog.warn(LogTag.plugin("cursor"), "optional \(label) response was invalid")
+            return nil
+        }
+        return body
     }
 
     private func requestBasedResult(accessToken: String, planName: String?, unavailableMessage: String) async throws -> CursorMappedUsage {

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
@@ -11,7 +11,27 @@ struct CursorUsageCSVRow: Sendable, Equatable {
     var imputedCostDollars: Double?
 }
 
+struct CursorUsageCSVParseResult: Sendable, Equatable {
+    var rows: [CursorUsageCSVRow]
+    var rejectedRowCount: Int
+}
+
+enum CursorUsageCSVError: Error, Equatable {
+    case missingColumns([String])
+    case malformedCSV
+}
+
 enum CursorUsageCSV {
+    private enum Column {
+        static let date = "Date"
+        static let model = "Model"
+        static let cacheWrite = "Input (w/ Cache Write)"
+        static let input = "Input (w/o Cache Write)"
+        static let cacheRead = "Cache Read"
+        static let output = "Output Tokens"
+        static let required = [date, model, cacheWrite, input, cacheRead, output]
+    }
+
     // Date parsing runs once per row of a potentially large export; the three fixed-format parsers are
     // stateless after configuration, so they're built once instead of per call. DateFormatter and
     // ISO8601DateFormatter are thread-safe for parsing; `nonisolated(unsafe)` shares the immutable
@@ -33,28 +53,52 @@ enum CursorUsageCSV {
         return f
     }()
 
-    /// Pure parser: maps Cursor's exported CSV text into priced rows. Rows with an unparseable date or
-    /// header are skipped.
+    /// Pure boundary parser: maps Cursor's exported CSV text into priced rows, rejects malformed rows,
+    /// and fails when the export schema itself is unusable. Empty numeric cells are valid zeroes; a
+    /// non-empty non-integer or negative token count rejects that row instead of silently becoming zero.
     ///
     /// Cursor's CSV rows are aggregates, not individual requests, so long-context thresholds and Max
     /// Mode uplift cannot be applied reliably from row totals; rows bill at the base model API rate.
-    static func parse(csv: String, pricing: ModelPricing) -> [CursorUsageCSVRow] {
+    static func parse(csv: String, pricing: ModelPricing) throws -> CursorUsageCSVParseResult {
         var rows: [CursorUsageCSVRow] = []
-        CursorCSVParser.forEachRecord(in: csv) { r in
-            guard let dateStr = r["Date"]?.trimmingCharacters(in: .whitespaces),
+        var rejectedRowCount = 0
+        var acceptedTokenCount = 0
+        var missingColumns = Column.required
+        var hasDuplicateColumns = false
+        let summary = CursorCSVParser.forEachRecord(in: csv, header: { header in
+            let available = Set(header)
+            missingColumns = Column.required.filter { !available.contains($0) }
+            hasDuplicateColumns = available.count != header.count
+        }) { r in
+            guard let dateStr = r[Column.date]?.trimmingCharacters(in: .whitespaces),
                   !dateStr.isEmpty,
-                  let date = parseDate(dateStr)
-            else { return }
+                  let date = parseDate(dateStr),
+                  let model = r[Column.model]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !model.isEmpty,
+                  let cacheWrite = parseIntValue(r[Column.cacheWrite]),
+                  let input = parseIntValue(r[Column.input]),
+                  let cacheRead = parseIntValue(r[Column.cacheRead]),
+                  let output = parseIntValue(r[Column.output]),
+                  let rowTokenCount = addingWithoutOverflow([cacheWrite, input, cacheRead, output])
+            else {
+                rejectedRowCount += 1
+                return
+            }
+            let aggregate = acceptedTokenCount.addingReportingOverflow(rowTokenCount)
+            guard !aggregate.overflow else {
+                rejectedRowCount += 1
+                return
+            }
+            acceptedTokenCount = aggregate.partialValue
 
-            let model = (r["Model"] ?? "").trimmingCharacters(in: .whitespaces)
             // The CSV's "Input (w/ Cache Write)" tokens were written to the prompt cache; Anthropic
             // bills those at the 5-minute cache-write rate, other providers at the input rate (their
             // pricing entries carry cacheWrite == input).
             let tokens = TokenBreakdown(
-                input: parseIntValue(r["Input (w/o Cache Write)"] ?? ""),
-                cacheWrite5m: parseIntValue(r["Input (w/ Cache Write)"] ?? ""),
-                cacheRead: parseIntValue(r["Cache Read"] ?? ""),
-                output: parseIntValue(r["Output Tokens"] ?? "")
+                input: input,
+                cacheWrite5m: cacheWrite,
+                cacheRead: cacheRead,
+                output: output
             )
 
             rows.append(CursorUsageCSVRow(
@@ -68,7 +112,12 @@ enum CursorUsageCSV {
                 )
             ))
         }
-        return rows
+        guard summary.isStructurallyComplete, !hasDuplicateColumns else {
+            throw CursorUsageCSVError.malformedCSV
+        }
+        guard missingColumns.isEmpty else { throw CursorUsageCSVError.missingColumns(missingColumns) }
+        rejectedRowCount += summary.rejectedRecordCount
+        return CursorUsageCSVParseResult(rows: rows, rejectedRowCount: rejectedRowCount)
     }
 
     private static func parseDate(_ raw: String) -> Date? {
@@ -77,10 +126,37 @@ enum CursorUsageCSV {
         return plainDateTime.date(from: raw)
     }
 
-    private static func parseIntValue(_ raw: String) -> Int {
-        let normalized = raw.replacingOccurrences(of: ",", with: "")
-            .trimmingCharacters(in: .whitespaces)
+    private static func parseIntValue(_ raw: String?) -> Int? {
+        guard let raw else { return nil }
+        let normalized = raw.trimmingCharacters(in: .whitespaces)
         if normalized.isEmpty { return 0 }
-        return Int(normalized) ?? 0
+
+        let groups = normalized.split(separator: ",", omittingEmptySubsequences: false)
+        if groups.count > 1 {
+            guard let first = groups.first,
+                  (1...3).contains(first.utf8.count),
+                  isASCIIDigits(first),
+                  groups.dropFirst().allSatisfy({ $0.utf8.count == 3 && isASCIIDigits($0) })
+            else {
+                return nil
+            }
+        } else if !isASCIIDigits(normalized[...]) {
+            return nil
+        }
+        return Int(groups.joined())
+    }
+
+    private static func isASCIIDigits(_ value: Substring) -> Bool {
+        !value.isEmpty && value.utf8.allSatisfy { (48...57).contains($0) }
+    }
+
+    private static func addingWithoutOverflow(_ values: [Int]) -> Int? {
+        var total = 0
+        for value in values {
+            let addition = total.addingReportingOverflow(value)
+            guard !addition.overflow else { return nil }
+            total = addition.partialValue
+        }
+        return total
     }
 }

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -360,11 +360,9 @@ enum CursorUsageMapper {
         }
     }
 
-    static func stripeBalanceCents(from response: HTTPResponse?) -> Double {
-        guard let response,
-              (200..<300).contains(response.statusCode),
-              let stripe = ProviderParse.jsonObject(response.body),
-              let balance = ProviderParse.number(stripe["customerBalance"]),
+    static func stripeBalanceCents(from body: [String: Any]?) -> Double {
+        guard let body,
+              let balance = ProviderParse.number(body["customerBalance"]),
               balance < 0
         else {
             return 0

--- a/Sources/OpenUsage/Support/ProviderParse.swift
+++ b/Sources/OpenUsage/Support/ProviderParse.swift
@@ -18,9 +18,12 @@ enum ProviderParse {
         }
     }
 
-    /// Permissive numeric read: accepts JSON numbers and numeric strings, rejecting non-finite values.
+    /// Permissive numeric read: accepts JSON numbers and numeric strings, rejecting booleans and
+    /// non-finite values. `JSONSerialization` bridges booleans through `NSNumber`, so the Core
+    /// Foundation type check is required to keep `true`/`false` from becoming `1`/`0`.
     static func number(_ value: Any?) -> Double? {
         if let number = value as? NSNumber {
+            guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
             let doubleValue = number.doubleValue
             return doubleValue.isFinite ? doubleValue : nil
         }

--- a/Tests/OpenUsageTests/CursorCSVBoundaryTests.swift
+++ b/Tests/OpenUsageTests/CursorCSVBoundaryTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import OpenUsage
+
+final class CursorCSVBoundaryTests: XCTestCase {
+    private let header = "Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens"
+
+    func testParserRejectsIllegalQuotePlacement() {
+        let malformed = [
+            "Date,Model\n2026-01-01T00:00:00Z,\"composer-1\"suffix",
+            "Date,Model\n2026-01-01T00:00:00Z,com\"poser-1"
+        ]
+
+        for csv in malformed {
+            let summary = CursorCSVParser.forEachRecord(in: csv) { _ in
+                XCTFail("a structurally malformed record must not be emitted")
+            }
+            XCTAssertFalse(summary.isStructurallyComplete, csv)
+        }
+    }
+
+    func testUsageCSVValidatesGroupedAndUngroupedIntegers() throws {
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,,,,
+        2026-01-01T00:00:00Z,composer-1,0,"1,234",0,0
+        2026-01-01T00:00:00Z,composer-1,0,",",0,0
+        2026-01-01T00:00:00Z,composer-1,0,"1,2",0,0
+        2026-01-01T00:00:00Z,composer-1,0,"1,,2",0,0
+        2026-01-01T00:00:00Z,composer-1,0,"12,34",0,0
+        2026-01-01T00:00:00Z,composer-1,0,-1,0,0
+        2026-01-01T00:00:00Z,composer-1,0,1.5,0,0
+        2026-01-01T00:00:00Z,composer-1,0,1e3,0,0
+        2026-01-01T00:00:00Z,composer-1,0,9223372036854775808,0,0
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.tokens.totalTokens), [0, 1_234])
+        XCTAssertEqual(parsed.rejectedRowCount, 8)
+    }
+
+    func testUsageCSVRejectsRowsWhoseTokenBucketsOverflow() throws {
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,\(Int.max),1,0,0
+        2026-01-01T00:00:00Z,composer-1,0,100,0,0
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.tokens.totalTokens), [100])
+        XCTAssertEqual(parsed.rejectedRowCount, 1)
+    }
+
+    func testUsageCSVRejectsAggregateOverflowWithoutDiscardingSafeRows() throws {
+        let firstRowTokens = Int.max - 1
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,0,\(firstRowTokens),0,0
+        2026-01-02T00:00:00Z,composer-1,0,2,0,0
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.tokens.totalTokens), [firstRowTokens])
+        XCTAssertEqual(parsed.rejectedRowCount, 1)
+    }
+
+    func testUsageCSVAcceptsLargeNonOverflowingValues() throws {
+        let large = Int.max / 2
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,0,\(large),0,1
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.first?.tokens.totalTokens, large + 1)
+        XCTAssertEqual(parsed.rejectedRowCount, 0)
+    }
+
+    func testUsageCSVRejectsMismatchedRecordWidths() throws {
+        let csv = """
+        \(header)
+        2026-01-01T00:00:00Z,composer-1,0,10,0,20
+        2026-01-01T00:00:00Z,composer-1,0,10,0,20,
+        2026-01-01T00:00:00Z,composer-1,0,10,0
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.tokens.totalTokens), [30])
+        XCTAssertEqual(parsed.rejectedRowCount, 2)
+    }
+
+    func testUsageCSVAcceptsBOMQuotedHeadersAndOptionalColumns() throws {
+        let csv = """
+        "﻿Date","Model","Input (w/ Cache Write)","Input (w/o Cache Write)","Cache Read","Output Tokens",Cost
+        2026-01-01T00:00:00Z,composer-1,,,,,Included
+        """
+
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.first?.tokens.totalTokens, 0)
+        XCTAssertEqual(parsed.rejectedRowCount, 0)
+    }
+
+    func testUsageCSVRejectsMissingDuplicateAndStructurallyMalformedColumns() {
+        let missingOutput = """
+        Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read
+        2026-01-01T00:00:00Z,composer-1,0,10,0
+        """
+        XCTAssertThrowsError(try CursorUsageCSV.parse(csv: missingOutput, pricing: TestPricing.bundled)) { error in
+            XCTAssertEqual(error as? CursorUsageCSVError, .missingColumns(["Output Tokens"]))
+        }
+
+        let duplicateDate = """
+        Date,Date,Model,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens
+        2026-01-01T00:00:00Z,2026-01-01T00:00:00Z,composer-1,0,10,0,20
+        """
+        XCTAssertThrowsError(try CursorUsageCSV.parse(csv: duplicateDate, pricing: TestPricing.bundled)) { error in
+            XCTAssertEqual(error as? CursorUsageCSVError, .malformedCSV)
+        }
+
+        let unterminated = """
+        \(header)
+        2026-01-01T00:00:00Z,"composer-1,0,10,0,20
+        """
+        XCTAssertThrowsError(try CursorUsageCSV.parse(csv: unterminated, pricing: TestPricing.bundled)) { error in
+            XCTAssertEqual(error as? CursorUsageCSVError, .malformedCSV)
+        }
+    }
+}

--- a/Tests/OpenUsageTests/CursorOptionalEndpointTests.swift
+++ b/Tests/OpenUsageTests/CursorOptionalEndpointTests.swift
@@ -105,7 +105,7 @@ final class CursorOptionalEndpointTests: XCTestCase {
         XCTAssertTrue(logs.contains("optional prepaid-balance response contained invalid balance metadata"), logs)
     }
 
-    func testMalformedCreditMetadataIsLoggedWithoutBogusBalance() async throws {
+    func testBooleanCreditAndPrepaidMetadataIsLoggedWithoutBogusBalance() async throws {
         let provider = makeProvider { request in
             switch request.url {
             case CursorUsageClient.usageURL:
@@ -120,10 +120,10 @@ final class CursorOptionalEndpointTests: XCTestCase {
                 return HTTPResponse(
                     statusCode: 200,
                     headers: [:],
-                    body: Data(#"{"hasCreditGrants":true,"totalCents":"10000","usedCents":"broken"}"#.utf8)
+                    body: Data(#"{"hasCreditGrants":true,"totalCents":true,"usedCents":0}"#.utf8)
                 )
             case CursorUsageClient.stripeURL:
-                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"customerBalance":0}"#.utf8))
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"customerBalance":true}"#.utf8))
             default:
                 return HTTPResponse(statusCode: 404, headers: [:], body: Data())
             }
@@ -134,6 +134,7 @@ final class CursorOptionalEndpointTests: XCTestCase {
         XCTAssertNil(snapshot.errorCategory)
         XCTAssertNil(snapshot.lines.first { $0.label == "Credits" })
         XCTAssertTrue(logs.contains("optional credit-grants response contained invalid grant metadata"), logs)
+        XCTAssertTrue(logs.contains("optional prepaid-balance response contained invalid balance metadata"), logs)
     }
 
     func testFailedGenericRequestFallbackIsLoggedBeforePrimaryMappingError() async throws {

--- a/Tests/OpenUsageTests/CursorOptionalEndpointTests.swift
+++ b/Tests/OpenUsageTests/CursorOptionalEndpointTests.swift
@@ -1,0 +1,251 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class CursorOptionalEndpointTests: XCTestCase {
+    func testOptionalSchemaAndHTTPFailuresAreLoggedWithoutDiscardingPrimaryUsage() async throws {
+        let accessToken = makeCursorJWT(includeSubject: true)
+        let provider = makeProvider(accessToken: accessToken) { request in
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return Self.primaryUsageResponse
+            case CursorUsageClient.planURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"planInfo":{"planName":42}}"#.utf8))
+            case CursorUsageClient.creditsURL:
+                return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+            case CursorUsageClient.stripeURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data("not-json".utf8))
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertEqual(progress(snapshot.lines, "Total usage")?.used, 20)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional plan response contained invalid plan metadata"), logs)
+        XCTAssertTrue(logs.contains("optional credit-grants request returned HTTP 503"), logs)
+        XCTAssertTrue(logs.contains("optional prepaid-balance response was invalid"), logs)
+        XCTAssertFalse(logs.contains(accessToken), logs)
+    }
+
+    func testOptionalTransportAndSessionPreparationFailuresAreLogged() async throws {
+        let provider = makeProvider(accessToken: makeCursorJWT(includeSubject: false)) { request in
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return Self.primaryUsageResponse
+            case CursorUsageClient.planURL, CursorUsageClient.creditsURL:
+                throw URLError(.cannotConnectToHost)
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertEqual(progress(snapshot.lines, "Total usage")?.used, 20)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional plan request failed"), logs)
+        XCTAssertTrue(logs.contains("optional credit-grants request failed"), logs)
+        XCTAssertTrue(logs.contains("optional prepaid-balance request could not be prepared from the current session"), logs)
+    }
+
+    func testInvalidPlanMetadataStillEnablesRequestBasedFallback() async throws {
+        let provider = makeProvider { request in
+            if request.url.absoluteString.hasPrefix(CursorUsageClient.restUsageURL.absoluteString) {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"gpt-4":{"maxRequestUsage":500,"numRequests":100}}"#.utf8)
+                )
+            }
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"enabled":true}"#.utf8))
+            case CursorUsageClient.planURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"planInfo":{"planName":42}}"#.utf8))
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertEqual(progress(snapshot.lines, "Requests")?.used, 100)
+        XCTAssertEqual(progress(snapshot.lines, "Requests")?.limit, 500)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional plan response contained invalid plan metadata"), logs)
+    }
+
+    func testMissingPrepaidBalanceMetadataIsLoggedWithoutDiscardingPrimaryUsage() async throws {
+        let provider = makeProvider { request in
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return Self.primaryUsageResponse
+            case CursorUsageClient.planURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"planInfo":{"planName":"pro"}}"#.utf8)
+                )
+            case CursorUsageClient.creditsURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"hasCreditGrants":false}"#.utf8))
+            case CursorUsageClient.stripeURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"unexpected":true}"#.utf8))
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertEqual(progress(snapshot.lines, "Total usage")?.used, 20)
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional prepaid-balance response contained invalid balance metadata"), logs)
+    }
+
+    func testMalformedCreditMetadataIsLoggedWithoutBogusBalance() async throws {
+        let provider = makeProvider { request in
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return Self.primaryUsageResponse
+            case CursorUsageClient.planURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"planInfo":{"planName":"pro"}}"#.utf8)
+                )
+            case CursorUsageClient.creditsURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"hasCreditGrants":true,"totalCents":"10000","usedCents":"broken"}"#.utf8)
+                )
+            case CursorUsageClient.stripeURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"customerBalance":0}"#.utf8))
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertNil(snapshot.lines.first { $0.label == "Credits" })
+        XCTAssertTrue(logs.contains("optional credit-grants response contained invalid grant metadata"), logs)
+    }
+
+    func testFailedGenericRequestFallbackIsLoggedBeforePrimaryMappingError() async throws {
+        let provider = makeProvider { request in
+            if request.url.absoluteString.hasPrefix(CursorUsageClient.restUsageURL.absoluteString) {
+                return HTTPResponse(statusCode: 502, headers: [:], body: Data())
+            }
+            switch request.url {
+            case CursorUsageClient.usageURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"enabled":true,"planUsage":{}}"#.utf8)
+                )
+            case CursorUsageClient.planURL:
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"planInfo":{"planName":"pro"}}"#.utf8)
+                )
+            default:
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let (snapshot, logs) = try await captureLogs { await provider.refresh() }
+
+        XCTAssertNotNil(snapshot.errorCategory)
+        XCTAssertTrue(logs.contains("optional request-based usage fallback failed"), logs)
+    }
+
+    private nonisolated static var primaryUsageResponse: HTTPResponse {
+        HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data(
+                #"{"enabled":true,"billingCycleEnd":1772592000000,"planUsage":{"limit":40000,"remaining":32000,"totalPercentUsed":20}}"#.utf8
+            )
+        )
+    }
+
+    private func makeProvider(
+        accessToken: String = makeCursorJWT(includeSubject: true),
+        handler: @escaping @Sendable (HTTPRequest) async throws -> HTTPResponse
+    ) -> CursorProvider {
+        CursorProvider(
+            authStore: CursorAuthStore(
+                sqlite: OptionalCursorSQLite(values: [CursorAuthStore.accessTokenKey: accessToken]),
+                keychain: FakeKeychain()
+            ),
+            usageClient: CursorUsageClient(http: RoutingHTTPClient(handler: handler)),
+            now: { Date(timeIntervalSince1970: 1_800_000_000) },
+            pricing: { TestPricing.bundled }
+        )
+    }
+
+    private func captureLogs(
+        _ operation: () async -> ProviderSnapshot
+    ) async throws -> (ProviderSnapshot, String) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.CursorOptional.\(UUID().uuidString)", isDirectory: true)
+        let sink = LogFile(directory: directory, fileName: "OpenUsage.log")
+        sink.open()
+        let originalSink = AppLog.sink
+        AppLog.sink = sink
+        AppLog.reloadLevel(.warn)
+        defer {
+            AppLog.sink = originalSink
+            AppLog.reloadLevel()
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let snapshot = await operation()
+        let logs = try String(contentsOf: directory.appendingPathComponent("OpenUsage.log"), encoding: .utf8)
+        return (snapshot, logs)
+    }
+
+    private func progress(
+        _ lines: [MetricLine],
+        _ label: String
+    ) -> (used: Double, limit: Double)? {
+        guard case .progress(_, let used, let limit, _, _, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return (used, limit)
+    }
+}
+
+private func makeCursorJWT(includeSubject: Bool) -> String {
+    let payload = includeSubject
+        ? #"{"exp":9999999999,"sub":"google-oauth2|user"}"#
+        : #"{"exp":9999999999}"#
+    let encoded = Data(payload.utf8).base64EncodedString()
+        .replacingOccurrences(of: "=", with: "")
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+    return "a.\(encoded).c"
+}
+
+private final class OptionalCursorSQLite: SQLiteAccessing, @unchecked Sendable {
+    private let values: [String: String]
+
+    init(values: [String: String]) {
+        self.values = values
+    }
+
+    func queryValue(path: String, sql: String) throws -> String? {
+        for (key, value) in values where sql.contains(key) {
+            return value
+        }
+        return nil
+    }
+
+    func execute(path: String, sql: String) throws {}
+}

--- a/Tests/OpenUsageTests/CursorProviderTests.swift
+++ b/Tests/OpenUsageTests/CursorProviderTests.swift
@@ -165,6 +165,26 @@ final class CursorUsageMapperTests: XCTestCase {
         XCTAssertEqual(total.limit, 400, accuracy: 0.001)   // of a $400.00 limit
         XCTAssertFalse(mapped.lines.contains { $0.label == "Bonus spend" })
     }
+
+    func testTeamBooleanTotalSpendFallsBackToLimitMinusRemaining() throws {
+        let mapped = try CursorUsageMapper.mapUsage(
+            usage: [
+                "enabled": true,
+                "planUsage": [
+                    "limit": 40_000,
+                    "remaining": 32_000,
+                    "totalSpend": true
+                ]
+            ],
+            planName: "Team",
+            creditGrants: nil,
+            stripeBalanceCents: 0
+        )
+
+        let total = try XCTUnwrap(progress(mapped.lines, "Total usage"))
+        XCTAssertEqual(total.used, 80, accuracy: 0.001)
+        XCTAssertEqual(total.limit, 400, accuracy: 0.001)
+    }
 }
 
 @MainActor

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -15,6 +15,7 @@ final class CursorCSVParserTests: XCTestCase {
         XCTAssertTrue(summary.isStructurallyComplete)
         XCTAssertEqual(summary.rejectedRecordCount, 0)
         XCTAssertEqual(records.count, 2)
+        guard records.count == 2 else { return }
         XCTAssertEqual(records[0]["Note"], #"a, b "quoted" c"#)
         XCTAssertEqual(records[1]["Note"], "line one\r\nline two")
         XCTAssertEqual(records[1]["Model"], "composer-1")

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -4,49 +4,50 @@ import XCTest
 // MARK: - CSV parser
 
 final class CursorCSVParserTests: XCTestCase {
-    func testParsesQuotedCommasEscapedQuotesAndEmbeddedNewlines() {
-        let csv = """
-        Date,Model,Note
-        2026-01-01T00:00:00Z,"composer-1","a, b ""quoted"" c"
-        2026-01-02T00:00:00Z,composer-1,"line one
-        line two"
-        """
+    func testParsesQuotedCommasEscapedQuotesEmbeddedNewlinesAndCRLF() {
+        let csv = "Date,Model,Note\r\n"
+            + "2026-01-01T00:00:00Z,\"composer-1\",\"a, b \"\"quoted\"\" c\"\r\n"
+            + "2026-01-02T00:00:00Z,composer-1,\"line one\r\nline two\"\r\n"
         var records: [[String: String]] = []
-        CursorCSVParser.forEachRecord(in: csv) { records.append($0) }
 
+        let summary = CursorCSVParser.forEachRecord(in: csv) { records.append($0) }
+
+        XCTAssertTrue(summary.isStructurallyComplete)
+        XCTAssertEqual(summary.rejectedRecordCount, 0)
         XCTAssertEqual(records.count, 2)
         XCTAssertEqual(records[0]["Note"], #"a, b "quoted" c"#)
-        XCTAssertEqual(records[1]["Note"], "line one\nline two")
+        XCTAssertEqual(records[1]["Note"], "line one\r\nline two")
         XCTAssertEqual(records[1]["Model"], "composer-1")
     }
 
     func testParsesTrailingPartialRowWithoutNewline() {
         let csv = "Date,Model\n2026-01-01T00:00:00Z,composer-1"
         var records: [[String: String]] = []
-        CursorCSVParser.forEachRecord(in: csv) { records.append($0) }
 
+        let summary = CursorCSVParser.forEachRecord(in: csv) { records.append($0) }
+
+        XCTAssertTrue(summary.isStructurallyComplete)
         XCTAssertEqual(records.count, 1)
         XCTAssertEqual(records[0]["Date"], "2026-01-01T00:00:00Z")
         XCTAssertEqual(records[0]["Model"], "composer-1")
     }
 
-    func testUsageCSVMapsColumnsToPricedRows() {
+    func testUsageCSVMapsColumnsToPricedRows() throws {
         let csv = """
         Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Cost
         2026-01-01T00:00:00Z,composer-1,No,0,0,0,1000000,Included
         2026-01-01T00:00:00Z,totally-unknown-model-xyz,No,0,100,0,0,Included
         ,skipped-no-date,No,0,0,0,0,Included
         """
-        let rows = CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
 
-        XCTAssertEqual(rows.count, 2) // the dateless row is skipped
-        XCTAssertEqual(rows[0].model, "composer-1")
-        XCTAssertEqual(rows[0].tokens.output, 1_000_000)
-        // composer-1 output is $10/M → 1M output = $10.
-        XCTAssertEqual(rows[0].imputedCostDollars!, 10.0, accuracy: 1e-9)
-        // No pricing source knows the second model: tokens counted, cost nil (flags the day incomplete).
-        XCTAssertEqual(rows[1].tokens.totalTokens, 100)
-        XCTAssertNil(rows[1].imputedCostDollars)
+        XCTAssertEqual(parsed.rows.count, 2)
+        XCTAssertEqual(parsed.rejectedRowCount, 1)
+        XCTAssertEqual(parsed.rows[0].model, "composer-1")
+        XCTAssertEqual(parsed.rows[0].tokens.output, 1_000_000)
+        XCTAssertEqual(parsed.rows[0].imputedCostDollars!, 10.0, accuracy: 1e-9)
+        XCTAssertEqual(parsed.rows[1].tokens.totalTokens, 100)
+        XCTAssertNil(parsed.rows[1].imputedCostDollars)
     }
 
     func testUsageCSVDoesNotTreatAggregatedRowsAsSingleLongContextRequests() throws {
@@ -68,7 +69,7 @@ final class CursorCSVParserTests: XCTestCase {
         2026-01-01T00:00:00Z,test-model,No,0,300000,0,100000,Included
         """
 
-        let row = try XCTUnwrap(CursorUsageCSV.parse(csv: csv, pricing: pricing).first)
+        let row = try XCTUnwrap(CursorUsageCSV.parse(csv: csv, pricing: pricing).rows.first)
 
         // A CSV row combines many requests, so its total cannot prove that any one request crossed 200k.
         XCTAssertEqual(row.imputedCostDollars!, 2.4, accuracy: 0.0001)
@@ -360,8 +361,8 @@ final class CursorSpendProviderTests: XCTestCase {
 
     func testSpendTileRendersCombinedCostAndTokensWithValueTooltip() async {
         let cursor = CursorProvider()
-        // Spend tiles are gated off the live provider (issue #758), so source the descriptor from the
-        // shared factory — this keeps the combined "cost · tokens" render shape covered for re-enable.
+        // Source the descriptor from the shared factory so this test can isolate the combined
+        // "cost · tokens" render shape from the provider's network refresh behavior.
         let descriptor = try! XCTUnwrap(WidgetDescriptor.spendTiles(provider: cursor.provider).first { $0.id == "cursor.today" })
 
         // The combined tile joins the dollar and the labeled token count. The render shape for a zero
@@ -427,11 +428,9 @@ final class CursorSpendProviderTests: XCTestCase {
 // MARK: - Client request contract
 
 final class CursorUsageClientRequestTests: XCTestCase {
-    // The provider-level CSV integration tests were removed when spend tracking was disabled (issue
-    // #758), but `CursorUsageClient.fetchUsageCSV` is kept intact for re-enable. Pin its request contract
-    // directly at the client level — endpoint, epoch-ms range, `strategy=tokens`, the session cookie, and
-    // `Accept: text/csv` — so a silent regression in URL/header construction can't slip through while the
-    // feature is off (this test runs regardless of `CursorProvider.spendTrackingEnabled`).
+    // Pin the request contract directly at the client level — endpoint, epoch-ms range,
+    // `strategy=tokens`, the session cookie, and `Accept: text/csv` — so a silent regression in
+    // URL/header construction cannot slip through.
     func testFetchUsageCSVBuildsTokenStrategyRequestWithSessionCookie() async throws {
         let accessToken = makeCursorJWT(sub: "google-oauth2|user_abc123")
         let http = RoutingHTTPClient { _ in

--- a/Tests/OpenUsageTests/ProviderParseTests.swift
+++ b/Tests/OpenUsageTests/ProviderParseTests.swift
@@ -10,4 +10,18 @@ final class ProviderParseTests: XCTestCase {
         )
         XCTAssertEqual("café".urlFormEncoded, "caf%C3%A9")
     }
+
+    func testNumberDistinguishesJSONBooleansFromNumbers() throws {
+        let object = try XCTUnwrap(ProviderParse.jsonObject(Data(
+            #"{"true":true,"false":false,"one":1,"zero":0,"decimal":1.5,"string":" 2.5 "}"#.utf8
+        )))
+
+        XCTAssertNil(ProviderParse.number(object["true"]))
+        XCTAssertNil(ProviderParse.number(object["false"]))
+        XCTAssertEqual(ProviderParse.number(object["one"]), 1)
+        XCTAssertEqual(ProviderParse.number(object["zero"]), 0)
+        XCTAssertEqual(ProviderParse.number(object["decimal"]), 1.5)
+        XCTAssertEqual(ProviderParse.number(object["string"]), 2.5)
+        XCTAssertEqual(ProviderParse.bool(object["true"]), true)
+    }
 }

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -26,6 +26,7 @@ Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export.
 
 - **"Not logged in" / token errors** — open Cursor and make sure you're signed in, then refresh.
 - **Some metrics missing** — Cursor omits fields depending on plan type (e.g. Requests only exists on request-based accounts); missing metrics simply show "No data".
+- **Optional lookup failed** — plan, credit-grant, prepaid-balance, and request-fallback failures stay nonfatal when primary usage is available. OpenUsage records fixed, credential-free reasons in the diagnostic log.
 
 ## Under the hood
 

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -20,7 +20,7 @@ Just be signed into the Cursor app. OpenUsage reads Cursor's local state databas
 
 ## Spend history
 
-Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export. OpenUsage uses the exported token counts and shared model pricing to estimate the cost locally. Cursor's export may occasionally arrive late, so the newest figures can lag behind current activity.
+Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export. OpenUsage uses the exported token counts and shared model pricing to estimate the cost locally. Cursor's export may occasionally arrive late, so the newest figures can lag behind current activity. OpenUsage leaves isolated malformed rows out instead of silently counting broken values as zero. A failed download, invalid export schema, or broken CSV structure leaves spend history unavailable for that refresh. Each failure is recorded in the diagnostic log without including the exported usage data.
 
 ## Troubleshooting
 
@@ -29,4 +29,4 @@ Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export.
 
 ## Under the hood
 
-Connect RPC on `api2.cursor.sh` (dashboard usage), REST fallback at `cursor.com/api/usage` for request-based accounts, and Stripe balance at `cursor.com/api/auth/stripe`. A 401/403 triggers one token refresh and retry. Per-day spend imputation uses token counts priced through the shared [model pricing](../pricing.md); Cursor-native models (`auto`, `composer-*`, …) come from its supplement layer, which maintainers sync from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md). (The usage-events CSV export at `cursor.com/api/dashboard/export-usage-events-csv` previously fed the spend history; it's not currently fetched — see above.)
+Connect RPC on `api2.cursor.sh` (dashboard usage), REST fallback at `cursor.com/api/usage` for request-based accounts, Stripe balance at `cursor.com/api/auth/stripe`, and the usage-events CSV export at `cursor.com/api/dashboard/export-usage-events-csv`. The primary dashboard usage request refreshes the token and retries once after a 401/403; optional endpoint failures stay nonfatal and are recorded in the diagnostic log. Per-day spend imputation uses exported token counts priced through the shared [model pricing](../pricing.md); Cursor-native models (`auto`, `composer-*`, …) come from its supplement layer, which maintainers sync from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md).

--- a/docs/research/model-hover/02-data-and-architecture.md
+++ b/docs/research/model-hover/02-data-and-architecture.md
@@ -2,6 +2,8 @@
 
 Research date: 2026-07-04. Scope: current `main`-line SwiftPM app architecture in this worktree. This is read-only technical research for a hover-revealed per-model spend/usage breakdown on the existing `Today`, `Yesterday`, and `Last 30 Days` spend rows.
 
+> **Status update (2026-07-10):** This document records the preimplementation architecture at its research date. The current code now carries per-model usage through `ModelUsageSeries`; Cursor's boundary parser also throws on unusable CSV structure and returns `CursorUsageCSVParseResult` (`rows` plus `rejectedRowCount`). See [Cursor](../../providers/cursor.md) for current user-facing behavior.
+
 ## Executive conclusion
 
 This feature is technically feasible for Cursor, Claude, Codex, and partially for Grok without adding new external usage APIs. The raw provider inputs already carry a model dimension before the current spend pipeline collapses them into `DailyUsageSeries`.


### PR DESCRIPTION
## TL;DR

Validates Cursor usage exports and optional financial metadata at their network boundaries, so malformed data cannot silently change spend or credit figures. JSON booleans can no longer be coerced into numeric usage or money, and the primary usage snapshot remains usable when optional lookups fail, with fixed credential-free diagnostics.

## What was happening

- Malformed CSV quoting, headers, row widths, token values, and integer overflow could be accepted, coerced to zero, or crash aggregation.
- Plan, credit-grant, prepaid-balance, and request-fallback failures were handled repeatedly and often silently.
- Foundation bridges JSON booleans through `NSNumber`, so the shared numeric parser could interpret `true`/`false` as `1`/`0`.
- Prepaid HTTP and JSON validation lived in the usage mapper instead of at the provider boundary.
- The Cursor provider documentation contradicted the enabled usage-export path.

## What this changes

- Strictly validates CSV structure, required headers, canonical grouped integers, row widths, and safe token aggregation while retaining valid rows.
- Keeps export failures nonfatal to live usage and logs only fixed reasons and rejection counts—never credentials, response bodies, model names, or exported values.
- Routes optional JSON endpoints through one shared transport/status/schema helper.
- Validates plan, credit-grant, and prepaid-balance metadata before mapping financial values.
- Rejects JSON booleans in the shared numeric parser while continuing to accept real JSON numbers and numeric strings.
- Gives the mapper already-decoded prepaid data, keeping I/O validation in the provider.
- Updates the Cursor behavior and troubleshooting documentation, and labels the earlier model-hover architecture note as a historical snapshot.
- Keeps production in reviewable commits: CSV integrity, optional endpoint DRY/boundary cleanup, review follow-up, and the focused JSON-boundary regression fix.

## Heads-up

- This is a compact replacement for #929 and #930. It deliberately excludes unrelated Cursor auth and retry hardening.
- The diff is 873 gross changed lines, including 481 lines of focused regression tests; production and documentation churn is 392 lines.
- No visual behavior changed, so screenshots are not applicable.

## Tests

- `swift test --filter Cursor`: 42 passed.
- Focused parser/optional/mapper regression scope: 13 passed.
- `swift test`: 978 XCTest cases passed, 3 expected skips; 3 Swift Testing cases passed.
- `script/build_and_run.sh verify`: release build, app staging, signing, exact-worktree launch, and process verification passed.
- `codesign --verify --deep --strict dist/OpenUsage.app`: passed.
- `git diff --check origin/main...HEAD`: passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how usage exports and financial metadata are parsed and mapped (credits, spend tiles, team totals), but failures are nonfatal for primary usage and behavior is heavily regression-tested.
> 
> **Overview**
> Hardens **Cursor** spend and enrichment data at parse/network boundaries so bad exports and optional JSON cannot silently skew dollars, credits, or tokens, while **primary dashboard usage** still refreshes when spend or optional lookups fail.
> 
> **CSV path:** `CursorCSVParser` now uses a quote state machine, returns structural `Summary`, normalizes headers (including BOM), and drops width-mismatched rows. `CursorUsageCSV.parse` **throws** on missing/duplicate columns or broken structure, returns `CursorUsageCSVParseResult` with `rejectedRowCount`, and rejects invalid token cells (non-integers, bad grouping, overflow) instead of coercing to zero. `appendSpendLines` logs fixed, credential-free reasons and still only adds spend tiles when parsing succeeds.
> 
> **Optional endpoints:** Plan, credit-grants, prepaid balance, and request-fallback flows share `fetchOptionalJSONObject` with consistent transport/HTTP/schema handling and warnings; invalid plan or grant metadata no longer poisons mapping. **Shared:** `ProviderParse.number` ignores JSON booleans so `true`/`false` are not read as `1`/`0`; Stripe balance validation moves to the provider before `stripeBalanceCents(from:)`.
> 
> Docs describe malformed-row handling and nonfatal optional failures; new boundary regression tests cover CSV, optional endpoints, and boolean parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc87bad90cdd856fa97ce51f588c02775d39499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

