### PR TITLE
Isolate Claude usage cache from account changes

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -62,11 +62,44 @@ struct ClaudeCredentialState: Hashable, Sendable {
     }
 }
 
+/// Token-bearing credential candidates in their effective probe order. Environment-only inference
+/// tokens are excluded because they never fetch live usage; every stored candidate that can affect
+/// selection remains, including an earlier source that the current refresh already tried and rejected.
+struct ClaudeCredentialGeneration: Equatable, Sendable {
+    struct Candidate: Equatable, Sendable {
+        let oauth: ClaudeOAuth
+        let source: ClaudeCredentialState.Source
+
+        init(_ state: ClaudeCredentialState) {
+            oauth = state.oauth
+            source = state.source
+        }
+    }
+
+    var candidates: [Candidate]
+
+    init(_ states: [ClaudeCredentialState]) {
+        candidates = states
+            .filter { $0.hasUsableAccessToken && !$0.inferenceOnly }
+            .map(Candidate.init)
+    }
+
+    func replacing(_ state: ClaudeCredentialState) -> Self {
+        var updated = self
+        guard let index = updated.candidates.firstIndex(where: { $0.source == state.source }) else {
+            fatalError("live usage source missing from Claude credential generation")
+        }
+        updated.candidates[index] = Candidate(state)
+        return updated
+    }
+}
+
 enum ClaudeAuthError: Error, LocalizedError, Equatable {
     case notLoggedIn
     case desktopAppOnly
     case sessionExpired
     case tokenExpired
+    case credentialsChanged
     case invalidOAuthURL(String)
 
     var errorDescription: String? {
@@ -79,6 +112,8 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
             return "Session expired. Run `claude` to log in again."
         case .tokenExpired:
             return "Token expired. Run `claude` to log in again."
+        case .credentialsChanged:
+            return "Claude login changed during refresh. Refresh again."
         case .invalidOAuthURL(let value):
             return "Invalid Claude OAuth URL: \(value). Check CLAUDE_CODE_CUSTOM_OAUTH_URL / CLAUDE_LOCAL_OAUTH_API_BASE."
         }
@@ -94,7 +129,7 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
         switch self {
         case .sessionExpired, .tokenExpired:
             return true
-        case .notLoggedIn, .desktopAppOnly, .invalidOAuthURL:
+        case .notLoggedIn, .desktopAppOnly, .credentialsChanged, .invalidOAuthURL:
             return false
         }
     }
@@ -189,11 +224,19 @@ struct ClaudeAuthStore: Sendable {
         return expiresAt - now().timeIntervalSince1970 * 1000 <= 5 * 60 * 1000
     }
 
-    func save(_ state: ClaudeCredentialState) throws {
+    func credentialGeneration() -> ClaudeCredentialGeneration {
+        ClaudeCredentialGeneration(loadCredentialCandidates())
+    }
+
+    /// Save an OAuth rotation only if the ordered effective candidate set is unchanged. Checking the
+    /// whole generation catches a newly added higher-priority source as well as replacement in place.
+    /// The underlying stores provide no atomic compare-and-swap, so this remains best-effort.
+    func save(_ state: ClaudeCredentialState, ifUnchanged expected: ClaudeCredentialGeneration) throws -> Bool {
+        guard credentialGeneration() == expected else { return false }
         var fullData = state.fullData ?? ClaudeCredentialsFile()
         fullData.claudeAiOauth = state.oauth
         let data = try JSONEncoder().encode(fullData)
-        guard let text = String(data: data, encoding: .utf8) else { return }
+        guard let text = String(data: data, encoding: .utf8) else { return false }
 
         switch state.source {
         case .file:
@@ -203,10 +246,11 @@ struct ClaudeAuthStore: Sendable {
         case .keychainLegacy(let service):
             try keychain.writeGenericPassword(service: service, value: text)
         case .environment:
-            return
+            return false
         }
         // NEVER log the credential blob/tokens — only that a rotation was persisted, and to where.
         AppLog.debug(LogTag.auth("claude"), "persisted rotated credentials (source=\(state.source.label))")
+        return true
     }
 
     /// Why the live-usage endpoint (`/api/oauth/usage`, which backs Session / Weekly / Sonnet / Extra
@@ -414,5 +458,3 @@ struct ClaudeAuthStore: Sendable {
         return String(digest.map { String(format: "%02x", $0) }.joined().prefix(8))
     }
 }
-
-

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 @MainActor
@@ -23,6 +24,7 @@ final class ClaudeProvider: ProviderRuntime {
     /// last-good bars with a staleness note instead of blanking the dashboard, and skip the live call
     /// entirely until the cooldown expires so we don't keep hammering an endpoint that's already limiting
     /// us. Mirrors the legacy plugin's `cachedUsageData` + `rateLimitedUntilMs`.
+    private var cachedCredentialFingerprint: Data?
     private var lastGoodUsage: ClaudeMappedUsage?
     private var rateLimitedUntil: Date?
     private static let rateLimitCooldown: TimeInterval = 5 * 60
@@ -59,6 +61,12 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     func refresh() async -> ProviderSnapshot {
+        await refresh(credentialReloadsRemaining: 1)
+    }
+
+    /// Claude Code can replace a login while a request is in flight. Reload once when that happens so
+    /// the older account cannot reach the dashboard or cache; bound the retry for a changing source.
+    private func refresh(credentialReloadsRemaining: Int) async -> ProviderSnapshot {
         let storedCandidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
         let candidates = storedCandidates.filter(\.hasUsableAccessToken)
         guard !candidates.isEmpty else {
@@ -86,11 +94,18 @@ final class ClaudeProvider: ProviderRuntime {
         // through to the next rather than failing the whole refresh; any non-auth error (rate limit,
         // request/transport failure) surfaces immediately so a real outage is never masked as a retry.
         var lastFallbackError: Error?
+        var credentialGeneration = ClaudeCredentialGeneration(storedCandidates)
         for state in candidates {
             do {
-                let snapshot = try await probe(state: state)
+                let snapshot = try await probe(
+                    state: state,
+                    credentialGeneration: &credentialGeneration
+                )
                 AppLog.info(LogTag.plugin("claude"), "refresh end (\(Int(Date().timeIntervalSince(start) * 1000))ms)")
                 return snapshot
+            } catch ClaudeAuthError.credentialsChanged where credentialReloadsRemaining > 0 {
+                AppLog.info(LogTag.auth("claude"), "credential source changed during refresh; reloading current login")
+                return await refresh(credentialReloadsRemaining: credentialReloadsRemaining - 1)
             } catch let error as ClaudeAuthError where error.allowsAuthFallback {
                 AppLog.warn(LogTag.auth("claude"), "\(state.source.label) failed (\(error)); falling back to next source if any")
                 lastFallbackError = error
@@ -105,7 +120,10 @@ final class ClaudeProvider: ProviderRuntime {
         )
     }
 
-    private func probe(state initialState: ClaudeCredentialState) async throws -> ProviderSnapshot {
+    private func probe(
+        state initialState: ClaudeCredentialState,
+        credentialGeneration: inout ClaudeCredentialGeneration
+    ) async throws -> ProviderSnapshot {
         var state = initialState
         var mapped = ClaudeMappedUsage(
             plan: ClaudeUsageMapper.formatPlan(
@@ -118,7 +136,10 @@ final class ClaudeProvider: ProviderRuntime {
         var warning: String?
         switch authStore.liveUsageAvailability(state) {
         case .available:
-            mapped = try await fetchLiveUsage(state: &state)
+            mapped = try await fetchLiveUsage(
+                state: &state,
+                credentialGeneration: &credentialGeneration
+            )
             // A rate-limited fetch rides its "Updates blocked by Anthropic" notice on the mapped usage so
             // it reaches the header triangle even when the badge/note lines aren't in the user's layout.
             warning = mapped.warning
@@ -155,7 +176,14 @@ final class ClaudeProvider: ProviderRuntime {
         return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: mapped.lines, refreshedAt: now(), warning: warning)
     }
 
-    private func fetchLiveUsage(state: inout ClaudeCredentialState) async throws -> ClaudeMappedUsage {
+    private func fetchLiveUsage(
+        state: inout ClaudeCredentialState,
+        credentialGeneration: inout ClaudeCredentialGeneration
+    ) async throws -> ClaudeMappedUsage {
+        var expectedGeneration = credentialGeneration
+        defer { credentialGeneration = expectedGeneration }
+        activateLiveUsageCache(for: state.oauth)
+
         // Inside an active rate-limit cooldown, skip the live call and serve the last-good usage so a
         // constantly-limited endpoint doesn't blank the dashboard (and we don't pile on more 429s).
         if let until = rateLimitedUntil, now() < until {
@@ -166,7 +194,13 @@ final class ClaudeProvider: ProviderRuntime {
         if authStore.needsRefresh(state.oauth),
            let refreshToken = state.oauth.refreshToken,
            !refreshToken.isEmpty {
-            state.oauth.accessToken = try await refreshAccessToken(state: &state, refreshToken: refreshToken)
+            let refreshed = try await refreshAccessToken(
+                state: &state,
+                refreshToken: refreshToken,
+                expectedGeneration: expectedGeneration
+            )
+            state.oauth.accessToken = refreshed.accessToken
+            if refreshed.persisted { expectedGeneration = expectedGeneration.replacing(state) }
         }
 
         var working = state
@@ -178,11 +212,24 @@ final class ClaudeProvider: ProviderRuntime {
                 guard let refreshToken = working.oauth.refreshToken, !refreshToken.isEmpty else {
                     throw ClaudeAuthError.tokenExpired
                 }
-                return try await self.refreshAccessToken(state: &working, refreshToken: refreshToken)
+                let refreshed = try await self.refreshAccessToken(
+                    state: &working,
+                    refreshToken: refreshToken,
+                    expectedGeneration: expectedGeneration
+                )
+                if refreshed.persisted {
+                    expectedGeneration = expectedGeneration.replacing(working)
+                }
+                return refreshed.accessToken
             },
             connectionFailed: ClaudeUsageError.connectionFailed,
             authExpired: ClaudeAuthError.tokenExpired
         )
+
+        let currentGeneration = await loadOffMainActor { [authStore] in
+            authStore.credentialGeneration()
+        }
+        guard currentGeneration == expectedGeneration else { throw ClaudeAuthError.credentialsChanged }
 
         // 429 can come back from either attempt; the helper hands both through unchanged. Start a cooldown
         // (respecting Retry-After) and serve the last-good usage rather than a bare badge.
@@ -212,7 +259,34 @@ final class ClaudeProvider: ProviderRuntime {
         return mapped
     }
 
-    private func refreshAccessToken(state: inout ClaudeCredentialState, refreshToken: String) async throws -> String {
+    /// Cache state belongs to the complete access + refresh credential pair. A login change therefore
+    /// clears both last-good usage and cooldown, even when the two accounts share an access token.
+    private func activateLiveUsageCache(for credentials: ClaudeOAuth) {
+        let fingerprint = Self.credentialFingerprint(credentials)
+        guard cachedCredentialFingerprint != fingerprint else { return }
+        cachedCredentialFingerprint = fingerprint
+        lastGoodUsage = nil
+        rateLimitedUntil = nil
+    }
+
+    private static func credentialFingerprint(_ credentials: ClaudeOAuth) -> Data {
+        let access = Data((credentials.accessToken ?? "").utf8)
+        let refresh = Data((credentials.refreshToken ?? "").utf8)
+        var pair = Data(SHA256.hash(data: access))
+        pair.append(contentsOf: SHA256.hash(data: refresh))
+        return Data(SHA256.hash(data: pair))
+    }
+
+    private struct RefreshedAccess {
+        var accessToken: String
+        var persisted: Bool
+    }
+
+    private func refreshAccessToken(
+        state: inout ClaudeCredentialState,
+        refreshToken: String,
+        expectedGeneration: ClaudeCredentialGeneration
+    ) async throws -> RefreshedAccess {
         AppLog.info(LogTag.auth("claude"), "token refresh attempt")
         let response = try await usageClient.refreshToken(refreshToken, config: authStore.oauthConfig())
         if response.statusCode == 400 || response.statusCode == 401 {
@@ -232,6 +306,7 @@ final class ClaudeProvider: ProviderRuntime {
         }
         // NEVER log decoded.accessToken / refreshToken — only the fact that a rotation happened.
         let decoded = try JSONDecoder().decode(ClaudeRefreshResponse.self, from: response.body)
+        let previousOAuth = state.oauth
         state.oauth.accessToken = decoded.accessToken
         if let refreshToken = decoded.refreshToken {
             state.oauth.refreshToken = refreshToken
@@ -243,13 +318,25 @@ final class ClaudeProvider: ProviderRuntime {
         // next launch refreshes with a server-invalidated token and the user sees a misleading
         // "session expired". The refreshed token still works for this session, so we log and continue
         // rather than fail the live fetch.
+        let persisted: Bool
         do {
-            try authStore.save(state)
+            guard try await Task.detached(priority: .utility, operation: { [authStore, state] in
+                try authStore.save(state, ifUnchanged: expectedGeneration)
+            }).value else {
+                throw ClaudeAuthError.credentialsChanged
+            }
+            persisted = true
+        } catch let error as ClaudeAuthError where error == .credentialsChanged {
+            throw error
         } catch {
             AppLog.error(LogTag.auth("claude"), "failed to persist rotated credentials; using the refreshed token for this session only: \(error.localizedDescription)")
+            persisted = false
+        }
+        if cachedCredentialFingerprint == Self.credentialFingerprint(previousOAuth) {
+            cachedCredentialFingerprint = Self.credentialFingerprint(state.oauth)
         }
         AppLog.info(LogTag.auth("claude"), "token refresh ok (rotated)")
-        return decoded.accessToken
+        return RefreshedAccess(accessToken: decoded.accessToken, persisted: persisted)
     }
 
 }

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -55,6 +55,7 @@ extension ClaudeAuthError: CategorizedError {
         case .notLoggedIn, .desktopAppOnly: .notLoggedIn
         case .sessionExpired, .tokenExpired: .authExpired
         case .invalidOAuthURL: .authInvalid
+        case .credentialsChanged: .other
         }
     }
 }

--- a/Tests/OpenUsageTests/ClaudeAccountIsolationTests.swift
+++ b/Tests/OpenUsageTests/ClaudeAccountIsolationTests.swift
@@ -1,0 +1,317 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class ClaudeAccountIsolationTests: XCTestCase {
+    private let path = "/tmp/claude/.credentials.json"
+
+    func testNewLoginBypassesPreviousLoginCacheAndCooldown() async {
+        let calls = IsolationCallCounter()
+        let fixture = makeFixture(
+            credentials: credentials(access: "account-a", refresh: "refresh-a", plan: "pro")
+        ) { request in
+            if request.headers["Authorization"] == "Bearer account-a" {
+                return calls.next() == 1
+                    ? Self.usageResponse(percent: 25)
+                    : HTTPResponse(statusCode: 429, headers: ["retry-after": "600"], body: Data())
+            }
+            return Self.usageResponse(percent: 70)
+        }
+
+        let initial = await fixture.provider.refresh()
+        let limited = await fixture.provider.refresh()
+        XCTAssertEqual(sessionUsage(initial), 25)
+        XCTAssertEqual(sessionUsage(limited), 25)
+
+        fixture.files.files[path] = credentials(
+            access: "account-b", refresh: "refresh-b", plan: "max"
+        )
+        let switched = await fixture.provider.refresh()
+
+        XCTAssertEqual(switched.plan, "Max")
+        XCTAssertEqual(sessionUsage(switched), 70)
+        XCTAssertEqual(usageRequests(fixture.http).count, 3)
+    }
+
+    func testRefreshTokenChangeSeparatesCacheWhenAccessTokenIsShared() async {
+        let calls = IsolationCallCounter()
+        let fixture = makeFixture(
+            credentials: credentials(access: "shared", refresh: "refresh-a", plan: "pro")
+        ) { request in
+            guard request.url.absoluteString.hasSuffix("/api/oauth/usage") else {
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+            return calls.next() == 1
+                ? Self.usageResponse(percent: 25)
+                : HTTPResponse(statusCode: 429, headers: ["retry-after": "600"], body: Data())
+        }
+
+        let initial = await fixture.provider.refresh()
+        XCTAssertEqual(sessionUsage(initial), 25)
+        fixture.files.files[path] = credentials(
+            access: "shared", refresh: "refresh-b", plan: "max"
+        )
+
+        let switched = await fixture.provider.refresh()
+
+        XCTAssertNil(sessionUsage(switched), "account A usage must not cross into account B")
+        XCTAssertEqual(status(switched)?.hasPrefix("Rate limited"), true)
+    }
+
+    func testValidatedTokenRotationKeepsSameLoginCache() async {
+        let fixture = makeFixture(
+            credentials: credentials(access: "old-access", refresh: "old-refresh", plan: "pro")
+        ) { request in
+            if request.url.absoluteString.hasSuffix("/v1/oauth/token") {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}"#.utf8)
+                )
+            }
+            if request.headers["Authorization"] == "Bearer old-access" {
+                return Self.usageResponse(percent: 25)
+            }
+            return HTTPResponse(statusCode: 429, headers: ["retry-after": "600"], body: Data())
+        }
+
+        let initial = await fixture.provider.refresh()
+        XCTAssertEqual(sessionUsage(initial), 25)
+        fixture.files.files[path] = credentials(
+            access: "old-access", refresh: "old-refresh", plan: "pro", expiresAt: 1
+        )
+
+        let rotated = await fixture.provider.refresh()
+
+        XCTAssertEqual(sessionUsage(rotated), 25)
+        XCTAssertTrue(fixture.files.files[path]?.contains("new-refresh") == true)
+    }
+
+    func testReloginDuringTokenRotationCannotBeOverwrittenOrPublished() async {
+        let accountA = credentials(
+            access: "account-a", refresh: "refresh-a", plan: "pro", expiresAt: 1
+        )
+        let accountB = credentials(access: "account-b", refresh: "refresh-b", plan: "max")
+        let files = FakeFiles([path: accountA])
+        let fixture = makeFixture(files: files) { [path] request in
+            if request.url.absoluteString.hasSuffix("/v1/oauth/token") {
+                files.files[path] = accountB
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"access_token":"account-a2","refresh_token":"refresh-a2","expires_in":3600}"#.utf8)
+                )
+            }
+            XCTAssertEqual(request.headers["Authorization"], "Bearer account-b")
+            return Self.usageResponse(percent: 75)
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertEqual(sessionUsage(snapshot), 75)
+        XCTAssertEqual(fixture.files.files[path], accountB)
+        XCTAssertFalse(fixture.http.requests.contains {
+            $0.headers["Authorization"] == "Bearer account-a2"
+        })
+    }
+
+    func testReloginDuringUsageRequestReloadsBeforePublishing() async {
+        let accountA = credentials(access: "account-a", refresh: "refresh-a", plan: "pro")
+        let accountB = credentials(access: "account-b", refresh: "refresh-b", plan: "max")
+        let files = FakeFiles([path: accountA])
+        let fixture = makeFixture(files: files) { [path] request in
+            if request.headers["Authorization"] == "Bearer account-a" {
+                files.files[path] = accountB
+                return Self.usageResponse(percent: 25)
+            }
+            return Self.usageResponse(percent: 75)
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertEqual(snapshot.plan, "Max")
+        XCTAssertEqual(sessionUsage(snapshot), 75)
+        XCTAssertEqual(usageRequests(fixture.http).count, 2)
+    }
+
+    func testHigherPriorityLoginAddedDuringUsageRequestWins() async {
+        let accountA = credentials(access: "account-a", refresh: "refresh-a", plan: "pro")
+        let accountB = credentials(access: "account-b", refresh: "refresh-b", plan: "max")
+        let files = FakeFiles([path: accountA])
+        let keychain = ServiceKeychain()
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files,
+            keychain: keychain
+        )
+        let service = store.keychainServiceCandidates().first!
+        let fixture = makeFixture(files: files, keychain: keychain) { request in
+            if request.headers["Authorization"] == "Bearer account-a" {
+                keychain.currentUserValues[service] = accountB
+                return Self.usageResponse(percent: 25)
+            }
+            return Self.usageResponse(percent: 75)
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertEqual(snapshot.plan, "Max")
+        XCTAssertEqual(sessionUsage(snapshot), 75)
+        XCTAssertEqual(usageRequests(fixture.http).count, 2)
+    }
+
+    func testHigherPriorityLoginAddedDuringTokenRotationPreventsOldWriteAndQuery() async {
+        let accountA = credentials(
+            access: "account-a", refresh: "refresh-a", plan: "pro", expiresAt: 1
+        )
+        let accountB = credentials(access: "account-b", refresh: "refresh-b", plan: "max")
+        let files = FakeFiles([path: accountA])
+        let keychain = ServiceKeychain()
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files,
+            keychain: keychain
+        )
+        let service = store.keychainServiceCandidates().first!
+        let fixture = makeFixture(files: files, keychain: keychain) { request in
+            if request.url.absoluteString.hasSuffix("/v1/oauth/token") {
+                keychain.currentUserValues[service] = accountB
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"access_token":"account-a2","refresh_token":"refresh-a2","expires_in":3600}"#.utf8)
+                )
+            }
+            XCTAssertEqual(request.headers["Authorization"], "Bearer account-b")
+            return Self.usageResponse(percent: 75)
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertEqual(sessionUsage(snapshot), 75)
+        XCTAssertEqual(files.files[path], accountA)
+        XCTAssertFalse(fixture.http.requests.contains {
+            $0.headers["Authorization"] == "Bearer account-a2"
+        })
+    }
+
+    func testEarlierCandidateRotationStillAllowsFallbackToNextSource() async {
+        let fileAccount = credentials(access: "file-b", refresh: "file-refresh", plan: "pro")
+        let keychainAccount = credentials(
+            access: "keychain-a", refresh: "keychain-refresh", plan: "max"
+        )
+        let files = FakeFiles([path: fileAccount])
+        let keychain = ServiceKeychain()
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files,
+            keychain: keychain
+        )
+        let service = store.keychainServiceCandidates().first!
+        keychain.currentUserValues[service] = keychainAccount
+        let fixture = makeFixture(files: files, keychain: keychain) { request in
+            if request.url.absoluteString.hasSuffix("/v1/oauth/token") {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"access_token":"keychain-a2","refresh_token":"keychain-refresh-2","expires_in":3600}"#.utf8)
+                )
+            }
+            if request.headers["Authorization"] == "Bearer file-b" {
+                return Self.usageResponse(percent: 75)
+            }
+            return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertEqual(sessionUsage(snapshot), 75)
+        XCTAssertEqual(
+            usageRequests(fixture.http).compactMap { $0.headers["Authorization"] },
+            ["Bearer keychain-a", "Bearer keychain-a2", "Bearer file-b"]
+        )
+    }
+
+    private struct Fixture {
+        var provider: ClaudeProvider
+        var files: FakeFiles
+        var http: RoutingHTTPClient
+    }
+
+    private func makeFixture(
+        credentials: String,
+        handler: @escaping @Sendable (HTTPRequest) async throws -> HTTPResponse
+    ) -> Fixture {
+        makeFixture(files: FakeFiles([path: credentials]), handler: handler)
+    }
+
+    private func makeFixture(
+        files: FakeFiles,
+        keychain: any KeychainAccessing = FakeKeychain(),
+        handler: @escaping @Sendable (HTTPRequest) async throws -> HTTPResponse
+    ) -> Fixture {
+        let http = RoutingHTTPClient(handler: handler)
+        let now = Date(timeIntervalSince1970: 1_771_603_200)
+        return Fixture(
+            provider: ClaudeProvider(
+                authStore: ClaudeAuthStore(
+                    environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+                    files: files,
+                    keychain: keychain,
+                    now: { now }
+                ),
+                usageClient: ClaudeUsageClient(httpClient: http),
+                logUsageScanner: ClaudeLogFixture.scanner(home: nil),
+                now: { now },
+                pricing: { TestPricing.bundled }
+            ),
+            files: files,
+            http: http
+        )
+    }
+
+    private func credentials(
+        access: String,
+        refresh: String,
+        plan: String,
+        expiresAt: Double = 4_102_444_800_000
+    ) -> String {
+        #"{"claudeAiOauth":{"accessToken":"\#(access)","refreshToken":"\#(refresh)","expiresAt":\#(expiresAt),"subscriptionType":"\#(plan)","scopes":["user:profile"]}}"#
+    }
+
+    private nonisolated static func usageResponse(percent: Double) -> HTTPResponse {
+        HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data(#"{"five_hour":{"utilization":\#(percent),"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+        )
+    }
+
+    private func usageRequests(_ http: RoutingHTTPClient) -> [HTTPRequest] {
+        http.requests.filter { $0.url.absoluteString.hasSuffix("/api/oauth/usage") }
+    }
+
+    private func sessionUsage(_ snapshot: ProviderSnapshot) -> Double? {
+        guard case .progress(_, let used, _, _, _, _, _) = snapshot.line(label: "Session") else {
+            return nil
+        }
+        return used
+    }
+
+    private func status(_ snapshot: ProviderSnapshot) -> String? {
+        guard case .badge(_, let text, _, _) = snapshot.line(label: "Status") else { return nil }
+        return text
+    }
+}
+
+private final class IsolationCallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func next() -> Int {
+        lock.withLock {
+            value += 1
+            return value
+        }
+    }
+}

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -24,7 +24,7 @@ Sign in once with Claude Code; OpenUsage reads the same credentials. It checks e
 
 A `CLAUDE_CODE_OAUTH_TOKEN` — usually a long-lived `claude setup-token` — can run the model but can't read your Session and Weekly limits, and it often lingers in your shell environment. So when a real keychain or file login is present, OpenUsage uses that login for the live meters and keeps the environment token only as a fallback; the Session/Weekly meters no longer go blank just because that token is set. If the environment token is your *only* credential (a headless setup), it's used on its own and the spend tiles still load from local logs.
 
-If one source holds an expired or "locked out" token, OpenUsage falls back to the others — so signing in again with `claude` outside the app is picked up on the next refresh, without restarting OpenUsage. Tokens are refreshed automatically; rotated tokens are written back where they came from.
+If one source holds an expired or "locked out" token, OpenUsage falls back to the others — so signing in again with `claude` outside the app is picked up on the next refresh, without restarting OpenUsage. Tokens are refreshed automatically; rotated tokens are written back only while the ordered login candidates still match the start of the refresh, so a newly added higher-priority login wins.
 
 ## The spend tiles
 
@@ -35,7 +35,7 @@ Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the C
 - **"Not logged in"** — run `claude` and sign in, then refresh.
 - **"Signed in to the Claude desktop app?"** — a login done only in the Claude desktop app is stored encrypted in a way OpenUsage can't read. Run `claude` in a terminal and sign in once; both logins coexist, and OpenUsage picks up the CLI one.
 - **"Re-login for live usage"** (an amber warning on the Claude header) — your saved login can authenticate for inference but can't read your subscription limits, because it lacks the `user:profile` access (this is what an inference-only token from `claude setup-token` carries). Run `claude` and sign in again with your Claude account, then refresh; the spend tiles keep working in the meantime.
-- **"Updates blocked by Anthropic"** (an amber warning on the Claude header) — the usage API is throttling OpenUsage. It keeps your last values, shows when it will retry, and backs off in the meantime — manual refreshes only extend the block, so the best fix is patience.
+- **"Updates blocked by Anthropic"** (an amber warning on the Claude header) — the usage API is throttling OpenUsage. It keeps the last values from the same login, shows when it will retry, and backs off in the meantime. A different login starts with a fresh cache and cooldown.
 - **Spend tiles show "No data"** — OpenUsage found no Claude Code logs in the last 30 days. If your logs live somewhere custom, set `CLAUDE_CONFIG_DIR` so both Claude Code and OpenUsage look in the same place.
 
 ## Under the hood


### PR DESCRIPTION
## TL;DR

Scopes Claude live-usage cache and cooldown state to the active access + refresh credential pair, and prevents an in-flight refresh from overwriting or publishing a newer Claude Code login. This is the compact account-isolation replacement for #922.

## What was happening

- `ClaudeProvider` kept last-good usage and rate-limit cooldown state for its full process lifetime, so a new login could inherit another account's quota or backoff.
- An external `claude` re-login could replace credentials while OpenUsage was waiting for OAuth or usage responses. The older request could then overwrite the new login or reach the dashboard/cache.

## What this changes

- Keys last-good usage and cooldown state to an in-memory SHA-256 fingerprint derived from both access and refresh tokens; the fingerprint is never logged or persisted.
- Clears cached usage and cooldown when that complete identity changes, while carrying them across a validated OAuth rotation performed by OpenUsage itself.
- Compares the ordered effective candidate generation before writing a rotation, then reloads once if any candidate or priority changed.
- Rechecks that ordered generation after an in-flight usage response before it can update the cache or dashboard.
- Keeps the existing Claude provider test file untouched and adds one focused account-isolation suite.
- Updates the Claude provider documentation to describe same-login cache behavior and guarded rotation writes.

## Heads-up

- File and keychain APIs do not provide an atomic compare-and-swap, so the compare-before-write guard is intentionally best-effort at that system boundary.
- This deliberately excludes #922's broader URL, response-validation, error-taxonomy, copy, and test-reorganization changes.

## Tests

- `ClaudeAccountIsolationTests`: 8/8 passed.
- Claude-focused scope: 67 XCTest cases passed with 2 expected skips, plus 1 Swift Testing case.
- Full suite: 970 XCTest cases passed with 3 expected skips, plus 3 Swift Testing cases.
- Release build, app staging, hardened-runtime signing, strict code-signature validation, and exact-path launch succeeded. The staged executable ran as PID 93493 from this worktree and was then stopped.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth persistence and refresh concurrency when external logins race in-flight requests; behavior is guarded and heavily tested but compare-before-write remains best-effort at the keychain/file boundary.
> 
> **Overview**
> **Claude account isolation** so switching logins (or re-logging in via `claude` mid-refresh) cannot leak another account’s cached meters or throttle state.
> 
> Live-usage **last-good usage** and **429 cooldown** are keyed to an in-memory SHA-256 fingerprint of both access and refresh tokens; changing that identity clears the cache (including when only the refresh token changes). OpenUsage’s own OAuth rotation keeps the cache when the login is unchanged.
> 
> **`ClaudeCredentialGeneration`** snapshots the ordered live-usage credential candidates. **`save(_:ifUnchanged:)`** persists token rotation only when that set still matches (best-effort; no atomic CAS on disk/keychain). After usage fetches and before publishing results, the provider rechecks the generation and throws **`credentialsChanged`**, which triggers **one bounded full refresh reload** instead of falling through to the next source.
> 
> Adds **`ClaudeAccountIsolationTests`** and updates **`docs/providers/claude.md`** for guarded rotation writes and per-login rate-limit cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309f298edcd5f699e877e272d6d81162cd3d34c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->