### PR TITLE
Add a machine-readable limits API and global openusage command

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
         .macOS(.v15)
     ],
     products: [
-        .executable(name: "OpenUsage", targets: ["OpenUsage"])
+        .executable(name: "OpenUsage", targets: ["OpenUsageApp"]),
+        .executable(name: "openusage-cli", targets: ["OpenUsageCLI"])
     ],
     dependencies: [
         // The de-facto standard recorder + global hotkey for Mac apps (System Settings-style field).
@@ -19,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.62.0")
     ],
     targets: [
-        .executableTarget(
+        .target(
             name: "OpenUsage",
             dependencies: [
                 .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
@@ -37,10 +38,34 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
+        .executableTarget(
+            name: "OpenUsageApp",
+            dependencies: ["OpenUsage"],
+            path: "Sources/OpenUsageApp",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .executableTarget(
+            name: "OpenUsageCLI",
+            dependencies: ["OpenUsage"],
+            path: "Sources/OpenUsageCLI",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "OpenUsageTests",
             dependencies: ["OpenUsage"],
             path: "Tests/OpenUsageTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
+        .testTarget(
+            name: "OpenUsageCLITests",
+            dependencies: ["OpenUsageCLI"],
+            path: "Tests/OpenUsageCLITests",
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Most providers read the credentials already on your machine (keychain, auth file
 - **Global shortcut.** Toggle the popover from anywhere — record any combo in Settings.
 - **Customize.** Turn providers and metrics on or off, choose which rows stay Always Visible or On Demand, and drag-reorder both.
 - **Stale-while-revalidate.** Cached values display instantly at launch; refresh runs every 5 minutes.
+- **[One-shot CLI](docs/cli.md).** Agents can read the same five-minute cached JSON with `openusage`, or bypass freshness with `openusage --force`; the menu-bar app does not need to be running.
 - **[Local HTTP API](docs/local-http-api.md).** Other apps can read your usage as JSON from `127.0.0.1:6736` (`/v1/usage`), same format as the original app. It is loopback-only and serves usage numbers, never credentials; note that browser pages can read it too — see the [privacy note](docs/local-http-api.md#cors-and-privacy).
 - **[Proxy support](docs/proxy.md).** Route provider requests through SOCKS5 or HTTP(S) via `~/.openusage/config.json`.
 - **Native settings.** Launch at login, global shortcut, icon style, theme, density, 12/24-hour time — see [Settings](docs/settings.md).
@@ -51,7 +52,7 @@ Most providers read the credentials already on your machine (keychain, auth file
 
 ## Documentation
 
-Behavior docs live in [docs/](docs/README.md): the [dashboard](docs/dashboard.md), [menu bar pins](docs/menu-bar.md), [settings](docs/settings.md), [refresh & caching](docs/refreshing.md), the [local HTTP API](docs/local-http-api.md), the [proxy](docs/proxy.md), and one page per provider.
+Behavior docs live in [docs/](docs/README.md): the [dashboard](docs/dashboard.md), [menu bar pins](docs/menu-bar.md), [settings](docs/settings.md), [refresh & caching](docs/refreshing.md), the [CLI](docs/cli.md), the [local HTTP API](docs/local-http-api.md), the [proxy](docs/proxy.md), and one page per provider.
 
 For working on the code, see the developer docs: [architecture](docs/architecture.md), [adding a provider](docs/adding-a-provider.md), and [debugging & capturing logs](docs/debugging.md).
 
@@ -78,7 +79,7 @@ swift test             # run the test suite
 
 ## Architecture
 
-SwiftPM executable, SwiftUI content hosted in an AppKit-owned `NSStatusItem` + custom key-capable `NSPanel`, Swift 6 strict concurrency. Providers implement a small `ProviderRuntime` protocol (auth store → usage client → mapper → `ProviderSnapshot`), and the UI renders normalized `MetricLine` values — see the [architecture overview](docs/architecture.md) for how the pieces fit together and [AGENTS.md](AGENTS.md) for engineering conventions.
+SwiftPM package, SwiftUI content hosted in an AppKit-owned `NSStatusItem` + custom key-capable `NSPanel`, Swift 6 strict concurrency. The app and CLI share one module: providers implement a small `ProviderRuntime` protocol (auth store → usage client → mapper → `ProviderSnapshot`), and both surfaces read the same normalized data — see the [architecture overview](docs/architecture.md) for how the pieces fit together and [AGENTS.md](AGENTS.md) for engineering conventions.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Most providers read the credentials already on your machine (keychain, auth file
 - **Global shortcut.** Toggle the popover from anywhere — record any combo in Settings.
 - **Customize.** Turn providers and metrics on or off, choose which rows stay Always Visible or On Demand, and drag-reorder both.
 - **Stale-while-revalidate.** Cached values display instantly at launch; refresh runs every 5 minutes.
-- **[One-shot CLI](docs/cli.md).** Agents can read the same five-minute cached JSON with `openusage`, or bypass freshness with `openusage --force`; the menu-bar app does not need to be running.
-- **[Local HTTP API](docs/local-http-api.md).** Other apps can read your usage as JSON from `127.0.0.1:6736` (`/v1/usage`), same format as the original app. It is loopback-only and serves usage numbers, never credentials; note that browser pages can read it too — see the [privacy note](docs/local-http-api.md#cors-and-privacy).
+- **[One-shot CLI](docs/cli.md).** Agents can read stable limit JSON through the same five-minute cache with `openusage`, or bypass freshness with `openusage --force`; the menu-bar app does not need to be running.
+- **[Local HTTP API](docs/local-http-api.md).** Other apps can read machine-friendly limits from `127.0.0.1:6736/v1/limits`; the legacy `/v1/usage` UI contract remains supported. It is loopback-only and never serves credentials; note that browser pages can read it too — see the [privacy note](docs/local-http-api.md#cors-and-privacy).
 - **[Proxy support](docs/proxy.md).** Route provider requests through SOCKS5 or HTTP(S) via `~/.openusage/config.json`.
 - **Native settings.** Launch at login, global shortcut, icon style, theme, density, 12/24-hour time — see [Settings](docs/settings.md).
 - **[Automatic updates](docs/updates.md).** Signed, notarized in-app updates via Sparkle, with an optional beta channel.

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -55,23 +55,7 @@ final class AppContainer {
         // run from a terminal. Warmed here so the first refresh finds the cache ready.
         LoginShellEnvironment.shared.prewarm()
 
-        // Default provider order (see AGENTS.md "## Providers"): the three established providers first —
-        // Claude, Codex, Cursor — then every other provider alphabetically by display name. This registry
-        // order is the default provider order (`LayoutStore.orderedProviderIDs` falls back to it, and
-        // `resetToDefault` seeds it), so the dashboard, Customize sections, and the per-provider reset
-        // menu all read this way.
-        let providers: [ProviderRuntime] = [
-            ClaudeProvider(),
-            CodexProvider(),
-            CursorProvider(),
-            AntigravityProvider(),
-            CopilotProvider(),
-            DevinProvider(),
-            GrokProvider(),
-            OpenCodeProvider(),
-            OpenRouterProvider(),
-            ZAIProvider()
-        ]
+        let providers = ProviderCatalog.make()
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
         let enablement = ProviderEnablementStore()

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -173,7 +173,7 @@ final class AppContainer {
         self.transparency = PopoverTransparencyStore()
         self.localAPI = LocalUsageServer(state: { [layout, enablement, dataStore] in
             LocalUsageAPI.State(
-                enabledOrderedIDs: layout.providerOrder.filter { enablement.isEnabled($0) },
+                enabledOrderedIDs: layout.orderedProviderIDs().filter { enablement.isEnabled($0) },
                 knownIDs: Set(registry.providers.map(\.id)),
                 snapshots: dataStore.snapshots,
                 limitDescriptors: registry.limitDescriptorsByProvider,

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -175,7 +175,9 @@ final class AppContainer {
             LocalUsageAPI.State(
                 enabledOrderedIDs: layout.providerOrder.filter { enablement.isEnabled($0) },
                 knownIDs: Set(registry.providers.map(\.id)),
-                snapshots: dataStore.snapshots
+                snapshots: dataStore.snapshots,
+                limitDescriptors: registry.limitDescriptorsByProvider,
+                errors: dataStore.providerErrors
             )
         })
         self.refreshTask = Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry)

--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -1,28 +1,17 @@
 import AppKit
-import SwiftUI
-
-@main
-struct OpenUsageApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-
-    var body: some Scene {
-        // Menu-bar app: the status item and custom panel are AppKit-owned (see StatusItemController),
-        // so no window scene is wanted. `Settings` gives SwiftUI a valid scene without creating
-        // an activation window.
-        Settings {
-            EmptyView()
-        }
-    }
-}
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var container: AppContainer?
     private var statusItemController: StatusItemController?
     private var singleInstanceLock: SingleInstanceLock.Token?
     private let updater = UpdaterController()
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
+    public override init() {
+        super.init()
+    }
+
+    public func applicationDidFinishLaunching(_ notification: Notification) {
         // Open/trim the file log, seed the cached level, and emit the startup line BEFORE anything
         // else logs, so the first lines of a session are captured.
         AppLog.bootstrap()
@@ -89,7 +78,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Flush queued telemetry on quit. The SDK's lifecycle autocapture is off (we emit our own daily
     /// rollups), so it won't auto-flush on termination — this explicit flush keeps low-frequency events
     /// from being stranded across a clean quit.
-    func applicationWillTerminate(_ notification: Notification) {
+    public func applicationWillTerminate(_ notification: Notification) {
         container?.telemetry.flush()
     }
 }

--- a/Sources/OpenUsage/Models/LimitResourceDescriptor.swift
+++ b/Sources/OpenUsage/Models/LimitResourceDescriptor.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Stable, machine-facing metadata for one resource exported by `/v1/limits`.
+///
+/// Providers still produce `MetricLine` once. This metadata only names the subset that is useful to
+/// programs and says how to select a scalar from an already-normalized line; presentation-only rows
+/// simply have no descriptor and therefore cannot leak into the limits contract.
+struct LimitResourceDescriptor: Hashable, Sendable {
+    enum Kind: String, Hashable, Sendable, Encodable {
+        case consumption
+        case balance
+    }
+
+    enum Source: Hashable, Sendable {
+        case progress
+        case value(kind: MetricKind, label: String? = nil)
+        /// A provider may report the same consumption as bounded progress or as an uncapped scalar.
+        case progressOrValue(kind: MetricKind, label: String? = nil)
+    }
+
+    let key: String
+    let kind: Kind
+    let unit: String
+    let source: Source
+    var estimated = false
+}
+
+extension WidgetDescriptor {
+    /// Adds one scalar to the public limits contract without changing the widget or provider mapper.
+    func exportingLimit(
+        _ key: String,
+        kind: LimitResourceDescriptor.Kind = .consumption,
+        unit: String,
+        source: LimitResourceDescriptor.Source = .progress,
+        estimated: Bool = false
+    ) -> WidgetDescriptor {
+        var copy = self
+        copy.limitResources.append(LimitResourceDescriptor(
+            key: key,
+            kind: kind,
+            unit: unit,
+            source: source,
+            estimated: estimated
+        ))
+        return copy
+    }
+}

--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -116,7 +116,8 @@ extension WidgetDescriptor {
                 metricLabel: descriptor.metricLabel,
                 sample: sample,
                 pinnable: descriptor.pinnable,
-                isSpendTile: true
+                isSpendTile: true,
+                limitResources: descriptor.limitResources
             )
         }
     }

--- a/Sources/OpenUsage/Models/WidgetDescriptor.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor.swift
@@ -14,6 +14,8 @@ struct WidgetDescriptor: Identifiable, Hashable {
     /// The Total Spend card keys on this to decide which providers feed the ring — a title match would
     /// wrongly rope in look-alike rows like OpenRouter's API-spend "Today".
     var isSpendTile: Bool = false
+    /// Stable scalar resources exported by `/v1/limits`. Empty for UI-only/history widgets.
+    var limitResources: [LimitResourceDescriptor] = []
 
     /// The metric's single display name.
     var title: String { sample.title }

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
@@ -35,10 +35,14 @@ final class AntigravityProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: AntigravityMetric.geminiID, provider: provider, title: AntigravityMetric.sessionLabel, isSessionWindow: true),
-            .percent(id: AntigravityMetric.geminiWeeklyID, provider: provider, title: AntigravityMetric.weeklyLabel),
-            .percent(id: AntigravityMetric.claudeID, provider: provider, title: AntigravityMetric.claudeLabel, isSessionWindow: true),
+            .percent(id: AntigravityMetric.geminiID, provider: provider, title: AntigravityMetric.sessionLabel, isSessionWindow: true)
+                .exportingLimit("geminiSession", unit: "percent"),
+            .percent(id: AntigravityMetric.geminiWeeklyID, provider: provider, title: AntigravityMetric.weeklyLabel)
+                .exportingLimit("geminiWeekly", unit: "percent"),
+            .percent(id: AntigravityMetric.claudeID, provider: provider, title: AntigravityMetric.claudeLabel, isSessionWindow: true)
+                .exportingLimit("nonGeminiSession", unit: "percent"),
             .percent(id: AntigravityMetric.claudeWeeklyID, provider: provider, title: AntigravityMetric.claudeWeeklyLabel)
+                .exportingLimit("nonGeminiWeekly", unit: "percent")
         ]
     }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -45,11 +45,16 @@ final class ClaudeProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "claude.session", provider: provider, title: "Session", isSessionWindow: true),
-            .percent(id: "claude.weekly", provider: provider, title: "Weekly"),
-            .percent(id: "claude.sonnet", provider: provider, title: "Sonnet"),
-            .percent(id: "claude.fable", provider: provider, title: "Fable"),
-            .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent"),
+            .percent(id: "claude.session", provider: provider, title: "Session", isSessionWindow: true)
+                .exportingLimit("session", unit: "percent"),
+            .percent(id: "claude.weekly", provider: provider, title: "Weekly")
+                .exportingLimit("weekly", unit: "percent"),
+            .percent(id: "claude.sonnet", provider: provider, title: "Sonnet")
+                .exportingLimit("sonnet", unit: "percent"),
+            .percent(id: "claude.fable", provider: provider, title: "Fable")
+                .exportingLimit("fable", unit: "percent"),
+            .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent")
+                .exportingLimit("extraUsage", unit: "usd", source: .progressOrValue(kind: .dollars)),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)
     }

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -34,15 +34,22 @@ final class CodexProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "codex.session", provider: provider, title: "Session"),
-            .percent(id: "codex.weekly", provider: provider, title: "Weekly"),
+            .percent(id: "codex.session", provider: provider, title: "Session")
+                .exportingLimit("session", unit: "percent"),
+            .percent(id: "codex.weekly", provider: provider, title: "Weekly")
+                .exportingLimit("weekly", unit: "percent"),
             // Model-specific Spark limits (GPT-5.3-Codex-Spark), parsed from `additional_rate_limits`.
             // Declared right after Weekly so they group with the core rate-limit meters; seeded On
             // Demand (below the caret) and unpinned in `DefaultLayout`.
-            .percent(id: "codex.spark", provider: provider, title: "Spark"),
-            .percent(id: "codex.sparkWeekly", provider: provider, title: "Spark Weekly"),
-            .combined(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"),
-            .values(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets", traySuffix: "resets", showsResetExpiries: true),
+            .percent(id: "codex.spark", provider: provider, title: "Spark")
+                .exportingLimit("spark", unit: "percent"),
+            .percent(id: "codex.sparkWeekly", provider: provider, title: "Spark Weekly")
+                .exportingLimit("sparkWeekly", unit: "percent"),
+            .combined(id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits")
+                .exportingLimit("credits", kind: .balance, unit: "credits", source: .value(kind: .count, label: "credits"))
+                .exportingLimit("creditValue", kind: .balance, unit: "usd", source: .value(kind: .dollars)),
+            .values(id: "codex.rateLimitResets", provider: provider, title: "Rate Limit Resets", metricLabel: "Rate Limit Resets", traySuffix: "resets", showsResetExpiries: true)
+                .exportingLimit("rateLimitResets", kind: .balance, unit: "resets", source: .value(kind: .count, label: "available")),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)
     }

--- a/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
@@ -38,12 +38,18 @@ final class CopilotProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "copilot.premium", provider: provider, title: "Credits"),
-            .values(id: "copilot.extra", provider: provider, title: "Extra Usage", selection: .kind(.count)),
-            .values(id: "copilot.orgCredits", provider: provider, title: "Org Credits", selection: .kind(.count)),
-            .values(id: "copilot.orgSpend", provider: provider, title: "Org Spend", selection: .kind(.dollars), valueWord: "spent"),
-            .percent(id: "copilot.chat", provider: provider, title: "Chat"),
+            .percent(id: "copilot.premium", provider: provider, title: "Credits")
+                .exportingLimit("premiumCredits", unit: "percent"),
+            .values(id: "copilot.extra", provider: provider, title: "Extra Usage", selection: .kind(.count))
+                .exportingLimit("extraUsage", unit: "count", source: .value(kind: .count)),
+            .values(id: "copilot.orgCredits", provider: provider, title: "Org Credits", selection: .kind(.count))
+                .exportingLimit("orgCredits", unit: "credits", source: .value(kind: .count, label: "credits")),
+            .values(id: "copilot.orgSpend", provider: provider, title: "Org Spend", selection: .kind(.dollars), valueWord: "spent")
+                .exportingLimit("orgSpend", unit: "usd", source: .value(kind: .dollars)),
+            .percent(id: "copilot.chat", provider: provider, title: "Chat")
+                .exportingLimit("chat", unit: "percent"),
             .percent(id: "copilot.completions", provider: provider, title: "Completions")
+                .exportingLimit("completions", unit: "percent")
         ]
     }
 

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -31,13 +31,19 @@ final class CursorProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "cursor.usage", provider: provider, title: "Total Usage", metricLabel: "Total usage"),
-            .percent(id: "cursor.auto", provider: provider, title: "Auto Usage", metricLabel: "Auto usage"),
-            .percent(id: "cursor.api", provider: provider, title: "API Usage", metricLabel: "API usage"),
-            .boundedDollars(id: "cursor.onDemand", provider: provider, title: "Extra Usage", metricLabel: "On-demand", limit: 100, valueWord: "spent"),
+            .percent(id: "cursor.usage", provider: provider, title: "Total Usage", metricLabel: "Total usage")
+                .exportingLimit("totalUsage", unit: "percent"),
+            .percent(id: "cursor.auto", provider: provider, title: "Auto Usage", metricLabel: "Auto usage")
+                .exportingLimit("autoUsage", unit: "percent"),
+            .percent(id: "cursor.api", provider: provider, title: "API Usage", metricLabel: "API usage")
+                .exportingLimit("apiUsage", unit: "percent"),
+            .boundedDollars(id: "cursor.onDemand", provider: provider, title: "Extra Usage", metricLabel: "On-demand", limit: 100, valueWord: "spent")
+                .exportingLimit("onDemand", unit: "usd", source: .progressOrValue(kind: .dollars)),
             .boundedCount(id: "cursor.requests", provider: provider, title: "Requests", limit: 500,
-                          suffix: "requests", periodDurationMs: CursorUsageMapper.billingPeriodMs),
-            .dollarBalance(id: "cursor.credits", provider: provider, title: "Credits", valueWord: "left"),
+                          suffix: "requests", periodDurationMs: CursorUsageMapper.billingPeriodMs)
+                .exportingLimit("requests", unit: "requests"),
+            .dollarBalance(id: "cursor.credits", provider: provider, title: "Credits", valueWord: "left")
+                .exportingLimit("credits", kind: .balance, unit: "usd", source: .value(kind: .dollars)),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(
             provider: provider,

--- a/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
+++ b/Sources/OpenUsage/Providers/Devin/DevinProvider.swift
@@ -27,9 +27,12 @@ final class DevinProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "devin.daily", provider: provider, title: "Daily", metricLabel: "Daily quota"),
-            .percent(id: "devin.weekly", provider: provider, title: "Weekly", metricLabel: "Weekly quota"),
+            .percent(id: "devin.daily", provider: provider, title: "Daily", metricLabel: "Daily quota")
+                .exportingLimit("daily", unit: "percent"),
+            .percent(id: "devin.weekly", provider: provider, title: "Weekly", metricLabel: "Weekly quota")
+                .exportingLimit("weekly", unit: "percent"),
             .dollarBalance(id: "devin.extra", provider: provider, title: "Extra Balance", metricLabel: "Extra usage balance", valueWord: "left")
+                .exportingLimit("extraUsageBalance", kind: .balance, unit: "usd", source: .value(kind: .dollars))
         ]
     }
 

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -33,7 +33,8 @@ final class GrokProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "grok.weekly", provider: provider, title: "Weekly", metricLabel: "Weekly limit"),
+            .percent(id: "grok.weekly", provider: provider, title: "Weekly", metricLabel: "Weekly limit")
+                .exportingLimit("weekly", unit: "percent"),
             .badge(id: "grok.payAsYouGo", provider: provider, title: "Extra Usage", metricLabel: "Pay as you go"),
             .usageTrend(provider: provider)
             // Local spend tiles, estimated from the Grok CLI log (see GrokLogUsageScanner).

--- a/Sources/OpenUsage/Providers/OpenCode/OpenCodeProvider.swift
+++ b/Sources/OpenUsage/Providers/OpenCode/OpenCodeProvider.swift
@@ -64,9 +64,12 @@ final class OpenCodeProvider: ProviderRuntime {
         // Go plan caps read from local `opencode-go` spend (Session/Weekly above the fold, Monthly on
         // demand); the spend tiles + trend below sum combined OpenCode-hosted (Go + Zen) spend.
         [
-            .boundedDollars(id: "opencode.session", provider: provider, title: "Session", limit: OpenCodeUsageMapper.sessionCap),
-            .boundedDollars(id: "opencode.weekly", provider: provider, title: "Weekly", limit: OpenCodeUsageMapper.weeklyCap),
-            .boundedDollars(id: "opencode.monthly", provider: provider, title: "Monthly", limit: OpenCodeUsageMapper.monthlyCap),
+            .boundedDollars(id: "opencode.session", provider: provider, title: "Session", limit: OpenCodeUsageMapper.sessionCap)
+                .exportingLimit("session", unit: "usd", estimated: true),
+            .boundedDollars(id: "opencode.weekly", provider: provider, title: "Weekly", limit: OpenCodeUsageMapper.weeklyCap)
+                .exportingLimit("weekly", unit: "usd", estimated: true),
+            .boundedDollars(id: "opencode.monthly", provider: provider, title: "Monthly", limit: OpenCodeUsageMapper.monthlyCap)
+                .exportingLimit("monthly", unit: "usd", estimated: true),
             .usageTrend(provider: provider)
         ] + WidgetDescriptor.spendTiles(provider: provider)
     }

--- a/Sources/OpenUsage/Providers/OpenRouter/OpenRouterProvider.swift
+++ b/Sources/OpenUsage/Providers/OpenRouter/OpenRouterProvider.swift
@@ -29,9 +29,11 @@ final class OpenRouterProvider: ProviderRuntime {
     var widgetDescriptors: [WidgetDescriptor] {
         [
             .boundedDollars(id: "openrouter.credits", provider: provider, title: "Credits",
-                            metricLabel: "Credits", limit: 100, limitNoun: "purchased"),
+                            metricLabel: "Credits", limit: 100, limitNoun: "purchased")
+                .exportingLimit("credits", unit: "usd"),
             .dollarBalance(id: "openrouter.balance", provider: provider, title: "Balance",
-                           metricLabel: "Balance", valueWord: "left"),
+                           metricLabel: "Balance", valueWord: "left")
+                .exportingLimit("balance", kind: .balance, unit: "usd", source: .value(kind: .dollars)),
             .values(id: "openrouter.today", provider: provider, title: "Today",
                     metricLabel: "Today", selection: .kind(.dollars), isUsagePeriod: true),
             .values(id: "openrouter.week", provider: provider, title: "This Week",
@@ -40,6 +42,7 @@ final class OpenRouterProvider: ProviderRuntime {
                     metricLabel: "This Month", selection: .kind(.dollars), isUsagePeriod: true),
             .boundedDollars(id: "openrouter.keyLimit", provider: provider, title: "Key Limit",
                             metricLabel: "Key Limit", limit: 100, valueWord: "spent")
+                .exportingLimit("keyLimit", unit: "usd")
         ]
     }
 

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// The installed provider set and its canonical order. Both the menu-bar app and one-shot CLI build
+/// their runtimes here so credentials, refresh behavior, pricing, and normalization can never drift.
+@MainActor
+enum ProviderCatalog {
+    static func make(defaults: UserDefaults = .standard) -> [ProviderRuntime] {
+        // Default provider order (see AGENTS.md "## Providers"): the three established providers first,
+        // then every other provider alphabetically by display name.
+        [
+            ClaudeProvider(),
+            CodexProvider(),
+            CursorProvider(),
+            AntigravityProvider(),
+            CopilotProvider(defaults: defaults),
+            DevinProvider(),
+            GrokProvider(),
+            OpenCodeProvider(),
+            OpenRouterProvider(),
+            ZAIProvider()
+        ]
+    }
+}

--- a/Sources/OpenUsage/Providers/ZAI/ZAIProvider.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIProvider.swift
@@ -29,12 +29,15 @@ final class ZAIProvider: ProviderRuntime {
     var widgetDescriptors: [WidgetDescriptor] {
         [
             .percent(id: "zai.session", provider: provider, title: "Session",
-                     metricLabel: "Session"),
+                     metricLabel: "Session")
+                .exportingLimit("session", unit: "percent"),
             .percent(id: "zai.weekly", provider: provider, title: "Weekly",
-                     metricLabel: "Weekly"),
+                     metricLabel: "Weekly")
+                .exportingLimit("weekly", unit: "percent"),
             .boundedCount(id: "zai.webSearches", provider: provider, title: "Web Searches",
                           metricLabel: "Web Searches", limit: 1000, suffix: "searches",
                           periodDurationMs: ZAIUsageMapper.monthlyPeriodMs)
+                .exportingLimit("webSearches", unit: "searches")
         ]
     }
 

--- a/Sources/OpenUsage/Services/CommandLineToolInstaller.swift
+++ b/Sources/OpenUsage/Services/CommandLineToolInstaller.swift
@@ -1,0 +1,152 @@
+import AppKit
+import Foundation
+import Observation
+
+/// Installs the bundled one-shot CLI on the stock macOS PATH without copying it out of the app.
+/// The symlink survives in-place Sparkle updates because its destination path stays stable.
+@MainActor
+@Observable
+final class CommandLineToolInstaller {
+    enum Status: Equatable {
+        case notInstalled
+        case installed
+        case conflict
+    }
+
+    enum Operation { case install, uninstall }
+    enum OperationResult { case success, cancelled, failure(String) }
+
+    private(set) var status: Status
+    private(set) var errorMessage: String?
+
+    let destinationPath: String
+    private let sourcePath: String
+    private let fileManager: FileManager
+    private let performPrivileged: @MainActor (Operation, String, String) -> OperationResult
+
+    init(
+        sourcePath: String = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Helpers/openusage").path,
+        destinationPath: String = "/usr/local/bin/openusage",
+        fileManager: FileManager = .default,
+        performPrivileged: (@MainActor (Operation, String, String) -> OperationResult)? = nil
+    ) {
+        self.sourcePath = sourcePath
+        self.destinationPath = destinationPath
+        self.fileManager = fileManager
+        self.performPrivileged = performPrivileged ?? { operation, source, destination in
+            CommandLineToolInstaller.runPrivileged(
+                operation: operation,
+                sourcePath: source,
+                destinationPath: destination
+            )
+        }
+        self.status = Self.currentStatus(
+            sourcePath: sourcePath,
+            destinationPath: destinationPath,
+            fileManager: fileManager
+        )
+    }
+
+    func refreshStatus() {
+        status = Self.currentStatus(
+            sourcePath: sourcePath,
+            destinationPath: destinationPath,
+            fileManager: fileManager
+        )
+    }
+
+    func install() {
+        refreshStatus()
+        guard status != .installed else { return }
+        guard status != .conflict else {
+            errorMessage = "\(destinationPath) already exists and wasn't installed by OpenUsage."
+            return
+        }
+        guard fileManager.isExecutableFile(atPath: sourcePath) else {
+            errorMessage = "The bundled terminal helper couldn't be found. Reinstall OpenUsage and try again."
+            return
+        }
+        handle(performPrivileged(.install, sourcePath, destinationPath), action: "install")
+    }
+
+    func uninstall() {
+        refreshStatus()
+        guard status == .installed else { return }
+        handle(performPrivileged(.uninstall, sourcePath, destinationPath), action: "remove")
+    }
+
+    private func handle(_ result: OperationResult, action: String) {
+        switch result {
+        case .success:
+            errorMessage = nil
+        case .cancelled:
+            break
+        case .failure(let message):
+            errorMessage = "Couldn't \(action) the terminal helper: \(message)"
+            AppLog.error(.config, "Terminal helper \(action) failed: \(message)")
+        }
+        refreshStatus()
+    }
+
+    private static func currentStatus(
+        sourcePath: String,
+        destinationPath: String,
+        fileManager: FileManager
+    ) -> Status {
+        guard let target = try? fileManager.destinationOfSymbolicLink(atPath: destinationPath) else {
+            return fileManager.fileExists(atPath: destinationPath) ? .conflict : .notInstalled
+        }
+        // The installer always writes this exact absolute target, and uninstall checks the same string
+        // again under privilege. A manually-created relative/equivalent link is therefore foreign.
+        return target == sourcePath ? .installed : .conflict
+    }
+
+    private static func runPrivileged(
+        operation: Operation,
+        sourcePath: String,
+        destinationPath: String
+    ) -> OperationResult {
+        let directory = (destinationPath as NSString).deletingLastPathComponent
+        let command: String
+        switch operation {
+        case .install:
+            command = """
+            if [ -e \(shellQuote(destinationPath)) ] || [ -L \(shellQuote(destinationPath)) ]; then exit 73; fi
+            /bin/mkdir -p \(shellQuote(directory)) && /bin/ln -s \(shellQuote(sourcePath)) \(shellQuote(destinationPath))
+            """
+        case .uninstall:
+            command = """
+            target=$(/usr/bin/readlink \(shellQuote(destinationPath))) || exit 74
+            [ "$target" = \(shellQuote(sourcePath)) ] || exit 75
+            /bin/rm \(shellQuote(destinationPath))
+            """
+        }
+
+        let source = "do shell script \(appleScriptStringLiteral(command)) with administrator privileges"
+        guard let script = NSAppleScript(source: source) else {
+            return .failure("macOS couldn't prepare the authorization request.")
+        }
+        var errorInfo: NSDictionary?
+        script.executeAndReturnError(&errorInfo)
+        guard let errorInfo else { return .success }
+        if let code = errorInfo[NSAppleScript.errorNumber] as? Int, code == -128 {
+            return .cancelled
+        }
+        return .failure(
+            (errorInfo[NSAppleScript.errorMessage] as? String)
+                ?? "macOS rejected the authorization request."
+        )
+    }
+
+    private static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private static func appleScriptStringLiteral(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+}

--- a/Sources/OpenUsage/Services/LocalLimitsAPI.swift
+++ b/Sources/OpenUsage/Services/LocalLimitsAPI.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// Machine-facing limits serializer shared by the one-shot CLI and local HTTP API.
+/// Provider refresh/mapping remains the single source of truth; this edge only selects scalar resources
+/// explicitly declared on `WidgetDescriptor` and gives them stable public names.
+enum LocalLimitsAPI {
+    static let schema = "openusage.limits.v1"
+
+    static func encode(providerIDs: [String], state: LocalUsageAPI.State) -> Data {
+        var providers: [String: WireProvider] = [:]
+        for providerID in providerIDs {
+            guard let snapshot = state.snapshots[providerID] else { continue }
+            let descriptors = state.limitDescriptors[providerID] ?? []
+            providers[providerID] = WireProvider(
+                snapshot: snapshot,
+                descriptors: descriptors,
+                generatedAt: state.generatedAt
+            )
+        }
+        let errors = providerIDs.compactMap { providerID in
+            state.errors[providerID].map { WireError(providerID: providerID, message: $0) }
+        }
+        return encode(WireEnvelope(
+            schema: schema,
+            generatedAt: OpenUsageISO8601.string(from: state.generatedAt),
+            providers: providers,
+            errors: errors
+        ))
+    }
+
+    private static func encode(_ value: some Encodable) -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return (try? encoder.encode(value)) ?? Data(#"{"errors":[],"providers":{},"schema":"openusage.limits.v1"}"#.utf8)
+    }
+
+    private struct WireEnvelope: Encodable {
+        let schema: String
+        let generatedAt: String
+        let providers: [String: WireProvider]
+        let errors: [WireError]
+    }
+
+    private struct WireError: Encodable {
+        let providerID: String
+        let message: String
+
+        enum CodingKeys: String, CodingKey {
+            case providerID = "providerId"
+            case message
+        }
+    }
+
+    private struct WireProvider: Encodable {
+        let displayName: String
+        let plan: String?
+        let fetchedAt: String
+        let expiresAt: String
+        let stale: Bool
+        let resources: [String: WireResource]
+
+        init(snapshot: ProviderSnapshot, descriptors: [WidgetDescriptor], generatedAt: Date) {
+            displayName = snapshot.displayName
+            plan = snapshot.plan
+            fetchedAt = OpenUsageISO8601.string(from: snapshot.refreshedAt)
+            let expiry = snapshot.refreshedAt.addingTimeInterval(RefreshSetting.interval)
+            expiresAt = OpenUsageISO8601.string(from: expiry)
+            stale = generatedAt >= expiry
+
+            var resources: [String: WireResource] = [:]
+            for descriptor in descriptors {
+                guard let line = snapshot.line(label: descriptor.metricLabel) else { continue }
+                for resource in descriptor.limitResources {
+                    if let value = WireResource(resource: resource, line: line) {
+                        resources[resource.key] = value
+                    }
+                }
+            }
+            self.resources = resources
+        }
+    }
+
+    private struct WireResource: Encodable {
+        let kind: LimitResourceDescriptor.Kind
+        let unit: String
+        var used: Double?
+        var available: Double?
+        var limit: Double?
+        var remaining: Double?
+        var utilization: Double?
+        var resetsAt: String?
+        var windowSeconds: Double?
+        var expiresAt: [String]?
+        var estimated: Bool?
+
+        init?(resource: LimitResourceDescriptor, line: MetricLine) {
+            kind = resource.kind
+            unit = resource.unit
+
+            switch (resource.source, line) {
+            case (.progress, .progress(_, let rawUsed, let rawLimit, _, let reset, let periodMs, _)):
+                applyProgress(
+                    used: rawUsed, limit: rawLimit, reset: reset, periodMs: periodMs,
+                    resource: resource
+                )
+
+            case (.progressOrValue(_, _),
+                  .progress(_, let rawUsed, let rawLimit, _, let reset, let periodMs, _)):
+                applyProgress(
+                    used: rawUsed, limit: rawLimit, reset: reset, periodMs: periodMs,
+                    resource: resource
+                )
+
+            case (.value(let expectedKind, let expectedLabel),
+                  .values(_, let values, _, let expiries, _, _)),
+                 (.progressOrValue(let expectedKind, let expectedLabel),
+                  .values(_, let values, _, let expiries, _, _)):
+                guard let metric = values.first(where: { value in
+                    value.kind == expectedKind && (expectedLabel == nil || value.label == expectedLabel)
+                }) else { return nil }
+                if resource.kind == .balance {
+                    available = metric.number
+                } else {
+                    used = metric.number
+                }
+                expiresAt = expiries.isEmpty ? nil : expiries.sorted().map(OpenUsageISO8601.string(from:))
+                estimated = resource.estimated || metric.estimated ? true : nil
+
+            default:
+                return nil
+            }
+        }
+
+        private mutating func applyProgress(
+            used rawUsed: Double,
+            limit rawLimit: Double,
+            reset: Date?,
+            periodMs: Int?,
+            resource: LimitResourceDescriptor
+        ) {
+            let boundedLimit = max(0, rawLimit)
+            let boundedUsed = max(0, rawUsed)
+            used = resource.kind == .consumption ? boundedUsed : nil
+            available = resource.kind == .balance ? boundedUsed : nil
+            limit = boundedLimit
+            remaining = max(0, boundedLimit - boundedUsed)
+            utilization = boundedLimit > 0 ? boundedUsed / boundedLimit : nil
+            resetsAt = reset.map(OpenUsageISO8601.string(from:))
+            windowSeconds = periodMs.map { Double($0) / 1_000 }
+            estimated = resource.estimated ? true : nil
+        }
+    }
+}

--- a/Sources/OpenUsage/Services/LocalUsageAPI.swift
+++ b/Sources/OpenUsage/Services/LocalUsageAPI.swift
@@ -45,7 +45,11 @@ enum LocalUsageAPI {
             guard method == "GET" else { return error(405, "method_not_allowed") }
             let providerID = segments[2]
             guard state.knownIDs.contains(providerID) else { return error(404, "provider_not_found") }
-            guard state.snapshots[providerID] != nil else { return Response(status: 204, body: nil) }
+            // A failed refresh without a last-good snapshot still has useful machine-readable output.
+            // Only the genuinely untouched state is 204; failures return the normal envelope + error.
+            guard state.snapshots[providerID] != nil || state.errors[providerID] != nil else {
+                return Response(status: 204, body: nil)
+            }
             return Response(
                 status: 200,
                 body: LocalLimitsAPI.encode(providerIDs: [providerID], state: state)

--- a/Sources/OpenUsage/Services/LocalUsageAPI.swift
+++ b/Sources/OpenUsage/Services/LocalUsageAPI.swift
@@ -12,6 +12,10 @@ enum LocalUsageAPI {
         /// Every provider the registry knows — single-provider lookups work for disabled ones too.
         var knownIDs: Set<String>
         var snapshots: [String: ProviderSnapshot]
+        /// Only descriptors explicitly opted into the stable limits contract.
+        var limitDescriptors: [String: [WidgetDescriptor]] = [:]
+        var errors: [String: String] = [:]
+        var generatedAt = Date()
     }
 
     struct Response: Equatable, Sendable {
@@ -30,6 +34,23 @@ enum LocalUsageAPI {
             .map(String.init)
 
         switch (segments.count, segments.first, segments.dropFirst().first) {
+        case (2, "v1", "limits"):
+            guard method == "GET" else { return error(405, "method_not_allowed") }
+            return Response(
+                status: 200,
+                body: LocalLimitsAPI.encode(providerIDs: state.enabledOrderedIDs, state: state)
+            )
+
+        case (3, "v1", "limits"):
+            guard method == "GET" else { return error(405, "method_not_allowed") }
+            let providerID = segments[2]
+            guard state.knownIDs.contains(providerID) else { return error(404, "provider_not_found") }
+            guard state.snapshots[providerID] != nil else { return Response(status: 204, body: nil) }
+            return Response(
+                status: 200,
+                body: LocalLimitsAPI.encode(providerIDs: [providerID], state: state)
+            )
+
         case (2, "v1", "usage"):
             guard method == "GET" else { return error(405, "method_not_allowed") }
             let snapshots = state.enabledOrderedIDs.compactMap { state.snapshots[$0] }

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+public struct UsageReadResult: Sendable {
+    public let data: Data
+    public let warnings: [String]
+}
+
+public enum UsageReaderError: LocalizedError, Sendable {
+    case unknownProvider(String)
+    case noCachedSnapshot(String)
+    case refreshFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unknownProvider(let providerID):
+            "Unknown provider: \(providerID)"
+        case .noCachedSnapshot(let providerID):
+            "No cached usage for \(providerID). Run with --force to fetch it."
+        case .refreshFailed(let message):
+            "Refresh failed: \(message)"
+        }
+    }
+}
+
+/// One-shot access to the same provider cache and refresh engine used by the menu-bar app.
+/// It owns no timer, local server, status item, updater, or other long-lived app service.
+@MainActor
+public struct UsageReader {
+    private let defaults: UserDefaults
+    private let providersOverride: [ProviderRuntime]?
+
+    public init(userDefaults: UserDefaults) {
+        self.defaults = userDefaults
+        self.providersOverride = nil
+    }
+
+    init(userDefaults: UserDefaults, providers: [ProviderRuntime]) {
+        self.defaults = userDefaults
+        self.providersOverride = providers
+    }
+
+    public func read(providerID requestedProviderID: String? = nil, force: Bool = false) async throws -> UsageReadResult {
+        let providerID = requestedProviderID?.lowercased()
+        let providers = providersOverride ?? ProviderCatalog.make(defaults: defaults)
+        let registry = WidgetRegistry.from(providers)
+        let knownIDs = Set(registry.providers.map(\.id))
+        if let providerID, !knownIDs.contains(providerID) {
+            throw UsageReaderError.unknownProvider(providerID)
+        }
+
+        let enablement = ProviderEnablementStore(defaults: defaults)
+        let includesProvider: @MainActor (String) -> Bool = { id in
+            providerID.map { $0 == id } ?? enablement.isEnabled(id)
+        }
+        let cache = ProviderSnapshotCache(userDefaults: defaults, allowsPersistedFreshness: true)
+        let allProviderIDs = registry.providers.map(\.id)
+        let cachedSnapshots = cache.loadSnapshots(providerIDs: allProviderIDs)
+        let orderedIDs = orderedProviderIDs(registry: registry)
+        let enabledOrderedIDs = orderedIDs.filter(includesProvider)
+        let needsRefresh = force || enabledOrderedIDs.contains { cache.snapshot(providerID: $0) == nil }
+        var snapshots = cachedSnapshots
+        var warnings: [String] = []
+
+        if needsRefresh {
+            LoginShellEnvironment.shared.prewarm()
+            let dataStore = WidgetDataStore(
+                registry: registry,
+                providers: providers,
+                cache: cache,
+                defaults: defaults,
+                isProviderEnabled: includesProvider
+            )
+            if let providerID {
+                _ = await dataStore.refresh(providerID: providerID, force: force)
+            } else {
+                await dataStore.refreshAll(force: force)
+            }
+            snapshots = dataStore.snapshots
+            warnings = orderedProviderIDs(registry: registry)
+                .compactMap { id in dataStore.providerErrors[id].map { "\(id): \($0)" } }
+        }
+
+        let state = LocalUsageAPI.State(
+            enabledOrderedIDs: enabledOrderedIDs,
+            knownIDs: knownIDs,
+            snapshots: snapshots
+        )
+        let path = providerID.map { "/v1/usage/\($0)" } ?? "/v1/usage"
+        let response = LocalUsageAPI.respond(method: "GET", path: path, state: state)
+        guard let data = response.body else {
+            if let warning = warnings.first {
+                throw UsageReaderError.refreshFailed(warning)
+            }
+            throw UsageReaderError.noCachedSnapshot(providerID ?? "enabled providers")
+        }
+        return UsageReadResult(data: data, warnings: warnings)
+    }
+
+    private func orderedProviderIDs(registry: WidgetRegistry) -> [String] {
+        let defaultsOrder = registry.providers.map(\.id)
+        let savedOrder = LayoutPersistence(
+            defaults: defaults,
+            storageKey: "openusage.layout.v1"
+        ).loadProviderOrder() ?? []
+        let knownIDs = Set(defaultsOrder)
+        let validSavedOrder = savedOrder.filter { knownIDs.contains($0) }
+        let savedIDs = Set(validSavedOrder)
+        return validSavedOrder + defaultsOrder.filter { !savedIDs.contains($0) }
+    }
+}

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -55,7 +55,11 @@ public struct UsageReader {
         let cache = ProviderSnapshotCache(userDefaults: defaults, allowsPersistedFreshness: true)
         let allProviderIDs = registry.providers.map(\.id)
         let cachedSnapshots = cache.loadSnapshots(providerIDs: allProviderIDs)
-        let orderedIDs = orderedProviderIDs(registry: registry)
+        let savedOrder = LayoutPersistence(
+            defaults: defaults,
+            storageKey: "openusage.layout.v1"
+        ).loadProviderOrder() ?? []
+        let orderedIDs = registry.orderedProviderIDs(savedOrder: savedOrder)
         let enabledOrderedIDs = orderedIDs.filter(includesProvider)
         let needsRefresh = force || enabledOrderedIDs.contains { cache.snapshot(providerID: $0) == nil }
         var snapshots = cachedSnapshots
@@ -78,7 +82,7 @@ public struct UsageReader {
             }
             snapshots = dataStore.snapshots
             errors = dataStore.providerErrors
-            warnings = orderedProviderIDs(registry: registry)
+            warnings = orderedIDs
                 .compactMap { id in errors[id].map { "\(id): \($0)" } }
         }
 
@@ -100,15 +104,4 @@ public struct UsageReader {
         return UsageReadResult(data: data, warnings: warnings)
     }
 
-    private func orderedProviderIDs(registry: WidgetRegistry) -> [String] {
-        let defaultsOrder = registry.providers.map(\.id)
-        let savedOrder = LayoutPersistence(
-            defaults: defaults,
-            storageKey: "openusage.layout.v1"
-        ).loadProviderOrder() ?? []
-        let knownIDs = Set(defaultsOrder)
-        let validSavedOrder = savedOrder.filter { knownIDs.contains($0) }
-        let savedIDs = Set(validSavedOrder)
-        return validSavedOrder + defaultsOrder.filter { !savedIDs.contains($0) }
-    }
 }

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -60,6 +60,7 @@ public struct UsageReader {
         let needsRefresh = force || enabledOrderedIDs.contains { cache.snapshot(providerID: $0) == nil }
         var snapshots = cachedSnapshots
         var warnings: [String] = []
+        var errors: [String: String] = [:]
 
         if needsRefresh {
             LoginShellEnvironment.shared.prewarm()
@@ -76,16 +77,19 @@ public struct UsageReader {
                 await dataStore.refreshAll(force: force)
             }
             snapshots = dataStore.snapshots
+            errors = dataStore.providerErrors
             warnings = orderedProviderIDs(registry: registry)
-                .compactMap { id in dataStore.providerErrors[id].map { "\(id): \($0)" } }
+                .compactMap { id in errors[id].map { "\(id): \($0)" } }
         }
 
         let state = LocalUsageAPI.State(
             enabledOrderedIDs: enabledOrderedIDs,
             knownIDs: knownIDs,
-            snapshots: snapshots
+            snapshots: snapshots,
+            limitDescriptors: registry.limitDescriptorsByProvider,
+            errors: errors
         )
-        let path = providerID.map { "/v1/usage/\($0)" } ?? "/v1/usage"
+        let path = providerID.map { "/v1/limits/\($0)" } ?? "/v1/limits"
         let response = LocalUsageAPI.respond(method: "GET", path: path, state: state)
         guard let data = response.body else {
             if let warning = warnings.first {

--- a/Sources/OpenUsage/Stores/LayoutStore+Customization.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore+Customization.swift
@@ -42,10 +42,7 @@ extension LayoutStore {
     /// Known providers in the user's saved order, with any not-yet-seen provider appended in registry order
     /// so a newly added provider still shows up.
     func orderedProviderIDs() -> [String] {
-        let known = registry.providers.map(\.id)
-        let ordered = providerOrder.filter { known.contains($0) }
-        let missing = known.filter { !ordered.contains($0) }
-        return ordered + missing
+        registry.orderedProviderIDs(savedOrder: providerOrder)
     }
 
     private func orderedProviders() -> [Provider] {

--- a/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
+++ b/Sources/OpenUsage/Stores/ProviderSnapshotCache.swift
@@ -28,6 +28,9 @@ struct ProviderSnapshotCache {
     /// fresh regardless of its `refreshedAt` — see `sessionWrites`. Tests inject a fixed TTL for a
     /// deterministic freshness window.
     private let ttl: TimeInterval
+    /// The menu-bar app deliberately refreshes once per launch, even when its persisted snapshot is
+    /// young. A one-shot reader has no meaningful session, so it opts into timestamp-only freshness.
+    private let allowsPersistedFreshness: Bool
     private let now: () -> Date
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -49,11 +52,13 @@ struct ProviderSnapshotCache {
         // decode cleanly without it, but the bump fetches fresh snapshots so hover panels appear right away.
         storageKey: String = "openusage.providerSnapshots.v7",
         ttl: TimeInterval = RefreshSetting.interval,
+        allowsPersistedFreshness: Bool = false,
         now: @escaping () -> Date = Date.init
     ) {
         self.userDefaults = userDefaults
         self.storageKey = storageKey
         self.ttl = ttl
+        self.allowsPersistedFreshness = allowsPersistedFreshness
         self.now = now
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -84,8 +89,9 @@ struct ProviderSnapshotCache {
         // promptly instead of waiting out the previous session's remaining interval (#697).
         let writtenThisSession = sessionWrites.withLock { $0.contains(providerID) }
         let age = now().timeIntervalSince(snapshot.refreshedAt)
-        let fresh = writtenThisSession && age < ttl
-        let reason = !writtenThisSession ? "stale (not written this session)"
+        let trusted = allowsPersistedFreshness || writtenThisSession
+        let fresh = trusted && age < ttl
+        let reason = !trusted ? "stale (not written this session)"
             : fresh ? "fresh" : "stale"
         AppLog.debug(.cache, "\(providerID) staleness \(Int(age))s vs ttl \(Int(ttl))s -> \(reason)")
         return fresh ? snapshot : nil

--- a/Sources/OpenUsage/Stores/WidgetRegistry.swift
+++ b/Sources/OpenUsage/Stores/WidgetRegistry.swift
@@ -44,6 +44,16 @@ struct WidgetRegistry: Sendable {
         descriptorsByProvider[providerID] ?? []
     }
 
+    /// Saved order filtered to installed providers, with newly introduced providers appended in the
+    /// canonical registry order. Shared by the dashboard, local API, and one-shot CLI.
+    func orderedProviderIDs(savedOrder: [String]) -> [String] {
+        let defaults = providers.map(\.id)
+        let known = Set(defaults)
+        let saved = savedOrder.filter { known.contains($0) }
+        let savedIDs = Set(saved)
+        return saved + defaults.filter { !savedIDs.contains($0) }
+    }
+
     var limitDescriptorsByProvider: [String: [WidgetDescriptor]] {
         descriptorsByProvider.mapValues { $0.filter { !$0.limitResources.isEmpty } }
     }

--- a/Sources/OpenUsage/Stores/WidgetRegistry.swift
+++ b/Sources/OpenUsage/Stores/WidgetRegistry.swift
@@ -44,6 +44,10 @@ struct WidgetRegistry: Sendable {
         descriptorsByProvider[providerID] ?? []
     }
 
+    var limitDescriptorsByProvider: [String: [WidgetDescriptor]] {
+        descriptorsByProvider.mapValues { $0.filter { !$0.limitResources.isEmpty } }
+    }
+
     @MainActor
     static func from(_ runtimes: [ProviderRuntime]) -> WidgetRegistry {
         let providers = runtimes.map(\.provider)

--- a/Sources/OpenUsage/Support/ContainingAppBundle.swift
+++ b/Sources/OpenUsage/Support/ContainingAppBundle.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Finds the `.app` containing an executable, including helpers invoked through a symlink on `PATH`.
+public enum ContainingAppBundle {
+    public static func url(for executableURL: URL) -> URL? {
+        var candidate = executableURL.resolvingSymlinksInPath().standardizedFileURL
+        while candidate.path != "/" {
+            if candidate.pathExtension == "app" { return candidate }
+            candidate.deleteLastPathComponent()
+        }
+        return nil
+    }
+}

--- a/Sources/OpenUsage/Support/ResourceBundle.swift
+++ b/Sources/OpenUsage/Support/ResourceBundle.swift
@@ -14,9 +14,13 @@ extension Bundle {
     /// `Bundle.module` for `swift run` / `swift test`, where the build path is valid.
     static let openUsageResources: Bundle = {
         let bundleName = "OpenUsage_OpenUsage.bundle"
+        let containingAppResources = Bundle.main.executableURL
+            .flatMap(ContainingAppBundle.url(for:))?
+            .appendingPathComponent("Contents/Resources", isDirectory: true)
         let searchBases: [URL?] = [
             Bundle.main.resourceURL,                          // packaged .app: Contents/Resources
             Bundle.main.bundleURL,                            // bundle beside the app root
+            containingAppResources,                          // bundled CLI: helper -> app Resources
             Bundle(for: ResourceBundleToken.self).resourceURL,
             Bundle(for: ResourceBundleToken.self).bundleURL
         ]

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -15,6 +15,7 @@ struct SettingsScreen: View {
     @Environment(UpdaterController.self) private var updater
 
     @State private var launchAtLogin = LaunchAtLoginSetting()
+    @State private var commandLineTool = CommandLineToolInstaller()
     @AppStorage(TotalSpendSetting.key) private var showTotalSpend = true
     @AppStorage(AppearanceSetting.key) private var appearance = AppearanceSetting.system
     @AppStorage(TimeFormatSetting.key) private var timeFormat = TimeFormatSetting.auto
@@ -156,6 +157,7 @@ struct SettingsScreen: View {
                     .padding(.bottom, 8)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+            commandLineSection
             advancedSection
             // Visible whenever the updater is active (only the signed release build ships a feed; the
             // dev build and a bare `swift run`, with no feed, hide this).
@@ -195,6 +197,7 @@ struct SettingsScreen: View {
         .padding(.vertical, 12)
         .task { await refreshNotificationsAuth() }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            commandLineTool.refreshStatus()
             Task { await refreshNotificationsAuth() }
         }
     }
@@ -301,6 +304,35 @@ struct SettingsScreen: View {
         case .denied: notificationsAuth = .denied
         case .notDetermined: notificationsAuth = .notDetermined
         default: notificationsAuth = .authorized
+        }
+    }
+
+    // MARK: - Command Line
+
+    private var commandLineSection: some View {
+        section("Command Line") {
+            row("Terminal Helper") {
+                switch commandLineTool.status {
+                case .installed:
+                    Button("Uninstall") { commandLineTool.uninstall() }
+                case .notInstalled:
+                    Button("Install…") { commandLineTool.install() }
+                case .conflict:
+                    Text("Unavailable")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Text("Adds a global `openusage` command agents can use to monitor limits.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if commandLineTool.status == .conflict {
+                inlineNotice("\(commandLineTool.destinationPath) already exists and wasn't installed by OpenUsage.")
+            } else if let errorMessage = commandLineTool.errorMessage {
+                inlineNotice(errorMessage)
+            }
         }
     }
 

--- a/Sources/OpenUsageApp/OpenUsageApp.swift
+++ b/Sources/OpenUsageApp/OpenUsageApp.swift
@@ -1,0 +1,16 @@
+import OpenUsage
+import SwiftUI
+
+@main
+struct OpenUsageApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+    var body: some Scene {
+        // Menu-bar app: the status item and custom panel are AppKit-owned (see StatusItemController),
+        // so no window scene is wanted. `Settings` gives SwiftUI a valid scene without creating
+        // an activation window.
+        Settings {
+            EmptyView()
+        }
+    }
+}

--- a/Sources/OpenUsageCLI/AppBundleLocator.swift
+++ b/Sources/OpenUsageCLI/AppBundleLocator.swift
@@ -1,0 +1,27 @@
+import Foundation
+import OpenUsage
+
+struct AppBundleLocator: Sendable {
+    let bundleIdentifier: String
+    let version: String?
+
+    static func locate(
+        executableURL: URL = Bundle.main.executableURL ?? URL(fileURLWithPath: CommandLine.arguments[0]),
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> AppBundleLocator {
+        if let suite = environment["OPENUSAGE_DEFAULTS_SUITE"], !suite.isEmpty {
+            return AppBundleLocator(bundleIdentifier: suite, version: nil)
+        }
+
+        if let appURL = ContainingAppBundle.url(for: executableURL),
+           let info = NSDictionary(contentsOf: appURL.appendingPathComponent("Contents/Info.plist")),
+           let bundleIdentifier = info["CFBundleIdentifier"] as? String {
+            return AppBundleLocator(
+                bundleIdentifier: bundleIdentifier,
+                version: info["CFBundleShortVersionString"] as? String
+            )
+        }
+
+        return AppBundleLocator(bundleIdentifier: "com.robinebers.openusage", version: nil)
+    }
+}

--- a/Sources/OpenUsageCLI/CLIArguments.swift
+++ b/Sources/OpenUsageCLI/CLIArguments.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct CLIArguments: Equatable, Sendable {
+    var providerID: String?
+    var force = false
+    var showHelp = false
+    var showVersion = false
+
+    static func parse(_ arguments: [String]) throws -> CLIArguments {
+        var parsed = CLIArguments()
+        for argument in arguments {
+            switch argument {
+            case "--force": parsed.force = true
+            case "-h", "--help": parsed.showHelp = true
+            case "-v", "--version": parsed.showVersion = true
+            default:
+                if argument.hasPrefix("-") {
+                    throw CLIError.usage("Unknown option: \(argument)")
+                }
+                guard parsed.providerID == nil else {
+                    throw CLIError.usage("Only one provider can be requested at a time.")
+                }
+                parsed.providerID = argument.lowercased()
+            }
+        }
+        return parsed
+    }
+}
+
+enum CLIError: Error, Equatable {
+    case usage(String)
+    case appDefaultsUnavailable
+}

--- a/Sources/OpenUsageCLI/OpenUsageCLI.swift
+++ b/Sources/OpenUsageCLI/OpenUsageCLI.swift
@@ -1,0 +1,66 @@
+import Darwin
+import Foundation
+import OpenUsage
+
+@main
+struct OpenUsageCLI {
+    static func main() async {
+        do {
+            let arguments = try CLIArguments.parse(Array(CommandLine.arguments.dropFirst()))
+            if arguments.showHelp {
+                print(help)
+                return
+            }
+
+            let app = AppBundleLocator.locate()
+            if arguments.showVersion {
+                print(app.version.map { "openusage \($0)" } ?? "openusage (development build)")
+                return
+            }
+
+            guard let defaults = UserDefaults(suiteName: app.bundleIdentifier) else {
+                throw CLIError.appDefaultsUnavailable
+            }
+            let result = try await UsageReader(userDefaults: defaults).read(
+                providerID: arguments.providerID,
+                force: arguments.force
+            )
+            FileHandle.standardOutput.write(result.data)
+            FileHandle.standardOutput.write(Data("\n".utf8))
+            if !result.warnings.isEmpty {
+                result.warnings.forEach { writeError("warning: \($0)") }
+                exit(4)
+            }
+        } catch CLIError.usage(let message) {
+            fail("\(message)\nRun 'openusage --help' for usage.", code: 2)
+        } catch CLIError.appDefaultsUnavailable {
+            fail("Could not open the OpenUsage settings domain.", code: 4)
+        } catch UsageReaderError.noCachedSnapshot(let providerID) {
+            fail("No cached usage for \(providerID). Run with --force to fetch it.", code: 3)
+        } catch UsageReaderError.unknownProvider(let providerID) {
+            fail("Unknown provider: \(providerID)", code: 2)
+        } catch {
+            fail(error.localizedDescription, code: 4)
+        }
+    }
+
+    private static func writeError(_ message: String) {
+        FileHandle.standardError.write(Data("openusage: \(message)\n".utf8))
+    }
+
+    private static func fail(_ message: String, code: Int32) -> Never {
+        writeError(message)
+        exit(code)
+    }
+
+    private static let help = """
+    Usage: openusage [provider] [--force]
+
+    Read usage through OpenUsage's shared five-minute cache and exit. Output is always JSON.
+
+    Options:
+      --force      Refresh even when the shared cache is still fresh
+      -v, --version
+      -h, --help
+    """
+}

--- a/Sources/OpenUsageCLI/OpenUsageCLI.swift
+++ b/Sources/OpenUsageCLI/OpenUsageCLI.swift
@@ -56,7 +56,7 @@ struct OpenUsageCLI {
     private static let help = """
     Usage: openusage [provider] [--force]
 
-    Read usage through OpenUsage's shared five-minute cache and exit. Output is always JSON.
+    Read limits through OpenUsage's shared five-minute cache and exit. Output is always JSON.
 
     Options:
       --force      Refresh even when the shared cache is still fresh

--- a/Tests/OpenUsageCLITests/AppBundleLocatorTests.swift
+++ b/Tests/OpenUsageCLITests/AppBundleLocatorTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import OpenUsageCLI
+
+final class AppBundleLocatorTests: XCTestCase {
+    func testFindsContainingAppThroughHelperSymlink() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let app = root.appendingPathComponent("OpenUsage.app")
+        let contents = app.appendingPathComponent("Contents")
+        let helpers = contents.appendingPathComponent("Helpers")
+        let bin = root.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: helpers, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let plist: [String: Any] = [
+            "CFBundleIdentifier": "com.example.openusage",
+            "CFBundleShortVersionString": "1.2.3"
+        ]
+        let plistData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try plistData.write(to: contents.appendingPathComponent("Info.plist"))
+        let helper = helpers.appendingPathComponent("openusage")
+        try Data().write(to: helper)
+        let symlink = bin.appendingPathComponent("openusage")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: helper)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let located = AppBundleLocator.locate(
+            executableURL: symlink,
+            environment: [:]
+        )
+
+        XCTAssertEqual(located.bundleIdentifier, "com.example.openusage")
+        XCTAssertEqual(located.version, "1.2.3")
+    }
+
+    func testEnvironmentCanSelectDefaultsSuiteForDevelopment() {
+        let located = AppBundleLocator.locate(
+            executableURL: URL(fileURLWithPath: "/tmp/openusage"),
+            environment: ["OPENUSAGE_DEFAULTS_SUITE": "com.example.dev"]
+        )
+
+        XCTAssertEqual(located.bundleIdentifier, "com.example.dev")
+    }
+}

--- a/Tests/OpenUsageCLITests/CLIArgumentsTests.swift
+++ b/Tests/OpenUsageCLITests/CLIArgumentsTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import OpenUsageCLI
+
+final class CLIArgumentsTests: XCTestCase {
+    func testParsesProviderAndForce() throws {
+        let parsed = try CLIArguments.parse(["Codex", "--force"])
+        XCTAssertEqual(parsed.providerID, "codex")
+        XCTAssertTrue(parsed.force)
+    }
+
+    func testRejectsUnknownOptionsAndMultipleProviders() {
+        XCTAssertThrowsError(try CLIArguments.parse(["--json"]))
+        XCTAssertThrowsError(try CLIArguments.parse(["claude", "codex"]))
+    }
+}

--- a/Tests/OpenUsageTests/CommandLineToolInstallerTests.swift
+++ b/Tests/OpenUsageTests/CommandLineToolInstallerTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class CommandLineToolInstallerTests: XCTestCase {
+    private func fixture() throws -> (root: URL, source: String, destination: String) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let source = root.appendingPathComponent("OpenUsage.app/Contents/Helpers/openusage")
+        let destination = root.appendingPathComponent("bin/openusage")
+        try FileManager.default.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data().write(to: source)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: source.path)
+        return (root, source.path, destination.path)
+    }
+
+    func testInstallAndUninstallOwnSymlink() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let installer = CommandLineToolInstaller(
+            sourcePath: fixture.source,
+            destinationPath: fixture.destination,
+            performPrivileged: { operation, source, destination in
+                do {
+                    switch operation {
+                    case .install:
+                        try FileManager.default.createDirectory(
+                            atPath: (destination as NSString).deletingLastPathComponent,
+                            withIntermediateDirectories: true
+                        )
+                        try FileManager.default.createSymbolicLink(atPath: destination, withDestinationPath: source)
+                    case .uninstall:
+                        try FileManager.default.removeItem(atPath: destination)
+                    }
+                    return .success
+                } catch {
+                    return .failure(error.localizedDescription)
+                }
+            }
+        )
+
+        XCTAssertEqual(installer.status, .notInstalled)
+        installer.install()
+        XCTAssertEqual(installer.status, .installed)
+        installer.uninstall()
+        XCTAssertEqual(installer.status, .notInstalled)
+    }
+
+    func testForeignPathIsNeverOverwritten() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try FileManager.default.createDirectory(
+            atPath: (fixture.destination as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try Data("foreign".utf8).write(to: URL(fileURLWithPath: fixture.destination))
+        var operationRan = false
+        let installer = CommandLineToolInstaller(
+            sourcePath: fixture.source,
+            destinationPath: fixture.destination,
+            performPrivileged: { _, _, _ in
+                operationRan = true
+                return .success
+            }
+        )
+
+        XCTAssertEqual(installer.status, .conflict)
+        installer.install()
+        XCTAssertFalse(operationRan)
+        XCTAssertNotNil(installer.errorMessage)
+        XCTAssertEqual(try String(contentsOfFile: fixture.destination, encoding: .utf8), "foreign")
+    }
+
+    func testForeignSymlinkIsNeverClaimedOrRemoved() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try FileManager.default.createDirectory(
+            atPath: (fixture.destination as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: fixture.destination,
+            withDestinationPath: "/tmp/another-openusage"
+        )
+        var operationRan = false
+        let installer = CommandLineToolInstaller(
+            sourcePath: fixture.source,
+            destinationPath: fixture.destination,
+            performPrivileged: { _, _, _ in
+                operationRan = true
+                return .success
+            }
+        )
+
+        XCTAssertEqual(installer.status, .conflict)
+        installer.uninstall()
+        XCTAssertFalse(operationRan)
+        XCTAssertEqual(
+            try FileManager.default.destinationOfSymbolicLink(atPath: fixture.destination),
+            "/tmp/another-openusage"
+        )
+    }
+}

--- a/Tests/OpenUsageTests/LocalLimitsAPITests.swift
+++ b/Tests/OpenUsageTests/LocalLimitsAPITests.swift
@@ -83,7 +83,7 @@ final class LocalLimitsAPITests: XCTestCase {
     }
 
     func testKnownProviderRouteUsesSameEnvelopeAndPreservesMissingSnapshotStatus() throws {
-        let state = LocalUsageAPI.State(
+        var state = LocalUsageAPI.State(
             enabledOrderedIDs: [],
             knownIDs: ["codex"],
             snapshots: [:],
@@ -91,6 +91,15 @@ final class LocalLimitsAPITests: XCTestCase {
         )
         XCTAssertEqual(LocalUsageAPI.respond(method: "GET", path: "/v1/limits/codex", state: state).status, 204)
         XCTAssertEqual(LocalUsageAPI.respond(method: "GET", path: "/v1/limits/nope", state: state).status, 404)
+
+        state.errors["codex"] = "Not logged in"
+        let failed = LocalUsageAPI.respond(method: "GET", path: "/v1/limits/codex", state: state)
+        let root = try json(failed.body)
+        let errors = try XCTUnwrap(root["errors"] as? [[String: Any]])
+        XCTAssertEqual(failed.status, 200)
+        XCTAssertTrue((root["providers"] as? [String: Any])?.isEmpty == true)
+        XCTAssertEqual(errors.first?["providerId"] as? String, "codex")
+        XCTAssertEqual(errors.first?["message"] as? String, "Not logged in")
     }
 
     func testFlexibleConsumptionExportsUncappedValueWithoutInventingLimit() throws {

--- a/Tests/OpenUsageTests/LocalLimitsAPITests.swift
+++ b/Tests/OpenUsageTests/LocalLimitsAPITests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import OpenUsage
+
+final class LocalLimitsAPITests: XCTestCase {
+    private let fetchedAt = OpenUsageISO8601.date(from: "2026-07-13T01:39:30.000Z")!
+    private let generatedAt = OpenUsageISO8601.date(from: "2026-07-13T01:40:00.000Z")!
+
+    private func json(_ data: Data?) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: XCTUnwrap(data)) as? [String: Any])
+    }
+
+    func testLimitsEnvelopeCarriesRawScalarsAndFreshnessWithoutUIPresentation() throws {
+        let provider = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+        let session = WidgetDescriptor.percent(id: "codex.session", provider: provider, title: "Session")
+            .exportingLimit("session", unit: "percent")
+        let credits = WidgetDescriptor.combined(
+            id: "codex.credits", provider: provider, title: "Extra Usage", metricLabel: "Credits"
+        )
+        .exportingLimit("credits", kind: .balance, unit: "credits", source: .value(kind: .count, label: "credits"))
+        .exportingLimit("creditValue", kind: .balance, unit: "usd", source: .value(kind: .dollars))
+        let snapshot = ProviderSnapshot(
+            providerID: "codex",
+            displayName: "Codex",
+            plan: "Pro 20x",
+            lines: [
+                .progress(
+                    label: "Session", used: 42, limit: 100, format: .percent,
+                    resetsAt: OpenUsageISO8601.date(from: "2026-07-13T06:00:00.000Z"),
+                    periodDurationMs: 18_000_000,
+                    colorHex: "#ff0000"
+                ),
+                .values(label: "Credits", values: [
+                    MetricValue(number: 32.84, kind: .dollars),
+                    MetricValue(number: 821, kind: .count, label: "credits")
+                ]),
+                .chart(label: "Usage Trend", points: [], note: "UI only")
+            ],
+            refreshedAt: fetchedAt
+        )
+        let state = LocalUsageAPI.State(
+            enabledOrderedIDs: ["codex"],
+            knownIDs: ["codex"],
+            snapshots: ["codex": snapshot],
+            limitDescriptors: ["codex": [session, credits]],
+            generatedAt: generatedAt
+        )
+
+        let response = LocalUsageAPI.respond(method: "GET", path: "/v1/limits", state: state)
+        let root = try json(response.body)
+        let providerJSON = try XCTUnwrap((root["providers"] as? [String: Any])?["codex"] as? [String: Any])
+        let resources = try XCTUnwrap(providerJSON["resources"] as? [String: Any])
+        let sessionJSON = try XCTUnwrap(resources["session"] as? [String: Any])
+        let creditsJSON = try XCTUnwrap(resources["credits"] as? [String: Any])
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(root["schema"] as? String, "openusage.limits.v1")
+        XCTAssertEqual(root["generatedAt"] as? String, "2026-07-13T01:40:00.000Z")
+        XCTAssertEqual(providerJSON["plan"] as? String, "Pro 20x")
+        XCTAssertEqual(providerJSON["fetchedAt"] as? String, "2026-07-13T01:39:30.000Z")
+        XCTAssertEqual(providerJSON["expiresAt"] as? String, "2026-07-13T01:44:30.000Z")
+        XCTAssertEqual(providerJSON["stale"] as? Bool, false)
+        XCTAssertEqual(sessionJSON["kind"] as? String, "consumption")
+        XCTAssertEqual(sessionJSON["unit"] as? String, "percent")
+        XCTAssertEqual(sessionJSON["used"] as? Double, 42)
+        XCTAssertEqual(sessionJSON["limit"] as? Double, 100)
+        XCTAssertEqual(sessionJSON["remaining"] as? Double, 58)
+        XCTAssertEqual(try XCTUnwrap(sessionJSON["utilization"] as? Double), 0.42, accuracy: 0.000_001)
+        XCTAssertEqual(sessionJSON["windowSeconds"] as? Double, 18_000)
+        XCTAssertEqual(creditsJSON["kind"] as? String, "balance")
+        XCTAssertEqual(creditsJSON["available"] as? Double, 821)
+        XCTAssertNotNil(resources["creditValue"])
+        XCTAssertNil(resources["Usage Trend"])
+        XCTAssertNil(sessionJSON["color"])
+        XCTAssertNil(sessionJSON["subtitle"])
+        XCTAssertNil(sessionJSON["label"])
+
+        var expiredState = state
+        expiredState.generatedAt = fetchedAt.addingTimeInterval(RefreshSetting.interval)
+        let expiredRoot = try json(LocalUsageAPI.respond(method: "GET", path: "/v1/limits", state: expiredState).body)
+        let expiredProviders = try XCTUnwrap(expiredRoot["providers"] as? [String: Any])
+        let expiredProvider = try XCTUnwrap(expiredProviders["codex"] as? [String: Any])
+        XCTAssertEqual(expiredProvider["stale"] as? Bool, true)
+    }
+
+    func testKnownProviderRouteUsesSameEnvelopeAndPreservesMissingSnapshotStatus() throws {
+        let state = LocalUsageAPI.State(
+            enabledOrderedIDs: [],
+            knownIDs: ["codex"],
+            snapshots: [:],
+            generatedAt: generatedAt
+        )
+        XCTAssertEqual(LocalUsageAPI.respond(method: "GET", path: "/v1/limits/codex", state: state).status, 204)
+        XCTAssertEqual(LocalUsageAPI.respond(method: "GET", path: "/v1/limits/nope", state: state).status, 404)
+    }
+
+    func testFlexibleConsumptionExportsUncappedValueWithoutInventingLimit() throws {
+        let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let extra = WidgetDescriptor.boundedDollars(
+            id: "claude.extra", provider: provider, title: "Extra Usage",
+            metricLabel: "Extra usage spent", limit: 100
+        ).exportingLimit("extraUsage", unit: "usd", source: .progressOrValue(kind: .dollars))
+        let snapshot = ProviderSnapshot(
+            providerID: "claude",
+            displayName: "Claude",
+            lines: [.values(label: "Extra usage spent", values: [MetricValue(number: 12.5, kind: .dollars)])],
+            refreshedAt: fetchedAt
+        )
+        let state = LocalUsageAPI.State(
+            enabledOrderedIDs: ["claude"],
+            knownIDs: ["claude"],
+            snapshots: ["claude": snapshot],
+            limitDescriptors: ["claude": [extra]],
+            generatedAt: generatedAt
+        )
+
+        let root = try json(LocalUsageAPI.respond(method: "GET", path: "/v1/limits", state: state).body)
+        let providers = try XCTUnwrap(root["providers"] as? [String: Any])
+        let claude = try XCTUnwrap(providers["claude"] as? [String: Any])
+        let resources = try XCTUnwrap(claude["resources"] as? [String: Any])
+        let resource = try XCTUnwrap(resources["extraUsage"] as? [String: Any])
+
+        XCTAssertEqual(resource["used"] as? Double, 12.5)
+        XCTAssertNil(resource["limit"])
+        XCTAssertNil(resource["remaining"])
+        XCTAssertNil(resource["utilization"])
+    }
+
+    @MainActor
+    func testEveryProviderDeclaresTheApprovedPublicResourceKeys() {
+        let defaults = UserDefaults(suiteName: "LocalLimitsAPITests.\(UUID().uuidString)")!
+        let registry = WidgetRegistry.from(ProviderCatalog.make(defaults: defaults))
+        let actual = registry.limitDescriptorsByProvider.mapValues { descriptors in
+            Set(descriptors.flatMap(\.limitResources).map(\.key))
+        }
+        let expected: [String: Set<String>] = [
+            "claude": ["session", "weekly", "sonnet", "fable", "extraUsage"],
+            "codex": ["session", "weekly", "spark", "sparkWeekly", "credits", "creditValue", "rateLimitResets"],
+            "cursor": ["totalUsage", "autoUsage", "apiUsage", "onDemand", "requests", "credits"],
+            "antigravity": ["geminiSession", "geminiWeekly", "nonGeminiSession", "nonGeminiWeekly"],
+            "copilot": ["premiumCredits", "extraUsage", "orgCredits", "orgSpend", "chat", "completions"],
+            "devin": ["daily", "weekly", "extraUsageBalance"],
+            "grok": ["weekly"],
+            "opencode": ["session", "weekly", "monthly"],
+            "openrouter": ["credits", "balance", "keyLimit"],
+            "zai": ["session", "weekly", "webSearches"]
+        ]
+
+        XCTAssertEqual(actual, expected)
+    }
+}

--- a/Tests/OpenUsageTests/UsageReaderTests.swift
+++ b/Tests/OpenUsageTests/UsageReaderTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class UsageReaderTests: XCTestCase {
+    private final class StubProvider: ProviderRuntime {
+        let provider = Provider(id: "stub", displayName: "Stub", icon: .providerMark("stub"))
+        var widgetDescriptors: [WidgetDescriptor] { [] }
+        var refreshCount = 0
+        var refreshError: String?
+        var refreshedAt = Date()
+
+        func hasLocalCredentials() async -> Bool { true }
+
+        func refresh() async -> ProviderSnapshot {
+            refreshCount += 1
+            if let refreshError {
+                return .error(provider: provider, message: refreshError)
+            }
+            return ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [.progress(label: "Weekly", used: 20, limit: 100, format: .percent)],
+                refreshedAt: refreshedAt
+            )
+        }
+    }
+
+    private func defaults() -> UserDefaults {
+        let suite = "UsageReaderTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    func testReadsSharedSnapshotCacheWithoutRefreshing() async throws {
+        let defaults = defaults()
+        let provider = StubProvider()
+        ProviderSnapshotCache(userDefaults: defaults).store(await provider.refresh())
+        provider.refreshCount = 0
+
+        let result = try await UsageReader(userDefaults: defaults, providers: [provider]).read(providerID: "stub")
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: result.data) as? [String: Any])
+
+        XCTAssertEqual(object["providerId"] as? String, "stub")
+        XCTAssertEqual(provider.refreshCount, 0)
+        XCTAssertTrue(result.warnings.isEmpty)
+    }
+
+    func testForceUsesSharedProviderAndStoresResult() async throws {
+        let defaults = defaults()
+        let provider = StubProvider()
+        let reader = UsageReader(userDefaults: defaults, providers: [provider])
+
+        let result = try await reader.read(providerID: "stub", force: true)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: result.data) as? [String: Any])
+        let cached = ProviderSnapshotCache(userDefaults: defaults).loadSnapshots(providerIDs: ["stub"])
+
+        XCTAssertEqual(provider.refreshCount, 1)
+        XCTAssertEqual(object["providerId"] as? String, "stub")
+        XCTAssertEqual(cached["stub"]?.line(label: "Weekly"), .progress(
+            label: "Weekly",
+            used: 20,
+            limit: 100,
+            format: .percent,
+            resetsAt: nil,
+            periodDurationMs: nil,
+            colorHex: nil
+        ))
+    }
+
+    func testStalePersistedSnapshotRefreshesBeforeReading() async throws {
+        let defaults = defaults()
+        let provider = StubProvider()
+        provider.refreshedAt = Date().addingTimeInterval(-RefreshSetting.interval - 1)
+        ProviderSnapshotCache(userDefaults: defaults).store(await provider.refresh())
+        provider.refreshCount = 0
+        provider.refreshedAt = Date()
+
+        let result = try await UsageReader(userDefaults: defaults, providers: [provider]).read(providerID: "stub")
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: result.data) as? [String: Any])
+
+        XCTAssertEqual(object["providerId"] as? String, "stub")
+        XCTAssertEqual(provider.refreshCount, 1)
+    }
+
+    func testUnknownProviderFailsBeforeRefresh() async {
+        let defaults = defaults()
+        let provider = StubProvider()
+
+        do {
+            _ = try await UsageReader(userDefaults: defaults, providers: [provider]).read(providerID: "missing", force: true)
+            XCTFail("Expected unknown provider error")
+        } catch UsageReaderError.unknownProvider(let providerID) {
+            XCTAssertEqual(providerID, "missing")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(provider.refreshCount, 0)
+    }
+
+    func testFailedForceWithoutCacheReportsRefreshError() async {
+        let defaults = defaults()
+        let provider = StubProvider()
+        provider.refreshError = "Not logged in"
+
+        do {
+            _ = try await UsageReader(userDefaults: defaults, providers: [provider]).read(providerID: "stub", force: true)
+            XCTFail("Expected refresh failure")
+        } catch UsageReaderError.refreshFailed(let message) {
+            XCTAssertEqual(message, "stub: Not logged in")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/Tests/OpenUsageTests/UsageReaderTests.swift
+++ b/Tests/OpenUsageTests/UsageReaderTests.swift
@@ -118,18 +118,18 @@ final class UsageReaderTests: XCTestCase {
         XCTAssertEqual(provider.refreshCount, 0)
     }
 
-    func testFailedForceWithoutCacheReportsRefreshError() async {
+    func testFailedForceWithoutCacheReturnsMachineReadableError() async throws {
         let defaults = defaults()
         let provider = StubProvider()
         provider.refreshError = "Not logged in"
 
-        do {
-            _ = try await UsageReader(userDefaults: defaults, providers: [provider]).read(providerID: "stub", force: true)
-            XCTFail("Expected refresh failure")
-        } catch UsageReaderError.refreshFailed(let message) {
-            XCTAssertEqual(message, "stub: Not logged in")
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
+        let result = try await UsageReader(userDefaults: defaults, providers: [provider])
+            .read(providerID: "stub", force: true)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: result.data) as? [String: Any])
+        let errors = try XCTUnwrap(root["errors"] as? [[String: Any]])
+
+        XCTAssertEqual(result.warnings, ["stub: Not logged in"])
+        XCTAssertEqual(errors.first?["providerId"] as? String, "stub")
+        XCTAssertEqual(errors.first?["message"] as? String, "Not logged in")
     }
 }

--- a/Tests/OpenUsageTests/UsageReaderTests.swift
+++ b/Tests/OpenUsageTests/UsageReaderTests.swift
@@ -4,11 +4,18 @@ import XCTest
 @MainActor
 final class UsageReaderTests: XCTestCase {
     private final class StubProvider: ProviderRuntime {
-        let provider = Provider(id: "stub", displayName: "Stub", icon: .providerMark("stub"))
-        var widgetDescriptors: [WidgetDescriptor] { [] }
+        let provider: Provider
+        var widgetDescriptors: [WidgetDescriptor] {
+            [WidgetDescriptor.percent(id: "\(provider.id).weekly", provider: provider, title: "Weekly")
+                .exportingLimit("weekly", unit: "percent")]
+        }
         var refreshCount = 0
         var refreshError: String?
         var refreshedAt = Date()
+
+        init(id: String = "stub") {
+            self.provider = Provider(id: id, displayName: id.capitalized, icon: .providerMark(id))
+        }
 
         func hasLocalCredentials() async -> Bool { true }
 
@@ -42,7 +49,7 @@ final class UsageReaderTests: XCTestCase {
         let result = try await UsageReader(userDefaults: defaults, providers: [provider]).read(providerID: "stub")
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: result.data) as? [String: Any])
 
-        XCTAssertEqual(object["providerId"] as? String, "stub")
+        XCTAssertNotNil((object["providers"] as? [String: Any])?["stub"])
         XCTAssertEqual(provider.refreshCount, 0)
         XCTAssertTrue(result.warnings.isEmpty)
     }
@@ -57,7 +64,7 @@ final class UsageReaderTests: XCTestCase {
         let cached = ProviderSnapshotCache(userDefaults: defaults).loadSnapshots(providerIDs: ["stub"])
 
         XCTAssertEqual(provider.refreshCount, 1)
-        XCTAssertEqual(object["providerId"] as? String, "stub")
+        XCTAssertNotNil((object["providers"] as? [String: Any])?["stub"])
         XCTAssertEqual(cached["stub"]?.line(label: "Weekly"), .progress(
             label: "Weekly",
             used: 20,
@@ -80,8 +87,20 @@ final class UsageReaderTests: XCTestCase {
         let result = try await UsageReader(userDefaults: defaults, providers: [provider]).read(providerID: "stub")
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: result.data) as? [String: Any])
 
-        XCTAssertEqual(object["providerId"] as? String, "stub")
+        XCTAssertNotNil((object["providers"] as? [String: Any])?["stub"])
         XCTAssertEqual(provider.refreshCount, 1)
+    }
+
+    func testForcedProviderReadRefreshesOnlyRequestedProvider() async throws {
+        let defaults = defaults()
+        let requested = StubProvider(id: "requested")
+        let other = StubProvider(id: "other")
+
+        _ = try await UsageReader(userDefaults: defaults, providers: [requested, other])
+            .read(providerID: "requested", force: true)
+
+        XCTAssertEqual(requested.refreshCount, 1)
+        XCTAssertEqual(other.refreshCount, 0)
     }
 
     func testUnknownProviderFailsBeforeRefresh() async {

--- a/Tests/OpenUsageTests/WidgetRegistryTests.swift
+++ b/Tests/OpenUsageTests/WidgetRegistryTests.swift
@@ -60,6 +60,18 @@ final class WidgetRegistryTests: XCTestCase {
         XCTAssertEqual(registry.descriptors(for: "missing"), [])
     }
 
+    func testProviderOrderFiltersUnknownAndAppendsNewProviders() {
+        let claude = provider("claude")
+        let codex = provider("codex")
+        let cursor = provider("cursor")
+        let registry = WidgetRegistry(providers: [claude, codex, cursor], descriptors: [])
+
+        XCTAssertEqual(
+            registry.orderedProviderIDs(savedOrder: ["codex", "removed", "claude"]),
+            ["codex", "claude", "cursor"]
+        )
+    }
+
     /// With duplicate ids, both single-entry lookups resolve to the first match — matching the original
     /// `.first { $0.id == id }` accessors so the refactor can't change which descriptor/provider wins.
     func testDuplicateIDsResolveToFirstMatch() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ What the app does and how it behaves. These pages describe **behavior, not visua
 
 ## Integrations
 
+- [Command-line interface](cli.md) — one-shot cached and forced usage reads for agents and scripts
 - [Local HTTP API](local-http-api.md) — read your usage from other apps on `127.0.0.1:6736`
 - [Proxy](proxy.md) — route provider requests through SOCKS5 or HTTP(S)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,8 +5,9 @@ A high-level map of how OpenUsage is put together, for people working on the cod
 
 ## The shape of the app
 
-OpenUsage is a single SwiftPM executable — there is no Xcode project. It's a menu-bar app: a SwiftUI
-interface hosted inside an AppKit status item and panel. The code is grouped by role:
+OpenUsage is a SwiftPM package with a shared module and two thin executables — there is no Xcode project.
+The main executable is a menu-bar app: a SwiftUI interface hosted inside an AppKit status item and panel.
+The code is grouped by role:
 
 - `App/` — startup and the AppKit bridge (status item, panel, the app entry point).
 - `Models/` — the small value types the rest of the app speaks in (`MetricLine`, `WidgetData`, descriptors).
@@ -22,6 +23,10 @@ interface hosted inside an AppKit status item and panel. The code is grouped by 
 providers, turns it into a `WidgetRegistry`, creates the stores, starts the periodic refresh loop, and
 starts the local HTTP API. Everything else receives what it needs from here rather than reaching for
 globals, which keeps the pieces testable in isolation.
+
+The `openusage` executable imports the same module. A normal invocation reads `ProviderSnapshotCache`
+and exits; `--force` constructs the canonical `ProviderCatalog` and calls `WidgetDataStore`'s forced
+refresh path before reading. It never launches the GUI or duplicates provider, auth, or pricing logic.
 
 ## The provider pipeline
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,9 @@ globals, which keeps the pieces testable in isolation.
 
 The `openusage` executable imports the same module. A normal invocation reads `ProviderSnapshotCache`
 and exits; `--force` constructs the canonical `ProviderCatalog` and calls `WidgetDataStore`'s forced
-refresh path before reading. It never launches the GUI or duplicates provider, auth, or pricing logic.
+refresh path before reading. Providers annotate the scalar resources they export through the stable
+limits contract; the CLI and `/v1/limits` share one serializer over those same normalized snapshots.
+It never launches the GUI or duplicates provider, auth, pricing, or mapping logic.
 
 ## The provider pipeline
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,33 @@
+# Command-Line Interface
+
+OpenUsage ships a one-shot `openusage` command for agents and scripts. It prints the documented usage
+JSON and exits; it never launches or leaves the menu-bar app running.
+
+```sh
+openusage                 # every enabled provider, refreshing stale cache entries
+openusage codex           # one provider, refreshing when its cache is stale
+openusage codex --force   # refresh through the shared provider engine, cache, print, exit
+```
+
+The command and app import the same providers, authentication stores, pricing, refresh coordinator, and
+snapshot cache. A normal read reuses snapshots less than five minutes old and refreshes missing or stale
+ones. `--force` is the CLI equivalent of the app's manual refresh: it bypasses that freshness gate and
+writes successful results to the same cache. Credentials are used locally and never appear in the output.
+
+## Install on `PATH`
+
+The signed executable lives at `OpenUsage.app/Contents/Helpers/openusage`. The Homebrew cask exposes
+that helper as the global `openusage` command and owns the symlink across upgrades and uninstalls.
+
+For a direct-download app in `/Applications`, create a user-owned link instead:
+
+```sh
+mkdir -p ~/.local/bin
+ln -sf /Applications/OpenUsage.app/Contents/Helpers/openusage ~/.local/bin/openusage
+```
+
+Make sure `~/.local/bin` is on your shell's `PATH`. The link stays current when Sparkle replaces the app
+in place.
+
+Exit codes are `0` for success, `2` for invalid arguments, `3` when a requested provider has no snapshot,
+and `4` when a refresh or local read fails.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,9 @@
 # Command-Line Interface
 
-OpenUsage ships a one-shot `openusage` command for agents and scripts. It prints the documented usage
-JSON and exits; it never launches or leaves the menu-bar app running.
+OpenUsage ships a one-shot `openusage` command for agents and scripts. It prints the documented
+[`/v1/limits`](local-http-api.md#get-v1limits) JSON and exits; it never launches or leaves the menu-bar
+app running. The output contains stable scalar limits and balances, not UI rows, colors, subtitles,
+charts, or spend-history tiles.
 
 ```sh
 openusage                 # every enabled provider, refreshing stale cache entries
@@ -16,18 +18,9 @@ writes successful results to the same cache. Credentials are used locally and ne
 
 ## Install on `PATH`
 
-The signed executable lives at `OpenUsage.app/Contents/Helpers/openusage`. The Homebrew cask exposes
-that helper as the global `openusage` command and owns the symlink across upgrades and uninstalls.
-
-For a direct-download app in `/Applications`, create a user-owned link instead:
-
-```sh
-mkdir -p ~/.local/bin
-ln -sf /Applications/OpenUsage.app/Contents/Helpers/openusage ~/.local/bin/openusage
-```
-
-Make sure `~/.local/bin` is on your shell's `PATH`. The link stays current when Sparkle replaces the app
-in place.
+In OpenUsage, open **Settings → Command Line** and click **Install…**. After the standard macOS
+administrator prompt, `openusage` is available globally in new terminal sessions. The installed symlink
+points to the signed helper inside OpenUsage, so in-place app updates also update the command.
 
 Exit codes are `0` for success, `2` for invalid arguments, `3` when a requested provider has no snapshot,
 and `4` when a refresh or local read fails.

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -18,8 +18,8 @@ and the exact format printed by the `openusage` CLI.
 
 Returns the same envelope containing one provider. It works for disabled providers too.
 
-- **200 OK** — limits envelope.
-- **204 No Content** — provider is known but has no snapshot yet.
+- **200 OK** — limits envelope, including an `errors` entry when a refresh failed.
+- **204 No Content** — provider is known but has neither a snapshot nor a recorded refresh failure yet.
 - **404 Not Found** — provider ID is unknown.
 
 ### `GET /v1/usage`

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -8,9 +8,24 @@ The server starts automatically with the app. If the port is already in use, the
 
 ## Routes
 
+### `GET /v1/limits`
+
+Returns a machine-facing envelope for all **enabled** providers. Providers and resources are keyed by
+stable IDs; values are raw scalars with explicit units. This is the preferred route for new integrations
+and the exact format printed by the `openusage` CLI.
+
+### `GET /v1/limits/:providerId`
+
+Returns the same envelope containing one provider. It works for disabled providers too.
+
+- **200 OK** — limits envelope.
+- **204 No Content** — provider is known but has no snapshot yet.
+- **404 Not Found** — provider ID is unknown.
+
 ### `GET /v1/usage`
 
-Returns the latest snapshots for all **enabled** providers, in your dashboard order.
+Returns the legacy UI-oriented snapshots for all **enabled** providers, in your dashboard order. Existing
+consumers remain supported; new consumers should use `/v1/limits`.
 
 - **200 OK** — JSON array (may be empty `[]` if nothing has been fetched yet).
 
@@ -26,7 +41,68 @@ Returns the latest snapshot for one provider. Works for disabled providers too.
 
 Methods other than `GET`/`OPTIONS` return **405**; unknown routes return **404**. When the server is already handling its maximum of 16 concurrent connections, requests get **503** — back off and retry.
 
-## Response shape
+## Limits response shape
+
+```jsonc
+{
+  "schema": "openusage.limits.v1",
+  "generatedAt": "2026-07-13T01:40:00.000Z",
+  "providers": {
+    "codex": {
+      "displayName": "Codex",
+      "plan": "Pro 20x",
+      "fetchedAt": "2026-07-13T01:39:30.000Z",
+      "expiresAt": "2026-07-13T01:44:30.000Z",
+      "stale": false,
+      "resources": {
+        "session": {
+          "kind": "consumption",
+          "unit": "percent",
+          "used": 42,
+          "limit": 100,
+          "remaining": 58,
+          "utilization": 0.42,
+          "resetsAt": "2026-07-13T06:00:00.000Z",
+          "windowSeconds": 18000
+        },
+        "credits": {
+          "kind": "balance",
+          "unit": "credits",
+          "available": 821
+        }
+      }
+    }
+  },
+  "errors": []
+}
+```
+
+`kind` is `consumption` (`used`) or `balance` (`available`). Bounded consumption also carries `limit`,
+`remaining`, and a 0–1 `utilization`. Reset, window, expiry-list, and `estimated` fields appear only when
+the provider supplies that meaning. A provider or resource with no current value is omitted rather than
+invented as zero. `expiresAt` is always `fetchedAt` plus the same five-minute freshness interval used by
+the app and CLI; `stale` says whether that instant has passed. Refresh failures appear in `errors` as
+`{"providerId":"…","message":"…"}` while a last-good provider snapshot remains available.
+
+### Public resources
+
+| Provider | Resource keys |
+| --- | --- |
+| Claude | `session`, `weekly`, `sonnet`, `fable`, `extraUsage` |
+| Codex | `session`, `weekly`, `spark`, `sparkWeekly`, `credits`, `creditValue`, `rateLimitResets` |
+| Cursor | `totalUsage`, `autoUsage`, `apiUsage`, `onDemand`, `requests`, `credits` |
+| Antigravity | `geminiSession`, `geminiWeekly`, `nonGeminiSession`, `nonGeminiWeekly` |
+| Copilot | `premiumCredits`, `extraUsage`, `orgCredits`, `orgSpend`, `chat`, `completions` |
+| Devin | `daily`, `weekly`, `extraUsageBalance` |
+| Grok | `weekly` |
+| OpenCode | `session`, `weekly`, `monthly` |
+| OpenRouter | `credits`, `balance`, `keyLimit` |
+| Z.ai | `session`, `weekly`, `webSearches` |
+
+Charts, colors, subtitles, formatted badges, layout state, and historical spend periods stay out of this
+contract. Codex's combined Credits UI row becomes two scalar resources: `credits` and `creditValue`.
+
+## Legacy usage response shape
 
 ```jsonc
 {

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -5,6 +5,7 @@
 - All enabled providers refresh together: once at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Opening the popover does not start a second automatic pass. Providers fetch in parallel — one slow provider doesn't delay the others.
 - Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running.
 - The Dashboard and Settings footer shows `Next update in Nm`. **Clicking it (or pressing ⌘R while that footer is present)** refreshes immediately, skipping the cache.
+- The one-shot `openusage` command reuses this same persisted cache for five minutes, refreshes missing or stale entries without starting the app, and exits. `openusage --force` runs the same forced provider refresh as ⌘R regardless of cache age.
 - While a provider is fetching, a small spinner appears next to its name (and one shows in the footer beside the countdown), so you can tell a refresh is in flight rather than wondering if the numbers are stale.
 
 ## Caching

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -30,8 +30,10 @@ DIST_DIR="$ROOT_DIR/dist"
 APP_BUNDLE="$DIST_DIR/$APP_DISPLAY.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
+APP_HELPERS="$APP_CONTENTS/Helpers"
 APP_RESOURCES="$APP_CONTENTS/Resources"
 APP_BINARY="$APP_MACOS/$TARGET_NAME"
+CLI_BINARY="$APP_HELPERS/openusage"
 INFO_PLIST="$APP_CONTENTS/Info.plist"
 RESOURCE_BUNDLE_NAME="${TARGET_NAME}_${TARGET_NAME}.bundle"
 ENTITLEMENTS="$ROOT_DIR/script/OpenUsage.dev.entitlements.plist"
@@ -42,17 +44,27 @@ echo "==> swift build ($CONFIG)"
 swift build -c "$CONFIG"
 BUILD_DIR="$(swift build -c "$CONFIG" --show-bin-path)"
 BUILD_BINARY="$BUILD_DIR/$TARGET_NAME"
+BUILD_CLI_BINARY="$BUILD_DIR/openusage-cli"
 
 if [ ! -x "$BUILD_BINARY" ]; then
   echo "missing built binary: $BUILD_BINARY" >&2
   exit 1
 fi
+if [ ! -x "$BUILD_CLI_BINARY" ]; then
+  echo "missing built CLI: $BUILD_CLI_BINARY" >&2
+  exit 1
+fi
 
 echo "==> staging $APP_BUNDLE"
 rm -rf "$APP_BUNDLE"
-mkdir -p "$APP_MACOS" "$APP_RESOURCES"
+mkdir -p "$APP_MACOS" "$APP_HELPERS" "$APP_RESOURCES"
 cp "$BUILD_BINARY" "$APP_BINARY"
+cp "$BUILD_CLI_BINARY" "$CLI_BINARY"
 chmod +x "$APP_BINARY"
+chmod +x "$CLI_BINARY"
+# The shared module links Sparkle even though the one-shot CLI never initializes the updater. Helpers
+# sit one directory below Contents, so give dyld the same embedded-framework location as the app binary.
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$CLI_BINARY"
 
 # SwiftPM stamps LC_BUILD_VERSION's `sdk` field with the deployment target (macOS 15), not the real
 # SDK it compiled against. macOS gates the modern Liquid Glass control appearance (pop-up buttons,
@@ -148,6 +160,7 @@ fi
 "$ROOT_DIR/script/embed_sparkle.sh" "$APP_BUNDLE" "$APP_BINARY" "$CODESIGN_IDENTITY" "--options runtime"
 
 if [ -n "$CODESIGN_IDENTITY" ]; then
+  /usr/bin/codesign --force --options runtime --sign "$CODESIGN_IDENTITY" "$CLI_BINARY" >/dev/null
   # Not --deep: the Sparkle framework is already signed above and must keep that signature.
   /usr/bin/codesign --force --options runtime \
     --sign "$CODESIGN_IDENTITY" \
@@ -155,6 +168,7 @@ if [ -n "$CODESIGN_IDENTITY" ]; then
     "$APP_BUNDLE" >/dev/null
   echo "==> signed with: $CODESIGN_IDENTITY"
 else
+  /usr/bin/codesign --force --sign - "$CLI_BINARY" >/dev/null
   /usr/bin/codesign --force --sign - --entitlements "$ENTITLEMENTS" "$APP_BUNDLE" >/dev/null
   echo "WARNING: no Apple Development identity found; ad-hoc signed." >&2
 fi

--- a/script/release.sh
+++ b/script/release.sh
@@ -44,8 +44,10 @@ DIST_DIR="$ROOT_DIR/dist"
 APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
+APP_HELPERS="$APP_CONTENTS/Helpers"
 APP_RESOURCES="$APP_CONTENTS/Resources"
 APP_BINARY="$APP_MACOS/$APP_NAME"
+CLI_BINARY="$APP_HELPERS/openusage"
 DMG_PATH="$DIST_DIR/$DMG_NAME"
 # dSYMs for crash symbolication (uploaded to PostHog by release.yml). A folder, since posthog-cli's
 # `dsym upload --directory` and Sparkle both want a directory of bundles, not a single path.
@@ -78,20 +80,28 @@ echo "==> building $APP_NAME $VERSION ($BUILD) — universal (arm64 + x86_64)"
 # `-Xswiftc -g` emits DWARF so `dsymutil` can build a real (line-level) dSYM for crash symbolication.
 # This does NOT grow the shipped binary: Mach-O keeps DWARF in the .o files (referenced by the binary's
 # debug map) and dsymutil extracts it into the .dSYM — the executable only carries the symbol table.
-swift build -c release --arch arm64 --arch x86_64 -Xswiftc -g
+swift build -c release --arch arm64 --arch x86_64 -Xswiftc -g --product OpenUsage
+swift build -c release --arch arm64 --arch x86_64 -Xswiftc -g --product openusage-cli
 BUILD_DIR="$(swift build -c release --arch arm64 --arch x86_64 -Xswiftc -g --show-bin-path)"
 BUILD_BINARY="$BUILD_DIR/$APP_NAME"
+BUILD_CLI_BINARY="$BUILD_DIR/openusage-cli"
 [ -x "$BUILD_BINARY" ] || { echo "missing built binary: $BUILD_BINARY" >&2; exit 1; }
+[ -x "$BUILD_CLI_BINARY" ] || { echo "missing built CLI: $BUILD_CLI_BINARY" >&2; exit 1; }
 
 echo "==> staging $APP_BUNDLE"
 rm -rf "$APP_BUNDLE"
-mkdir -p "$APP_MACOS" "$APP_RESOURCES"
+mkdir -p "$APP_MACOS" "$APP_HELPERS" "$APP_RESOURCES"
 cp "$BUILD_BINARY" "$APP_BINARY"
+cp "$BUILD_CLI_BINARY" "$CLI_BINARY"
 chmod +x "$APP_BINARY"
+chmod +x "$CLI_BINARY"
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$CLI_BINARY"
 # Fail loudly if the build ever silently regresses to a single arch (e.g. a dropped --arch flag): a
 # fat binary is the whole point, and generate_appcast derives Sparkle's hardwareRequirements from it.
 lipo -archs "$APP_BINARY" | grep -q "x86_64" && lipo -archs "$APP_BINARY" | grep -q "arm64" \
   || { echo "Expected a universal (arm64 + x86_64) binary, got: $(lipo -archs "$APP_BINARY")" >&2; exit 1; }
+lipo -archs "$CLI_BINARY" | grep -q "x86_64" && lipo -archs "$CLI_BINARY" | grep -q "arm64" \
+  || { echo "Expected a universal CLI, got: $(lipo -archs "$CLI_BINARY")" >&2; exit 1; }
 
 # SwiftPM stamps LC_BUILD_VERSION's `sdk` field with the deployment target (macOS 15), not the real
 # SDK it compiled against. macOS gates the modern Liquid Glass control appearance (pop-up buttons,
@@ -176,6 +186,7 @@ PLIST
 
 # Embed + sign Sparkle (Developer ID, hardened runtime, secure timestamp).
 "$ROOT_DIR/script/embed_sparkle.sh" "$APP_BUNDLE" "$APP_BINARY" "$CODESIGN_IDENTITY" "--options runtime --timestamp"
+codesign --force --options runtime --timestamp --sign "$CODESIGN_IDENTITY" "$CLI_BINARY"
 
 echo "==> signing app (Developer ID, hardened runtime)"
 # Not --deep: the Sparkle framework is signed above and must keep that signature. No get-task-allow


### PR DESCRIPTION
## TL;DR

Adds a stable, machine-readable limits API and a global `openusage` command agents can use to monitor limits.

`GET /v1/limits`, `GET /v1/limits/:providerId`, and the one-shot CLI all return the same presentation-free `openusage.limits.v1` contract. The existing `/v1/usage` API remains unchanged for compatibility.

## What was happening

- The local API only exposed `/v1/usage`, whose response mirrors UI rows and leaks presentation details such as colors, subtitles, formatted badges, charts, and spend history.
- Agents had no stable, computation-friendly limits contract.
- Agents also had no global one-shot command for reading limits without managing the local API or keeping the menu-bar app running.
- Implementing provider auth, refresh, pricing, caching, or normalization separately for the API and CLI would cause them to drift from the app.
- The bundled helper had no user-facing installation path for making `openusage` globally available.

## What this changes

### Limits API

Adds two additive local API routes:

```text
GET /v1/limits
GET /v1/limits/:providerId
```

Both return the new `openusage.limits.v1` envelope:

- Stable provider and resource IDs intended for programmatic consumers.
- Raw scalar values instead of formatted UI strings.
- Explicit units, limits, remaining values, utilization, reset/window metadata, and freshness timestamps.
- Structured provider errors.
- No colors, subtitles, badges, chart data, usage trends, or spend history.
- Uncapped usage is represented without inventing a limit; bounded accounts additionally expose `limit`, `remaining`, and `utilization`.
- Combined display rows become useful independent scalars where needed—for example, Codex credits become `credits` and `creditValue`.

Example:

```json
{
  "schema": "openusage.limits.v1",
  "providers": {
    "codex": {
      "resources": {
        "session": {
          "used": 34,
          "limit": 100,
          "remaining": 66,
          "utilization": 0.34,
          "unit": "percent",
          "resetsAt": "2026-07-13T07:00:00Z"
        }
      },
      "fetchedAt": "2026-07-13T02:00:00Z",
      "expiresAt": "2026-07-13T02:05:00Z",
      "stale": false
    }
  },
  "errors": []
}
```

The existing routes remain available and unchanged:

```text
GET /v1/usage
GET /v1/usage/:providerId
```

This lets current consumers stay on `/v1/usage` while new integrations adopt `/v1/limits`. The UI-shaped usage contract can be retired separately in the future.

### Global one-shot command

Bundles a signed helper at `OpenUsage.app/Contents/Helpers/openusage` and adds **Settings → Command Line → Install…** to install:

```text
/usr/local/bin/openusage
```

The installer uses the standard macOS administrator prompt, refuses to overwrite foreign files or symlinks, and only uninstalls the exact OpenUsage-managed link.

Agents and users can then run:

```sh
openusage
openusage codex
openusage codex --force
```

- `openusage` reads every enabled provider.
- `openusage <provider>` reads only that provider.
- `--force` refreshes only the requested scope before printing.
- Each invocation prints the same `openusage.limits.v1` envelope as the API and exits.
- It does not launch the menu-bar app or leave a process running.

### Cache and refresh behavior

- API and CLI use OpenUsage's existing provider engine and normalized snapshots.
- CLI reads share the same persisted cache and five-minute freshness interval as the app.
- Fresh entries return immediately without network requests.
- Missing or older-than-five-minute entries refresh before output.
- `--force` bypasses freshness and performs a refresh.
- Provider-scoped commands never refresh unrelated providers.
- Failed refreshes return structured errors while preserving any available last-good snapshot.
- The menu-bar app's own launch and periodic-refresh behavior are untouched.

### Shared implementation

- Moves reusable code into one shared `OpenUsage` Swift module with thin app and CLI entry points.
- Uses one canonical `ProviderCatalog` and the existing provider runtimes, auth stores, usage clients, mappers, pricing engine, refresh coordinator, and snapshot cache.
- Adds small limits-export annotations beside each provider's existing widget descriptors, then serializes the already-normalized `ProviderSnapshot`.
- Shares provider ordering normalization across the dashboard, limits API, and CLI so newly added providers cannot disappear from one surface.

The API and CLI therefore expose the same contract from the same normalized state; neither reimplements provider behavior.

## Heads-up

- `openusage.limits.v1` is a new public machine-facing contract. Provider and resource keys should be treated as stable.
- The new API is additive; no existing endpoint is removed or changed.
- The limits API remains loopback-only, matching the existing local API.
- Installing or invoking the CLI does not change the app lifecycle.

## Tests

- Full suite: 1,079 XCTest cases passed (3 skipped), plus 3 Swift Testing cases.
- Contract coverage verifies bounded consumption, balances, expiry lists, uncapped values, stale/fresh timestamps, presentation-field omission, and the approved resource-key set for all ten providers.
- API coverage verifies aggregate and provider-scoped `/v1/limits` routes, structured refresh errors, and consistent provider ordering.
- Compatibility coverage verifies the legacy `/v1/usage` response remains unchanged.
- Cache coverage verifies fresh reads do not refresh, stale reads refresh first, `--force` persists a new snapshot, and provider-scoped force refreshes only that provider.
- Installer coverage verifies safe install/uninstall and refusal to replace foreign paths.
- Signed bundle E2E verified:
  - `/usr/local/bin/openusage codex` returned `openusage.limits.v1`.
  - An immediate cached invocation exited in 0.126 seconds.
  - Live `/v1/limits/codex` returned the new contract.
  - `/v1/usage/codex` retained the legacy response.
- `./script/build_and_run.sh run` built the release app and helper, embedded and signed Sparkle, passed strict code-sign verification, and launched the app.

## Screenshots

Settings includes **Command Line → Terminal Helper** with an Install/Uninstall action.
