### PR TITLE
Bind credential caches to verified local state

### DIFF
--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityAuthStore.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Credentials Antigravity already has on the machine. On current builds the OAuth tokens live in the
@@ -34,11 +35,21 @@ struct AntigravityAuthStore: Sendable {
     }
 
     /// Blocking keychain read — call off the main actor.
-    func loadKeychainToken() -> AntigravityKeychainToken? {
-        guard let raw = try? keychain.readGenericPassword(service: Self.keychainService, account: Self.keychainAccount),
-              let token = Self.extractToken(fromKeychainRaw: raw)
-        else {
-            return nil
+    func loadKeychainToken() throws -> AntigravityKeychainToken? {
+        let raw: String?
+        do {
+            raw = try keychain.readGenericPassword(
+                service: Self.keychainService,
+                account: Self.keychainAccount
+            )
+        } catch {
+            AppLog.error(LogTag.auth("antigravity"), "keychain credential read failed")
+            throw AntigravityError.credentialStoreUnreadable
+        }
+        guard let raw else { return nil }
+        guard let token = Self.extractToken(fromKeychainRaw: raw) else {
+            AppLog.error(LogTag.auth("antigravity"), "keychain credential is malformed")
+            throw AntigravityError.invalidCredentialData
         }
         return token
     }
@@ -51,29 +62,56 @@ struct AntigravityAuthStore: Sendable {
 
     // MARK: - Refreshed-token cache
 
-    struct CachedToken: Codable {
+    private struct CachedToken: Codable {
         var accessToken: String
         var expiresAtMs: Double
+        /// SHA-256 of the Keychain refresh credential that produced this derived access token. This is
+        /// optional only so older unbound cache files decode as a safe miss during migration.
+        var credentialFingerprint: Data?
     }
 
-    func loadCachedToken() -> String? {
+    func loadCachedToken(matching source: AntigravityKeychainToken) -> String? {
+        guard let expectedFingerprint = Self.credentialFingerprint(for: source.refreshToken) else {
+            discardCachedToken()
+            return nil
+        }
         // Require at least `refreshBuffer` of life left, matching `isUsable(expiry:)` for the keychain
         // token — a near-expiry cached token would otherwise yield a near-certain 401 and a wasteful
         // extra refresh.
-        guard files.exists(Self.cachePath),
-              let text = try? files.readText(Self.cachePath),
-              let data = text.data(using: .utf8),
-              let cached = try? JSONDecoder().decode(CachedToken.self, from: data),
-              cached.expiresAtMs > (now().timeIntervalSince1970 + Self.refreshBuffer) * 1000
-        else {
+        let text: String
+        do {
+            guard let stored = try files.readTextIfPresent(Self.cachePath) else { return nil }
+            text = stored
+        } catch {
+            AppLog.warn(LogTag.auth("antigravity"), "refreshed-token cache read failed; ignoring it")
             return nil
         }
-        return cached.accessToken.nilIfEmpty
+        guard let cached = try? JSONDecoder().decode(CachedToken.self, from: Data(text.utf8)) else {
+            AppLog.warn(LogTag.auth("antigravity"), "refreshed-token cache is malformed; discarding it")
+            discardCachedToken()
+            return nil
+        }
+        guard cached.credentialFingerprint == expectedFingerprint,
+              cached.expiresAtMs > (now().timeIntervalSince1970 + Self.refreshBuffer) * 1000,
+              let token = cached.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        else {
+            discardCachedToken()
+            return nil
+        }
+        return token
     }
 
-    func cacheToken(_ accessToken: String, expiresIn: Double) {
+    func cacheToken(_ accessToken: String, expiresIn: Double, sourceRefreshToken: String) {
+        guard let credentialFingerprint = Self.credentialFingerprint(for: sourceRefreshToken),
+              accessToken.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty != nil else {
+            return
+        }
         let expiresAtMs = (now().timeIntervalSince1970 + expiresIn) * 1000
-        let cached = CachedToken(accessToken: accessToken, expiresAtMs: expiresAtMs)
+        let cached = CachedToken(
+            accessToken: accessToken,
+            expiresAtMs: expiresAtMs,
+            credentialFingerprint: credentialFingerprint
+        )
         do {
             let data = try JSONEncoder().encode(cached)
             try files.writeText(Self.cachePath, String(decoding: data, as: UTF8.self))
@@ -84,6 +122,24 @@ struct AntigravityAuthStore: Sendable {
         }
     }
 
+    /// Remove only OpenUsage's derived token; Antigravity's Keychain entry is never modified.
+    func discardCachedToken() {
+        do {
+            try files.remove(Self.cachePath)
+        } catch {
+            AppLog.warn(LogTag.auth("antigravity"), "failed to remove stale refreshed-token cache")
+        }
+    }
+
+    private static func credentialFingerprint(for refreshToken: String?) -> Data? {
+        guard let refreshToken = refreshToken?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty else {
+            return nil
+        }
+        return Data(SHA256.hash(data: Data(refreshToken.utf8)))
+    }
+
     // MARK: - Token extraction (pure)
 
     /// Decode the keychain value into tokens. Mirrors the `agy` format: an optional
@@ -92,14 +148,19 @@ struct AntigravityAuthStore: Sendable {
     static func extractToken(fromKeychainRaw raw: String) -> AntigravityKeychainToken? {
         guard let text = ProviderParse.unwrapGoKeyring(raw) else { return nil }
 
-        if let data = text.data(using: .utf8),
-           let json = try? JSONSerialization.jsonObject(with: data) {
+        if let json = try? JSONSerialization.jsonObject(with: Data(text.utf8)) {
             if let dict = json as? [String: Any] {
                 return tokenFromObject(dict)
             }
             if let string = (json as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
                 return AntigravityKeychainToken(accessToken: string, refreshToken: nil, expiry: nil)
             }
+            return nil
+        }
+
+        // Broken structured material is never sent as a raw bearer token.
+        if text.hasPrefix("{") || text.hasPrefix("[") {
+            return nil
         }
 
         if text.hasPrefix("Bearer ") {

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityAuthStore.swift
@@ -146,7 +146,14 @@ struct AntigravityAuthStore: Sendable {
     /// `go-keyring-base64:` wrapper around JSON `{ token: { access_token, refresh_token, expiry }, … }`,
     /// with fallbacks for a bare JSON string, a `Bearer …` value, or a raw token.
     static func extractToken(fromKeychainRaw raw: String) -> AntigravityKeychainToken? {
-        guard let text = ProviderParse.unwrapGoKeyring(raw) else { return nil }
+        let boundaryCharacters = CharacterSet.whitespacesAndNewlines
+            .union(CharacterSet(charactersIn: "\u{FEFF}"))
+        let normalizedRaw = raw.trimmingCharacters(in: boundaryCharacters)
+        guard let unwrapped = ProviderParse.unwrapGoKeyring(normalizedRaw),
+              let text = unwrapped.trimmingCharacters(in: boundaryCharacters).nilIfEmpty
+        else {
+            return nil
+        }
 
         if let json = try? JSONSerialization.jsonObject(with: Data(text.utf8)) {
             if let dict = json as? [String: Any] {

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityErrors.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityErrors.swift
@@ -6,6 +6,10 @@ import Foundation
 enum AntigravityError: Error, LocalizedError, Equatable {
     /// No usable credentials anywhere (no LS running, no keychain token, nothing cached).
     case notSignedIn
+    /// The Keychain credential may exist, but macOS would not let OpenUsage read it.
+    case credentialStoreUnreadable
+    /// The Keychain item was present but did not contain usable Antigravity credential data.
+    case invalidCredentialData
     /// A token was found but rejected (401/403) and a refresh couldn't recover it.
     case authExpired
     /// Credentials exist and look valid, but every endpoint was unreachable (network / server outage).
@@ -16,6 +20,10 @@ enum AntigravityError: Error, LocalizedError, Equatable {
         switch self {
         case .notSignedIn:
             return "Start Antigravity or run `agy` and try again."
+        case .credentialStoreUnreadable:
+            return "Couldn't read Antigravity credentials from Keychain. Unlock Keychain or sign in to Antigravity again."
+        case .invalidCredentialData:
+            return "Antigravity credentials are invalid. Open Antigravity or run `agy` to sign in again."
         case .authExpired:
             return "Antigravity sign-in expired. Open Antigravity or run `agy` to refresh."
         case .unavailable:

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
@@ -43,11 +43,15 @@ final class AntigravityProvider: ProviderRuntime {
     }
 
     func hasLocalCredentials() async -> Bool {
-        // The keychain token (or our refreshed-token cache) is the works-with-the-app-closed source
-        // `refresh()` falls back to; a logged-in Antigravity install has it even when no language
-        // server is running, so process discovery isn't needed here.
-        await loadOffMainActor { [authStore] in
-            authStore.loadKeychainToken() != nil || authStore.loadCachedToken() != nil
+        // The Keychain login is the source of truth. The app-owned access-token cache is derivative
+        // and must never independently enable the provider after logout.
+        do {
+            return try await loadOffMainActor { [authStore] in
+                try authStore.loadKeychainToken()
+            } != nil
+        } catch {
+            // Detection runs once; keep an indeterminate store enabled so refresh can show the repair.
+            return true
         }
     }
 
@@ -153,19 +157,27 @@ final class AntigravityProvider: ProviderRuntime {
 
     private func probeCloudCode() async throws -> StrategyResult {
         let authStore = self.authStore
-        let keychainToken = await loadOffMainActor({ authStore.loadKeychainToken() })
+        let keychainToken = try await loadOffMainActor { try authStore.loadKeychainToken() }
+
+        guard let keychainToken else {
+            // Proven logout invalidates the derived cache. A Keychain read failure throws above and
+            // deliberately leaves the cache untouched for recovery.
+            await loadOffMainActor { authStore.discardCachedToken() }
+            throw AntigravityError.notSignedIn
+        }
 
         var tokens: [String] = []
-        if let keychainToken, let access = keychainToken.accessToken, authStore.isUsable(expiry: keychainToken.expiry) {
+        if let access = keychainToken.accessToken, authStore.isUsable(expiry: keychainToken.expiry) {
             tokens.append(access)
         }
-        if let cached = authStore.loadCachedToken(), !tokens.contains(cached) {
+        if let cached = await loadOffMainActor({ authStore.loadCachedToken(matching: keychainToken) }),
+           !tokens.contains(cached) {
             tokens.append(cached)
         }
 
         // We have something to authenticate with if any token was tried or a refresh token exists. Used
         // to tell a transient outage ("temporarily unavailable") apart from a genuine "not signed in".
-        let hasCredentials = !tokens.isEmpty || (keychainToken?.refreshToken?.isEmpty == false)
+        let hasCredentials = !tokens.isEmpty || (keychainToken.refreshToken?.isEmpty == false)
 
         var sawAuthFailure = false
         for token in tokens {
@@ -178,10 +190,16 @@ final class AntigravityProvider: ProviderRuntime {
 
         // Only refresh on evidence of an auth failure (or no token to try) — a transient Cloud Code
         // outage must not trigger a Google OAuth refresh every cycle.
-        if sawAuthFailure || tokens.isEmpty, let refreshToken = keychainToken?.refreshToken {
+        if sawAuthFailure || tokens.isEmpty, let refreshToken = keychainToken.refreshToken {
             switch await usageClient.refreshGoogleToken(refreshToken) {
             case .refreshed(let accessToken, let expiresIn):
-                authStore.cacheToken(accessToken, expiresIn: expiresIn)
+                await loadOffMainActor {
+                    authStore.cacheToken(
+                        accessToken,
+                        expiresIn: expiresIn,
+                        sourceRefreshToken: refreshToken
+                    )
+                }
                 switch await fetchCloudCode(token: accessToken) {
                 case .success(let result): return result
                 case .authFailed: throw AntigravityError.authExpired

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
@@ -46,9 +46,14 @@ final class AntigravityProvider: ProviderRuntime {
         // The Keychain login is the source of truth. The app-owned access-token cache is derivative
         // and must never independently enable the provider after logout.
         do {
-            return try await loadOffMainActor { [authStore] in
+            let keychainToken = try await loadOffMainActor { [authStore] in
                 try authStore.loadKeychainToken()
-            } != nil
+            }
+            guard keychainToken != nil else {
+                await loadOffMainActor { [authStore] in authStore.discardCachedToken() }
+                return false
+            }
+            return true
         } catch {
             // Detection runs once; keep an indeterminate store enabled so refresh can show the repair.
             return true

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -14,6 +14,8 @@ enum ErrorCategory: String, Sendable, CaseIterable, Codable {
     case authExpired = "auth_expired"
     /// Auth is structurally wrong rather than stale (bad payload, misconfigured OAuth URL, unsupported key).
     case authInvalid = "auth_invalid"
+    /// Local credential material exists, but its file, database, or Keychain entry could not be read.
+    case credentialAccess = "credential_access"
     /// The request never completed (transport / connection failure).
     case network = "network"
     /// A response came back but could not be parsed / a required field was missing.
@@ -222,6 +224,8 @@ extension AntigravityError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {
         case .notSignedIn: .notLoggedIn
+        case .credentialStoreUnreadable: .credentialAccess
+        case .invalidCredentialData: .authInvalid
         case .authExpired: .authExpired
         case .unavailable: .network
         }

--- a/Sources/OpenUsage/Providers/ProviderRuntime.swift
+++ b/Sources/OpenUsage/Providers/ProviderRuntime.swift
@@ -42,3 +42,8 @@ protocol ProviderRuntime: AnyObject {
 func loadOffMainActor<T: Sendable>(_ load: @escaping @Sendable () -> T) async -> T {
     await Task.detached(priority: .utility, operation: load).value
 }
+
+/// Throwing counterpart for blocking credential reads that distinguish absence from access failure.
+func loadOffMainActor<T: Sendable>(_ load: @escaping @Sendable () throws -> T) async throws -> T {
+    try await Task.detached(priority: .utility, operation: load).value
+}

--- a/Sources/OpenUsage/Services/SystemClients.swift
+++ b/Sources/OpenUsage/Services/SystemClients.swift
@@ -19,11 +19,23 @@ struct ProcessEnvironmentReader: EnvironmentReading {
 
 protocol TextFileAccessing: Sendable {
     func exists(_ path: String) -> Bool
+    /// Read a UTF-8 file when it exists. `nil` means the path is absent; permission, encoding, and
+    /// other failures still throw so credential callers do not confuse broken storage with logout.
+    func readTextIfPresent(_ path: String) throws -> String?
     func readText(_ path: String) throws -> String
     func writeText(_ path: String, _ text: String) throws
     /// Remove the file at `path`. A missing file is not an error — the caller wants the key gone, and
     /// it already is. Used by the in-app API-key editor's Remove / Clear-override actions.
     func remove(_ path: String) throws
+}
+
+extension TextFileAccessing {
+    /// Compatibility path for test doubles. The production accessor classifies the read error directly
+    /// so it does not have an exists-then-read race.
+    func readTextIfPresent(_ path: String) throws -> String? {
+        guard exists(path) else { return nil }
+        return try readText(path)
+    }
 }
 
 struct LocalTextFileAccessor: TextFileAccessing {
@@ -38,6 +50,14 @@ struct LocalTextFileAccessor: TextFileAccessing {
 
     func readText(_ path: String) throws -> String {
         try String(contentsOfFile: expandHome(path), encoding: .utf8)
+    }
+
+    func readTextIfPresent(_ path: String) throws -> String? {
+        do {
+            return try readText(path)
+        } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+            return nil
+        }
     }
 
     func writeText(_ path: String, _ text: String) throws {
@@ -127,7 +147,10 @@ struct SQLiteCLIAccessor: SQLiteAccessing {
     }
 
     func queryValue(path: String, sql: String) throws -> String? {
-        let result = try run(path: path, sql: sql)
+        // A normal sqlite3 open can create a missing database. Credential probes must be read-only and
+        // side-effect free, so absence returns nil before a process is launched.
+        guard try databaseExists(path) else { return nil }
+        let result = try run(path: path, sql: sql, readOnly: true)
         guard result.succeeded else {
             throw SQLiteError.queryFailed(result.stderr)
         }
@@ -142,19 +165,29 @@ struct SQLiteCLIAccessor: SQLiteAccessing {
         }
     }
 
-    private func run(path: String, sql: String) throws -> ProcessResult {
-        try processRunner.run(
+    private func run(path: String, sql: String, readOnly: Bool = false) throws -> ProcessResult {
+        var arguments = ["-batch", "-noheader"]
+        if readOnly { arguments.append("-readonly") }
+        arguments += [
+            "-cmd", ".timeout 1000",
+            expandHome(path),
+            sql
+        ]
+        return try processRunner.run(
             executable: "/usr/bin/sqlite3",
-            arguments: [
-                "-batch",
-                "-noheader",
-                "-cmd", ".timeout 1000",
-                expandHome(path),
-                sql
-            ],
+            arguments: arguments,
             environment: [:],
             timeout: 5
         )
+    }
+
+    private func databaseExists(_ path: String) throws -> Bool {
+        do {
+            _ = try FileManager.default.attributesOfItem(atPath: expandHome(path))
+            return true
+        } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+            return false
+        }
     }
 }
 

--- a/Tests/OpenUsageTests/AntigravityProviderTests.swift
+++ b/Tests/OpenUsageTests/AntigravityProviderTests.swift
@@ -265,20 +265,25 @@ final class AntigravityProviderTests: XCTestCase {
     func testLoadCachedTokenAppliesRefreshBuffer() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         func store(expiresInSeconds: Double) -> AntigravityAuthStore {
-            let ms = (now.timeIntervalSince1970 + expiresInSeconds) * 1000
-            let files = FakeFiles([AntigravityAuthStore.cachePath: #"{"accessToken":"ya29.cached","expiresAtMs":\#(ms)}"#])
-            return AntigravityAuthStore(keychain: FakeKeychain(nil), files: files, now: { now })
+            let store = AntigravityAuthStore(keychain: FakeKeychain(nil), files: FakeFiles(), now: { now })
+            store.cacheToken(
+                "ya29.cached",
+                expiresIn: expiresInSeconds,
+                sourceRefreshToken: "refresh"
+            )
+            return store
         }
+        let source = AntigravityKeychainToken(accessToken: nil, refreshToken: "refresh", expiry: nil)
         // Within the 60s refresh buffer -> treated as expired (avoids a near-certain 401 + extra refresh).
-        XCTAssertNil(store(expiresInSeconds: 30).loadCachedToken())
-        XCTAssertEqual(store(expiresInSeconds: 7200).loadCachedToken(), "ya29.cached")
+        XCTAssertNil(store(expiresInSeconds: 30).loadCachedToken(matching: source))
+        XCTAssertEqual(store(expiresInSeconds: 7200).loadCachedToken(matching: source), "ya29.cached")
     }
 
-    func testLoadKeychainTokenThroughStore() {
+    func testLoadKeychainTokenThroughStore() throws {
         let inner = #"{"token":{"access_token":"ya29.kc","refresh_token":"1//r"}}"#
         let wrapped = "go-keyring-base64:" + Data(inner.utf8).base64EncodedString()
         let store = AntigravityAuthStore(keychain: FakeKeychain(wrapped), files: FakeFiles())
-        let token = store.loadKeychainToken()
+        let token = try store.loadKeychainToken()
         XCTAssertEqual(token?.accessToken, "ya29.kc")
         XCTAssertEqual(token?.refreshToken, "1//r")
     }

--- a/Tests/OpenUsageTests/CredentialCacheIntegrityTests.swift
+++ b/Tests/OpenUsageTests/CredentialCacheIntegrityTests.swift
@@ -1,0 +1,261 @@
+import XCTest
+@testable import OpenUsage
+
+final class CredentialSystemClientIntegrityTests: XCTestCase {
+    func testReadTextIfPresentReturnsNilOnlyForMissingFile() throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.missing.\(UUID().uuidString)")
+        XCTAssertNil(try LocalTextFileAccessor().readTextIfPresent(missing.path))
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.directory.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        XCTAssertThrowsError(try LocalTextFileAccessor().readTextIfPresent(directory.path))
+    }
+
+    func testSQLiteQueryDoesNotLaunchForMissingDatabase() throws {
+        let runner = CredentialCountingProcessRunner()
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.missing.\(UUID().uuidString).sqlite")
+
+        XCTAssertNil(
+            try SQLiteCLIAccessor(processRunner: runner)
+                .queryValue(path: path.path, sql: "SELECT value FROM ItemTable LIMIT 1")
+        )
+        XCTAssertEqual(runner.callCount, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path.path))
+    }
+
+    func testSQLiteQueryOpensExistingDatabaseReadOnly() throws {
+        let database = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageTests.existing.\(UUID().uuidString).sqlite")
+        try Data().write(to: database)
+        defer { try? FileManager.default.removeItem(at: database) }
+        let runner = CredentialCountingProcessRunner()
+
+        XCTAssertNil(
+            try SQLiteCLIAccessor(processRunner: runner)
+                .queryValue(path: database.path, sql: "SELECT value FROM ItemTable LIMIT 1")
+        )
+        XCTAssertEqual(runner.callCount, 1)
+        XCTAssertTrue(runner.lastArguments.contains("-readonly"))
+    }
+}
+
+@MainActor
+final class AntigravityCredentialCacheIntegrityTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testCachedTokenLoadsOnlyForMatchingLogin() {
+        let files = FakeFiles()
+        let store = makeStore(files: files)
+        store.cacheToken("current-access", expiresIn: 7_200, sourceRefreshToken: "current-refresh")
+        let current = AntigravityKeychainToken(
+            accessToken: nil,
+            refreshToken: "current-refresh",
+            expiry: nil
+        )
+
+        XCTAssertEqual(store.loadCachedToken(matching: current), "current-access")
+        XCTAssertFalse(files.files[AntigravityAuthStore.cachePath]?.contains("current-refresh") == true)
+
+        store.cacheToken("old-access", expiresIn: 7_200, sourceRefreshToken: "old-refresh")
+        XCTAssertNil(store.loadCachedToken(matching: current))
+        XCTAssertNil(files.files[AntigravityAuthStore.cachePath])
+    }
+
+    func testLegacyMalformedAndExpiredCachesAreDiscarded() {
+        let source = AntigravityKeychainToken(accessToken: nil, refreshToken: "refresh", expiry: nil)
+        let expiresAtMs = (now.timeIntervalSince1970 + 7_200) * 1_000
+        for cache in [
+            #"{"accessToken":"legacy","expiresAtMs":\#(expiresAtMs)}"#,
+            "{ not-json"
+        ] {
+            let files = FakeFiles([AntigravityAuthStore.cachePath: cache])
+            XCTAssertNil(makeStore(files: files).loadCachedToken(matching: source))
+            XCTAssertNil(files.files[AntigravityAuthStore.cachePath])
+        }
+
+        let files = FakeFiles()
+        let store = makeStore(files: files)
+        store.cacheToken("expired", expiresIn: 30, sourceRefreshToken: "refresh")
+        XCTAssertNil(store.loadCachedToken(matching: source))
+        XCTAssertNil(files.files[AntigravityAuthStore.cachePath])
+    }
+
+    func testLogoutRemovesCacheWithoutSendingIt() async {
+        let files = FakeFiles()
+        makeStore(files: files)
+            .cacheToken("old-access", expiresIn: 7_200, sourceRefreshToken: "old-refresh")
+        let http = RoutingHTTPClient { _ in
+            XCTFail("a derived token must not be sent after logout")
+            return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+        }
+        let provider = makeProvider(keychain: FakeKeychain(), files: files, http: http)
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertFalse(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+        XCTAssertTrue(http.requests.isEmpty)
+        XCTAssertNil(files.files[AntigravityAuthStore.cachePath])
+    }
+
+    func testKeychainReadFailureRetainsButNeverUsesCache() async {
+        let files = FakeFiles()
+        makeStore(files: files)
+            .cacheToken("old-access", expiresIn: 7_200, sourceRefreshToken: "old-refresh")
+        let http = RoutingHTTPClient { _ in
+            XCTFail("an unverified derived token must not leave the machine")
+            return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+        }
+        let provider = makeProvider(keychain: FailingAntigravityKeychain(), files: files, http: http)
+
+        let detected = await provider.hasLocalCredentials()
+        XCTAssertTrue(detected)
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .credentialAccess)
+        XCTAssertTrue(http.requests.isEmpty)
+        XCTAssertNotNil(files.files[AntigravityAuthStore.cachePath])
+    }
+
+    func testAccountSwitchNeverSendsPreviousCachedToken() async {
+        let files = FakeFiles()
+        makeStore(files: files)
+            .cacheToken("old-access", expiresIn: 7_200, sourceRefreshToken: "old-refresh")
+        let http = RoutingHTTPClient { request in
+            if request.url.host == "oauth2.googleapis.com" {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"access_token":"new-access","expires_in":3600}"#.utf8)
+                )
+            }
+            if request.url.path.contains("retrieveUserQuotaSummary") {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"groups":[]}"#.utf8))
+            }
+            return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+        }
+        let provider = makeProvider(
+            keychain: FakeKeychain(keychainToken(access: "expired-access", refresh: "new-refresh")),
+            files: files,
+            http: http
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        let authorizations = http.requests.compactMap { $0.headers["Authorization"] }
+        XCTAssertTrue(authorizations.contains("Bearer new-access"))
+        XCTAssertFalse(authorizations.contains("Bearer old-access"))
+    }
+
+    func testMatchingCacheAvoidsAnotherOAuthRefresh() async {
+        let files = FakeFiles()
+        makeStore(files: files)
+            .cacheToken("cached-access", expiresIn: 7_200, sourceRefreshToken: "current-refresh")
+        let http = RoutingHTTPClient { request in
+            if request.url.host == "oauth2.googleapis.com" {
+                XCTFail("a cache bound to the current login should avoid another OAuth refresh")
+                return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+            }
+            if request.url.path.contains("retrieveUserQuotaSummary") {
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"groups":[]}"#.utf8))
+            }
+            return HTTPResponse(statusCode: 503, headers: [:], body: Data())
+        }
+        let provider = makeProvider(
+            keychain: FakeKeychain(keychainToken(access: "expired-access", refresh: "current-refresh")),
+            files: files,
+            http: http
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertFalse(http.requests.contains { $0.url.host == "oauth2.googleapis.com" })
+        let authorizations = http.requests.compactMap { $0.headers["Authorization"] }
+        XCTAssertEqual(Set(authorizations), ["Bearer cached-access"])
+    }
+
+    func testMalformedStructuredKeychainValueIsNotSentAsBearerToken() async {
+        let http = RoutingHTTPClient { _ in
+            XCTFail("malformed structured credentials must not be sent")
+            return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+        }
+        let provider = makeProvider(keychain: FakeKeychain("{broken-json"), files: FakeFiles(), http: http)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertTrue(http.requests.isEmpty)
+    }
+
+    private func makeStore(files: TextFileAccessing) -> AntigravityAuthStore {
+        let fixedNow = now
+        return AntigravityAuthStore(keychain: FakeKeychain(), files: files, now: { fixedNow })
+    }
+
+    private func makeProvider(
+        keychain: KeychainAccessing,
+        files: TextFileAccessing,
+        http: RoutingHTTPClient
+    ) -> AntigravityProvider {
+        let fixedNow = now
+        return AntigravityProvider(
+            authStore: AntigravityAuthStore(keychain: keychain, files: files, now: { fixedNow }),
+            usageClient: AntigravityUsageClient(lsHTTP: http, http: http),
+            discovery: LanguageServerDiscovery(processRunner: CredentialEmptyProcessRunner()),
+            now: { fixedNow }
+        )
+    }
+
+    private func keychainToken(access: String, refresh: String) -> String {
+        let json = """
+        {"token":{"access_token":"\(access)","refresh_token":"\(refresh)","expiry":"2000-01-01T00:00:00Z"}}
+        """
+        return "go-keyring-base64:" + Data(json.utf8).base64EncodedString()
+    }
+}
+
+private final class CredentialCountingProcessRunner: ProcessRunning, @unchecked Sendable {
+    private(set) var callCount = 0
+    private(set) var lastArguments: [String] = []
+
+    func run(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) throws -> ProcessResult {
+        callCount += 1
+        lastArguments = arguments
+        return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+    }
+}
+
+private struct CredentialEmptyProcessRunner: ProcessRunning {
+    func run(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) throws -> ProcessResult {
+        ProcessResult(exitCode: 0, stdout: "", stderr: "")
+    }
+}
+
+private struct FailingAntigravityKeychain: KeychainAccessing {
+    func readGenericPassword(service: String) throws -> String? {
+        throw FailingAntigravityKeychainError.unreadable
+    }
+
+    func writeGenericPassword(service: String, value: String) throws {}
+}
+
+private enum FailingAntigravityKeychainError: Error {
+    case unreadable
+}

--- a/Tests/OpenUsageTests/CredentialCacheIntegrityTests.swift
+++ b/Tests/OpenUsageTests/CredentialCacheIntegrityTests.swift
@@ -96,6 +96,7 @@ final class AntigravityCredentialCacheIntegrityTests: XCTestCase {
 
         let detected = await provider.hasLocalCredentials()
         XCTAssertFalse(detected)
+        XCTAssertNil(files.files[AntigravityAuthStore.cachePath])
         let snapshot = await provider.refresh()
 
         XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)

--- a/Tests/OpenUsageTests/CredentialCacheIntegrityTests.swift
+++ b/Tests/OpenUsageTests/CredentialCacheIntegrityTests.swift
@@ -195,6 +195,20 @@ final class AntigravityCredentialCacheIntegrityTests: XCTestCase {
         XCTAssertTrue(http.requests.isEmpty)
     }
 
+    func testBOMPrefixedMalformedStructuredKeychainValueIsNotSentAsBearerToken() async {
+        let http = RoutingHTTPClient { _ in
+            XCTFail("BOM-prefixed malformed structured credentials must not be sent")
+            return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+        }
+        let malformed = "\u{FEFF} \n\t{broken-json"
+        let provider = makeProvider(keychain: FakeKeychain(malformed), files: FakeFiles(), http: http)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(snapshot.errorCategory, .authInvalid)
+        XCTAssertTrue(http.requests.isEmpty)
+    }
+
     private func makeStore(files: TextFileAccessing) -> AntigravityAuthStore {
         let fixedNow = now
         return AntigravityAuthStore(keychain: FakeKeychain(), files: files, now: { fixedNow })

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -24,7 +24,9 @@ It also reports **crashes**, so we can find and fix the bugs that make the app q
 
 OpenUsage primarily reads credentials that provider tools already keep on your Mac. When it writes a
 user-supplied API key or saves a refreshed credential, the file is replaced atomically and restricted to
-your macOS account (owner read and write only).
+your macOS account (owner read and write only). Antigravity's short-lived refreshed-token cache is tied
+to the current Keychain login using a one-way fingerprint; the refresh credential itself is not copied.
+The cache is never used after logout, an account change, or while Keychain access is unavailable.
 
 ## Other network requests
 

--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -23,13 +23,14 @@ While a pool's rolling 5-hour window has no usage yet, that meter reads **Not st
 OpenUsage never asks for a token — it reads what Antigravity already has:
 
 - **Antigravity running** — OpenUsage talks to the app's local language server (the richest source, and where the plan name comes from).
-- **App closed** — it falls back to the OAuth token Antigravity / `agy` store in your macOS Keychain and queries Google's Cloud Code API. An expired token is refreshed automatically (OpenUsage never writes back to Antigravity's own keychain item).
+- **App closed** — it falls back to the OAuth token Antigravity / `agy` store in your macOS Keychain and queries Google's Cloud Code API. An expired token is refreshed automatically (OpenUsage never writes back to Antigravity's own keychain item). Its short-lived cache is reused only while the same Keychain login is present and readable.
 
 If neither is available you'll see *Start Antigravity or run `agy` and try again.*
 
 ## Troubleshooting
 
 - **"Start Antigravity or run `agy`…"** — sign in to the Antigravity app (or run `agy`) so a usable token exists, then refresh.
+- **"Couldn't read Antigravity credentials…"** — unlock Keychain or sign in to Antigravity again. OpenUsage will not use its cached access token until the current login can be verified.
 - **The weekly meters show "No data"** — your Antigravity build doesn't expose the quota-summary endpoint yet (only newer builds do). The 5-hour meters still work from the older endpoints; updating Antigravity brings the weekly meters back.
 - **A meter shows "No data"** — that pool/window wasn't in the latest response (some tiers only report certain windows). The other meters still update.
 - **Where did the Gemini Pro and Flash meters go?** — merged: both models draw from the one shared Gemini pool, which is now the single Session meter.
@@ -37,6 +38,6 @@ If neither is available you'll see *Start Antigravity or run `agy` and try again
 
 ## Under the hood
 
-Best source first: the local language server discovered by scanning for the `language_server` / `agy` process and reading its CSRF token and listening ports; then Google Cloud Code using the Keychain token, refreshed via Google OAuth when needed. On each source OpenUsage asks the quota-summary endpoint first (`RetrieveUserQuotaSummary` on the language server, `v1internal:retrieveUserQuotaSummary` on Cloud Code) — the only endpoint that reports the merged pools and the weekly windows. Builds without it fall back to the legacy per-model endpoints (`GetUserStatus` / `GetCommandModelConfigs` locally, `fetchAvailableModels` / `retrieveUserQuota` remotely), whose per-model quotas are merged into the two pools by keeping each pool's worst remaining fraction; those endpoints only know the 5-hour windows. The plan name prefers Antigravity's own `userTier` over the inherited Windsurf plan field.
+Best source first: the local language server discovered by scanning for the `language_server` / `agy` process and reading its CSRF token and listening ports; then Google Cloud Code using the Keychain token, refreshed via Google OAuth when needed. OpenUsage binds its short-lived refreshed-token cache to a one-way fingerprint of the current Keychain refresh credential. Logout, account changes, legacy caches, and expired or malformed entries cannot reuse a previous account's access token. On each source OpenUsage asks the quota-summary endpoint first (`RetrieveUserQuotaSummary` on the language server, `v1internal:retrieveUserQuotaSummary` on Cloud Code) — the only endpoint that reports the merged pools and the weekly windows. Builds without it fall back to the legacy per-model endpoints (`GetUserStatus` / `GetCommandModelConfigs` locally, `fetchAvailableModels` / `retrieveUserQuota` remotely), whose per-model quotas are merged into the two pools by keeping each pool's worst remaining fraction; those endpoints only know the 5-hour windows. The plan name prefers Antigravity's own `userTier` over the inherited Windsurf plan field.
 
 > Reverse-engineered from the app and language-server binary; endpoints and storage may change without notice.


### PR DESCRIPTION
## TL;DR
Replacement for #954, which closed when its base branch (`codex/secure-credential-files`, #910) was deleted after merge. Same commits, rebased onto current `main`.

## What this changes
- Bind Antigravity credential caches to verified local state
- Stop SQLite probes from creating empty DB files
- Reject malformed keychain data as bearer tokens

## Tests
Existing PR tests rebased onto main; CI will re-run.


Made with [Cursor](https://cursor.com)