### PR TITLE
Refactor LayoutStore into cohesive source files

### DIFF
--- a/Sources/OpenUsage/Stores/LayoutStore+Customization.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore+Customization.swift
@@ -173,10 +173,10 @@ extension LayoutStore {
     /// Reorder metrics within one provider when `dragged` is dropped onto `target` (both descriptor ids of
     /// that provider). Operates on the provider's full metric order so disabled metrics keep their place too.
     ///
-    /// Dropping onto a row in the *other* section moves `dragged` across the "Shown on expand" divider:
-    /// its expanded membership follows the target's, so dragging a metric under an expanded one tucks it
-    /// away too (and vice versa). The stored order is rebuilt as always-shown rows then expanded rows, so
-    /// it always matches the partitioned layout the UI draws. Returns whether anything actually changed —
+    /// Dropping onto a row in the *other* section moves `dragged` between Always Visible and On Demand:
+    /// its On Demand membership follows the target's, so dragging a metric under an On Demand one tucks it
+    /// away too (and vice versa). The stored order is rebuilt in those two sections, so it always matches
+    /// the partitioned layout the UI draws. Returns whether anything actually changed —
     /// the drag gestures key haptics off it.
     @discardableResult
     func reorderMetric(dragged: String, target: String, in providerID: String) -> Bool {
@@ -202,7 +202,7 @@ extension LayoutStore {
         let consumedExpandOnEnable = !expanded.contains(dragged)
             && defaultExpandedOnEnableIDs.remove(dragged) != nil
 
-        // Lay the provider out the way it renders — always-shown rows, then expanded rows — keeping each
+        // Lay the provider out the way it renders — Always Visible rows, then On Demand rows — keeping each
         // section in its current order, then drop `dragged` next to `target` within that combined sequence.
         let partitioned = ordered.filter { !expanded.contains($0) } + ordered.filter { expanded.contains($0) }
         guard let next = Self.reordered(partitioned, dragged: dragged, target: target) else {
@@ -225,7 +225,7 @@ extension LayoutStore {
     }
 
     /// Apply a provider metric order that includes one visual divider sentinel. Metrics before the
-    /// sentinel become always-shown; metrics after it become shown-on-expand. This is the clean drag
+    /// sentinel become Always Visible; metrics after it become On Demand. This is the clean drag
     /// model for Customize: the divider participates in target geometry like a row, but persistence
     /// remains metric-only.
     @discardableResult

--- a/Sources/OpenUsage/Stores/LayoutStore+Customization.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore+Customization.swift
@@ -1,0 +1,345 @@
+extension LayoutStore {
+    func provider(id: String) -> Provider? { registry.provider(id: id) }
+
+    func descriptor(for widget: PlacedWidget) -> WidgetDescriptor? {
+        registry.descriptor(id: widget.descriptorID)
+    }
+
+    private func providerID(of widget: PlacedWidget) -> String? {
+        registry.descriptor(id: widget.descriptorID)?.providerID
+    }
+
+    var visiblePlaced: [PlacedWidget] {
+        placed.filter { widget in
+            guard let providerID = providerID(of: widget) else { return true }
+            return isProviderEnabled(providerID)
+        }
+    }
+
+    func isMetricEnabled(_ descriptorID: String) -> Bool {
+        placed.contains { $0.descriptorID == descriptorID }
+    }
+
+    /// Whether any enabled provider ships the local spend tiles — the capability gate for the
+    /// Total Spend card. Keyed off the registry's descriptors, not off refreshed data, so the card
+    /// can show its "No spend data" state on a fresh morning instead of vanishing.
+    var hasSpendCapableProvider: Bool {
+        !spendCapableProviders.isEmpty
+    }
+
+    /// Enabled providers that ship the local spend tiles (`WidgetDescriptor.spendTiles`), in the
+    /// user's provider order — the exact set the Total Spend card aggregates. Deliberately *not*
+    /// `displayGroups`: a provider whose every metric is hidden in Customize still spends money and
+    /// must still count, and look-alike dollar rows from other providers (OpenRouter's API-spend
+    /// "Today") must not.
+    var spendCapableProviders: [Provider] {
+        let capableIDs = Set(registry.descriptors.filter(\.isSpendTile).map(\.providerID))
+        return orderedProviders().filter { capableIDs.contains($0.id) && isProviderEnabled($0.id) }
+    }
+
+    // MARK: - Provider grouping
+
+    /// Known providers in the user's saved order, with any not-yet-seen provider appended in registry order
+    /// so a newly added provider still shows up.
+    func orderedProviderIDs() -> [String] {
+        let known = registry.providers.map(\.id)
+        let ordered = providerOrder.filter { known.contains($0) }
+        let missing = known.filter { !ordered.contains($0) }
+        return ordered + missing
+    }
+
+    private func orderedProviders() -> [Provider] {
+        orderedProviderIDs().compactMap { registry.provider(id: $0) }
+    }
+
+    /// Enabled (and provider-enabled) widgets grouped by provider, in the user's provider order, each
+    /// provider's metrics kept in the provider's custom metric order. Drives the grouped dashboard list; providers with
+    /// no visible metric are dropped so the dashboard only shows groups that have something to show.
+    var displayGroups: [ProviderGroup] {
+        orderedProviders().compactMap { provider in
+            let widgetsByDescriptor = Dictionary(
+                visiblePlaced
+                    .filter { providerID(of: $0) == provider.id }
+                    .map { ($0.descriptorID, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            let widgets = metricOrder(for: provider.id).compactMap { widgetsByDescriptor[$0] }
+            guard !widgets.isEmpty else { return nil }
+            let alwaysShown = widgets.filter { !expandedMetricIDs.contains($0.descriptorID) }
+            let expanded = widgets.filter { expandedMetricIDs.contains($0.descriptorID) }
+            // A provider whose only enabled metrics are all marked expanded would otherwise render an
+            // empty card with a caret — promote them to always-shown so the card always has rows.
+            if alwaysShown.isEmpty {
+                return ProviderGroup(provider: provider, alwaysShownWidgets: expanded, expandedWidgets: [])
+            }
+            return ProviderGroup(provider: provider, alwaysShownWidgets: alwaysShown, expandedWidgets: expanded)
+        }
+    }
+
+    /// Every enabled provider with *all* the metrics it supports, in its saved metric order. Enabled and
+    /// disabled rows stay in-place; the switch only controls visibility.
+    var customizeGroups: [ProviderMetrics] {
+        orderedProviders().compactMap { provider in
+            guard isProviderEnabled(provider.id) else { return nil }
+            let metrics = orderedSupportedMetrics(for: provider.id)
+            guard !metrics.isEmpty else { return nil }
+            return ProviderMetrics(
+                provider: provider,
+                alwaysShownMetrics: metrics.filter { !expandedMetricIDs.contains($0.id) },
+                expandedMetrics: metrics.filter { expandedMetricIDs.contains($0.id) }
+            )
+        }
+    }
+
+    /// The L1 Customize list: every known provider in the user's saved order, regardless of enablement.
+    /// Disabled providers appear here (greyed in the UI) so the user can re-enable them or open their
+    /// detail — unlike the enabled-provider reorder list exposed by `customizeGroups`, which filters them
+    /// out. Each row carries the enablement flag and total metric count shown by the list.
+    var customizeProviderRows: [ProviderRow] {
+        orderedProviders().map { provider in
+            ProviderRow(
+                provider: provider,
+                isEnabled: isProviderEnabled(provider.id),
+                metricCount: metricCount(for: provider.id)
+            )
+        }
+    }
+
+    /// Total metrics a provider supports — the L1 row's badge number. Registry descriptor count,
+    /// independent of how many the user has enabled.
+    func metricCount(for providerID: String) -> Int {
+        registry.descriptors(for: providerID).count
+    }
+
+    /// The L2 Customize detail for one provider: every metric it supports, split across the
+    /// "Always Visible" / "On Demand" divider, in its saved metric order. Available even when the
+    /// provider is disabled so L2 can render dimmed-but-editable. nil for an unknown provider or one
+    /// with no metrics — the per-provider slice of `customizeGroups` without the enablement guard.
+    func customizeDetail(for providerID: String) -> ProviderMetrics? {
+        guard let provider = registry.provider(id: providerID) else { return nil }
+        let metrics = orderedSupportedMetrics(for: providerID)
+        guard !metrics.isEmpty else { return nil }
+        return ProviderMetrics(
+            provider: provider,
+            alwaysShownMetrics: metrics.filter { !expandedMetricIDs.contains($0.id) },
+            expandedMetrics: metrics.filter { expandedMetricIDs.contains($0.id) }
+        )
+    }
+
+    /// A provider's supported metrics in custom order, independent of whether each metric is enabled.
+    func orderedSupportedMetrics(for providerID: String) -> [WidgetDescriptor] {
+        metricOrder(for: providerID).compactMap { registry.descriptor(id: $0) }
+    }
+
+    func metricOrderWithDivider(for providerID: String, dividerID: String) -> [String] {
+        let ordered = orderedSupportedMetrics(for: providerID).map(\.id)
+        return ordered.filter { !expandedMetricIDs.contains($0) }
+            + [dividerID]
+            + ordered.filter { expandedMetricIDs.contains($0) }
+    }
+
+    /// Pinned metrics grouped by provider, in the user's Customize order (provider order, then each
+    /// provider's metric order). A temporarily disabled provider is excluded from the rendered groups
+    /// but keeps its pins. Drives the menu-bar strip.
+    var pinnedGroups: [ProviderMetrics] {
+        orderedProviders().compactMap { provider in
+            guard isProviderEnabled(provider.id) else { return nil }
+            // Keep the strip order matching Customize: always-shown pins first, then expanded ones.
+            let metrics = orderedSupportedMetrics(for: provider.id).filter { pinnedMetricIDs.contains($0.id) }
+            return metrics.isEmpty ? nil : ProviderMetrics(
+                provider: provider,
+                alwaysShownMetrics: metrics.filter { !expandedMetricIDs.contains($0.id) },
+                expandedMetrics: metrics.filter { expandedMetricIDs.contains($0.id) }
+            )
+        }
+    }
+
+    /// Reorder whole providers when `dragged`'s header is dropped onto `target`'s. Works on the currently
+    /// shown (enabled) provider order; disabled providers keep their relative tail position.
+    /// Returns whether the order actually changed — the drag gestures key haptics off it.
+    @discardableResult
+    func reorderProvider(dragged: String, target: String) -> Bool {
+        recordingUndoStep {
+            let shown = customizeGroups.map(\.provider.id)
+            guard let next = Self.reordered(shown, dragged: dragged, target: target) else { return false }
+            let rest = orderedProviderIDs().filter { !next.contains($0) }
+            providerOrder = next + rest
+            persistProviderOrder()
+            syncPlacedOrder()
+            return true
+        }
+    }
+
+    /// Reorder metrics within one provider when `dragged` is dropped onto `target` (both descriptor ids of
+    /// that provider). Operates on the provider's full metric order so disabled metrics keep their place too.
+    ///
+    /// Dropping onto a row in the *other* section moves `dragged` across the "Shown on expand" divider:
+    /// its expanded membership follows the target's, so dragging a metric under an expanded one tucks it
+    /// away too (and vice versa). The stored order is rebuilt as always-shown rows then expanded rows, so
+    /// it always matches the partitioned layout the UI draws. Returns whether anything actually changed —
+    /// the drag gestures key haptics off it.
+    @discardableResult
+    func reorderMetric(dragged: String, target: String, in providerID: String) -> Bool {
+        recordingUndoStep { reorderMetricImpl(dragged: dragged, target: target, in: providerID) }
+    }
+
+    private func reorderMetricImpl(dragged: String, target: String, in providerID: String) -> Bool {
+        guard dragged != target else { return false }
+        let ordered = metricOrder(for: providerID)
+        guard ordered.contains(dragged), ordered.contains(target) else { return false }
+
+        var expanded = expandedMetricIDs
+        let membershipChanged = expanded.contains(dragged) != expanded.contains(target)
+        if expanded.contains(target) {
+            expanded.insert(dragged)
+        } else {
+            expanded.remove(dragged)
+        }
+
+        // Landing a metric in the always-shown section is an explicit placement, so it consumes its
+        // expand-on-enable default — otherwise enabling it later would tuck it back below the caret,
+        // overriding this drag.
+        let consumedExpandOnEnable = !expanded.contains(dragged)
+            && defaultExpandedOnEnableIDs.remove(dragged) != nil
+
+        // Lay the provider out the way it renders — always-shown rows, then expanded rows — keeping each
+        // section in its current order, then drop `dragged` next to `target` within that combined sequence.
+        let partitioned = ordered.filter { !expanded.contains($0) } + ordered.filter { expanded.contains($0) }
+        guard let next = Self.reordered(partitioned, dragged: dragged, target: target) else {
+            guard membershipChanged || consumedExpandOnEnable else { return false }
+            metricOrderByProvider[providerID] = partitioned
+            expandedMetricIDs = expanded
+            persistMetricOrder()
+            persistExpanded()
+            if consumedExpandOnEnable { persistExpandOnEnable() }
+            syncPlacedOrder()
+            return true
+        }
+        metricOrderByProvider[providerID] = next
+        expandedMetricIDs = expanded
+        persistMetricOrder()
+        if membershipChanged { persistExpanded() }
+        if consumedExpandOnEnable { persistExpandOnEnable() }
+        syncPlacedOrder()
+        return true
+    }
+
+    /// Apply a provider metric order that includes one visual divider sentinel. Metrics before the
+    /// sentinel become always-shown; metrics after it become shown-on-expand. This is the clean drag
+    /// model for Customize: the divider participates in target geometry like a row, but persistence
+    /// remains metric-only.
+    @discardableResult
+    func applyMetricDividerOrder(_ orderedIDsWithDivider: [String], dragged: String, dividerID: String, in providerID: String) -> Bool {
+        recordingUndoStep {
+            applyMetricDividerOrderImpl(orderedIDsWithDivider, dragged: dragged, dividerID: dividerID, in: providerID)
+        }
+    }
+
+    private func applyMetricDividerOrderImpl(_ orderedIDsWithDivider: [String], dragged: String, dividerID: String, in providerID: String) -> Bool {
+        let validIDs = metricOrder(for: providerID)
+        let validSet = Set(validIDs)
+        guard orderedIDsWithDivider.contains(dividerID) else { return false }
+
+        var seen = Set<String>()
+        var alwaysShown: [String] = []
+        var expanded: [String] = []
+        var isBelowDivider = false
+
+        for id in orderedIDsWithDivider {
+            if id == dividerID {
+                isBelowDivider = true
+                continue
+            }
+            guard validSet.contains(id), seen.insert(id).inserted else { continue }
+            if isBelowDivider {
+                expanded.append(id)
+            } else {
+                alwaysShown.append(id)
+            }
+        }
+
+        // Dashboard rows only render enabled metrics. Merge disabled rows back into their previous
+        // sections so a dashboard drag does not push hidden Customize rows to the end.
+        let desiredAlwaysShown = Set(alwaysShown)
+        let desiredExpanded = Set(expanded)
+        let previousAlwaysShown = validIDs.filter { !expandedMetricIDs.contains($0) && !desiredExpanded.contains($0) }
+        let previousExpanded = validIDs.filter { expandedMetricIDs.contains($0) && !desiredAlwaysShown.contains($0) }
+        alwaysShown = Self.mergingMissingMetrics(into: alwaysShown, previous: previousAlwaysShown)
+        expanded = Self.mergingMissingMetrics(into: expanded, previous: previousExpanded)
+
+        let nextOrder = alwaysShown + expanded
+        let providerExpanded = Set(expanded)
+        let providerIDs = Set(validIDs)
+        let nextExpanded = expandedMetricIDs.subtracting(providerIDs).union(providerExpanded)
+        // Only the dragged metric's expand-on-enable entry is consumed — an explicit placement.
+        // Clearing every metric in the list (the old `subtracting(seen)`) also cleared disabled
+        // optional metrics that `metricOrderWithDivider` includes by default but the user never moved,
+        // so they lost their below-caret default. Matches `reorderMetric`, which consumes only the
+        // dragged id.
+        var nextDefaultExpandedOnEnableIDs = defaultExpandedOnEnableIDs
+        let consumedExpandOnEnable = nextDefaultExpandedOnEnableIDs.remove(dragged) != nil
+        guard metricOrderByProvider[providerID] != nextOrder || expandedMetricIDs != nextExpanded || consumedExpandOnEnable else {
+            return false
+        }
+
+        metricOrderByProvider[providerID] = nextOrder
+        expandedMetricIDs = nextExpanded
+        defaultExpandedOnEnableIDs = nextDefaultExpandedOnEnableIDs
+        persistMetricOrder()
+        persistExpanded()
+        if consumedExpandOnEnable { persistExpandOnEnable() }
+        syncPlacedOrder()
+        return true
+    }
+
+    private static func mergingMissingMetrics(into ordered: [String], previous: [String]) -> [String] {
+        let orderedSet = Set(ordered)
+        var result: [String] = []
+        var emitted = Set<String>()
+        var orderedIndex = ordered.startIndex
+
+        func emitDesiredRows(through id: String) {
+            while orderedIndex < ordered.endIndex {
+                let next = ordered[orderedIndex]
+                orderedIndex = ordered.index(after: orderedIndex)
+                if emitted.insert(next).inserted {
+                    result.append(next)
+                }
+                if next == id { break }
+            }
+        }
+
+        for id in previous {
+            if orderedSet.contains(id) {
+                emitDesiredRows(through: id)
+            } else if emitted.insert(id).inserted {
+                result.append(id)
+            }
+        }
+
+        while orderedIndex < ordered.endIndex {
+            let next = ordered[orderedIndex]
+            orderedIndex = ordered.index(after: orderedIndex)
+            if emitted.insert(next).inserted {
+                result.append(next)
+            }
+        }
+
+        return result
+    }
+
+    /// Pure reorder: remove `dragged`, reinsert it adjacent to `target` (after it when moving down, before
+    /// it when moving up). Returns nil when either id is missing or they're identical. Mirrors the proven
+    /// macOS drag-reorder math from crafcat7/Peakmon (Apache-2.0).
+    static func reordered(_ ids: [String], dragged: String, target: String) -> [String]? {
+        guard dragged != target,
+              let from = ids.firstIndex(of: dragged),
+              let to = ids.firstIndex(of: target) else { return nil }
+        var next = ids
+        next.remove(at: from)
+        guard let adjusted = next.firstIndex(of: target) else { return nil }
+        let insert = from < to ? adjusted + 1 : adjusted
+        next.insert(dragged, at: min(insert, next.count))
+        return next
+    }
+}

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -6,6 +6,8 @@ import Observation
 @MainActor
 @Observable
 final class LayoutStore {
+    // Swift's private access is file-scoped. Members shared with `LayoutStore+Customization.swift`
+    // stay module-internal below; implementation details used only here remain private.
     var placed: [PlacedWidget]
 
     /// In-popover navigation (screen, Customize master/detail, screen-switch slide). Its own store so
@@ -51,7 +53,7 @@ final class LayoutStore {
     /// them behind a caret until the user taps it, and Customize lists them under the divider.
     /// Membership only — the sequence within each section follows the provider's metric order, like
     /// pins. A metric keeps its membership while disabled, so re-enabling restores its section.
-    private(set) var expandedMetricIDs: Set<String>
+    var expandedMetricIDs: Set<String>
 
     /// Provider IDs whose dashboard cards are currently opened with their expanded metrics visible.
     /// Unlike hover and drag state, this is a user preference: if someone likes Codex open, it should
@@ -100,13 +102,13 @@ final class LayoutStore {
         didSet { persistence.saveMenuBarStyle(menuBarStyle) }
     }
 
-    private let registry: WidgetRegistry
+    let registry: WidgetRegistry
     private let persistence: LayoutPersistence
     private let defaultMetricIDs: [String]
     private let defaultPinnedMetricIDs: [String]
     private let defaultExpandedMetricIDs: [String]
-    private var defaultExpandedOnEnableIDs: Set<String>
-    private let isProviderEnabled: @MainActor (String) -> Bool
+    var defaultExpandedOnEnableIDs: Set<String>
+    let isProviderEnabled: @MainActor (String) -> Bool
 
     init(
         registry: WidgetRegistry,
@@ -149,145 +151,6 @@ final class LayoutStore {
         if initial.shouldPersistExpanded { persistExpanded() }
         if let seededDefaults = initial.seededDefaultsToPersist { persistSeededDefaults(seededDefaults) }
         syncPlacedOrder(persistChanges: initial.shouldPersistPlaced)
-    }
-
-    func provider(id: String) -> Provider? { registry.provider(id: id) }
-
-    func descriptor(for widget: PlacedWidget) -> WidgetDescriptor? {
-        registry.descriptor(id: widget.descriptorID)
-    }
-
-    private func providerID(of widget: PlacedWidget) -> String? {
-        registry.descriptor(id: widget.descriptorID)?.providerID
-    }
-
-    var visiblePlaced: [PlacedWidget] {
-        placed.filter { widget in
-            guard let providerID = providerID(of: widget) else { return true }
-            return isProviderEnabled(providerID)
-        }
-    }
-
-    func isMetricEnabled(_ descriptorID: String) -> Bool {
-        placed.contains { $0.descriptorID == descriptorID }
-    }
-
-    /// Whether any enabled provider ships the local spend tiles — the capability gate for the
-    /// Total Spend card. Keyed off the registry's descriptors, not off refreshed data, so the card
-    /// can show its "No spend data" state on a fresh morning instead of vanishing.
-    var hasSpendCapableProvider: Bool {
-        !spendCapableProviders.isEmpty
-    }
-
-    /// Enabled providers that ship the local spend tiles (`WidgetDescriptor.spendTiles`), in the
-    /// user's provider order — the exact set the Total Spend card aggregates. Deliberately *not*
-    /// `displayGroups`: a provider whose every metric is hidden in Customize still spends money and
-    /// must still count, and look-alike dollar rows from other providers (OpenRouter's API-spend
-    /// "Today") must not.
-    var spendCapableProviders: [Provider] {
-        let capableIDs = Set(registry.descriptors.filter(\.isSpendTile).map(\.providerID))
-        return orderedProviders().filter { capableIDs.contains($0.id) && isProviderEnabled($0.id) }
-    }
-
-    // MARK: - Provider grouping
-
-    /// Known providers in the user's saved order, with any not-yet-seen provider appended in registry order
-    /// so a newly added provider still shows up.
-    private func orderedProviderIDs() -> [String] {
-        let known = registry.providers.map(\.id)
-        let ordered = providerOrder.filter { known.contains($0) }
-        let missing = known.filter { !ordered.contains($0) }
-        return ordered + missing
-    }
-
-    private func orderedProviders() -> [Provider] {
-        orderedProviderIDs().compactMap { registry.provider(id: $0) }
-    }
-
-    /// Enabled (and provider-enabled) widgets grouped by provider, in the user's provider order, each
-    /// provider's metrics kept in the provider's custom metric order. Drives the grouped dashboard list; providers with
-    /// no visible metric are dropped so the dashboard only shows groups that have something to show.
-    var displayGroups: [ProviderGroup] {
-        orderedProviders().compactMap { provider in
-            let widgetsByDescriptor = Dictionary(
-                visiblePlaced
-                    .filter { providerID(of: $0) == provider.id }
-                    .map { ($0.descriptorID, $0) },
-                uniquingKeysWith: { first, _ in first }
-            )
-            let widgets = metricOrder(for: provider.id).compactMap { widgetsByDescriptor[$0] }
-            guard !widgets.isEmpty else { return nil }
-            let alwaysShown = widgets.filter { !expandedMetricIDs.contains($0.descriptorID) }
-            let expanded = widgets.filter { expandedMetricIDs.contains($0.descriptorID) }
-            // A provider whose only enabled metrics are all marked expanded would otherwise render an
-            // empty card with a caret — promote them to always-shown so the card always has rows.
-            if alwaysShown.isEmpty {
-                return ProviderGroup(provider: provider, alwaysShownWidgets: expanded, expandedWidgets: [])
-            }
-            return ProviderGroup(provider: provider, alwaysShownWidgets: alwaysShown, expandedWidgets: expanded)
-        }
-    }
-
-    /// Every enabled provider with *all* the metrics it supports, in its saved metric order. Enabled and
-    /// disabled rows stay in-place; the switch only controls visibility.
-    var customizeGroups: [ProviderMetrics] {
-        orderedProviders().compactMap { provider in
-            guard isProviderEnabled(provider.id) else { return nil }
-            let metrics = orderedSupportedMetrics(for: provider.id)
-            guard !metrics.isEmpty else { return nil }
-            return ProviderMetrics(
-                provider: provider,
-                alwaysShownMetrics: metrics.filter { !expandedMetricIDs.contains($0.id) },
-                expandedMetrics: metrics.filter { expandedMetricIDs.contains($0.id) }
-            )
-        }
-    }
-
-    /// The L1 Customize list: every known provider in the user's saved order, regardless of enablement.
-    /// Disabled providers appear here (greyed in the UI) so the user can re-enable them or open their
-    /// detail — unlike the enabled-provider reorder list exposed by `customizeGroups`, which filters them
-    /// out. Each row carries the enablement flag and total metric count shown by the list.
-    var customizeProviderRows: [ProviderRow] {
-        orderedProviders().map { provider in
-            ProviderRow(
-                provider: provider,
-                isEnabled: isProviderEnabled(provider.id),
-                metricCount: metricCount(for: provider.id)
-            )
-        }
-    }
-
-    /// Total metrics a provider supports — the L1 row's badge number. Registry descriptor count,
-    /// independent of how many the user has enabled.
-    func metricCount(for providerID: String) -> Int {
-        registry.descriptors(for: providerID).count
-    }
-
-    /// The L2 Customize detail for one provider: every metric it supports, split across the
-    /// "Always Visible" / "On Demand" divider, in its saved metric order. Available even when the
-    /// provider is disabled so L2 can render dimmed-but-editable. nil for an unknown provider or one
-    /// with no metrics — the per-provider slice of `customizeGroups` without the enablement guard.
-    func customizeDetail(for providerID: String) -> ProviderMetrics? {
-        guard let provider = registry.provider(id: providerID) else { return nil }
-        let metrics = orderedSupportedMetrics(for: providerID)
-        guard !metrics.isEmpty else { return nil }
-        return ProviderMetrics(
-            provider: provider,
-            alwaysShownMetrics: metrics.filter { !expandedMetricIDs.contains($0.id) },
-            expandedMetrics: metrics.filter { expandedMetricIDs.contains($0.id) }
-        )
-    }
-
-    /// A provider's supported metrics in custom order, independent of whether each metric is enabled.
-    func orderedSupportedMetrics(for providerID: String) -> [WidgetDescriptor] {
-        metricOrder(for: providerID).compactMap { registry.descriptor(id: $0) }
-    }
-
-    func metricOrderWithDivider(for providerID: String, dividerID: String) -> [String] {
-        let ordered = orderedSupportedMetrics(for: providerID).map(\.id)
-        return ordered.filter { !expandedMetricIDs.contains($0) }
-            + [dividerID]
-            + ordered.filter { expandedMetricIDs.contains($0) }
     }
 
     func isProviderExpanded(_ providerID: String) -> Bool {
@@ -349,7 +212,7 @@ final class LayoutStore {
     /// action (toggling an already-on metric, dropping a row back where it started) doesn't pollute the
     /// stack with empty steps. Re-entrant calls (a mutation built from smaller ones) and undo replay
     /// itself coalesce into the single outer step via `isApplyingUndo`.
-    private func recordingUndoStep<T>(_ body: () -> T) -> T {
+    func recordingUndoStep<T>(_ body: () -> T) -> T {
         // Already inside an undoable scope (or replaying an undo): just run — the outer scope owns the
         // single recorded step, and undo must never record itself.
         guard !isApplyingUndo else { return body() }
@@ -392,195 +255,6 @@ final class LayoutStore {
         persistPins()
         persistExpanded()
         persistExpandOnEnable()
-    }
-
-    /// Reorder whole providers when `dragged`'s header is dropped onto `target`'s. Works on the currently
-    /// shown (enabled) provider order; disabled providers keep their relative tail position.
-    /// Returns whether the order actually changed — the drag gestures key haptics off it.
-    @discardableResult
-    func reorderProvider(dragged: String, target: String) -> Bool {
-        recordingUndoStep {
-            let shown = customizeGroups.map(\.provider.id)
-            guard let next = Self.reordered(shown, dragged: dragged, target: target) else { return false }
-            let rest = orderedProviderIDs().filter { !next.contains($0) }
-            providerOrder = next + rest
-            persistProviderOrder()
-            syncPlacedOrder()
-            return true
-        }
-    }
-
-    /// Reorder metrics within one provider when `dragged` is dropped onto `target` (both descriptor ids of
-    /// that provider). Operates on the provider's full metric order so disabled metrics keep their place too.
-    ///
-    /// Dropping onto a row in the *other* section moves `dragged` across the "Shown on expand" divider:
-    /// its expanded membership follows the target's, so dragging a metric under an expanded one tucks it
-    /// away too (and vice versa). The stored order is rebuilt as always-shown rows then expanded rows, so
-    /// it always matches the partitioned layout the UI draws. Returns whether anything actually changed —
-    /// the drag gestures key haptics off it.
-    @discardableResult
-    func reorderMetric(dragged: String, target: String, in providerID: String) -> Bool {
-        recordingUndoStep { reorderMetricImpl(dragged: dragged, target: target, in: providerID) }
-    }
-
-    private func reorderMetricImpl(dragged: String, target: String, in providerID: String) -> Bool {
-        guard dragged != target else { return false }
-        let ordered = metricOrder(for: providerID)
-        guard ordered.contains(dragged), ordered.contains(target) else { return false }
-
-        var expanded = expandedMetricIDs
-        let membershipChanged = expanded.contains(dragged) != expanded.contains(target)
-        if expanded.contains(target) {
-            expanded.insert(dragged)
-        } else {
-            expanded.remove(dragged)
-        }
-
-        // Landing a metric in the always-shown section is an explicit placement, so it consumes its
-        // expand-on-enable default — otherwise enabling it later would tuck it back below the caret,
-        // overriding this drag.
-        let consumedExpandOnEnable = !expanded.contains(dragged)
-            && defaultExpandedOnEnableIDs.remove(dragged) != nil
-
-        // Lay the provider out the way it renders — always-shown rows, then expanded rows — keeping each
-        // section in its current order, then drop `dragged` next to `target` within that combined sequence.
-        let partitioned = ordered.filter { !expanded.contains($0) } + ordered.filter { expanded.contains($0) }
-        guard let next = Self.reordered(partitioned, dragged: dragged, target: target) else {
-            guard membershipChanged || consumedExpandOnEnable else { return false }
-            metricOrderByProvider[providerID] = partitioned
-            expandedMetricIDs = expanded
-            persistMetricOrder()
-            persistExpanded()
-            if consumedExpandOnEnable { persistExpandOnEnable() }
-            syncPlacedOrder()
-            return true
-        }
-        metricOrderByProvider[providerID] = next
-        expandedMetricIDs = expanded
-        persistMetricOrder()
-        if membershipChanged { persistExpanded() }
-        if consumedExpandOnEnable { persistExpandOnEnable() }
-        syncPlacedOrder()
-        return true
-    }
-
-    /// Apply a provider metric order that includes one visual divider sentinel. Metrics before the
-    /// sentinel become always-shown; metrics after it become shown-on-expand. This is the clean drag
-    /// model for Customize: the divider participates in target geometry like a row, but persistence
-    /// remains metric-only.
-    @discardableResult
-    func applyMetricDividerOrder(_ orderedIDsWithDivider: [String], dragged: String, dividerID: String, in providerID: String) -> Bool {
-        recordingUndoStep {
-            applyMetricDividerOrderImpl(orderedIDsWithDivider, dragged: dragged, dividerID: dividerID, in: providerID)
-        }
-    }
-
-    private func applyMetricDividerOrderImpl(_ orderedIDsWithDivider: [String], dragged: String, dividerID: String, in providerID: String) -> Bool {
-        let validIDs = metricOrder(for: providerID)
-        let validSet = Set(validIDs)
-        guard orderedIDsWithDivider.contains(dividerID) else { return false }
-
-        var seen = Set<String>()
-        var alwaysShown: [String] = []
-        var expanded: [String] = []
-        var isBelowDivider = false
-
-        for id in orderedIDsWithDivider {
-            if id == dividerID {
-                isBelowDivider = true
-                continue
-            }
-            guard validSet.contains(id), seen.insert(id).inserted else { continue }
-            if isBelowDivider {
-                expanded.append(id)
-            } else {
-                alwaysShown.append(id)
-            }
-        }
-
-        // Dashboard rows only render enabled metrics. Merge disabled rows back into their previous
-        // sections so a dashboard drag does not push hidden Customize rows to the end.
-        let desiredAlwaysShown = Set(alwaysShown)
-        let desiredExpanded = Set(expanded)
-        let previousAlwaysShown = validIDs.filter { !expandedMetricIDs.contains($0) && !desiredExpanded.contains($0) }
-        let previousExpanded = validIDs.filter { expandedMetricIDs.contains($0) && !desiredAlwaysShown.contains($0) }
-        alwaysShown = Self.mergingMissingMetrics(into: alwaysShown, previous: previousAlwaysShown)
-        expanded = Self.mergingMissingMetrics(into: expanded, previous: previousExpanded)
-
-        let nextOrder = alwaysShown + expanded
-        let providerExpanded = Set(expanded)
-        let providerIDs = Set(validIDs)
-        let nextExpanded = expandedMetricIDs.subtracting(providerIDs).union(providerExpanded)
-        // Only the dragged metric's expand-on-enable entry is consumed — an explicit placement.
-        // Clearing every metric in the list (the old `subtracting(seen)`) also cleared disabled
-        // optional metrics that `metricOrderWithDivider` includes by default but the user never moved,
-        // so they lost their below-caret default. Matches `reorderMetric`, which consumes only the
-        // dragged id.
-        var nextDefaultExpandedOnEnableIDs = defaultExpandedOnEnableIDs
-        let consumedExpandOnEnable = nextDefaultExpandedOnEnableIDs.remove(dragged) != nil
-        guard metricOrderByProvider[providerID] != nextOrder || expandedMetricIDs != nextExpanded || consumedExpandOnEnable else {
-            return false
-        }
-
-        metricOrderByProvider[providerID] = nextOrder
-        expandedMetricIDs = nextExpanded
-        defaultExpandedOnEnableIDs = nextDefaultExpandedOnEnableIDs
-        persistMetricOrder()
-        persistExpanded()
-        if consumedExpandOnEnable { persistExpandOnEnable() }
-        syncPlacedOrder()
-        return true
-    }
-
-    private static func mergingMissingMetrics(into ordered: [String], previous: [String]) -> [String] {
-        let orderedSet = Set(ordered)
-        var result: [String] = []
-        var emitted = Set<String>()
-        var orderedIndex = ordered.startIndex
-
-        func emitDesiredRows(through id: String) {
-            while orderedIndex < ordered.endIndex {
-                let next = ordered[orderedIndex]
-                orderedIndex = ordered.index(after: orderedIndex)
-                if emitted.insert(next).inserted {
-                    result.append(next)
-                }
-                if next == id { break }
-            }
-        }
-
-        for id in previous {
-            if orderedSet.contains(id) {
-                emitDesiredRows(through: id)
-            } else if emitted.insert(id).inserted {
-                result.append(id)
-            }
-        }
-
-        while orderedIndex < ordered.endIndex {
-            let next = ordered[orderedIndex]
-            orderedIndex = ordered.index(after: orderedIndex)
-            if emitted.insert(next).inserted {
-                result.append(next)
-            }
-        }
-
-        return result
-    }
-
-    /// Pure reorder: remove `dragged`, reinsert it adjacent to `target` (after it when moving down, before
-    /// it when moving up). Returns nil when either id is missing or they're identical. Mirrors the proven
-    /// macOS drag-reorder math from crafcat7/Peakmon (Apache-2.0).
-    static func reordered(_ ids: [String], dragged: String, target: String) -> [String]? {
-        guard dragged != target,
-              let from = ids.firstIndex(of: dragged),
-              let to = ids.firstIndex(of: target) else { return nil }
-        var next = ids
-        next.remove(at: from)
-        guard let adjusted = next.firstIndex(of: target) else { return nil }
-        let insert = from < to ? adjusted + 1 : adjusted
-        next.insert(dragged, at: min(insert, next.count))
-        return next
     }
 
     // MARK: - Menu bar pins
@@ -668,31 +342,15 @@ final class LayoutStore {
         setPinned(!isPinned(descriptorID), for: descriptorID)
     }
 
-    /// Pinned metrics grouped by provider, in the user's Customize order (provider order, then each
-    /// provider's metric order). A temporarily disabled provider is excluded from the rendered groups
-    /// but keeps its pins. Drives the menu-bar strip.
-    var pinnedGroups: [ProviderMetrics] {
-        orderedProviders().compactMap { provider in
-            guard isProviderEnabled(provider.id) else { return nil }
-            // Keep the strip order matching Customize: always-shown pins first, then expanded ones.
-            let metrics = orderedSupportedMetrics(for: provider.id).filter { pinnedMetricIDs.contains($0.id) }
-            return metrics.isEmpty ? nil : ProviderMetrics(
-                provider: provider,
-                alwaysShownMetrics: metrics.filter { !expandedMetricIDs.contains($0.id) },
-                expandedMetrics: metrics.filter { expandedMetricIDs.contains($0.id) }
-            )
-        }
-    }
-
-    private func persistPins() {
+    func persistPins() {
         persistence.savePins(pinnedMetricIDs)
     }
 
-    private func persistExpanded() {
+    func persistExpanded() {
         persistence.saveExpandedMetrics(expandedMetricIDs)
     }
 
-    private func persistExpandOnEnable() {
+    func persistExpandOnEnable() {
         persistence.saveExpandOnEnable(defaultExpandedOnEnableIDs)
     }
 
@@ -793,15 +451,15 @@ final class LayoutStore {
         draggingID = nil
     }
 
-    private func persist() {
+    func persist() {
         persistence.savePlaced(placed)
     }
 
-    private func persistProviderOrder() {
+    func persistProviderOrder() {
         persistence.saveProviderOrder(providerOrder)
     }
 
-    private func persistMetricOrder() {
+    func persistMetricOrder() {
         persistence.saveMetricOrder(metricOrderByProvider)
     }
 
@@ -809,13 +467,13 @@ final class LayoutStore {
         persistence.saveSeededDefaults(ids)
     }
 
-    private func metricOrder(for providerID: String) -> [String] {
+    func metricOrder(for providerID: String) -> [String] {
         let valid = registry.descriptors(for: providerID).map(\.id)
         let saved = metricOrderByProvider[providerID] ?? []
         return LayoutOrdering.normalizedMetricIDs(saved, validIDs: valid)
     }
 
-    private func syncPlacedOrder(persistChanges: Bool = true) {
+    func syncPlacedOrder(persistChanges: Bool = true) {
         let byDescriptor = Dictionary(
             placed.map { ($0.descriptorID, $0) },
             uniquingKeysWith: { first, _ in first }
@@ -830,65 +488,4 @@ final class LayoutStore {
         if persistChanges { persist() }
     }
 
-}
-
-/// A provider and its placed (visible) widgets, split into the always-shown rows and the ones tucked
-/// behind the dashboard's "show more" caret. Drives the grouped dashboard list.
-struct ProviderGroup: Identifiable {
-    let provider: Provider
-    let alwaysShownWidgets: [PlacedWidget]
-    let expandedWidgets: [PlacedWidget]
-    var id: String { provider.id }
-
-    /// Every visible widget in display order (always-shown first, then expanded). Used where the split
-    /// doesn't matter — reorder id lists and the lifted drag preview.
-    var widgets: [PlacedWidget] { alwaysShownWidgets + expandedWidgets }
-    var hasExpandedMetrics: Bool { !expandedWidgets.isEmpty }
-}
-
-/// A provider and every metric it supports, in the provider's custom order, split across the "Shown on
-/// expand" divider. Drives the Customize screen and the menu-bar pin grouping.
-struct ProviderMetrics: Identifiable {
-    let provider: Provider
-    let alwaysShownMetrics: [WidgetDescriptor]
-    let expandedMetrics: [WidgetDescriptor]
-    var id: String { provider.id }
-
-    init(provider: Provider, alwaysShownMetrics: [WidgetDescriptor], expandedMetrics: [WidgetDescriptor]) {
-        self.provider = provider
-        self.alwaysShownMetrics = alwaysShownMetrics
-        self.expandedMetrics = expandedMetrics
-    }
-
-    /// Convenience for callers that don't partition (e.g. tests): everything is always-shown.
-    init(provider: Provider, metrics: [WidgetDescriptor]) {
-        self.init(provider: provider, alwaysShownMetrics: metrics, expandedMetrics: [])
-    }
-
-    /// Every supported metric in custom order (always-shown first, then expanded).
-    var metrics: [WidgetDescriptor] { alwaysShownMetrics + expandedMetrics }
-}
-
-/// One row in the Customize provider list (L1): the provider plus the derived bits the row renders —
-/// whether it's enabled (the master toggle + Active/Inactive label), how many metrics it supports
-/// (the badge), and how many are pinned. Drives `CustomizeProviderListView`. Unlike `ProviderMetrics`,
-/// this includes disabled providers so they stay visible in the list.
-struct ProviderRow: Identifiable {
-    let provider: Provider
-    let isEnabled: Bool
-    let metricCount: Int
-    var id: String { provider.id }
-}
-
-/// Tone for the transient in-Customize pill (`LayoutStore.customizationNotice`): green success or
-/// orange denial.
-enum CustomizationNoticeTone {
-    case positive
-    case notice
-}
-
-/// The message + tone carried by the Customize pill's `TransientNotice`, so its two fields clear together.
-struct CustomizationNoticeContent {
-    var message: String
-    var tone: CustomizationNoticeTone
 }

--- a/Sources/OpenUsage/Stores/LayoutStoreModels.swift
+++ b/Sources/OpenUsage/Stores/LayoutStoreModels.swift
@@ -1,5 +1,5 @@
-/// A provider and its placed (visible) widgets, split into the always-shown rows and the ones tucked
-/// behind the dashboard's "show more" caret. Drives the grouped dashboard list.
+/// A provider and its placed (visible) widgets, split into Always Visible rows and On Demand rows
+/// behind the dashboard's caret. Drives the grouped dashboard list.
 struct ProviderGroup: Identifiable {
     let provider: Provider
     let alwaysShownWidgets: [PlacedWidget]
@@ -12,8 +12,8 @@ struct ProviderGroup: Identifiable {
     var hasExpandedMetrics: Bool { !expandedWidgets.isEmpty }
 }
 
-/// A provider and every metric it supports, in the provider's custom order, split across the "Shown on
-/// expand" divider. Drives the Customize screen and the menu-bar pin grouping.
+/// A provider and every metric it supports, in the provider's custom order, split between Always
+/// Visible and On Demand. Drives the Customize screen and the menu-bar pin grouping.
 struct ProviderMetrics: Identifiable {
     let provider: Provider
     let alwaysShownMetrics: [WidgetDescriptor]

--- a/Sources/OpenUsage/Stores/LayoutStoreModels.swift
+++ b/Sources/OpenUsage/Stores/LayoutStoreModels.swift
@@ -1,0 +1,60 @@
+/// A provider and its placed (visible) widgets, split into the always-shown rows and the ones tucked
+/// behind the dashboard's "show more" caret. Drives the grouped dashboard list.
+struct ProviderGroup: Identifiable {
+    let provider: Provider
+    let alwaysShownWidgets: [PlacedWidget]
+    let expandedWidgets: [PlacedWidget]
+    var id: String { provider.id }
+
+    /// Every visible widget in display order (always-shown first, then expanded). Used where the split
+    /// doesn't matter — reorder id lists and the lifted drag preview.
+    var widgets: [PlacedWidget] { alwaysShownWidgets + expandedWidgets }
+    var hasExpandedMetrics: Bool { !expandedWidgets.isEmpty }
+}
+
+/// A provider and every metric it supports, in the provider's custom order, split across the "Shown on
+/// expand" divider. Drives the Customize screen and the menu-bar pin grouping.
+struct ProviderMetrics: Identifiable {
+    let provider: Provider
+    let alwaysShownMetrics: [WidgetDescriptor]
+    let expandedMetrics: [WidgetDescriptor]
+    var id: String { provider.id }
+
+    init(provider: Provider, alwaysShownMetrics: [WidgetDescriptor], expandedMetrics: [WidgetDescriptor]) {
+        self.provider = provider
+        self.alwaysShownMetrics = alwaysShownMetrics
+        self.expandedMetrics = expandedMetrics
+    }
+
+    /// Convenience for callers that don't partition (e.g. tests): everything is always-shown.
+    init(provider: Provider, metrics: [WidgetDescriptor]) {
+        self.init(provider: provider, alwaysShownMetrics: metrics, expandedMetrics: [])
+    }
+
+    /// Every supported metric in custom order (always-shown first, then expanded).
+    var metrics: [WidgetDescriptor] { alwaysShownMetrics + expandedMetrics }
+}
+
+/// One row in the Customize provider list (L1): the provider plus the derived bits the row renders —
+/// whether it's enabled (the master toggle + Active/Inactive label), how many metrics it supports
+/// (the badge), and how many are pinned. Drives `CustomizeProviderListView`. Unlike `ProviderMetrics`,
+/// this includes disabled providers so they stay visible in the list.
+struct ProviderRow: Identifiable {
+    let provider: Provider
+    let isEnabled: Bool
+    let metricCount: Int
+    var id: String { provider.id }
+}
+
+/// Tone for the transient in-Customize pill (`LayoutStore.customizationNotice`): green success or
+/// orange denial.
+enum CustomizationNoticeTone {
+    case positive
+    case notice
+}
+
+/// The message + tone carried by the Customize pill's `TransientNotice`, so its two fields clear together.
+struct CustomizationNoticeContent {
+    var message: String
+    var tone: CustomizationNoticeTone
+}

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -698,7 +698,7 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(primaryByProvider["claude"], ["claude.session", "claude.weekly", "claude.extra", "claude.trend"])
         XCTAssertEqual(expandedByProvider["claude"], ["claude.sonnet", "claude.fable", "claude.today", "claude.yesterday", "claude.last30"])
         XCTAssertEqual(primaryByProvider["codex"], ["codex.session", "codex.weekly", "codex.trend"])
-        // Spark (the optional model-specific limits) leads the expanded section, before credits.
+        // Spark (the optional model-specific limits) leads the On Demand section, before credits.
         XCTAssertEqual(expandedByProvider["codex"], [
             "codex.spark", "codex.sparkWeekly",
             "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30"
@@ -809,7 +809,7 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.placed.map(\.descriptorID), ["claude.session"])
     }
 
-    // MARK: - Expanded ("Shown on expand") membership
+    // MARK: - On Demand membership
 
     func testDividerDragMovesMetricBelowDividerAndPersists() {
         let defaults = makeDefaults("ExpandMove")


### PR DESCRIPTION
## TL;DR

Split the 894-line `LayoutStore` implementation into three cohesive source files without changing behavior. Core state and persistence stay together, derived grouping and ordering live in one extension, and value models have a small dedicated file.

## What was happening

- One 894-line file mixed stored state, persistence, presentation grouping, drag ordering, and supporting value models.
- The size made navigation and ownership harder even when a change concerned only one responsibility.

## What this changes

- Keeps state, initialization, undo, pins, notices, persistence, and reset mutations in `LayoutStore.swift`.
- Moves derived provider/metric groups and drag-ordering logic to `LayoutStore+Customization.swift`.
- Moves the four supporting value types to `LayoutStoreModels.swift`.
- Leaves all three files below 500 lines: 491, 345, and 60 lines.
- Widens only the implementation seams Swift requires for cross-file extensions; the source documents why those members are module-internal.
- Changes no product behavior, persistence format, tests, or user-facing documentation.

## Heads-up

This is intentionally a mechanical move. A normalized line-multiset comparison of the pre-split file and the three resulting files produced the same SHA-256 (`647c0c5b7317bc1541d75069a14dfdf576a2e83833aa61724721aed4a060e401`) after ignoring file wrappers, access modifiers required by the split, blank lines, and the new access-control note.

## Tests

- `swift test --filter "Layout(Store|Bootstrap|Persistence)"` — 73 passed.
- `swift test` — 960 XCTest cases passed with 3 expected skips; 3 Swift Testing cases passed.
- `./script/build_and_run.sh verify` — release bundle built, signed with Apple Development, and launched.
- `codesign --verify --deep --strict --verbose=2 dist/OpenUsage.app` — valid and satisfies its designated requirement.

No visual behavior changes; screenshots are not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical file split with no intended logic or persistence changes; risk is limited to accidental access-level or wiring mistakes, which existing LayoutStore tests are meant to catch.
> 
> **Overview**
> Splits the monolithic **`LayoutStore`** implementation into three files so each stays under ~500 lines, without changing layout behavior or persistence.
> 
> **`LayoutStore.swift`** keeps core state, init, undo, pins, notices, mutations, and persistence. **`LayoutStore+Customization.swift`** holds derived dashboard/Customize groupings, spend-capable provider logic, and provider/metric drag-reorder (`reorderProvider`, `reorderMetric`, `applyMetricDividerOrder`, `reordered`). **`LayoutStoreModels.swift`** moves **`ProviderGroup`**, **`ProviderMetrics`**, **`ProviderRow`**, and customization notice types out of the store file.
> 
> Because Swift `private` is file-scoped, selected members (`registry`, `expandedMetricIDs`, `recordingUndoStep`, persist/sync helpers, etc.) are widened to module-internal so the extension can share them; a short comment in the main file documents that seam.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a37838773f425672d7b27cc42780b16ef0e9853e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->