### PR TITLE
Reject malformed Z.ai quota values

### DIFF
--- a/Sources/OpenUsage/Providers/ZAI/ZAIProvider.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIProvider.swift
@@ -62,8 +62,12 @@ final class ZAIProvider: ProviderRuntime {
             if ZAIUsageMapper.isNoCodingPlan(body) {
                 return ProviderSnapshot.error(provider: provider, error: ZAIUsageError.noCodingPlan)
             }
-            let mapped = ZAIUsageMapper.map(quotaBody: body, subscriptionBody: subscription)
-            return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
+            do {
+                let mapped = try ZAIUsageMapper.map(quotaBody: body, subscriptionBody: subscription)
+                return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now())
+            } catch {
+                return ProviderSnapshot.error(provider: provider, error: error)
+            }
         case .authFailure:
             return ProviderSnapshot.error(provider: provider, error: ZAIAuthError.invalidKey)
         case .failed(let error):

--- a/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
@@ -110,8 +110,8 @@ enum ZAIUsageMapper {
     }
 
     private static func classifyTokenWindow(_ entry: [String: Any]) throws -> TokenWindow? {
-        guard let unit = strictNumber(entry["unit"]),
-              let number = strictNumber(entry["number"]),
+        guard let unit = ProviderParse.number(entry["unit"]),
+              let number = ProviderParse.number(entry["number"]),
               number > 0 else {
             throw ZAIUsageError.invalidResponse
         }
@@ -138,7 +138,7 @@ enum ZAIUsageMapper {
 
     /// A percentage meter (Session or Weekly) from a `TOKENS_LIMIT` entry.
     private static func percentLine(_ entry: [String: Any], label: String, periodMs: Int) throws -> MetricLine {
-        guard let rawPercentage = strictNumber(entry["percentage"]) else {
+        guard let rawPercentage = ProviderParse.number(entry["percentage"]) else {
             throw ZAIUsageError.invalidResponse
         }
         let percentage = ProviderParse.clampPercent(rawPercentage)
@@ -155,8 +155,8 @@ enum ZAIUsageMapper {
 
     /// TIME_LIMIT → a count meter (used / limit) for monthly web-search/reader calls.
     private static func webSearchLine(from entry: [String: Any]) throws -> MetricLine {
-        guard let used = strictNumber(entry["currentValue"]),
-              let limit = strictNumber(entry["usage"]),
+        guard let used = ProviderParse.number(entry["currentValue"]),
+              let limit = ProviderParse.number(entry["usage"]),
               used >= 0,
               limit >= 0 else {
             throw ZAIUsageError.invalidResponse
@@ -183,19 +183,6 @@ enum ZAIUsageMapper {
             }
         }
         return nil
-    }
-
-    /// JSON booleans bridge through `NSNumber`; they are not quota numbers. Finite numeric strings are
-    /// retained for compatibility with payload revisions the shared parser already accepts.
-    private static func strictNumber(_ value: Any?) -> Double? {
-        if let bridged = value as? NSNumber,
-           CFGetTypeID(bridged) == CFBooleanGetTypeID() {
-            return nil
-        }
-        guard let number = ProviderParse.number(value), number.isFinite else {
-            return nil
-        }
-        return number
     }
 
     /// `nextResetTime` arrives as epoch milliseconds (e.g. `1770648402389`).

--- a/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
@@ -19,9 +19,9 @@ enum ZAIUsageMapper {
     /// `(plan, lines)` from the quota + subscription payloads. `subscription` may be `nil` (the
     /// request is best-effort) and the quota's `limits` array may carry one to three entries — only
     /// what's present is mapped, so a plan without web searches still shows the session meter.
-    static func map(quotaBody: Data, subscriptionBody: Data?) -> (plan: String?, lines: [MetricLine]) {
+    static func map(quotaBody: Data, subscriptionBody: Data?) throws -> (plan: String?, lines: [MetricLine]) {
         let plan = subscriptionBody.flatMap { planName(from: $0) }
-        let lines = mapQuota(quotaBody)
+        let lines = try mapQuota(quotaBody)
         return (plan, lines)
     }
 
@@ -36,37 +36,53 @@ enum ZAIUsageMapper {
         return ((root["msg"] as? String) ?? "").lowercased().contains("coding plan")
     }
 
-    /// Session + weekly + web-search meters from the quota payload. Emits the "No usage data"
-    /// placeholder when the payload carries no usable limits, matching the legacy plugin.
-    static func mapQuota(_ body: Data) -> [MetricLine] {
-        guard let root = ProviderParse.jsonObject(body) else { return [.noUsageData] }
+    /// Session + weekly + web-search meters from the quota payload. Missing required values are an
+    /// invalid response rather than zero usage; an explicit empty array remains a valid no-data state.
+    static func mapQuota(_ body: Data) throws -> [MetricLine] {
+        guard let root = ProviderParse.jsonObject(body) else {
+            throw ZAIUsageError.invalidResponse
+        }
         // The limits array lives under `data.limits`; the legacy plugin also tolerated the root object
         // being the container directly (no `data` wrapper), so honor both.
-        let container = root["data"] as? [String: Any] ?? root
-        guard let limits = container["limits"] as? [[String: Any]], !limits.isEmpty else {
+        let container: [String: Any]
+        if let data = root["data"] {
+            guard let data = data as? [String: Any] else { throw ZAIUsageError.invalidResponse }
+            container = data
+        } else {
+            container = root
+        }
+        guard let limits = container["limits"] as? [[String: Any]] else {
+            throw ZAIUsageError.invalidResponse
+        }
+        guard !limits.isEmpty else {
             return [.noUsageData]
         }
 
         var lines: [MetricLine] = []
+        var sawRecognizedLimit = false
 
         // Split the TOKENS_LIMIT entries by window length: a sub-daily window is the session meter,
         // a multi-day window is the weekly meter. Z.ai reports both, and both are percentage meters.
         let tokenLimits = limits.filter { ($0["type"] as? String) == "TOKENS_LIMIT" || ($0["name"] as? String) == "TOKENS_LIMIT" }
         for entry in tokenLimits {
-            switch classifyTokenWindow(entry) {
+            sawRecognizedLimit = true
+            guard let window = try classifyTokenWindow(entry) else { continue }
+            switch window {
             case .session(let periodMs):
-                lines.append(percentLine(entry, label: "Session", periodMs: periodMs))
+                lines.append(try percentLine(entry, label: "Session", periodMs: periodMs))
             case .weekly(let periodMs):
-                lines.append(percentLine(entry, label: "Weekly", periodMs: periodMs))
-            case .unknown:
-                continue
+                lines.append(try percentLine(entry, label: "Weekly", periodMs: periodMs))
             }
         }
         if let web = findLimit(limits, type: "TIME_LIMIT") {
-            lines.append(webSearchLine(from: web))
+            sawRecognizedLimit = true
+            lines.append(try webSearchLine(from: web))
         }
 
-        MetricLine.appendNoDataIfNeeded(&lines)
+        guard !lines.isEmpty else {
+            if sawRecognizedLimit { throw ZAIUsageError.invalidResponse }
+            return [.noUsageData]
+        }
         return lines
     }
 
@@ -86,16 +102,32 @@ enum ZAIUsageMapper {
 
     /// How a `TOKENS_LIMIT` entry's window maps to a meter. Z.ai encodes the window as a `(unit, number)`
     /// pair: `unit: 3` is hours (session), `unit: 6` is weeks (weekly), `unit: 5` is months. A sub-daily
-    /// window is the session meter; a multi-day window is the weekly meter; anything unrecognized is
-    /// skipped so a future unit value can't silently overwrite a known meter.
+    /// window is the session meter; a multi-day window is the weekly meter. Unknown units are ignored
+    /// so a future Z.ai window cannot hide meters whose units OpenUsage still understands.
     private enum TokenWindow {
         case session(periodMs: Int)
         case weekly(periodMs: Int)
-        case unknown
     }
 
-    private static func classifyTokenWindow(_ entry: [String: Any]) -> TokenWindow {
-        guard let periodMs = periodDurationMs(for: entry) else { return .unknown }
+    private static func classifyTokenWindow(_ entry: [String: Any]) throws -> TokenWindow? {
+        guard let unit = strictNumber(entry["unit"]),
+              let number = strictNumber(entry["number"]),
+              number > 0 else {
+            throw ZAIUsageError.invalidResponse
+        }
+        let unitMs: Double
+        switch unit {
+        case 3: unitMs = 60 * 60 * 1000
+        case 4: unitMs = 24 * 60 * 60 * 1000
+        case 6: unitMs = 7 * 24 * 60 * 60 * 1000
+        case 5: unitMs = 30 * 24 * 60 * 60 * 1000
+        default: return nil
+        }
+        let duration = unitMs * number
+        guard duration >= 1, duration < Double(Int.max) else {
+            throw ZAIUsageError.invalidResponse
+        }
+        let periodMs = Int(duration)
         // Sub-daily → session; multi-day → weekly. The computed window rides along so the meter's
         // cadence reflects the payload instead of a hardcoded constant.
         if periodMs < 24 * 60 * 60 * 1000 {
@@ -104,26 +136,12 @@ enum ZAIUsageMapper {
         return .weekly(periodMs: periodMs)
     }
 
-    /// Resolve a `(unit, number)` window to milliseconds. `unit` is Z.ai's internal time-unit code.
-    private static func periodDurationMs(for entry: [String: Any]) -> Int? {
-        guard let unit = ProviderParse.number(entry["unit"]),
-              let number = ProviderParse.number(entry["number"]) else {
-            return nil
-        }
-        let unitMs: Double
-        switch unit {
-        case 3: unitMs = 60 * 60 * 1000           // hours
-        case 4: unitMs = 24 * 60 * 60 * 1000      // days
-        case 6: unitMs = 7 * 24 * 60 * 60 * 1000  // weeks
-        case 5: unitMs = 30 * 24 * 60 * 60 * 1000 // months
-        default: return nil
-        }
-        return Int(unitMs * number)
-    }
-
     /// A percentage meter (Session or Weekly) from a `TOKENS_LIMIT` entry.
-    private static func percentLine(_ entry: [String: Any], label: String, periodMs: Int) -> MetricLine {
-        let percentage = ProviderParse.clampPercent(ProviderParse.number(entry["percentage"]) ?? 0)
+    private static func percentLine(_ entry: [String: Any], label: String, periodMs: Int) throws -> MetricLine {
+        guard let rawPercentage = strictNumber(entry["percentage"]) else {
+            throw ZAIUsageError.invalidResponse
+        }
+        let percentage = ProviderParse.clampPercent(rawPercentage)
         let resetsAt = ProviderParse.number(entry["nextResetTime"]).map { epochMsToDate($0) }
         return .progress(
             label: label,
@@ -136,9 +154,13 @@ enum ZAIUsageMapper {
     }
 
     /// TIME_LIMIT → a count meter (used / limit) for monthly web-search/reader calls.
-    private static func webSearchLine(from entry: [String: Any]) -> MetricLine {
-        let used = max(0, ProviderParse.number(entry["currentValue"]) ?? 0)
-        let limit = max(0, ProviderParse.number(entry["usage"]) ?? 0)
+    private static func webSearchLine(from entry: [String: Any]) throws -> MetricLine {
+        guard let used = strictNumber(entry["currentValue"]),
+              let limit = strictNumber(entry["usage"]),
+              used >= 0,
+              limit >= 0 else {
+            throw ZAIUsageError.invalidResponse
+        }
         // TIME_LIMIT carries a nextResetTime in current payloads (monthly renewal); honor it when
         // present so the countdown shows the real reset, otherwise the period cadence reads "monthly".
         let resetsAt = ProviderParse.number(entry["nextResetTime"]).map { epochMsToDate($0) }
@@ -161,6 +183,19 @@ enum ZAIUsageMapper {
             }
         }
         return nil
+    }
+
+    /// JSON booleans bridge through `NSNumber`; they are not quota numbers. Finite numeric strings are
+    /// retained for compatibility with payload revisions the shared parser already accepts.
+    private static func strictNumber(_ value: Any?) -> Double? {
+        if let bridged = value as? NSNumber,
+           CFGetTypeID(bridged) == CFBooleanGetTypeID() {
+            return nil
+        }
+        guard let number = ProviderParse.number(value), number.isFinite else {
+            return nil
+        }
+        return number
     }
 
     /// `nextResetTime` arrives as epoch milliseconds (e.g. `1770648402389`).

--- a/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
@@ -65,8 +65,8 @@ enum ZAIUsageMapper {
         // a multi-day window is the weekly meter. Z.ai reports both, and both are percentage meters.
         let tokenLimits = limits.filter { ($0["type"] as? String) == "TOKENS_LIMIT" || ($0["name"] as? String) == "TOKENS_LIMIT" }
         for entry in tokenLimits {
-            sawRecognizedLimit = true
             guard let window = try classifyTokenWindow(entry) else { continue }
+            sawRecognizedLimit = true
             switch window {
             case .session(let periodMs):
                 lines.append(try percentLine(entry, label: "Session", periodMs: periodMs))

--- a/Tests/OpenUsageTests/ZAILiveResponseMappingTests.swift
+++ b/Tests/OpenUsageTests/ZAILiveResponseMappingTests.swift
@@ -20,7 +20,7 @@ final class ZAILiveResponseMappingTests: XCTestCase {
     """#
 
     func testMapsLiveResponseToSessionWeeklyAndWebSearches() throws {
-        let mapped = ZAIUsageMapper.map(
+        let mapped = try ZAIUsageMapper.map(
             quotaBody: Data(liveQuota.utf8),
             subscriptionBody: Data(liveSubscription.utf8)
         )

--- a/Tests/OpenUsageTests/ZAIProviderTests.swift
+++ b/Tests/OpenUsageTests/ZAIProviderTests.swift
@@ -250,7 +250,7 @@ final class ZAIAuthStoreTests: XCTestCase {
 
 final class ZAIUsageMapperTests: XCTestCase {
     func testMapsBothLimitsToSessionAndWebSearches() throws {
-        let mapped = ZAIUsageMapper.map(quotaBody: data(quotaBothLimitsJSON), subscriptionBody: data(subscriptionJSON))
+        let mapped = try ZAIUsageMapper.map(quotaBody: data(quotaBothLimitsJSON), subscriptionBody: data(subscriptionJSON))
 
         XCTAssertEqual(mapped.plan, "GLM Coding Max")
 
@@ -292,7 +292,7 @@ final class ZAIUsageMapperTests: XCTestCase {
           "success": true
         }
         """#
-        let mapped = ZAIUsageMapper.map(quotaBody: data(divergentJSON), subscriptionBody: nil)
+        let mapped = try ZAIUsageMapper.map(quotaBody: data(divergentJSON), subscriptionBody: nil)
         XCTAssertEqual(try XCTUnwrap(progress(mapped.lines, "Session")).periodDurationMs,
                        3 * 60 * 60 * 1000)
         XCTAssertEqual(try XCTUnwrap(progress(mapped.lines, "Weekly")).periodDurationMs,
@@ -300,7 +300,7 @@ final class ZAIUsageMapperTests: XCTestCase {
     }
 
     func testMapsSessionOnlyWhenNoTimeLimit() throws {
-        let mapped = ZAIUsageMapper.map(quotaBody: data(quotaSessionOnlyJSON), subscriptionBody: nil)
+        let mapped = try ZAIUsageMapper.map(quotaBody: data(quotaSessionOnlyJSON), subscriptionBody: nil)
 
         XCTAssertNil(mapped.plan)
         XCTAssertNotNil(progress(mapped.lines, "Session"))
@@ -315,8 +315,8 @@ final class ZAIUsageMapperTests: XCTestCase {
         XCTAssertNil(ZAIUsageMapper.planName(from: data(#"{"data":[]}"#)))
     }
 
-    func testEmptyLimitsYieldNoUsageData() {
-        let mapped = ZAIUsageMapper.map(quotaBody: data(#"{"data":{"limits":[]}}"#), subscriptionBody: nil)
+    func testEmptyLimitsYieldNoUsageData() throws {
+        let mapped = try ZAIUsageMapper.map(quotaBody: data(#"{"data":{"limits":[]}}"#), subscriptionBody: nil)
         // No usable limits → the shared "No usage data" placeholder, not a blank tile.
         XCTAssertTrue(mapped.lines.contains { $0.label == "Status" })
     }
@@ -337,7 +337,7 @@ final class ZAIUsageMapperTests: XCTestCase {
         let body = data(#"""
         {"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":150,"currentValue":10,"usage":10}]}}
         """#)
-        let lines = ZAIUsageMapper.mapQuota(body)
+        let lines = try ZAIUsageMapper.mapQuota(body)
         let sessionUsed = try XCTUnwrap(progress(lines, "Session")?.used)
         XCTAssertEqual(sessionUsed, 100, accuracy: 0.001)
     }
@@ -347,7 +347,7 @@ final class ZAIUsageMapperTests: XCTestCase {
         let body = data(#"""
         {"data":{"limits":[{"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":25}]}}
         """#)
-        let lines = ZAIUsageMapper.mapQuota(body)
+        let lines = try ZAIUsageMapper.mapQuota(body)
         XCTAssertNil(progress(lines, "Session"))
         let weekly = try XCTUnwrap(progress(lines, "Weekly"))
         XCTAssertEqual(weekly.used, 25, accuracy: 0.001)

--- a/Tests/OpenUsageTests/ZAIQuotaValidationTests.swift
+++ b/Tests/OpenUsageTests/ZAIQuotaValidationTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import OpenUsage
+
+final class ZAIQuotaValidationMapperTests: XCTestCase {
+    func testMissingRequiredValuesNeverBecomeZeroUsage() {
+        let malformedLimits = [
+            #"{"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5}]}}"#,
+            #"{"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":true}]}}"#,
+            #"{"data":{"limits":[{"type":"TIME_LIMIT","usage":1000}]}}"#,
+            #"{"data":{"limits":[{"type":"TIME_LIMIT","currentValue":10}]}}"#,
+            #"{"data":{"limits":[{"type":"TIME_LIMIT","currentValue":-1,"usage":1000}]}}"#
+        ]
+
+        for body in malformedLimits {
+            XCTAssertThrowsError(try ZAIUsageMapper.mapQuota(Data(body.utf8)), body) { error in
+                XCTAssertEqual(error as? ZAIUsageError, .invalidResponse, body)
+            }
+        }
+    }
+
+    func testMalformedEnvelopeIsRejectedButExplicitEmptyLimitsRemainValid() throws {
+        for body in ["not-json", #"{"data":[]}"#, #"{"data":{}}"#, #"{"data":{"limits":{}}}"#] {
+            XCTAssertThrowsError(try ZAIUsageMapper.mapQuota(Data(body.utf8)), body) { error in
+                XCTAssertEqual(error as? ZAIUsageError, .invalidResponse, body)
+            }
+        }
+
+        let lines = try ZAIUsageMapper.mapQuota(Data(#"{"data":{"limits":[]}}"#.utf8))
+        XCTAssertNotNil(lines.first { $0.label == "Status" })
+    }
+
+    func testUnknownEntriesDoNotHideKnownMeters() throws {
+        let body = Data(
+            #"{"data":{"limits":[{"type":"FUTURE_LIMIT"},{"type":"TOKENS_LIMIT","unit":99,"number":1,"percentage":70},{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":25}]}}"#.utf8
+        )
+
+        let lines = try ZAIUsageMapper.mapQuota(body)
+
+        XCTAssertNotNil(lines.first { $0.label == "Session" })
+        XCTAssertNil(lines.first { $0.label == "Weekly" })
+    }
+}
+
+@MainActor
+final class ZAIQuotaValidationProviderTests: XCTestCase {
+    func testMissingUsageReportsInvalidResponseInsteadOfZeroMeter() async {
+        let provider = ZAIProvider(
+            authStore: ZAIAuthStore(
+                files: FakeFiles(),
+                environment: FakeEnvironment(["ZAI_API_KEY": "zai-test"])
+            ),
+            usageClient: ZAIUsageClient(http: RoutingHTTPClient { request in
+                if request.url == ZAIUsageClient.quotaURL {
+                    return HTTPResponse(
+                        statusCode: 200,
+                        headers: [:],
+                        body: Data(#"{"data":{"limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5}]}}"#.utf8)
+                    )
+                }
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"data":[]}"#.utf8))
+            })
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .decoding)
+        XCTAssertNil(snapshot.line(label: "Session"))
+    }
+}

--- a/Tests/OpenUsageTests/ZAIQuotaValidationTests.swift
+++ b/Tests/OpenUsageTests/ZAIQuotaValidationTests.swift
@@ -39,6 +39,16 @@ final class ZAIQuotaValidationMapperTests: XCTestCase {
         XCTAssertNotNil(lines.first { $0.label == "Session" })
         XCTAssertNil(lines.first { $0.label == "Weekly" })
     }
+
+    func testOnlyUnknownLimitsRemainForwardCompatibleNoData() throws {
+        let body = Data(
+            #"{"data":{"limits":[{"type":"FUTURE_LIMIT"},{"type":"TOKENS_LIMIT","unit":99,"number":1,"percentage":70}]}}"#.utf8
+        )
+
+        let lines = try ZAIUsageMapper.mapQuota(body)
+
+        XCTAssertNotNil(lines.first { $0.label == "Status" })
+    }
 }
 
 @MainActor

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -45,7 +45,9 @@ Two undocumented internal endpoints Z.ai's own subscription UI uses (stable in p
 - `GET https://api.z.ai/api/monitor/usage/quota/limit` — the quota meters.
 
 The quota response carries a `limits` array. Each `TOKENS_LIMIT` entry is a token window; its
-window length decides which meter it feeds (sub-daily → Session, multi-day → Weekly), so a `TIME_LIMIT` entry is the monthly web-search count. Reset times come back as epoch milliseconds.
+window length decides which meter it feeds (sub-daily → Session, multi-day → Weekly), while a
+`TIME_LIMIT` entry is the monthly web-search count. Reset times come back as epoch milliseconds.
+Missing required usage values are reported as an invalid response instead of being shown as zero.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## TL;DR

Rejects malformed Z.ai quota payloads instead of silently turning missing required values into zero usage, while keeping explicit empty and future unknown limit shapes forward-compatible. This is stacked on #948 so Z.ai reuses the shared numeric boundary parser rather than duplicating it.

## What was happening

- A recognized token quota without `percentage` became `0%` usage.
- A web-search quota without `currentValue` or `usage` became a zero-valued meter.
- Malformed quota envelopes fell through to the same "No usage data" state as an explicitly empty limits list.
- The earlier broad fix mixed this invariant with additional business-error taxonomy and was too costly to review.

## What this changes

- Makes quota mapping fail with the existing typed invalid-response error when a recognized meter omits or corrupts required numeric values.
- Reuses `ProviderParse.number` from #948 for boolean rejection, finite-number validation, and numeric-string compatibility; the duplicate Z.ai parser is removed.
- Keeps an explicit empty `limits` array as valid no-data.
- Ignores unknown limit types and future window units when known meters remain usable.
- Preserves the existing no-plan behavior and avoids adding new provider error states.
- Documents that malformed required usage values are never presented as zero.

## Heads-up

- This PR is intentionally based on `codex/cursor-boundary-integrity`; merge #948 first.
- This supersedes #918 with a smaller, forward-compatible implementation focused only on preventing fabricated quota values.

## Tests

- `swift test --filter ZAI`: 41 passed.
- `swift test`: 983 XCTest cases passed, 3 expected skips; 3 Swift Testing cases passed.
- `./script/build_and_run.sh verify`: release build, staging, signing, and launch passed.
- Exact executable-path verification confirmed the staged `dist/OpenUsage.app` binary was running.
- `codesign --verify --deep --strict --verbose=2 dist/OpenUsage.app`: passed.
- `git diff --check`: passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how live Z.ai quota JSON is interpreted for the dashboard; users may see a decoding error instead of false zero meters, but auth and billing paths are untouched.
> 
> **Overview**
> **Z.ai quota mapping no longer fabricates zero usage** when required fields are missing or corrupt. `ZAIUsageMapper.map` / `mapQuota` and the helpers that build Session, Weekly, and Web Search lines now **throw** `ZAIUsageError.invalidResponse` instead of defaulting omitted `percentage`, `currentValue`, or `usage` to `0`, or treating bad envelopes like an empty limits list.
> 
> `ZAIProvider.refresh()` **wraps mapping in `do/catch`** so those failures become a provider error snapshot (e.g. decoding category in tests) rather than misleading meters.
> 
> **Forward compatibility is preserved:** an explicit empty `limits` array still yields the "No usage data" placeholder; unknown limit types and unrecognized token window units are skipped when a known meter can still be built; only recognized-but-unmappable limits trigger invalid response.
> 
> Adds **`ZAIQuotaValidationTests`** (mapper + provider) and a short note in **`docs/providers/zai.md`** that missing required values are not shown as zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31d37b99cacffa83842902a436336ff8628fcb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->