### PR TITLE
Read Claude Desktop login safely

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -19,6 +19,7 @@ struct ClaudeCredentialState: Hashable, Sendable {
         case file
         case keychainCurrentUser(service: String)
         case keychainLegacy(service: String)
+        case desktop
         case environment
 
         /// Log-safe source kind — NEVER the keychain service name or any token.
@@ -27,6 +28,7 @@ struct ClaudeCredentialState: Hashable, Sendable {
             case .file: "file"
             case .keychainCurrentUser: "keychainCurrentUser"
             case .keychainLegacy: "keychainLegacy"
+            case .desktop: "desktop"
             case .environment: "environment"
             }
         }
@@ -94,9 +96,16 @@ struct ClaudeCredentialGeneration: Equatable, Sendable {
     }
 }
 
+struct ClaudeCredentialLoad: Sendable {
+    var candidates: [ClaudeCredentialState]
+    var desktopStatus: ClaudeDesktopCredentialStatus
+}
+
 enum ClaudeAuthError: Error, LocalizedError, Equatable {
     case notLoggedIn
-    case desktopAppOnly
+    case desktopPermissionRequired
+    case desktopTokenExpired
+    case desktopCredentialsUnavailable
     case sessionExpired
     case tokenExpired
     case credentialsChanged
@@ -106,8 +115,12 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
         switch self {
         case .notLoggedIn:
             return "Not logged in. Run `claude` to authenticate."
-        case .desktopAppOnly:
-            return "Signed in to the Claude desktop app? OpenUsage needs a CLI login — run `claude` in a terminal and sign in once."
+        case .desktopPermissionRequired:
+            return "Claude Desktop login found. Refresh once and choose Always Allow to connect it."
+        case .desktopTokenExpired:
+            return "Claude Desktop login is stale. Open Claude Desktop, then refresh OpenUsage."
+        case .desktopCredentialsUnavailable:
+            return "Claude Desktop login couldn't be read. Open Claude Desktop, then try again."
         case .sessionExpired:
             return "Session expired. Run `claude` to log in again."
         case .tokenExpired:
@@ -127,9 +140,10 @@ enum ClaudeAuthError: Error, LocalizedError, Equatable {
     /// `CodexAuthError.allowsAuthFallback`.
     var allowsAuthFallback: Bool {
         switch self {
-        case .sessionExpired, .tokenExpired:
+        case .sessionExpired, .tokenExpired, .desktopTokenExpired:
             return true
-        case .notLoggedIn, .desktopAppOnly, .credentialsChanged, .invalidOAuthURL:
+        case .notLoggedIn, .desktopPermissionRequired, .desktopCredentialsUnavailable,
+             .credentialsChanged, .invalidOAuthURL:
             return false
         }
     }
@@ -153,17 +167,20 @@ struct ClaudeAuthStore: Sendable {
     var environment: EnvironmentReading
     var files: TextFileAccessing
     var keychain: KeychainAccessing
+    var desktop: ClaudeDesktopAuthStore
     var now: @Sendable () -> Date
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
         files: TextFileAccessing = LocalTextFileAccessor(),
         keychain: KeychainAccessing = SecurityKeychainAccessor(),
+        desktop: ClaudeDesktopAuthStore? = nil,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.environment = environment
         self.files = files
         self.keychain = keychain
+        self.desktop = desktop ?? ClaudeDesktopAuthStore(files: files, now: now)
         self.now = now
     }
 
@@ -172,8 +189,40 @@ struct ClaudeAuthStore: Sendable {
     /// (`ClaudeAuthError.allowsAuthFallback`) — falls through to the next, so an external `claude`
     /// re-login is picked up no matter which source it lands in, even when a stale/locked-out token still
     /// sits in another. Re-read on every refresh; nothing is cached in memory.
+    func loadCredentialSet(
+        allowDesktopInteraction: Bool = false,
+        forceDesktopFallback: Bool = false
+    ) -> ClaudeCredentialLoad {
+        var stored = orderedStoredCandidates()
+        var desktopStatus: ClaudeDesktopCredentialStatus = .notChecked
+        // A working CLI login remains the source of truth and avoids a second Keychain prompt. Desktop
+        // is a fallback for people who only use the native app (or whose stored CLI login lacks profile
+        // scope), never a competing account source.
+        let hasUsableCLILogin = stored.contains {
+            $0.hasUsableAccessToken && liveUsageAvailability($0) == .available
+        }
+        if forceDesktopFallback || !hasUsableCLILogin {
+            let result = desktop.load(allowInteraction: allowDesktopInteraction)
+            desktopStatus = result.status
+            if let oauth = result.oauth {
+                stored.insert(ClaudeCredentialState(
+                    oauth: oauth,
+                    source: .desktop,
+                    fullData: nil,
+                    inferenceOnly: false
+                ), at: 0)
+            }
+        }
+
+        let candidates = applyingEnvironmentToken(to: stored)
+        return ClaudeCredentialLoad(candidates: candidates, desktopStatus: desktopStatus)
+    }
+
     func loadCredentialCandidates() -> [ClaudeCredentialState] {
-        let stored = orderedStoredCandidates()
+        loadCredentialSet().candidates
+    }
+
+    private func applyingEnvironmentToken(to stored: [ClaudeCredentialState]) -> [ClaudeCredentialState] {
         guard let envAccessToken = envText("CLAUDE_CODE_OAUTH_TOKEN") else {
             return stored
         }
@@ -204,28 +253,13 @@ struct ClaudeAuthStore: Sendable {
         return liveCapable.isEmpty ? [envCandidate] : liveCapable + [envCandidate]
     }
 
-    /// Data folders the Claude desktop app keeps under `~/Library/Application Support` — the standalone
-    /// Claude Code app and the Claude Code area inside the main Claude app. Their presence (checked only
-    /// when no CLI credentials exist anywhere) means the user likely signed in through the desktop app,
-    /// whose session lives in an Electron `safeStorage`-encrypted blob OpenUsage can't read (#825).
-    private static let desktopAppDataPaths = [
-        "~/Library/Application Support/Claude Code",
-        "~/Library/Application Support/Claude/claude-code"
-    ]
-
-    /// Whether a desktop-app login is the likely reason no CLI credentials were found, so the provider
-    /// can explain that a one-time `claude` CLI login is needed instead of a bare "Not logged in".
-    func hasDesktopAppData() -> Bool {
-        Self.desktopAppDataPaths.contains { files.exists($0) }
-    }
-
     func needsRefresh(_ oauth: ClaudeOAuth) -> Bool {
         guard let expiresAt = oauth.expiresAt else { return false }
         return expiresAt - now().timeIntervalSince1970 * 1000 <= 5 * 60 * 1000
     }
 
-    func credentialGeneration() -> ClaudeCredentialGeneration {
-        ClaudeCredentialGeneration(loadCredentialCandidates())
+    func credentialGeneration(forceDesktopFallback: Bool = false) -> ClaudeCredentialGeneration {
+        ClaudeCredentialGeneration(loadCredentialSet(forceDesktopFallback: forceDesktopFallback).candidates)
     }
 
     /// Save an OAuth rotation only if the ordered effective candidate set is unchanged. Checking the
@@ -245,6 +279,8 @@ struct ClaudeAuthStore: Sendable {
             try keychain.writeGenericPasswordForCurrentUser(service: service, value: text)
         case .keychainLegacy(let service):
             try keychain.writeGenericPassword(service: service, value: text)
+        case .desktop:
+            return false
         case .environment:
             return false
         }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -202,33 +202,16 @@ struct ClaudeAuthStore: Sendable {
             $0.hasUsableAccessToken && liveUsageAvailability($0) == .available
         }
         if forceDesktopFallback || !hasUsableCLILogin {
-            if forceDesktopFallback, hasUsableCLILogin {
-                AppLog.info(LogTag.auth("claude"), "desktop load forced (CLI login present but falling through)")
-            }
             let result = desktop.load(allowInteraction: allowDesktopInteraction)
             desktopStatus = result.status
             if let oauth = result.oauth {
-                AppLog.info(
-                    LogTag.auth("claude"),
-                    "credential set: using desktop (status=\(desktopStatus) sub=\(oauth.subscriptionType ?? "<nil>") tier=\(oauth.rateLimitTier ?? "<nil>"))"
-                )
                 stored.insert(ClaudeCredentialState(
                     oauth: oauth,
                     source: .desktop,
                     fullData: nil,
                     inferenceOnly: false
                 ), at: 0)
-            } else {
-                AppLog.info(LogTag.auth("claude"), "credential set: desktop unavailable (status=\(desktopStatus))")
             }
-        } else {
-            let now = now()
-            let cli = stored
-                .filter { $0.hasUsableAccessToken && liveUsageAvailability($0) == .available }
-                .map { $0.diagnosticsLabel(now: now) }
-                .joined(separator: ", ")
-            AppLog.info(LogTag.auth("claude"), "credential set: skipping desktop (CLI login present: \(cli))")
-            desktopStatus = .notChecked
         }
 
         let candidates = applyingEnvironmentToken(to: stored)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -202,16 +202,33 @@ struct ClaudeAuthStore: Sendable {
             $0.hasUsableAccessToken && liveUsageAvailability($0) == .available
         }
         if forceDesktopFallback || !hasUsableCLILogin {
+            if forceDesktopFallback, hasUsableCLILogin {
+                AppLog.info(LogTag.auth("claude"), "desktop load forced (CLI login present but falling through)")
+            }
             let result = desktop.load(allowInteraction: allowDesktopInteraction)
             desktopStatus = result.status
             if let oauth = result.oauth {
+                AppLog.info(
+                    LogTag.auth("claude"),
+                    "credential set: using desktop (status=\(desktopStatus) sub=\(oauth.subscriptionType ?? "<nil>") tier=\(oauth.rateLimitTier ?? "<nil>"))"
+                )
                 stored.insert(ClaudeCredentialState(
                     oauth: oauth,
                     source: .desktop,
                     fullData: nil,
                     inferenceOnly: false
                 ), at: 0)
+            } else {
+                AppLog.info(LogTag.auth("claude"), "credential set: desktop unavailable (status=\(desktopStatus))")
             }
+        } else {
+            let now = now()
+            let cli = stored
+                .filter { $0.hasUsableAccessToken && liveUsageAvailability($0) == .available }
+                .map { $0.diagnosticsLabel(now: now) }
+                .joined(separator: ", ")
+            AppLog.info(LogTag.auth("claude"), "credential set: skipping desktop (CLI login present: \(cli))")
+            desktopStatus = .notChecked
         }
 
         let candidates = applyingEnvironmentToken(to: stored)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
@@ -125,18 +125,37 @@ struct ClaudeDesktopAuthStore: Sendable {
 
     func load(allowInteraction: Bool) -> ClaudeDesktopCredentialResult {
         guard hasCredentialMaterial() else {
+            AppLog.info(LogTag.auth("claude"), "desktop load: no credential material (config/cookies missing)")
             return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
         }
 
         do {
             guard let key = try safeStorageKey(allowInteraction: allowInteraction) else {
+                AppLog.info(LogTag.auth("claude"), "desktop load: Safe Storage key unavailable (interaction=\(allowInteraction))")
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
             }
-            guard let activeOrg = try loadActiveOrganization(key: key),
-                  let caches = try loadCaches(key: key)
-            else {
+            let accountUUID = loadLastKnownAccountUUID()
+            guard let activeOrg = try loadActiveOrganization(key: key) else {
+                AppLog.info(
+                    LogTag.auth("claude"),
+                    "desktop load: no lastActiveOrg cookie (account=\(Self.shortID(accountUUID)))"
+                )
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
             }
+            guard let caches = try loadCaches(key: key) else {
+                AppLog.info(
+                    LogTag.auth("claude"),
+                    "desktop load: token cache unreadable (org=\(Self.shortID(activeOrg)) account=\(Self.shortID(accountUUID)))"
+                )
+                return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
+            }
+
+            let v2Orgs = Self.organizationIDs(in: caches.v2)
+            let v1Orgs = Self.organizationIDs(in: caches.v1)
+            AppLog.info(
+                LogTag.auth("claude"),
+                "desktop load: lastActiveOrg=\(Self.shortID(activeOrg)) account=\(Self.shortID(accountUUID)) v2Orgs=\(v2Orgs.map(Self.shortID).sorted()) v1Orgs=\(v1Orgs.map(Self.shortID).sorted())"
+            )
 
             let selection = Self.selectCredential(
                 activeOrganization: activeOrg,
@@ -146,20 +165,66 @@ struct ClaudeDesktopAuthStore: Sendable {
             )
             switch selection {
             case .available(let oauth):
+                AppLog.info(
+                    LogTag.auth("claude"),
+                    "desktop load: selected org=\(Self.shortID(activeOrg)) \(Self.oauthDebugSummary(oauth))"
+                )
                 return ClaudeDesktopCredentialResult(oauth: oauth, status: .available)
             case .stale:
+                AppLog.info(LogTag.auth("claude"), "desktop load: only stale tokens for org=\(Self.shortID(activeOrg))")
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .stale)
             case .notFound:
+                AppLog.info(LogTag.auth("claude"), "desktop load: no usable profile-scoped token for org=\(Self.shortID(activeOrg))")
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
             case .invalid:
+                AppLog.info(LogTag.auth("claude"), "desktop load: invalid cache entries for org=\(Self.shortID(activeOrg))")
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
             }
         } catch ClaudeDesktopCredentialError.permissionRequired {
+            AppLog.info(LogTag.auth("claude"), "desktop load: keychain permission required (manual refresh + Always Allow)")
             return ClaudeDesktopCredentialResult(oauth: nil, status: .permissionRequired)
         } catch {
             AppLog.error(LogTag.auth("claude"), "Claude Desktop credential read failed: \(error.localizedDescription)")
             return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
         }
+    }
+
+    /// Account UUID Claude Desktop persists separately from the org cookie — who is logged in, not which org is active.
+    private func loadLastKnownAccountUUID() -> String? {
+        guard let text = try? files.readTextIfPresent(path(Self.configRelativePath)),
+              let data = text.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let value = root["lastKnownAccountUuid"] as? String,
+              UUID(uuidString: value) != nil
+        else {
+            return nil
+        }
+        return value.lowercased()
+    }
+
+    /// Log-safe short UUID (`aaaaaaaa…bbbbbbbb`) — never the full id in spammy lines, never tokens.
+    private static func shortID(_ value: String?) -> String {
+        guard let value, value.count >= 13 else { return value ?? "<none>" }
+        return "\(value.prefix(8))…\(value.suffix(4))"
+    }
+
+    private static func oauthDebugSummary(_ oauth: ClaudeOAuth) -> String {
+        let sub = oauth.subscriptionType ?? "<nil>"
+        let tier = oauth.rateLimitTier ?? "<nil>"
+        let scopes = (oauth.scopes ?? []).joined(separator: " ")
+        let scopeLabel = scopes.isEmpty ? "<none>" : scopes
+        return "sub=\(sub) tier=\(tier) scopes=[\(scopeLabel)]"
+    }
+
+    private static func organizationIDs(in cache: [String: Any]?) -> [String] {
+        guard let cache else { return [] }
+        var orgs = Set<String>()
+        for key in cache.keys {
+            if let parsed = parseCacheKey(key) {
+                orgs.insert(parsed.organization)
+            }
+        }
+        return Array(orgs)
     }
 
     private func safeStorageKey(allowInteraction: Bool) throws -> Data? {
@@ -259,7 +324,17 @@ struct ClaudeDesktopAuthStore: Sendable {
     ) -> Selection {
         let normalizedOrg = activeOrganization.lowercased()
         let v2Candidates = candidates(in: v2, organization: normalizedOrg, now: now)
-        if let best = v2Candidates.available.max(by: { $0.expiresAt < $1.expiresAt }) {
+        if !v2Candidates.available.isEmpty {
+            AppLog.info(
+                LogTag.auth("claude"),
+                "desktop select: org=\(shortID(normalizedOrg)) cache=v2 candidates=[\(v2Candidates.available.map(\.debugLabel).joined(separator: "; "))]"
+            )
+        }
+        if let best = v2Candidates.available.max(by: { $0.rank < $1.rank }) {
+            AppLog.info(
+                LogTag.auth("claude"),
+                "desktop select: org=\(shortID(normalizedOrg)) winner=v2 \(best.debugLabel)"
+            )
             return .available(best.oauth)
         }
 
@@ -269,7 +344,17 @@ struct ClaudeDesktopAuthStore: Sendable {
             organization: normalizedOrg,
             now: now
         )
-        if let best = v1Candidates.available.max(by: { $0.expiresAt < $1.expiresAt }) {
+        if !v1Candidates.available.isEmpty {
+            AppLog.info(
+                LogTag.auth("claude"),
+                "desktop select: org=\(shortID(normalizedOrg)) cache=v1 candidates=[\(v1Candidates.available.map(\.debugLabel).joined(separator: "; "))]"
+            )
+        }
+        if let best = v1Candidates.available.max(by: { $0.rank < $1.rank }) {
+            AppLog.info(
+                LogTag.auth("claude"),
+                "desktop select: org=\(shortID(normalizedOrg)) winner=v1 \(best.debugLabel)"
+            )
             return .available(best.oauth)
         }
         if v2Candidates.sawStale || v1Candidates.sawStale { return .stale }
@@ -277,9 +362,45 @@ struct ClaudeDesktopAuthStore: Sendable {
         return .notFound
     }
 
+    /// The OAuth client ID Claude's production login (Claude Code / Desktop) mints full-scope tokens
+    /// under. Desktop's cache can hold several entries for one org — partial-scope leftovers from older
+    /// logins included — and this client is how Desktop itself resolves the active login.
+    private static let productionClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+    private static let inferenceScope = "user:inference"
+
     private struct Candidate {
         var oauth: ClaudeOAuth
+        var clientID: String
+        var scopes: [String]
         var expiresAt: Double
+
+        /// Selection order mirrors Desktop's own resolution instead of raw expiry: production client
+        /// with full scopes first, then any full-scope entry over bare `user:profile` leftovers, then
+        /// scope richness, with expiry only as the final tiebreak. A stale wrong-tier token with a
+        /// longer TTL must not outrank the current login.
+        var rank: (Int, Int, Int, Double) {
+            let hasFullScope = scopes.contains(ClaudeDesktopAuthStore.usageScope)
+                && scopes.contains(ClaudeDesktopAuthStore.inferenceScope)
+            let isProductionClient = clientID == ClaudeDesktopAuthStore.productionClientID
+            return (
+                isProductionClient && hasFullScope ? 1 : 0,
+                hasFullScope ? 1 : 0,
+                scopes.count,
+                expiresAt
+            )
+        }
+
+        /// Token-free label for selection logs (client prefix, scopes, stamped plan metadata, expiry).
+        var debugLabel: String {
+            let client = clientID.count >= 8 ? String(clientID.prefix(8)) : clientID
+            let sub = oauth.subscriptionType ?? "<nil>"
+            let tier = oauth.rateLimitTier ?? "<nil>"
+            let scopeText = scopes.joined(separator: "+")
+            let exp = expiresAt.isFinite
+                ? ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: expiresAt / 1000))
+                : "<nil>"
+            return "client=\(client) scopes=\(scopeText) sub=\(sub) tier=\(tier) exp=\(exp)"
+        }
     }
 
     private static func candidates(
@@ -321,12 +442,18 @@ struct ClaudeDesktopAuthStore: Sendable {
                 rateLimitTier: entry["rateLimitTier"] as? String,
                 scopes: parsedKey.scopes
             )
-            available.append(Candidate(oauth: oauth, expiresAt: expiresAt))
+            available.append(Candidate(
+                oauth: oauth,
+                clientID: parsedKey.clientID,
+                scopes: parsedKey.scopes,
+                expiresAt: expiresAt
+            ))
         }
         return (available, sawStale, sawInvalid)
     }
 
     private struct CacheKey {
+        var clientID: String
         var organization: String
         var apiHost: String
         var scopes: [String]
@@ -345,7 +472,7 @@ struct ClaudeDesktopAuthStore: Sendable {
         let scopes = value[markerRange.upperBound...]
             .split(whereSeparator: \.isWhitespace)
             .map(String.init)
-        return CacheKey(organization: organization, apiHost: apiHost, scopes: scopes)
+        return CacheKey(clientID: clientID, organization: organization, apiHost: apiHost, scopes: scopes)
     }
 
     private static func number(_ value: Any?) -> Double? {

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
@@ -1,0 +1,464 @@
+import CommonCrypto
+import CryptoKit
+import Foundation
+import LocalAuthentication
+import Security
+
+enum ClaudeDesktopCredentialStatus: Sendable, Equatable {
+    case notChecked
+    case notFound
+    case permissionRequired
+    case stale
+    case invalid
+    case available
+}
+
+struct ClaudeDesktopCredentialResult: Sendable {
+    var oauth: ClaudeOAuth?
+    var status: ClaudeDesktopCredentialStatus
+}
+
+protocol ClaudeDesktopSafeStorageKeyReading: Sendable {
+    func readPassword(allowInteraction: Bool) throws -> String?
+}
+
+struct ClaudeDesktopSafeStorageKeyReader: ClaudeDesktopSafeStorageKeyReading {
+    private static let service = "Claude Safe Storage"
+    private static let account = "Claude Key"
+
+    func readPassword(allowInteraction: Bool) throws -> String? {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: Self.account,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: true
+        ]
+        if !allowInteraction {
+            let context = LAContext()
+            context.interactionNotAllowed = true
+            query[kSecUseAuthenticationContext as String] = context
+        }
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data,
+                  let password = String(data: data, encoding: .utf8),
+                  !password.isEmpty
+            else {
+                throw ClaudeDesktopCredentialError.invalidSafeStorageKey
+            }
+            return password
+        case errSecItemNotFound:
+            return nil
+        case errSecInteractionNotAllowed, errSecAuthFailed, errSecUserCanceled:
+            throw ClaudeDesktopCredentialError.permissionRequired
+        default:
+            throw ClaudeDesktopCredentialError.keychainFailure(Int(status))
+        }
+    }
+}
+
+enum ClaudeDesktopCredentialError: Error, Sendable {
+    case permissionRequired
+    case invalidSafeStorageKey
+    case keychainFailure(Int)
+    case invalidCiphertext
+    case decryptionFailed(Int32)
+}
+
+/// Reads Claude Desktop's Electron OAuth cache as an externally owned, read-only credential source.
+///
+/// The refresh token is deliberately never decoded into `ClaudeOAuth`: Anthropic rotates refresh
+/// tokens, so using one here would invalidate Claude Desktop's copy. OpenUsage only borrows a currently
+/// valid access token and waits for Desktop to renew it.
+struct ClaudeDesktopAuthStore: Sendable {
+    private static let configRelativePath = "Library/Application Support/Claude/config.json"
+    private static let cookieRelativePaths = [
+        "Library/Application Support/Claude/Cookies",
+        "Library/Application Support/Claude/Network/Cookies"
+    ]
+    private static let cacheV1Key = "oauth:tokenCache"
+    private static let cacheV2Key = "oauth:tokenCacheV2"
+    private static let apiHost = "https://api.anthropic.com"
+    private static let usageScope = "user:profile"
+    private static let expirySafetyMarginMs = 2 * 60 * 1000.0
+    private static let cookieHosts = [".claude.ai", "claude.ai"]
+
+    var files: TextFileAccessing
+    var sqlite: SQLiteAccessing
+    var keyReader: ClaudeDesktopSafeStorageKeyReading
+    var homeDirectory: @Sendable () -> URL
+    var now: @Sendable () -> Date
+    private let keyCache: SafeStorageKeyCache
+
+    init(
+        files: TextFileAccessing = LocalTextFileAccessor(),
+        sqlite: SQLiteAccessing = SQLiteCLIAccessor(),
+        keyReader: ClaudeDesktopSafeStorageKeyReading = ClaudeDesktopSafeStorageKeyReader(),
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        now: @escaping @Sendable () -> Date = Date.init,
+        keyCache: SafeStorageKeyCache = SafeStorageKeyCache()
+    ) {
+        self.files = files
+        self.sqlite = sqlite
+        self.keyReader = keyReader
+        self.homeDirectory = homeDirectory
+        self.now = now
+        self.keyCache = keyCache
+    }
+
+    /// Cheap, prompt-free evidence for first-run detection. The real refresh still decrypts and validates.
+    func hasCredentialMaterial() -> Bool {
+        let configPath = path(Self.configRelativePath)
+        guard let text = try? files.readTextIfPresent(configPath),
+              let data = text.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              root[Self.cacheV2Key] is String || root[Self.cacheV1Key] is String
+        else {
+            return false
+        }
+        return Self.cookieRelativePaths.contains { files.exists(path($0)) }
+    }
+
+    func load(allowInteraction: Bool) -> ClaudeDesktopCredentialResult {
+        guard hasCredentialMaterial() else {
+            return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
+        }
+
+        do {
+            guard let key = try safeStorageKey(allowInteraction: allowInteraction) else {
+                return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
+            }
+            guard let activeOrg = try loadActiveOrganization(key: key),
+                  let caches = try loadCaches(key: key)
+            else {
+                return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
+            }
+
+            let selection = Self.selectCredential(
+                activeOrganization: activeOrg,
+                v2: caches.v2,
+                v1: caches.v1,
+                now: now()
+            )
+            switch selection {
+            case .available(let oauth):
+                return ClaudeDesktopCredentialResult(oauth: oauth, status: .available)
+            case .stale:
+                return ClaudeDesktopCredentialResult(oauth: nil, status: .stale)
+            case .notFound:
+                return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
+            case .invalid:
+                return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
+            }
+        } catch ClaudeDesktopCredentialError.permissionRequired {
+            return ClaudeDesktopCredentialResult(oauth: nil, status: .permissionRequired)
+        } catch {
+            AppLog.error(LogTag.auth("claude"), "Claude Desktop credential read failed: \(error.localizedDescription)")
+            return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
+        }
+    }
+
+    private func safeStorageKey(allowInteraction: Bool) throws -> Data? {
+        if let cached = keyCache.value { return cached }
+        guard let password = try keyReader.readPassword(allowInteraction: allowInteraction) else {
+            return nil
+        }
+        let key = try Self.deriveKey(password: password)
+        keyCache.value = key
+        return key
+    }
+
+    private func loadActiveOrganization(key: Data) throws -> String? {
+        for relativePath in Self.cookieRelativePaths {
+            let databasePath = path(relativePath)
+            guard files.exists(databasePath) else { continue }
+            for host in Self.cookieHosts {
+                let hostSQL = host.replacingOccurrences(of: "'", with: "''")
+                let sql = """
+                SELECT CASE
+                    WHEN length(value) > 0 THEN 'plain:' || hex(CAST(value AS BLOB))
+                    ELSE 'encrypted:' || hex(encrypted_value)
+                END
+                FROM cookies
+                WHERE name = 'lastActiveOrg' AND host_key = '\(hostSQL)'
+                ORDER BY last_update_utc DESC
+                LIMIT 1;
+                """
+                guard let encoded = try sqlite.queryValue(path: databasePath, sql: sql),
+                      let separator = encoded.firstIndex(of: ":")
+                else {
+                    continue
+                }
+                let mode = String(encoded[..<separator])
+                let hex = String(encoded[encoded.index(after: separator)...])
+                guard let stored = Data(hexString: hex) else { continue }
+
+                let value: Data
+                if mode == "plain" {
+                    value = stored
+                } else if mode == "encrypted" {
+                    let decrypted = try Self.decrypt(stored, key: key)
+                    let hostHash = Data(SHA256.hash(data: Data(host.utf8)))
+                    guard decrypted.starts(with: hostHash) else { continue }
+                    value = decrypted.dropFirst(hostHash.count)
+                } else {
+                    continue
+                }
+                guard let organization = String(data: value, encoding: .utf8),
+                      UUID(uuidString: organization) != nil
+                else {
+                    continue
+                }
+                return organization.lowercased()
+            }
+        }
+        return nil
+    }
+
+    private func loadCaches(key: Data) throws -> (v2: [String: Any]?, v1: [String: Any]?)? {
+        guard let text = try files.readTextIfPresent(path(Self.configRelativePath)),
+              let data = text.data(using: .utf8),
+              let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return (
+            v2: try Self.decodeCache(root[Self.cacheV2Key], key: key),
+            v1: try Self.decodeCache(root[Self.cacheV1Key], key: key)
+        )
+    }
+
+    private static func decodeCache(_ stored: Any?, key: Data) throws -> [String: Any]? {
+        guard let base64 = stored as? String else { return nil }
+        guard let encrypted = Data(base64Encoded: base64) else {
+            throw ClaudeDesktopCredentialError.invalidCiphertext
+        }
+        let plaintext = try decrypt(encrypted, key: key)
+        guard let object = try JSONSerialization.jsonObject(with: plaintext) as? [String: Any] else {
+            throw ClaudeDesktopCredentialError.invalidCiphertext
+        }
+        return object
+    }
+
+    enum Selection: Sendable {
+        case available(ClaudeOAuth)
+        case stale
+        case notFound
+        case invalid
+    }
+
+    static func selectCredential(
+        activeOrganization: String,
+        v2: [String: Any]?,
+        v1: [String: Any]?,
+        now: Date
+    ) -> Selection {
+        let normalizedOrg = activeOrganization.lowercased()
+        let v2Candidates = candidates(in: v2, organization: normalizedOrg, now: now)
+        if let best = v2Candidates.available.max(by: { $0.expiresAt < $1.expiresAt }) {
+            return .available(best.oauth)
+        }
+
+        let v2Keys = Set(v2?.keys ?? Dictionary<String, Any>().keys)
+        let v1Candidates = candidates(
+            in: v1?.filter { !v2Keys.contains($0.key) },
+            organization: normalizedOrg,
+            now: now
+        )
+        if let best = v1Candidates.available.max(by: { $0.expiresAt < $1.expiresAt }) {
+            return .available(best.oauth)
+        }
+        if v2Candidates.sawStale || v1Candidates.sawStale { return .stale }
+        if v2Candidates.sawInvalid || v1Candidates.sawInvalid { return .invalid }
+        return .notFound
+    }
+
+    private struct Candidate {
+        var oauth: ClaudeOAuth
+        var expiresAt: Double
+    }
+
+    private static func candidates(
+        in cache: [String: Any]?,
+        organization: String,
+        now: Date
+    ) -> (available: [Candidate], sawStale: Bool, sawInvalid: Bool) {
+        guard let cache else { return ([], false, false) }
+        var available: [Candidate] = []
+        var sawStale = false
+        var sawInvalid = false
+        for (cacheKey, rawEntry) in cache {
+            guard let parsedKey = parseCacheKey(cacheKey),
+                  parsedKey.organization == organization,
+                  parsedKey.apiHost == apiHost,
+                  parsedKey.scopes.contains(usageScope)
+            else {
+                continue
+            }
+            guard !(rawEntry is NSNull) else { continue }
+            guard let entry = rawEntry as? [String: Any],
+                  let token = entry["token"] as? String,
+                  !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let expiresAt = number(entry["expiresAt"]),
+                  expiresAt.isFinite
+            else {
+                sawInvalid = true
+                continue
+            }
+            guard expiresAt > now.timeIntervalSince1970 * 1000 + expirySafetyMarginMs else {
+                sawStale = true
+                continue
+            }
+            let oauth = ClaudeOAuth(
+                accessToken: token,
+                refreshToken: nil,
+                expiresAt: expiresAt,
+                subscriptionType: entry["subscriptionType"] as? String,
+                rateLimitTier: entry["rateLimitTier"] as? String,
+                scopes: parsedKey.scopes
+            )
+            available.append(Candidate(oauth: oauth, expiresAt: expiresAt))
+        }
+        return (available, sawStale, sawInvalid)
+    }
+
+    private struct CacheKey {
+        var organization: String
+        var apiHost: String
+        var scopes: [String]
+    }
+
+    private static func parseCacheKey(_ value: String) -> CacheKey? {
+        let marker = ":\(apiHost):"
+        guard let markerRange = value.range(of: marker) else { return nil }
+        let prefix = value[..<markerRange.lowerBound]
+        guard let firstColon = prefix.firstIndex(of: ":") else { return nil }
+        let clientID = String(prefix[..<firstColon])
+        let organization = String(prefix[prefix.index(after: firstColon)...]).lowercased()
+        guard UUID(uuidString: clientID) != nil, UUID(uuidString: organization) != nil else {
+            return nil
+        }
+        let scopes = value[markerRange.upperBound...]
+            .split(whereSeparator: \.isWhitespace)
+            .map(String.init)
+        return CacheKey(organization: organization, apiHost: apiHost, scopes: scopes)
+    }
+
+    private static func number(_ value: Any?) -> Double? {
+        if let value = value as? Double { return value }
+        if let value = value as? Int { return Double(value) }
+        if let value = value as? NSNumber { return value.doubleValue }
+        return nil
+    }
+
+    static func deriveKey(password: String) throws -> Data {
+        let passwordData = Data(password.utf8)
+        let salt = Data("saltysalt".utf8)
+        var key = Data(count: kCCKeySizeAES128)
+        let keyCount = key.count
+        let result = key.withUnsafeMutableBytes { keyBytes in
+            passwordData.withUnsafeBytes { passwordBytes in
+                salt.withUnsafeBytes { saltBytes in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordBytes.bindMemory(to: Int8.self).baseAddress,
+                        passwordData.count,
+                        saltBytes.bindMemory(to: UInt8.self).baseAddress,
+                        salt.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA1),
+                        1003,
+                        keyBytes.bindMemory(to: UInt8.self).baseAddress,
+                        keyCount
+                    )
+                }
+            }
+        }
+        guard result == kCCSuccess else {
+            throw ClaudeDesktopCredentialError.invalidSafeStorageKey
+        }
+        return key
+    }
+
+    static func decrypt(_ encrypted: Data, key: Data) throws -> Data {
+        guard encrypted.count > 3,
+              encrypted.prefix(3) == Data("v10".utf8),
+              key.count == kCCKeySizeAES128
+        else {
+            throw ClaudeDesktopCredentialError.invalidCiphertext
+        }
+
+        let payload = encrypted.dropFirst(3)
+        let iv = Data(repeating: 0x20, count: kCCBlockSizeAES128)
+        var output = Data(count: payload.count + kCCBlockSizeAES128)
+        var outputLength = 0
+        let outputCapacity = output.count
+        let status = output.withUnsafeMutableBytes { outputBytes in
+            payload.withUnsafeBytes { payloadBytes in
+                key.withUnsafeBytes { keyBytes in
+                    iv.withUnsafeBytes { ivBytes in
+                        CCCrypt(
+                            CCOperation(kCCDecrypt),
+                            CCAlgorithm(kCCAlgorithmAES),
+                            CCOptions(kCCOptionPKCS7Padding),
+                            keyBytes.baseAddress,
+                            key.count,
+                            ivBytes.baseAddress,
+                            payloadBytes.baseAddress,
+                            payload.count,
+                            outputBytes.baseAddress,
+                            outputCapacity,
+                            &outputLength
+                        )
+                    }
+                }
+            }
+        }
+        guard status == kCCSuccess else {
+            throw ClaudeDesktopCredentialError.decryptionFailed(status)
+        }
+        output.count = outputLength
+        return output
+    }
+
+    private func path(_ relativePath: String) -> String {
+        homeDirectory().appendingPathComponent(relativePath).path
+    }
+}
+
+final class SafeStorageKeyCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Data?
+
+    var value: Data? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return stored
+        }
+        set {
+            lock.lock()
+            stored = newValue
+            lock.unlock()
+        }
+    }
+}
+
+private extension Data {
+    init?(hexString: String) {
+        guard hexString.count.isMultiple(of: 2) else { return nil }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(hexString.count / 2)
+        var index = hexString.startIndex
+        while index < hexString.endIndex {
+            let next = hexString.index(index, offsetBy: 2)
+            guard let byte = UInt8(hexString[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        self.init(bytes)
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
@@ -125,37 +125,18 @@ struct ClaudeDesktopAuthStore: Sendable {
 
     func load(allowInteraction: Bool) -> ClaudeDesktopCredentialResult {
         guard hasCredentialMaterial() else {
-            AppLog.info(LogTag.auth("claude"), "desktop load: no credential material (config/cookies missing)")
             return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
         }
 
         do {
             guard let key = try safeStorageKey(allowInteraction: allowInteraction) else {
-                AppLog.info(LogTag.auth("claude"), "desktop load: Safe Storage key unavailable (interaction=\(allowInteraction))")
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
             }
-            let accountUUID = loadLastKnownAccountUUID()
-            guard let activeOrg = try loadActiveOrganization(key: key) else {
-                AppLog.info(
-                    LogTag.auth("claude"),
-                    "desktop load: no lastActiveOrg cookie (account=\(Self.shortID(accountUUID)))"
-                )
+            guard let activeOrg = try loadActiveOrganization(key: key),
+                  let caches = try loadCaches(key: key)
+            else {
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
             }
-            guard let caches = try loadCaches(key: key) else {
-                AppLog.info(
-                    LogTag.auth("claude"),
-                    "desktop load: token cache unreadable (org=\(Self.shortID(activeOrg)) account=\(Self.shortID(accountUUID)))"
-                )
-                return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
-            }
-
-            let v2Orgs = Self.organizationIDs(in: caches.v2)
-            let v1Orgs = Self.organizationIDs(in: caches.v1)
-            AppLog.info(
-                LogTag.auth("claude"),
-                "desktop load: lastActiveOrg=\(Self.shortID(activeOrg)) account=\(Self.shortID(accountUUID)) v2Orgs=\(v2Orgs.map(Self.shortID).sorted()) v1Orgs=\(v1Orgs.map(Self.shortID).sorted())"
-            )
 
             let selection = Self.selectCredential(
                 activeOrganization: activeOrg,
@@ -165,66 +146,20 @@ struct ClaudeDesktopAuthStore: Sendable {
             )
             switch selection {
             case .available(let oauth):
-                AppLog.info(
-                    LogTag.auth("claude"),
-                    "desktop load: selected org=\(Self.shortID(activeOrg)) \(Self.oauthDebugSummary(oauth))"
-                )
                 return ClaudeDesktopCredentialResult(oauth: oauth, status: .available)
             case .stale:
-                AppLog.info(LogTag.auth("claude"), "desktop load: only stale tokens for org=\(Self.shortID(activeOrg))")
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .stale)
             case .notFound:
-                AppLog.info(LogTag.auth("claude"), "desktop load: no usable profile-scoped token for org=\(Self.shortID(activeOrg))")
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
             case .invalid:
-                AppLog.info(LogTag.auth("claude"), "desktop load: invalid cache entries for org=\(Self.shortID(activeOrg))")
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
             }
         } catch ClaudeDesktopCredentialError.permissionRequired {
-            AppLog.info(LogTag.auth("claude"), "desktop load: keychain permission required (manual refresh + Always Allow)")
             return ClaudeDesktopCredentialResult(oauth: nil, status: .permissionRequired)
         } catch {
             AppLog.error(LogTag.auth("claude"), "Claude Desktop credential read failed: \(error.localizedDescription)")
             return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
         }
-    }
-
-    /// Account UUID Claude Desktop persists separately from the org cookie — who is logged in, not which org is active.
-    private func loadLastKnownAccountUUID() -> String? {
-        guard let text = try? files.readTextIfPresent(path(Self.configRelativePath)),
-              let data = text.data(using: .utf8),
-              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let value = root["lastKnownAccountUuid"] as? String,
-              UUID(uuidString: value) != nil
-        else {
-            return nil
-        }
-        return value.lowercased()
-    }
-
-    /// Log-safe short UUID (`aaaaaaaa…bbbbbbbb`) — never the full id in spammy lines, never tokens.
-    private static func shortID(_ value: String?) -> String {
-        guard let value, value.count >= 13 else { return value ?? "<none>" }
-        return "\(value.prefix(8))…\(value.suffix(4))"
-    }
-
-    private static func oauthDebugSummary(_ oauth: ClaudeOAuth) -> String {
-        let sub = oauth.subscriptionType ?? "<nil>"
-        let tier = oauth.rateLimitTier ?? "<nil>"
-        let scopes = (oauth.scopes ?? []).joined(separator: " ")
-        let scopeLabel = scopes.isEmpty ? "<none>" : scopes
-        return "sub=\(sub) tier=\(tier) scopes=[\(scopeLabel)]"
-    }
-
-    private static func organizationIDs(in cache: [String: Any]?) -> [String] {
-        guard let cache else { return [] }
-        var orgs = Set<String>()
-        for key in cache.keys {
-            if let parsed = parseCacheKey(key) {
-                orgs.insert(parsed.organization)
-            }
-        }
-        return Array(orgs)
     }
 
     private func safeStorageKey(allowInteraction: Bool) throws -> Data? {
@@ -324,17 +259,7 @@ struct ClaudeDesktopAuthStore: Sendable {
     ) -> Selection {
         let normalizedOrg = activeOrganization.lowercased()
         let v2Candidates = candidates(in: v2, organization: normalizedOrg, now: now)
-        if !v2Candidates.available.isEmpty {
-            AppLog.info(
-                LogTag.auth("claude"),
-                "desktop select: org=\(shortID(normalizedOrg)) cache=v2 candidates=[\(v2Candidates.available.map(\.debugLabel).joined(separator: "; "))]"
-            )
-        }
         if let best = v2Candidates.available.max(by: { $0.rank < $1.rank }) {
-            AppLog.info(
-                LogTag.auth("claude"),
-                "desktop select: org=\(shortID(normalizedOrg)) winner=v2 \(best.debugLabel)"
-            )
             return .available(best.oauth)
         }
 
@@ -344,17 +269,7 @@ struct ClaudeDesktopAuthStore: Sendable {
             organization: normalizedOrg,
             now: now
         )
-        if !v1Candidates.available.isEmpty {
-            AppLog.info(
-                LogTag.auth("claude"),
-                "desktop select: org=\(shortID(normalizedOrg)) cache=v1 candidates=[\(v1Candidates.available.map(\.debugLabel).joined(separator: "; "))]"
-            )
-        }
         if let best = v1Candidates.available.max(by: { $0.rank < $1.rank }) {
-            AppLog.info(
-                LogTag.auth("claude"),
-                "desktop select: org=\(shortID(normalizedOrg)) winner=v1 \(best.debugLabel)"
-            )
             return .available(best.oauth)
         }
         if v2Candidates.sawStale || v1Candidates.sawStale { return .stale }
@@ -388,18 +303,6 @@ struct ClaudeDesktopAuthStore: Sendable {
                 scopes.count,
                 expiresAt
             )
-        }
-
-        /// Token-free label for selection logs (client prefix, scopes, stamped plan metadata, expiry).
-        var debugLabel: String {
-            let client = clientID.count >= 8 ? String(clientID.prefix(8)) : clientID
-            let sub = oauth.subscriptionType ?? "<nil>"
-            let tier = oauth.rateLimitTier ?? "<nil>"
-            let scopeText = scopes.joined(separator: "+")
-            let exp = expiresAt.isFinite
-                ? ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: expiresAt / 1000))
-                : "<nil>"
-            return "client=\(client) scopes=\(scopeText) sub=\(sub) tier=\(tier) exp=\(exp)"
         }
     }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -65,29 +65,78 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     func hasLocalCredentials() async -> Bool {
-        // Same sources and same usability filter as `refresh()` (see `hasUsableAccessToken`).
-        await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
-            .contains(where: \.hasUsableAccessToken)
+        // Never trigger another app's Keychain prompt during first-run detection. Encrypted Desktop
+        // material still counts as a local login; the first manual refresh requests access if needed.
+        let load = await loadOffMainActor { [authStore] in authStore.loadCredentialSet() }
+        if load.candidates.contains(where: \.hasUsableAccessToken) { return true }
+        return load.desktopStatus == .permissionRequired || load.desktopStatus == .stale
     }
 
     func refresh() async -> ProviderSnapshot {
-        await refresh(credentialReloadsRemaining: 1)
+        await refresh(
+            credentialReloadsRemaining: 1,
+            forceDesktopFallback: false,
+            previousFallbackError: nil
+        )
     }
 
     /// Claude Code can replace a login while a request is in flight. Reload once when that happens so
     /// the older account cannot reach the dashboard or cache; bound the retry for a changing source.
-    private func refresh(credentialReloadsRemaining: Int) async -> ProviderSnapshot {
-        let storedCandidates = await loadOffMainActor { [authStore] in authStore.loadCredentialCandidates() }
-        let candidates = storedCandidates.filter(\.hasUsableAccessToken)
+    private func refresh(
+        credentialReloadsRemaining: Int,
+        forceDesktopFallback: Bool,
+        previousFallbackError: ClaudeAuthError?
+    ) async -> ProviderSnapshot {
+        let allowDesktopInteraction = ProviderRefreshContext.isManual
+        let credentialLoad = await loadOffMainActor { [authStore] in
+            authStore.loadCredentialSet(
+                allowDesktopInteraction: allowDesktopInteraction,
+                forceDesktopFallback: forceDesktopFallback
+            )
+        }
+        let storedCandidates = credentialLoad.candidates
+        let candidates = storedCandidates.filter {
+            $0.hasUsableAccessToken && (!forceDesktopFallback || $0.source == .desktop)
+        }
+        if forceDesktopFallback {
+            switch credentialLoad.desktopStatus {
+            case .permissionRequired:
+                return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.desktopPermissionRequired)
+            case .stale, .invalid, .notFound:
+                if let previousFallbackError {
+                    return ProviderSnapshot.error(provider: provider, error: previousFallbackError)
+                }
+            case .notChecked, .available:
+                break
+            }
+        }
+        let hasLiveUsageCandidate = candidates.contains {
+            authStore.liveUsageAvailability($0) == .available
+        }
+        let desktopFallbackWarning: String? = if !hasLiveUsageCandidate {
+            switch credentialLoad.desktopStatus {
+            case .permissionRequired:
+                ClaudeAuthError.desktopPermissionRequired.localizedDescription
+            case .stale:
+                ClaudeAuthError.desktopTokenExpired.localizedDescription
+            case .invalid:
+                ClaudeAuthError.desktopCredentialsUnavailable.localizedDescription
+            case .notChecked, .notFound, .available:
+                nil
+            }
+        } else {
+            nil
+        }
         guard !candidates.isEmpty else {
-            // No CLI credentials anywhere. A login done only in the Claude desktop app is stored in an
-            // Electron-encrypted blob OpenUsage can't read, so a bare "Not logged in" reads as wrong to
-            // a user who is clearly signed in (#825) — point them at the one-time CLI login instead.
-            // Gated on the store finding nothing at all: a stored-but-blank token means the CLI *did*
-            // write credentials, so the plain "Not logged in" is the right guidance there.
-            if storedCandidates.isEmpty, await loadOffMainActor({ [authStore] in authStore.hasDesktopAppData() }) {
-                AppLog.info(LogTag.auth("claude"), "no CLI credentials, but desktop app data found — CLI login needed")
-                return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.desktopAppOnly)
+            switch credentialLoad.desktopStatus {
+            case .permissionRequired:
+                return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.desktopPermissionRequired)
+            case .stale:
+                return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.desktopTokenExpired)
+            case .invalid:
+                return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.desktopCredentialsUnavailable)
+            case .notChecked, .notFound, .available:
+                break
             }
             AppLog.info(LogTag.auth("claude"), "no access token, not logged in")
             return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.notLoggedIn)
@@ -103,19 +152,24 @@ final class ClaudeProvider: ProviderRuntime {
         // stale/locked-out token that an external `claude` re-login replaced in another source) falls
         // through to the next rather than failing the whole refresh; any non-auth error (rate limit,
         // request/transport failure) surfaces immediately so a real outage is never masked as a retry.
-        var lastFallbackError: Error?
+        var lastFallbackError: ClaudeAuthError?
         var credentialGeneration = ClaudeCredentialGeneration(storedCandidates)
         for state in candidates {
             do {
                 let snapshot = try await probe(
                     state: state,
-                    credentialGeneration: &credentialGeneration
+                    credentialGeneration: &credentialGeneration,
+                    fallbackWarning: desktopFallbackWarning
                 )
                 AppLog.info(LogTag.plugin("claude"), "refresh end (\(Int(Date().timeIntervalSince(start) * 1000))ms)")
                 return snapshot
             } catch ClaudeAuthError.credentialsChanged where credentialReloadsRemaining > 0 {
                 AppLog.info(LogTag.auth("claude"), "credential source changed during refresh; reloading current login")
-                return await refresh(credentialReloadsRemaining: credentialReloadsRemaining - 1)
+                return await refresh(
+                    credentialReloadsRemaining: credentialReloadsRemaining - 1,
+                    forceDesktopFallback: forceDesktopFallback,
+                    previousFallbackError: previousFallbackError
+                )
             } catch let error as ClaudeAuthError where error.allowsAuthFallback {
                 AppLog.warn(LogTag.auth("claude"), "\(state.source.label) failed (\(error)); falling back to next source if any")
                 lastFallbackError = error
@@ -123,6 +177,17 @@ final class ClaudeProvider: ProviderRuntime {
             } catch {
                 return ProviderSnapshot.error(provider: provider, error: error)
             }
+        }
+        if !forceDesktopFallback,
+           lastFallbackError != nil,
+           credentialLoad.desktopStatus == .notChecked
+        {
+            AppLog.info(LogTag.auth("claude"), "stored Claude login failed; trying Claude Desktop")
+            return await refresh(
+                credentialReloadsRemaining: credentialReloadsRemaining,
+                forceDesktopFallback: true,
+                previousFallbackError: lastFallbackError
+            )
         }
         return ProviderSnapshot.error(
             provider: provider,
@@ -132,7 +197,8 @@ final class ClaudeProvider: ProviderRuntime {
 
     private func probe(
         state initialState: ClaudeCredentialState,
-        credentialGeneration: inout ClaudeCredentialGeneration
+        credentialGeneration: inout ClaudeCredentialGeneration,
+        fallbackWarning: String?
     ) async throws -> ProviderSnapshot {
         var state = initialState
         var mapped = ClaudeMappedUsage(
@@ -165,6 +231,9 @@ final class ClaudeProvider: ProviderRuntime {
             // An explicit CLAUDE_CODE_OAUTH_TOKEN is inference-only by design; nothing to fetch and nothing
             // to nag about — the spend tiles still load below.
             break
+        }
+        if let fallbackWarning {
+            warning = fallbackWarning
         }
 
         // Local spend tiles, scanned natively from Claude Code's session logs and priced through the
@@ -232,6 +301,9 @@ final class ClaudeProvider: ProviderRuntime {
             token: working.oauth.accessToken ?? "",
             attempt: { try await self.usageClient.fetchUsage(accessToken: $0, config: self.authStore.oauthConfig()) },
             refreshAccessToken: {
+                if working.source == .desktop {
+                    throw ClaudeAuthError.desktopTokenExpired
+                }
                 guard let refreshToken = working.oauth.refreshToken, !refreshToken.isEmpty else {
                     throw ClaudeAuthError.tokenExpired
                 }
@@ -249,8 +321,9 @@ final class ClaudeProvider: ProviderRuntime {
             authExpired: ClaudeAuthError.tokenExpired
         )
 
+        let forceDesktopGeneration = working.source == .desktop
         let currentGeneration = await loadOffMainActor { [authStore] in
-            authStore.credentialGeneration()
+            authStore.credentialGeneration(forceDesktopFallback: forceDesktopGeneration)
         }
         guard currentGeneration == expectedGeneration else { throw ClaudeAuthError.credentialsChanged }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -155,6 +155,19 @@ final class ClaudeProvider: ProviderRuntime {
         var lastFallbackError: ClaudeAuthError?
         var credentialGeneration = ClaudeCredentialGeneration(storedCandidates)
         for state in candidates {
+            // The environment token cannot read subscription usage. If a CLI login was rejected, try
+            // Desktop before this spend-only fallback can turn the refresh into a false success.
+            if !forceDesktopFallback,
+               lastFallbackError != nil,
+               credentialLoad.desktopStatus == .notChecked,
+               authStore.liveUsageAvailability(state) == .inferenceOnlyToken
+            {
+                return await refresh(
+                    credentialReloadsRemaining: credentialReloadsRemaining,
+                    forceDesktopFallback: true,
+                    previousFallbackError: lastFallbackError
+                )
+            }
             do {
                 let snapshot = try await probe(
                     state: state,

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -54,9 +54,10 @@ protocol CategorizedError: Error {
 extension ClaudeAuthError: CategorizedError {
     var errorCategory: ErrorCategory {
         switch self {
-        case .notLoggedIn, .desktopAppOnly: .notLoggedIn
-        case .sessionExpired, .tokenExpired: .authExpired
-        case .invalidOAuthURL: .authInvalid
+        case .notLoggedIn: .notLoggedIn
+        case .sessionExpired, .tokenExpired, .desktopTokenExpired: .authExpired
+        case .invalidOAuthURL, .desktopCredentialsUnavailable: .authInvalid
+        case .desktopPermissionRequired: .credentialAccess
         case .credentialsChanged: .other
         }
     }

--- a/Sources/OpenUsage/Providers/ProviderRuntime.swift
+++ b/Sources/OpenUsage/Providers/ProviderRuntime.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+enum ProviderRefreshContext {
+    @TaskLocal static var isManual = false
+}
+
 /// One AI provider OpenUsage can track. A conformer reads credentials already on the machine, calls the
 /// provider's API, and normalizes the result into a `ProviderSnapshot` of `MetricLine` values that the UI
 /// renders. See `docs/adding-a-provider.md` for the full walkthrough.

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -247,7 +247,9 @@ final class WidgetDataStore {
         refreshingProviderIDs.insert(providerID)
         defer { refreshingProviderIDs.remove(providerID) }
         let start = Date()
-        var snapshot = await provider.refresh()
+        var snapshot = await ProviderRefreshContext.$isManual.withValue(force) {
+            await provider.refresh()
+        }
         let durationMs = Int(Date().timeIntervalSince(start) * 1000)
         if let message = Self.errorMessage(in: snapshot) {
             // Failed refresh: surface the error but keep the last good snapshot on screen rather than

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -1,0 +1,425 @@
+import CommonCrypto
+import CryptoKit
+import Foundation
+import XCTest
+@testable import OpenUsage
+
+final class ClaudeDesktopAuthStoreTests: XCTestCase {
+    private let home = URL(fileURLWithPath: "/fixture-home", isDirectory: true)
+    private let organization = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    private let otherOrganization = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    private let clientID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    private let password = "fixture-safe-storage-password"
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testDecryptsElectronSafeStorageValue() throws {
+        let key = try ClaudeDesktopAuthStore.deriveKey(password: password)
+        let plaintext = Data(#"{"token":"secret"}"#.utf8)
+        let encrypted = try encrypt(plaintext, key: key)
+
+        XCTAssertEqual(try ClaudeDesktopAuthStore.decrypt(encrypted, key: key), plaintext)
+        XCTAssertThrowsError(try ClaudeDesktopAuthStore.decrypt(Data("v11bad".utf8), key: key))
+    }
+
+    func testSelectsActiveOrganizationFromV2Cache() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600),
+                cacheKey(organization: otherOrganization): tokenEntry("other-token", expiresIn: 7_200)
+            ],
+            v1: [
+                cacheKey(organization: organization): tokenEntry("old-token", expiresIn: 10_800)
+            ]
+        )
+
+        let result = fixture.store.load(allowInteraction: false)
+
+        XCTAssertEqual(result.status, .available)
+        XCTAssertEqual(result.oauth?.accessToken, "desktop-token")
+        XCTAssertNil(result.oauth?.refreshToken)
+        XCTAssertEqual(result.oauth?.scopes, ["user:profile", "user:inference"])
+    }
+
+    func testV1FallbackDoesNotOverrideTombstonedV2Key() throws {
+        let key = cacheKey(organization: organization)
+        let selection = ClaudeDesktopAuthStore.selectCredential(
+            activeOrganization: organization,
+            v2: [key: NSNull()],
+            v1: [key: tokenEntry("resurrected-token", expiresIn: 3_600)],
+            now: now
+        )
+
+        guard case .notFound = selection else {
+            return XCTFail("V2 tombstone should suppress the matching V1 token")
+        }
+    }
+
+    func testBackgroundReadDoesNotPromptButManualReadCan() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)],
+            requiresInteraction: true
+        )
+
+        XCTAssertEqual(fixture.store.load(allowInteraction: false).status, .permissionRequired)
+        XCTAssertEqual(fixture.keyReader.calls, [false])
+        XCTAssertEqual(fixture.store.load(allowInteraction: true).status, .available)
+        XCTAssertEqual(fixture.keyReader.calls, [false, true])
+
+        // The derived key is cached after approval, so later background refreshes are prompt-free.
+        XCTAssertEqual(fixture.store.load(allowInteraction: false).status, .available)
+        XCTAssertEqual(fixture.keyReader.calls, [false, true])
+    }
+
+    func testExpiredDesktopTokenIsStale() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("expired", expiresIn: -1)]
+        )
+
+        XCTAssertEqual(fixture.store.load(allowInteraction: false).status, .stale)
+    }
+
+    func testWorkingCLICredentialsSkipDesktopProbe() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)]
+        )
+        let now = now
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: fixture.files,
+            keychain: FakeKeychain(
+                #"{"claudeAiOauth":{"accessToken":"cli-token","expiresAt":4102444800000,"scopes":["user:profile"]}}"#
+            ),
+            desktop: fixture.store,
+            now: { now }
+        )
+
+        let load = authStore.loadCredentialSet()
+
+        XCTAssertEqual(load.candidates.first?.oauth.accessToken, "cli-token")
+        XCTAssertEqual(load.desktopStatus, .notChecked)
+        XCTAssertTrue(fixture.keyReader.calls.isEmpty)
+    }
+
+    func testWhitespaceOnlyCLIEntryDoesNotBlockDesktop() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)]
+        )
+        let now = now
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: fixture.files,
+            keychain: FakeKeychain(
+                #"{"claudeAiOauth":{"accessToken":"   ","expiresAt":4102444800000,"scopes":["user:profile"]}}"#
+            ),
+            desktop: fixture.store,
+            now: { now }
+        )
+
+        let load = authStore.loadCredentialSet()
+
+        XCTAssertEqual(load.candidates.first?.source, .desktop)
+        XCTAssertEqual(load.candidates.first?.oauth.accessToken, "desktop-token")
+        XCTAssertEqual(fixture.keyReader.calls, [false])
+    }
+
+    @MainActor
+    func testDesktopPermissionIsNotMaskedByScopedCLIToken() async throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)],
+            requiresInteraction: true
+        )
+        let now = now
+        let httpClient = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data()))
+        let provider = ClaudeProvider(
+            authStore: ClaudeAuthStore(
+                environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+                files: fixture.files,
+                keychain: FakeKeychain(
+                    #"{"claudeAiOauth":{"accessToken":"inference-only-cli","expiresAt":4102444800000,"scopes":["user:inference"]}}"#
+                ),
+                desktop: fixture.store,
+                now: { now }
+            ),
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            logUsageScanner: ClaudeLogFixture.scanner(home: nil),
+            now: { now },
+            pricing: { TestPricing.bundled }
+        )
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+        XCTAssertEqual(snapshot.warning, ClaudeAuthError.desktopPermissionRequired.localizedDescription)
+        XCTAssertTrue(httpClient.requests.isEmpty)
+        XCTAssertEqual(fixture.keyReader.calls, [false])
+    }
+
+    func testDesktopCredentialsAreNeverSaved() throws {
+        let files = FakeFiles()
+        let keychain = FakeKeychain()
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)]
+        )
+        let now = now
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(),
+            files: files,
+            keychain: keychain,
+            desktop: fixture.store,
+            now: { now }
+        )
+        let state = authStore.loadCredentialCandidates().first!
+
+        XCTAssertFalse(try authStore.save(state, ifUnchanged: ClaudeCredentialGeneration([state])))
+        XCTAssertTrue(files.files.isEmpty)
+        XCTAssertNil(keychain.value)
+    }
+
+    @MainActor
+    func testDesktop401NeverAttemptsRefreshTokenExchange() async throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)]
+        )
+        let httpClient = RoutingHTTPClient { request in
+            XCTAssertTrue(request.url.absoluteString.hasSuffix("/api/oauth/usage"))
+            return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+        }
+        let now = now
+        let provider = ClaudeProvider(
+            authStore: ClaudeAuthStore(
+                environment: FakeEnvironment(),
+                files: fixture.files,
+                keychain: FakeKeychain(),
+                desktop: fixture.store,
+                now: { now }
+            ),
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            logUsageScanner: ClaudeLogFixture.scanner(home: nil),
+            now: { now },
+            pricing: { TestPricing.bundled }
+        )
+
+        let snapshot = await ProviderRefreshContext.$isManual.withValue(true) {
+            await provider.refresh()
+        }
+
+        XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.desktopTokenExpired.localizedDescription)
+        XCTAssertEqual(httpClient.requests.count, 1)
+    }
+
+    @MainActor
+    func testRevokedCLILoginFallsBackToDesktop() async throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)]
+        )
+        let now = now
+        let httpClient = RoutingHTTPClient { request in
+            let authorization = request.headers["Authorization"] ?? ""
+            if authorization.contains("desktop-token") {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":25,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+        }
+        let provider = ClaudeProvider(
+            authStore: ClaudeAuthStore(
+                environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+                files: fixture.files,
+                keychain: FakeKeychain(
+                    #"{"claudeAiOauth":{"accessToken":"revoked-cli","expiresAt":4102444800000,"scopes":["user:profile"]}}"#
+                ),
+                desktop: fixture.store,
+                now: { now }
+            ),
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            logUsageScanner: ClaudeLogFixture.scanner(home: nil),
+            now: { now },
+            pricing: { TestPricing.bundled }
+        )
+
+        let snapshot = await ProviderRefreshContext.$isManual.withValue(true) {
+            await provider.refresh()
+        }
+
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+        XCTAssertEqual(httpClient.requests.count, 2)
+        XCTAssertTrue(httpClient.requests.last?.headers["Authorization"]?.contains("desktop-token") == true)
+    }
+
+    @MainActor
+    func testStaleDesktopDoesNotMaskRevokedCLIError() async throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("expired-desktop", expiresIn: -1)]
+        )
+        let now = now
+        let httpClient = RoutingHTTPClient { _ in
+            HTTPResponse(statusCode: 401, headers: [:], body: Data())
+        }
+        let provider = ClaudeProvider(
+            authStore: ClaudeAuthStore(
+                environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+                files: fixture.files,
+                keychain: FakeKeychain(
+                    #"{"claudeAiOauth":{"accessToken":"revoked-cli","expiresAt":4102444800000,"scopes":["user:profile"]}}"#
+                ),
+                desktop: fixture.store,
+                now: { now }
+            ),
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            logUsageScanner: ClaudeLogFixture.scanner(home: nil),
+            now: { now },
+            pricing: { TestPricing.bundled }
+        )
+
+        let snapshot = await ProviderRefreshContext.$isManual.withValue(true) {
+            await provider.refresh()
+        }
+
+        XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.tokenExpired.localizedDescription)
+        XCTAssertEqual(httpClient.requests.count, 1)
+    }
+
+    private func makeFixture(
+        activeOrganization: String,
+        v2: [String: Any],
+        v1: [String: Any]? = nil,
+        requiresInteraction: Bool = false
+    ) throws -> DesktopFixture {
+        let key = try ClaudeDesktopAuthStore.deriveKey(password: password)
+        let cookieHost = ".claude.ai"
+        let cookiePlaintext = Data(SHA256.hash(data: Data(cookieHost.utf8))) + Data(activeOrganization.utf8)
+        let encryptedCookie = try encrypt(cookiePlaintext, key: key)
+        let v2Data = try JSONSerialization.data(withJSONObject: v2)
+        let encryptedV2 = try encrypt(v2Data, key: key)
+        var config: [String: Any] = ["oauth:tokenCacheV2": encryptedV2.base64EncodedString()]
+        if let v1 {
+            let v1Data = try JSONSerialization.data(withJSONObject: v1)
+            config["oauth:tokenCache"] = try encrypt(v1Data, key: key).base64EncodedString()
+        }
+        let configText = String(decoding: try JSONSerialization.data(withJSONObject: config), as: UTF8.self)
+        let configPath = home.appendingPathComponent("Library/Application Support/Claude/config.json").path
+        let cookiesPath = home.appendingPathComponent("Library/Application Support/Claude/Cookies").path
+        let files = FakeFiles([configPath: configText, cookiesPath: "sqlite-fixture"])
+        let sqlite = FakeClaudeDesktopSQLite(value: "encrypted:\(hex(encryptedCookie))")
+        let keyReader = FakeClaudeDesktopKeyReader(password: password, requiresInteraction: requiresInteraction)
+        let fixtureHome = home
+        let fixtureNow = now
+        let store = ClaudeDesktopAuthStore(
+            files: files,
+            sqlite: sqlite,
+            keyReader: keyReader,
+            homeDirectory: { fixtureHome },
+            now: { fixtureNow }
+        )
+        return DesktopFixture(store: store, files: files, keyReader: keyReader)
+    }
+
+    private func cacheKey(organization: String) -> String {
+        "\(clientID):\(organization):https://api.anthropic.com:user:profile user:inference"
+    }
+
+    private func tokenEntry(_ token: String, expiresIn seconds: TimeInterval) -> [String: Any] {
+        [
+            "token": token,
+            "expiresAt": (now.timeIntervalSince1970 + seconds) * 1000,
+            "subscriptionType": "max",
+            "rateLimitTier": "default"
+        ]
+    }
+
+    private func encrypt(_ plaintext: Data, key: Data) throws -> Data {
+        let iv = Data(repeating: 0x20, count: kCCBlockSizeAES128)
+        var output = Data(count: plaintext.count + kCCBlockSizeAES128)
+        var outputLength = 0
+        let capacity = output.count
+        let status = output.withUnsafeMutableBytes { outputBytes in
+            plaintext.withUnsafeBytes { plaintextBytes in
+                key.withUnsafeBytes { keyBytes in
+                    iv.withUnsafeBytes { ivBytes in
+                        CCCrypt(
+                            CCOperation(kCCEncrypt),
+                            CCAlgorithm(kCCAlgorithmAES),
+                            CCOptions(kCCOptionPKCS7Padding),
+                            keyBytes.baseAddress,
+                            key.count,
+                            ivBytes.baseAddress,
+                            plaintextBytes.baseAddress,
+                            plaintext.count,
+                            outputBytes.baseAddress,
+                            capacity,
+                            &outputLength
+                        )
+                    }
+                }
+            }
+        }
+        guard status == kCCSuccess else {
+            throw ClaudeDesktopCredentialError.decryptionFailed(status)
+        }
+        output.count = outputLength
+        return Data("v10".utf8) + output
+    }
+
+    private func hex(_ data: Data) -> String {
+        data.map { String(format: "%02X", $0) }.joined()
+    }
+
+    private func badge(_ lines: [MetricLine], _ label: String) -> String? {
+        guard case .badge(_, let text, _, _) = lines.first(where: { $0.label == label }) else {
+            return nil
+        }
+        return text
+    }
+}
+
+private struct DesktopFixture {
+    var store: ClaudeDesktopAuthStore
+    var files: FakeFiles
+    var keyReader: FakeClaudeDesktopKeyReader
+}
+
+private final class FakeClaudeDesktopKeyReader: ClaudeDesktopSafeStorageKeyReading, @unchecked Sendable {
+    let password: String
+    let requiresInteraction: Bool
+    var calls: [Bool] = []
+
+    init(password: String, requiresInteraction: Bool) {
+        self.password = password
+        self.requiresInteraction = requiresInteraction
+    }
+
+    func readPassword(allowInteraction: Bool) throws -> String? {
+        calls.append(allowInteraction)
+        if requiresInteraction, !allowInteraction {
+            throw ClaudeDesktopCredentialError.permissionRequired
+        }
+        return password
+    }
+}
+
+private final class FakeClaudeDesktopSQLite: SQLiteAccessing, @unchecked Sendable {
+    let value: String?
+
+    init(value: String?) {
+        self.value = value
+    }
+
+    func queryValue(path: String, sql: String) throws -> String? {
+        value
+    }
+
+    func execute(path: String, sql: String) throws {}
+}

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -307,6 +307,52 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testRevokedCLILoginTriesDesktopBeforeEnvironmentToken() async throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)]
+        )
+        let now = now
+        let httpClient = RoutingHTTPClient { request in
+            let authorization = request.headers["Authorization"] ?? ""
+            if authorization.contains("desktop-token") {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"five_hour":{"utilization":25,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+                )
+            }
+            return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+        }
+        let provider = ClaudeProvider(
+            authStore: ClaudeAuthStore(
+                environment: FakeEnvironment([
+                    "CLAUDE_CONFIG_DIR": "/tmp/claude",
+                    "CLAUDE_CODE_OAUTH_TOKEN": "inference-only-env"
+                ]),
+                files: fixture.files,
+                keychain: FakeKeychain(
+                    #"{"claudeAiOauth":{"accessToken":"revoked-cli","expiresAt":4102444800000,"scopes":["user:profile"]}}"#
+                ),
+                desktop: fixture.store,
+                now: { now }
+            ),
+            usageClient: ClaudeUsageClient(httpClient: httpClient),
+            logUsageScanner: ClaudeLogFixture.scanner(home: nil),
+            now: { now },
+            pricing: { TestPricing.bundled }
+        )
+
+        let snapshot = await ProviderRefreshContext.$isManual.withValue(true) {
+            await provider.refresh()
+        }
+
+        XCTAssertNil(badge(snapshot.lines, "Error"))
+        XCTAssertEqual(httpClient.requests.count, 2)
+        XCTAssertTrue(httpClient.requests.last?.headers["Authorization"]?.contains("desktop-token") == true)
+    }
+
+    @MainActor
     func testStaleDesktopDoesNotMaskRevokedCLIError() async throws {
         let fixture = try makeFixture(
             activeOrganization: organization,

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -9,6 +9,7 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
     private let organization = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
     private let otherOrganization = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
     private let clientID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    private let otherClientID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
     private let password = "fixture-safe-storage-password"
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
 
@@ -53,6 +54,53 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         guard case .notFound = selection else {
             return XCTFail("V2 tombstone should suppress the matching V1 token")
         }
+    }
+
+    func testFullScopeProductionClientOutranksLongerLivedProfileOnlyEntry() throws {
+        // Two live entries under the same org: a long-TTL profile-only leftover carrying a stale 5x
+        // tier, and the current full-scope Claude Code production login (20x) expiring sooner. Expiry
+        // alone would pick the stale 5x token; the ranking must pick the production login.
+        let productionClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+        let selection = ClaudeDesktopAuthStore.selectCredential(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization, scopes: "user:profile"):
+                    tokenEntry("stale-5x-token", expiresIn: 86_400, rateLimitTier: "default_claude_max_5x"),
+                cacheKey(
+                    organization: organization,
+                    clientID: productionClientID,
+                    scopes: "user:profile user:inference"
+                ):
+                    tokenEntry("current-20x-token", expiresIn: 1_800, rateLimitTier: "default_claude_max_20x")
+            ],
+            v1: nil,
+            now: now
+        )
+
+        guard case .available(let oauth) = selection else {
+            return XCTFail("expected an available credential, got \(selection)")
+        }
+        XCTAssertEqual(oauth.accessToken, "current-20x-token")
+        XCTAssertEqual(oauth.rateLimitTier, "default_claude_max_20x")
+    }
+
+    func testFullScopeEntryOutranksProfileOnlyEntryForNonProductionClients() throws {
+        let selection = ClaudeDesktopAuthStore.selectCredential(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization, scopes: "user:profile"):
+                    tokenEntry("profile-only-token", expiresIn: 86_400),
+                cacheKey(organization: organization, clientID: otherClientID, scopes: "user:profile user:inference"):
+                    tokenEntry("full-scope-token", expiresIn: 1_800)
+            ],
+            v1: nil,
+            now: now
+        )
+
+        guard case .available(let oauth) = selection else {
+            return XCTFail("expected an available credential, got \(selection)")
+        }
+        XCTAssertEqual(oauth.accessToken, "full-scope-token")
     }
 
     func testBackgroundReadDoesNotPromptButManualReadCan() throws {
@@ -327,16 +375,24 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         return DesktopFixture(store: store, files: files, keyReader: keyReader)
     }
 
-    private func cacheKey(organization: String) -> String {
-        "\(clientID):\(organization):https://api.anthropic.com:user:profile user:inference"
+    private func cacheKey(
+        organization: String,
+        clientID: String? = nil,
+        scopes: String = "user:profile user:inference"
+    ) -> String {
+        "\(clientID ?? self.clientID):\(organization):https://api.anthropic.com:\(scopes)"
     }
 
-    private func tokenEntry(_ token: String, expiresIn seconds: TimeInterval) -> [String: Any] {
+    private func tokenEntry(
+        _ token: String,
+        expiresIn seconds: TimeInterval,
+        rateLimitTier: String = "default"
+    ) -> [String: Any] {
         [
             "token": token,
             "expiresAt": (now.timeIntervalSince1970 + seconds) * 1000,
             "subscriptionType": "max",
-            "rateLimitTier": "default"
+            "rateLimitTier": rateLimitTier
         ]
     }
 

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -615,11 +615,7 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertEqual(badge(snapshot.lines, "Error"), ClaudeAuthError.sessionExpired.localizedDescription)
     }
 
-    func testDesktopAppOnlyLoginExplainsCLILoginInsteadOfNotLoggedIn() async {
-        // #825: a login done only in the Claude desktop app lives in an Electron-encrypted blob the app
-        // can't read, so a bare "Not logged in" reads as wrong to a signed-in user. When no CLI
-        // credentials exist but the desktop app's data folder does, the error must point at the
-        // one-time `claude` CLI login instead.
+    func testNoCredentialsReportsNotLoggedIn() async {
         func makeProvider(files: FakeFiles) -> ClaudeProvider {
             ClaudeProvider(
                 authStore: ClaudeAuthStore(
@@ -633,24 +629,14 @@ final class ClaudeProviderTests: XCTestCase {
             )
         }
 
-        let desktopOnly = makeProvider(files: FakeFiles([
-            "~/Library/Application Support/Claude/claude-code": ""
-        ]))
-        let desktopSnapshot = await desktopOnly.refresh()
-        XCTAssertEqual(badge(desktopSnapshot.lines, "Error"), ClaudeAuthError.desktopAppOnly.localizedDescription)
-        XCTAssertEqual(desktopSnapshot.errorCategory, .notLoggedIn)
-
-        // Without any desktop-app data the plain "Not logged in" guidance stays.
         let noneAtAll = makeProvider(files: FakeFiles())
         let plainSnapshot = await noneAtAll.refresh()
         XCTAssertEqual(badge(plainSnapshot.lines, "Error"), ClaudeAuthError.notLoggedIn.localizedDescription)
 
         // A stored-but-blank CLI token (whitespace accessToken survives the store's isEmpty check but is
-        // dropped by the provider's trim filter) means the CLI did write credentials — the desktop-app
-        // hint must not fire even when the desktop folder exists; plain "Not logged in" is correct.
+        // dropped by the provider's trim filter) is still unusable.
         let corruptCLI = makeProvider(files: FakeFiles([
-            "~/.claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"   "}}"#,
-            "~/Library/Application Support/Claude/claude-code": ""
+            "~/.claude/.credentials.json": #"{"claudeAiOauth":{"accessToken":"   "}}"#
         ]))
         let corruptSnapshot = await corruptCLI.refresh()
         XCTAssertEqual(badge(corruptSnapshot.lines, "Error"), ClaudeAuthError.notLoggedIn.localizedDescription)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -29,6 +29,10 @@ your macOS account (owner read and write only). Antigravity's short-lived refres
 to the current Keychain login using a one-way fingerprint; the refresh credential itself is not copied.
 The cache is never used after logout, an account change, or while Keychain access is unavailable.
 
+Claude Desktop access is strictly read-only. OpenUsage may ask macOS for permission to use the
+`Claude Safe Storage` Keychain item so it can decrypt Desktop's current access token. It never uses
+Desktop's rotating refresh token and never modifies Desktop's config, cookies, or Keychain data.
+
 ## Other network requests
 
 Besides the provider API calls the vendor's own tools would make, OpenUsage fetches public [model price lists](pricing.md) about once an hour (from `raw.githubusercontent.com`, `models.dev`, and this project's GitHub Pages). These are plain downloads of public data — they carry no usage, log, or account information, and they run regardless of the Share Anonymous Usage setting. The spend tiles are computed from local CLI logs entirely on your Mac; no log data ever leaves it.

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -1,6 +1,6 @@
 # Claude
 
-Tracks your Claude subscription limits using the login you already have from Claude Code.
+Tracks your Claude subscription limits using the login you already have from Claude Code or Claude Desktop.
 
 ## What it tracks
 
@@ -17,15 +17,26 @@ When Claude reports your plan name, OpenUsage shows it beside the provider name.
 
 ## Where credentials come from
 
-Sign in once with Claude Code; OpenUsage reads the same credentials. It checks every place Claude Code can store them, preferring the login that can actually read your subscription usage:
+Sign in with Claude Code or Claude Desktop; OpenUsage reads the existing login. It checks these sources, preferring one that can read your subscription usage:
 
 1. The macOS keychain entry Claude Code maintains (its source of truth on macOS)
 2. `~/.claude/.credentials.json` (or `$CLAUDE_CONFIG_DIR/.credentials.json`)
-3. `CLAUDE_CODE_OAUTH_TOKEN` environment variable
+3. Claude Desktop's encrypted login cache, when no working Claude Code login is available
+4. `CLAUDE_CODE_OAUTH_TOKEN` environment variable
+
+Claude Desktop support is read-only. OpenUsage decrypts its currently valid access token using the
+`Claude Safe Storage` item in your macOS Keychain. It never reads or uses Desktop's refresh token, and
+never changes Desktop's config, cookies, or Keychain entry. This prevents OpenUsage from invalidating
+Claude Desktop's session.
+
+macOS asks once before OpenUsage can access that Keychain item. Background refreshes never open the
+password dialog: OpenUsage first asks you to refresh manually, and choosing **Always Allow** makes later
+refreshes silent. If Desktop's short-lived token expires, open Claude Desktop so it can renew the login,
+then refresh OpenUsage.
 
 A `CLAUDE_CODE_OAUTH_TOKEN` — usually a long-lived `claude setup-token` — can run the model but can't read your Session and Weekly limits, and it often lingers in your shell environment. So when a real keychain or file login is present, OpenUsage uses that login for the live meters and keeps the environment token only as a fallback; the Session/Weekly meters no longer go blank just because that token is set. If the environment token is your *only* credential (a headless setup), it's used on its own and the spend tiles still load from local logs.
 
-If one source holds an expired or "locked out" token, OpenUsage falls back to the others — so signing in again with `claude` outside the app is picked up on the next refresh, without restarting OpenUsage. Tokens are refreshed automatically; rotated tokens are written back only while the ordered login candidates still match the start of the refresh, so a newly added higher-priority login wins.
+If one source holds an expired or "locked out" token, OpenUsage falls back to the others — so signing in again with `claude` outside the app is picked up on the next refresh, without restarting OpenUsage. Claude Code tokens are refreshed automatically; rotated tokens are written back only while the ordered login candidates still match the start of the refresh, so a newly added higher-priority login wins. Claude Desktop tokens are never refreshed or written by OpenUsage.
 
 ## The spend tiles
 
@@ -34,13 +45,14 @@ Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the C
 ## Troubleshooting
 
 - **"Not logged in"** — run `claude` and sign in, then refresh.
-- **"Signed in to the Claude desktop app?"** — a login done only in the Claude desktop app is stored encrypted in a way OpenUsage can't read. Run `claude` in a terminal and sign in once; both logins coexist, and OpenUsage picks up the CLI one.
+- **"Claude Desktop login found"** — refresh manually and choose **Always Allow** when macOS asks for access to `Claude Safe Storage`.
+- **"Claude Desktop login is stale"** — open Claude Desktop so it can renew the login, then refresh OpenUsage.
 - **"Re-login for live usage"** (an amber warning on the Claude header) — your saved login can authenticate for inference but can't read your subscription limits, because it lacks the `user:profile` access (this is what an inference-only token from `claude setup-token` carries). Run `claude` and sign in again with your Claude account, then refresh; the spend tiles keep working in the meantime.
 - **"Updates blocked by Anthropic"** (an amber warning on the Claude header) — the usage API is throttling OpenUsage. It keeps the last values from the same login, shows when it will retry, and backs off in the meantime. A different login starts with a fresh cache and cooldown.
 - **Spend tiles show "No data"** — OpenUsage found no Claude Code logs in the last 30 days. If your logs live somewhere custom, set `CLAUDE_CONFIG_DIR` so both Claude Code and OpenUsage look in the same place.
 
 ## Under the hood
 
-`GET https://api.anthropic.com/api/oauth/usage` with the Claude Code OAuth token; refresh via `platform.claude.com/v1/oauth/token`. A 401/403 triggers one token refresh and retry. If that still fails because the token is expired or revoked, OpenUsage retries with the next credential source before reporting an error.
+`GET https://api.anthropic.com/api/oauth/usage` with the selected OAuth token. Claude Code tokens refresh via `platform.claude.com/v1/oauth/token`; Claude Desktop tokens are read-only and must be renewed by Desktop itself. If a token is expired or revoked, OpenUsage retries with the next credential source before reporting an error.
 
 When the five-hour session window has no usage yet, the Session row shows **Not started** on the trailing label; hover explains that the session begins after your first message.


### PR DESCRIPTION
## TL;DR
OpenUsage can now use an existing Claude Desktop login without requiring a separate Claude Code login. Claude Code stays first in line, Desktop is the fallback, and the integration never consumes or writes Desktop's rotating refresh token.

## What was happening
- Claude Desktop stores its OAuth cache behind Electron Safe Storage, so OpenUsage could only tell Desktop users to install and sign in through Claude Code.
- Refreshing Desktop-owned OAuth credentials outside Desktop could invalidate its session.
- Desktop can cache tokens for several organizations, but only its currently selected organization should ever be used.
- An inference-only `CLAUDE_CODE_OAUTH_TOKEN` could stop fallback after a stored CLI login failed, preventing a valid Desktop login from being tried.
- Background refreshes must not trigger unexpected macOS Keychain dialogs.

## What this changes
- Decrypts Claude Desktop's OAuth cache and active-organization cookie using the `Claude Safe Storage` Keychain item.
- Selects a valid full-scope token only from Desktop's active organization; cached tokens for other organizations never enter the candidate list.
- Tries working Claude Code credentials first, then Desktop when CLI credentials are missing or rejected.
- Tries Desktop before the inference-only environment token, so that token cannot turn a failed CLI refresh into a false success.
- Uses only Desktop's current access token; refresh tokens and all Desktop-owned files remain untouched.
- Allows Keychain interaction only for manual refreshes and caches the approved Safe Storage key in memory.
- Removes the temporary account and token-selection logging used while debugging the integration.
- Documents the one-time Keychain prompt, read-only behavior, and stale-token recovery.

## Heads-up
- Claude Desktop access tokens are short-lived. When one expires, users must open Claude Desktop so it can renew its own session.
- A failed CLI login remains the reported error when Desktop has no usable fallback, so an unrelated stale Desktop token does not hide the real failure.

## Tests
- `swift test --build-system native` — 1,121 XCTest cases executed with 0 failures and 3 skipped, plus 3 Swift Testing cases passed.
- `swift test --build-system native --filter ClaudeDesktopAuthStoreTests` — 15 tests passed.
- `./script/build_and_run.sh verify` — release build staged, signed, launched, and process-verified.
- Manual smoke test confirmed the Claude Desktop login works in the running app.
