### PR TITLE
fix(pricing): accept xhigh effort suffix on grok-4.5 alias rules

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
-  "updated_at": "2026-07-13",
+  "updated_at": "2026-07-14",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -135,9 +135,9 @@
     { "pattern": "^composer-2\\.5$", "canonical": "composer-2.5" },
     { "pattern": "^composer-2\\.5-fast$", "canonical": "composer-2.5-fast" },
     { "pattern": "^github_bugbot$", "canonical": "github_bugbot" },
-    { "pattern": "^(?:cursor-)?grok-4\\.5-fast(?:-(?:low|medium|high))?$", "canonical": "grok-4.5-fast" },
-    { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high))?-fast$", "canonical": "grok-4.5-fast" },
-    { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high))?$", "canonical": "grok-4.5" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.5-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5" },
     { "pattern": "^kimi-k2\\.7(?:-code)?$", "canonical": "kimi-k2.7-code" },
     { "pattern": "^kimi-k2p7(?:-code)?$", "canonical": "kimi-k2.7-code" },
     { "pattern": "^claude-4\\.5-haiku(?:-thinking)?$", "canonical": "claude-haiku-4-5" },

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -195,6 +195,8 @@ final class PricingBundledResourceTests: XCTestCase {
         // Cursor CSV uses fast-before-effort (`grok-4.5-fast-high`); also accept effort-before-fast.
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-high"), fast)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-medium"), fast)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-xhigh"), fast)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-xhigh"), standard)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-medium-fast"), fast)
         // Cursor usage export sometimes prefixes first-party Grok with `cursor-`.
         XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-high-fast"), fast)


### PR DESCRIPTION
## TL;DR
`grok-4.5-fast-xhigh` showed up as an unknown model in the Cursor spend tile because the grok-4.5 alias rules didn't accept the `xhigh` effort suffix.

## What was happening
- The grok-4.5 alias patterns only allowed `low|medium|high` effort suffixes.
- Cursor's CSV now emits `grok-4.5-fast-xhigh`, which matched no rule, so the model went unpriced and triggered the "Unknown models found" warning.

## What this changes
- Adds `xhigh` to all three grok-4.5 alias rules (fast-before-effort, effort-before-fast, and standard), matching how the Claude/GPT rules already handle it.
- Bumps `updated_at` to 2026-07-14.

## Tests
- Added `grok-4.5-fast-xhigh` and `grok-4.5-xhigh` resolution assertions to `PricingBundledResourceTests`.
- `swift test --filter "ModelPricing|PricingBundledResource"` — 49 tests, 0 failures. Supplement validation script passes.

Made with [Cursor](https://cursor.com)