### PR TITLE
fix(pricing): recognize cursor-grok-4.5 usage slugs

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
-  "updated_at": "2026-07-08",
+  "updated_at": "2026-07-13",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -135,9 +135,9 @@
     { "pattern": "^composer-2\\.5$", "canonical": "composer-2.5" },
     { "pattern": "^composer-2\\.5-fast$", "canonical": "composer-2.5-fast" },
     { "pattern": "^github_bugbot$", "canonical": "github_bugbot" },
-    { "pattern": "^grok-4\\.5-fast(?:-(?:low|medium|high))?$", "canonical": "grok-4.5-fast" },
-    { "pattern": "^grok-4\\.5(?:-(?:low|medium|high))?-fast$", "canonical": "grok-4.5-fast" },
-    { "pattern": "^grok-4\\.5(?:-(?:low|medium|high))?$", "canonical": "grok-4.5" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5-fast(?:-(?:low|medium|high))?$", "canonical": "grok-4.5-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high))?-fast$", "canonical": "grok-4.5-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high))?$", "canonical": "grok-4.5" },
     { "pattern": "^kimi-k2\\.7(?:-code)?$", "canonical": "kimi-k2.7-code" },
     { "pattern": "^kimi-k2p7(?:-code)?$", "canonical": "kimi-k2.7-code" },
     { "pattern": "^claude-4\\.5-haiku(?:-thinking)?$", "canonical": "claude-haiku-4-5" },

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -51,6 +51,7 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "grok-4.5")?.inputPerMillion, 2)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-high")?.inputPerMillion, 4)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-high-fast")?.inputPerMillion, 4)
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-high-fast")?.inputPerMillion, 4)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2p5")?.inputPerMillion, 0.6)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2.7-code")?.inputPerMillion, 0.95)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2p7")?.inputPerMillion, 0.95)
@@ -195,6 +196,10 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-high"), fast)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-medium"), fast)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-medium-fast"), fast)
+        // Cursor usage export sometimes prefixes first-party Grok with `cursor-`.
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-high-fast"), fast)
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-fast-high"), fast)
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-high"), standard)
     }
 
     /// Kimi K2.7 Code: Cursor's published rates override messy public-catalog entries.


### PR DESCRIPTION
## TL;DR
Prices Cursor’s `cursor-grok-4.5-*` usage slugs (including `cursor-grok-4.5-high-fast`) at the existing Grok 4.5 rates.

## What was happening
- Cursor spend showed **Unknown model found — cursor-grok-4.5-high-fast**.
- Alias rules only matched bare `grok-4.5…` slugs, not the `cursor-` prefix Cursor’s export uses for this first-party model.

## What this changes
- Makes the optional `cursor-` prefix part of all three Grok 4.5 alias rules (fast-before-effort, effort-before-fast, and standard).
- Bumps `updated_at` to `2026-07-13`.
- Adds regression coverage for `cursor-grok-4.5-high-fast`, `cursor-grok-4.5-fast-high`, and `cursor-grok-4.5-high`.

## Heads-up
- Source: [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md) / [Grok 4.5](https://cursor.com/docs/models/grok-4-5) — standard $2/$6 and fast $4/$18 per million input/output; no rate changes in this PR.
- Publishes via the pricing-supplement workflow after merge; no app release needed.

## Tests
- Supplement JSON + regex validation
- `swift test --filter "ModelPricing|PricingBundledResource"`


Made with [Cursor](https://cursor.com)