### PR TITLE
Fix Codex weekly-only window labeling

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -8,6 +8,12 @@ struct CodexMappedUsage: Equatable, Sendable {
 enum CodexUsageMapper {
     static let sessionPeriodMs = MetricPeriod.sessionMs
     static let weeklyPeriodMs = MetricPeriod.weekMs
+
+    private enum WindowKind {
+        case session
+        case weekly
+    }
+
     /// Codex flex credits are worth 4¢ each; the credits line leads with the dollar value
     /// (mirrors the JS plugin's `CREDIT_USD_RATE`).
     static let creditUSDRate = 0.04
@@ -32,49 +38,22 @@ enum CodexUsageMapper {
         let primaryWindow = rateLimit?["primary_window"] as? [String: Any]
         let secondaryWindow = rateLimit?["secondary_window"] as? [String: Any]
 
-        if let used = ProviderParse.number(primaryWindow?["used_percent"]) {
-            let periodDurationMs = readPeriodMs(primaryWindow) ?? sessionPeriodMs
-            lines.append(progress(
-                label: "Session",
-                used: normalizedUsedPercent(used, resetWindow: primaryWindow, now: now, periodDurationMs: periodDurationMs),
-                resetWindow: primaryWindow,
-                now: now,
-                periodDurationMs: periodDurationMs
-            ))
-        }
-        if let used = ProviderParse.number(secondaryWindow?["used_percent"]) {
-            let periodDurationMs = readPeriodMs(secondaryWindow) ?? weeklyPeriodMs
-            lines.append(progress(
-                label: "Weekly",
-                used: normalizedUsedPercent(used, resetWindow: secondaryWindow, now: now, periodDurationMs: periodDurationMs),
-                resetWindow: secondaryWindow,
-                now: now,
-                periodDurationMs: periodDurationMs
-            ))
-        }
+        appendWindowLine(to: &lines, sessionLabel: "Session", weeklyLabel: "Weekly",
+                         usedPercent: ProviderParse.number(primaryWindow?["used_percent"]),
+                         window: primaryWindow, fallbackKind: .session, now: now)
+        appendWindowLine(to: &lines, sessionLabel: "Session", weeklyLabel: "Weekly",
+                         usedPercent: ProviderParse.number(secondaryWindow?["used_percent"]),
+                         window: secondaryWindow, fallbackKind: .weekly, now: now)
 
-        if !lines.contains(where: { $0.label == "Session" }),
-           let used = ProviderParse.number(response.header("x-codex-primary-used-percent")) {
-            let periodDurationMs = readPeriodMs(primaryWindow) ?? sessionPeriodMs
-            lines.append(progress(
-                label: "Session",
-                used: normalizedUsedPercent(used, resetWindow: primaryWindow, now: now, periodDurationMs: periodDurationMs),
-                resetWindow: primaryWindow,
-                now: now,
-                periodDurationMs: periodDurationMs
-            ))
-        }
-        if !lines.contains(where: { $0.label == "Weekly" }),
-           let used = ProviderParse.number(response.header("x-codex-secondary-used-percent")) {
-            let periodDurationMs = readPeriodMs(secondaryWindow) ?? weeklyPeriodMs
-            lines.append(progress(
-                label: "Weekly",
-                used: normalizedUsedPercent(used, resetWindow: secondaryWindow, now: now, periodDurationMs: periodDurationMs),
-                resetWindow: secondaryWindow,
-                now: now,
-                periodDurationMs: periodDurationMs
-            ))
-        }
+        // Header fallback when the body carried no usable percentage. Each header value is still
+        // classified through its body window's metadata, so a weekly-only primary window can't
+        // reappear as Session.
+        appendWindowLine(to: &lines, sessionLabel: "Session", weeklyLabel: "Weekly",
+                         usedPercent: ProviderParse.number(response.header("x-codex-primary-used-percent")),
+                         window: primaryWindow, fallbackKind: .session, now: now)
+        appendWindowLine(to: &lines, sessionLabel: "Session", weeklyLabel: "Weekly",
+                         usedPercent: ProviderParse.number(response.header("x-codex-secondary-used-percent")),
+                         window: secondaryWindow, fallbackKind: .weekly, now: now)
 
         // Model-specific limits (e.g. GPT-5.3-Codex-Spark) ride in a separate `additional_rate_limits`
         // array, each entry reusing the primary/secondary window shape. Surfaced as their own Spark /
@@ -119,6 +98,48 @@ enum CodexUsageMapper {
         )
     }
 
+    /// Appends one rate-limit meter, labeling it by the window's declared duration rather than its
+    /// primary/secondary slot. Codex normally carries the 5-hour window in `primary_window` and the
+    /// weekly window in `secondary_window`, but moves the weekly window into primary while the 5-hour
+    /// restriction is disabled (issue #978) — the slot alone can't be trusted. The slot still decides
+    /// the label when the window omits `limit_window_seconds` or reports an unrecognized duration.
+    /// A window whose label is already present is skipped, so the header fallback can't repeat a body
+    /// window under the other name.
+    private static func appendWindowLine(
+        to lines: inout [MetricLine],
+        sessionLabel: String,
+        weeklyLabel: String,
+        usedPercent: Double?,
+        window: [String: Any]?,
+        fallbackKind: WindowKind,
+        now: Date
+    ) {
+        guard let usedPercent else { return }
+        let kind = windowKind(window, fallback: fallbackKind)
+        let label = kind == .session ? sessionLabel : weeklyLabel
+        guard !lines.contains(where: { $0.label == label }) else { return }
+
+        let periodDurationMs = readPeriodMs(window) ?? (kind == .session ? sessionPeriodMs : weeklyPeriodMs)
+        lines.append(progress(
+            label: label,
+            used: normalizedUsedPercent(usedPercent, resetWindow: window, now: now, periodDurationMs: periodDurationMs),
+            resetWindow: window,
+            now: now,
+            periodDurationMs: periodDurationMs
+        ))
+    }
+
+    private static func windowKind(_ window: [String: Any]?, fallback: WindowKind) -> WindowKind {
+        guard let periodMs = readPeriodMs(window) else { return fallback }
+        if periodMs == sessionPeriodMs {
+            return .session
+        }
+        if periodMs == weeklyPeriodMs {
+            return .weekly
+        }
+        return fallback
+    }
+
     /// Spark (and any future model-specific) limits from `additional_rate_limits`. Each array entry is a
     /// named limit whose `rate_limit` reuses the primary (5-hour) / secondary (weekly) window shape, so
     /// the parsing mirrors the core Session/Weekly path exactly — including the fresh-window 1%→0
@@ -139,26 +160,12 @@ enum CodexUsageMapper {
         let primaryWindow = rateLimit["primary_window"] as? [String: Any]
         let secondaryWindow = rateLimit["secondary_window"] as? [String: Any]
 
-        if let used = ProviderParse.number(primaryWindow?["used_percent"]) {
-            let periodDurationMs = readPeriodMs(primaryWindow) ?? sessionPeriodMs
-            lines.append(progress(
-                label: "Spark",
-                used: normalizedUsedPercent(used, resetWindow: primaryWindow, now: now, periodDurationMs: periodDurationMs),
-                resetWindow: primaryWindow,
-                now: now,
-                periodDurationMs: periodDurationMs
-            ))
-        }
-        if let used = ProviderParse.number(secondaryWindow?["used_percent"]) {
-            let periodDurationMs = readPeriodMs(secondaryWindow) ?? weeklyPeriodMs
-            lines.append(progress(
-                label: "Spark Weekly",
-                used: normalizedUsedPercent(used, resetWindow: secondaryWindow, now: now, periodDurationMs: periodDurationMs),
-                resetWindow: secondaryWindow,
-                now: now,
-                periodDurationMs: periodDurationMs
-            ))
-        }
+        appendWindowLine(to: &lines, sessionLabel: "Spark", weeklyLabel: "Spark Weekly",
+                         usedPercent: ProviderParse.number(primaryWindow?["used_percent"]),
+                         window: primaryWindow, fallbackKind: .session, now: now)
+        appendWindowLine(to: &lines, sessionLabel: "Spark", weeklyLabel: "Spark Weekly",
+                         usedPercent: ProviderParse.number(secondaryWindow?["used_percent"]),
+                         window: secondaryWindow, fallbackKind: .weekly, now: now)
         return lines
     }
 

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -373,6 +373,38 @@ final class CodexUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 10)
     }
 
+    func testClassifiesWeeklyOnlySparkPrimaryWindowByReportedDuration() throws {
+        // Spark windows reuse the core primary/secondary shape, so a disabled 5-hour Spark limit moves
+        // the weekly window into `primary_window` the same way (issue #978) — it must surface as Spark
+        // Weekly, not Spark.
+        let body = Data("""
+        {
+          "additional_rate_limits": [
+            {
+              "limit_name": "GPT-5.3-Codex-Spark",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 42,
+                  "limit_window_seconds": 604800,
+                  "reset_after_seconds": 345600
+                }
+              }
+            }
+          ]
+        }
+        """.utf8)
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            response,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertNil(progress(mapped.lines, "Spark"))
+        XCTAssertEqual(progress(mapped.lines, "Spark Weekly")?.used, 42)
+        XCTAssertEqual(progress(mapped.lines, "Spark Weekly")?.periodDurationMs, CodexUsageMapper.weeklyPeriodMs)
+    }
+
     func testMatchesSparkByMeteredFeatureWhenLimitNameLacksSpark() throws {
         // `limit_name` wording can shift; matching `metered_feature` too keeps the row resolving.
         let now = Date(timeIntervalSince1970: 1_800_000_000)

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -178,6 +178,65 @@ final class CodexUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Session")?.periodDurationMs, 18_000_000)
     }
 
+    func testClassifiesWeeklyOnlyPrimaryWindowByReportedDuration() throws {
+        // Codex temporarily removed the 5-hour restriction and moved the remaining weekly limit into
+        // `primary_window` (issue #978). The slot is transport structure; the declared duration is the
+        // window's meaning. The primary header must not resurrect the same window as Session either.
+        let body = Data("""
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 42,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 345600
+            }
+          }
+        }
+        """.utf8)
+        let response = HTTPResponse(
+            statusCode: 200,
+            headers: ["x-codex-primary-used-percent": "99"],
+            body: body
+        )
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            response,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertNil(progress(mapped.lines, "Session"))
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 42)
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.periodDurationMs, CodexUsageMapper.weeklyPeriodMs)
+    }
+
+    func testClassifiesRestoredSessionAndWeeklyWindowsByReportedDuration() throws {
+        // When the 5-hour limit returns, both slots resolve back to their usual labels with no
+        // further code change.
+        let body = Data("""
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 12,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": 34,
+              "limit_window_seconds": 604800
+            }
+          }
+        }
+        """.utf8)
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: body)
+
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            response,
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertEqual(progress(mapped.lines, "Session")?.used, 12)
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 34)
+    }
+
     func testMapsWindowsCreditsAndPlan() throws {
         let body = Data("""
         {

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -30,7 +30,7 @@ Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the C
 
 ## Under the hood
 
-`GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry. Session and Weekly are read from the usage window in that response, with the response headers used only when the window fields are missing.
+`GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry. Session and Weekly are identified by each usage window's reported duration, with the usual primary/secondary positions kept as a fallback for older responses and response headers used only when the window fields are missing. This keeps a weekly-only response labeled Weekly when Codex temporarily removes the 5-hour limit, and naturally restores both rows when that limit returns.
 
 Spark and Spark Weekly come from the same response's `additional_rate_limits` array — model-specific limits that reuse the Session/Weekly window shape. OpenUsage surfaces the entry whose name identifies GPT-5.3-Codex-Spark as those two meters; accounts without the limit simply omit the entry, so the rows read "No data". Other model limits in that array aren't shown.
 


### PR DESCRIPTION
## TL;DR

Identify Codex rate-limit windows by their reported duration instead of assuming `primary_window` is always the five-hour Session limit. A weekly-only response now shows under Weekly, and the five-hour row comes back automatically when Codex restores that limit.

Fixes #978.

## What was happening

- Codex temporarily removed the five-hour usage restriction for Plus, Business, and Pro plans ([announcement](https://x.com/thsottiaux/status/2076365965915467978)).
- With the five-hour window absent, the remaining seven-day limit ships in `primary_window`.
- The mapper labeled `primary_window` as Session unconditionally, so the weekly percentage showed under Session and the Weekly row read "No data".
- The `x-codex-primary-used-percent` header fallback could repeat the same weekly window as a second Session meter.

## What this changes

- Classifies each window as Session or Weekly by its `limit_window_seconds` (5 h vs. 7 days), keeping the usual primary/secondary slot as the fallback when a response omits the duration or reports an unrecognized one.
- Routes the header fallback through the same classification, so a weekly-only primary window can't reappear as Session; a window whose label is already mapped is skipped.
- Applies the same resolution to the model-specific Spark / Spark Weekly windows, which reuse the identical shape.
- Refactors the six near-identical window-mapping blocks into one `appendWindowLine` helper (fresh-window 1%→0 normalization and reset handling unchanged).
- Updates `docs/providers/codex.md` to describe the duration-based labeling.

## Heads-up

- Nothing hardcodes the temporary removal: when Codex restores the 5-hour window (`limit_window_seconds: 18000`), Session and Weekly both map normally with no further change.
- In the degenerate case where both body windows report the same duration, only the first is kept — previously the second would have been shown under a wrong label.

## Tests

- New regression tests: weekly-only `primary_window` (with a conflicting primary header) maps to Weekly with no Session row, and the restored 5h + weekly shape maps both rows.
- A weekly-only Spark `primary_window` likewise maps to Spark Weekly with no Spark row.
- `swift test --filter CodexUsageMapperTests`: all 22 tests pass.
- Full `swift test`: the only failures are 4 pre-existing ones on clean `main` in local token-spend pricing tests (environment-dependent), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

