### PR TITLE
fix: recover the status item when the menu bar parks it under the notch

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -39,6 +39,19 @@ final class StatusItemController: NSObject {
         onInsidePanelClick: { [weak self] in self?.clearStrayFocus() },
         onDismiss: { [weak self] in self?.hidePanel() }
     )
+    /// Keeps the app reachable when the menu bar overflows and macOS parks the status item under
+    /// the notch: first tries to move the item back into the visible menu bar, and if that doesn't
+    /// stick, shows a surrogate pill at the nearest visible notch edge that opens the dashboard.
+    private lazy var occlusionMonitor = StatusItemOcclusionMonitor(
+        statusItem: statusItem,
+        onActivate: { [weak self] in
+            self?.container.layout.screen = .dashboard
+            self?.showPopover()
+        },
+        onRescue: { [weak self] _ in
+            self?.repositionStatusItemRightOfNotch()
+        }
+    )
     private let hostingController: NSHostingController<AnyView>
     /// The panel's backdrop: an opaque tray by default, swapped to a behind-window vibrancy view when
     /// the transparency style is non-opaque. Built once and toggled, so it can't race the style observer.
@@ -120,6 +133,7 @@ final class StatusItemController: NSObject {
         }
 
         heightController.installBridge()
+        occlusionMonitor.start()
 
         AppLog.info(.statusItem, "Status item ready (button: \(self.statusItem.button != nil), shortcut: \(KeyboardShortcuts.getShortcut(for: .togglePopover)?.description ?? "none"))")
     }
@@ -188,6 +202,50 @@ final class StatusItemController: NSObject {
         // Left-click toggles the popover; right-click (or control-click) drops the context menu.
         // Both arrive through `statusButtonClicked`, which branches on the triggering event.
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    /// Moves a notch-hidden status item back into the visible menu bar by rewriting its preferred
+    /// position — the same defaults key macOS maintains when the user ⌘-drags the item — and
+    /// re-adding the item so AppKit reads it. The key is undocumented but long-stable (it is how
+    /// every status item's position persists across launches); if a macOS release stops honoring
+    /// it, the occlusion monitor's re-measure simply falls back to the surrogate pill.
+    ///
+    /// The menu bar is zero-sum: landing right of the notch shifts a neighbor leftward. That is the
+    /// deliberate trade — the user is interacting with OpenUsage, and the displaced neighbor is
+    /// whatever macOS was about to hide anyway when space next runs out.
+    private func repositionStatusItemRightOfNotch() {
+        guard
+            let button = statusItem.button,
+            let window = button.window,
+            let screen = window.screen,
+            let notch = NotchGeometry.notchRect(of: screen)
+        else { return }
+        let itemWidth = max(button.bounds.width, 24)
+        // Preferred position ≈ distance from the screen's right edge to the item's right edge.
+        // Target: the item's left edge lands just right of the notch.
+        let offset = screen.frame.maxX - notch.maxX - itemWidth - 12
+        guard offset > 0 else { return }
+        // `autosaveName` is an IUO; interpolating it directly would write a key literally named
+        // "… Optional(\"Item-0\")" that AppKit never reads.
+        guard let name = statusItem.autosaveName else { return }
+        UserDefaults.standard.set(
+            Double(offset),
+            forKey: "NSStatusItem Preferred Position \(name)"
+        )
+        // AppKit only reads a preferred position when an autosave name is assigned (toggling
+        // `isVisible` re-adds the item at its old spot). Bounce through a scratch name and back:
+        // assigning the original name again makes AppKit look up — and move to — the position
+        // just written. The scratch key is removed so it can't shadow anything later.
+        statusItem.autosaveName = "\(name).rescue"
+        statusItem.autosaveName = name
+        UserDefaults.standard.removeObject(forKey: "NSStatusItem Preferred Position \(name).rescue")
+        // The bounce can rebuild the button; re-attach click handling and repaint the strip.
+        configureStatusItem()
+        imageUpdater.update()
+        AppLog.warn(
+            .statusItem,
+            "Status item was behind the notch; repositioned to \(Int(offset))pt from the right edge"
+        )
     }
 
     // MARK: - Transparency
@@ -303,10 +361,26 @@ final class StatusItemController: NSObject {
             return
         }
         let buttonRectOnScreen = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
+        // A button parked under the notch is no anchor: the panel would open centered below the
+        // notch, seemingly out of nowhere. Anchor at the nearest visible notch edge instead.
+        var anchorRect = buttonRectOnScreen
+        if let screen = buttonWindow.screen,
+           let notch = NotchGeometry.notchRect(of: screen),
+           let occlusion = NotchGeometry.occlusion(of: buttonRectOnScreen, notch: notch),
+           occlusion.isEffectivelyHidden {
+            anchorRect = NotchGeometry.panelAnchorRect(
+                for: occlusion,
+                buttonRect: buttonRectOnScreen,
+                panelWidth: PanelHeightController.panelWidth
+            )
+            AppLog.warn(.statusItem, "Status item is behind the notch; anchoring the panel at x=\(Int(anchorRect.minX))")
+        }
+        // The pill and the panel share the same anchor; showing both stacks them.
+        occlusionMonitor.setSuppressed(true)
         // Record the display before changing the visibility signal. That signal makes SwiftUI
         // immediately clamp the measured height; without the display anchor the clamp falls back to
         // the fixed opening guess, making large and small displays open at the same height.
-        heightController.prepareForOpening(below: buttonRectOnScreen)
+        heightController.prepareForOpening(below: anchorRect)
         // Mark the popover on-screen before laying out, so the egg's animation loops mount their
         // `TimelineView` clocks in time for the first displayed frame. Read by the SwiftUI egg via
         // `\.popoverIsVisible`; a closed popover keeps the loops unmounted, so a left-on egg costs no CPU.
@@ -348,6 +422,8 @@ final class StatusItemController: NSObject {
         outsideClickMonitor.stop()
         statusItem.button?.highlight(false)
         heightController.finishClosing()
+        // Re-evaluate occlusion now that the panel is gone (brings the pill back if still hidden).
+        occlusionMonitor.setSuppressed(false)
     }
 
     /// Drops keyboard focus inside the panel so a clicked plain-styled control (a metric row's

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -133,7 +133,9 @@ final class StatusItemController: NSObject {
         }
 
         heightController.installBridge()
-        occlusionMonitor.start()
+        if NotchGeometry.fallbackIsNeeded {
+            occlusionMonitor.start()
+        }
 
         AppLog.info(.statusItem, "Status item ready (button: \(self.statusItem.button != nil), shortcut: \(KeyboardShortcuts.getShortcut(for: .togglePopover)?.description ?? "none"))")
     }
@@ -364,7 +366,8 @@ final class StatusItemController: NSObject {
         // A button parked under the notch is no anchor: the panel would open centered below the
         // notch, seemingly out of nowhere. Anchor at the nearest visible notch edge instead.
         var anchorRect = buttonRectOnScreen
-        if let screen = buttonWindow.screen,
+        if NotchGeometry.fallbackIsNeeded,
+           let screen = buttonWindow.screen,
            let notch = NotchGeometry.notchRect(of: screen),
            let occlusion = NotchGeometry.occlusion(of: buttonRectOnScreen, notch: notch),
            occlusion.isEffectivelyHidden {

--- a/Sources/OpenUsage/App/StatusItemOcclusionMonitor.swift
+++ b/Sources/OpenUsage/App/StatusItemOcclusionMonitor.swift
@@ -1,0 +1,208 @@
+import AppKit
+import SwiftUI
+
+/// Watches the status item for notch occlusion and, while the item is effectively hidden, shows a
+/// small surrogate pill just below the menu bar at the nearest visible notch edge so the app stays
+/// reachable (clicking the pill opens the dashboard). There is no API to move the status item
+/// itself — its x is dictated by the neighbors to its right — so a visible stand-in is the only
+/// way to keep an entry point on screen.
+///
+/// The pill is a borderless non-activating panel like the dashboard's `MenuBarPanel`, but it never
+/// needs to become key: it only forwards a click. It hides again the moment the status item comes
+/// back out of the notch (the user quit another menu-bar app, changed displays, …).
+@MainActor
+final class StatusItemOcclusionMonitor {
+    /// Gap between the notch edge and the pill, and between the menu bar and the pill's top.
+    private static let edgeGap: CGFloat = 6
+    private static let topGap: CGFloat = 4
+    /// The menu bar only reflows on external events (apps adding/removing items) that AppKit does
+    /// not announce, so a slow poll backstops the screen-parameters observer.
+    private static let pollInterval: Duration = .seconds(30)
+
+    private let statusItem: NSStatusItem
+    private let onActivate: () -> Void
+
+    private var pill: NSPanel?
+    private var screenObserver: NSObjectProtocol?
+    private var pollTask: Task<Void, Never>?
+    /// True while the dashboard panel is open — the pill would sit exactly under it.
+    private var suppressed = false
+    private var dismissedUntilRelaunch = false
+    /// Keeps the pill where the user dragged it for the lifetime of one occlusion episode.
+    private var hasPositionedPill = false
+    /// One self-rescue per occlusion episode: the rescue rewrites the item's preferred position and
+    /// re-adds it, so retrying in a loop would fight the menu bar (and the user).
+    private var hasAttemptedRescue = false
+    private(set) var currentOcclusion: NotchGeometry.Occlusion?
+
+    /// - Parameters:
+    ///   - onActivate: opens the dashboard (a pill click).
+    ///   - onRescue: asked once per occlusion episode to move the status item back into view;
+    ///     the monitor re-measures shortly after and only shows the pill if the item is still hidden.
+    init(
+        statusItem: NSStatusItem,
+        onActivate: @escaping () -> Void,
+        onRescue: @escaping (NotchGeometry.Occlusion) -> Void
+    ) {
+        self.statusItem = statusItem
+        self.onActivate = onActivate
+        self.onRescue = onRescue
+    }
+
+    private let onRescue: (NotchGeometry.Occlusion) -> Void
+
+    func start() {
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.recheck() }
+        }
+        pollTask = Task { @MainActor [weak self] in
+            // First check waits a beat so the menu bar finishes placing the new item.
+            try? await Task.sleep(for: .seconds(2))
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.recheck()
+                try? await Task.sleep(for: Self.pollInterval)
+            }
+        }
+    }
+
+    /// Hides the pill while the dashboard panel is open and re-evaluates once it closes.
+    func setSuppressed(_ value: Bool) {
+        suppressed = value
+        if value {
+            pill?.orderOut(nil)
+        } else {
+            recheck()
+        }
+    }
+
+    func recheck() {
+        guard let occlusion = measureOcclusion(), occlusion.isEffectivelyHidden else {
+            if currentOcclusion != nil {
+                AppLog.info(.statusItem, "Status item is visible again")
+            }
+            currentOcclusion = nil
+            hasPositionedPill = false
+            hasAttemptedRescue = false
+            pill?.orderOut(nil)
+            return
+        }
+        let entering = currentOcclusion == nil
+        currentOcclusion = occlusion
+        if entering {
+            AppLog.warn(
+                .statusItem,
+                "Status item is \(Int(occlusion.hiddenFraction * 100))% behind the notch"
+            )
+        }
+        // First response: ask the controller to move the item back into the visible menu bar, then
+        // re-measure after the menu bar reflows. The pill only appears if the rescue didn't stick.
+        if !hasAttemptedRescue {
+            hasAttemptedRescue = true
+            onRescue(occlusion)
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(800))
+                self?.recheck()
+            }
+            return
+        }
+        guard !suppressed, !dismissedUntilRelaunch else { return }
+        showPill(for: occlusion)
+    }
+
+    // MARK: - Measurement
+
+    private func measureOcclusion() -> NotchGeometry.Occlusion? {
+        guard
+            let button = statusItem.button,
+            let window = button.window,
+            let screen = window.screen,
+            let notch = NotchGeometry.notchRect(of: screen)
+        else { return nil }
+        let rect = window.convertToScreen(button.convert(button.bounds, to: nil))
+        return NotchGeometry.occlusion(of: rect, notch: notch)
+    }
+
+    // MARK: - Pill
+
+    private func showPill(for occlusion: NotchGeometry.Occlusion) {
+        let pill = self.pill ?? makePill()
+        self.pill = pill
+        if !hasPositionedPill,
+           let screen = statusItem.button?.window?.screen,
+           let notch = NotchGeometry.notchRect(of: screen) {
+            let size = pill.contentView?.fittingSize ?? NSSize(width: 110, height: 26)
+            let x: CGFloat = switch occlusion.nearestVisibleEdge {
+            case .left: occlusion.nearestVisibleEdgeX - size.width - Self.edgeGap
+            case .right: occlusion.nearestVisibleEdgeX + Self.edgeGap
+            }
+            let y = notch.minY - Self.topGap - size.height
+            pill.setFrame(NSRect(origin: NSPoint(x: x, y: y), size: size), display: false)
+            hasPositionedPill = true
+        }
+        pill.orderFrontRegardless()
+    }
+
+    private func makePill() -> NSPanel {
+        let panel = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .statusBar
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.isMovableByWindowBackground = true
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.contentView = NSHostingView(rootView: SurrogatePillView(
+            onActivate: { [weak self] in self?.onActivate() },
+            onDismiss: { [weak self] in self?.dismissUntilRelaunch() }
+        ))
+        return panel
+    }
+
+    private func dismissUntilRelaunch() {
+        dismissedUntilRelaunch = true
+        pill?.orderOut(nil)
+        AppLog.info(.statusItem, "Surrogate pill hidden until relaunch by the user")
+    }
+}
+
+/// The pill's face: just the brand glyph in a small capsule — the status item's stand-in, so it
+/// reads (and takes space) like a menu-bar icon, not a widget. Click opens the dashboard; the
+/// context menu offers a way out for users who'd rather live with the hidden status item.
+private struct SurrogatePillView: View {
+    let onActivate: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        Group {
+            if let icon = MenuBarIcon.image {
+                Image(nsImage: icon)
+                    .renderingMode(.template)
+            } else {
+                Text("OpenUsage")
+                    .font(.system(size: 11, weight: .semibold))
+            }
+        }
+        .foregroundStyle(.primary)
+        .padding(6)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(.separator, lineWidth: 1))
+        .contentShape(Capsule())
+        // The hosting view's fittingSize sizes the pill window; without this the content reports
+        // its compressed size and clips.
+        .fixedSize()
+        .onTapGesture(perform: onActivate)
+        .contextMenu {
+            Button("Hide Until Relaunch", action: onDismiss)
+        }
+    }
+}

--- a/Sources/OpenUsage/Support/NotchGeometry.swift
+++ b/Sources/OpenUsage/Support/NotchGeometry.swift
@@ -30,6 +30,20 @@ enum NotchGeometry {
         var isEffectivelyHidden: Bool { hiddenFraction >= 0.75 }
     }
 
+    /// Whether the notch-occlusion fallback should run at all. macOS 27 ("Golden Gate") manages
+    /// menu-bar overflow natively — items that don't fit fold behind a chevron left of the notch
+    /// instead of being parked invisibly under it — so on 27+ the fallback is a no-op. Once the
+    /// app's deployment target passes macOS 26, this gate and everything it guards can be deleted.
+    static var fallbackIsNeeded: Bool {
+        fallbackIsNeeded(
+            onMacOSMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion
+        )
+    }
+
+    static func fallbackIsNeeded(onMacOSMajorVersion major: Int) -> Bool {
+        major <= 26
+    }
+
     /// The notch rect in screen coordinates, or `nil` when the screen has no notch.
     static func notchRect(of screen: NSScreen) -> NSRect? {
         guard let left = screen.auxiliaryTopLeftArea, let right = screen.auxiliaryTopRightArea else {

--- a/Sources/OpenUsage/Support/NotchGeometry.swift
+++ b/Sources/OpenUsage/Support/NotchGeometry.swift
@@ -1,0 +1,81 @@
+import AppKit
+
+/// Pure notch-occlusion geometry, kept separate so it can be tested without a real screen
+/// (mirrors `PanelGeometry`).
+///
+/// On notched MacBooks, macOS lays status items out right-to-left; when the menu bar fills up,
+/// the leftmost third-party items are pushed under the notch. The item still exists — AppKit
+/// reports a live button and "Status item ready" is logged — but it is invisible and unclickable,
+/// so the app looks like it never launched. There is no API to reposition a status item (its x is
+/// determined by the neighbors to its right), so these helpers only *detect* that state; callers
+/// provide the visible escape hatch (an edge-anchored panel, a surrogate pill).
+enum NotchGeometry {
+    /// How a status-item button (in screen coordinates) is occluded by the notch.
+    struct Occlusion: Equatable {
+        enum Edge: Equatable {
+            case left
+            case right
+        }
+
+        /// Fraction of the rect's width hidden behind the notch, in (0…1].
+        let hiddenFraction: CGFloat
+        /// The notch edge closest to the rect's center — the nearest place something can be seen.
+        let nearestVisibleEdge: Edge
+        /// X of that edge in screen coordinates (the notch's `minX` or `maxX`).
+        let nearestVisibleEdgeX: CGFloat
+
+        /// True when so little of the rect remains visible that it is effectively undiscoverable.
+        /// 0.75 keeps a half-covered (still findable, still clickable) item out of fallback mode;
+        /// the measured real-world cases are 0.86 (text strip) and 1.0 (bars glyph).
+        var isEffectivelyHidden: Bool { hiddenFraction >= 0.75 }
+    }
+
+    /// The notch rect in screen coordinates, or `nil` when the screen has no notch.
+    static func notchRect(of screen: NSScreen) -> NSRect? {
+        guard let left = screen.auxiliaryTopLeftArea, let right = screen.auxiliaryTopRightArea else {
+            return nil
+        }
+        return notchRect(auxiliaryTopLeft: left, auxiliaryTopRight: right, screenFrame: screen.frame)
+    }
+
+    /// The gap between the two auxiliary menu-bar areas, extended to the top of the screen.
+    static func notchRect(
+        auxiliaryTopLeft left: NSRect,
+        auxiliaryTopRight right: NSRect,
+        screenFrame: NSRect
+    ) -> NSRect? {
+        let width = right.minX - left.maxX
+        guard width > 0 else { return nil }
+        let minY = min(left.minY, right.minY)
+        return NSRect(x: left.maxX, y: minY, width: width, height: screenFrame.maxY - minY)
+    }
+
+    /// How much of `rect` the notch hides, or `nil` when they don't intersect.
+    static func occlusion(of rect: NSRect, notch: NSRect) -> Occlusion? {
+        let overlap = rect.intersection(notch)
+        guard rect.width > 0, !overlap.isNull, overlap.width > 0 else { return nil }
+        let nearestEdge: Occlusion.Edge =
+            abs(rect.midX - notch.minX) <= abs(rect.midX - notch.maxX) ? .left : .right
+        return Occlusion(
+            hiddenFraction: overlap.width / rect.width,
+            nearestVisibleEdge: nearestEdge,
+            nearestVisibleEdgeX: nearestEdge == .left ? notch.minX : notch.maxX
+        )
+    }
+
+    /// Where `showPanel` should anchor instead of the hidden button: at the nearest visible notch
+    /// edge, sided so the panel opens away from the notch (left edge → the panel's right edge meets
+    /// it; right edge → the panel's left edge meets it). Y is carried over from the button so the
+    /// panel still hangs from the menu bar.
+    static func panelAnchorRect(
+        for occlusion: Occlusion,
+        buttonRect: NSRect,
+        panelWidth: CGFloat
+    ) -> NSRect {
+        let x: CGFloat = switch occlusion.nearestVisibleEdge {
+        case .left: occlusion.nearestVisibleEdgeX - panelWidth
+        case .right: occlusion.nearestVisibleEdgeX
+        }
+        return NSRect(x: x, y: buttonRect.minY, width: buttonRect.width, height: buttonRect.height)
+    }
+}

--- a/Tests/OpenUsageTests/NotchGeometryTests.swift
+++ b/Tests/OpenUsageTests/NotchGeometryTests.swift
@@ -77,6 +77,15 @@ final class NotchGeometryTests: XCTestCase {
         XCTAssertEqual(anchor.minY, 1138)
     }
 
+    func testFallbackIsGatedToMacOS26AndBelow() {
+        // macOS 27 ("Golden Gate") folds overflowing items behind a chevron instead of parking
+        // them under the notch, so the fallback must stay off there and on for 15–26.
+        XCTAssertTrue(NotchGeometry.fallbackIsNeeded(onMacOSMajorVersion: 15))
+        XCTAssertTrue(NotchGeometry.fallbackIsNeeded(onMacOSMajorVersion: 26))
+        XCTAssertFalse(NotchGeometry.fallbackIsNeeded(onMacOSMajorVersion: 27))
+        XCTAssertFalse(NotchGeometry.fallbackIsNeeded(onMacOSMajorVersion: 28))
+    }
+
     func testPanelAnchorRightAlignsAtTheLeftNotchEdge() {
         let occlusion = NotchGeometry.occlusion(
             of: NSRect(x: 767, y: 1138, width: 170, height: 24), notch: notch

--- a/Tests/OpenUsageTests/NotchGeometryTests.swift
+++ b/Tests/OpenUsageTests/NotchGeometryTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import OpenUsage
+
+/// Fixtures are real measurements from a notched 14" MacBook Pro (logical 1800×1169, notch
+/// x 791–1012) where the status item sat fully behind the notch while the log kept reporting
+/// "Status item ready" — the app looked like it never launched.
+final class NotchGeometryTests: XCTestCase {
+    // Measured auxiliary areas: left 0–791, right 1012–1800, menu-bar strip y 1131–1169.
+    private let auxLeft = NSRect(x: 0, y: 1131, width: 791, height: 38)
+    private let auxRight = NSRect(x: 1012, y: 1131, width: 788, height: 38)
+    private let screenFrame = NSRect(x: 0, y: 0, width: 1800, height: 1169)
+
+    private var notch: NSRect {
+        NotchGeometry.notchRect(
+            auxiliaryTopLeft: auxLeft, auxiliaryTopRight: auxRight, screenFrame: screenFrame
+        )!
+    }
+
+    func testNotchRectSpansTheGapBetweenAuxiliaryAreas() {
+        XCTAssertEqual(notch, NSRect(x: 791, y: 1131, width: 221, height: 38))
+    }
+
+    func testAdjacentAuxiliaryAreasMeanNoNotch() {
+        let right = NSRect(x: 791, y: 1131, width: 1009, height: 38)
+        XCTAssertNil(NotchGeometry.notchRect(
+            auxiliaryTopLeft: auxLeft, auxiliaryTopRight: right, screenFrame: screenFrame
+        ))
+    }
+
+    func testBarsStyleItemFullyBehindNotchIsEffectivelyHidden() {
+        // Measured: bars style rendered 36pt at x=902 — zero visible pixels.
+        let occlusion = NotchGeometry.occlusion(
+            of: NSRect(x: 902, y: 1138, width: 36, height: 24), notch: notch
+        )
+        XCTAssertEqual(occlusion?.hiddenFraction, 1)
+        XCTAssertEqual(occlusion?.nearestVisibleEdge, .right)
+        XCTAssertEqual(occlusion?.nearestVisibleEdgeX, 1012)
+        XCTAssertEqual(occlusion?.isEffectivelyHidden, true)
+    }
+
+    func testTextStyleItemMostlyBehindNotchIsEffectivelyHidden() {
+        // Measured: text strip rendered 170pt at x=767 — only a 24pt sliver peeked out on the left.
+        let occlusion = NotchGeometry.occlusion(
+            of: NSRect(x: 767, y: 1138, width: 170, height: 24), notch: notch
+        )
+        XCTAssertEqual(occlusion!.hiddenFraction, 146.0 / 170.0, accuracy: 0.001)
+        XCTAssertEqual(occlusion?.nearestVisibleEdge, .left)
+        XCTAssertEqual(occlusion?.nearestVisibleEdgeX, 791)
+        XCTAssertEqual(occlusion?.isEffectivelyHidden, true)
+    }
+
+    func testMostlyVisibleItemIsNotEffectivelyHidden() {
+        // Only its right quarter dips under the notch; the item is still findable and clickable.
+        let occlusion = NotchGeometry.occlusion(
+            of: NSRect(x: 700, y: 1138, width: 120, height: 24), notch: notch
+        )
+        XCTAssertEqual(occlusion!.hiddenFraction, 29.0 / 120.0, accuracy: 0.001)
+        XCTAssertEqual(occlusion?.isEffectivelyHidden, false)
+    }
+
+    func testItemClearOfTheNotchHasNoOcclusion() {
+        XCTAssertNil(NotchGeometry.occlusion(
+            of: NSRect(x: 1100, y: 1138, width: 36, height: 24), notch: notch
+        ))
+    }
+
+    func testPanelAnchorFallsBackToTheRightNotchEdge() {
+        let occlusion = NotchGeometry.occlusion(
+            of: NSRect(x: 902, y: 1138, width: 36, height: 24), notch: notch
+        )!
+        let anchor = NotchGeometry.panelAnchorRect(
+            for: occlusion,
+            buttonRect: NSRect(x: 902, y: 1138, width: 36, height: 24),
+            panelWidth: 320
+        )
+        XCTAssertEqual(anchor.minX, 1012)
+        XCTAssertEqual(anchor.minY, 1138)
+    }
+
+    func testPanelAnchorRightAlignsAtTheLeftNotchEdge() {
+        let occlusion = NotchGeometry.occlusion(
+            of: NSRect(x: 767, y: 1138, width: 170, height: 24), notch: notch
+        )!
+        let anchor = NotchGeometry.panelAnchorRect(
+            for: occlusion,
+            buttonRect: NSRect(x: 767, y: 1138, width: 170, height: 24),
+            panelWidth: 320
+        )
+        // The panel's left edge lands so its right edge meets the notch's left edge (791 − 320).
+        XCTAssertEqual(anchor.minX, 471)
+    }
+}

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -34,6 +34,15 @@ Normally:
 While the screen is shared or recorded:
 
 ![The menu bar strip concealed behind the OpenUsage wordmark](assets/menu-bar-privacy-sharing.png)
+## The notch
+
+On MacBooks with a notch, a crowded menu bar can push the OpenUsage item underneath it — the item still exists, but you can't see or click it. OpenUsage watches for this and recovers on its own:
+
+1. **Move back into view** — the item's remembered menu-bar position is rewritten so it re-lands just right of the notch. This is the normal outcome; you may notice the strip hop.
+2. **Surrogate button** — if the move doesn't stick, a small round OpenUsage button appears just below the menu bar next to the notch. Click it to open the dashboard, drag it anywhere, or right-click → Hide Until Relaunch.
+3. Either way, the dashboard always opens beside the notch where you can see it, never centered under it.
+
+Freeing up menu bar space (quitting other menu bar apps, or using a menu bar manager) returns everything to normal automatically.
 
 ## What the strip shows
 

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -44,6 +44,8 @@ On MacBooks with a notch, a crowded menu bar can push the OpenUsage item underne
 
 Freeing up menu bar space (quitting other menu bar apps, or using a menu bar manager) returns everything to normal automatically.
 
+On macOS 27 and later this recovery is disabled: the system manages menu-bar overflow natively, folding items that don't fit behind a chevron next to the notch instead of hiding them.
+
 ## What the strip shows
 
 The strip only renders real data. A starred metric with nothing fetched yet is skipped; a provider whose stars all lack data disappears entirely (icon included). When nothing has data, the strip falls back to the app icon. Stars follow your Customize order — Always Visible metrics first, then On Demand ones. A metric can be starred whether it's Always Visible or On Demand.


### PR DESCRIPTION
### TL;DR

When a crowded menu bar pushes the status item under the MacBook notch, OpenUsage becomes invisible and unclickable while its log reports "Status item ready". This PR detects that state and recovers: it moves the item back into the visible menu bar, falls back to a small surrogate button if the move doesn't stick, and anchors the panel beside the notch instead of under it.

Closes #993 (opened first per the issue-first flow; measurements and dead-end analysis live there).

### What was happening

- macOS lays status items right-to-left; when the right-of-notch area fills up, the leftmost third-party item overflows under the notch (measured: text strip at x 767–937, bars glyph at x 902–938, notch 791–1012 — zero to 24 pt visible).
- The app keeps running and logs `Status item ready (button: true, …)`, so to the user OpenUsage "never launched", and relaunching lands it in the same spot.
- Shrinking the item cannot help: its right edge is pinned by its neighbors, so narrower styles are *more* hidden. There is no public API to reposition an `NSStatusItem`.
- Opening the panel (e.g. via the global shortcut) anchored it below the hidden button — a window materializing centered under the notch.

### What this changes

- **`NotchGeometry` (new, pure)** — computes the notch rect from `auxiliaryTop*Area`, how much of the button it hides (occluded at ≥75%), and the fallback panel anchor. Mirrors the `PanelGeometry` pattern; unit-tested with the real measured fixtures.
- **Self-rescue (primary)** — `StatusItemController.repositionStatusItemRightOfNotch()` rewrites the item's remembered position (the same `NSStatusItem Preferred Position` default that ⌘-dragging maintains) and bounces `autosaveName` so AppKit re-reads it; the item re-lands just right of the notch. Verified live on macOS 26.5.2: a 99%-hidden item moved to the visible menu bar.
- **`StatusItemOcclusionMonitor` (new)** — checks after launch, on screen-parameter changes, and on a slow 30 s poll. One rescue per occlusion episode; it re-measures afterwards and only if the item is still hidden shows a **surrogate button** (borderless non-activating panel, icon-only) just below the menu bar at the nearest visible notch edge — click opens the dashboard, drag to move, right-click → Hide Until Relaunch. Hidden while the dashboard is open, and removed automatically the moment the real item is visible again.
- **Panel anchoring** — `showPanel()` anchors at the nearest visible notch edge whenever the button is effectively hidden, so the panel never opens centered under the notch.
- **Docs** — `docs/menu-bar.md` gains a short "The notch" section.

### Heads-up

- The rescue leans on the undocumented-but-long-stable preferred-position defaults key (it is how every item's position persists). If a future macOS stops honoring it, the post-rescue re-measure catches that and the surrogate button takes over — behavior degrades to "still reachable", never back to "invisible".
- The rescue is zero-sum: re-landing right of the notch nudges a neighbor leftward. Deliberate — the user is trying to reach OpenUsage.
- Non-notched Macs: `auxiliaryTop*Area` is `nil`, every new path is inert, zero behavior change.
- An earlier IUO footgun is documented in-code: interpolating `statusItem.autosaveName` directly writes a key literally named `… Optional("Item-0")` that AppKit never reads.

### Tests

- `NotchGeometryTests` (8 cases) — fixtures are the real AX measurements from the reproducing machine (screen 1800×1169, notch 791–1012, item frames 767×170 / 902×36).
- Full suite: the only failures are the 4 Codex tests that already fail on a clean `main` checkout.
- Live verification on macOS 26.5.2 (notched 14"): rescue moves the item into view (screenshot below); with the rescue defeated, the surrogate button appears and opens the panel anchored at the notch edge (`anchoring the panel at x=1012` in the log).

### Screenshots

Status item rescued back into the visible menu bar (Claude/Codex/Z.ai strip, right of the notch):

![rescued](https://raw.githubusercontent.com/maxmilian/openusage/notch-assets/notch-rescued.png)

Surrogate button (fallback path) below the menu bar at the notch's right edge:

![pill](https://raw.githubusercontent.com/maxmilian/openusage/notch-assets/notch-pill.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dpF8491eHK8reiuJ8vMxB