### PR TITLE
Add secure nearby Mac usage sync

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -26,6 +26,8 @@ final class AppContainer {
     /// ephemeral secret-code easter-egg state, and the system accessibility flags it yields to. Read by both
     /// the SwiftUI surface and the AppKit panel (`StatusItemController`).
     let transparency: PopoverTransparencyStore
+    /// Opt-in Bonjour discovery and encrypted aggregation of machine-local usage from approved Macs.
+    let lanSync: LANSyncStore
     /// One-time onboarding state (the first-run Customize hint card). Only ever marked pending by
     /// `FirstRunSeeder` on a fresh install, so existing installs never see the card.
     let onboarding: OnboardingStore
@@ -185,16 +187,30 @@ final class AppContainer {
         dataStore.onRefreshOutcome = { [weak telemetry] providerID, outcome, category, manual in
             telemetry?.record(providerID: providerID, outcome: outcome, category: category, manual: manual)
         }
+        let lanSync = LANSyncStore(
+            localSnapshots: { [weak dataStore] in dataStore?.shareableSnapshots() ?? [:] },
+            applyRemoteSnapshots: { [weak dataStore] deviceID, snapshots in
+                dataStore?.setRemoteSnapshots(snapshots, for: deviceID)
+            },
+            removeRemoteSnapshots: { [weak dataStore] deviceID in
+                dataStore?.removeRemoteSnapshots(for: deviceID)
+            }
+        )
+        dataStore.onRefreshCompleted = { [weak lanSync] in
+            await lanSync?.refreshAvailablePeers()
+        }
+        self.lanSync = lanSync
         self.telemetry = telemetry
         self.transparency = PopoverTransparencyStore()
         self.localAPI = LocalUsageServer(state: { [layout, enablement, dataStore] in
             LocalUsageAPI.State(
                 enabledOrderedIDs: layout.providerOrder.filter { enablement.isEnabled($0) },
                 knownIDs: Set(registry.providers.map(\.id)),
-                snapshots: dataStore.snapshots
+                snapshots: dataStore.displaySnapshots
             )
         })
         self.refreshTask = Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry)
+        lanSync.start()
         localAPI.start()
         // Become the notification-center delegate so banners show while frontmost — a menu-bar accessory
         // effectively always is. Notification authorization is requested the first time a trigger is

--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -8,11 +8,39 @@ struct OpenUsageApp: App {
     var body: some Scene {
         // Menu-bar app: the status item and custom panel are AppKit-owned (see StatusItemController),
         // so no window scene is wanted. `Settings` gives SwiftUI a valid scene without creating
-        // an activation window.
+        // an activation window. macOS can still open this scene (⌘, or the app menu whenever the
+        // app gets activated, e.g. by a system permission dialog), which used to show a bare empty
+        // window — the redirect view closes it and opens the real in-popover Settings screen instead.
         Settings {
-            EmptyView()
+            SettingsWindowRedirect()
         }
     }
+}
+
+/// Content of the stub SwiftUI `Settings` scene: immediately closes its own window and routes the
+/// user to the in-popover Settings screen instead.
+private struct SettingsWindowRedirect: View {
+    var body: some View {
+        Color.clear
+            .frame(width: 1, height: 1)
+            .background(SettingsWindowCloser())
+    }
+}
+
+/// Resolves the hosting `NSWindow` directly (no title/identifier guessing) and closes it on the next
+/// runloop tick, after ordering the in-popover Settings screen open.
+private struct SettingsWindowCloser: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        Task { @MainActor [weak view] in
+            guard let window = view?.window else { return }
+            MenuBarPopover.showSettingsHandler?()
+            window.close()
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
 @MainActor

--- a/Sources/OpenUsage/App/PanelOutsideClickMonitor.swift
+++ b/Sources/OpenUsage/App/PanelOutsideClickMonitor.swift
@@ -6,6 +6,7 @@ final class PanelOutsideClickMonitor {
     private let panel: MenuBarPanel
     private let statusItem: NSStatusItem
     private let isMorphing: () -> Bool
+    private let isPairingActive: () -> Bool
     private let onInsidePanelClick: () -> Void
     private let onDismiss: () -> Void
     private var monitors: [Any] = []
@@ -14,12 +15,14 @@ final class PanelOutsideClickMonitor {
         panel: MenuBarPanel,
         statusItem: NSStatusItem,
         isMorphing: @escaping () -> Bool,
+        isPairingActive: @escaping () -> Bool = { false },
         onInsidePanelClick: @escaping () -> Void,
         onDismiss: @escaping () -> Void
     ) {
         self.panel = panel
         self.statusItem = statusItem
         self.isMorphing = isMorphing
+        self.isPairingActive = isPairingActive
         self.onInsidePanelClick = onInsidePanelClick
         self.onDismiss = onDismiss
     }
@@ -70,6 +73,7 @@ final class PanelOutsideClickMonitor {
         let buttonWindowID = statusItem.button?.window.map(ObjectIdentifier.init)
         let context = PanelOutsideClickContext(
             isMorphing: isMorphing(),
+            isPairingActive: isPairingActive(),
             hasAttachedSheet: panel.attachedSheet != nil,
             isOnStatusButton: isOnStatusButton(screenPoint),
             isInsidePanel: isInsidePanel,
@@ -94,6 +98,7 @@ final class PanelOutsideClickMonitor {
 
 struct PanelOutsideClickContext {
     var isMorphing = false
+    var isPairingActive = false
     var hasAttachedSheet = false
     var isOnStatusButton = false
     var isInsidePanel = false
@@ -105,6 +110,10 @@ struct PanelOutsideClickContext {
 enum PanelOutsideClickPolicy {
     static func shouldKeepOpen(_ context: PanelOutsideClickContext) -> Bool {
         context.isMorphing
+            // A Nearby Macs pairing is mid-flight: the user may need to click a system permission
+            // dialog or read the comparison code, and either would otherwise read as an outside
+            // click and dismiss the pairing UI. Explicit dismissals (Esc, status-item click) still work.
+            || context.isPairingActive
             || context.hasAttachedSheet
             || context.isOnStatusButton
             || context.isInsidePanel

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -36,6 +36,7 @@ final class StatusItemController: NSObject {
         panel: panel,
         statusItem: statusItem,
         isMorphing: { [weak self] in self?.heightController.isMorphing ?? false },
+        isPairingActive: { [weak self] in self?.container.lanSync.isPairingActive ?? false },
         onInsidePanelClick: { [weak self] in self?.clearStrayFocus() },
         onDismiss: { [weak self] in self?.hidePanel() }
     )
@@ -117,6 +118,9 @@ final class StatusItemController: NSObject {
         MenuBarPopover.showHandler = { [weak self] in
             self?.container.layout.screen = .dashboard
             self?.showPopover()
+        }
+        MenuBarPopover.showSettingsHandler = { [weak self] in
+            self?.openSettings()
         }
 
         heightController.installBridge()

--- a/Sources/OpenUsage/Models/LANSyncModels.swift
+++ b/Sources/OpenUsage/Models/LANSyncModels.swift
@@ -19,9 +19,17 @@ struct LANIncomingPairRequest: Identifiable, Sendable {
 }
 
 enum LANOutgoingPairing: Equatable, Sendable {
-    case connecting(name: String)
-    case compareCode(name: String, code: String)
-    case failed(name: String, message: String)
+    case connecting(deviceID: String, name: String)
+    case compareCode(deviceID: String, name: String, code: String)
+    case failed(deviceID: String, name: String, message: String)
+
+    /// The Mac being paired with; the Settings list hides its plain discovered row while this
+    /// status card is on screen so the device doesn't appear twice.
+    var deviceID: String {
+        switch self {
+        case .connecting(let id, _), .compareCode(let id, _, _), .failed(let id, _, _): id
+        }
+    }
 }
 
 struct LANPeerSyncState: Equatable, Sendable {

--- a/Sources/OpenUsage/Models/LANSyncModels.swift
+++ b/Sources/OpenUsage/Models/LANSyncModels.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+struct LANPairedDevice: Codable, Hashable, Identifiable, Sendable {
+    let id: String
+    var name: String
+}
+
+struct LANNearbyDevice: Hashable, Identifiable, Sendable {
+    let id: String
+    let name: String
+    let isPaired: Bool
+}
+
+struct LANIncomingPairRequest: Identifiable, Sendable {
+    let id: UUID
+    let deviceID: String
+    let name: String
+    let code: String
+}
+
+enum LANOutgoingPairing: Equatable, Sendable {
+    case connecting(name: String)
+    case compareCode(name: String, code: String)
+    case failed(name: String, message: String)
+}
+
+struct LANPeerSyncState: Equatable, Sendable {
+    var isAvailable = false
+    var isSyncing = false
+    var lastSyncedAt: Date?
+    var errorMessage: String?
+}

--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -99,7 +99,11 @@ extension WidgetDescriptor {
     /// The three local-spend tiles every spend-tracking provider exposes — Today / Yesterday / Last 30
     /// Days — each a combined "cost · tokens" row, backed by `SpendTileMapper`. Ids are
     /// `<provider>.today|yesterday|last30`, so the set is identical across Claude / Codex / Cursor / Grok.
-    static func spendTiles(provider: Provider, valueTooltipNote: String? = nil) -> [WidgetDescriptor] {
+    static func spendTiles(
+        provider: Provider,
+        valueTooltipNote: String? = nil,
+        accountWide: Bool = false
+    ) -> [WidgetDescriptor] {
         let descriptors: [WidgetDescriptor] = [
             .combined(id: "\(provider.id).today", provider: provider, title: "Today", isUsagePeriod: true),
             .combined(id: "\(provider.id).yesterday", provider: provider, title: "Yesterday", isUsagePeriod: true),
@@ -116,7 +120,8 @@ extension WidgetDescriptor {
                 metricLabel: descriptor.metricLabel,
                 sample: sample,
                 pinnable: descriptor.pinnable,
-                isSpendTile: true
+                isSpendTile: true,
+                isAccountWideUsage: accountWide
             )
         }
     }
@@ -150,11 +155,13 @@ extension WidgetDescriptor {
     /// The Usage Trend row: a day-by-day token sparkline backed by a provider `.chart` line. Not
     /// pinnable — the tray can't draw a chart — but otherwise a normal Customize metric (toggle,
     /// reorder, hide). `isChart` tells the dashboard how to render live chart points.
-    static func usageTrend(provider: Provider) -> WidgetDescriptor {
+    static func usageTrend(provider: Provider, accountWide: Bool = false) -> WidgetDescriptor {
         var sample = WidgetData(title: "Usage Trend", icon: provider.icon, kind: .count, used: 0, limit: nil)
         sample.isChart = true
-        return make(id: "\(provider.id).trend", provider: provider, metricLabel: "Usage Trend",
-                    sample: sample, pinnable: false)
+        var descriptor = make(id: "\(provider.id).trend", provider: provider, metricLabel: "Usage Trend",
+                              sample: sample, pinnable: false)
+        descriptor.isAccountWideUsage = accountWide
+        return descriptor
     }
 
     private static func make(

--- a/Sources/OpenUsage/Models/WidgetDescriptor.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor.swift
@@ -14,6 +14,11 @@ struct WidgetDescriptor: Identifiable, Hashable {
     /// The Total Spend card keys on this to decide which providers feed the ring — a title match would
     /// wrongly rope in look-alike rows like OpenRouter's API-spend "Today".
     var isSpendTile: Bool = false
+    /// True for usage metrics sourced from the provider's account (server-side exports like Cursor's
+    /// usage CSV) rather than this machine's local logs. Nearby-Mac sync must never merge these:
+    /// every Mac signed in to the same account reports the identical numbers, so adding them
+    /// double-counts. Machine-local metrics (Claude/Codex/Grok log scans) stay additive.
+    var isAccountWideUsage: Bool = false
 
     /// The metric's single display name.
     var title: String { sample.title }

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -38,10 +38,13 @@ final class CursorProvider: ProviderRuntime {
             .boundedCount(id: "cursor.requests", provider: provider, title: "Requests", limit: 500,
                           suffix: "requests", periodDurationMs: CursorUsageMapper.billingPeriodMs),
             .dollarBalance(id: "cursor.credits", provider: provider, title: "Credits", valueWord: "left"),
-            .usageTrend(provider: provider)
+            // Cursor's trend and spend tiles come from the account-wide usage CSV export, not a local
+            // log — every Mac on the account sees the same numbers, so nearby-Mac sync must not add them.
+            .usageTrend(provider: provider, accountWide: true)
         ] + WidgetDescriptor.spendTiles(
             provider: provider,
-            valueTooltipNote: WidgetData.cursorUsageHistoryNote
+            valueTooltipNote: WidgetData.cursorUsageHistoryNote,
+            accountWide: true
         )
     }
 

--- a/Sources/OpenUsage/Services/LANSyncProtocol.swift
+++ b/Sources/OpenUsage/Services/LANSyncProtocol.swift
@@ -9,7 +9,7 @@ enum LANSyncProtocol {
     static let serviceType = "_openusage._tcp"
     static let maxFrameBytes = 8 * 1024 * 1024
 
-    enum Mode: String, Codable, Sendable { case pair, sync }
+    enum Mode: String, Codable, Sendable { case pair, sync, unpair }
 
     struct Hello: Codable, Sendable {
         let version: Int
@@ -27,6 +27,11 @@ enum LANSyncProtocol {
         let publicKey: Data
         let nonce: Data
         let proof: Data?
+        /// True when the responder no longer knows this pairing (e.g. the user hit Forget there).
+        /// Sent before authentication, so the requester treats it as advisory only: it improves the
+        /// error message but never removes a pairing by itself. Optional so version-1 peers that
+        /// don't send the field still decode.
+        var notPaired: Bool?
     }
 
     struct PairDecision: Codable, Sendable {
@@ -53,6 +58,7 @@ enum LANSyncProtocol {
         case authenticationFailed
         case pairingDenied
         case missingPairSecret
+        case peerNotPaired
         case connectionClosed
         case timedOut
 
@@ -65,6 +71,7 @@ enum LANSyncProtocol {
             case .authenticationFailed: "The nearby Mac could not be authenticated."
             case .pairingDenied: "The connection request was declined."
             case .missingPairSecret: "This Mac no longer has the key for that paired device. Pair it again."
+            case .peerNotPaired: "That Mac no longer recognizes this connection. Forget it and connect again."
             case .connectionClosed: "The nearby Mac closed the connection."
             case .timedOut: "The nearby Mac didn't respond in time."
             }

--- a/Sources/OpenUsage/Services/LANSyncProtocol.swift
+++ b/Sources/OpenUsage/Services/LANSyncProtocol.swift
@@ -1,0 +1,328 @@
+import CryptoKit
+import Foundation
+import Network
+import os
+import Security
+
+enum LANSyncProtocol {
+    static let version = 1
+    static let serviceType = "_openusage._tcp"
+    static let maxFrameBytes = 8 * 1024 * 1024
+
+    enum Mode: String, Codable, Sendable { case pair, sync }
+
+    struct Hello: Codable, Sendable {
+        let version: Int
+        let mode: Mode
+        let deviceID: String
+        let displayName: String
+        let publicKey: Data
+        let nonce: Data
+    }
+
+    struct ServerHello: Codable, Sendable {
+        let version: Int
+        let deviceID: String
+        let displayName: String
+        let publicKey: Data
+        let nonce: Data
+        let proof: Data?
+    }
+
+    struct PairDecision: Codable, Sendable {
+        let accepted: Bool
+        let sealedSecret: Data?
+    }
+
+    struct PairSecretPayload: Codable, Sendable { let secret: Data }
+
+    struct AuthProof: Codable, Sendable { let proof: Data }
+
+    struct SnapshotPayload: Codable, Sendable {
+        let version: Int
+        let deviceID: String
+        let generatedAt: Date
+        let snapshots: [String: ProviderSnapshot]
+    }
+
+    enum ProtocolError: Error, LocalizedError {
+        case invalidFrame
+        case frameTooLarge
+        case incompatibleVersion
+        case invalidKey
+        case authenticationFailed
+        case pairingDenied
+        case missingPairSecret
+        case connectionClosed
+        case timedOut
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFrame: "The nearby Mac sent an invalid message."
+            case .frameTooLarge: "The nearby Mac sent too much data."
+            case .incompatibleVersion: "The nearby Mac uses an incompatible OpenUsage sync version."
+            case .invalidKey: "The nearby Mac sent an invalid security key."
+            case .authenticationFailed: "The nearby Mac could not be authenticated."
+            case .pairingDenied: "The connection request was declined."
+            case .missingPairSecret: "This Mac no longer has the key for that paired device. Pair it again."
+            case .connectionClosed: "The nearby Mac closed the connection."
+            case .timedOut: "The nearby Mac didn't respond in time."
+            }
+        }
+    }
+
+    struct SessionContext: Sendable {
+        let transcript: Data
+        let key: SymmetricKey
+        let code: String
+    }
+
+    static func randomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        guard SecRandomCopyBytes(kSecRandomDefault, count, &bytes) == errSecSuccess else {
+            throw ProtocolError.invalidKey
+        }
+        return Data(bytes)
+    }
+
+    static func context(
+        clientHello: Hello,
+        serverHello: ServerHello,
+        privateKey: Curve25519.KeyAgreement.PrivateKey,
+        pairSecret: Data? = nil
+    ) throws -> SessionContext {
+        guard clientHello.version == version, serverHello.version == version else {
+            throw ProtocolError.incompatibleVersion
+        }
+        let remotePublicData = privateKey.publicKey.rawRepresentation == clientHello.publicKey
+            ? serverHello.publicKey : clientHello.publicKey
+        let remotePublic: Curve25519.KeyAgreement.PublicKey
+        do {
+            remotePublic = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: remotePublicData)
+        } catch {
+            throw ProtocolError.invalidKey
+        }
+        let shared = try privateKey.sharedSecretFromKeyAgreement(with: remotePublic)
+        let transcript = transcript(clientHello: clientHello, serverHello: serverHello)
+        let salt = pairSecret ?? Data(SHA256.hash(data: clientHello.nonce + serverHello.nonce))
+        let key = shared.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: salt,
+            sharedInfo: transcript,
+            outputByteCount: 32
+        )
+        let codeMAC = HMAC<SHA256>.authenticationCode(for: Data("pair-code".utf8) + transcript, using: key)
+        let number = codeMAC.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) } % 1_000_000
+        return SessionContext(transcript: transcript, key: key, code: String(format: "%06u", number))
+    }
+
+    static func proof(role: String, transcript: Data, pairSecret: Data) -> Data {
+        Data(HMAC<SHA256>.authenticationCode(
+            for: Data(role.utf8) + transcript,
+            using: SymmetricKey(data: pairSecret)
+        ))
+    }
+
+    static func verify(_ proof: Data, role: String, transcript: Data, pairSecret: Data) -> Bool {
+        HMAC<SHA256>.isValidAuthenticationCode(
+            proof,
+            authenticating: Data(role.utf8) + transcript,
+            using: SymmetricKey(data: pairSecret)
+        )
+    }
+
+    static func seal<T: Encodable>(_ value: T, using key: SymmetricKey) throws -> Data {
+        let encoded = try encoder.encode(value)
+        return try ChaChaPoly.seal(encoded, using: key).combined
+    }
+
+    static func open<T: Decodable>(_ type: T.Type, sealed: Data, using key: SymmetricKey) throws -> T {
+        do {
+            let box = try ChaChaPoly.SealedBox(combined: sealed)
+            return try decoder.decode(type, from: ChaChaPoly.open(box, using: key))
+        } catch {
+            throw ProtocolError.authenticationFailed
+        }
+    }
+
+    static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    private static func transcript(clientHello: Hello, serverHello: ServerHello) -> Data {
+        var data = Data("OpenUsage LAN sync v\(version)".utf8)
+        for part in [
+            clientHello.mode.rawValue.data(using: .utf8)!,
+            Data(clientHello.deviceID.utf8), Data(clientHello.displayName.utf8),
+            Data(serverHello.deviceID.utf8), Data(serverHello.displayName.utf8),
+            clientHello.publicKey, serverHello.publicKey,
+            clientHello.nonce, serverHello.nonce
+        ] {
+            var length = UInt32(part.count).bigEndian
+            data.append(Data(bytes: &length, count: 4))
+            data.append(part)
+        }
+        return data
+    }
+}
+
+protocol LANSyncSecretStoring: Sendable {
+    func secret(for deviceID: String) throws -> Data?
+    func store(_ secret: Data, for deviceID: String) throws
+    func deleteSecret(for deviceID: String) throws
+}
+
+struct KeychainLANSyncSecretStore: LANSyncSecretStoring {
+    private var service: String {
+        (Bundle.main.bundleIdentifier ?? "com.robinebers.openusage") + ".lan-sync"
+    }
+
+    func secret(for deviceID: String) throws -> Data? {
+        var query = baseQuery(deviceID)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = item as? Data else {
+            throw LANSyncProtocol.ProtocolError.missingPairSecret
+        }
+        return data
+    }
+
+    func store(_ secret: Data, for deviceID: String) throws {
+        let query = baseQuery(deviceID)
+        let attributes = [
+            kSecValueData as String: secret,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ] as [String: Any]
+        let update = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if update == errSecSuccess { return }
+        guard update == errSecItemNotFound else { throw LANSyncProtocol.ProtocolError.invalidKey }
+        var item = query
+        attributes.forEach { item[$0.key] = $0.value }
+        guard SecItemAdd(item as CFDictionary, nil) == errSecSuccess else {
+            throw LANSyncProtocol.ProtocolError.invalidKey
+        }
+    }
+
+    func deleteSecret(for deviceID: String) throws {
+        let status = SecItemDelete(baseQuery(deviceID) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw LANSyncProtocol.ProtocolError.invalidKey
+        }
+    }
+
+    private func baseQuery(_ deviceID: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: deviceID
+        ]
+    }
+}
+
+/// Length-prefixed frames on top of one TCP connection. All application payloads after pairing/auth
+/// are ChaCha20-Poly1305 sealed; this type only owns stream framing and a strict allocation cap.
+actor LANFramedChannel {
+    private let connection: NWConnection
+    private let queue = DispatchQueue(label: "openusage.lan-sync.connection")
+    private let timeout: TimeInterval
+    private var buffer = Data()
+
+    init(connection: NWConnection, timeout: TimeInterval = 15) {
+        self.connection = connection
+        self.timeout = timeout
+        connection.start(queue: queue)
+    }
+
+    func send<T: Encodable>(_ value: T) async throws {
+        let payload = try LANSyncProtocol.encoder.encode(value)
+        try await sendFrame(payload)
+    }
+
+    func receive<T: Decodable>(_ type: T.Type) async throws -> T {
+        try LANSyncProtocol.decoder.decode(type, from: await receiveFrame())
+    }
+
+    func sendFrame(_ payload: Data) async throws {
+        guard payload.count <= LANSyncProtocol.maxFrameBytes else { throw LANSyncProtocol.ProtocolError.frameTooLarge }
+        var length = UInt32(payload.count).bigEndian
+        let framed = Data(bytes: &length, count: 4) + payload
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            let gate = LANContinuationGate(continuation)
+            queue.asyncAfter(deadline: .now() + timeout) { [connection] in
+                if gate.resume(.failure(LANSyncProtocol.ProtocolError.timedOut)) { connection.cancel() }
+            }
+            connection.send(content: framed, completion: .contentProcessed { error in
+                if let error { _ = gate.resume(.failure(error)) }
+                else { _ = gate.resume(.success(())) }
+            })
+        }
+    }
+
+    func receiveFrame() async throws -> Data {
+        while true {
+            if buffer.count >= 4 {
+                let length = buffer.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+                guard length <= LANSyncProtocol.maxFrameBytes else { throw LANSyncProtocol.ProtocolError.frameTooLarge }
+                let total = 4 + Int(length)
+                if buffer.count >= total {
+                    let payload = buffer.subdata(in: 4..<total)
+                    buffer.removeSubrange(0..<total)
+                    return payload
+                }
+            }
+            let chunk = try await receiveChunk()
+            guard !chunk.isEmpty else { throw LANSyncProtocol.ProtocolError.connectionClosed }
+            buffer.append(chunk)
+        }
+    }
+
+    func cancel() { connection.cancel() }
+
+    private func receiveChunk() async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            let gate = LANContinuationGate(continuation)
+            queue.asyncAfter(deadline: .now() + timeout) { [connection] in
+                if gate.resume(.failure(LANSyncProtocol.ProtocolError.timedOut)) { connection.cancel() }
+            }
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { data, _, complete, error in
+                if let error { _ = gate.resume(.failure(error)) }
+                else if let data, !data.isEmpty { _ = gate.resume(.success(data)) }
+                else if complete { _ = gate.resume(.failure(LANSyncProtocol.ProtocolError.connectionClosed)) }
+                else { _ = gate.resume(.success(Data())) }
+            }
+        }
+    }
+}
+
+private final class LANContinuationGate<Value: Sendable>: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: false)
+    private let continuation: CheckedContinuation<Value, any Error>
+
+    init(_ continuation: CheckedContinuation<Value, any Error>) {
+        self.continuation = continuation
+    }
+
+    @discardableResult
+    func resume(_ result: Result<Value, any Error>) -> Bool {
+        let shouldResume = lock.withLock { resumed in
+            guard !resumed else { return false }
+            resumed = true
+            return true
+        }
+        guard shouldResume else { return false }
+        continuation.resume(with: result)
+        return true
+    }
+}

--- a/Sources/OpenUsage/Services/LANSyncProtocol.swift
+++ b/Sources/OpenUsage/Services/LANSyncProtocol.swift
@@ -242,6 +242,19 @@ actor LANFramedChannel {
     init(connection: NWConnection, timeout: TimeInterval = 15) {
         self.connection = connection
         self.timeout = timeout
+        // Fail fast instead of hanging into the frame timeout: a connection that can't be established
+        // (stale Bonjour endpoint, unreachable peer) parks in `.waiting` and silently retries forever,
+        // so pending send/receive callbacks would never fire and every failure would read as a
+        // generic "didn't respond in time". Cancelling here makes those callbacks return the real error.
+        connection.stateUpdateHandler = { [weak connection] state in
+            switch state {
+            case .waiting(let error), .failed(let error):
+                AppLog.warn(.localAPI, "LAN sync connection unusable: \(error.localizedDescription)")
+                connection?.cancel()
+            default:
+                break
+            }
+        }
         connection.start(queue: queue)
     }
 
@@ -282,9 +295,9 @@ actor LANFramedChannel {
                     return payload
                 }
             }
-            let chunk = try await receiveChunk()
-            guard !chunk.isEmpty else { throw LANSyncProtocol.ProtocolError.connectionClosed }
-            buffer.append(chunk)
+            // An empty chunk is a receive that completed without data (not end-of-stream — that
+            // throws `.connectionClosed` inside `receiveChunk`); loop and keep reading.
+            buffer.append(try await receiveChunk())
         }
     }
 

--- a/Sources/OpenUsage/Services/LANUsageAggregator.swift
+++ b/Sources/OpenUsage/Services/LANUsageAggregator.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Selects and combines the only metrics that are safe to add across Macs: usage reconstructed from
+/// machine-local logs/CSV files. Account-wide quota meters are deliberately never exported because two
+/// Macs signed in to the same account would report the same quota and double-count it.
+enum LANUsageAggregator {
+    static func shareableSnapshots(
+        _ snapshots: [String: ProviderSnapshot],
+        registry: WidgetRegistry
+    ) -> [String: ProviderSnapshot] {
+        snapshots.compactMapValues { snapshot in
+            let labels = shareableLabels(for: snapshot.providerID, registry: registry)
+            let lines = snapshot.lines.compactMap { line in
+                labels.contains(line.label) ? sanitizedShareableLine(line) : nil
+            }
+            guard !lines.isEmpty else { return nil }
+            return ProviderSnapshot(
+                providerID: snapshot.providerID,
+                displayName: snapshot.displayName,
+                lines: lines,
+                refreshedAt: snapshot.refreshedAt
+            )
+        }
+    }
+
+    static func combinedSnapshots(
+        local: [String: ProviderSnapshot],
+        remotes: [String: [String: ProviderSnapshot]],
+        registry: WidgetRegistry
+    ) -> [String: ProviderSnapshot] {
+        var result = local
+        let remoteSnapshots = remotes.values.flatMap { $0.values }
+        let providerIDs = Set(remoteSnapshots.map(\.providerID))
+
+        for providerID in providerIDs.union(local.keys) {
+            let labels = shareableLabels(for: providerID, registry: registry)
+            guard !labels.isEmpty else { continue }
+            let sources = ([local[providerID]] + remoteSnapshots.filter { $0.providerID == providerID })
+                .compactMap { $0 }
+            guard let template = local[providerID] ?? sources.first else { continue }
+
+            var linesByLabel: [String: [MetricLine]] = [:]
+            for snapshot in sources {
+                for line in snapshot.lines where labels.contains(line.label) {
+                    linesByLabel[line.label, default: []].append(line)
+                }
+            }
+
+            // Only this Mac is authoritative for account-wide rows. A remote-only provider starts with
+            // no quota/plan data at all, then receives just the additive local-usage rows below.
+            let mergedLines = (local[providerID]?.lines.filter { !labels.contains($0.label) } ?? [])
+                + registry.descriptors(for: providerID)
+                    .map(\.metricLabel)
+                    .uniqued()
+                    .compactMap { label in
+                        guard let lines = linesByLabel[label], !lines.isEmpty else { return nil }
+                        return merge(lines, label: label)
+                    }
+
+            result[providerID] = ProviderSnapshot(
+                providerID: providerID,
+                displayName: template.displayName,
+                plan: local[providerID]?.plan,
+                lines: mergedLines,
+                refreshedAt: sources.map(\.refreshedAt).max() ?? template.refreshedAt,
+                warning: local[providerID]?.warning,
+                errorCategory: local[providerID]?.errorCategory
+            )
+        }
+        return result
+    }
+
+    private static func shareableLabels(for providerID: String, registry: WidgetRegistry) -> Set<String> {
+        Set(registry.descriptors(for: providerID).compactMap { descriptor in
+            descriptor.isSpendTile || descriptor.sample.isChart ? descriptor.metricLabel : nil
+        })
+    }
+
+    /// The wire is a system boundary even for an approved peer. Keep the additive shapes bounded and
+    /// numeric so a malformed/older peer cannot feed NaN, negatives, or an unbounded chart into the UI.
+    private static func sanitizedShareableLine(_ line: MetricLine) -> MetricLine? {
+        switch line {
+        case .values(let label, let values, _, _, let unknownModels, _):
+            let valid = values.filter { $0.number.isFinite && $0.number >= 0 }
+            guard !valid.isEmpty else { return nil }
+            return .values(
+                label: label,
+                values: valid,
+                unknownModels: unknownModels.prefix(100).map { String($0.prefix(128)) }
+            )
+        case .chart(let label, let points, _):
+            let valid = points.filter { $0.value.isFinite && $0.value >= 0 }.prefix(64)
+            guard !valid.isEmpty else { return nil }
+            return .chart(
+                label: label,
+                points: valid.map {
+                    MetricChartPoint(
+                        value: $0.value,
+                        label: String($0.label.prefix(64)),
+                        valueLabel: MetricFormatter.number($0.value, kind: .count, style: .row) + " tokens"
+                    )
+                }
+            )
+        default:
+            return nil
+        }
+    }
+
+    private static func merge(_ lines: [MetricLine], label: String) -> MetricLine? {
+        if lines.count == 1 { return lines[0] }
+        if lines.allSatisfy({ if case .values = $0 { true } else { false } }) {
+            return mergeValues(lines, label: label)
+        }
+        if lines.allSatisfy({ if case .chart = $0 { true } else { false } }) {
+            return mergeCharts(lines, label: label)
+        }
+        // A peer on a newer protocol may someday send a different shape. Do not invent a conversion;
+        // keep the local/first value and log the incompatibility at the boundary.
+        AppLog.warn(.localAPI, "LAN sync skipped incompatible \(label) metric shapes")
+        return lines.first
+    }
+
+    private struct ValueKey: Hashable {
+        let kind: MetricKind
+        let label: String?
+    }
+
+    private static func mergeValues(_ lines: [MetricLine], label: String) -> MetricLine {
+        var order: [ValueKey] = []
+        var totals: [ValueKey: Double] = [:]
+        var estimates: [ValueKey: Bool] = [:]
+        var unknownModels = Set<String>()
+
+        for case .values(_, let values, _, _, let unknown, _) in lines {
+            unknownModels.formUnion(unknown)
+            for value in values {
+                let key = ValueKey(kind: value.kind, label: value.label)
+                if totals[key] == nil { order.append(key) }
+                totals[key, default: 0] += value.number
+                estimates[key, default: false] = estimates[key, default: false] || value.estimated
+            }
+        }
+
+        let values = order.compactMap { key -> MetricValue? in
+            guard let total = totals[key], total.isFinite else { return nil }
+            return MetricValue(number: total, kind: key.kind, label: key.label, estimated: estimates[key] ?? false)
+        }
+        return .values(label: label, values: values, unknownModels: unknownModels.sorted())
+    }
+
+    private static func mergeCharts(_ lines: [MetricLine], label: String) -> MetricLine {
+        let series = lines.compactMap { line -> [MetricChartPoint]? in
+            if case .chart(_, let points, _) = line { return points }
+            return nil
+        }
+        let labels = series.max(by: { $0.count < $1.count }) ?? []
+        let points = labels.indices.compactMap { index -> MetricChartPoint? in
+            let total = series.compactMap { $0.indices.contains(index) ? $0[index].value : nil }.reduce(0, +)
+            guard total.isFinite else { return nil }
+            return MetricChartPoint(
+                value: total,
+                label: labels[index].label,
+                valueLabel: MetricFormatter.number(total, kind: .count, style: .row) + " tokens"
+            )
+        }
+        return .chart(label: label, points: points, note: "Local usage across connected Macs")
+    }
+}
+
+private extension Sequence where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}

--- a/Sources/OpenUsage/Services/LANUsageAggregator.swift
+++ b/Sources/OpenUsage/Services/LANUsageAggregator.swift
@@ -72,7 +72,8 @@ enum LANUsageAggregator {
 
     private static func shareableLabels(for providerID: String, registry: WidgetRegistry) -> Set<String> {
         Set(registry.descriptors(for: providerID).compactMap { descriptor in
-            descriptor.isSpendTile || descriptor.sample.isChart ? descriptor.metricLabel : nil
+            guard !descriptor.isAccountWideUsage else { return nil }
+            return descriptor.isSpendTile || descriptor.sample.isChart ? descriptor.metricLabel : nil
         })
     }
 

--- a/Sources/OpenUsage/Stores/LANSyncStore.swift
+++ b/Sources/OpenUsage/Stores/LANSyncStore.swift
@@ -100,7 +100,7 @@ final class LANSyncStore {
     }
 
     private func beginPairing(deviceID: String, name: String, endpoint: NWEndpoint) {
-        outgoingPairing = .connecting(name: name)
+        outgoingPairing = .connecting(deviceID: deviceID, name: name)
         launchTask { [weak self] in
             await self?.performPairing(deviceID: deviceID, name: name, endpoint: endpoint)
         }
@@ -117,6 +117,14 @@ final class LANSyncStore {
     func dismissPairingStatus() { outgoingPairing = nil }
 
     func forget(_ deviceID: String) {
+        // Best-effort courtesy: while this Mac still holds the shared secret, tell the peer (if
+        // currently reachable) to drop its side of the pairing too, so it doesn't keep a stale
+        // "Connected" entry that only errors on the next sync. Local cleanup never waits on this.
+        if let endpoint = endpoints[deviceID], let secret = try? secretStore.secret(for: deviceID) {
+            launchTask { [weak self] in
+                await self?.sendUnpair(deviceID: deviceID, endpoint: endpoint, secret: secret)
+            }
+        }
         pairedDevices.removeAll { $0.id == deviceID }
         persistPairedDevices()
         do {
@@ -270,6 +278,7 @@ final class LANSyncStore {
             switch hello.mode {
             case .pair: try await handleIncomingPair(hello, channel: channel)
             case .sync: try await handleIncomingSync(hello, channel: channel)
+            case .unpair: try await handleIncomingUnpair(hello, channel: channel)
             }
         } catch {
             AppLog.warn(.localAPI, "LAN sync incoming connection failed: \(error.localizedDescription)")
@@ -317,6 +326,12 @@ final class LANSyncStore {
     private func handleIncomingSync(_ hello: LANSyncProtocol.Hello, channel: LANFramedChannel) async throws {
         guard let secret = try secretStore.secret(for: hello.deviceID),
               pairedDevices.contains(where: { $0.id == hello.deviceID }) else {
+            // Tell the requester why instead of dropping the connection — otherwise all it can
+            // report is a generic timeout. Advisory only; the requester never auto-forgets on it.
+            try await channel.send(LANSyncProtocol.ServerHello(
+                version: LANSyncProtocol.version, deviceID: deviceID, displayName: deviceName,
+                publicKey: Data(), nonce: Data(), proof: nil, notPaired: true
+            ))
             throw LANSyncProtocol.ProtocolError.missingPairSecret
         }
         let privateKey = Curve25519.KeyAgreement.PrivateKey()
@@ -350,6 +365,75 @@ final class LANSyncStore {
         try await channel.sendFrame(try LANSyncProtocol.seal(payload, using: context.key))
     }
 
+    /// A peer the user unpaired is telling us to drop our side too. Same mutual HMAC authentication
+    /// as a sync — only a Mac that still holds the shared secret can trigger the removal.
+    private func handleIncomingUnpair(_ hello: LANSyncProtocol.Hello, channel: LANFramedChannel) async throws {
+        guard let secret = try secretStore.secret(for: hello.deviceID),
+              pairedDevices.contains(where: { $0.id == hello.deviceID }) else { return }
+        let privateKey = Curve25519.KeyAgreement.PrivateKey()
+        let unsigned = LANSyncProtocol.ServerHello(
+            version: LANSyncProtocol.version,
+            deviceID: deviceID,
+            displayName: deviceName,
+            publicKey: privateKey.publicKey.rawRepresentation,
+            nonce: try LANSyncProtocol.randomBytes(count: 32),
+            proof: nil
+        )
+        let context = try LANSyncProtocol.context(
+            clientHello: hello, serverHello: unsigned, privateKey: privateKey, pairSecret: secret
+        )
+        try await channel.send(LANSyncProtocol.ServerHello(
+            version: unsigned.version, deviceID: unsigned.deviceID, displayName: unsigned.displayName,
+            publicKey: unsigned.publicKey, nonce: unsigned.nonce,
+            proof: LANSyncProtocol.proof(role: "server", transcript: context.transcript, pairSecret: secret)
+        ))
+        let clientProof = try await channel.receive(LANSyncProtocol.AuthProof.self)
+        guard LANSyncProtocol.verify(
+            clientProof.proof, role: "client", transcript: context.transcript, pairSecret: secret
+        ) else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
+        let name = pairedDevices.first { $0.id == hello.deviceID }?.name ?? hello.displayName
+        pairedDevices.removeAll { $0.id == hello.deviceID }
+        persistPairedDevices()
+        try? secretStore.deleteSecret(for: hello.deviceID)
+        removeRemoteSnapshots(hello.deviceID)
+        peerStates[hello.deviceID] = nil
+        rebuildNearbyDevices()
+        AppLog.info(.localAPI, "LAN sync unpaired by \(name)")
+    }
+
+    /// The outbound half of Forget: authenticate with the still-held secret and ask the peer to drop
+    /// its pairing entry. Best-effort — failure only means the peer shows a stale entry until its
+    /// next sync attempt errors.
+    private func sendUnpair(deviceID remoteID: String, endpoint: NWEndpoint, secret: Data) async {
+        let channel = LANFramedChannel(connection: NWConnection(to: endpoint, using: .tcp))
+        defer { Task { await channel.cancel() } }
+        do {
+            let privateKey = Curve25519.KeyAgreement.PrivateKey()
+            let hello = LANSyncProtocol.Hello(
+                version: LANSyncProtocol.version,
+                mode: .unpair,
+                deviceID: deviceID,
+                displayName: deviceName,
+                publicKey: privateKey.publicKey.rawRepresentation,
+                nonce: try LANSyncProtocol.randomBytes(count: 32)
+            )
+            try await channel.send(hello)
+            let serverHello = try await channel.receive(LANSyncProtocol.ServerHello.self)
+            guard serverHello.deviceID == remoteID else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
+            let context = try LANSyncProtocol.context(
+                clientHello: hello, serverHello: serverHello, privateKey: privateKey, pairSecret: secret
+            )
+            guard let proof = serverHello.proof, LANSyncProtocol.verify(
+                proof, role: "server", transcript: context.transcript, pairSecret: secret
+            ) else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
+            try await channel.send(LANSyncProtocol.AuthProof(
+                proof: LANSyncProtocol.proof(role: "client", transcript: context.transcript, pairSecret: secret)
+            ))
+        } catch {
+            AppLog.info(.localAPI, "LAN sync unpair notice to \(remoteID) not delivered: \(error.localizedDescription)")
+        }
+    }
+
     private func performPairing(deviceID remoteID: String, name: String, endpoint: NWEndpoint) async {
         let channel = LANFramedChannel(connection: NWConnection(to: endpoint, using: .tcp), timeout: 120)
         defer { Task { await channel.cancel() } }
@@ -367,7 +451,7 @@ final class LANSyncStore {
             let serverHello = try await channel.receive(LANSyncProtocol.ServerHello.self)
             guard serverHello.deviceID == remoteID else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
             let context = try LANSyncProtocol.context(clientHello: hello, serverHello: serverHello, privateKey: privateKey)
-            outgoingPairing = .compareCode(name: name, code: context.code)
+            outgoingPairing = .compareCode(deviceID: remoteID, name: name, code: context.code)
             let decision = try await channel.receive(LANSyncProtocol.PairDecision.self)
             guard decision.accepted, let sealed = decision.sealedSecret else {
                 throw LANSyncProtocol.ProtocolError.pairingDenied
@@ -380,7 +464,7 @@ final class LANSyncStore {
             outgoingPairing = nil
             await sync(device: LANPairedDevice(id: remoteID, name: serverHello.displayName), endpoint: endpoint)
         } catch {
-            outgoingPairing = .failed(name: name, message: error.localizedDescription)
+            outgoingPairing = .failed(deviceID: remoteID, name: name, message: error.localizedDescription)
             AppLog.warn(.localAPI, "LAN sync pairing failed: \(error.localizedDescription)")
         }
     }
@@ -410,6 +494,7 @@ final class LANSyncStore {
             try await channel.send(hello)
             let serverHello = try await channel.receive(LANSyncProtocol.ServerHello.self)
             guard serverHello.deviceID == device.id else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
+            if serverHello.notPaired == true { throw LANSyncProtocol.ProtocolError.peerNotPaired }
             let context = try LANSyncProtocol.context(
                 clientHello: hello, serverHello: serverHello, privateKey: privateKey, pairSecret: secret
             )

--- a/Sources/OpenUsage/Stores/LANSyncStore.swift
+++ b/Sources/OpenUsage/Stores/LANSyncStore.swift
@@ -1,0 +1,475 @@
+import CryptoKit
+import Foundation
+import Network
+import Observation
+
+/// Owns Bonjour discovery, explicit pairing approval, authenticated encrypted snapshot fetches, and
+/// paired-device persistence. Networking is opt-in and stops completely when the Settings toggle is off.
+@MainActor
+@Observable
+final class LANSyncStore {
+    static let enabledKey = "lanSync.enabled"
+    private static let deviceIDKey = "lanSync.deviceID"
+    private static let pairedDevicesKey = "lanSync.pairedDevices.v1"
+
+    var enabled: Bool {
+        didSet {
+            defaults.set(enabled, forKey: Self.enabledKey)
+            enabled ? start() : stop()
+        }
+    }
+    private(set) var nearbyDevices: [LANNearbyDevice] = []
+    private(set) var pairedDevices: [LANPairedDevice]
+    private(set) var incomingPairRequests: [LANIncomingPairRequest] = []
+    private(set) var outgoingPairing: LANOutgoingPairing?
+    private(set) var peerStates: [String: LANPeerSyncState] = [:]
+    private(set) var serviceError: String?
+
+    let deviceID: String
+    let deviceName: String
+
+    @ObservationIgnored private let defaults: UserDefaults
+    @ObservationIgnored private let secretStore: any LANSyncSecretStoring
+    @ObservationIgnored private let localSnapshots: @MainActor () -> [String: ProviderSnapshot]
+    @ObservationIgnored private let applyRemoteSnapshots: @MainActor (String, [String: ProviderSnapshot]) -> Void
+    @ObservationIgnored private let removeRemoteSnapshots: @MainActor (String) -> Void
+    @ObservationIgnored private let queue = DispatchQueue(label: "openusage.lan-sync")
+    @ObservationIgnored private var listener: NWListener?
+    @ObservationIgnored private var browser: NWBrowser?
+    @ObservationIgnored private(set) var testingListenerEndpoint: NWEndpoint?
+    @ObservationIgnored private var endpoints: [String: NWEndpoint] = [:]
+    @ObservationIgnored private var discoveredNames: [String: String] = [:]
+    @ObservationIgnored private var approvalContinuations: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    @ObservationIgnored private var runningTasks: [UUID: Task<Void, Never>] = [:]
+
+    init(
+        defaults: UserDefaults = .standard,
+        secretStore: any LANSyncSecretStoring = KeychainLANSyncSecretStore(),
+        localSnapshots: @escaping @MainActor () -> [String: ProviderSnapshot],
+        applyRemoteSnapshots: @escaping @MainActor (String, [String: ProviderSnapshot]) -> Void,
+        removeRemoteSnapshots: @escaping @MainActor (String) -> Void
+    ) {
+        self.defaults = defaults
+        self.secretStore = secretStore
+        self.localSnapshots = localSnapshots
+        self.applyRemoteSnapshots = applyRemoteSnapshots
+        self.removeRemoteSnapshots = removeRemoteSnapshots
+        if let existing = defaults.string(forKey: Self.deviceIDKey) {
+            self.deviceID = existing
+        } else {
+            let id = UUID().uuidString.lowercased()
+            defaults.set(id, forKey: Self.deviceIDKey)
+            self.deviceID = id
+        }
+        self.deviceName = Host.current().localizedName?.nilIfEmpty ?? "Mac"
+        self.pairedDevices = Self.loadPairedDevices(defaults: defaults)
+        self.enabled = defaults.bool(forKey: Self.enabledKey)
+    }
+
+    deinit {
+        listener?.cancel()
+        browser?.cancel()
+        runningTasks.values.forEach { $0.cancel() }
+    }
+
+    func start() {
+        guard enabled, listener == nil, browser == nil else { return }
+        serviceError = nil
+        startListener()
+        startBrowser()
+    }
+
+    func pair(with deviceID: String) {
+        guard enabled, let endpoint = endpoints[deviceID],
+              let nearby = nearbyDevices.first(where: { $0.id == deviceID }) else { return }
+        beginPairing(deviceID: deviceID, name: nearby.name, endpoint: endpoint)
+    }
+
+    /// Direct-endpoint seams for the opt-in integration test. Production always reaches these operations
+    /// through Bonjour discovery; the seams keep authenticated TCP testable on hosts that block mDNS.
+    func pairForTesting(deviceID: String, name: String, endpoint: NWEndpoint) {
+        beginPairing(deviceID: deviceID, name: name, endpoint: endpoint)
+    }
+
+    func syncForTesting(device: LANPairedDevice, endpoint: NWEndpoint) async {
+        await sync(device: device, endpoint: endpoint)
+    }
+
+    private func beginPairing(deviceID: String, name: String, endpoint: NWEndpoint) {
+        outgoingPairing = .connecting(name: name)
+        launchTask { [weak self] in
+            await self?.performPairing(deviceID: deviceID, name: name, endpoint: endpoint)
+        }
+    }
+
+    func approvePairing(_ requestID: UUID) {
+        finishApproval(requestID, approved: true)
+    }
+
+    func denyPairing(_ requestID: UUID) {
+        finishApproval(requestID, approved: false)
+    }
+
+    func dismissPairingStatus() { outgoingPairing = nil }
+
+    func forget(_ deviceID: String) {
+        pairedDevices.removeAll { $0.id == deviceID }
+        persistPairedDevices()
+        do {
+            try secretStore.deleteSecret(for: deviceID)
+        } catch {
+            serviceError = "Couldn't remove the saved connection key: \(error.localizedDescription)"
+            AppLog.error(.localAPI, "LAN sync key deletion failed: \(error.localizedDescription)")
+        }
+        removeRemoteSnapshots(deviceID)
+        peerStates[deviceID] = nil
+        rebuildNearbyDevices()
+    }
+
+    /// Fetch each currently discoverable approved Mac in parallel. Called after every normal/manual
+    /// provider refresh and once immediately after pairing succeeds.
+    func refreshAvailablePeers() async {
+        guard enabled else { return }
+        let targets = pairedDevices.compactMap { device -> (LANPairedDevice, NWEndpoint)? in
+            endpoints[device.id].map { (device, $0) }
+        }
+        for (device, endpoint) in targets {
+            launchTask { [weak self] in
+                await self?.sync(device: device, endpoint: endpoint)
+            }
+        }
+    }
+
+    private func startListener() {
+        do {
+            let listener = try NWListener(using: .tcp)
+            listener.service = NWListener.Service(
+                name: deviceName,
+                type: LANSyncProtocol.serviceType,
+                txtRecord: NWTXTRecord([
+                    "id": deviceID,
+                    "name": deviceName,
+                    "v": String(LANSyncProtocol.version)
+                ])
+            )
+            listener.stateUpdateHandler = { [weak self] state in
+                Task { @MainActor in self?.listenerStateChanged(state) }
+            }
+            listener.newConnectionHandler = { [weak self] connection in
+                Task { @MainActor in self?.accept(connection) }
+            }
+            listener.start(queue: queue)
+            self.listener = listener
+        } catch {
+            serviceError = "Couldn't share usage on the local network: \(error.localizedDescription)"
+            AppLog.error(.localAPI, "LAN sync listener failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func startBrowser() {
+        let browser = NWBrowser(for: .bonjour(type: LANSyncProtocol.serviceType, domain: nil), using: .tcp)
+        browser.stateUpdateHandler = { [weak self] state in
+            Task { @MainActor in self?.browserStateChanged(state) }
+        }
+        browser.browseResultsChangedHandler = { [weak self] results, _ in
+            Task { @MainActor in self?.browserResultsChanged(results) }
+        }
+        browser.start(queue: queue)
+        self.browser = browser
+    }
+
+    private func stop() {
+        listener?.cancel()
+        browser?.cancel()
+        listener = nil
+        browser = nil
+        testingListenerEndpoint = nil
+        endpoints.removeAll()
+        discoveredNames.removeAll()
+        nearbyDevices.removeAll()
+        outgoingPairing = nil
+        approvalContinuations.values.forEach { $0.resume(returning: false) }
+        approvalContinuations.removeAll()
+        incomingPairRequests.removeAll()
+        runningTasks.values.forEach { $0.cancel() }
+        runningTasks.removeAll()
+        for device in pairedDevices { removeRemoteSnapshots(device.id) }
+        peerStates = pairedDevices.reduce(into: [:]) { $0[$1.id] = LANPeerSyncState() }
+    }
+
+    private func listenerStateChanged(_ state: NWListener.State) {
+        switch state {
+        case .failed(let error):
+            serviceError = "Couldn't share usage on the local network: \(error.localizedDescription)"
+            AppLog.error(.localAPI, "LAN sync listener failed: \(error.localizedDescription)")
+        case .ready:
+            if let port = listener?.port {
+                testingListenerEndpoint = .hostPort(host: "127.0.0.1", port: port)
+            }
+            AppLog.info(.localAPI, "LAN sync advertising as \(deviceName)")
+        default: break
+        }
+    }
+
+    private func browserStateChanged(_ state: NWBrowser.State) {
+        if case .failed(let error) = state {
+            serviceError = "Couldn't find Macs on the local network: \(error.localizedDescription)"
+            AppLog.error(.localAPI, "LAN sync browser failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func browserResultsChanged(_ results: Set<NWBrowser.Result>) {
+        var found: [String: (name: String, endpoint: NWEndpoint)] = [:]
+        for result in results {
+            guard case .bonjour(let record) = result.metadata,
+                  let id = record["id"], id != deviceID,
+                  record["v"] == String(LANSyncProtocol.version) else { continue }
+            found[id] = (record["name"]?.nilIfEmpty ?? serviceName(from: result.endpoint), result.endpoint)
+        }
+        endpoints = found.mapValues(\.endpoint)
+        discoveredNames = found.mapValues(\.name)
+        let availableIDs = Set(found.keys)
+        for device in pairedDevices {
+            var state = peerStates[device.id] ?? LANPeerSyncState()
+            state.isAvailable = availableIDs.contains(device.id)
+            peerStates[device.id] = state
+            if !state.isAvailable { removeRemoteSnapshots(device.id) }
+        }
+        rebuildNearbyDevices(found: found)
+    }
+
+    private func rebuildNearbyDevices(found: [String: (name: String, endpoint: NWEndpoint)]? = nil) {
+        let pairedIDs = Set(pairedDevices.map(\.id))
+        if let found { discoveredNames = found.mapValues(\.name) }
+        nearbyDevices = endpoints.map { id, _ in
+            LANNearbyDevice(id: id, name: discoveredNames[id] ?? "Mac", isPaired: pairedIDs.contains(id))
+        }.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        launchTask { [weak self] in await self?.handleIncoming(connection) }
+    }
+
+    private func handleIncoming(_ connection: NWConnection) async {
+        let channel = LANFramedChannel(connection: connection)
+        defer { Task { await channel.cancel() } }
+        do {
+            let hello = try await channel.receive(LANSyncProtocol.Hello.self)
+            guard hello.version == LANSyncProtocol.version, hello.deviceID != deviceID else {
+                throw LANSyncProtocol.ProtocolError.incompatibleVersion
+            }
+            switch hello.mode {
+            case .pair: try await handleIncomingPair(hello, channel: channel)
+            case .sync: try await handleIncomingSync(hello, channel: channel)
+            }
+        } catch {
+            AppLog.warn(.localAPI, "LAN sync incoming connection failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleIncomingPair(_ hello: LANSyncProtocol.Hello, channel: LANFramedChannel) async throws {
+        let privateKey = Curve25519.KeyAgreement.PrivateKey()
+        let serverHello = LANSyncProtocol.ServerHello(
+            version: LANSyncProtocol.version,
+            deviceID: deviceID,
+            displayName: deviceName,
+            publicKey: privateKey.publicKey.rawRepresentation,
+            nonce: try LANSyncProtocol.randomBytes(count: 32),
+            proof: nil
+        )
+        try await channel.send(serverHello)
+        let context = try LANSyncProtocol.context(clientHello: hello, serverHello: serverHello, privateKey: privateKey)
+        let requestID = UUID()
+        incomingPairRequests.append(LANIncomingPairRequest(
+            id: requestID,
+            deviceID: hello.deviceID,
+            name: hello.displayName,
+            code: context.code
+        ))
+        let approvalTimeout = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(120))
+            self?.finishApproval(requestID, approved: false)
+        }
+        let approved = await withCheckedContinuation { approvalContinuations[requestID] = $0 }
+        approvalTimeout.cancel()
+        incomingPairRequests.removeAll { $0.id == requestID }
+        guard approved else {
+            try await channel.send(LANSyncProtocol.PairDecision(accepted: false, sealedSecret: nil))
+            return
+        }
+        let secret = try LANSyncProtocol.randomBytes(count: 32)
+        try secretStore.store(secret, for: hello.deviceID)
+        remember(LANPairedDevice(id: hello.deviceID, name: hello.displayName))
+        let sealed = try LANSyncProtocol.seal(LANSyncProtocol.PairSecretPayload(secret: secret), using: context.key)
+        try await channel.send(LANSyncProtocol.PairDecision(accepted: true, sealedSecret: sealed))
+        AppLog.info(.localAPI, "LAN sync paired with \(hello.displayName)")
+    }
+
+    private func handleIncomingSync(_ hello: LANSyncProtocol.Hello, channel: LANFramedChannel) async throws {
+        guard let secret = try secretStore.secret(for: hello.deviceID),
+              pairedDevices.contains(where: { $0.id == hello.deviceID }) else {
+            throw LANSyncProtocol.ProtocolError.missingPairSecret
+        }
+        let privateKey = Curve25519.KeyAgreement.PrivateKey()
+        let unsigned = LANSyncProtocol.ServerHello(
+            version: LANSyncProtocol.version,
+            deviceID: deviceID,
+            displayName: deviceName,
+            publicKey: privateKey.publicKey.rawRepresentation,
+            nonce: try LANSyncProtocol.randomBytes(count: 32),
+            proof: nil
+        )
+        let context = try LANSyncProtocol.context(
+            clientHello: hello, serverHello: unsigned, privateKey: privateKey, pairSecret: secret
+        )
+        let serverHello = LANSyncProtocol.ServerHello(
+            version: unsigned.version, deviceID: unsigned.deviceID, displayName: unsigned.displayName,
+            publicKey: unsigned.publicKey, nonce: unsigned.nonce,
+            proof: LANSyncProtocol.proof(role: "server", transcript: context.transcript, pairSecret: secret)
+        )
+        try await channel.send(serverHello)
+        let clientProof = try await channel.receive(LANSyncProtocol.AuthProof.self)
+        guard LANSyncProtocol.verify(
+            clientProof.proof, role: "client", transcript: context.transcript, pairSecret: secret
+        ) else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
+        let payload = LANSyncProtocol.SnapshotPayload(
+            version: LANSyncProtocol.version,
+            deviceID: deviceID,
+            generatedAt: Date(),
+            snapshots: localSnapshots()
+        )
+        try await channel.sendFrame(try LANSyncProtocol.seal(payload, using: context.key))
+    }
+
+    private func performPairing(deviceID remoteID: String, name: String, endpoint: NWEndpoint) async {
+        let channel = LANFramedChannel(connection: NWConnection(to: endpoint, using: .tcp), timeout: 120)
+        defer { Task { await channel.cancel() } }
+        do {
+            let privateKey = Curve25519.KeyAgreement.PrivateKey()
+            let hello = LANSyncProtocol.Hello(
+                version: LANSyncProtocol.version,
+                mode: .pair,
+                deviceID: deviceID,
+                displayName: deviceName,
+                publicKey: privateKey.publicKey.rawRepresentation,
+                nonce: try LANSyncProtocol.randomBytes(count: 32)
+            )
+            try await channel.send(hello)
+            let serverHello = try await channel.receive(LANSyncProtocol.ServerHello.self)
+            guard serverHello.deviceID == remoteID else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
+            let context = try LANSyncProtocol.context(clientHello: hello, serverHello: serverHello, privateKey: privateKey)
+            outgoingPairing = .compareCode(name: name, code: context.code)
+            let decision = try await channel.receive(LANSyncProtocol.PairDecision.self)
+            guard decision.accepted, let sealed = decision.sealedSecret else {
+                throw LANSyncProtocol.ProtocolError.pairingDenied
+            }
+            let payload = try LANSyncProtocol.open(
+                LANSyncProtocol.PairSecretPayload.self, sealed: sealed, using: context.key
+            )
+            try secretStore.store(payload.secret, for: remoteID)
+            remember(LANPairedDevice(id: remoteID, name: serverHello.displayName))
+            outgoingPairing = nil
+            await sync(device: LANPairedDevice(id: remoteID, name: serverHello.displayName), endpoint: endpoint)
+        } catch {
+            outgoingPairing = .failed(name: name, message: error.localizedDescription)
+            AppLog.warn(.localAPI, "LAN sync pairing failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func sync(device: LANPairedDevice, endpoint: NWEndpoint) async {
+        var state = peerStates[device.id] ?? LANPeerSyncState(isAvailable: true)
+        guard !state.isSyncing else { return }
+        state.isAvailable = true
+        state.isSyncing = true
+        state.errorMessage = nil
+        peerStates[device.id] = state
+        let channel = LANFramedChannel(connection: NWConnection(to: endpoint, using: .tcp))
+        defer { Task { await channel.cancel() } }
+        do {
+            guard let secret = try secretStore.secret(for: device.id) else {
+                throw LANSyncProtocol.ProtocolError.missingPairSecret
+            }
+            let privateKey = Curve25519.KeyAgreement.PrivateKey()
+            let hello = LANSyncProtocol.Hello(
+                version: LANSyncProtocol.version,
+                mode: .sync,
+                deviceID: deviceID,
+                displayName: deviceName,
+                publicKey: privateKey.publicKey.rawRepresentation,
+                nonce: try LANSyncProtocol.randomBytes(count: 32)
+            )
+            try await channel.send(hello)
+            let serverHello = try await channel.receive(LANSyncProtocol.ServerHello.self)
+            guard serverHello.deviceID == device.id else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
+            let context = try LANSyncProtocol.context(
+                clientHello: hello, serverHello: serverHello, privateKey: privateKey, pairSecret: secret
+            )
+            guard let proof = serverHello.proof, LANSyncProtocol.verify(
+                proof, role: "server", transcript: context.transcript, pairSecret: secret
+            ) else { throw LANSyncProtocol.ProtocolError.authenticationFailed }
+            try await channel.send(LANSyncProtocol.AuthProof(
+                proof: LANSyncProtocol.proof(role: "client", transcript: context.transcript, pairSecret: secret)
+            ))
+            let sealed = try await channel.receiveFrame()
+            let payload = try LANSyncProtocol.open(
+                LANSyncProtocol.SnapshotPayload.self, sealed: sealed, using: context.key
+            )
+            guard payload.version == LANSyncProtocol.version, payload.deviceID == device.id else {
+                throw LANSyncProtocol.ProtocolError.authenticationFailed
+            }
+            applyRemoteSnapshots(device.id, payload.snapshots)
+            state.isSyncing = false
+            state.lastSyncedAt = Date()
+            state.errorMessage = nil
+            peerStates[device.id] = state
+        } catch {
+            removeRemoteSnapshots(device.id)
+            state.isSyncing = false
+            state.errorMessage = error.localizedDescription
+            peerStates[device.id] = state
+            AppLog.warn(.localAPI, "LAN sync fetch from \(device.name) failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func finishApproval(_ requestID: UUID, approved: Bool) {
+        approvalContinuations.removeValue(forKey: requestID)?.resume(returning: approved)
+    }
+
+    private func remember(_ device: LANPairedDevice) {
+        pairedDevices.removeAll { $0.id == device.id }
+        pairedDevices.append(device)
+        pairedDevices.sort { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+        var state = peerStates[device.id] ?? LANPeerSyncState()
+        state.isAvailable = endpoints[device.id] != nil
+        peerStates[device.id] = state
+        persistPairedDevices()
+        rebuildNearbyDevices()
+    }
+
+    private func persistPairedDevices() {
+        do { defaults.set(try JSONEncoder().encode(pairedDevices), forKey: Self.pairedDevicesKey) }
+        catch { AppLog.error(.config, "LAN paired-device save failed: \(error.localizedDescription)") }
+    }
+
+    private static func loadPairedDevices(defaults: UserDefaults) -> [LANPairedDevice] {
+        guard let data = defaults.data(forKey: pairedDevicesKey) else { return [] }
+        do { return try JSONDecoder().decode([LANPairedDevice].self, from: data) }
+        catch {
+            AppLog.error(.config, "LAN paired-device load failed: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    private func launchTask(_ operation: @escaping @MainActor () async -> Void) {
+        let id = UUID()
+        runningTasks[id] = Task { [weak self] in
+            await operation()
+            self?.runningTasks[id] = nil
+        }
+    }
+
+    private func serviceName(from endpoint: NWEndpoint) -> String {
+        if case .service(let name, _, _, _) = endpoint { return name }
+        return "Mac"
+    }
+}

--- a/Sources/OpenUsage/Stores/LANSyncStore.swift
+++ b/Sources/OpenUsage/Stores/LANSyncStore.swift
@@ -23,6 +23,10 @@ final class LANSyncStore {
     private(set) var incomingPairRequests: [LANIncomingPairRequest] = []
     private(set) var outgoingPairing: LANOutgoingPairing?
     private(set) var peerStates: [String: LANPeerSyncState] = [:]
+    /// True while a pairing handshake or approval prompt is on screen. The panel's outside-click
+    /// policy keeps the popover open in this state so a click on a system dialog (or a stray click
+    /// while comparing codes) doesn't tear the pairing UI down mid-flow.
+    var isPairingActive: Bool { outgoingPairing != nil || !incomingPairRequests.isEmpty }
     private(set) var serviceError: String?
 
     let deviceID: String
@@ -167,7 +171,12 @@ final class LANSyncStore {
     }
 
     private func startBrowser() {
-        let browser = NWBrowser(for: .bonjour(type: LANSyncProtocol.serviceType, domain: nil), using: .tcp)
+        // .bonjourWithTXTRecord is required: a plain .bonjour browse returns results with no metadata,
+        // so the id/version filter below would silently drop every discovered Mac.
+        let browser = NWBrowser(
+            for: .bonjourWithTXTRecord(type: LANSyncProtocol.serviceType, domain: nil),
+            using: .tcp
+        )
         browser.stateUpdateHandler = { [weak self] state in
             Task { @MainActor in self?.browserStateChanged(state) }
         }

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -46,6 +46,21 @@ final class WidgetDataStore {
     private static let failureRetryBackoff: TimeInterval = 60
 
     var snapshots: [String: ProviderSnapshot] = [:]
+    /// Machine-local spend snapshots received from approved nearby Macs, keyed by the stable peer id.
+    /// These are memory-only: an unavailable Mac stops contributing immediately and remote data never
+    /// becomes part of this Mac's provider cache.
+    private var remoteSnapshotsByDevice: [String: [String: ProviderSnapshot]] = [:]
+
+    /// What every display/API surface should render: local account-wide metrics plus additive local-log
+    /// usage from currently available approved Macs. Pairing transport exports only shareable rows, so
+    /// quota/session meters can never be duplicated here.
+    var displaySnapshots: [String: ProviderSnapshot] {
+        LANUsageAggregator.combinedSnapshots(
+            local: snapshots,
+            remotes: remoteSnapshotsByDevice,
+            registry: registry
+        )
+    }
     var refreshingProviderIDs: Set<String> = []
     /// Wall-clock time the most recent full refresh pass finished. Together with the chosen refresh
     /// cadence it drives the dashboard footer's live "Next update in …" countdown, so the footer reflects
@@ -70,6 +85,9 @@ final class WidgetDataStore {
     /// bulk — so the recorder can roll daily usage and error counts up into one event per provider per
     /// day. `nil` (and so a no-op) in tests and previews. Not observable UI state.
     @ObservationIgnored var onRefreshOutcome: (@MainActor (String, RefreshOutcome, ErrorCategory?, Bool) -> Void)?
+    /// Post-pass hook used by LAN sync so launch, timer, popover-open, and manual refreshes all gather
+    /// nearby usage through the same path. Nil in tests/previews.
+    @ObservationIgnored var onRefreshCompleted: (@MainActor () async -> Void)?
 
     /// Global meter style: whether every bounded tile (and the menu-bar value) renders as "used" or
     /// "left/remaining". Persisted so the choice survives relaunch; defaults to `.remaining`.
@@ -153,6 +171,7 @@ final class WidgetDataStore {
         let cached = outcomes.count { $0 == .cacheHit }
         let backedOff = outcomes.count { $0 == .backedOff }
         AppLog.info(.refresh, "batch end (\(durationMs)ms, \(refreshed) ok / \(failed) failed / \(cached) cached / \(backedOff) backed off)")
+        await onRefreshCompleted?()
     }
 
     /// Evaluate every visible, enabled metric for a quota pace milestone and post a notification for any
@@ -295,7 +314,7 @@ final class WidgetDataStore {
 
     func data(for descriptor: WidgetDescriptor) -> WidgetData {
         var result: WidgetData
-        if let snapshot = snapshots[descriptor.providerID],
+        if let snapshot = displaySnapshots[descriptor.providerID],
            let line = snapshot.line(label: descriptor.metricLabel),
            let data = resolve(line, descriptor: descriptor) {
             result = data
@@ -318,7 +337,24 @@ final class WidgetDataStore {
     /// The plan label for a provider's latest snapshot. `nil` until a snapshot exists or when the
     /// provider doesn't expose a plan. Provider section headers render this beside the provider name.
     func plan(for providerID: String) -> String? {
-        snapshots[providerID]?.plan
+        displaySnapshots[providerID]?.plan
+    }
+
+    func setRemoteSnapshots(_ snapshots: [String: ProviderSnapshot], for deviceID: String) {
+        // Treat the wire as a system boundary even after authentication: an older/buggy peer cannot
+        // smuggle account-wide quota rows into aggregation.
+        remoteSnapshotsByDevice[deviceID] = LANUsageAggregator.shareableSnapshots(snapshots, registry: registry)
+    }
+
+    func removeRemoteSnapshots(for deviceID: String) {
+        remoteSnapshotsByDevice[deviceID] = nil
+    }
+
+    func shareableSnapshots() -> [String: ProviderSnapshot] {
+        LANUsageAggregator.shareableSnapshots(
+            snapshots.filter { isProviderEnabled($0.key) },
+            registry: registry
+        )
     }
 
     /// How long a displayed snapshot may age before the header calls it out. A healthy provider's

--- a/Sources/OpenUsage/Support/PopoverDismissReader.swift
+++ b/Sources/OpenUsage/Support/PopoverDismissReader.swift
@@ -156,6 +156,10 @@ enum MenuBarPopover {
     /// quota pace notification banner).
     static var showHandler: (() -> Void)?
 
+    /// Installed by `StatusItemController` at launch; opens the popover directly on the Settings
+    /// screen. Used by the redirect in the app's stub `Settings` scene (see `OpenUsageApp`).
+    static var showSettingsHandler: (() -> Void)?
+
     /// Auto-resize bridge — the "single clock". SwiftUI owns the animated height and the AppKit panel
     /// is a passive follower: `applyHeight` is called once per animation frame from a SwiftUI
     /// `Animatable` modifier with the interpolated height, and the controller hops it onto the main

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -229,7 +229,11 @@ struct SettingsScreen: View {
                 ForEach(lan.pairedDevices) { device in
                     pairedDeviceRow(device)
                 }
-                let unpaired = lan.nearbyDevices.filter { !$0.isPaired }
+                // A Mac already represented by a pairing card (incoming approval or an in-flight
+                // outgoing attempt) shouldn't also appear as a plain discovered row below it.
+                let representedIDs = Set(lan.incomingPairRequests.map(\.deviceID))
+                    .union(lan.outgoingPairing.map { [$0.deviceID] } ?? [])
+                let unpaired = lan.nearbyDevices.filter { !$0.isPaired && !representedIDs.contains($0.id) }
                 ForEach(unpaired) { device in
                     nearbyDeviceRow(device)
                 }
@@ -249,19 +253,19 @@ struct SettingsScreen: View {
         VStack(alignment: .leading, spacing: 8) {
             Divider()
             switch pairing {
-            case .connecting(let name):
+            case .connecting(_, let name):
                 HStack(spacing: 8) {
                     ProgressView().controlSize(.small)
                     Text("Connecting to \(name)…")
                 }
-            case .compareCode(let name, let code):
+            case .compareCode(_, let name, let code):
                 Text("Compare this code on \(name), then approve there.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Text(code)
                     .font(.title2.monospacedDigit().weight(.semibold))
                     .textSelection(.enabled)
-            case .failed(let name, let message):
+            case .failed(_, let name, let message):
                 Text("Couldn't connect to \(name)").fontWeight(.medium)
                 Text(message).font(.caption).foregroundStyle(.secondary)
                 Button("Dismiss") { container.lanSync.dismissPairingStatus() }

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -68,6 +68,7 @@ struct SettingsScreen: View {
                         .hoverTooltip("Open OpenUsage from anywhere")
                 }
             }
+            nearbyMacsSection
             section("Appearance") {
                 row("Icon Style") {
                     picker($layout.menuBarStyle, options: MenuBarStyle.allCases, label: \.label)
@@ -197,6 +198,144 @@ struct SettingsScreen: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             Task { await refreshNotificationsAuth() }
         }
+    }
+
+    // MARK: - Nearby Macs
+
+    private var nearbyMacsSection: some View {
+        @Bindable var lan = container.lanSync
+        return section("Nearby Macs") {
+            row("Share Across Macs") {
+                Toggle("", isOn: $lan.enabled)
+                    .settingsSwitchStyle()
+            }
+            Text("Discovers OpenUsage on your local network and combines machine-local tokens and spend. Account limits, credentials, and raw logs are never shared.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.bottom, lan.enabled ? 8 : 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if lan.enabled {
+                if let error = lan.serviceError {
+                    inlineNotice(error)
+                }
+                if let pairing = lan.outgoingPairing {
+                    pairingStatus(pairing)
+                }
+                ForEach(lan.incomingPairRequests) { request in
+                    incomingPairing(request)
+                }
+                ForEach(lan.pairedDevices) { device in
+                    pairedDeviceRow(device)
+                }
+                let unpaired = lan.nearbyDevices.filter { !$0.isPaired }
+                ForEach(unpaired) { device in
+                    nearbyDeviceRow(device)
+                }
+                if lan.pairedDevices.isEmpty && unpaired.isEmpty && lan.incomingPairRequests.isEmpty {
+                    Text("No other Macs found yet. Turn on Share Across Macs in OpenUsage on both computers.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 10)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private func pairingStatus(_ pairing: LANOutgoingPairing) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+            switch pairing {
+            case .connecting(let name):
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Connecting to \(name)…")
+                }
+            case .compareCode(let name, let code):
+                Text("Compare this code on \(name), then approve there.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(code)
+                    .font(.title2.monospacedDigit().weight(.semibold))
+                    .textSelection(.enabled)
+            case .failed(let name, let message):
+                Text("Couldn't connect to \(name)").fontWeight(.medium)
+                Text(message).font(.caption).foregroundStyle(.secondary)
+                Button("Dismiss") { container.lanSync.dismissPairingStatus() }
+                    .buttonStyle(.bordered)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func incomingPairing(_ request: LANIncomingPairRequest) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+            Text("Connect \(request.name)?").fontWeight(.medium)
+            Text("Only approve if this code matches on both Macs.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(request.code)
+                .font(.title2.monospacedDigit().weight(.semibold))
+                .textSelection(.enabled)
+            HStack {
+                Button("Don't Allow") { container.lanSync.denyPairing(request.id) }
+                    .buttonStyle(.bordered)
+                Button("Allow") { container.lanSync.approvePairing(request.id) }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func pairedDeviceRow(_ device: LANPairedDevice) -> some View {
+        let state = container.lanSync.peerStates[device.id] ?? LANPeerSyncState()
+        return HStack(spacing: 8) {
+            Circle()
+                .fill(state.isAvailable ? Color.green : Color.secondary.opacity(0.45))
+                .frame(width: 7, height: 7)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(device.name)
+                Text(peerStatusText(state))
+                    .font(.caption)
+                    .foregroundStyle(state.errorMessage == nil ? Color.secondary : Color.orange)
+            }
+            Spacer(minLength: 8)
+            if state.isSyncing { ProgressView().controlSize(.small) }
+            Button("Forget") { container.lanSync.forget(device.id) }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+
+    private func nearbyDeviceRow(_ device: LANNearbyDevice) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "desktopcomputer")
+                .foregroundStyle(.secondary)
+            Text(device.name)
+            Spacer(minLength: 8)
+            Button("Connect") { container.lanSync.pair(with: device.id) }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+
+    private func peerStatusText(_ state: LANPeerSyncState) -> String {
+        if let error = state.errorMessage { return error }
+        if state.isSyncing { return "Syncing…" }
+        if state.lastSyncedAt != nil { return state.isAvailable ? "Connected" : "Unavailable" }
+        return state.isAvailable ? "Ready" : "Unavailable"
     }
 
     // MARK: - Notifications

--- a/Sources/OpenUsage/Views/TotalSpendCard.swift
+++ b/Sources/OpenUsage/Views/TotalSpendCard.swift
@@ -42,7 +42,7 @@ struct TotalSpendCard: View {
     }
 
     private var total: TotalSpend {
-        TotalSpendAggregator.total(for: period, providers: providers, snapshots: dataStore.snapshots)
+        TotalSpendAggregator.total(for: period, providers: providers, snapshots: dataStore.displaySnapshots)
     }
 
     private var projection: TotalSpendProjection {

--- a/Tests/OpenUsageTests/LANSyncProtocolTests.swift
+++ b/Tests/OpenUsageTests/LANSyncProtocolTests.swift
@@ -1,0 +1,71 @@
+import CryptoKit
+import XCTest
+@testable import OpenUsage
+
+final class LANSyncProtocolTests: XCTestCase {
+    func testPairingDerivesMatchingCodeAndEncryptedSession() throws {
+        let clientKey = Curve25519.KeyAgreement.PrivateKey()
+        let serverKey = Curve25519.KeyAgreement.PrivateKey()
+        let client = LANSyncProtocol.Hello(
+            version: LANSyncProtocol.version,
+            mode: .pair,
+            deviceID: "client",
+            displayName: "Studio Mac",
+            publicKey: clientKey.publicKey.rawRepresentation,
+            nonce: Data(repeating: 1, count: 32)
+        )
+        let server = LANSyncProtocol.ServerHello(
+            version: LANSyncProtocol.version,
+            deviceID: "server",
+            displayName: "MacBook Pro",
+            publicKey: serverKey.publicKey.rawRepresentation,
+            nonce: Data(repeating: 2, count: 32),
+            proof: nil
+        )
+
+        let clientContext = try LANSyncProtocol.context(
+            clientHello: client, serverHello: server, privateKey: clientKey
+        )
+        let serverContext = try LANSyncProtocol.context(
+            clientHello: client, serverHello: server, privateKey: serverKey
+        )
+
+        XCTAssertEqual(clientContext.code, serverContext.code)
+        XCTAssertEqual(clientContext.code.count, 6)
+        let sealed = try LANSyncProtocol.seal(["message": "private"], using: clientContext.key)
+        let opened = try LANSyncProtocol.open([String: String].self, sealed: sealed, using: serverContext.key)
+        XCTAssertEqual(opened, ["message": "private"])
+    }
+
+    func testPairedProofsAreRoleBoundAndRejectAnotherSecret() throws {
+        let transcript = Data("bound transcript".utf8)
+        let secret = Data(repeating: 7, count: 32)
+        let wrongSecret = Data(repeating: 8, count: 32)
+        let proof = LANSyncProtocol.proof(role: "server", transcript: transcript, pairSecret: secret)
+
+        XCTAssertTrue(LANSyncProtocol.verify(proof, role: "server", transcript: transcript, pairSecret: secret))
+        XCTAssertFalse(LANSyncProtocol.verify(proof, role: "client", transcript: transcript, pairSecret: secret))
+        XCTAssertFalse(LANSyncProtocol.verify(proof, role: "server", transcript: transcript, pairSecret: wrongSecret))
+    }
+
+    func testPairingCodeBindsAdvertisedIdentity() throws {
+        let clientKey = Curve25519.KeyAgreement.PrivateKey()
+        let serverKey = Curve25519.KeyAgreement.PrivateKey()
+        let client = LANSyncProtocol.Hello(
+            version: LANSyncProtocol.version, mode: .pair, deviceID: "client", displayName: "Mac A",
+            publicKey: clientKey.publicKey.rawRepresentation, nonce: Data(repeating: 3, count: 32)
+        )
+        let server = LANSyncProtocol.ServerHello(
+            version: LANSyncProtocol.version, deviceID: "server", displayName: "Mac B",
+            publicKey: serverKey.publicKey.rawRepresentation, nonce: Data(repeating: 4, count: 32), proof: nil
+        )
+        let renamed = LANSyncProtocol.ServerHello(
+            version: server.version, deviceID: server.deviceID, displayName: "Spoofed Mac",
+            publicKey: server.publicKey, nonce: server.nonce, proof: nil
+        )
+
+        let expected = try LANSyncProtocol.context(clientHello: client, serverHello: server, privateKey: clientKey)
+        let tampered = try LANSyncProtocol.context(clientHello: client, serverHello: renamed, privateKey: clientKey)
+        XCTAssertNotEqual(expected.transcript, tampered.transcript)
+    }
+}

--- a/Tests/OpenUsageTests/LANSyncStoreIntegrationTests.swift
+++ b/Tests/OpenUsageTests/LANSyncStoreIntegrationTests.swift
@@ -58,7 +58,7 @@ final class LANSyncStoreIntegrationTests: XCTestCase {
             if case .compareCode = storeA.outgoingPairing { return !storeB.incomingPairRequests.isEmpty }
             return false
         }
-        guard case .compareCode(_, let codeA) = storeA.outgoingPairing,
+        guard case .compareCode(_, _, let codeA) = storeA.outgoingPairing,
               let request = storeB.incomingPairRequests.first else {
             return XCTFail("expected code on both peers")
         }

--- a/Tests/OpenUsageTests/LANSyncStoreIntegrationTests.swift
+++ b/Tests/OpenUsageTests/LANSyncStoreIntegrationTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import XCTest
+@testable import OpenUsage
+
+/// Real Bonjour + TCP integration. Opt-in because hosted CI environments often block multicast DNS.
+/// Run locally with `OPENUSAGE_RUN_LAN_INTEGRATION=1 swift test --filter LANSyncStoreIntegrationTests`.
+@MainActor
+final class LANSyncStoreIntegrationTests: XCTestCase {
+    func testTwoStoresDiscoverPairAndExchangeEncryptedSnapshots() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["OPENUSAGE_RUN_LAN_INTEGRATION"] == "1",
+            "Set OPENUSAGE_RUN_LAN_INTEGRATION=1 to exercise local Bonjour networking."
+        )
+        let defaultsA = makeDefaults("A")
+        let defaultsB = makeDefaults("B")
+        defer {
+            defaultsA.removePersistentDomain(forName: defaultsASuite)
+            defaultsB.removePersistentDomain(forName: defaultsBSuite)
+        }
+        var receivedByA: [String: ProviderSnapshot] = [:]
+        var receivedByB: [String: ProviderSnapshot] = [:]
+        let snapshotA = snapshot(device: "A", tokens: 100)
+        let snapshotB = snapshot(device: "B", tokens: 250)
+        let storeA = LANSyncStore(
+            defaults: defaultsA,
+            secretStore: MemoryLANSecretStore(),
+            localSnapshots: { ["test": snapshotA] },
+            applyRemoteSnapshots: { _, snapshots in receivedByA = snapshots },
+            removeRemoteSnapshots: { _ in receivedByA = [:] }
+        )
+        let storeB = LANSyncStore(
+            defaults: defaultsB,
+            secretStore: MemoryLANSecretStore(),
+            localSnapshots: { ["test": snapshotB] },
+            applyRemoteSnapshots: { _, snapshots in receivedByB = snapshots },
+            removeRemoteSnapshots: { _ in receivedByB = [:] }
+        )
+        defer {
+            storeA.enabled = false
+            storeB.enabled = false
+        }
+
+        storeA.enabled = true
+        storeB.enabled = true
+        try await waitUntil("Bonjour listeners to register") {
+            storeA.testingListenerEndpoint != nil && storeB.testingListenerEndpoint != nil
+        }
+        guard let endpointA = storeA.testingListenerEndpoint,
+              let endpointB = storeB.testingListenerEndpoint else {
+            return XCTFail("expected listener endpoints")
+        }
+
+        // Hosted test runners can deny multicast browsing even though both Bonjour listeners register.
+        // Connect through their real listener ports so the full pairing/auth/encryption transport still
+        // runs over Network.framework rather than falling back to a mock channel.
+        storeA.pairForTesting(deviceID: storeB.deviceID, name: storeB.deviceName, endpoint: endpointB)
+        try await waitUntil("pairing code") {
+            if case .compareCode = storeA.outgoingPairing { return !storeB.incomingPairRequests.isEmpty }
+            return false
+        }
+        guard case .compareCode(_, let codeA) = storeA.outgoingPairing,
+              let request = storeB.incomingPairRequests.first else {
+            return XCTFail("expected code on both peers")
+        }
+        XCTAssertEqual(codeA, request.code)
+        storeB.approvePairing(request.id)
+
+        try await waitUntil("pairing and first encrypted sync") {
+            storeA.pairedDevices.contains(where: { $0.id == storeB.deviceID })
+                && storeB.pairedDevices.contains(where: { $0.id == storeA.deviceID })
+                && receivedByA["test"] != nil
+        }
+        XCTAssertEqual(tokenCount(in: receivedByA["test"]), 250)
+
+        await storeB.syncForTesting(
+            device: LANPairedDevice(id: storeA.deviceID, name: storeA.deviceName),
+            endpoint: endpointA
+        )
+        try await waitUntil("reverse encrypted sync") { receivedByB["test"] != nil }
+        XCTAssertEqual(tokenCount(in: receivedByB["test"]), 100)
+    }
+
+    private let defaultsASuite = "OpenUsageTests.LANSync.Integration.A"
+    private let defaultsBSuite = "OpenUsageTests.LANSync.Integration.B"
+
+    private func makeDefaults(_ suffix: String) -> UserDefaults {
+        let name = suffix == "A" ? defaultsASuite : defaultsBSuite
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    private func snapshot(device: String, tokens: Double) -> ProviderSnapshot {
+        ProviderSnapshot(
+            providerID: "test",
+            displayName: "Test",
+            lines: [.values(label: "Today", values: [
+                MetricValue(number: tokens, kind: .count, label: "tokens")
+            ])],
+            warning: device
+        )
+    }
+
+    private func tokenCount(in snapshot: ProviderSnapshot?) -> Double? {
+        guard let line = snapshot?.line(label: "Today"),
+              case .values(_, let values, _, _, _, _) = line else { return nil }
+        return values.first(where: { $0.kind == .count })?.number
+    }
+
+    private func waitUntil(
+        _ description: String,
+        timeout: Duration = .seconds(15),
+        condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition() {
+            guard clock.now < deadline else {
+                XCTFail("Timed out waiting for \(description)")
+                throw IntegrationError.timeout(description)
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+    }
+
+    private enum IntegrationError: Error { case timeout(String) }
+}
+
+private final class MemoryLANSecretStore: LANSyncSecretStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String: Data] = [:]
+
+    func secret(for deviceID: String) throws -> Data? {
+        lock.withLock { values[deviceID] }
+    }
+
+    func store(_ secret: Data, for deviceID: String) throws {
+        lock.withLock { values[deviceID] = secret }
+    }
+
+    func deleteSecret(for deviceID: String) throws {
+        lock.withLock { values[deviceID] = nil }
+    }
+}

--- a/Tests/OpenUsageTests/LANUsageAggregatorTests.swift
+++ b/Tests/OpenUsageTests/LANUsageAggregatorTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import OpenUsage
+
+final class LANUsageAggregatorTests: XCTestCase {
+    private let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("test"))
+
+    func testShareableSnapshotsExcludeAccountWideQuota() {
+        let registry = makeRegistry()
+        let snapshot = makeSnapshot(quota: 42, tokens: 100, dollars: 1.5, chart: 100)
+
+        let shared = LANUsageAggregator.shareableSnapshots(["test": snapshot], registry: registry)
+
+        XCTAssertNil(shared["test"]?.line(label: "Session"))
+        XCTAssertNotNil(shared["test"]?.line(label: "Today"))
+        XCTAssertNotNil(shared["test"]?.line(label: "Usage Trend"))
+        XCTAssertNil(shared["test"]?.plan)
+        XCTAssertNil(shared["test"]?.warning)
+    }
+
+    func testCombiningPeersSumsOnlyLocalUsageAndKeepsLocalQuota() {
+        let registry = makeRegistry()
+        let local = makeSnapshot(quota: 42, tokens: 100, dollars: 1.5, chart: 100)
+        // The remote quota is included deliberately to prove the aggregator still refuses to merge it.
+        let remote = makeSnapshot(quota: 90, tokens: 250, dollars: 3.25, chart: 250)
+
+        let combined = LANUsageAggregator.combinedSnapshots(
+            local: ["test": local],
+            remotes: ["remote-device": ["test": remote]],
+            registry: registry
+        )["test"]
+
+        guard let quotaLine = combined?.line(label: "Session"),
+              case .progress(_, let used, _, _, _, _, _) = quotaLine else {
+            return XCTFail("expected local quota")
+        }
+        XCTAssertEqual(used, 42)
+
+        guard let spendLine = combined?.line(label: "Today"),
+              case .values(_, let values, _, _, _, _) = spendLine else {
+            return XCTFail("expected combined spend")
+        }
+        XCTAssertEqual(values.first(where: { $0.kind == .count })?.number, 350)
+        XCTAssertEqual(values.first(where: { $0.kind == .dollars })?.number, 4.75)
+
+        guard let chartLine = combined?.line(label: "Usage Trend"),
+              case .chart(_, let points, let note) = chartLine else {
+            return XCTFail("expected combined trend")
+        }
+        XCTAssertEqual(points.single?.value, 350)
+        XCTAssertEqual(note, "Local usage across connected Macs")
+    }
+
+    func testRemoteOnlyProviderStillCannotSupplyQuotaOrPlan() {
+        let remote = makeSnapshot(quota: 90, tokens: 250, dollars: 3.25, chart: 250)
+        let combined = LANUsageAggregator.combinedSnapshots(
+            local: [:],
+            remotes: ["remote-device": ["test": remote]],
+            registry: makeRegistry()
+        )["test"]
+
+        XCTAssertNil(combined?.line(label: "Session"))
+        XCTAssertNil(combined?.plan)
+        XCTAssertNil(combined?.warning)
+        XCTAssertNotNil(combined?.line(label: "Today"))
+    }
+
+    private func makeRegistry() -> WidgetRegistry {
+        WidgetRegistry(
+            providers: [provider],
+            descriptors: [
+                .percent(id: "test.session", provider: provider, title: "Session"),
+                WidgetDescriptor.spendTiles(provider: provider)[0],
+                .usageTrend(provider: provider)
+            ]
+        )
+    }
+
+    private func makeSnapshot(quota: Double, tokens: Double, dollars: Double, chart: Double) -> ProviderSnapshot {
+        ProviderSnapshot(
+            providerID: provider.id,
+            displayName: provider.displayName,
+            plan: "Pro",
+            lines: [
+                .progress(label: "Session", used: quota, limit: 100, format: .percent),
+                .values(label: "Today", values: [
+                    MetricValue(number: dollars, kind: .dollars, estimated: true),
+                    MetricValue(number: tokens, kind: .count, label: "tokens")
+                ]),
+                .chart(label: "Usage Trend", points: [
+                    MetricChartPoint(value: chart, label: "Jul 12", valueLabel: "\(Int(chart)) tokens")
+                ], note: "Local")
+            ],
+            warning: "Local warning"
+        )
+    }
+}
+
+private extension Collection {
+    var single: Element? { count == 1 ? first : nil }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ What the app does and how it behaves. These pages describe **behavior, not visua
 - [Dashboard](dashboard.md) — the popover: rows, toggles, reordering, keyboard shortcuts
 - [Menu bar](menu-bar.md) — pinning metrics into the menu bar
 - [Settings](settings.md) — every option, what it changes
+- [Nearby Macs](nearby-macs.md) — securely combine machine-local usage over your local network
 - [Refreshing & caching](refreshing.md) — when data updates and what happens when a fetch fails
 - [Model pricing](pricing.md) — how spend tiles price tokens, and where the rates come from
 - [Updates](updates.md) — automatic updates, manual checks, and the beta channel

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,17 @@ The UI reads from a few observable stores:
 Refresh runs on a timer in `AppContainer`; each pass respects the cache, so the network is only hit once a
 snapshot has actually expired.
 
+## Nearby Mac sync
+
+`LANSyncStore` uses Bonjour through Network.framework to advertise and discover OpenUsage on the local
+network. Pairing is explicit: both sides derive a short comparison code from an ephemeral key exchange,
+and the receiving Mac must approve it. The saved per-device secret lives in Keychain. Later refreshes use
+that secret to authenticate both peers and encrypt a fresh ephemeral session.
+
+Only `SpendTileMapper` rows and Usage Trend charts cross the wire. `LANUsageAggregator` sums those
+machine-local values while leaving account-wide quota meters local. Received snapshots stay in memory;
+`ProviderSnapshotCache` continues to contain this Mac's data only.
+
 ## The AppKit bridge
 
 macOS menu-bar apps live in an `NSStatusItem`. OpenUsage shows its content in a custom, key-capable

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -2,6 +2,9 @@
 
 OpenUsage exposes a read-only HTTP API on the loopback interface so other local apps can consume the same usage data shown in the menu bar.
 
+When [Nearby Macs](nearby-macs.md) is enabled, the API reflects the same combined machine-local usage as
+the dashboard. It remains bound to loopback and is never exposed to the local network.
+
 **Base URL:** `http://127.0.0.1:6736`
 
 The server starts automatically with the app. If the port is already in use, the feature is silently disabled for that session.

--- a/docs/nearby-macs.md
+++ b/docs/nearby-macs.md
@@ -1,0 +1,41 @@
+# Nearby Macs
+
+OpenUsage can combine machine-local usage from several Macs on the same local network. There is no
+cloud account or relay: the Macs find and talk to each other directly.
+
+## Connect two Macs
+
+1. Open **Settings → Nearby Macs** on both computers.
+2. Turn on **Share Across Macs**. macOS asks for Local Network permission the first time.
+3. When the other Mac appears, click **Connect**.
+4. Compare the six-digit code shown on both Macs, then click **Allow** on the receiving Mac.
+
+The connection stays approved until you click **Forget**. Turning Share Across Macs off pauses all
+discovery and sharing without forgetting approved Macs.
+
+## What gets combined
+
+OpenUsage adds the usage each computer measures from its own local history:
+
+- Today, Yesterday, and Last 30 Days cost/token totals
+- Usage Trend day totals
+
+Account-wide limits such as Session and Weekly are not added. Those values already describe the whole
+provider account, so adding the same limit from several Macs would be wrong. They continue to come from
+the Mac whose menu bar you are viewing.
+
+Nearby usage updates after each normal or manual refresh. When a Mac leaves the network, its contribution
+is removed until it becomes available and syncs again. Remote snapshots are kept only in memory and are
+never written into the local provider cache.
+
+## Security and privacy
+
+- Discovery uses Bonjour and is off until you enable it.
+- Pairing requires a matching code and approval on the receiving Mac.
+- Each approved pair gets its own secret saved in the macOS Keychain.
+- Every later refresh authenticates both Macs and encrypts the usage payload.
+- Provider credentials, cookies, API keys, and raw log files never leave their Mac.
+- No OpenUsage server or other internet service is involved.
+
+If a Mac is lost or no longer trusted, click **Forget** beside it. This deletes that pair's saved key and
+stops its data from contributing.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -33,6 +33,13 @@ The cache is never used after logout, an account change, or while Keychain acces
 
 Besides the provider API calls the vendor's own tools would make, OpenUsage fetches public [model price lists](pricing.md) about once an hour (from `raw.githubusercontent.com`, `models.dev`, and this project's GitHub Pages). These are plain downloads of public data — they carry no usage, log, or account information, and they run regardless of the Share Anonymous Usage setting. The spend tiles are computed from local CLI logs entirely on your Mac; no log data ever leaves it.
 
+## Nearby Macs
+
+[Nearby Macs](nearby-macs.md) is off by default. When enabled, OpenUsage uses Bonjour on your local network
+to find other copies of OpenUsage. Only Macs you explicitly approve can exchange normalized local
+cost/token totals and usage trends. Transfers are authenticated and encrypted directly between the Macs;
+credentials and raw logs are never shared, and no external service is involved.
+
 ## How it works
 
 - Data is fully anonymous: OpenUsage never identifies you to the analytics service and creates no user profile.

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -3,6 +3,7 @@
 ## When data updates
 
 - All enabled providers refresh together: once at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Opening the popover does not start a second automatic pass. Providers fetch in parallel — one slow provider doesn't delay the others.
+- After each refresh, approved [Nearby Macs](nearby-macs.md) that are currently available are asked for their machine-local usage. A manual refresh does this too.
 - Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running.
 - The Dashboard and Settings footer shows `Next update in Nm`. **Clicking it (or pressing ⌘R while that footer is present)** refreshes immediately, skipping the cache.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -22,6 +22,15 @@ Settings lives inside the popover — there is no separate window. Open it from 
 | Time Format | Auto / 12-hour / 24-hour | How exact times read (e.g. "Resets today at 6:38 PM" vs "18:38"). Auto follows the system. |
 | Increase Transparency | Off / On | Off (default) keeps the popover a solid panel. On makes it translucent so your desktop shows through, while keeping the numbers and Options control legible with adaptive frosted surfaces. It pauses automatically when you have the macOS **Reduce Transparency** or **Increase Contrast** accessibility setting turned on (a note explains why), so it never works against those preferences. |
 
+## Nearby Macs
+
+| Setting | Options | What it does |
+|---|---|---|
+| Share Across Macs | On / Off | Discovers OpenUsage on the local network and combines machine-local token and spend history from Macs you approve. Off by default. |
+
+Connecting requires a matching six-digit code and approval on the receiving Mac. Approved devices can be
+removed with **Forget**. See [Nearby Macs](nearby-macs.md) for what is shared and how it is protected.
+
 ## Usage Display
 
 | Setting | Options | What it does |

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -130,6 +130,12 @@ cat >"$INFO_PLIST" <<PLIST
   <string>NSApplication</string>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>OpenUsage uses your local network to discover approved Macs and combine their machine-local usage.</string>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_openusage._tcp</string>
+  </array>
 </dict>
 </plist>
 PLIST

--- a/script/release.sh
+++ b/script/release.sh
@@ -166,6 +166,8 @@ cat >"$APP_CONTENTS/Info.plist" <<PLIST
   <key>LSUIElement</key><true/>
   <key>NSPrincipalClass</key><string>NSApplication</string>
   <key>NSHighResolutionCapable</key><true/>
+  <key>NSLocalNetworkUsageDescription</key><string>OpenUsage uses your local network to discover approved Macs and combine their machine-local usage.</string>
+  <key>NSBonjourServices</key><array><string>_openusage._tcp</string></array>
   <key>SUFeedURL</key><string>$FEED_URL</string>
   <key>SUPublicEDKey</key><string>$SPARKLE_PUBLIC_KEY</string>
   <key>SUEnableAutomaticChecks</key><true/>


### PR DESCRIPTION
## TL;DR

Adds opt-in, same-network usage aggregation between approved Macs. OpenUsage discovers peers with Bonjour, pairs them with a comparison code, encrypts every transfer, and combines only machine-local spend/token history so account-wide quotas are never double-counted.

## What was happening

- OpenUsage could read usage from only the Mac it was running on.
- People using provider CLIs across several computers had no built-in way to combine local token/spend history.
- The loopback API could expose the current Mac's normalized snapshots, but it was intentionally unavailable to the LAN and had no pairing or authentication model.

## What this changes

- Adds a **Nearby Macs** Settings section with an off-by-default **Share Across Macs** toggle, discovery, Connect, matching-code approval, status, and Forget controls.
- Advertises and browses `_openusage._tcp` with Network.framework/Bonjour and adds the macOS Local Network privacy declarations to development and release bundles.
- Uses ephemeral Curve25519 key agreement for pairing/session keys, a six-digit comparison code, per-device secrets stored in Keychain, HMAC mutual authentication, and ChaCha20-Poly1305 payload encryption.
- Exports only normalized Today / Yesterday / Last 30 Days values and Usage Trend points. Credentials, cookies, API keys, raw logs, plans, warnings, and account-wide quota meters stay on their Mac.
- Keeps received snapshots in memory only, removes a peer's contribution when it becomes unavailable, and refreshes available peers after normal and manual provider refreshes.
- Makes dashboard widgets, Total Spend, the menu bar, and the loopback API read the same combined snapshot view.
- Documents setup, aggregation rules, security, privacy, refresh behavior, architecture, and local API behavior.

## Heads-up

- Bonjour browsing requires macOS Local Network permission. The feature does not touch the LAN until the user turns it on.
- The comparison code must match on both Macs before the receiving Mac approves the request; this is what prevents a network intermediary from silently substituting keys during first pairing.
- Only additive machine-local metrics are merged. Session/Weekly/account quotas deliberately remain local because several Macs usually report the same account-wide value.
- The opt-in integration test uses direct listener endpoints after both Bonjour listeners register because some hosted runners block multicast browsing; production always resolves endpoints through `NWBrowser`.
- The local UI automation bridge was unavailable in this environment (`native pipe startup failed`), so the Settings screenshot is still pending for this draft.

## Tests

- `swift test` — 1,067 tests, 4 existing skips, 0 failures
- `OPENUSAGE_RUN_LAN_INTEGRATION=1 swift test --filter LANSyncStoreIntegrationTests` — two real Network.framework listeners, code match + approval, independent secret stores, authenticated encrypted sync in both directions
- `./script/build_and_run.sh verify` — release build, signed bundle staging, launch, and process verification succeeded
- `git diff --check`

## Screenshots

- Pending before ready-for-review: Nearby Macs off, discovered-peer, code-approval, and connected states. The available UI automation runtime failed to start in this environment.
