### PR TITLE
Fix Codex window routing by duration

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexUsageMapper.swift
@@ -29,29 +29,15 @@ enum CodexUsageMapper {
 
         var lines: [MetricLine] = []
         let rateLimit = body["rate_limit"] as? [String: Any]
-        let primaryWindow = rateLimit?["primary_window"] as? [String: Any]
-        let secondaryWindow = rateLimit?["secondary_window"] as? [String: Any]
-
-        if let line = windowLine(label: "Session", usedPercent: ProviderParse.number(primaryWindow?["used_percent"]),
-                                 window: primaryWindow, defaultPeriodMs: sessionPeriodMs, now: now) {
-            lines.append(line)
-        }
-        if let line = windowLine(label: "Weekly", usedPercent: ProviderParse.number(secondaryWindow?["used_percent"]),
-                                 window: secondaryWindow, defaultPeriodMs: weeklyPeriodMs, now: now) {
-            lines.append(line)
-        }
-
-        // Header fallback when the body carried no window (only fills a Session/Weekly not already present).
-        if !lines.contains(where: { $0.label == "Session" }),
-           let line = windowLine(label: "Session", usedPercent: ProviderParse.number(response.header("x-codex-primary-used-percent")),
-                                 window: primaryWindow, defaultPeriodMs: sessionPeriodMs, now: now) {
-            lines.append(line)
-        }
-        if !lines.contains(where: { $0.label == "Weekly" }),
-           let line = windowLine(label: "Weekly", usedPercent: ProviderParse.number(response.header("x-codex-secondary-used-percent")),
-                                 window: secondaryWindow, defaultPeriodMs: weeklyPeriodMs, now: now) {
-            lines.append(line)
-        }
+        lines.append(contentsOf: classifiedWindowLines(
+            rateLimit: rateLimit,
+            labels: (session: "Session", weekly: "Weekly"),
+            headerPercents: (
+                primary: ProviderParse.number(response.header("x-codex-primary-used-percent")),
+                secondary: ProviderParse.number(response.header("x-codex-secondary-used-percent"))
+            ),
+            now: now
+        ))
 
         // Model-specific limits (e.g. GPT-5.3-Codex-Spark) ride in a separate `additional_rate_limits`
         // array, each entry reusing the primary/secondary window shape. Surfaced as their own Spark /
@@ -117,6 +103,79 @@ enum CodexUsageMapper {
         )
     }
 
+    private enum WindowKind {
+        case session
+        case weekly
+    }
+
+    private struct WindowCandidate {
+        var window: [String: Any]
+        var usedPercent: Double?
+        var fallbackKind: WindowKind
+    }
+
+    /// Codex normally returns the five-hour window as `primary_window` and the weekly window as
+    /// `secondary_window`, but it can move a temporarily sole weekly limit into the primary slot.
+    /// Classify by the explicit duration when present; keep the historical slot mapping only as a
+    /// compatibility fallback for payloads that omit or introduce an unfamiliar duration.
+    private static func classifiedWindowLines(
+        rateLimit: [String: Any]?,
+        labels: (session: String, weekly: String),
+        headerPercents: (primary: Double?, secondary: Double?) = (nil, nil),
+        now: Date
+    ) -> [MetricLine] {
+        let candidates = [
+            windowCandidate(rateLimit?["primary_window"], headerPercent: headerPercents.primary, fallbackKind: .session),
+            windowCandidate(rateLimit?["secondary_window"], headerPercent: headerPercents.secondary, fallbackKind: .weekly)
+        ].compactMap { $0 }
+
+        return [
+            classifiedWindowLine(kind: .session, label: labels.session, candidates: candidates, now: now),
+            classifiedWindowLine(kind: .weekly, label: labels.weekly, candidates: candidates, now: now)
+        ].compactMap { $0 }
+    }
+
+    private static func windowCandidate(
+        _ value: Any?,
+        headerPercent: Double?,
+        fallbackKind: WindowKind
+    ) -> WindowCandidate? {
+        guard let window = value as? [String: Any] ?? (headerPercent == nil ? nil : [:]) else { return nil }
+        return WindowCandidate(
+            window: window,
+            usedPercent: ProviderParse.number(window["used_percent"]) ?? headerPercent,
+            fallbackKind: fallbackKind
+        )
+    }
+
+    private static func classifiedWindowLine(
+        kind: WindowKind,
+        label: String,
+        candidates: [WindowCandidate],
+        now: Date
+    ) -> MetricLine? {
+        let exact = candidates.first { exactKind(for: $0.window) == kind }
+        let fallback = candidates.first { exactKind(for: $0.window) == nil && $0.fallbackKind == kind }
+        guard let candidate = exact ?? fallback else { return nil }
+        let defaultPeriodMs = kind == .session ? sessionPeriodMs : weeklyPeriodMs
+        return windowLine(
+            label: label,
+            usedPercent: candidate.usedPercent,
+            window: candidate.window,
+            defaultPeriodMs: defaultPeriodMs,
+            now: now
+        )
+    }
+
+    private static func exactKind(for window: [String: Any]) -> WindowKind? {
+        guard let periodMs = readPeriodMs(window) else { return nil }
+        switch periodMs {
+        case sessionPeriodMs: return .session
+        case weeklyPeriodMs: return .weekly
+        default: return nil
+        }
+    }
+
     /// Spark (and any future model-specific) limits from `additional_rate_limits`. Each array entry is a
     /// named limit whose `rate_limit` reuses the primary (5-hour) / secondary (weekly) window shape, so
     /// the parsing mirrors the core Session/Weekly path exactly. We surface the entry whose
@@ -133,19 +192,11 @@ enum CodexUsageMapper {
             return []
         }
 
-        var lines: [MetricLine] = []
-        let primaryWindow = rateLimit["primary_window"] as? [String: Any]
-        let secondaryWindow = rateLimit["secondary_window"] as? [String: Any]
-
-        if let line = windowLine(label: "Spark", usedPercent: ProviderParse.number(primaryWindow?["used_percent"]),
-                                 window: primaryWindow, defaultPeriodMs: sessionPeriodMs, now: now) {
-            lines.append(line)
-        }
-        if let line = windowLine(label: "Spark Weekly", usedPercent: ProviderParse.number(secondaryWindow?["used_percent"]),
-                                 window: secondaryWindow, defaultPeriodMs: weeklyPeriodMs, now: now) {
-            lines.append(line)
-        }
-        return lines
+        return classifiedWindowLines(
+            rateLimit: rateLimit,
+            labels: (session: "Spark", weekly: "Spark Weekly"),
+            now: now
+        )
     }
 
     /// True when an `additional_rate_limits` entry is the Spark limit — matched on either `limit_name`

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -154,6 +154,46 @@ final class CodexUsageMapperTests: XCTestCase {
         XCTAssertEqual(progress(mapped.lines, "Session")?.periodDurationMs, 18_000_000)
     }
 
+    func testMapsWeeklyOnlyPrimaryWindowByDuration() throws {
+        let body = Data("""
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 5,
+              "limit_window_seconds": 604800,
+              "reset_after_seconds": 60
+            },
+            "secondary_window": null
+          }
+        }
+        """.utf8)
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            HTTPResponse(statusCode: 200, headers: [:], body: body),
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertNil(progress(mapped.lines, "Session"))
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 5)
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.periodDurationMs, CodexUsageMapper.weeklyPeriodMs)
+    }
+
+    func testUnknownWindowDurationKeepsPositionalFallback() throws {
+        let body = Data("""
+        {
+          "rate_limit": {
+            "primary_window": { "used_percent": 11, "limit_window_seconds": 86400 },
+            "secondary_window": { "used_percent": 22, "limit_window_seconds": 2592000 }
+          }
+        }
+        """.utf8)
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            HTTPResponse(statusCode: 200, headers: [:], body: body)
+        )
+
+        XCTAssertEqual(progress(mapped.lines, "Session")?.used, 11)
+        XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 22)
+    }
+
     func testMapsWindowsCreditsAndPlan() throws {
         let body = Data("""
         {
@@ -288,6 +328,32 @@ final class CodexUsageMapperTests: XCTestCase {
         // The core Session/Weekly windows are unaffected by the new parsing.
         XCTAssertEqual(progress(mapped.lines, "Session")?.used, 5)
         XCTAssertEqual(progress(mapped.lines, "Weekly")?.used, 10)
+    }
+
+    func testMapsWeeklyOnlySparkPrimaryWindowByDuration() throws {
+        let body = Data("""
+        {
+          "additional_rate_limits": [{
+            "limit_name": "GPT-5.3-Codex-Spark",
+            "rate_limit": {
+              "primary_window": {
+                "used_percent": 7,
+                "limit_window_seconds": 604800,
+                "reset_after_seconds": 60
+              },
+              "secondary_window": null
+            }
+          }]
+        }
+        """.utf8)
+        let mapped = try CodexUsageMapper.mapUsageResponse(
+            HTTPResponse(statusCode: 200, headers: [:], body: body),
+            now: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+
+        XCTAssertNil(progress(mapped.lines, "Spark"))
+        XCTAssertEqual(progress(mapped.lines, "Spark Weekly")?.used, 7)
+        XCTAssertEqual(progress(mapped.lines, "Spark Weekly")?.periodDurationMs, CodexUsageMapper.weeklyPeriodMs)
     }
 
     func testMatchesSparkByMeteredFeatureWhenLimitNameLacksSpark() throws {

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -31,9 +31,9 @@ Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the C
 
 ## Under the hood
 
-`GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry. Session and Weekly are read from the usage window in that response, with the response headers used only when the window fields are missing.
+`GET https://chatgpt.com/backend-api/wham/usage` with the Codex OAuth token; refresh via `auth.openai.com`. A 401/403 triggers one token refresh and retry. Session and Weekly are classified by each usage window's duration rather than by its primary/secondary slot. This matters when Codex temporarily removes one limit and moves the remaining weekly window into the primary slot. Payloads without a recognized duration retain the primary-as-Session and secondary-as-Weekly compatibility fallback; response headers fill percentages missing from the corresponding window.
 
-Spark and Spark Weekly come from the same response's `additional_rate_limits` array — model-specific limits that reuse the Session/Weekly window shape. OpenUsage surfaces the entry whose name identifies GPT-5.3-Codex-Spark as those two meters; accounts without the limit simply omit the entry, so the rows read "No data". Other model limits in that array aren't shown.
+Spark and Spark Weekly come from the same response's `additional_rate_limits` array — model-specific limits that reuse the duration-based Session/Weekly classification. OpenUsage surfaces the entry whose name identifies GPT-5.3-Codex-Spark as those two meters; accounts without the limit simply omit the entry, so the rows read "No data". Other model limits in that array aren't shown.
 
 OpenUsage preserves Codex's reported `used_percent` verbatim. If the API reports 1% used for an untouched window, the app shows 99% left; if it reports 0%, the app shows 100% left. Codex rows use the normal reset label rather than inferring a special "Not started" state. Burn-rate pacing still waits until enough of the window has elapsed to make a useful projection.
 


### PR DESCRIPTION
## TL;DR

Classify Codex Session and Weekly quota windows by their reported duration, so a weekly-only limit placed in `primary_window` is shown as Weekly instead of Session. The same routing now applies to Spark limits.

## What was happening

- Codex temporarily removed the five-hour session limit and returned the remaining seven-day limit in `primary_window` with `secondary_window: null`.
- OpenUsage assumed primary always meant Session and secondary always meant Weekly, so the weekly quota appeared under the wrong widget and pace-notification identity.
- Spark limits had the same positional assumption.

## What this changes

- Routes exact five-hour windows to Session and exact seven-day windows to Weekly, regardless of primary/secondary placement.
- Applies the same duration classification to Spark and Spark Weekly.
- Preserves the positional mapping as a compatibility fallback when duration is missing or unfamiliar.
- Keeps body percentages ahead of response-header fallbacks and documents the behavior.
- Adds regression coverage for weekly-only primary windows, Spark weekly-only windows, and unknown-duration fallback.

## Heads-up

- This intentionally leaves Session/Spark unbacked when Codex supplies only a weekly window; those widgets show No data rather than presenting a weekly quota under a session label.

## Tests

- `swift test --filter CodexUsageMapperTests` — 24 passed
- `swift test` — 1,063 passed, 3 skipped after rebasing onto latest `main`
- Rebuilt and relaunched the macOS app with `script/build_and_run.sh verify`.
- Verified against this machine's live Codex response: the 604,800-second primary windows surfaced as Weekly and Spark Weekly, with no Session or Spark quota lines.

## Screenshots

- Not applicable: this changes provider-data routing without changing UI layout or styling; live normalized API output was verified as described above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Codex usage parsing and display routing with regression tests; no auth, networking, or persistence changes.
> 
> **Overview**
> Fixes mislabeled quota meters when Codex returns only a weekly limit in `primary_window` (session limit temporarily removed). **Session** and **Weekly** (and **Spark** / **Spark Weekly**) are now chosen by matching `limit_window_seconds` to the known five-hour and seven-day periods, not by assuming primary = session and secondary = weekly.
> 
> Core and Spark parsing share a new `classifiedWindowLines` helper; body `used_percent` still wins over `x-codex-*-used-percent` headers when a window exists. Unrecognized durations keep the old slot-based mapping. When only a weekly window is present, Session/Spark rows stay absent (**No data**) instead of showing weekly usage under the wrong label.
> 
> Docs in `docs/providers/codex.md` describe the behavior; new mapper tests cover weekly-only primary, Spark weekly-only primary, and unknown-duration fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ddf233faf118aefcadd80dc525064fe44cb689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->