### PR TITLE
feat: bundle an agent-friendly usage CLI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
         .macOS(.v15)
     ],
     products: [
-        .executable(name: "OpenUsage", targets: ["OpenUsage"])
+        .executable(name: "OpenUsage", targets: ["OpenUsage"]),
+        .executable(name: "openusage-cli", targets: ["OpenUsageCLI"])
     ],
     dependencies: [
         // The de-facto standard recorder + global hotkey for Mac apps (System Settings-style field).
@@ -37,10 +38,25 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+        .executableTarget(
+            name: "OpenUsageCLI",
+            path: "Sources/OpenUsageCLI",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "OpenUsageTests",
             dependencies: ["OpenUsage"],
             path: "Tests/OpenUsageTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
+            name: "OpenUsageCLITests",
+            dependencies: ["OpenUsageCLI"],
+            path: "Tests/OpenUsageCLITests",
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Most providers read the credentials already on your machine (keychain, auth file
 - **Customize.** Turn providers and metrics on or off, choose which rows stay Always Visible or On Demand, and drag-reorder both.
 - **Stale-while-revalidate.** Cached values display instantly at launch; refresh runs every 5 minutes.
 - **[Local HTTP API](docs/local-http-api.md).** Other apps can read your usage as JSON from `127.0.0.1:6736` (`/v1/usage`), same format as the original app. It is loopback-only and serves usage numbers, never credentials; note that browser pages can read it too — see the [privacy note](docs/local-http-api.md#cors-and-privacy).
+- **[Agent-friendly CLI](docs/cli.md).** `openusage` renders usage in a terminal and emits stable JSON when piped. It reuses the running app's provider sessions, requires no additional API keys, and updates with the app.
 - **[Proxy support](docs/proxy.md).** Route provider requests through SOCKS5 or HTTP(S) via `~/.openusage/config.json`.
 - **Native settings.** Launch at login, global shortcut, icon style, theme, density, 12/24-hour time — see [Settings](docs/settings.md).
 - **[Automatic updates](docs/updates.md).** Signed, notarized in-app updates via Sparkle, with an optional beta channel.

--- a/Sources/OpenUsageCLI/CLIArguments.swift
+++ b/Sources/OpenUsageCLI/CLIArguments.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct CLIArguments: Equatable, Sendable {
+    enum Output: Equatable, Sendable {
+        case automatic
+        case json
+        case table
+    }
+
+    var providerID: String?
+    var output: Output = .automatic
+    var launchApp = true
+    var showHelp = false
+    var showVersion = false
+
+    static func parse(_ arguments: [String]) throws -> CLIArguments {
+        var parsed = CLIArguments()
+        for argument in arguments {
+            switch argument {
+            case "--json": parsed.output = .json
+            case "--table": parsed.output = .table
+            case "--no-launch": parsed.launchApp = false
+            case "-h", "--help": parsed.showHelp = true
+            case "-v", "--version": parsed.showVersion = true
+            default:
+                if argument.hasPrefix("-") {
+                    throw CLIError.usage("Unknown option: \(argument)")
+                }
+                guard parsed.providerID == nil else {
+                    throw CLIError.usage("Only one provider can be requested at a time.")
+                }
+                parsed.providerID = argument.lowercased()
+            }
+        }
+        return parsed
+    }
+}
+
+enum CLIError: Error, Equatable {
+    case usage(String)
+    case appUnavailable
+    case request(String)
+}

--- a/Sources/OpenUsageCLI/CLIModels.swift
+++ b/Sources/OpenUsageCLI/CLIModels.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+struct UsageSnapshot: Decodable, Sendable {
+    var providerId: String
+    var displayName: String
+    var plan: String?
+    var lines: [UsageLine]
+    var fetchedAt: String
+}
+
+struct UsageLine: Decodable, Sendable {
+    struct Format: Decodable, Sendable {
+        var kind: String
+        var suffix: String?
+    }
+
+    var type: String
+    var label: String
+    var value: String?
+    var used: Double?
+    var limit: Double?
+    var format: Format?
+    var resetsAt: String?
+    var text: String?
+    var points: [ChartPoint]?
+
+    init(
+        type: String,
+        label: String,
+        value: String? = nil,
+        used: Double? = nil,
+        limit: Double? = nil,
+        format: Format? = nil,
+        resetsAt: String? = nil,
+        text: String? = nil,
+        points: [ChartPoint]? = nil
+    ) {
+        self.type = type
+        self.label = label
+        self.value = value
+        self.used = used
+        self.limit = limit
+        self.format = format
+        self.resetsAt = resetsAt
+        self.text = text
+        self.points = points
+    }
+}
+
+struct ChartPoint: Decodable, Sendable {
+    var label: String
+    var value: Double
+    var valueLabel: String?
+}
+
+struct APIErrorBody: Decodable, Sendable {
+    var error: String
+}

--- a/Sources/OpenUsageCLI/OpenUsageCLI.swift
+++ b/Sources/OpenUsageCLI/OpenUsageCLI.swift
@@ -1,0 +1,114 @@
+import Darwin
+import Foundation
+
+@main
+struct OpenUsageCLI {
+    static func main() async {
+        do {
+            let arguments = try CLIArguments.parse(Array(CommandLine.arguments.dropFirst()))
+            if arguments.showHelp {
+                print(help)
+                return
+            }
+            if arguments.showVersion {
+                print(version())
+                return
+            }
+
+            let result = try await fetch(arguments)
+            let jsonOutput = arguments.output == .json
+                || (arguments.output == .automatic && isatty(STDOUT_FILENO) == 0)
+            if jsonOutput {
+                FileHandle.standardOutput.write(result.0)
+                FileHandle.standardOutput.write(Data("\n".utf8))
+            } else {
+                print(TerminalRenderer.render(result.1))
+            }
+        } catch CLIError.usage(let message) {
+            fail("\(message)\nRun 'openusage --help' for usage.", code: 2)
+        } catch CLIError.appUnavailable {
+            fail("OpenUsage is not running. Open the app and try again, or omit --no-launch.", code: 3)
+        } catch CLIError.request(let message) {
+            fail("Could not read usage: \(message)", code: 4)
+        } catch {
+            fail("Could not read usage: \(error.localizedDescription)", code: 4)
+        }
+    }
+
+    private static func fetch(_ arguments: CLIArguments) async throws -> (Data, [UsageSnapshot]) {
+        let client = UsageAPIClient()
+        do {
+            return try await client.fetch(providerID: arguments.providerID)
+        } catch CLIError.appUnavailable where arguments.launchApp {
+            try launchContainingApp()
+            for _ in 0..<20 {
+                try await Task.sleep(for: .milliseconds(250))
+                do {
+                    let result = try await client.fetch(providerID: arguments.providerID)
+                    return result
+                } catch CLIError.appUnavailable {
+                    continue
+                } catch {
+                    // The app now owns the port and returned a meaningful HTTP/decode/transport error.
+                    // Surface it immediately instead of retrying until it is mislabeled "not running".
+                    throw error
+                }
+            }
+            throw CLIError.appUnavailable
+        }
+    }
+
+    private static func launchContainingApp() throws {
+        let executable = ExecutableLocator.current()
+        let appURL = executable.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        guard appURL.pathExtension == "app" else { throw CLIError.appUnavailable }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-gja", appURL.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { throw CLIError.appUnavailable }
+    }
+
+    private static func version() -> String {
+        let executable = ExecutableLocator.current()
+        let plist = executable.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: plist),
+              let dictionary = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+              let version = dictionary["CFBundleShortVersionString"] as? String else {
+            return "openusage (development build)"
+        }
+        return "openusage \(version)"
+    }
+
+    private static func fail(_ message: String, code: Int32) -> Never {
+        FileHandle.standardError.write(Data("openusage: \(message)\n".utf8))
+        exit(code)
+    }
+
+    private static let help = """
+    Usage: openusage [provider] [options]
+
+    Read the latest usage collected by the OpenUsage menu-bar app.
+
+    Options:
+      --json       Print the stable JSON wire format
+      --table      Print a compact human-readable table
+      --no-launch  Do not launch OpenUsage when it is not running
+      -v, --version
+      -h, --help
+
+    Output defaults to a table in a terminal and JSON when piped, making
+    `openusage` directly consumable by agents and scripts.
+    """
+}
+
+enum ExecutableLocator {
+    static func current(
+        argument0: String = CommandLine.arguments[0],
+        bundleExecutableURL: URL? = Bundle.main.executableURL
+    ) -> URL {
+        let executable = bundleExecutableURL ?? URL(fileURLWithPath: argument0)
+        return executable.resolvingSymlinksInPath().standardizedFileURL
+    }
+}

--- a/Sources/OpenUsageCLI/TerminalRenderer.swift
+++ b/Sources/OpenUsageCLI/TerminalRenderer.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+enum TerminalRenderer {
+    static func render(_ snapshots: [UsageSnapshot], now: Date = Date()) -> String {
+        guard !snapshots.isEmpty else { return "No usage data yet." }
+        return snapshots.map { snapshot in
+            var rows = [header(snapshot)]
+            rows += snapshot.lines.map { "  \($0.label): \(value($0, now: now))" }
+            rows.append("  Updated: \(relativeDate(snapshot.fetchedAt, now: now))")
+            return rows.joined(separator: "\n")
+        }.joined(separator: "\n\n")
+    }
+
+    private static func header(_ snapshot: UsageSnapshot) -> String {
+        guard let plan = snapshot.plan, !plan.isEmpty else { return snapshot.displayName }
+        return "\(snapshot.displayName) (\(plan))"
+    }
+
+    private static func value(_ line: UsageLine, now: Date) -> String {
+        switch line.type {
+        case "progress":
+            guard let used = line.used, let limit = line.limit else { return "No data" }
+            let rendered: String
+            if line.format?.kind == "percent", limit != 0 {
+                rendered = "\(integerOrDecimal(used / limit * 100))% used"
+            } else {
+                let suffix = line.format?.suffix.map { " \($0)" } ?? ""
+                rendered = "\(integerOrDecimal(used)) / \(integerOrDecimal(limit))\(suffix)"
+            }
+            guard let resetsAt = line.resetsAt else { return rendered }
+            return "\(rendered) · resets \(relativeDate(resetsAt, now: now))"
+        case "badge":
+            return line.text ?? "No data"
+        case "barChart":
+            guard let point = line.points?.last else { return "No data" }
+            return point.valueLabel ?? "\(compactCount(point.value)) tokens"
+        default:
+            return line.value ?? "No data"
+        }
+    }
+
+    private static func integerOrDecimal(_ value: Double) -> String {
+        value.rounded() == value ? String(Int(value)) : String(format: "%.1f", value)
+    }
+
+    private static func compactCount(_ value: Double) -> String {
+        value.formatted(
+            .number
+                .notation(.compactName)
+                .precision(.fractionLength(0...1))
+                .locale(Locale(identifier: "en_US"))
+        )
+    }
+
+    private static func relativeDate(_ value: String, now: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        guard let date = formatter.date(from: value) else { return value }
+        let seconds = Int(date.timeIntervalSince(now))
+        if abs(seconds) < 60 { return seconds >= 0 ? "in <1m" : "just now" }
+        let minutes = abs(seconds) / 60
+        if minutes < 60 { return seconds >= 0 ? "in \(minutes)m" : "\(minutes)m ago" }
+        let hours = minutes / 60
+        if hours < 48 { return seconds >= 0 ? "in \(hours)h" : "\(hours)h ago" }
+        let days = hours / 24
+        return seconds >= 0 ? "in \(days)d" : "\(days)d ago"
+    }
+}

--- a/Sources/OpenUsageCLI/UsageAPIClient.swift
+++ b/Sources/OpenUsageCLI/UsageAPIClient.swift
@@ -1,0 +1,52 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct UsageAPIClient: Sendable {
+    static let baseURL = URL(string: "http://127.0.0.1:6736/v1/usage")!
+
+    func fetch(providerID: String?) async throws -> (Data, [UsageSnapshot]) {
+        let url = providerID.map { Self.baseURL.appendingPathComponent($0) } ?? Self.baseURL
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        let (data, response): (Data, URLResponse)
+        do {
+            // The CLI is a one-shot local client. An ephemeral session avoids creating a disk cache or
+            // persisting any response metadata for normalized usage values.
+            (data, response) = try await URLSession(configuration: .ephemeral).data(for: request)
+        } catch {
+            throw Self.classifyTransportError(error)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw CLIError.request("OpenUsage returned an invalid response.")
+        }
+        switch http.statusCode {
+        case 200:
+            let decoder = JSONDecoder()
+            let snapshots: [UsageSnapshot]
+            if providerID == nil {
+                snapshots = try decoder.decode([UsageSnapshot].self, from: data)
+            } else {
+                snapshots = [try decoder.decode(UsageSnapshot.self, from: data)]
+            }
+            return (data, snapshots)
+        case 204:
+            return (Data(providerID == nil ? "[]".utf8 : "null".utf8), [])
+        default:
+            let code = (try? JSONDecoder().decode(APIErrorBody.self, from: data))?.error
+                ?? "HTTP \(http.statusCode)"
+            throw CLIError.request(code.replacingOccurrences(of: "_", with: " "))
+        }
+    }
+
+    /// Connection refusal means no process owns the loopback port, so the caller may launch the app
+    /// and retry. Every other transport failure is a real request error; reporting it as "not running"
+    /// would hide timeouts, dropped connections, and local networking failures behind the wrong exit code.
+    static func classifyTransportError(_ error: Error) -> CLIError {
+        if (error as? URLError)?.code == .cannotConnectToHost {
+            return .appUnavailable
+        }
+        return .request(error.localizedDescription)
+    }
+}

--- a/Tests/OpenUsageCLITests/CLIArgumentsTests.swift
+++ b/Tests/OpenUsageCLITests/CLIArgumentsTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import OpenUsageCLI
+
+final class CLIArgumentsTests: XCTestCase {
+    func testParsesProviderAndAgentOptions() throws {
+        let parsed = try CLIArguments.parse(["Claude", "--json", "--no-launch"])
+        XCTAssertEqual(parsed.providerID, "claude")
+        XCTAssertEqual(parsed.output, .json)
+        XCTAssertFalse(parsed.launchApp)
+    }
+
+    func testRejectsUnknownOptionsAndMultipleProviders() {
+        XCTAssertThrowsError(try CLIArguments.parse(["--wat"]))
+        XCTAssertThrowsError(try CLIArguments.parse(["claude", "codex"]))
+    }
+
+    func testExecutableLocatorPrefersRealExecutableWhenArgumentZeroIsBareCommand() {
+        let executable = URL(fileURLWithPath: "/Applications/OpenUsage.app/Contents/Helpers/openusage")
+
+        let resolved = ExecutableLocator.current(
+            argument0: "openusage",
+            bundleExecutableURL: executable
+        )
+
+        XCTAssertEqual(resolved, executable)
+    }
+}

--- a/Tests/OpenUsageCLITests/TerminalRendererTests.swift
+++ b/Tests/OpenUsageCLITests/TerminalRendererTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import OpenUsageCLI
+
+final class TerminalRendererTests: XCTestCase {
+    func testRendersProgressTextAndPlan() {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let now = formatter.date(from: "2026-07-12T10:00:00.000Z")!
+        let snapshot = UsageSnapshot(
+            providerId: "claude",
+            displayName: "Claude",
+            plan: "Pro",
+            lines: [
+                UsageLine(type: "progress", label: "Session", used: 42, limit: 100,
+                          format: .init(kind: "percent"), resetsAt: "2026-07-12T12:00:00.000Z"),
+                UsageLine(type: "text", label: "Today", value: "$5.17 · 9.2M tokens")
+            ],
+            fetchedAt: "2026-07-12T09:55:00.000Z"
+        )
+
+        XCTAssertEqual(TerminalRenderer.render([snapshot], now: now), """
+        Claude (Pro)
+          Session: 42% used · resets in 2h
+          Today: $5.17 · 9.2M tokens
+          Updated: 5m ago
+        """)
+    }
+}

--- a/Tests/OpenUsageCLITests/UsageAPIClientTests.swift
+++ b/Tests/OpenUsageCLITests/UsageAPIClientTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import XCTest
+@testable import OpenUsageCLI
+
+final class UsageAPIClientTests: XCTestCase {
+    func testConnectionRefusalMeansAppUnavailable() {
+        XCTAssertEqual(
+            UsageAPIClient.classifyTransportError(URLError(.cannotConnectToHost)),
+            .appUnavailable
+        )
+    }
+
+    func testOtherTransportFailuresRemainRequestErrors() {
+        let error = UsageAPIClient.classifyTransportError(URLError(.timedOut))
+        guard case .request(let message) = error else {
+            return XCTFail("Expected timeout to remain a request error, got \(error)")
+        }
+        XCTAssertFalse(message.isEmpty)
+    }
+
+    func testChartPointWithoutValueLabelDecodesAndRendersValue() throws {
+        let data = Data(#"""
+        [{
+          "providerId": "claude",
+          "displayName": "Claude",
+          "lines": [{
+            "type": "barChart",
+            "label": "Usage Trend",
+            "points": [{"label": "Jul 12", "value": 1200}]
+          }],
+          "fetchedAt": "2026-07-12T08:00:00.000Z"
+        }]
+        """#.utf8)
+
+        let snapshots = try JSONDecoder().decode([UsageSnapshot].self, from: data)
+
+        XCTAssertNil(snapshots[0].lines[0].points?[0].valueLabel)
+        XCTAssertTrue(TerminalRenderer.render(snapshots).contains("1.2K tokens"))
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ What the app does and how it behaves. These pages describe **behavior, not visua
 
 ## Integrations
 
+- [Command-line interface](cli.md) — terminal rendering and agent-friendly JSON
 - [Local HTTP API](local-http-api.md) — read your usage from other apps on `127.0.0.1:6736`
 - [Proxy](proxy.md) — route provider requests through SOCKS5 or HTTP(S)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ standard controls with the same behavior (the footer still pins, the buttons kee
 one of those version checks lives in a single file — `Support/LiquidGlassFallbacks.swift` — so the views
 stay free of `#available` checks.
 
-The release build (`script/release.sh`) ships a universal binary (arm64 + x86_64), so a single DMG runs
+The release build (`script/release.sh`) ships universal app and `openusage` CLI binaries (arm64 + x86_64), so a single DMG runs
 natively on both Apple Silicon and Intel Macs. The dev build (`script/build_and_run.sh`) stays host-arch
 only — a universal dev build just doubles compile time on the maintainer's own machine for no benefit.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,44 @@
+# Command-Line Interface
+
+OpenUsage ships an `openusage` command inside the macOS app. It gives people a compact terminal view
+and gives agents and scripts stable JSON without duplicating provider logins or asking for API keys.
+
+```sh
+openusage                    # table in a terminal; JSON when piped
+openusage claude             # one provider
+openusage --json             # always JSON
+openusage --table            # always a table
+openusage --no-launch        # fail instead of starting the menu-bar app
+```
+
+The command uses OpenUsage's loopback-only, read-only local connection. Provider credentials remain in
+the menu-bar app and are never returned. If OpenUsage is closed, the bundled command starts it and waits
+briefly for usage to become available. Values follow the app's normal refresh and caching rules.
+
+## Installation and Updates
+
+The executable lives at:
+
+```text
+/Applications/OpenUsage.app/Contents/Helpers/openusage
+```
+
+It is signed and shipped inside every app release, so Sparkle updates it together with the app. The
+Homebrew cask can expose that bundled executable on `PATH` with its `binary` artifact; direct-download
+users can invoke the full path or symlink it into a directory already on their `PATH`.
+
+This first version is macOS-only. A Linux build would require separating the provider engine from the
+AppKit app and replacing macOS-specific credential sources such as Keychain. Keeping that larger
+refactor out of the initial CLI avoids two provider implementations drifting apart.
+
+## Agent Usage
+
+When stdout is not a terminal, JSON is automatic:
+
+```sh
+openusage | jq '.[] | {providerId, lines}'
+openusage codex | jq '.lines[] | select(.type == "progress")'
+```
+
+The JSON is the same documented format as the [local HTTP API](local-http-api.md), including
+`providerId`, `fetchedAt`, and type-tagged metric lines.

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -1,5 +1,8 @@
 # Local HTTP API
 
+For terminal and agent use, prefer the bundled [`openusage` command](cli.md). It handles app startup,
+terminal rendering, and automatic JSON output while keeping this wire format available to scripts.
+
 OpenUsage exposes a read-only HTTP API on the loopback interface so other local apps can consume the same usage data shown in the menu bar.
 
 **Base URL:** `http://127.0.0.1:6736`

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -30,8 +30,10 @@ DIST_DIR="$ROOT_DIR/dist"
 APP_BUNDLE="$DIST_DIR/$APP_DISPLAY.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
+APP_HELPERS="$APP_CONTENTS/Helpers"
 APP_RESOURCES="$APP_CONTENTS/Resources"
 APP_BINARY="$APP_MACOS/$TARGET_NAME"
+CLI_BINARY="$APP_HELPERS/openusage"
 INFO_PLIST="$APP_CONTENTS/Info.plist"
 RESOURCE_BUNDLE_NAME="${TARGET_NAME}_${TARGET_NAME}.bundle"
 ENTITLEMENTS="$ROOT_DIR/script/OpenUsage.dev.entitlements.plist"
@@ -42,17 +44,24 @@ echo "==> swift build ($CONFIG)"
 swift build -c "$CONFIG"
 BUILD_DIR="$(swift build -c "$CONFIG" --show-bin-path)"
 BUILD_BINARY="$BUILD_DIR/$TARGET_NAME"
+BUILD_CLI_BINARY="$BUILD_DIR/openusage-cli"
 
 if [ ! -x "$BUILD_BINARY" ]; then
   echo "missing built binary: $BUILD_BINARY" >&2
   exit 1
 fi
+if [ ! -x "$BUILD_CLI_BINARY" ]; then
+  echo "missing built CLI: $BUILD_CLI_BINARY" >&2
+  exit 1
+fi
 
 echo "==> staging $APP_BUNDLE"
 rm -rf "$APP_BUNDLE"
-mkdir -p "$APP_MACOS" "$APP_RESOURCES"
+mkdir -p "$APP_MACOS" "$APP_HELPERS" "$APP_RESOURCES"
 cp "$BUILD_BINARY" "$APP_BINARY"
+cp "$BUILD_CLI_BINARY" "$CLI_BINARY"
 chmod +x "$APP_BINARY"
+chmod +x "$CLI_BINARY"
 
 # SwiftPM stamps LC_BUILD_VERSION's `sdk` field with the deployment target (macOS 15), not the real
 # SDK it compiled against. macOS gates the modern Liquid Glass control appearance (pop-up buttons,
@@ -148,6 +157,7 @@ fi
 "$ROOT_DIR/script/embed_sparkle.sh" "$APP_BUNDLE" "$APP_BINARY" "$CODESIGN_IDENTITY" "--options runtime"
 
 if [ -n "$CODESIGN_IDENTITY" ]; then
+  /usr/bin/codesign --force --options runtime --sign "$CODESIGN_IDENTITY" "$CLI_BINARY" >/dev/null
   # Not --deep: the Sparkle framework is already signed above and must keep that signature.
   /usr/bin/codesign --force --options runtime \
     --sign "$CODESIGN_IDENTITY" \
@@ -155,6 +165,7 @@ if [ -n "$CODESIGN_IDENTITY" ]; then
     "$APP_BUNDLE" >/dev/null
   echo "==> signed with: $CODESIGN_IDENTITY"
 else
+  /usr/bin/codesign --force --sign - "$CLI_BINARY" >/dev/null
   /usr/bin/codesign --force --sign - --entitlements "$ENTITLEMENTS" "$APP_BUNDLE" >/dev/null
   echo "WARNING: no Apple Development identity found; ad-hoc signed." >&2
 fi

--- a/script/release.sh
+++ b/script/release.sh
@@ -44,8 +44,10 @@ DIST_DIR="$ROOT_DIR/dist"
 APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
+APP_HELPERS="$APP_CONTENTS/Helpers"
 APP_RESOURCES="$APP_CONTENTS/Resources"
 APP_BINARY="$APP_MACOS/$APP_NAME"
+CLI_BINARY="$APP_HELPERS/openusage"
 DMG_PATH="$DIST_DIR/$DMG_NAME"
 # dSYMs for crash symbolication (uploaded to PostHog by release.yml). A folder, since posthog-cli's
 # `dsym upload --directory` and Sparkle both want a directory of bundles, not a single path.
@@ -81,17 +83,23 @@ echo "==> building $APP_NAME $VERSION ($BUILD) — universal (arm64 + x86_64)"
 swift build -c release --arch arm64 --arch x86_64 -Xswiftc -g
 BUILD_DIR="$(swift build -c release --arch arm64 --arch x86_64 -Xswiftc -g --show-bin-path)"
 BUILD_BINARY="$BUILD_DIR/$APP_NAME"
+BUILD_CLI_BINARY="$BUILD_DIR/openusage-cli"
 [ -x "$BUILD_BINARY" ] || { echo "missing built binary: $BUILD_BINARY" >&2; exit 1; }
+[ -x "$BUILD_CLI_BINARY" ] || { echo "missing built CLI: $BUILD_CLI_BINARY" >&2; exit 1; }
 
 echo "==> staging $APP_BUNDLE"
 rm -rf "$APP_BUNDLE"
-mkdir -p "$APP_MACOS" "$APP_RESOURCES"
+mkdir -p "$APP_MACOS" "$APP_HELPERS" "$APP_RESOURCES"
 cp "$BUILD_BINARY" "$APP_BINARY"
+cp "$BUILD_CLI_BINARY" "$CLI_BINARY"
 chmod +x "$APP_BINARY"
+chmod +x "$CLI_BINARY"
 # Fail loudly if the build ever silently regresses to a single arch (e.g. a dropped --arch flag): a
 # fat binary is the whole point, and generate_appcast derives Sparkle's hardwareRequirements from it.
 lipo -archs "$APP_BINARY" | grep -q "x86_64" && lipo -archs "$APP_BINARY" | grep -q "arm64" \
   || { echo "Expected a universal (arm64 + x86_64) binary, got: $(lipo -archs "$APP_BINARY")" >&2; exit 1; }
+lipo -archs "$CLI_BINARY" | grep -q "x86_64" && lipo -archs "$CLI_BINARY" | grep -q "arm64" \
+  || { echo "Expected a universal CLI, got: $(lipo -archs "$CLI_BINARY")" >&2; exit 1; }
 
 # SwiftPM stamps LC_BUILD_VERSION's `sdk` field with the deployment target (macOS 15), not the real
 # SDK it compiled against. macOS gates the modern Liquid Glass control appearance (pop-up buttons,
@@ -176,6 +184,9 @@ PLIST
 
 # Embed + sign Sparkle (Developer ID, hardened runtime, secure timestamp).
 "$ROOT_DIR/script/embed_sparkle.sh" "$APP_BUNDLE" "$APP_BINARY" "$CODESIGN_IDENTITY" "--options runtime --timestamp"
+
+echo "==> signing bundled CLI"
+codesign --force --options runtime --timestamp --sign "$CODESIGN_IDENTITY" "$CLI_BINARY"
 
 echo "==> signing app (Developer ID, hardened runtime)"
 # Not --deep: the Sparkle framework is signed above and must keep that signature. No get-task-allow


### PR DESCRIPTION
## TL;DR

Adds a small, signed `openusage` CLI inside the macOS app bundle. It gives humans a compact terminal view and gives agents/scripts stable JSON without duplicating provider authentication or requiring another OpenUsage service; Sparkle updates the CLI atomically with the app.

## What was happening

- OpenUsage usage was available in the menu-bar UI and through the loopback HTTP API, but there was no discoverable command for terminals or coding agents.
- A standalone provider implementation would duplicate credential reads, token refresh, provider requests, pricing, and normalization, creating a second engine that could drift from the app.
- Shipping a separate CLI artifact would also require a second signing, notarization, and update channel.

## What this changes

- Adds a dependency-free SwiftPM CLI product, staged into releases as `OpenUsage.app/Contents/Helpers/openusage`.
- Uses the existing loopback-only, read-only usage surface so provider credentials and refresh behavior remain owned by the app.
- Prints a compact table on a TTY and the existing stable JSON wire format when piped; `--json` and `--table` allow explicit selection.
- Supports a single provider argument, `--no-launch`, help, version reporting, documented exit codes, and friendly failures.
- Starts the containing OpenUsage app when necessary, including when invoked through a Homebrew-created symlink.
- Builds, architecture-checks, hardened-runtime signs, and bundles the universal CLI in the existing release pipeline.
- Stages and signs the helper in `script/build_and_run.sh` too, so the canonical local workflow exercises the shipped topology.
- Documents agent usage, update behavior, installation shape, and the deliberate macOS-first boundary.
- Adds focused argument and terminal-renderer regression tests.

## Heads-up

- This is intentionally a surgical macOS-first client, not a Linux provider-engine extraction. Linux would require replacing Keychain/AppKit-specific credential sources and splitting a large portion of the current executable target into shared libraries.
- The CLI reads the app's normal cached/periodically refreshed snapshots; it does not force provider API calls on every invocation, avoiding latency and provider rate-limit churn.
- After the first release containing the helper, the Homebrew cask needs a one-line `binary` artifact update pointing at `OpenUsage.app/Contents/Helpers/openusage` so cask installs expose `openusage` on `PATH`. Direct-download users can invoke or symlink the bundled path immediately.
- The SwiftPM build product is named `openusage-cli` to avoid a case-insensitive filesystem collision with the `OpenUsage` app product; release staging renames it to the user-facing `openusage`.
- E2E testing caught the same collision inside `Contents/MacOS`: on default case-insensitive APFS, `OpenUsage` and `openusage` are the same path. The final helper location is deliberately `Contents/Helpers/openusage`.

## Tests

- `swift test`: 1,067 XCTest cases passed, 3 skipped, 0 failures; 3 Swift Testing cases also passed.
- `CONFIG=release ./script/build_and_run.sh verify`: release-mode dev bundle built, nested helper signed, and app process verified.
- Live bundled CLI: non-empty collection JSON, provider-filtered JSON, table rendering, bundle-derived version, strict app/helper signatures.
- Symlink E2E: stopped the app, invoked the helper through a temporary Homebrew-style symlink, verified auto-launch and non-empty JSON.
- Universal release dry run through `script/release.sh`: app and CLI both `x86_64 arm64`, dSYM generated, nested code signatures strictly validated, DMG created and checksum verified.
- Universal bundle runtime: symlink auto-launch, non-empty JSON, process presence, and release version passed.
- `bash -n script/build_and_run.sh script/release.sh`
- `git diff --check`

The local release dry run deliberately skipped notarization via `ALLOW_UNNOTARIZED=1`; the existing release workflow retains the real Developer ID/notarization gate.

No UI changed, so screenshots are not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only local HTTP client with no credential handling; main app and API behavior are unchanged aside from packaging and signing the helper binary.
> 
> **Overview**
> Adds a **dependency-free `OpenUsageCLI` SwiftPM product** shipped as `OpenUsage.app/Contents/Helpers/openusage` (universal, signed with the app) so terminals and agents can read usage without a second provider stack or update channel.
> 
> The CLI **GETs the existing loopback API** (`127.0.0.1:6736/v1/usage`), decodes the same JSON wire format, prints a **compact table on a TTY** or **raw JSON when piped** (`--json` / `--table` override), optional **single provider** filter, **`--no-launch`**, help/version, and **documented exit codes**. If nothing is listening, it can **`open -gja` the containing `.app`** and retry briefly; transport errors other than connection refused stay real request failures.
> 
> **Release and dev scripts** stage the helper, verify universal `lipo`, and codesign it; **docs** cover `cli.md`, README, and HTTP API cross-links. **Tests** cover argument parsing, executable resolution for Homebrew-style symlinks, terminal rendering, and API client error classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10d43cfa6f6fd395ecd33f9851c62f7d9768d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->