### PR TITLE
feat(cursor): spend view toggle for included vs billed usage

### DIFF
--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -16,17 +16,21 @@ final class CursorProvider: ProviderRuntime {
     let usageClient: CursorUsageClient
     let now: @Sendable () -> Date
     let pricing: @Sendable () async -> ModelPricing
+    /// Read at each refresh so a toggle flip applies on the next snapshot without a restart.
+    let spendView: @Sendable () -> CursorSpendViewSetting
 
     init(
         authStore: CursorAuthStore = CursorAuthStore(),
         usageClient: CursorUsageClient = CursorUsageClient(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() },
+        spendView: @escaping @Sendable () -> CursorSpendViewSetting = { .current }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient
         self.now = now
         self.pricing = pricing
+        self.spendView = spendView
     }
 
     var widgetDescriptors: [WidgetDescriptor] {
@@ -186,7 +190,15 @@ final class CursorProvider: ProviderRuntime {
                     "usage CSV ignored \(parsed.rejectedRowCount) malformed row\(parsed.rejectedRowCount == 1 ? "" : "s")"
                 )
             }
-            return CursorUsageMapper.appendSpendLines(rows: parsed.rows, now: end, pricing: pricing, to: &lines)
+            let view = spendView()
+            if view != .all, !parsed.rows.isEmpty, parsed.rows.allSatisfy({ $0.billing == .unknown }) {
+                // An export without a Cost column can't be split; say so instead of a silent "No data".
+                AppLog.warn(
+                    LogTag.plugin("cursor"),
+                    "usage CSV carries no Cost column; the \(view.label) spend view has nothing to show"
+                )
+            }
+            return CursorUsageMapper.appendSpendLines(rows: parsed.rows, now: end, pricing: pricing, view: view, to: &lines)
         } catch let error as CursorUsageCSVError {
             switch error {
             case .missingColumns(let columns):

--- a/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorProvider.swift
@@ -16,17 +16,21 @@ final class CursorProvider: ProviderRuntime {
     let usageClient: CursorUsageClient
     let now: @Sendable () -> Date
     let pricing: @Sendable () async -> ModelPricing
+    /// Read at each refresh so a toggle flip applies on the next snapshot without a restart.
+    let spendView: @Sendable () -> CursorSpendViewSetting
 
     init(
         authStore: CursorAuthStore = CursorAuthStore(),
         usageClient: CursorUsageClient = CursorUsageClient(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() },
+        spendView: @escaping @Sendable () -> CursorSpendViewSetting = { .current }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient
         self.now = now
         self.pricing = pricing
+        self.spendView = spendView
     }
 
     var widgetDescriptors: [WidgetDescriptor] {
@@ -215,7 +219,15 @@ final class CursorProvider: ProviderRuntime {
                     "usage CSV ignored \(parsed.rejectedRowCount) malformed row\(parsed.rejectedRowCount == 1 ? "" : "s")"
                 )
             }
-            return CursorUsageMapper.appendSpendLines(rows: parsed.rows, now: end, pricing: pricing, to: &lines)
+            let view = spendView()
+            if view != .all, !parsed.rows.isEmpty, parsed.rows.allSatisfy({ $0.billing == .unknown }) {
+                // An export without a Cost column can't be split; say so instead of a silent "No data".
+                AppLog.warn(
+                    LogTag.plugin("cursor"),
+                    "usage CSV carries no Cost column; the \(view.label) spend view has nothing to show"
+                )
+            }
+            return CursorUsageMapper.appendSpendLines(rows: parsed.rows, now: end, pricing: pricing, view: view, to: &lines)
         } catch let error as CursorUsageCSVError {
             switch error {
             case .missingColumns(let columns):

--- a/Sources/OpenUsage/Providers/Cursor/CursorSpendViewSetting.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorSpendViewSetting.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Which side of Cursor's usage the spend tiles (Today / Yesterday / Last 30 Days) and the Usage
+/// Trend aggregate: everything, only plan-covered rows (the export's `Cost` column says `Included`),
+/// or only billed / on-demand rows (the column carries a dollar amount). The bounded meters
+/// (Total / Auto / API Usage %) always stay as Cursor reports them — they come from Cursor's live
+/// API, not the export, and re-deriving them locally would contradict the dashboard.
+///
+/// Rows an old export can't classify (no `Cost` column) only count in All Usage: quietly assigning
+/// them to a side would fake the split.
+enum CursorSpendViewSetting: String, Hashable, Sendable, CaseIterable, UserDefaultsBacked {
+    case all
+    case included
+    case api
+
+    static let key = "cursor.spendView"
+    static var fallback: CursorSpendViewSetting { .all }
+
+    // `current` (the user's current choice, read live) comes from `UserDefaultsBacked`.
+
+    var label: String {
+        switch self {
+        case .all: return "All Usage"
+        case .included: return "Included Usage"
+        case .api: return "API Usage"
+        }
+    }
+
+    /// Whether a CSV row with this billing kind counts in this view.
+    func includes(_ billing: CursorBillingKind) -> Bool {
+        switch self {
+        case .all: return true
+        case .included: return billing == .included
+        case .api: return billing == .billed
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/Cursor/CursorSpendViewSetting.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorSpendViewSetting.swift
@@ -11,7 +11,9 @@ import Foundation
 enum CursorSpendViewSetting: String, Hashable, Sendable, CaseIterable, UserDefaultsBacked {
     case all
     case included
-    case api
+    /// Named for the billing side, not the API: "API Usage" is already the bounded meter Cursor
+    /// reports, and reusing it here would read as if the picker filtered that meter.
+    case billed
 
     static let key = "cursor.spendView"
     static var fallback: CursorSpendViewSetting { .all }
@@ -22,7 +24,7 @@ enum CursorSpendViewSetting: String, Hashable, Sendable, CaseIterable, UserDefau
         switch self {
         case .all: return "All Usage"
         case .included: return "Included Usage"
-        case .api: return "API Usage"
+        case .billed: return "Billed"
         }
     }
 
@@ -31,7 +33,7 @@ enum CursorSpendViewSetting: String, Hashable, Sendable, CaseIterable, UserDefau
         switch self {
         case .all: return true
         case .included: return billing == .included
-        case .api: return billing == .billed
+        case .billed: return billing == .billed
         }
     }
 }

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageCSV.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+/// How Cursor billed a CSV row, read from the export's `Cost` column: `Included` marks consumption
+/// covered by the plan; anything else non-empty is a dollar amount for billed / on-demand usage.
+/// `unknown` covers exports that predate the column (or an empty cell) — those rows can't be split
+/// into either side, so only the combined view counts them.
+enum CursorBillingKind: Sendable, Equatable {
+    case included
+    case billed
+    case unknown
+}
+
 /// One parsed row from Cursor's CSV usage export. `imputedCostDollars` is the locally priced dollar
 /// amount (server CSV tokens × the shared model pricing); `nil` when no pricing source knows the
 /// model — those rows contribute tokens but flag the day's cost as incomplete. Ported from
@@ -9,6 +19,7 @@ struct CursorUsageCSVRow: Sendable, Equatable {
     var model: String
     var tokens: TokenBreakdown
     var imputedCostDollars: Double?
+    var billing: CursorBillingKind = .unknown
 }
 
 struct CursorUsageCSVParseResult: Sendable, Equatable {
@@ -29,6 +40,8 @@ enum CursorUsageCSV {
         static let input = "Input (w/o Cache Write)"
         static let cacheRead = "Cache Read"
         static let output = "Output Tokens"
+        /// Optional: exports predating this column still parse, with `billing` left `.unknown`.
+        static let cost = "Cost"
         static let required = [date, model, cacheWrite, input, cacheRead, output]
     }
 
@@ -109,7 +122,8 @@ enum CursorUsageCSV {
                     model: model,
                     tokens: tokens,
                     applyLongContextRates: false
-                )
+                ),
+                billing: parseBillingKind(r[Column.cost])
             ))
         }
         guard summary.isStructurallyComplete, !hasDuplicateColumns else {
@@ -118,6 +132,13 @@ enum CursorUsageCSV {
         guard missingColumns.isEmpty else { throw CursorUsageCSVError.missingColumns(missingColumns) }
         rejectedRowCount += summary.rejectedRecordCount
         return CursorUsageCSVParseResult(rows: rows, rejectedRowCount: rejectedRowCount)
+    }
+
+    private static func parseBillingKind(_ raw: String?) -> CursorBillingKind {
+        guard let value = raw?.trimmingCharacters(in: .whitespaces), !value.isEmpty else {
+            return .unknown
+        }
+        return value.lowercased() == "included" ? .included : .billed
     }
 
     private static func parseDate(_ raw: String) -> Date? {

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -266,11 +266,16 @@ enum CursorUsageMapper {
     /// family grouping). The raw slugs survive as `variants` — the per-effort breakdown the row's
     /// tooltip shows.
     static func appendSpendLines(
-        rows: [CursorUsageCSVRow],
+        rows allRows: [CursorUsageCSVRow],
         now: Date,
         pricing: ModelPricing,
+        view: CursorSpendViewSetting = .all,
         to lines: inout [MetricLine]
     ) -> ProviderUsageHistory {
+        // The spend-view setting picks which billing side counts (#609); `.all` is today's combined
+        // behavior. Filtered-out rows vanish entirely — tiles, trend, and model breakdown alike — so
+        // a view with no matching rows reads "No data", same as an idle export.
+        let rows = view == .all ? allRows : allRows.filter { view.includes($0.billing) }
         let calendar = Calendar.current
         var costByDay: [String: Double] = [:]
         var tokensByDay: [String: Int] = [:]

--- a/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Cursor/CursorUsageMapper.swift
@@ -297,11 +297,16 @@ enum CursorUsageMapper {
     /// family grouping). The raw slugs survive as `variants` — the per-effort breakdown the row's
     /// tooltip shows.
     static func appendSpendLines(
-        rows: [CursorUsageCSVRow],
+        rows allRows: [CursorUsageCSVRow],
         now: Date,
         pricing: ModelPricing,
+        view: CursorSpendViewSetting = .all,
         to lines: inout [MetricLine]
     ) -> ProviderUsageHistory {
+        // The spend-view setting picks which billing side counts (#609); `.all` is today's combined
+        // behavior. Filtered-out rows vanish entirely — tiles, trend, and model breakdown alike — so
+        // a view with no matching rows reads "No data", same as an idle export.
+        let rows = view == .all ? allRows : allRows.filter { view.includes($0.billing) }
         let calendar = Calendar.current
         var costByDay: [String: Double] = [:]
         var tokensByDay: [String: Int] = [:]

--- a/Sources/OpenUsage/Views/CursorSpendViewSection.swift
+++ b/Sources/OpenUsage/Views/CursorSpendViewSection.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// The Cursor-only spend-view card in its Customize detail: picks which side of the usage export
+/// the spend tiles (Today / Yesterday / Last 30 Days) and the Usage Trend aggregate — everything,
+/// plan-included rows only, or billed API usage only. The bounded meters (Total / Auto / API
+/// Usage %) always stay as Cursor reports them. Changing the view forces a refresh so the tiles
+/// update immediately instead of waiting for the next pass.
+struct CursorSpendViewSection: View {
+    @Environment(WidgetDataStore.self) private var dataStore
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @AppStorage(CursorSpendViewSetting.key) private var spendView = CursorSpendViewSetting.fallback
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
+            Text("Spend View")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+            VStack(spacing: 0) {
+                // Same row shape as a Settings row: label leading, popup picker trailing.
+                HStack(spacing: 10) {
+                    Text("Spend Tiles Show")
+                    Spacer(minLength: 8)
+                    Picker("", selection: $spendView) {
+                        ForEach(CursorSpendViewSetting.allCases, id: \.self) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .fixedSize()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, density.controlRowPadding)
+            }
+            .cardSurface()
+        }
+        .onChange(of: spendView) {
+            // The setting is read at refresh time, so force one for an immediate tile update.
+            Task { await dataStore.refresh(providerID: "cursor", force: true) }
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/CursorSpendViewSection.swift
+++ b/Sources/OpenUsage/Views/CursorSpendViewSection.swift
@@ -19,7 +19,10 @@ struct CursorSpendViewSection: View {
             VStack(spacing: 0) {
                 // Same row shape as a Settings row: label leading, popup picker trailing.
                 HStack(spacing: 10) {
-                    Text("Spend Tiles Show")
+                    // Section header already says "Spend View", so the row label just needs "Show".
+                    // Pin its width so the trailing Spacer can't squeeze it into a wrap.
+                    Text("Show")
+                        .fixedSize(horizontal: true, vertical: false)
                     Spacer(minLength: 8)
                     Picker("", selection: $spendView) {
                         ForEach(CursorSpendViewSetting.allCases, id: \.self) { option in

--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -36,6 +36,9 @@ struct CustomizeProviderDetailView: View {
                 if let keyProvider = container.apiKeyProviders.first(where: { $0.provider.id == providerID }) {
                     APIKeysSection(provider: keyProvider)
                 }
+                if providerID == "cursor" {
+                    CursorSpendViewSection()
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .animation(Motion.spring, value: layout.expandedMetricIDs)

--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -36,6 +36,9 @@ struct CustomizeProviderDetailView: View {
                 if providerID == "codex" {
                     CodexPricingSection()
                 }
+                if providerID == "cursor" {
+                    CursorSpendViewSection()
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .animation(Motion.spring, value: layout.expandedMetricIDs)

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -51,6 +51,32 @@ final class CursorCSVParserTests: XCTestCase {
         XCTAssertNil(parsed.rows[1].imputedCostDollars)
     }
 
+    func testUsageCSVParsesBillingKindFromCostColumn() throws {
+        // "Included" marks plan-covered rows; a dollar amount marks billed / on-demand rows.
+        let csv = """
+        Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Cost
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,Included
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,included
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,$1.23
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,1.23
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,
+        """
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.billing), [.included, .included, .billed, .billed, .unknown])
+    }
+
+    func testUsageCSVWithoutCostColumnMarksBillingUnknown() throws {
+        // Exports predating the Cost column still parse; their rows just can't be classified.
+        let csv = """
+        Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100
+        """
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.billing), [.unknown])
+    }
+
     func testUsageCSVDoesNotTreatAggregatedRowsAsSingleLongContextRequests() throws {
         var rates = ModelRates(
             inputPerMillion: 3,
@@ -263,13 +289,56 @@ final class CursorSpendRangeTests: XCTestCase {
         return unknownModels
     }
 
+    func testSpendViewFiltersRowsByBillingKind() {
+        // One included, one billed, and one unclassifiable row on the same day: each view mode sums
+        // exactly its own rows. Unknown rows only count in All Usage — old exports without a Cost
+        // column can't be split, and quietly assigning them to a side would fake the split.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let rows = [
+            makeRow(date: now, cost: 1.00, tokens: 100, billing: .included),
+            makeRow(date: now, cost: 2.00, tokens: 200, billing: .billed),
+            makeRow(date: now, cost: 4.00, tokens: 400, billing: .unknown)
+        ]
+
+        var allLines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .all, to: &allLines)
+        XCTAssertEqual(values(allLines, "Today"), [MetricValue(number: 7.00, kind: .dollars, estimated: true), MetricValue(number: 700, kind: .count, label: "tokens")])
+
+        var includedLines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .included, to: &includedLines)
+        XCTAssertEqual(values(includedLines, "Today"), [MetricValue(number: 1.00, kind: .dollars, estimated: true), MetricValue(number: 100, kind: .count, label: "tokens")])
+
+        var apiLines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .api, to: &apiLines)
+        XCTAssertEqual(values(apiLines, "Today"), [MetricValue(number: 2.00, kind: .dollars, estimated: true), MetricValue(number: 200, kind: .count, label: "tokens")])
+    }
+
+    func testSpendViewFilteringOutEveryRowLeavesTilesUnbacked() {
+        // A view with no matching rows behaves like an idle export: "No data", not a fabricated $0.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let rows = [makeRow(date: now, cost: 1.00, tokens: 100, billing: .included)]
+
+        var lines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .api, to: &lines)
+
+        XCTAssertNil(values(lines, "Today"))
+        XCTAssertNil(lines.first(where: { $0.label == "Usage Trend" }))
+    }
+
     /// `cost: nil` models a row no pricing source could price (the unknown-model case).
-    private func makeRow(date: Date, cost: Double?, tokens: Int, model: String = "composer-1") -> CursorUsageCSVRow {
+    private func makeRow(
+        date: Date,
+        cost: Double?,
+        tokens: Int,
+        model: String = "composer-1",
+        billing: CursorBillingKind = .unknown
+    ) -> CursorUsageCSVRow {
         CursorUsageCSVRow(
             date: date,
             model: model,
             tokens: TokenBreakdown(input: tokens),
-            imputedCostDollars: cost
+            imputedCostDollars: cost,
+            billing: billing
         )
     }
 

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -51,6 +51,32 @@ final class CursorCSVParserTests: XCTestCase {
         XCTAssertNil(parsed.rows[1].imputedCostDollars)
     }
 
+    func testUsageCSVParsesBillingKindFromCostColumn() throws {
+        // "Included" marks plan-covered rows; a dollar amount marks billed / on-demand rows.
+        let csv = """
+        Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens,Cost
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,Included
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,included
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,$1.23
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,1.23
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100,
+        """
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.billing), [.included, .included, .billed, .billed, .unknown])
+    }
+
+    func testUsageCSVWithoutCostColumnMarksBillingUnknown() throws {
+        // Exports predating the Cost column still parse; their rows just can't be classified.
+        let csv = """
+        Date,Model,Max Mode,Input (w/ Cache Write),Input (w/o Cache Write),Cache Read,Output Tokens
+        2026-01-01T00:00:00Z,composer-1,No,0,0,0,100
+        """
+        let parsed = try CursorUsageCSV.parse(csv: csv, pricing: TestPricing.bundled)
+
+        XCTAssertEqual(parsed.rows.map(\.billing), [.unknown])
+    }
+
     func testUsageCSVDoesNotTreatAggregatedRowsAsSingleLongContextRequests() throws {
         var rates = ModelRates(
             inputPerMillion: 3,
@@ -237,13 +263,56 @@ final class CursorSpendRangeTests: XCTestCase {
         return unknownModels
     }
 
+    func testSpendViewFiltersRowsByBillingKind() {
+        // One included, one billed, and one unclassifiable row on the same day: each view mode sums
+        // exactly its own rows. Unknown rows only count in All Usage — old exports without a Cost
+        // column can't be split, and quietly assigning them to a side would fake the split.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let rows = [
+            makeRow(date: now, cost: 1.00, tokens: 100, billing: .included),
+            makeRow(date: now, cost: 2.00, tokens: 200, billing: .billed),
+            makeRow(date: now, cost: 4.00, tokens: 400, billing: .unknown)
+        ]
+
+        var allLines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .all, to: &allLines)
+        XCTAssertEqual(values(allLines, "Today"), [MetricValue(number: 7.00, kind: .dollars, estimated: true), MetricValue(number: 700, kind: .count, label: "tokens")])
+
+        var includedLines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .included, to: &includedLines)
+        XCTAssertEqual(values(includedLines, "Today"), [MetricValue(number: 1.00, kind: .dollars, estimated: true), MetricValue(number: 100, kind: .count, label: "tokens")])
+
+        var apiLines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .api, to: &apiLines)
+        XCTAssertEqual(values(apiLines, "Today"), [MetricValue(number: 2.00, kind: .dollars, estimated: true), MetricValue(number: 200, kind: .count, label: "tokens")])
+    }
+
+    func testSpendViewFilteringOutEveryRowLeavesTilesUnbacked() {
+        // A view with no matching rows behaves like an idle export: "No data", not a fabricated $0.
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let rows = [makeRow(date: now, cost: 1.00, tokens: 100, billing: .included)]
+
+        var lines: [MetricLine] = []
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .api, to: &lines)
+
+        XCTAssertNil(values(lines, "Today"))
+        XCTAssertNil(lines.first(where: { $0.label == "Usage Trend" }))
+    }
+
     /// `cost: nil` models a row no pricing source could price (the unknown-model case).
-    private func makeRow(date: Date, cost: Double?, tokens: Int, model: String = "composer-1") -> CursorUsageCSVRow {
+    private func makeRow(
+        date: Date,
+        cost: Double?,
+        tokens: Int,
+        model: String = "composer-1",
+        billing: CursorBillingKind = .unknown
+    ) -> CursorUsageCSVRow {
         CursorUsageCSVRow(
             date: date,
             model: model,
             tokens: TokenBreakdown(input: tokens),
-            imputedCostDollars: cost
+            imputedCostDollars: cost,
+            billing: billing
         )
     }
 

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -283,7 +283,7 @@ final class CursorSpendRangeTests: XCTestCase {
         XCTAssertEqual(values(includedLines, "Today"), [MetricValue(number: 1.00, kind: .dollars, estimated: true), MetricValue(number: 100, kind: .count, label: "tokens")])
 
         var apiLines: [MetricLine] = []
-        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .api, to: &apiLines)
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .billed, to: &apiLines)
         XCTAssertEqual(values(apiLines, "Today"), [MetricValue(number: 2.00, kind: .dollars, estimated: true), MetricValue(number: 200, kind: .count, label: "tokens")])
     }
 
@@ -293,7 +293,7 @@ final class CursorSpendRangeTests: XCTestCase {
         let rows = [makeRow(date: now, cost: 1.00, tokens: 100, billing: .included)]
 
         var lines: [MetricLine] = []
-        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .api, to: &lines)
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .billed, to: &lines)
 
         XCTAssertNil(values(lines, "Today"))
         XCTAssertNil(lines.first(where: { $0.label == "Usage Trend" }))

--- a/Tests/OpenUsageTests/CursorSpendTests.swift
+++ b/Tests/OpenUsageTests/CursorSpendTests.swift
@@ -309,7 +309,7 @@ final class CursorSpendRangeTests: XCTestCase {
         XCTAssertEqual(values(includedLines, "Today"), [MetricValue(number: 1.00, kind: .dollars, estimated: true), MetricValue(number: 100, kind: .count, label: "tokens")])
 
         var apiLines: [MetricLine] = []
-        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .api, to: &apiLines)
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .billed, to: &apiLines)
         XCTAssertEqual(values(apiLines, "Today"), [MetricValue(number: 2.00, kind: .dollars, estimated: true), MetricValue(number: 200, kind: .count, label: "tokens")])
     }
 
@@ -319,7 +319,7 @@ final class CursorSpendRangeTests: XCTestCase {
         let rows = [makeRow(date: now, cost: 1.00, tokens: 100, billing: .included)]
 
         var lines: [MetricLine] = []
-        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .api, to: &lines)
+        CursorUsageMapper.appendSpendLines(rows: rows, now: now, pricing: TestPricing.bundled, view: .billed, to: &lines)
 
         XCTAssertNil(values(lines, "Today"))
         XCTAssertNil(lines.first(where: { $0.label == "Usage Trend" }))

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -23,6 +23,18 @@ Just be signed into the Cursor app. OpenUsage reads Cursor's local state databas
 
 Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export. OpenUsage uses the exported token counts and shared model pricing to estimate the cost locally. Cursor's export may occasionally arrive late, so the newest figures can lag behind current activity. OpenUsage leaves isolated malformed rows out instead of silently counting broken values as zero. A failed download, invalid export schema, or broken CSV structure leaves spend history unavailable for that refresh. Each failure is recorded in the diagnostic log without including the exported usage data.
 
+### Spend View
+
+Cursor's export marks each row as either plan-**included** usage or billed **API** (on-demand) usage. In the Cursor section of Customize, **Spend View** picks which side the spend tiles and Usage Trend add up:
+
+| Mode | Shows |
+|---|---|
+| **All Usage** (default) | Every row — the combined picture, unchanged from before |
+| **Included Usage** | Only rows the plan covers |
+| **API Usage** | Only billed / on-demand rows |
+
+The setting only affects the spend tiles (Today / Yesterday / Last 30 Days) and the Usage Trend. The bounded meters (Total / Auto / API Usage %) always stay as Cursor reports them — they come from Cursor's live API, not the export. Older exports without a Cost column can't be split, so their rows only appear under All Usage. The preference is stored per device and applies on the next refresh.
+
 ## Troubleshooting
 
 - **"Not logged in" / token errors** — open Cursor and make sure you're signed in, then refresh.

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -36,7 +36,7 @@ Cursor's export marks each row as either plan-**included** usage or billed **API
 |---|---|
 | **All Usage** (default) | Every row — the combined picture, unchanged from before |
 | **Included Usage** | Only rows the plan covers |
-| **API Usage** | Only billed / on-demand rows |
+| **Billed** | Only billed / on-demand rows |
 
 The setting only affects the spend tiles (Today / Yesterday / Last 30 Days) and the Usage Trend. The bounded meters (Total / Auto / API Usage %) always stay as Cursor reports them — they come from Cursor's live API, not the export. Older exports without a Cost column can't be split, so their rows only appear under All Usage. The preference is stored per device and applies on the next refresh.
 

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -31,7 +31,7 @@ Cursor's export marks each row as either plan-**included** usage or billed **API
 |---|---|
 | **All Usage** (default) | Every row — the combined picture, unchanged from before |
 | **Included Usage** | Only rows the plan covers |
-| **API Usage** | Only billed / on-demand rows |
+| **Billed** | Only billed / on-demand rows |
 
 The setting only affects the spend tiles (Today / Yesterday / Last 30 Days) and the Usage Trend. The bounded meters (Total / Auto / API Usage %) always stay as Cursor reports them — they come from Cursor's live API, not the export. Older exports without a Cost column can't be split, so their rows only appear under All Usage. The preference is stored per device and applies on the next refresh.
 

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -28,6 +28,18 @@ Just be signed into the Cursor app. OpenUsage reads Cursor's local state databas
 
 Today, Yesterday, Last 30 Days, and Usage Trend come from Cursor's usage export. OpenUsage uses the exported token counts and shared model pricing to estimate the cost locally. Cursor's export may occasionally arrive late, so the newest figures can lag behind current activity. OpenUsage leaves isolated malformed rows out instead of silently counting broken values as zero. A failed download, invalid export schema, or broken CSV structure leaves spend history unavailable for that refresh. Each failure is recorded in the diagnostic log without including the exported usage data.
 
+### Spend View
+
+Cursor's export marks each row as either plan-**included** usage or billed **API** (on-demand) usage. In the Cursor section of Customize, **Spend View** picks which side the spend tiles and Usage Trend add up:
+
+| Mode | Shows |
+|---|---|
+| **All Usage** (default) | Every row — the combined picture, unchanged from before |
+| **Included Usage** | Only rows the plan covers |
+| **API Usage** | Only billed / on-demand rows |
+
+The setting only affects the spend tiles (Today / Yesterday / Last 30 Days) and the Usage Trend. The bounded meters (Total / Auto / API Usage %) always stay as Cursor reports them — they come from Cursor's live API, not the export. Older exports without a Cost column can't be split, so their rows only appear under All Usage. The preference is stored per device and applies on the next refresh.
+
 ## Troubleshooting
 
 - **"Not logged in" / token errors** — open Cursor and make sure you're signed in, then refresh.


### PR DESCRIPTION
### TL;DR

Adds a Cursor **Spend View** toggle (All / Included / API Usage) so the spend tiles and Usage Trend can show plan-included usage, billed on-demand usage, or the combined picture — implementing #609.

Closes #609.

### What was happening

- Cursor's export marks each row as plan-**Included** or billed (a dollar `Cost`), but OpenUsage dropped the `Cost` column and summed every row together.
- The Today / Yesterday / Last 30 Days tiles and the Usage Trend therefore always mixed both kinds, so a user couldn't answer "how much of my included plan did I use?" vs "how much on-demand spend did I rack up?"

### What this changes

- **Parse billing kind** — `CursorUsageCSV` reads the `Cost` column into a new `CursorBillingKind` (`included` / `billed` / `unknown`). The column is optional: exports without it still parse, with rows left `.unknown`.
- **Spend View setting** — new `CursorSpendViewSetting` (`all` / `included` / `api`), a `UserDefaultsBacked` enum like `TimeFormatSetting`, persisted per device, default `all` (unchanged behavior).
- **Filtering** — `CursorUsageMapper.appendSpendLines` takes the view and filters rows before aggregating; a view with no matching rows reads "No data" rather than a fabricated \$0. Filtered rows drop out of tiles, trend, and the model breakdown alike.
- **Provider** — `CursorProvider` reads the setting at each refresh (so a flip applies on the next snapshot) and logs when a Cost-less export can't satisfy a non-All view.
- **UI** — a Cursor-only **Spend View** card in the Cursor Customize detail (`CursorSpendViewSection`), following the `APIKeysSection` pattern; changing it forces a refresh.
- **Docs** — `docs/providers/cursor.md` gains a Spend View subsection.

### Heads-up

- Per the issue's open question: the bounded meters (Total / Auto / API Usage %) intentionally **stay as Cursor reports them** — they come from Cursor's live API, not the export, and re-deriving them locally would contradict the dashboard. The toggle scopes to the CSV-derived spend tiles + trend only.
- `unknown` rows (Cost-less exports) count only under All Usage; assigning them to a side would fake the split.

### Tests

- `CursorSpendViewSetting` filtering: All = \$7 / 700 tok, Included = \$1 / 100 tok, API = \$2 / 200 tok on a mixed day; empty-after-filter → "No data".
- `Cost` column parsing: `Included`/`included` → included, `\$1.23`/`1.23` → billed, empty/absent column → unknown.
- Full suite green apart from the 4 Codex tests already red on a clean `main`.

### Screenshots

Cursor Customize detail → new **Spend View** card with the three-way picker:

![spend view picker](https://raw.githubusercontent.com/maxmilian/openusage/notch-assets/cursor-spend-view.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dpF8491eHK8reiuJ8vMxB