### PR TITLE
chore(stale): keep inactive issues open for 30 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/stale@v10
         with:
           stale-issue-message: >
-            This issue has been inactive for 7 days. It will be closed in 3 days
+            This issue has been inactive for 30 days. It will be closed in 3 days
             unless there is new activity. If this is still relevant, please comment.
           stale-pr-message: >
             This PR has been inactive for 7 days. It will be closed in 3 days
@@ -24,7 +24,8 @@ jobs:
             or push an update.
           close-issue-message: Closed due to inactivity.
           close-pr-message: Closed due to inactivity.
-          days-before-stale: 7
+          days-before-issue-stale: 30
+          days-before-pr-stale: 7
           days-before-close: 3
           stale-issue-label: stale
           stale-pr-label: stale


### PR DESCRIPTION
## TL;DR

Inactive issues now wait 30 days before the stale warning (then 3 more days before close). Untouched PR timing stays at 7 + 3.

## What was happening

- Issues and PRs shared a 7-day inactivity window before being marked stale.
- That was too aggressive for issues that still needed discussion or triage time.

## What this changes

- Issues: `days-before-issue-stale` set to 30; stale message updated to match.
- PRs: left at 7 days via `days-before-pr-stale`.
- The 3-day grace period before auto-close is unchanged for both.

## Screenshots

Not applicable

Made with [Cursor](https://cursor.com)