### PR TITLE
Fix menu-bar icon not closing panel on second click at top of screen

### DIFF
--- a/Sources/OpenUsage/App/PanelOutsideClickMonitor.swift
+++ b/Sources/OpenUsage/App/PanelOutsideClickMonitor.swift
@@ -88,7 +88,7 @@ final class PanelOutsideClickMonitor {
     private func isOnStatusButton(_ screenPoint: NSPoint) -> Bool {
         guard let button = statusItem.button, let buttonWindow = button.window else { return false }
         let buttonFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
-        return buttonFrame.contains(screenPoint)
+        return PanelOutsideClickPolicy.pointHitsStatusButton(screenPoint, buttonFrame: buttonFrame)
     }
 }
 
@@ -116,5 +116,17 @@ enum PanelOutsideClickPolicy {
             // the resets "Use" button — otherwise reads as an outside click and tears the panel down
             // before the control's mouse-up fires. Its backing window class is `_NSPopoverWindow`.
             || context.eventWindowTypeName?.localizedCaseInsensitiveContains("popover") == true
+    }
+
+    /// Status-button hit test with *inclusive* frame edges, unlike `NSRect.contains` (which excludes
+    /// the max edges). With the cursor slammed against the top of the screen — the natural way to
+    /// click the menu bar — `NSEvent.mouseLocation.y` is exactly the screen's `maxY`, which is also
+    /// the button frame's `maxY`. The exclusive check misread that dead-center click as an outside
+    /// click, so the panel dismissed on mouse-down and the button's mouse-up action toggled it right
+    /// back open — the second click never closed it (issue #1008).
+    static func pointHitsStatusButton(_ point: NSPoint, buttonFrame: NSRect) -> Bool {
+        guard !buttonFrame.isEmpty else { return false }
+        return point.x >= buttonFrame.minX && point.x <= buttonFrame.maxX
+            && point.y >= buttonFrame.minY && point.y <= buttonFrame.maxY
     }
 }

--- a/Sources/OpenUsage/App/PanelOutsideClickMonitor.swift
+++ b/Sources/OpenUsage/App/PanelOutsideClickMonitor.swift
@@ -88,7 +88,11 @@ final class PanelOutsideClickMonitor {
     private func isOnStatusButton(_ screenPoint: NSPoint) -> Bool {
         guard let button = statusItem.button, let buttonWindow = button.window else { return false }
         let buttonFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
-        return PanelOutsideClickPolicy.pointHitsStatusButton(screenPoint, buttonFrame: buttonFrame)
+        return PanelOutsideClickPolicy.pointHitsStatusButton(
+            screenPoint,
+            buttonFrame: buttonFrame,
+            screenTop: buttonWindow.screen?.frame.maxY
+        )
     }
 }
 
@@ -118,15 +122,23 @@ enum PanelOutsideClickPolicy {
             || context.eventWindowTypeName?.localizedCaseInsensitiveContains("popover") == true
     }
 
-    /// Status-button hit test with *inclusive* frame edges, unlike `NSRect.contains` (which excludes
-    /// the max edges). With the cursor slammed against the top of the screen — the natural way to
-    /// click the menu bar — `NSEvent.mouseLocation.y` is exactly the screen's `maxY`, which is also
-    /// the button frame's `maxY`. The exclusive check misread that dead-center click as an outside
-    /// click, so the panel dismissed on mouse-down and the button's mouse-up action toggled it right
-    /// back open — the second click never closed it (issue #1008).
-    static func pointHitsStatusButton(_ point: NSPoint, buttonFrame: NSRect) -> Bool {
+    /// Status-button hit test. Differs from `NSRect.contains(buttonFrame)` in two ways, both needed
+    /// so a click with the cursor slammed against the top of the screen — the natural way to click
+    /// the menu bar — counts as *on* the button (issue #1008):
+    /// - The hit zone extends from the button frame's top edge to the top of the button's screen:
+    ///   the button is a few points shorter than the menu bar (observed live: a 22pt-tall button
+    ///   frame ending at y=1551 in a menu bar whose screen tops out at y=1555), while macOS still
+    ///   routes a click in that strip to the button.
+    /// - Edges are inclusive, where `contains` excludes max edges: a top-pinned cursor reports
+    ///   exactly the screen's `maxY`.
+    /// Without these, the monitor misread a dead-center click on the icon as an outside click: the
+    /// panel dismissed on mouse-down, then the button's mouse-up action toggled it right back open —
+    /// the second click never closed it. The monitor must agree with how macOS routes the click, or
+    /// its dismissal races the button's toggle.
+    static func pointHitsStatusButton(_ point: NSPoint, buttonFrame: NSRect, screenTop: CGFloat?) -> Bool {
         guard !buttonFrame.isEmpty else { return false }
+        let top = max(buttonFrame.maxY, screenTop ?? buttonFrame.maxY)
         return point.x >= buttonFrame.minX && point.x <= buttonFrame.maxX
-            && point.y >= buttonFrame.minY && point.y <= buttonFrame.maxY
+            && point.y >= buttonFrame.minY && point.y <= top
     }
 }

--- a/Tests/OpenUsageTests/PanelOutsideClickPolicyTests.swift
+++ b/Tests/OpenUsageTests/PanelOutsideClickPolicyTests.swift
@@ -51,41 +51,70 @@ final class PanelOutsideClickPolicyTests: XCTestCase {
 
     // MARK: - Status-button hit test (issue #1008)
 
-    /// A menu-bar-height button frame whose top edge sits at the top of a pretend screen.
-    private let buttonFrame = NSRect(x: 100, y: 976, width: 40, height: 24)
+    /// A button frame a few points shorter than its menu bar, the way AppKit lays it out: the
+    /// screen tops out at y=1000 but the 24pt button frame ends at y=996.
+    private let buttonFrame = NSRect(x: 100, y: 972, width: 40, height: 24)
+    private let screenTop: CGFloat = 1000
 
     func testClickAtTopOfScreenHitsStatusButton() {
-        // With the cursor pinned to the top of the screen, `NSEvent.mouseLocation.y` reports exactly
-        // the screen's — and the button frame's — maxY. `NSRect.contains` excludes max edges, which
-        // made this dead-center click read as an outside click: the panel dismissed on mouse-down and
-        // the button's mouse-up toggle reopened it, so the second click never closed the panel.
+        // The issue #1008 geometry, live-captured: with the cursor pinned to the top of the screen,
+        // `NSEvent.mouseLocation.y` reports exactly the screen's maxY — a few points *above* the
+        // button frame's top, in the menu-bar strip macOS still routes to the button. Reading it as
+        // an outside click dismissed the panel on mouse-down, and the button's mouse-up toggle
+        // reopened it, so the second click never closed the panel.
         XCTAssertTrue(PanelOutsideClickPolicy.pointHitsStatusButton(
-            NSPoint(x: 120, y: buttonFrame.maxY), buttonFrame: buttonFrame
+            NSPoint(x: 120, y: screenTop), buttonFrame: buttonFrame, screenTop: screenTop
+        ))
+    }
+
+    func testClickAtTopOfScreenWithRealCapturedGeometryHits() {
+        // Verbatim from the diagnostic log that pinned the bug down: point {4122.98, 1555},
+        // buttonFrame {{4061, 1529}, {242.5, 22}}, screen {{1728, -65}, {2880, 1620}} (maxY 1555).
+        XCTAssertTrue(PanelOutsideClickPolicy.pointHitsStatusButton(
+            NSPoint(x: 4122.98046875, y: 1555),
+            buttonFrame: NSRect(x: 4061, y: 1529, width: 242.5, height: 22),
+            screenTop: 1555
         ))
     }
 
     func testClickInsideStatusButtonHits() {
         XCTAssertTrue(PanelOutsideClickPolicy.pointHitsStatusButton(
-            NSPoint(x: 120, y: 988), buttonFrame: buttonFrame
+            NSPoint(x: 120, y: 984), buttonFrame: buttonFrame, screenTop: screenTop
+        ))
+    }
+
+    func testClickInsideStatusButtonHitsWithoutAScreen() {
+        XCTAssertTrue(PanelOutsideClickPolicy.pointHitsStatusButton(
+            NSPoint(x: 120, y: buttonFrame.maxY), buttonFrame: buttonFrame, screenTop: nil
         ))
     }
 
     func testClickBesideStatusButtonMisses() {
         XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(
-            NSPoint(x: 99, y: 988), buttonFrame: buttonFrame
+            NSPoint(x: 99, y: 984), buttonFrame: buttonFrame, screenTop: screenTop
         ))
         XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(
-            NSPoint(x: 141, y: 988), buttonFrame: buttonFrame
+            NSPoint(x: 141, y: 984), buttonFrame: buttonFrame, screenTop: screenTop
+        ))
+    }
+
+    func testClickInTopStripBesideStatusButtonMisses() {
+        // The upward extension widens the hit zone only vertically — a top-edge click next to the
+        // button (over a neighboring status item) must still dismiss.
+        XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(
+            NSPoint(x: 150, y: screenTop), buttonFrame: buttonFrame, screenTop: screenTop
         ))
     }
 
     func testClickBelowStatusButtonMisses() {
         XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(
-            NSPoint(x: 120, y: 975), buttonFrame: buttonFrame
+            NSPoint(x: 120, y: 971), buttonFrame: buttonFrame, screenTop: screenTop
         ))
     }
 
     func testEmptyButtonFrameNeverHits() {
-        XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(.zero, buttonFrame: .zero))
+        XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(
+            .zero, buttonFrame: .zero, screenTop: nil
+        ))
     }
 }

--- a/Tests/OpenUsageTests/PanelOutsideClickPolicyTests.swift
+++ b/Tests/OpenUsageTests/PanelOutsideClickPolicyTests.swift
@@ -48,4 +48,44 @@ final class PanelOutsideClickPolicyTests: XCTestCase {
     func testUnrelatedWindowDismisses() {
         XCTAssertFalse(PanelOutsideClickPolicy.shouldKeepOpen(.init(eventWindowTypeName: "NSWindow")))
     }
+
+    // MARK: - Status-button hit test (issue #1008)
+
+    /// A menu-bar-height button frame whose top edge sits at the top of a pretend screen.
+    private let buttonFrame = NSRect(x: 100, y: 976, width: 40, height: 24)
+
+    func testClickAtTopOfScreenHitsStatusButton() {
+        // With the cursor pinned to the top of the screen, `NSEvent.mouseLocation.y` reports exactly
+        // the screen's — and the button frame's — maxY. `NSRect.contains` excludes max edges, which
+        // made this dead-center click read as an outside click: the panel dismissed on mouse-down and
+        // the button's mouse-up toggle reopened it, so the second click never closed the panel.
+        XCTAssertTrue(PanelOutsideClickPolicy.pointHitsStatusButton(
+            NSPoint(x: 120, y: buttonFrame.maxY), buttonFrame: buttonFrame
+        ))
+    }
+
+    func testClickInsideStatusButtonHits() {
+        XCTAssertTrue(PanelOutsideClickPolicy.pointHitsStatusButton(
+            NSPoint(x: 120, y: 988), buttonFrame: buttonFrame
+        ))
+    }
+
+    func testClickBesideStatusButtonMisses() {
+        XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(
+            NSPoint(x: 99, y: 988), buttonFrame: buttonFrame
+        ))
+        XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(
+            NSPoint(x: 141, y: 988), buttonFrame: buttonFrame
+        ))
+    }
+
+    func testClickBelowStatusButtonMisses() {
+        XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(
+            NSPoint(x: 120, y: 975), buttonFrame: buttonFrame
+        ))
+    }
+
+    func testEmptyButtonFrameNeverHits() {
+        XCTAssertFalse(PanelOutsideClickPolicy.pointHitsStatusButton(.zero, buttonFrame: .zero))
+    }
 }


### PR DESCRIPTION
## TL;DR

Clicking the menu-bar icon a second time now closes the panel even when the cursor is pinned against the very top of the screen. Root cause found via live click diagnostics; fix verified on macOS 27. Fixes #1008.

## What was happening

- Clicking the OpenUsage menu-bar icon while the panel was open didn't close it — the panel appeared to stay open (it actually closed on mouse-down and instantly reopened on mouse-up).
- Robin's repro nailed the trigger: it only failed with the cursor at the absolute top of the screen; a few pixels down, the second click closed the panel correctly.
- Live diagnostics captured the real geometry: the status button frame is a few points **shorter than the menu bar** — a 22pt-tall button frame ending at y=1551 on a screen whose top edge is y=1555. A cursor slammed against the top of the screen reports y=1555, which is *above* the button frame, so the outside-click monitor's `buttonFrame.contains(point)` hit test read a dead-center click on the icon as an outside click. The panel dismissed on mouse-down, then the button's mouse-up action toggled it right back open.
- The logs also showed that at the top edge the click reaches the app **only via the global event monitor** (no local `NSStatusBarWindow` event before the action fires, on macOS 27's rebuilt menu bar), so the geometric check is the only guard on that path — the `isStatusItemWindow` window-identity check can't save it.

## What this changes

- The status-button hit test now extends the hit zone from the button frame's top edge to the top of the button's screen — matching how macOS itself routes those clicks to the button — with inclusive edges (`NSRect.contains` excludes max edges, and a top-pinned cursor reports exactly the screen's `maxY`). The x-range is unchanged, so top-edge clicks beside the icon still dismiss the panel.
- The hit test is extracted into a pure `PanelOutsideClickPolicy.pointHitsStatusButton(_:buttonFrame:screenTop:)` so it's unit-testable.
- Adds regression tests: the exact captured failing geometry from the diagnostic log, top-edge hits, interior hits, misses beside/below the button (including a top-strip click beside the icon), the no-screen fallback, and an empty frame.

## Heads-up

- The first commit fixed only the inclusive-edges half and didn't resolve the issue on its own; the second commit adds the screen-top extension that live testing confirmed was the actual gap. Squash-merge recommended.

## Tests

- `swift test` — full suite green, including 8 hit-test cases in `PanelOutsideClickPolicyTests` (one verbatim from the captured diagnostic log).
- Verified live on macOS 27 (the reporter's environment): dev build from this branch, panel open, cursor slammed to the top of the screen, click on the icon — the panel now closes; clicks elsewhere still dismiss it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)