### PR TITLE
Enforce deterministic, warning-free builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Conventions for the per-provider modules under `Sources/OpenUsage/Providers/<Nam
 ## Running / Testing Changes
 
 - There is no hot reload. The app is a long-lived menu-bar process, so **every code change requires a full rebuild and restart of the running app** to take effect — kill the running instance, rebuild, and relaunch before testing.
+- Swift warnings are build and CI errors for both the app and test targets; keep every build warning-free.
 
 ## Pull Requests
 

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,8 @@ let package = Package(
                 .copy("Resources/pricing_models_dev_snapshot.json")
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error)
             ]
         ),
         .testTarget(
@@ -42,7 +43,8 @@ let package = Package(
             dependencies: ["OpenUsage"],
             path: "Tests/OpenUsageTests",
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error)
             ]
         )
     ]

--- a/Sources/OpenUsage/Models/RateLimitResetsPresentation.swift
+++ b/Sources/OpenUsage/Models/RateLimitResetsPresentation.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Pure presentation data for the rate-limit-resets popover. Keeping this outside the SwiftUI view
+/// makes the count/expiry state machine and timeline formatting independently testable and nonisolated.
+enum RateLimitResetsPresentation {
+    /// What the popover body renders after resolving the available count and expiry list.
+    enum Content: Equatable {
+        case timeline([Entry])
+        case unknownExpiries(count: Int)
+        case empty
+    }
+
+    /// One timeline node's display strings, derived from a credit's expiry instant.
+    struct Entry: Identifiable, Equatable {
+        let id: Int          // 0-based row index (soonest first)
+        let number: Int      // 1-based reset number, shown inside the dot
+        let severity: WidgetData.MeterSeverity
+        let time: String       // exact expiry, e.g. "Jul 12 at 5:30 PM"; "Expiring soon" when imminent
+        let countdown: String? // "12d 18h"; nil when imminent (no useful countdown to show)
+
+        var accessibilityLabel: String {
+            "Reset \(number), \(time)" + (countdown.map { ", expires in \($0)" } ?? "")
+        }
+    }
+
+    /// Empty `expiries` is ambiguous: a genuinely empty balance (`count == 0`) shows the empty state,
+    /// but a positive `count` with no expiries means the dedicated expiry fetch was unavailable and the
+    /// row fell back to the usage-body count — show that count rather than "no resets".
+    static func content(count: Int, expiries: [Date], now: Date = Date()) -> Content {
+        let entries = entries(from: expiries, now: now)
+        if !entries.isEmpty { return .timeline(entries) }
+        if count > 0 { return .unknownExpiries(count: count) }
+        return .empty
+    }
+
+    /// Build the timeline entries from raw expiry instants: sort soonest-first, number from 1, and pair
+    /// each exact expiry time with its countdown. A past-due or ≤5-minute expiry can't print a useful
+    /// exact time or countdown, so it reads "Expiring soon" with no trailing countdown. Imminence keys
+    /// off the *relative* window — `Formatters.whenLabel(.relative)` collapses to `soon` at ≤5 minutes,
+    /// while `.absolute` only collapses once past-due — so both formats agree instead of the exact time
+    /// printing a wall-clock while the countdown reads "soon".
+    static func entries(from expiries: [Date], now: Date = Date()) -> [Entry] {
+        expiries.sorted().enumerated().map { index, date in
+            let relative = Formatters.whenLabel(at: date, mode: .relative, now: now)
+            let absolute = Formatters.whenLabel(at: date, mode: .absolute, now: now)
+            let imminent = (relative == nil || relative == Formatters.imminent)
+            return Entry(
+                id: index,
+                number: index + 1,
+                severity: WidgetData.expirySeverity(secondsRemaining: date.timeIntervalSince(now)),
+                time: (imminent || absolute == nil) ? "Expiring soon" : absolute!,
+                countdown: imminent ? nil : relative
+            )
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -32,7 +32,7 @@ final class ClaudeProvider: ProviderRuntime {
         usageClient: ClaudeUsageClient = ClaudeUsageClient(),
         logUsageScanner: ClaudeLogUsageScanner = ClaudeLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -23,7 +23,7 @@ final class CodexProvider: ProviderRuntime {
         usageClient: CodexUsageClient = CodexUsageClient(),
         logUsageScanner: CodexLogUsageScanner = CodexLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient

--- a/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
@@ -175,9 +175,9 @@ enum CopilotUsageMapper {
         return dayOnlyFormatter.date(from: raw)
     }
 
-    /// `nonisolated(unsafe)` is sound: `DateFormatter` is documented thread-safe on macOS 10.9+, and the
-    /// formatter is never mutated after creation (same pattern as `CursorUsageCSV`/`OpenUsageISO8601`).
-    private nonisolated(unsafe) static let dayOnlyFormatter: DateFormatter = {
+    /// Foundation marks `DateFormatter` as sendable on supported macOS versions. This formatter is
+    /// configured once during initialization and never mutated afterward.
+    private static let dayOnlyFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -21,7 +21,7 @@ final class CursorProvider: ProviderRuntime {
         authStore: CursorAuthStore = CursorAuthStore(),
         usageClient: CursorUsageClient = CursorUsageClient(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -22,7 +22,7 @@ final class GrokProvider: ProviderRuntime {
         usageClient: GrokUsageClient = GrokUsageClient(),
         logUsageScanner: GrokLogUsageScanner = GrokLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -99,7 +99,7 @@ struct ProviderSnapshotCache {
         AppLog.debug(.cache, "write \(snapshot.providerID)")
         // Mark this provider as written *this session* so its snapshot now satisfies the freshness gate
         // (a launch-loaded snapshot never does — see `sessionWrites`).
-        sessionWrites.withLock { $0.insert(snapshot.providerID) }
+        _ = sessionWrites.withLock { $0.insert(snapshot.providerID) }
         var payload = loadPayload()
         payload.snapshots[snapshot.providerID] = snapshot
         save(payload)

--- a/Sources/OpenUsage/Views/RateLimitResetsDetail.swift
+++ b/Sources/OpenUsage/Views/RateLimitResetsDetail.swift
@@ -8,6 +8,8 @@ import SwiftUI
 /// are available it shows a centered empty state. Mirrors `ModelUsageDetail` / `UsageTrendDetail`'s
 /// calm — header + flat body — presented via `.popover`.
 struct RateLimitResetsDetail: View {
+    private typealias Entry = RateLimitResetsPresentation.Entry
+
     let title: String
     /// The row's "N available" count. Only used to disambiguate an empty `expiries` list: 0 → genuinely
     /// no credits (empty state); > 0 → credits we have but whose expiry times weren't fetched.
@@ -24,7 +26,7 @@ struct RateLimitResetsDetail: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             header
-            switch Self.content(count: count, expiries: expiries) {
+            switch RateLimitResetsPresentation.content(count: count, expiries: expiries) {
             case .timeline(let entries): timeline(entries)
             case .unknownExpiries(let count): unknownExpiriesState(count)
             case .empty: emptyState
@@ -149,56 +151,4 @@ struct RateLimitResetsDetail: View {
         .accessibilityLabel(entry.accessibilityLabel)
     }
 
-    /// What the body renders, resolved once from the count and expiry list so the "empty vs. count-only
-    /// vs. timeline" choice is unit-testable and can't drift between the view and its tests.
-    enum Content: Equatable {
-        case timeline([Entry])
-        case unknownExpiries(count: Int)
-        case empty
-    }
-
-    /// Empty `expiries` is ambiguous: a genuinely empty balance (`count == 0`) shows the empty state,
-    /// but a positive `count` with no expiries means the dedicated expiry fetch was unavailable and the
-    /// row fell back to the usage-body count — show that count rather than "no resets".
-    static func content(count: Int, expiries: [Date], now: Date = Date()) -> Content {
-        let entries = entries(from: expiries, now: now)
-        if !entries.isEmpty { return .timeline(entries) }
-        if count > 0 { return .unknownExpiries(count: count) }
-        return .empty
-    }
-
-    /// One timeline node's display strings, derived from a credit's expiry instant. Pure and static so
-    /// the phrasing is unit-testable without a view.
-    struct Entry: Identifiable, Equatable {
-        let id: Int          // 0-based row index (soonest first)
-        let number: Int      // 1-based reset number, shown inside the dot
-        let severity: WidgetData.MeterSeverity
-        let time: String       // exact expiry, e.g. "Jul 12 at 5:30 PM"; "Expiring soon" when imminent
-        let countdown: String? // "12d 18h"; nil when imminent (no useful countdown to show)
-
-        var accessibilityLabel: String {
-            "Reset \(number), \(time)" + (countdown.map { ", expires in \($0)" } ?? "")
-        }
-    }
-
-    /// Build the timeline entries from raw expiry instants: sort soonest-first, number from 1, and pair
-    /// each exact expiry time with its countdown. A past-due or ≤5-minute expiry can't print a useful
-    /// exact time or countdown, so it reads "Expiring soon" with no trailing countdown. Imminence keys
-    /// off the *relative* window — `Formatters.whenLabel(.relative)` collapses to `soon` at ≤5 minutes,
-    /// while `.absolute` only collapses once past-due — so both formats agree instead of the exact time
-    /// printing a wall-clock while the countdown reads "soon".
-    static func entries(from expiries: [Date], now: Date = Date()) -> [Entry] {
-        expiries.sorted().enumerated().map { index, date in
-            let relative = Formatters.whenLabel(at: date, mode: .relative, now: now)
-            let absolute = Formatters.whenLabel(at: date, mode: .absolute, now: now)
-            let imminent = (relative == nil || relative == Formatters.imminent)
-            return Entry(
-                id: index,
-                number: index + 1,
-                severity: WidgetData.expirySeverity(secondsRemaining: date.timeIntervalSince(now)),
-                time: (imminent || absolute == nil) ? "Expiring soon" : absolute!,
-                countdown: imminent ? nil : relative
-            )
-        }
-    }
 }

--- a/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
+++ b/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
@@ -1,3 +1,4 @@
+import os
 import XCTest
 @testable import OpenUsage
 
@@ -35,13 +36,13 @@ final class LoginShellEnvironmentTests: XCTestCase {
         let runner = RecordingRunner(stdout: [begin, "OPENROUTER_API_KEY=sk-or-test", end].joined(separator: "\0"))
         let env = LoginShellEnvironment(runner: runner)
         let captured = expectation(description: "captured off-main")
-        var value: String?
+        let value = OSAllocatedUnfairLock<String?>(initialState: nil)
         DispatchQueue.global().async {
-            value = env.value(for: "OPENROUTER_API_KEY")
+            value.withLock { $0 = env.value(for: "OPENROUTER_API_KEY") }
             captured.fulfill()
         }
         wait(for: [captured], timeout: 5)
-        XCTAssertEqual(value, "sk-or-test")
+        XCTAssertEqual(value.withLock { $0 }, "sk-or-test")
         XCTAssertEqual(runner.callCount, 1)
     }
 

--- a/Tests/OpenUsageTests/ResetDisplayTests.swift
+++ b/Tests/OpenUsageTests/ResetDisplayTests.swift
@@ -186,7 +186,7 @@ final class ResetDisplayTests: XCTestCase {
         // The popover timeline sorts the credits soonest-first, numbers them from 1, and pairs each
         // exact expiry time with its countdown. Per-credit dot color reuses the row's severity bands.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let entries = RateLimitResetsDetail.entries(
+        let entries = RateLimitResetsPresentation.entries(
             from: [
                 // Deliberately out of order to prove the sort.
                 now.addingTimeInterval(12 * 24 * 3600 + 18 * 3600),          // ~12d18h -> blue
@@ -207,7 +207,7 @@ final class ResetDisplayTests: XCTestCase {
         // wall-clock time or countdown, so it collapses to "Expiring soon" with no trailing countdown —
         // matching Formatters.imminent. Its dot stays red.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let entries = RateLimitResetsDetail.entries(from: [now.addingTimeInterval(-60)], now: now)
+        let entries = RateLimitResetsPresentation.entries(from: [now.addingTimeInterval(-60)], now: now)
 
         XCTAssertEqual(entries.count, 1)
         XCTAssertEqual(entries[0].time, "Expiring soon")
@@ -220,7 +220,7 @@ final class ResetDisplayTests: XCTestCase {
         // exact time must not print a wall-clock while the countdown vanishes — both collapse to
         // "Expiring soon" with no countdown.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
-        let entries = RateLimitResetsDetail.entries(from: [now.addingTimeInterval(180)], now: now)
+        let entries = RateLimitResetsPresentation.entries(from: [now.addingTimeInterval(180)], now: now)
 
         XCTAssertEqual(entries.count, 1)
         XCTAssertEqual(entries[0].time, "Expiring soon")
@@ -228,7 +228,7 @@ final class ResetDisplayTests: XCTestCase {
     }
 
     func testResetsPopoverEmptyWhenNoCredits() {
-        XCTAssertTrue(RateLimitResetsDetail.entries(from: [], now: Date()).isEmpty)
+        XCTAssertTrue(RateLimitResetsPresentation.entries(from: [], now: Date()).isEmpty)
     }
 
     func testCompactDurationAlwaysShowsHoursAtDayScale() {
@@ -245,18 +245,18 @@ final class ResetDisplayTests: XCTestCase {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
 
         // Zero credits -> the genuine empty state.
-        XCTAssertEqual(RateLimitResetsDetail.content(count: 0, expiries: [], now: now), .empty)
+        XCTAssertEqual(RateLimitResetsPresentation.content(count: 0, expiries: [], now: now), .empty)
 
         // Credits present but no expiry list (dedicated fetch unavailable -> usage-body count fallback):
         // must NOT read "no resets"; it states the count instead.
         XCTAssertEqual(
-            RateLimitResetsDetail.content(count: 3, expiries: [], now: now),
+            RateLimitResetsPresentation.content(count: 3, expiries: [], now: now),
             .unknownExpiries(count: 3)
         )
 
         // Expiries present -> the timeline.
         let expiries = [now.addingTimeInterval(4 * 24 * 3600)]
-        guard case .timeline(let entries) = RateLimitResetsDetail.content(count: 1, expiries: expiries, now: now) else {
+        guard case .timeline(let entries) = RateLimitResetsPresentation.content(count: 1, expiries: expiries, now: now) else {
             return XCTFail("expected timeline")
         }
         XCTAssertEqual(entries.count, 1)

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -13,10 +13,16 @@ The project script owns the build/run loop. From the repo root:
 ./script/build_and_run.sh verify   # launch and confirm the process is running
 ```
 
+Every invocation asks any running `OpenUsage` process to exit and waits up to five seconds before
+rebuilding. `verify` also polls the new launch for up to five seconds. The script fails loudly if either
+lifecycle transition stalls.
+
 The script builds a signed app bundle under `dist/` and launches it in place — nothing is installed to
-`/Applications`. The dev build uses its own bundle id (`com.robinebers.openusage.dev`), so it keeps its
-own settings and keychain and never disturbs a released OpenUsage. It ships no update feed, so it never
-checks for updates — test updates with a real signed, notarized release build.
+`/Applications`. The dev build uses its own bundle id (`com.robinebers.openusage.dev`), so its app
+preferences and single-instance state stay separate from the released bundle. Provider credential
+files, databases, keychain items, and OpenUsage API-key files remain shared intentionally, so
+authentication changes can affect provider tools or a released OpenUsage. The dev build ships no
+update feed; test updates with a real signed, notarized release build.
 
 ## Stream logs
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -13,9 +13,10 @@ The project script owns the build/run loop. From the repo root:
 ./script/build_and_run.sh verify   # launch and confirm the process is running
 ```
 
-Every invocation asks any running `OpenUsage` process to exit and waits up to five seconds before
-rebuilding. `verify` also polls the new launch for up to five seconds. The script fails loudly if either
-lifecycle transition stalls.
+Every invocation asks any running `OpenUsage.app` process to exit and waits up to five seconds before
+rebuilding. `verify` also polls this worktree's staged app for up to five seconds. The script ignores
+unrelated commands that happen to be named `OpenUsage`, and fails loudly if either app lifecycle
+transition stalls.
 
 The script builds a signed app bundle under `dist/` and launches it in place — nothing is installed to
 `/Applications`. The dev build uses its own bundle id (`com.robinebers.openusage.dev`), so its app

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 # to /Applications. The dev build:
 #   - is signed with a stable Apple Development identity, so keychain/permission grants stick across
 #     rebuilds (macOS keys those to the signing identity + bundle id, not the install location);
-#   - uses its own bundle id (com.robinebers.openusage.dev), so it never touches the real installed
-#     app's settings or keychain. To run against the real app's data instead, set BUNDLE_ID to
+#   - uses its own bundle id (com.robinebers.openusage.dev), isolating app preferences and
+#     single-instance state. Provider credential files, databases, and keychain items remain shared
+#     intentionally. To test the release app's settings domain, set BUNDLE_ID to
 #     com.robinebers.openusage below;
 #   - ships no Sparkle feed, so it never checks for or installs updates (test updates with a real
 #     signed + notarized release build — that's the only honest way).
@@ -36,7 +37,31 @@ INFO_PLIST="$APP_CONTENTS/Info.plist"
 RESOURCE_BUNDLE_NAME="${TARGET_NAME}_${TARGET_NAME}.bundle"
 ENTITLEMENTS="$ROOT_DIR/script/OpenUsage.dev.entitlements.plist"
 
-pkill -x "$TARGET_NAME" >/dev/null 2>&1 || true
+wait_for_app_exit() {
+  pkill -x "$TARGET_NAME" >/dev/null 2>&1 || return 0
+  for ((attempt = 0; attempt < 50; attempt++)); do
+    if ! pgrep -x "$TARGET_NAME" >/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "timed out waiting for the previous $APP_DISPLAY process to exit" >&2
+  return 1
+}
+
+wait_for_app_launch() {
+  for ((attempt = 0; attempt < 50; attempt++)); do
+    if pgrep -x "$TARGET_NAME" >/dev/null; then
+      echo "==> running"
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "$APP_DISPLAY exited before launch verification completed" >&2
+  return 1
+}
+
+wait_for_app_exit
 
 echo "==> swift build ($CONFIG)"
 swift build -c "$CONFIG"
@@ -177,8 +202,7 @@ case "$MODE" in
     ;;
   verify)
     launch_app
-    sleep 1
-    pgrep -x "$TARGET_NAME" >/dev/null && echo "==> running"
+    wait_for_app_launch
     ;;
   *)
     echo "usage: $0 [run|build|logs|verify]" >&2

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -26,7 +26,7 @@ MIN_SYSTEM_VERSION="15.0"
 APP_VERSION="0.7.0"
 APP_BUILD="0.7.0"
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 DIST_DIR="$ROOT_DIR/dist"
 APP_BUNDLE="$DIST_DIR/$APP_DISPLAY.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
@@ -37,10 +37,30 @@ INFO_PLIST="$APP_CONTENTS/Info.plist"
 RESOURCE_BUNDLE_NAME="${TARGET_NAME}_${TARGET_NAME}.bundle"
 ENTITLEMENTS="$ROOT_DIR/script/OpenUsage.dev.entitlements.plist"
 
+matching_app_pids() {
+  local exact_path="${1:-}"
+  local pid executable
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    executable="$(ps -ww -p "$pid" -o comm= 2>/dev/null)" || continue
+    if [ -n "$exact_path" ]; then
+      [ "$executable" = "$exact_path" ] || continue
+    elif [[ "$executable" != *"/$APP_DISPLAY.app/Contents/MacOS/$TARGET_NAME" ]]; then
+      continue
+    fi
+    printf '%s\n' "$pid"
+  done < <(pgrep -x "$TARGET_NAME" || true)
+}
+
 wait_for_app_exit() {
-  pkill -x "$TARGET_NAME" >/dev/null 2>&1 || return 0
+  local pid pids
+  pids="$(matching_app_pids)"
+  [ -n "$pids" ] || return 0
+  while IFS= read -r pid; do
+    kill "$pid" >/dev/null 2>&1 || true
+  done <<<"$pids"
   for ((attempt = 0; attempt < 50; attempt++)); do
-    if ! pgrep -x "$TARGET_NAME" >/dev/null; then
+    if [ -z "$(matching_app_pids)" ]; then
       return 0
     fi
     sleep 0.1
@@ -51,7 +71,7 @@ wait_for_app_exit() {
 
 wait_for_app_launch() {
   for ((attempt = 0; attempt < 50; attempt++)); do
-    if pgrep -x "$TARGET_NAME" >/dev/null; then
+    if [ -n "$(matching_app_pids "$APP_BINARY")" ]; then
       echo "==> running"
       return 0
     fi


### PR DESCRIPTION
## TL;DR

Keep Swift builds warning-free and make local app launch verification deterministic. This compact replacement preserves the useful build-quality changes from #912 and #938 in three reviewable commits.

## What was happening

- SwiftPM builds emitted warnings without failing, allowing new warning debt to accumulate.
- Pure rate-limit reset presentation logic lived inside a SwiftUI view, which made non-UI behavior actor-isolated and harder to test directly.
- The build script requested process termination without waiting, then verified a replacement launch after one fixed sleep.
- Process-name-only checks could mistake an unrelated executable named `OpenUsage` for the app.
- Debugging docs overstated the isolation provided by the development bundle identifier.

## What this changes

- Treats warnings as errors for both the OpenUsage executable and test targets, and resolves the existing warning sites.
- Moves reset timeline/count presentation into a 56-line Foundation model while leaving the SwiftUI view render-only.
- Waits up to five seconds for existing `OpenUsage.app` processes to exit and polls the exact staged executable for up to five seconds.
- Ignores unrelated same-name processes while still stopping installed and development app bundles.
- Documents the warning policy, bounded lifecycle checks, process scope, and exact settings/credential isolation boundary.

## Heads-up

- Supersedes #912 and #938; those PRs can be closed after this replacement is accepted.
- The presentation extraction has no intended visual or copy change.

## Tests

- `bash -n script/build_and_run.sh`
- Focused reset and login-shell tests: 24 passed
- `swift test`: 962 XCTest tests passed, 3 expected skips; 3 Swift Testing tests passed
- Same-name regression: with two unrelated `OpenUsage` processes present, `verify` launched the exact staged app and `build` stopped only that app
- `./script/build_and_run.sh verify`: release build, staging, Apple Development signing, launch, and exact-process verification passed
- `codesign --verify --deep --strict dist/OpenUsage.app`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly build hygiene, test refactors, and dev tooling; the presentation extraction is intended to be behavior-neutral for the Codex resets UI.
> 
> **Overview**
> SwiftPM now treats **warnings as errors** for the app and test targets, with small fixes across providers (drop redundant `await` on synchronous `ModelPricingStore.current()`), Copilot date formatting (remove `nonisolated(unsafe)`), snapshot cache, and a concurrency-safe off-main-thread test.
> 
> Rate-limit reset popover logic moves from `RateLimitResetsDetail` into **`RateLimitResetsPresentation`** so timeline/count resolution stays testable without SwiftUI; the view only renders.
> 
> **`script/build_and_run.sh`** waits up to five seconds for prior OpenUsage app processes to exit, matches PIDs by staged bundle path (not name alone), and polls launch for `verify`. **AGENTS.md** and **`docs/debugging.md`** document the warning policy, lifecycle behavior, and that the dev bundle id isolates preferences while provider credentials stay shared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb9b1d22ad91a4bc8a8b532129293634a45403e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->