### PR TITLE
Fix Sparkle updater windows opening in the background

### DIFF
--- a/Sources/OpenUsage/App/UpdaterController.swift
+++ b/Sources/OpenUsage/App/UpdaterController.swift
@@ -23,6 +23,7 @@ final class UpdaterController {
     // single isolation and break one of the two conformances under Swift 6.
     private let channelDelegate = UpdaterChannelDelegate()
     private let userDriverDelegate = UpdaterUserDriverDelegate()
+    private let presentationController: UpdaterPresentationController
     private var controller: SPUStandardUpdaterController?
     private var canCheckObservation: AnyCancellable?
 
@@ -54,7 +55,8 @@ final class UpdaterController {
         set { controller?.updater.automaticallyChecksForUpdates = newValue }
     }
 
-    init() {
+    init(presentationController: UpdaterPresentationController = UpdaterPresentationController()) {
+        self.presentationController = presentationController
         self.betaChannelEnabled = UserDefaults.standard.bool(forKey: Self.betaChannelDefaultsKey)
     }
 
@@ -73,6 +75,12 @@ final class UpdaterController {
         }
         userDriverDelegate.onUpdateResolved = { [weak self] in
             self?.availableUpdateVersion = nil
+        }
+        userDriverDelegate.onUpdateWillShow = { [weak self] in
+            self?.presentationController.bringToFront(reason: "Sparkle will show update")
+        }
+        userDriverDelegate.onUpdateSessionFinished = { [weak self] in
+            self?.presentationController.returnToMenuBar()
         }
         let controller = SPUStandardUpdaterController(
             startingUpdater: true,
@@ -94,7 +102,15 @@ final class UpdaterController {
 
     /// User-initiated check. Shows Sparkle's standard UI (progress, release notes, install prompt).
     func checkForUpdates() {
-        controller?.checkForUpdates(nil)
+        guard let controller else { return }
+        // Sparkle 2.9.4 also activates dockless apps with `ignoringOtherApps`, but promote OpenUsage
+        // before handing control over so the activation-policy transition cannot leave Sparkle's
+        // checking window behind the currently active app. The next-runloop handoff mirrors the
+        // workaround verified in sparkle-project/Sparkle#2889.
+        presentationController.bringToFront(reason: "user initiated check")
+        DispatchQueue.main.async {
+            controller.checkForUpdates(nil)
+        }
     }
 
     /// The banner's install action. A user-initiated check: if the banner's update is still current,
@@ -107,6 +123,62 @@ final class UpdaterController {
     /// it, so a dismissal is a snooze — not a permanent skip (that stays in Sparkle's own window).
     func dismissAvailableUpdate() {
         availableUpdateVersion = nil
+    }
+}
+
+/// Owns the narrow AppKit boundary required to present Sparkle from a dockless menu-bar app.
+///
+/// `NSApplication.activate()` is unreliable when another app is active (sparkle-project/Sparkle#2889),
+/// so user-initiated update UI deliberately uses the older API that ignores the current foreground app.
+/// The injected closures keep that behavior unit-testable without trying to automate macOS focus.
+@MainActor
+final class UpdaterPresentationController {
+    private let activationPolicy: @MainActor () -> NSApplication.ActivationPolicy
+    private let isActive: @MainActor () -> Bool
+    private let setActivationPolicy: @MainActor (NSApplication.ActivationPolicy) -> Bool
+    private let activate: @MainActor (Bool) -> Void
+
+    convenience init(application: NSApplication = .shared) {
+        self.init(
+            activationPolicy: { application.activationPolicy() },
+            isActive: { application.isActive },
+            setActivationPolicy: { application.setActivationPolicy($0) },
+            activate: { application.activate(ignoringOtherApps: $0) }
+        )
+    }
+
+    init(
+        activationPolicy: @escaping @MainActor () -> NSApplication.ActivationPolicy,
+        isActive: @escaping @MainActor () -> Bool,
+        setActivationPolicy: @escaping @MainActor (NSApplication.ActivationPolicy) -> Bool,
+        activate: @escaping @MainActor (Bool) -> Void
+    ) {
+        self.activationPolicy = activationPolicy
+        self.isActive = isActive
+        self.setActivationPolicy = setActivationPolicy
+        self.activate = activate
+    }
+
+    func bringToFront(reason: String) {
+        let beforePolicy = activationPolicy()
+        let beforeActive = isActive()
+        let policyChanged = setActivationPolicy(.regular)
+        activate(true)
+        AppLog.info(
+            .updates,
+            "foreground updater (reason=\(reason), policy=\(beforePolicy.rawValue)->\(activationPolicy().rawValue), " +
+                "active=\(beforeActive)->\(isActive()), policyChanged=\(policyChanged))"
+        )
+    }
+
+    func returnToMenuBar() {
+        let beforePolicy = activationPolicy()
+        let policyChanged = setActivationPolicy(.accessory)
+        AppLog.info(
+            .updates,
+            "finish updater presentation (policy=\(beforePolicy.rawValue)->\(activationPolicy().rawValue), " +
+                "active=\(isActive()), policyChanged=\(policyChanged))"
+        )
     }
 }
 
@@ -152,6 +224,10 @@ final class UpdaterUserDriverDelegate: NSObject, SPUStandardUserDriverDelegate {
     /// Clears the banner — the user gave the update attention (Sparkle's window is up) or the update
     /// session ended (installed, skipped, or dismissed).
     var onUpdateResolved: (@MainActor @Sendable () -> Void)?
+    /// Reasserts foreground activation immediately before Sparkle presents user-facing update UI.
+    var onUpdateWillShow: (@MainActor @Sendable () -> Void)?
+    /// Restores OpenUsage to its normal dockless activation policy after Sparkle finishes the session.
+    var onUpdateSessionFinished: (@MainActor @Sendable () -> Void)?
 
     /// Opt into "gentle" reminders: as a menu-bar (accessory) app we don't want Sparkle stealing focus
     /// with an alert for scheduled checks.
@@ -184,13 +260,13 @@ final class UpdaterUserDriverDelegate: NSObject, SPUStandardUserDriverDelegate {
         // Hoisted so the main-actor closure captures only the Sendable callback, not this
         // nonisolated `self` (which Swift 6 region isolation rejects).
         let onUpdateFound = onUpdateFound
+        let onUpdateWillShow = onUpdateWillShow
         MainActor.assumeIsolated {
             guard handleShowingUpdate else {
                 onUpdateFound?(version)
                 return
             }
-            NSApp.setActivationPolicy(.regular)
-            NSApp.activate()
+            onUpdateWillShow?()
         }
     }
 
@@ -207,8 +283,9 @@ final class UpdaterUserDriverDelegate: NSObject, SPUStandardUserDriverDelegate {
     /// indicator still left behind by a dismissal, skip, install, or failure.
     func standardUserDriverWillFinishUpdateSession() {
         let onUpdateResolved = onUpdateResolved
+        let onUpdateSessionFinished = onUpdateSessionFinished
         MainActor.assumeIsolated { () -> Void in
-            NSApp.setActivationPolicy(.accessory)
+            onUpdateSessionFinished?()
             onUpdateResolved?()
         }
     }

--- a/Tests/OpenUsageTests/UpdaterControllerTests.swift
+++ b/Tests/OpenUsageTests/UpdaterControllerTests.swift
@@ -3,18 +3,62 @@ import XCTest
 @testable import OpenUsage
 
 @MainActor
-final class UpdaterUserDriverDelegateTests: XCTestCase {
-    func testFinishingUpdateSessionClearsInAppUpdateIndicator() {
-        let application = NSApplication.shared
-        let originalPolicy = application.activationPolicy()
-        defer { application.setActivationPolicy(originalPolicy) }
+final class UpdaterPresentationControllerTests: XCTestCase {
+    func testBringToFrontUsesReliableActivationAfterChangingPolicy() {
+        var policy = NSApplication.ActivationPolicy.accessory
+        var active = false
+        var events: [String] = []
+        let presentationController = UpdaterPresentationController(
+            activationPolicy: { policy },
+            isActive: { active },
+            setActivationPolicy: { newPolicy in
+                events.append("policy:\(newPolicy.rawValue)")
+                policy = newPolicy
+                return true
+            },
+            activate: { ignoringOtherApps in
+                events.append("activate:\(ignoringOtherApps)")
+                active = true
+            }
+        )
 
+        presentationController.bringToFront(reason: "test")
+
+        XCTAssertEqual(policy, .regular)
+        XCTAssertTrue(active)
+        XCTAssertEqual(events, ["policy:\(NSApplication.ActivationPolicy.regular.rawValue)", "activate:true"])
+    }
+
+    func testReturnToMenuBarRestoresAccessoryPolicy() {
+        var policy = NSApplication.ActivationPolicy.regular
+        let presentationController = UpdaterPresentationController(
+            activationPolicy: { policy },
+            isActive: { true },
+            setActivationPolicy: { newPolicy in
+                policy = newPolicy
+                return true
+            },
+            activate: { _ in XCTFail("Finishing must not reactivate the app") }
+        )
+
+        presentationController.returnToMenuBar()
+
+        XCTAssertEqual(policy, .accessory)
+    }
+}
+
+@MainActor
+final class UpdaterUserDriverDelegateTests: XCTestCase {
+    func testFinishingUpdateSessionRestoresPresentationAndClearsIndicator() {
         let delegate = UpdaterUserDriverDelegate()
+        var sessionFinished = false
         var resolved = false
+        delegate.onUpdateSessionFinished = { sessionFinished = true }
         delegate.onUpdateResolved = { resolved = true }
 
         delegate.standardUserDriverWillFinishUpdateSession()
 
+        XCTAssertTrue(sessionFinished)
         XCTAssertTrue(resolved)
     }
 }

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -10,9 +10,11 @@ they install, so you always get a genuine, unmodified build.
   When one is found, an **Update Available** banner appears at the top of the popover instead of a
   window popping up behind your other apps. Click **Install Update** to open the update window (release
   notes, download, install) front and center. The banner's close button snoozes it; it comes back the
-  next time the app finds the update. Because OpenUsage lives in the menu bar, it briefly shows a Dock
-  icon while the update window is open, then hides again.
+  next time the app finds the update.
 - **Manual check.** Open **Settings → Updates** and click **Check for Updates…** at any time.
+  For both manual checks and banner installs, OpenUsage brings itself to the foreground before opening
+  Sparkle so the update window doesn't get buried behind another app. Because OpenUsage normally lives
+  only in the menu bar, it briefly shows a Dock icon for the update session, then hides again.
 - **Turn it off.** The **Update Automatically** switch in **Settings → Updates** stops the
   background checks. You can still check manually.
 


### PR DESCRIPTION
## TL;DR

OpenUsage now takes foreground ownership before handing a user-initiated update check to Sparkle, using the activation API Sparkle 2.9.4 adopted for dockless apps. It keeps the app available in the Dock for the update session and restores normal menu-bar-only behavior when Sparkle finishes.

## What was happening

- Sparkle 2.9.4 fixed its own initial activation call, but OpenUsage changed activation policy later and then called `NSApp.activate()`, the same API upstream found unreliable while another app is active.
- People could start a manual check or choose **Install Update** and have Sparkle's checking, update, or install window remain behind the foreground app.
- The dev build has no update feed, so the activation contract was not covered independently of a live signed update.

## What this changes

- Adds a small AppKit presentation coordinator that switches OpenUsage to a regular app and activates it with `ignoringOtherApps: true` before Sparkle starts.
- Defers the Sparkle check by one main run-loop turn, matching the workaround verified in sparkle-project/Sparkle#2889.
- Reasserts foreground activation immediately before Sparkle presents an update, then returns OpenUsage to accessory mode only after the update session finishes.
- Logs activation policy and active-state transitions so any remaining macOS focus failure can be diagnosed from the normal OpenUsage log.
- Adds regression tests for activation ordering, the `ignoringOtherApps` flag, accessory-policy restoration, and update-session cleanup.
- Updates the updater behavior documentation.

## Heads-up

- `activate(ignoringOtherApps:)` is an older AppKit API, but Sparkle deliberately restored it in 2.9.4 because `NSApp.activate()` is inconsistent for background and dockless apps.
- A dev bundle cannot exercise the live Sparkle window because it intentionally ships without `SUFeedURL`; the tests isolate the AppKit activation contract and the release-mode app build verifies integration and launch.

## Tests

- `swift test --filter 'Updater(PresentationController|UserDriverDelegate)Tests'` — 3 passed.
- `swift test --skip-build` — 1,089 tests run, 3 skipped, 0 failed.
- `./script/build_and_run.sh verify` — release build, staging, signing, launch, and process verification passed.
- `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized updater presentation and activation-policy changes with injected, test-covered AppKit boundaries; no auth, data, or feed logic changes.
> 
> **Overview**
> Fixes Sparkle update windows opening behind the active app when users run **Check for Updates** or **Install Update** from the banner.
> 
> Introduces **`UpdaterPresentationController`** to centralize AppKit focus: switch to `.regular`, call `activate(ignoringOtherApps: true)` (workaround aligned with Sparkle#2889), log policy/active transitions, then restore `.accessory` when the update session ends. **`checkForUpdates()`** now foregrounds first and defers the Sparkle call by one main run-loop turn. **`UpdaterUserDriverDelegate`** routes activation through new callbacks instead of touching `NSApp` directly.
> 
> Adds unit tests for activation ordering and session cleanup; **`docs/updates.md`** documents foreground behavior for manual checks and banner installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa517553cb506ff6e8e279aca98bcc1ee1192ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->