### PR TITLE
Cache parsed local usage logs across launches

### DIFF
--- a/Sources/OpenUsage/Pricing/ModelRates.swift
+++ b/Sources/OpenUsage/Pricing/ModelRates.swift
@@ -49,7 +49,7 @@ struct ModelRates: Sendable, Equatable {
 }
 
 /// Token counts split into the buckets that price differently. Every scanner normalizes into this.
-struct TokenBreakdown: Sendable, Equatable {
+struct TokenBreakdown: Codable, Sendable, Equatable {
     /// Input tokens billed at the plain input rate (not written to or read from cache).
     var input: Int = 0
     /// Input tokens written to the 5-minute ephemeral cache.

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -16,24 +16,20 @@ import Foundation
 ///   types stay represented only by the parent usage totals, avoiding double-counting.
 /// - Cost mode "auto": a line's `costUSD` when present, else tokens priced through `ModelPricing`.
 ///
-/// An actor so the whole scan runs off the main actor, and so the per-file parse cache (keyed by
-/// path + size + mtime) can persist across refreshes: the ~5-minute provider refresh re-parses only
-/// files that changed, then re-runs the cheap dedup + day aggregation over cached entries.
+/// An actor so the whole scan runs off the main actor. Parsed files are cached by path + size + mtime
+/// in memory and Application Support: refreshes and relaunches parse only changed files, then re-run
+/// the cheap dedup + day aggregation over cached entries before local model-rate estimates.
 actor ClaudeLogUsageScanner {
     private let environment: EnvironmentReading
     private let homeDirectory: @Sendable () -> URL
-
-    init(
-        environment: EnvironmentReading = ProcessEnvironmentReader(),
-        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser }
-    ) {
-        self.environment = environment
-        self.homeDirectory = homeDirectory
-    }
+    private let scanner: IncrementalJSONLScanner<Entry>
+    /// Scoped provider instances pass their stable parse-source identity here. Account or time filters
+    /// over the same physical roots deliberately pass the same value and share whole-file records.
+    private let cacheIdentityOverride: String?
 
     /// One parsed usage line. Token buckets are pre-normalized into `TokenBreakdown`; dedup fields
     /// ride along so the global dedup pass can run over cached entries.
-    struct Entry: Sendable, Equatable {
+    struct Entry: Codable, Sendable, Equatable {
         var timestamp: Date
         var tokens: TokenBreakdown
         var messageID: String?
@@ -46,23 +42,94 @@ actor ClaudeLogUsageScanner {
         var model: String?
     }
 
-    /// Off-main-actor incremental parse cache (keyed path + size + mtime), owned by the shared scanner.
-    private let scanner = IncrementalJSONLScanner<Entry>(logTag: LogTag.plugin("claude"))
+    /// Cards that read the same Claude home share one actor, so the first scan populates both the
+    /// in-memory and disk caches and the rest reuse it. Tests inject an isolated memory-only scanner.
+    private static let sharedScanner = IncrementalJSONLScanner<Entry>(
+        logTag: LogTag.plugin("claude"),
+        persistence: JSONLScanCachePersistence(namespace: "claude", schemaVersion: 1)
+    )
+
+    static func flushPersistentCacheWrites() async {
+        await sharedScanner.flushPendingWrites()
+    }
+
+    init(
+        environment: EnvironmentReading = ProcessEnvironmentReader(),
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        incrementalScanner: IncrementalJSONLScanner<Entry>? = nil,
+        cacheIdentityOverride: String? = nil
+    ) {
+        precondition(cacheIdentityOverride?.isEmpty != true)
+        self.environment = environment
+        self.homeDirectory = homeDirectory
+        self.scanner = incrementalScanner ?? Self.sharedScanner
+        self.cacheIdentityOverride = cacheIdentityOverride
+    }
 
     /// Scan the last `daysBack` days of Claude logs. Returns `nil` when no Claude data directory or
     /// no log files exist (the spend tiles then render "No data"); returns an empty series when logs
     /// exist but have no usage in the window.
     func scan(daysBack: Int = 30, now: Date = Date(), pricing: ModelPricing) async -> LogUsageScan? {
+        let since = JSONLScanning.sinceDate(daysBack: daysBack, now: now)
+        let cacheIdentity = parseCacheIdentity()
         let roots = claudeRoots()
-        guard !roots.isEmpty else { return nil }
+        guard !roots.isEmpty else {
+            _ = await scanner.items(
+                from: [], since: since, cacheIdentity: cacheIdentity, parse: Self.parseFile
+            )
+            return nil
+        }
 
         let files = Self.usageFiles(under: roots)
-        guard !files.isEmpty else { return nil }
+        guard !files.isEmpty else {
+            _ = await scanner.items(
+                from: [], since: since, cacheIdentity: cacheIdentity, parse: Self.parseFile
+            )
+            return nil
+        }
 
-        let since = JSONLScanning.sinceDate(daysBack: daysBack, now: now)
         // Entries come back concatenated in path-sorted file order, so dedup's keep-first is deterministic.
-        let entries = await scanner.items(from: files, since: since, parse: Self.parseFile)
+        let entries = await scanner.items(
+            from: files,
+            since: since,
+            cacheIdentity: cacheIdentity,
+            parse: Self.parseFile
+        )
         return Self.aggregate(entries: Self.dedup(entries), since: since, pricing: pricing)
+    }
+
+    /// Stable source configuration identity rather than the discovered root list: Cowork adds session
+    /// roots over time, and a new session must extend the same cache instead of cold-parsing every old
+    /// file. Scoped root overrides pass an explicit identity so distinct homes stay partitioned.
+    private func parseCacheIdentity() -> String {
+        if let cacheIdentityOverride { return cacheIdentityOverride }
+        let home = homeDirectory().resolvingSymlinksInPath().path
+        let configuredRoots: [URL]
+        if let raw = environment.value(for: "CLAUDE_CONFIG_DIR")?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty
+        {
+            configuredRoots = raw.split(separator: ",").compactMap { part in
+                let value = part.trimmingCharacters(in: .whitespaces)
+                guard !value.isEmpty else { return nil }
+                var url = URL(fileURLWithPath: expandHome(value))
+                if url.lastPathComponent == "projects" { url.deleteLastPathComponent() }
+                return url
+            }
+        } else {
+            let homeURL = homeDirectory()
+            let xdg = environment.value(for: "XDG_CONFIG_HOME")?.nilIfEmpty
+                .map { URL(fileURLWithPath: expandHome($0)) }
+                ?? homeURL.appendingPathComponent(".config")
+            configuredRoots = [
+                xdg.appendingPathComponent("claude"),
+                homeURL.appendingPathComponent(".claude"),
+            ]
+        }
+        let roots = Set(configuredRoots.map { $0.resolvingSymlinksInPath().standardizedFileURL.path })
+            .sorted()
+            .joined(separator: "\n")
+        return "home=\(home)\nroots=\(roots)"
     }
 
     // MARK: - Root and file discovery

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -89,12 +89,12 @@ actor ClaudeLogUsageScanner {
         }
 
         // Entries come back concatenated in path-sorted file order, so dedup's keep-first is deterministic.
-        let entries = await scanner.items(
+        guard let entries = await scanner.items(
             from: files,
             since: since,
             cacheIdentity: cacheIdentity,
             parse: Self.parseFile
-        )
+        ), !Task.isCancelled else { return nil }
         return Self.aggregate(entries: Self.dedup(entries), since: since, pricing: pricing)
     }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -256,7 +256,9 @@ final class ClaudeProvider: ProviderRuntime {
         let nativeScan = await logUsageScanner.scan(now: now(), pricing: pricing)
         let piScan = await PiUsageScanner.shared.scan(cardID: provider.id, now: now(), pricing: pricing)
         var usageHistory: ProviderUsageHistory?
-        if let scan = DailyUsageAccumulator.merged([nativeScan, piScan]) {
+        // Cancellation can land between the native and pi scans. Treat the pair as one unit so a
+        // partial result cannot replace the last-good combined history in WidgetDataStore.
+        if !Task.isCancelled, let scan = DailyUsageAccumulator.merged([nativeScan, piScan]) {
             let note = piScan == nil
                 ? "From your Claude usage history (estimated)"
                 : "From your Claude usage history and pi (estimated)"

--- a/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
@@ -94,12 +94,12 @@ actor CodexLogUsageScanner {
             return nil
         }
 
-        let events = await scanner.items(
+        guard let events = await scanner.items(
             from: files,
             since: since,
             cacheIdentity: identity,
             parse: Self.parseFile
-        )
+        ), !Task.isCancelled else { return nil }
         return Self.aggregate(events: events, since: since, pricing: pricing)
     }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
@@ -36,24 +36,17 @@ import Foundation
 ///   272k input tokens use OpenAI's higher rates for the whole request.
 ///
 /// An actor for the same reasons as `ClaudeLogUsageScanner`: scans run off the main actor, and a
-/// per-file parse cache keyed (path, size, mtime) makes the ~5-minute refresh re-parse only files
-/// that changed.
+/// versioned Application Support cache keyed by path + size + mtime makes both refreshes and relaunches
+/// re-parse only files that changed.
 actor CodexLogUsageScanner {
     private let environment: EnvironmentReading
     private let homeDirectory: @Sendable () -> URL
-
-    init(
-        environment: EnvironmentReading = ProcessEnvironmentReader(),
-        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser }
-    ) {
-        self.environment = environment
-        self.homeDirectory = homeDirectory
-    }
+    private let scanner: IncrementalJSONLScanner<Event>
 
     /// One turn's token usage, normalized from a `token_count` line (deltas already applied).
     /// `isFast` records whether the session was on the fast/priority service tier when the turn
     /// ran, tracked from the session's own log; absent tier metadata means standard.
-    struct Event: Sendable, Equatable {
+    struct Event: Codable, Sendable, Equatable {
         var timestamp: Date
         var model: String
         var input: Int
@@ -64,18 +57,49 @@ actor CodexLogUsageScanner {
         var isFast: Bool = false
     }
 
-    /// Off-main-actor incremental parse cache (keyed path + size + mtime), owned by the shared scanner.
-    private let scanner = IncrementalJSONLScanner<Event>(logTag: LogTag.plugin("codex"))
+    /// Multi-account cards that resolve the same Codex homes share this actor and parse each rollout
+    /// once. The version is the parser schema version; bump it when `Event` semantics change.
+    private static let sharedScanner = IncrementalJSONLScanner<Event>(
+        logTag: LogTag.plugin("codex"),
+        persistence: JSONLScanCachePersistence(namespace: "codex", schemaVersion: 1)
+    )
+
+    static func flushPersistentCacheWrites() async {
+        await sharedScanner.flushPendingWrites()
+    }
+
+    init(
+        environment: EnvironmentReading = ProcessEnvironmentReader(),
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        incrementalScanner: IncrementalJSONLScanner<Event>? = nil
+    ) {
+        self.environment = environment
+        self.homeDirectory = homeDirectory
+        self.scanner = incrementalScanner ?? Self.sharedScanner
+    }
 
     /// Scan the last `daysBack` days of Codex rollouts. Returns `nil` when no Codex home or no
     /// session files exist (the spend tiles then render "No data").
     func scan(daysBack: Int = 30, now: Date = Date(), pricing: ModelPricing) async -> LogUsageScan? {
         let homes = codexHomes()
-        let files = Self.sessionFiles(homes: homes)
-        guard !files.isEmpty else { return nil }
-
         let since = JSONLScanning.sinceDate(daysBack: daysBack, now: now)
-        let events = await scanner.items(from: files, since: since, parse: Self.parseFile)
+        let identityPaths = Set(homes.map { $0.resolvingSymlinksInPath().standardizedFileURL.path })
+            .sorted()
+        let identity = identityPaths.isEmpty ? "no-codex-home" : identityPaths.joined(separator: "\n")
+        let files = Self.sessionFiles(homes: homes)
+        guard !files.isEmpty else {
+            _ = await scanner.items(
+                from: [], since: since, cacheIdentity: identity, parse: Self.parseFile
+            )
+            return nil
+        }
+
+        let events = await scanner.items(
+            from: files,
+            since: since,
+            cacheIdentity: identity,
+            parse: Self.parseFile
+        )
         return Self.aggregate(events: events, since: since, pricing: pricing)
     }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -143,7 +143,9 @@ final class CodexProvider: ProviderRuntime {
         let nativeScan = await logUsageScanner.scan(now: now(), pricing: pricing)
         let piScan = await PiUsageScanner.shared.scan(cardID: provider.id, now: now(), pricing: pricing)
         var usageHistory: ProviderUsageHistory?
-        if let scan = DailyUsageAccumulator.merged([nativeScan, piScan]) {
+        // Cancellation can land between the native and pi scans. Treat the pair as one unit so a
+        // partial result cannot replace the last-good combined history in WidgetDataStore.
+        if !Task.isCancelled, let scan = DailyUsageAccumulator.merged([nativeScan, piScan]) {
             let note = piScan == nil
                 ? "From your Codex logs (estimated)"
                 : "From your Codex logs and pi (estimated)"

--- a/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
+++ b/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
@@ -105,20 +105,21 @@ actor IncrementalJSONLScanner<Item: Codable & Sendable> {
     /// every file's items concatenated in the input order — callers pass a path-sorted list so a
     /// keep-first dedup stays deterministic. Files whose mtime predates `since` are skipped, so a
     /// years-deep tree stays cheap to rescan; an unreadable file is skipped and not cached, so a
-    /// transient read failure doesn't stick.
+    /// transient read failure doesn't stick. `nil` means the scan was canceled; a completed scan with
+    /// no parsed rows returns `[]`, so callers never mistake cancellation for authoritative empty data.
     func items(
         from files: [JSONLScanning.DiscoveredFile],
         since: Date,
         cacheIdentity: String = "default",
         parse: @Sendable @escaping (Data) -> [Item]?
-    ) async -> [Item] {
+    ) async -> [Item]? {
         precondition(!cacheIdentity.isEmpty)
-        guard await acquire(cacheIdentity) else { return [] }
+        guard await acquire(cacheIdentity) else { return nil }
         defer { release(cacheIdentity) }
-        guard !Task.isCancelled else { return [] }
+        guard !Task.isCancelled else { return nil }
 
         await loadCacheIfNeeded(identity: cacheIdentity)
-        guard !Task.isCancelled else { return [] }
+        guard !Task.isCancelled else { return nil }
         let currentCache = caches[cacheIdentity] ?? [:]
         // Keep other same-parser scans' files in the shared partition until they age out of the window.
         // This lets multi-account cards with disjoint roots share one actor safely; only the current
@@ -140,10 +141,11 @@ actor IncrementalJSONLScanner<Item: Codable & Sendable> {
             permitPool: parsePermitPool,
             parse: parse
         )
-        guard !Task.isCancelled else { return [] }
+        guard !Task.isCancelled else { return nil }
         let checkedPaths = Set(parseResults.lazy.map(\.file.path))
         let unreadablePaths = Set(parseResults.lazy.filter(\.readFailed).map(\.file.path))
         await readFailureReporter.update(checkedPaths: checkedPaths, failingPaths: unreadablePaths)
+        guard !Task.isCancelled else { return nil }
         var parsedPaths: Set<String> = []
         for result in parseResults {
             let (file, parsed) = (result.file, result.items)
@@ -172,7 +174,7 @@ actor IncrementalJSONLScanner<Item: Codable & Sendable> {
             guard let cached = nextCache[file.path] else { continue }
             items.append(contentsOf: cached.items)
         }
-        return items
+        return Task.isCancelled ? nil : items
     }
 
     /// Wait for the real debounced tasks rather than bypassing them. Tests configure a tiny debounce,
@@ -186,11 +188,17 @@ actor IncrementalJSONLScanner<Item: Codable & Sendable> {
     /// Commits the latest snapshots immediately. One-shot processes call this before exiting; the
     /// long-lived app keeps the ordinary debounced path so refresh latency is unaffected.
     func flushPendingWrites() async {
-        let identities = Array(writeTasks.keys)
+        var identities = Set(writeTasks.keys)
+        identities.formUnion(dirtyUpsertPaths.compactMap { $0.value.isEmpty ? nil : $0.key })
+        identities.formUnion(dirtyRemovals.compactMap { $0.value.isEmpty ? nil : $0.key })
+        identities.formUnion(invalidPersistenceIdentities)
         for identity in identities {
             writeTasks[identity]?.cancel()
             writeTasks[identity] = nil
-            guard let generation = writeGenerations[identity] else { continue }
+            // Supersede an encoding or writer operation already in flight. Its generation guards then
+            // leave the dirty state for this explicit drain to commit instead of racing to clear it.
+            let generation = writeGenerations[identity, default: 0] + 1
+            writeGenerations[identity] = generation
             await persistCache(identity: identity, generation: generation)
         }
     }

--- a/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
+++ b/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
@@ -44,7 +44,7 @@ enum JSONLScanning {
     }
 }
 
-/// The incremental, off-main-actor scan machinery shared by the Claude and Codex log scanners: discover
+/// The incremental, off-main-actor scan machinery shared by the Claude, Codex, and pi log scanners: discover
 /// `*.jsonl` files, re-parse only those changed since the last scan (a per-file cache keyed by path +
 /// size + mtime), and return the parsed items concatenated in file order. Each provider supplies its own
 /// file discovery, per-file parser, and post-parse dedup/aggregation; this owns the cache, the parallel
@@ -52,26 +52,53 @@ enum JSONLScanning {
 /// isn't copied per provider.
 ///
 /// An actor so the parse cache persists across the ~5-minute provider refreshes while staying off the
-/// main actor. Held as an instance by each provider scanner; `Item` is the provider's parsed row.
-actor IncrementalJSONLScanner<Item: Sendable> {
-    private struct CachedFile {
-        var size: Int
-        var mtime: Date
-        var items: [Item]
+/// main actor. Provider scanner instances share one actor per parser; `Item` is that parser's row.
+actor IncrementalJSONLScanner<Item: Codable & Sendable> {
+    private typealias CachedFile = JSONLScanCachedFile<Item>
+
+    private struct IdentityWaiter {
+        var id: UUID
+        var continuation: CheckedContinuation<Bool, Never>
     }
 
-    private var cache: [String: CachedFile] = [:]
+    /// One in-memory partition per provider/home identity. Provider scanner instances share this actor,
+    /// so same-home multi-account cards reuse both memory and disk without letting disjoint homes prune
+    /// one another's files.
+    private var caches: [String: [String: CachedFile]] = [:]
+    private var persistedMetadata: [String: [String: JSONLScanCacheFileMetadata]] = [:]
+    private var dirtyUpsertPaths: [String: Set<String>] = [:]
+    private var dirtyRemovals: [String: [String: JSONLScanCacheFileMetadata]] = [:]
+    private var invalidPersistenceIdentities: Set<String> = []
+    private var loadedIdentities: Set<String> = []
+    private var activeIdentities: Set<String> = []
+    private var identityWaiters: [String: [IdentityWaiter]] = [:]
+    private var writeTasks: [String: Task<Void, Never>] = [:]
+    private var writeGenerations: [String: Int] = [:]
     private let maxConcurrentParses: Int
+    private let parsePermitPool: JSONLParsePermitPool
     private let readFailureReporter: UsageLogReadFailureReporter
+    private let persistence: JSONLScanCachePersistence?
 
     init(
         maxConcurrentParses: Int = 8,
         logTag: String = LogTag.refresh.rawValue,
-        readFailureWarning: UsageLogReadFailureReporter.Warning? = nil
+        readFailureWarning: UsageLogReadFailureReporter.Warning? = nil,
+        persistence: JSONLScanCachePersistence? = nil
     ) {
         precondition(maxConcurrentParses > 0)
         self.maxConcurrentParses = maxConcurrentParses
+        self.parsePermitPool = JSONLParsePermitPool(limit: maxConcurrentParses)
         self.readFailureReporter = UsageLogReadFailureReporter(logTag: logTag, warning: readFailureWarning)
+        self.persistence = persistence
+        if let persistence {
+            let cutoff = Date().addingTimeInterval(-JSONLScanCachePaths.staleIdentityRetention)
+            Task.detached(priority: .utility) {
+                await JSONLScanCacheWriter.shared.pruneStaleIdentities(
+                    persistence: persistence,
+                    before: cutoff
+                )
+            }
+        }
     }
 
     /// Re-parse the in-window files (reusing the cache on an unchanged path + size + mtime), then return
@@ -82,32 +109,63 @@ actor IncrementalJSONLScanner<Item: Sendable> {
     func items(
         from files: [JSONLScanning.DiscoveredFile],
         since: Date,
+        cacheIdentity: String = "default",
         parse: @Sendable @escaping (Data) -> [Item]?
     ) async -> [Item] {
-        var nextCache: [String: CachedFile] = [:]
+        precondition(!cacheIdentity.isEmpty)
+        guard await acquire(cacheIdentity) else { return [] }
+        defer { release(cacheIdentity) }
+        guard !Task.isCancelled else { return [] }
+
+        await loadCacheIfNeeded(identity: cacheIdentity)
+        guard !Task.isCancelled else { return [] }
+        let currentCache = caches[cacheIdentity] ?? [:]
+        // Keep other same-parser scans' files in the shared partition until they age out of the window.
+        // This lets multi-account cards with disjoint roots share one actor safely; only the current
+        // call's input paths are returned below.
+        var nextCache = currentCache.filter { $0.value.mtime >= since }
         var toParse: [JSONLScanning.DiscoveredFile] = []
         for file in files {
             guard file.mtime >= since else { continue }
-            if let cached = cache[file.path], cached.size == file.size, cached.mtime == file.mtime {
+            if let cached = currentCache[file.path], cached.size == file.size, cached.mtime == file.mtime {
                 nextCache[file.path] = cached
             } else {
+                nextCache[file.path] = nil
                 toParse.append(file)
             }
         }
         let parseResults = await Self.parseFiles(
             toParse,
             maxConcurrentParses: maxConcurrentParses,
+            permitPool: parsePermitPool,
             parse: parse
         )
+        guard !Task.isCancelled else { return [] }
         let checkedPaths = Set(parseResults.lazy.map(\.file.path))
         let unreadablePaths = Set(parseResults.lazy.filter(\.readFailed).map(\.file.path))
         await readFailureReporter.update(checkedPaths: checkedPaths, failingPaths: unreadablePaths)
+        var parsedPaths: Set<String> = []
         for result in parseResults {
             let (file, parsed) = (result.file, result.items)
             guard let parsed else { continue }
             nextCache[file.path] = CachedFile(size: file.size, mtime: file.mtime, items: parsed)
+            parsedPaths.insert(file.path)
         }
-        cache = nextCache
+        for (path, cached) in currentCache where nextCache[path] == nil {
+            dirtyRemovals[cacheIdentity, default: [:]][path] = JSONLScanCacheFileMetadata(
+                size: cached.size,
+                mtime: cached.mtime,
+                recordFileName: JSONLScanCachePaths.recordFileName(path: path)
+            )
+        }
+        caches[cacheIdentity] = nextCache
+        dirtyUpsertPaths[cacheIdentity, default: []].formUnion(parsedPaths)
+        if !dirtyUpsertPaths[cacheIdentity, default: []].isEmpty
+            || !dirtyRemovals[cacheIdentity, default: [:]].isEmpty
+            || invalidPersistenceIdentities.contains(cacheIdentity)
+        {
+            scheduleWrite(identity: cacheIdentity)
+        }
 
         var items: [Item] = []
         for file in files {
@@ -117,11 +175,233 @@ actor IncrementalJSONLScanner<Item: Sendable> {
         return items
     }
 
+    /// Wait for the real debounced tasks rather than bypassing them. Tests configure a tiny debounce,
+    /// then use this to prove ordinary scans actually schedule and finish persistence.
+    func waitForPendingWritesForTesting() async {
+        for task in Array(writeTasks.values) {
+            await task.value
+        }
+    }
+
+    /// Commits the latest snapshots immediately. One-shot processes call this before exiting; the
+    /// long-lived app keeps the ordinary debounced path so refresh latency is unaffected.
+    func flushPendingWrites() async {
+        let identities = Array(writeTasks.keys)
+        for identity in identities {
+            writeTasks[identity]?.cancel()
+            writeTasks[identity] = nil
+            guard let generation = writeGenerations[identity] else { continue }
+            await persistCache(identity: identity, generation: generation)
+        }
+    }
+
+    func cacheRecordURLForTesting(identity: String, filePath: String) -> URL? {
+        guard let persistence else { return nil }
+        return JSONLScanCachePaths.recordURL(
+            persistence: persistence,
+            identity: identity,
+            fileName: JSONLScanCachePaths.recordFileName(path: filePath)
+        )
+    }
+
+    func queuedScanCountForTesting(identity: String) -> Int {
+        identityWaiters[identity]?.count ?? 0
+    }
+
+    // MARK: - Same-identity scan serialization
+
+    /// Actors are reentrant at `await parseFiles`; without this gate two cards launched together can
+    /// cold-parse the same home concurrently and then race to replace its cache. Different identities
+    /// remain independent, while matching ones queue behind the first parse and immediately hit cache.
+    private func acquire(_ identity: String) async -> Bool {
+        guard activeIdentities.contains(identity) else {
+            activeIdentities.insert(identity)
+            return true
+        }
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else {
+                    identityWaiters[identity, default: []].append(
+                        IdentityWaiter(id: waiterID, continuation: continuation)
+                    )
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(identity: identity, waiterID: waiterID) }
+        }
+    }
+
+    private func cancelWaiter(identity: String, waiterID: UUID) {
+        guard var waiters = identityWaiters[identity],
+              let index = waiters.firstIndex(where: { $0.id == waiterID })
+        else { return }
+        let waiter = waiters.remove(at: index)
+        identityWaiters[identity] = waiters.isEmpty ? nil : waiters
+        waiter.continuation.resume(returning: false)
+    }
+
+    private func release(_ identity: String) {
+        guard var waiters = identityWaiters[identity], !waiters.isEmpty else {
+            activeIdentities.remove(identity)
+            identityWaiters[identity] = nil
+            return
+        }
+        let next = waiters.removeFirst()
+        identityWaiters[identity] = waiters.isEmpty ? nil : waiters
+        next.continuation.resume(returning: true)
+    }
+
+    // MARK: - Persistence
+
+    private func loadCacheIfNeeded(identity: String) async {
+        guard loadedIdentities.insert(identity).inserted, let persistence else { return }
+        do {
+            guard let snapshot = try JSONLScanCacheWriter.shared.load(
+                persistence: persistence,
+                identity: identity,
+                itemType: Item.self
+            ) else { return }
+            let manifest = snapshot.manifest
+            guard manifest.formatVersion == JSONLScanCachePaths.formatVersion,
+                  manifest.schemaVersion == persistence.schemaVersion,
+                  manifest.identity == identity
+            else {
+                AppLog.info(.cache, "\(persistence.namespace) log parse cache schema changed; rebuilding")
+                invalidPersistenceIdentities.insert(identity)
+                return
+            }
+            persistedMetadata[identity] = manifest.files
+            caches[identity] = snapshot.files
+            dirtyRemovals[identity, default: [:]].merge(snapshot.invalidRecords) { _, new in new }
+            if !snapshot.invalidRecords.isEmpty {
+                AppLog.warn(
+                    .cache,
+                    "\(persistence.namespace) log parse cache has \(snapshot.invalidRecords.count) unreadable file records; reparsing"
+                )
+            }
+            AppLog.debug(
+                .cache,
+                "loaded \(snapshot.files.count) \(persistence.namespace) log files from parse cache"
+            )
+        } catch {
+            invalidPersistenceIdentities.insert(identity)
+            AppLog.warn(
+                .cache,
+                "\(persistence.namespace) log parse cache unreadable; rebuilding: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func scheduleWrite(identity: String) {
+        guard let persistence else { return }
+        let generation = writeGenerations[identity, default: 0] + 1
+        writeGenerations[identity] = generation
+        writeTasks[identity]?.cancel()
+        writeTasks[identity] = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(for: persistence.writeDebounce)
+            } catch {
+                await self.finishWriteTask(identity: identity, generation: generation)
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await self.persistCache(identity: identity, generation: generation)
+            await self.finishWriteTask(identity: identity, generation: generation)
+        }
+    }
+
+    private func finishWriteTask(identity: String, generation: Int) {
+        guard writeGenerations[identity] == generation else { return }
+        writeTasks[identity] = nil
+    }
+
+    private func persistCache(identity: String, generation: Int) async {
+        guard let persistence,
+              writeGenerations[identity] == generation,
+              let files = caches[identity]
+        else { return }
+
+        let manifestFiles = metadata(for: files)
+        let pathsToWrite = dirtyUpsertPaths[identity, default: []]
+        let records = pathsToWrite.compactMap {
+            path -> (path: String, metadata: JSONLScanCacheFileMetadata, record: JSONLScanCacheRecord<Item>)? in
+            guard let cached = files[path], let metadata = manifestFiles[path] else { return nil }
+            return (
+                path,
+                metadata,
+                JSONLScanCacheRecord(path: path, size: cached.size, mtime: cached.mtime, items: cached.items)
+            )
+        }
+        let removalSnapshot = dirtyRemovals[identity, default: [:]]
+        do {
+            // Only changed per-source records are encoded, avoiding an O(all 30-day history) rewrite
+            // whenever the active rollout grows. The writer builds the small merged manifest under lock.
+            let upserts = try await Task.detached(priority: .utility) {
+                let encoder = PropertyListEncoder()
+                encoder.outputFormat = .binary
+                return try Dictionary(uniqueKeysWithValues: records.map { input in
+                    (
+                        input.path,
+                        JSONLScanCacheUpsert(
+                            metadata: input.metadata,
+                            recordData: try encoder.encode(input.record)
+                        )
+                    )
+                })
+            }.value
+            guard !Task.isCancelled, writeGenerations[identity] == generation else { return }
+            let result = try await JSONLScanCacheWriter.shared.commit(
+                JSONLScanCacheWriteBatch(
+                    persistence: persistence,
+                    identity: identity,
+                    upserts: upserts,
+                    removals: removalSnapshot
+                )
+            )
+            guard writeGenerations[identity] == generation else { return }
+            persistedMetadata[identity] = result.manifest.files
+            dirtyUpsertPaths[identity, default: []].subtract(result.acceptedUpsertPaths)
+            for path in removalSnapshot.keys {
+                dirtyRemovals[identity]?[path] = nil
+            }
+            invalidPersistenceIdentities.remove(identity)
+            AppLog.debug(
+                .cache,
+                "persisted \(result.acceptedUpsertPaths.count) changed / \(result.manifest.files.count) retained \(persistence.namespace) log files"
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            AppLog.warn(
+                .cache,
+                "could not persist \(persistence.namespace) log parse cache: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func metadata(for files: [String: CachedFile]) -> [String: JSONLScanCacheFileMetadata] {
+        var result: [String: JSONLScanCacheFileMetadata] = [:]
+        result.reserveCapacity(files.count)
+        for (path, cached) in files {
+            result[path] = JSONLScanCacheFileMetadata(
+                size: cached.size,
+                mtime: cached.mtime,
+                recordFileName: JSONLScanCachePaths.recordFileName(path: path)
+            )
+        }
+        return result
+    }
+
     /// Read + parse a bounded number of changed files in parallel. Results are keyed back to the input
     /// order; a `nil` item list marks an unreadable file.
     private static func parseFiles(
         _ files: [JSONLScanning.DiscoveredFile],
         maxConcurrentParses: Int,
+        permitPool: JSONLParsePermitPool,
         parse: @Sendable @escaping (Data) -> [Item]?
     ) async -> [(file: JSONLScanning.DiscoveredFile, items: [Item]?, readFailed: Bool)] {
         await withTaskGroup(
@@ -131,25 +411,33 @@ actor IncrementalJSONLScanner<Item: Sendable> {
             func addTask(at index: Int) {
                 let file = files[index]
                 group.addTask {
-                    guard FileManager.default.fileExists(atPath: file.path) else {
-                        return (index, nil, false)
+                    guard await permitPool.acquire() else { return (index, nil, false) }
+                    let result: (Int, [Item]?, Bool)
+                    if Task.isCancelled || !FileManager.default.fileExists(atPath: file.path) {
+                        result = (index, nil, false)
+                    } else if let data = FileManager.default.contents(atPath: file.path) {
+                        result = (index, parse(data), false)
+                    } else {
+                        result = (index, nil, true)
                     }
-                    guard let data = FileManager.default.contents(atPath: file.path) else {
-                        return (index, nil, true)
-                    }
-                    return (index, parse(data), false)
+                    await permitPool.release()
+                    return result
                 }
             }
 
             var nextIndex = 0
             let initialCount = min(maxConcurrentParses, files.count)
-            for index in 0..<initialCount {
+            for index in 0..<initialCount where !Task.isCancelled {
                 addTask(at: index)
                 nextIndex += 1
             }
 
             var results = files.map { (file: $0, items: Optional<[Item]>.none, readFailed: false) }
             for await (index, items, readFailed) in group {
+                if Task.isCancelled {
+                    group.cancelAll()
+                    break
+                }
                 results[index] = (files[index], items, readFailed)
                 if nextIndex < files.count {
                     addTask(at: nextIndex)

--- a/Sources/OpenUsage/Providers/JSONLScanCacheCoordination.swift
+++ b/Sources/OpenUsage/Providers/JSONLScanCacheCoordination.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// One scanner-wide I/O budget shared by every provider/home identity. Without this pool, eight parse
+/// tasks per identity can multiply into dozens of simultaneous reads during multi-account launch.
+actor JSONLParsePermitPool {
+    private struct Waiter {
+        var id: UUID
+        var continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var available: Int
+    private var waiters: [Waiter] = []
+
+    init(limit: Int) {
+        precondition(limit > 0)
+        self.available = limit
+    }
+
+    func acquire() async -> Bool {
+        guard !Task.isCancelled else { return false }
+        if available > 0 {
+            available -= 1
+            return true
+        }
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else {
+                    waiters.append(Waiter(id: waiterID, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancel(waiterID: waiterID) }
+        }
+    }
+
+    func release() {
+        guard !waiters.isEmpty else {
+            available += 1
+            return
+        }
+        waiters.removeFirst().continuation.resume(returning: true)
+    }
+
+    private func cancel(waiterID: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == waiterID }) else { return }
+        waiters.remove(at: index).continuation.resume(returning: false)
+    }
+}
+
+enum PersistentJSONLScanCaches {
+    /// A one-shot CLI has no run loop to outlive the debounce, so it explicitly drains every local-log
+    /// parser before returning. Scanners without pending work return immediately.
+    static func flushPendingWrites() async {
+        await ClaudeLogUsageScanner.flushPersistentCacheWrites()
+        await CodexLogUsageScanner.flushPersistentCacheWrites()
+        await PiUsageScanner.flushPersistentCacheWrites()
+    }
+}

--- a/Sources/OpenUsage/Providers/JSONLScanCacheStore.swift
+++ b/Sources/OpenUsage/Providers/JSONLScanCacheStore.swift
@@ -1,0 +1,446 @@
+import Darwin
+import Foundation
+
+/// Disk policy for one JSONL parser. `namespace` identifies the provider/parser; the scanner adds a
+/// stable provider/home identity below it. Bump `schemaVersion` whenever the persisted item meaning
+/// changes, including changes to nested values such as `TokenBreakdown`.
+struct JSONLScanCachePersistence: Sendable {
+    var namespace: String
+    var schemaVersion: Int
+    var directory: URL
+    var writeDebounce: Duration
+
+    init(
+        namespace: String,
+        schemaVersion: Int,
+        directory: URL = JSONLScanCachePaths.defaultDirectory,
+        writeDebounce: Duration = .seconds(2)
+    ) {
+        precondition(!namespace.isEmpty)
+        precondition(namespace.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" })
+        precondition(schemaVersion > 0)
+        self.namespace = namespace
+        self.schemaVersion = schemaVersion
+        self.directory = directory
+        self.writeDebounce = writeDebounce
+    }
+}
+
+struct JSONLScanCacheFileMetadata: Codable, Sendable, Equatable {
+    var size: Int
+    var mtime: Date
+    var recordFileName: String
+}
+
+struct JSONLScanCacheManifest: Codable, Sendable {
+    var formatVersion: Int
+    var schemaVersion: Int
+    var identity: String
+    /// Diagnostic/retention timestamp for the last successful lock-scoped manifest merge.
+    var generatedAt: Date
+    var files: [String: JSONLScanCacheFileMetadata]
+}
+
+struct JSONLScanCacheUpsert: Sendable {
+    var metadata: JSONLScanCacheFileMetadata
+    var recordData: Data
+}
+
+struct JSONLScanCacheWriteBatch: Sendable {
+    var persistence: JSONLScanCachePersistence
+    var identity: String
+    /// Only new or changed source paths are present. The writer verifies each path's current stat before
+    /// publishing it, so a slow process cannot replace a newer parse of the same source file.
+    var upserts: [String: JSONLScanCacheUpsert]
+    /// A removal applies only while the on-disk metadata still equals the value this scanner observed.
+    /// Paths added or changed by another app/CLI process are therefore preserved.
+    var removals: [String: JSONLScanCacheFileMetadata]
+}
+
+struct JSONLScanCacheCommitResult: Sendable {
+    var manifest: JSONLScanCacheManifest
+    var acceptedUpsertPaths: Set<String>
+}
+
+struct JSONLScanCacheRecord<Item: Codable & Sendable>: Codable, Sendable {
+    var path: String
+    var size: Int
+    var mtime: Date
+    var items: [Item]
+}
+
+struct JSONLScanCachedFile<Item: Codable & Sendable>: Sendable {
+    var size: Int
+    var mtime: Date
+    var items: [Item]
+}
+
+struct JSONLScanCacheReadSnapshot<Item: Codable & Sendable>: Sendable {
+    var manifest: JSONLScanCacheManifest
+    var files: [String: JSONLScanCachedFile<Item>]
+    var invalidRecords: [String: JSONLScanCacheFileMetadata]
+}
+
+enum JSONLScanCachePaths {
+    static let formatVersion = 1
+    static let staleIdentityRetention: TimeInterval = 35 * 86_400
+
+    static var defaultDirectory: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("OpenUsage/log-scan-cache", isDirectory: true)
+    }
+
+    static func identityDirectory(
+        persistence: JSONLScanCachePersistence,
+        identity: String
+    ) -> URL {
+        persistence.directory.appendingPathComponent(
+            "\(persistence.namespace)-\(stableFingerprint(identity))",
+            isDirectory: true
+        )
+    }
+
+    static func manifestURL(persistence: JSONLScanCachePersistence, identity: String) -> URL {
+        identityDirectory(persistence: persistence, identity: identity)
+            .appendingPathComponent("manifest.plist")
+    }
+
+    static func recordsDirectory(persistence: JSONLScanCachePersistence, identity: String) -> URL {
+        identityDirectory(persistence: persistence, identity: identity)
+            .appendingPathComponent("files", isDirectory: true)
+    }
+
+    static func recordFileName(path: String) -> String {
+        "\(stableFingerprint(path)).plist"
+    }
+
+    static func recordURL(
+        persistence: JSONLScanCachePersistence,
+        identity: String,
+        fileName: String
+    ) -> URL {
+        recordsDirectory(persistence: persistence, identity: identity)
+            .appendingPathComponent(fileName)
+    }
+
+    static func lockURL(persistence: JSONLScanCachePersistence, identity: String) -> URL {
+        let directoryName = identityDirectory(persistence: persistence, identity: identity).lastPathComponent
+        return persistence.directory.appendingPathComponent(".\(directoryName).lock")
+    }
+
+    /// Swift's `Hasher` is randomized per process; FNV-1a gives stable compact names across launches.
+    /// Manifests/records also carry and validate the unhashed identity/path, so a theoretical collision
+    /// causes a safe reparse instead of serving another source's items.
+    static func stableFingerprint(_ value: String) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(format: "%016llx", hash)
+    }
+}
+
+/// Serializes manifest publication within the process and uses `flock` to order app/CLI writers. Each
+/// batch carries path-level mutations, which are merged with the current manifest while locked so
+/// overlapping processes preserve one another's work. Records land before the manifest, so a crash can
+/// leave an orphan record but never publish metadata for a half-written one.
+actor JSONLScanCacheWriter {
+    static let shared = JSONLScanCacheWriter()
+
+    func commit(_ batch: JSONLScanCacheWriteBatch) throws -> JSONLScanCacheCommitResult {
+        let persistence = batch.persistence
+        let identity = batch.identity
+        let manifestURL = JSONLScanCachePaths.manifestURL(
+            persistence: persistence,
+            identity: identity
+        )
+
+        return try Self.withExclusiveLock(
+            at: JSONLScanCachePaths.lockURL(persistence: persistence, identity: identity)
+        ) {
+            let current = Self.readManifest(at: manifestURL)
+            var mergedFiles: [String: JSONLScanCacheFileMetadata]
+            if current?.formatVersion == JSONLScanCachePaths.formatVersion,
+               current?.schemaVersion == persistence.schemaVersion,
+               current?.identity == identity
+            {
+                mergedFiles = current?.files ?? [:]
+            } else {
+                mergedFiles = [:]
+            }
+
+            for (path, expectedMetadata) in batch.removals
+                where mergedFiles[path] == expectedMetadata
+            {
+                mergedFiles[path] = nil
+            }
+
+            let identityDirectory = JSONLScanCachePaths.identityDirectory(
+                persistence: persistence,
+                identity: identity
+            )
+            let recordsDirectory = JSONLScanCachePaths.recordsDirectory(
+                persistence: persistence,
+                identity: identity
+            )
+            var acceptedUpsertPaths: Set<String> = []
+            if !batch.upserts.isEmpty {
+                try Self.createPrivateDirectory(persistence.directory)
+                try Self.createPrivateDirectory(identityDirectory)
+                try Self.createPrivateDirectory(recordsDirectory)
+                for (path, upsert) in batch.upserts
+                    where Self.sourceMatches(path: path, metadata: upsert.metadata)
+                {
+                    try Self.writePrivate(
+                        upsert.recordData,
+                        to: recordsDirectory.appendingPathComponent(upsert.metadata.recordFileName)
+                    )
+                    mergedFiles[path] = upsert.metadata
+                    acceptedUpsertPaths.insert(path)
+                }
+            }
+
+            let manifest = JSONLScanCacheManifest(
+                formatVersion: JSONLScanCachePaths.formatVersion,
+                schemaVersion: persistence.schemaVersion,
+                identity: identity,
+                generatedAt: Date(),
+                files: mergedFiles
+            )
+            if mergedFiles.isEmpty {
+                if FileManager.default.fileExists(atPath: identityDirectory.path) {
+                    try FileManager.default.removeItem(at: identityDirectory)
+                }
+                return JSONLScanCacheCommitResult(
+                    manifest: manifest,
+                    acceptedUpsertPaths: acceptedUpsertPaths
+                )
+            }
+
+            try Self.createPrivateDirectory(persistence.directory)
+            try Self.createPrivateDirectory(identityDirectory)
+            try Self.createPrivateDirectory(recordsDirectory)
+            // Publish metadata last. A reader either sees the complete old generation or complete new one.
+            let encoder = PropertyListEncoder()
+            encoder.outputFormat = .binary
+            try Self.writePrivate(try encoder.encode(manifest), to: manifestURL)
+
+            let referenced = Set(mergedFiles.values.map(\.recordFileName))
+            let existing = try FileManager.default.contentsOfDirectory(
+                at: recordsDirectory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            )
+            for url in existing where url.pathExtension == "plist" && !referenced.contains(url.lastPathComponent) {
+                try FileManager.default.removeItem(at: url)
+            }
+            return JSONLScanCacheCommitResult(
+                manifest: manifest,
+                acceptedUpsertPaths: acceptedUpsertPaths
+            )
+        }
+    }
+
+    /// Reads one identity under a shared cross-process lock and marks it recently used before releasing
+    /// that lock. A concurrent stale-cache cleanup must then re-check the touched directory and keep it.
+    nonisolated func load<Item: Codable & Sendable>(
+        persistence: JSONLScanCachePersistence,
+        identity: String,
+        itemType: Item.Type
+    ) throws -> JSONLScanCacheReadSnapshot<Item>? {
+        _ = itemType
+        let identityDirectory = JSONLScanCachePaths.identityDirectory(
+            persistence: persistence,
+            identity: identity
+        )
+        guard FileManager.default.fileExists(atPath: identityDirectory.path) else { return nil }
+        return try Self.withSharedLock(
+            at: JSONLScanCachePaths.lockURL(persistence: persistence, identity: identity)
+        ) {
+            let manifestURL = JSONLScanCachePaths.manifestURL(
+                persistence: persistence,
+                identity: identity
+            )
+            let manifestData = try Data(contentsOf: manifestURL, options: .mappedIfSafe)
+            let manifest = try PropertyListDecoder().decode(
+                JSONLScanCacheManifest.self,
+                from: manifestData
+            )
+            var files: [String: JSONLScanCachedFile<Item>] = [:]
+            var invalidRecords: [String: JSONLScanCacheFileMetadata] = [:]
+            if manifest.formatVersion == JSONLScanCachePaths.formatVersion,
+               manifest.schemaVersion == persistence.schemaVersion,
+               manifest.identity == identity
+            {
+                files.reserveCapacity(manifest.files.count)
+                let recordDecoder = PropertyListDecoder()
+                for (path, metadata) in manifest.files {
+                    let url = JSONLScanCachePaths.recordURL(
+                        persistence: persistence,
+                        identity: identity,
+                        fileName: metadata.recordFileName
+                    )
+                    guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
+                          let record = try? recordDecoder.decode(
+                              JSONLScanCacheRecord<Item>.self,
+                              from: data
+                          ),
+                          record.path == path,
+                          record.size == metadata.size,
+                          record.mtime == metadata.mtime
+                    else {
+                        invalidRecords[path] = metadata
+                        continue
+                    }
+                    files[path] = JSONLScanCachedFile(
+                        size: record.size,
+                        mtime: record.mtime,
+                        items: record.items
+                    )
+                }
+            }
+            do {
+                try FileManager.default.setAttributes(
+                    [.modificationDate: Date()],
+                    ofItemAtPath: identityDirectory.path
+                )
+            } catch {
+                AppLog.warn(
+                    .cache,
+                    "could not mark \(persistence.namespace) log parse cache as used: \(error.localizedDescription)"
+                )
+            }
+            return JSONLScanCacheReadSnapshot(
+                manifest: manifest,
+                files: files,
+                invalidRecords: invalidRecords
+            )
+        }
+    }
+
+    /// Removes identity directories that have not been read or written for longer than the retained scan
+    /// window. The tiny lock files contain no usage data and intentionally remain: unlinking a lock
+    /// file while another process holds its inode would undermine cross-process exclusion.
+    func pruneStaleIdentities(
+        persistence: JSONLScanCachePersistence,
+        before cutoff: Date
+    ) {
+        let prefix = "\(persistence.namespace)-"
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: persistence.directory,
+            includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for directory in contents where directory.lastPathComponent.hasPrefix(prefix) {
+            guard let values = try? directory.resourceValues(
+                forKeys: [.isDirectoryKey, .contentModificationDateKey]
+            ),
+            values.isDirectory == true,
+            let modified = values.contentModificationDate,
+            modified < cutoff
+            else { continue }
+
+            let lockURL = persistence.directory.appendingPathComponent(".\(directory.lastPathComponent).lock")
+            do {
+                try Self.withExclusiveLock(at: lockURL, nonblocking: true) {
+                    guard let lockedValues = try? directory.resourceValues(
+                        forKeys: [.isDirectoryKey, .contentModificationDateKey]
+                    ),
+                    lockedValues.isDirectory == true,
+                    let lockedModified = lockedValues.contentModificationDate,
+                    lockedModified < cutoff
+                    else { return }
+                    try FileManager.default.removeItem(at: directory)
+                }
+            } catch let error as POSIXError where error.code == .EWOULDBLOCK {
+                continue
+            } catch {
+                AppLog.warn(
+                    .cache,
+                    "could not prune stale \(persistence.namespace) log parse cache: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    private static func readManifest(at url: URL) -> JSONLScanCacheManifest? {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else { return nil }
+        return try? PropertyListDecoder().decode(JSONLScanCacheManifest.self, from: data)
+    }
+
+    private static func sourceMatches(
+        path: String,
+        metadata: JSONLScanCacheFileMetadata
+    ) -> Bool {
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey,
+            .fileSizeKey,
+            .contentModificationDateKey,
+        ]
+        guard let values = try? URL(fileURLWithPath: path).resourceValues(forKeys: keys) else {
+            return false
+        }
+        return values.isRegularFile == true
+            && values.fileSize == metadata.size
+            && values.contentModificationDate == metadata.mtime
+    }
+
+    private static func createPrivateDirectory(_ url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+    }
+
+    private static func writePrivate(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    private static func withExclusiveLock<Result>(
+        at url: URL,
+        nonblocking: Bool = false,
+        _ body: () throws -> Result
+    ) throws -> Result {
+        try withLock(
+            at: url,
+            operation: LOCK_EX | (nonblocking ? LOCK_NB : 0),
+            body
+        )
+    }
+
+    private static func withSharedLock<Result>(
+        at url: URL,
+        _ body: () throws -> Result
+    ) throws -> Result {
+        try withLock(at: url, operation: LOCK_SH, body)
+    }
+
+    private static func withLock<Result>(
+        at url: URL,
+        operation: Int32,
+        _ body: () throws -> Result
+    ) throws -> Result {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: url.deletingLastPathComponent().path
+        )
+        let fd = Darwin.open(url.path, O_CREAT | O_RDWR | O_CLOEXEC, mode_t(S_IRUSR | S_IWUSR))
+        guard fd >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        defer {
+            flock(fd, LOCK_UN)
+            Darwin.close(fd)
+        }
+        guard Darwin.fchmod(fd, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+        guard flock(fd, operation) == 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+        return try body()
+    }
+}

--- a/Sources/OpenUsage/Providers/Pi/PiUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Pi/PiUsageScanner.swift
@@ -10,27 +10,38 @@ import Foundation
 /// Codex log scanners use. Pi's usage shape differs from Claude Code's (`usage.input`/`output`,
 /// nested `usage.cost.total`), so it has its own parser rather than routing through those scanners.
 ///
-/// An actor holding the incremental parse cache (keyed path + size + mtime) so the ~5-minute refreshes
-/// re-parse only changed session files. A single shared instance is used by every consuming provider,
-/// so pi's logs are parsed once per refresh rather than once per card.
+/// An actor holding the versioned incremental parse cache (keyed path + size + mtime) in memory and
+/// Application Support, so refreshes and relaunches parse only changed session files. A single shared
+/// instance is used by every consuming provider, so pi's logs are parsed once rather than once per card.
 actor PiUsageScanner {
     static let shared = PiUsageScanner()
 
     private let environment: EnvironmentReading
     private let homeDirectory: @Sendable () -> URL
-    private let scanner = IncrementalJSONLScanner<Entry>(logTag: LogTag.plugin("pi"))
+    private let scanner: IncrementalJSONLScanner<Entry>
+
+    private static let sharedScanner = IncrementalJSONLScanner<Entry>(
+        logTag: LogTag.plugin("pi"),
+        persistence: JSONLScanCachePersistence(namespace: "pi", schemaVersion: 1)
+    )
+
+    static func flushPersistentCacheWrites() async {
+        await sharedScanner.flushPendingWrites()
+    }
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
-        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser }
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        incrementalScanner: IncrementalJSONLScanner<Entry>? = nil
     ) {
         self.environment = environment
         self.homeDirectory = homeDirectory
+        self.scanner = incrementalScanner ?? Self.sharedScanner
     }
 
     /// One parsed assistant-message usage line. Raw timestamp is kept so a cached parse stays valid as
     /// the window slides; `cardID` is resolved at parse time so aggregation is a cheap filter.
-    struct Entry: Sendable, Equatable {
+    struct Entry: Codable, Sendable, Equatable {
         var id: String?
         var timestamp: Date
         var cardID: String
@@ -47,11 +58,22 @@ actor PiUsageScanner {
     /// has no log files at all, so a provider with no pi usage folds in nothing.
     func scan(cardID: String, daysBack: Int = 30, now: Date = Date(), pricing: ModelPricing) async -> LogUsageScan? {
         let directory = PiPaths.sessionsDirectory(environment: environment, homeDirectory: homeDirectory())
-        let files = JSONLScanning.jsonlFiles(under: directory)
-        guard !files.isEmpty else { return nil }
-
         let since = JSONLScanning.sinceDate(daysBack: daysBack, now: now)
-        let entries = await scanner.items(from: files, since: since, parse: Self.parseFile)
+        let cacheIdentity = directory.resolvingSymlinksInPath().path
+        let files = JSONLScanning.jsonlFiles(under: directory)
+        guard !files.isEmpty else {
+            _ = await scanner.items(
+                from: [], since: since, cacheIdentity: cacheIdentity, parse: Self.parseFile
+            )
+            return nil
+        }
+
+        let entries = await scanner.items(
+            from: files,
+            since: since,
+            cacheIdentity: cacheIdentity,
+            parse: Self.parseFile
+        )
         return Self.aggregate(entries: Self.dedup(entries), cardID: cardID, since: since, pricing: pricing)
     }
 

--- a/Sources/OpenUsage/Providers/Pi/PiUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Pi/PiUsageScanner.swift
@@ -68,12 +68,12 @@ actor PiUsageScanner {
             return nil
         }
 
-        let entries = await scanner.items(
+        guard let entries = await scanner.items(
             from: files,
             since: since,
             cacheIdentity: cacheIdentity,
             parse: Self.parseFile
-        )
+        ), !Task.isCancelled else { return nil }
         return Self.aggregate(entries: Self.dedup(entries), cardID: cardID, since: since, pricing: pricing)
     }
 

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -80,6 +80,9 @@ public struct UsageReader {
             } else {
                 await dataStore.refreshAll(force: force)
             }
+            if providersOverride == nil {
+                await PersistentJSONLScanCaches.flushPendingWrites()
+            }
             snapshots = dataStore.snapshots
             errors = dataStore.providerErrors
             warnings = orderedIDs

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -24,6 +24,10 @@ final class WidgetDataStore {
     private let orderedDescriptors: @MainActor () -> [WidgetDescriptor]
     /// Clock for the failure-backoff window. Injected so tests can advance time deterministically.
     private let now: () -> Date
+    /// Monotonic clock for refresh durations, kept separate from wall time so a clock adjustment cannot
+    /// produce a negative or wildly inflated provider timing. Tests inject exact ticks.
+    private let monotonicNow: () -> TimeInterval
+    private let slowProviderRefreshThreshold: TimeInterval
     /// Quota-notification preferences (three independent triggers). Injected; `nil` disables
     /// notifications entirely (tests and previews that don't wire it).
     private let notificationSettings: (@MainActor () -> NotificationSettingsStore)?
@@ -44,6 +48,7 @@ final class WidgetDataStore {
     /// 5-minute heartbeat always retries; it only suppresses the sub-interval re-probes a wake burst
     /// would cause. The manual `force` refresh (⌘R) always bypasses it.
     private static let failureRetryBackoff: TimeInterval = 60
+    static let defaultSlowProviderRefreshThreshold: TimeInterval = 10
 
     /// Rendered snapshots consumed by every UI/API surface. Equal to `localSnapshots` when iCloud sync
     /// is off; machine-local history rows are rebuilt from the union while sync is on.
@@ -106,9 +111,12 @@ final class WidgetDataStore {
         isProviderEnabled: @escaping @MainActor (String) -> Bool = { _ in true },
         orderedDescriptors: (@MainActor () -> [WidgetDescriptor])? = nil,
         now: @escaping () -> Date = Date.init,
+        monotonicNow: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+        slowProviderRefreshThreshold: TimeInterval = WidgetDataStore.defaultSlowProviderRefreshThreshold,
         notificationSettings: (@MainActor () -> NotificationSettingsStore)? = nil,
         postNotification: (@MainActor (String, String, String, String) async -> Bool)? = nil
     ) {
+        precondition(slowProviderRefreshThreshold >= 0)
         self.registry = registry
         self.providersByID = Dictionary(uniqueKeysWithValues: providers.map { ($0.provider.id, $0) })
         self.cache = cache
@@ -116,6 +124,8 @@ final class WidgetDataStore {
         self.isProviderEnabled = isProviderEnabled
         self.orderedDescriptors = orderedDescriptors ?? { registry.descriptors }
         self.now = now
+        self.monotonicNow = monotonicNow
+        self.slowProviderRefreshThreshold = slowProviderRefreshThreshold
         self.notificationSettings = notificationSettings
         self.postNotification = postNotification
             ?? { idPrefix, title, subtitle, body in
@@ -141,7 +151,7 @@ final class WidgetDataStore {
         // `Task {}` from MainActor context inherits the isolation (a task-group child can't capture
         // the non-Sendable store), so: fire one task per provider, then await them all.
         let providerIDs = registry.providers.map(\.id).filter { isProviderEnabled($0) }
-        let start = Date()
+        let start = monotonicNow()
         AppLog.info(.refresh, "batch start (\(providerIDs.count) providers, force=\(force))")
         let tasks = providerIDs.map { providerID in
             Task { await self.refresh(providerID: providerID, force: force, notifyHistoryChange: false) }
@@ -155,7 +165,7 @@ final class WidgetDataStore {
         // (this time + one refresh interval), mirroring the periodic loop that sleeps one interval
         // after each pass.
         lastRefreshAt = Date()
-        let durationMs = Int(Date().timeIntervalSince(start) * 1000)
+        let durationMs = durationMilliseconds(since: start)
         // Count THIS batch's actual outcomes, not the long-lived `providerErrors` map (which persists
         // across passes, so reading it would miscount cache hits and stale earlier failures).
         let refreshed = outcomes.count { $0 == .refreshed }
@@ -246,11 +256,17 @@ final class WidgetDataStore {
         }
         refreshingProviderIDs.insert(providerID)
         defer { refreshingProviderIDs.remove(providerID) }
-        let start = Date()
+        let start = monotonicNow()
         var snapshot = await ProviderRefreshContext.$isManual.withValue(force) {
             await provider.refresh()
         }
-        let durationMs = Int(Date().timeIntervalSince(start) * 1000)
+        let durationMs = durationMilliseconds(since: start)
+        if TimeInterval(durationMs) >= slowProviderRefreshThreshold * 1000 {
+            AppLog.warn(
+                .refresh,
+                "\(providerID) slow refresh (\(durationMs)ms, threshold=\(Int(slowProviderRefreshThreshold * 1000))ms)"
+            )
+        }
         if let message = Self.errorMessage(in: snapshot) {
             // Failed refresh: surface the error but keep the last good snapshot on screen rather than
             // collapsing every row to "No data". The provider error string is already user-safe.
@@ -291,6 +307,10 @@ final class WidgetDataStore {
         AppLog.info(.refresh, "\(providerID) ok (\(durationMs)ms)")
         onRefreshOutcome?(providerID, .refreshed, nil, force)
         return .refreshed
+    }
+
+    private func durationMilliseconds(since start: TimeInterval) -> Int {
+        max(0, Int((monotonicNow() - start) * 1000))
     }
 
     /// Clears a provider's failure backoff so the next pass probes it immediately. Called when the user

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -260,6 +260,12 @@ final class WidgetDataStore {
         var snapshot = await ProviderRefreshContext.$isManual.withValue(force) {
             await provider.refresh()
         }
+        // A canceled refresh may still return if a provider's underlying work is non-throwing. Never
+        // publish that potentially partial snapshot; keep the last-good state exactly as it was.
+        guard !Task.isCancelled else {
+            AppLog.debug(.refresh, "cancelled \(providerID) refresh; keeping last-good snapshot")
+            return .skipped
+        }
         let durationMs = durationMilliseconds(since: start)
         if TimeInterval(durationMs) >= slowProviderRefreshThreshold * 1000 {
             AppLog.warn(

--- a/Tests/OpenUsageTests/AppLogTests.swift
+++ b/Tests/OpenUsageTests/AppLogTests.swift
@@ -87,4 +87,34 @@ final class AppLogTests: XCTestCase {
         let contents = try fileContents()
         XCTAssertFalse(contents.contains("sk-1234567890abcdefghij"), contents)
     }
+
+    @MainActor
+    func testSlowProviderRefreshWritesWarningAtDefaultLogLevel() async throws {
+        AppLog.reloadLevel(.info)
+        let provider = Provider(id: "slow-test", displayName: "Slow Test", icon: .providerMark("codex"))
+        let runtime = TestProviderRuntime(
+            provider: provider,
+            descriptors: [],
+            snapshot: ProviderSnapshot(providerID: provider.id, displayName: provider.displayName, lines: [])
+        )
+        let defaultsName = "OpenUsageTests.AppLog.slow.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        var ticks = [100.0, 112.5]
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: []),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots"),
+            defaults: defaults,
+            monotonicNow: { ticks.removeFirst() }
+        )
+
+        _ = await store.refresh(providerID: provider.id, force: true)
+
+        let contents = try fileContents()
+        XCTAssertTrue(
+            contents.contains("[WARN] [refresh] slow-test slow refresh (12500ms, threshold=10000ms)"),
+            contents
+        )
+    }
 }

--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
@@ -571,7 +571,8 @@ final class ClaudeLogUsageScannerTests: XCTestCase {
         // ccusage accepts `CLAUDE_CONFIG_DIR` pointing at the `projects/` dir itself.
         let scanner = ClaudeLogUsageScanner(
             environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": home.appendingPathComponent("projects").path]),
-            homeDirectory: { FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-claude-home") }
+            homeDirectory: { FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-claude-home") },
+            incrementalScanner: IncrementalJSONLScanner<Entry>()
         )
 
         let result = await scanner.scan(now: now, pricing: pricing)

--- a/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
+++ b/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
@@ -3,6 +3,342 @@ import XCTest
 @testable import OpenUsage
 
 final class IncrementalJSONLScannerTests: XCTestCase {
+    func testPersistedCacheSurvivesFreshScannerInstanceAndIsScopedByIdentity() async throws {
+        let base = try makeDirectory("Persistence")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let file = try makeFile(named: "usage.jsonl", contents: "7", in: base, mtime: Date())
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test", schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"), writeDebounce: .milliseconds(1)
+        )
+
+        let firstCounter = ParseCounter()
+        let first = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let firstItems = await first.items(
+            from: [file], since: .distantPast, cacheIdentity: "home-a", parse: firstCounter.parse
+        )
+        XCTAssertEqual(firstItems, [7])
+        XCTAssertEqual(firstCounter.count, 1)
+        await first.waitForPendingWritesForTesting()
+
+        let relaunchedCounter = ParseCounter()
+        let relaunched = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let relaunchedItems = await relaunched.items(
+            from: [file], since: .distantPast, cacheIdentity: "home-a", parse: relaunchedCounter.parse
+        )
+        XCTAssertEqual(relaunchedItems, [7])
+        XCTAssertEqual(relaunchedCounter.count, 0, "an unchanged file should decode from the persisted cache")
+
+        let otherHomeCounter = ParseCounter()
+        let otherHome = IncrementalJSONLScanner<Int>(persistence: persistence)
+        _ = await otherHome.items(
+            from: [file], since: .distantPast, cacheIdentity: "home-b", parse: otherHomeCounter.parse
+        )
+        XCTAssertEqual(otherHomeCounter.count, 1, "a different home identity must not inherit another home's cache")
+        await otherHome.waitForPendingWritesForTesting()
+    }
+
+    func testPersistedCacheInvalidatesWhenSizeOrMtimeChanges() async throws {
+        let base = try makeDirectory("StatInvalidation")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let now = Date()
+        let firstFile = try makeFile(named: "a.jsonl", contents: "1", in: base, mtime: now)
+        let secondFile = try makeFile(named: "b.jsonl", contents: "2", in: base, mtime: now)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test", schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"), writeDebounce: .milliseconds(1)
+        )
+
+        let seed = IncrementalJSONLScanner<Int>(persistence: persistence)
+        _ = await seed.items(
+            from: [firstFile, secondFile], since: .distantPast, cacheIdentity: "home", parse: ParseCounter().parse
+        )
+        await seed.waitForPendingWritesForTesting()
+
+        let firstURL = URL(fileURLWithPath: firstFile.path)
+        try Data("11".utf8).write(to: firstURL)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: firstFile.path)
+        let resizedMtime = try XCTUnwrap(
+            firstURL.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+        )
+        let resized = JSONLScanning.DiscoveredFile(path: firstFile.path, size: 2, mtime: resizedMtime)
+        let sizeCounter = ParseCounter()
+        let afterSizeChange = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let resizedItems = await afterSizeChange.items(
+            from: [resized, secondFile], since: .distantPast, cacheIdentity: "home", parse: sizeCounter.parse
+        )
+        XCTAssertEqual(resizedItems, [11, 2])
+        XCTAssertEqual(sizeCounter.count, 1)
+        await afterSizeChange.waitForPendingWritesForTesting()
+
+        let secondURL = URL(fileURLWithPath: secondFile.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(1)],
+            ofItemAtPath: secondFile.path
+        )
+        let touchedMtime = try XCTUnwrap(
+            secondURL.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+        )
+        let touched = JSONLScanning.DiscoveredFile(
+            path: secondFile.path, size: secondFile.size, mtime: touchedMtime
+        )
+        let mtimeCounter = ParseCounter()
+        let afterMtimeChange = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let touchedItems = await afterMtimeChange.items(
+            from: [resized, touched], since: .distantPast, cacheIdentity: "home", parse: mtimeCounter.parse
+        )
+        XCTAssertEqual(touchedItems, [11, 2])
+        XCTAssertEqual(mtimeCounter.count, 1)
+        await afterMtimeChange.waitForPendingWritesForTesting()
+    }
+
+    func testPersistedCacheInvalidatesOnSchemaVersionChange() async throws {
+        let base = try makeDirectory("SchemaInvalidation")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let file = try makeFile(named: "usage.jsonl", contents: "7", in: base, mtime: Date())
+        let cacheDirectory = base.appendingPathComponent("cache")
+        let versionOne = JSONLScanCachePersistence(
+            namespace: "test", schemaVersion: 1, directory: cacheDirectory, writeDebounce: .milliseconds(1)
+        )
+        let seed = IncrementalJSONLScanner<Int>(persistence: versionOne)
+        _ = await seed.items(from: [file], since: .distantPast, cacheIdentity: "home", parse: ParseCounter().parse)
+        await seed.waitForPendingWritesForTesting()
+
+        let versionTwo = JSONLScanCachePersistence(
+            namespace: "test", schemaVersion: 2, directory: cacheDirectory, writeDebounce: .milliseconds(1)
+        )
+        let counter = ParseCounter()
+        let rebuilt = IncrementalJSONLScanner<Int>(persistence: versionTwo)
+        let rebuiltItems = await rebuilt.items(
+            from: [file], since: .distantPast, cacheIdentity: "home", parse: counter.parse
+        )
+        XCTAssertEqual(rebuiltItems, [7])
+        XCTAssertEqual(counter.count, 1)
+        await rebuilt.waitForPendingWritesForTesting()
+    }
+
+    func testDebouncedPersistenceWritesLatestPrunedSnapshot() async throws {
+        let base = try makeDirectory("Pruning")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let now = Date()
+        let firstFile = try makeFile(
+            named: "a.jsonl", contents: "1", in: base, mtime: now.addingTimeInterval(-10)
+        )
+        let secondFile = try makeFile(named: "b.jsonl", contents: "2", in: base, mtime: now)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test", schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"), writeDebounce: .milliseconds(1)
+        )
+        let scanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let parser = ParseCounter()
+
+        _ = await scanner.items(
+            from: [firstFile, secondFile], since: .distantPast, cacheIdentity: "home", parse: parser.parse
+        )
+        _ = await scanner.items(
+            from: [secondFile], since: now.addingTimeInterval(-1), cacheIdentity: "home", parse: parser.parse
+        )
+        await scanner.waitForPendingWritesForTesting()
+
+        let relaunchedParser = ParseCounter()
+        let relaunched = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let relaunchedItems = await relaunched.items(
+            from: [firstFile, secondFile],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: relaunchedParser.parse
+        )
+        XCTAssertEqual(relaunchedItems, [1, 2])
+        XCTAssertEqual(relaunchedParser.count, 1, "the pruned file should reparse while the retained file stays cached")
+        await relaunched.waitForPendingWritesForTesting()
+    }
+
+    func testChangingOneFileRewritesOnlyItsPersistedRecord() async throws {
+        let base = try makeDirectory("IncrementalWrites")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let now = Date()
+        let firstFile = try makeFile(named: "a.jsonl", contents: "1", in: base, mtime: now)
+        let secondFile = try makeFile(named: "b.jsonl", contents: "2", in: base, mtime: now)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test", schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"), writeDebounce: .milliseconds(1)
+        )
+        let scanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        _ = await scanner.items(
+            from: [firstFile, secondFile], since: .distantPast, cacheIdentity: "home", parse: ParseCounter().parse
+        )
+        await scanner.waitForPendingWritesForTesting()
+
+        let firstRecordValue = await scanner.cacheRecordURLForTesting(identity: "home", filePath: firstFile.path)
+        let secondRecordValue = await scanner.cacheRecordURLForTesting(identity: "home", filePath: secondFile.path)
+        let firstRecord = try XCTUnwrap(firstRecordValue)
+        let secondRecord = try XCTUnwrap(secondRecordValue)
+        let sentinel = Date(timeIntervalSince1970: 1_000_000)
+        try FileManager.default.setAttributes([.modificationDate: sentinel], ofItemAtPath: firstRecord.path)
+        try FileManager.default.setAttributes([.modificationDate: sentinel], ofItemAtPath: secondRecord.path)
+
+        let changedURL = URL(fileURLWithPath: firstFile.path)
+        try Data("11".utf8).write(to: changedURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(1)],
+            ofItemAtPath: firstFile.path
+        )
+        let changedMtime = try XCTUnwrap(
+            changedURL.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+        )
+        let changed = JSONLScanning.DiscoveredFile(
+            path: firstFile.path, size: 2, mtime: changedMtime
+        )
+        _ = await scanner.items(
+            from: [changed, secondFile], since: .distantPast, cacheIdentity: "home", parse: ParseCounter().parse
+        )
+        await scanner.waitForPendingWritesForTesting()
+
+        let firstMtime = try modificationDate(of: firstRecord)
+        let secondMtime = try modificationDate(of: secondRecord)
+        XCTAssertGreaterThan(firstMtime, sentinel)
+        XCTAssertEqual(secondMtime, sentinel, "an unchanged source record must not be rewritten")
+    }
+
+    func testDisjointScansSharingIdentityKeepEachOthersParsedFiles() async throws {
+        let base = try makeDirectory("SharedSubsets")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let now = Date()
+        let firstFile = try makeFile(named: "a.jsonl", contents: "1", in: base, mtime: now)
+        let secondFile = try makeFile(named: "b.jsonl", contents: "2", in: base, mtime: now)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test", schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"), writeDebounce: .milliseconds(1)
+        )
+        let parser = ParseCounter()
+        let scanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+
+        let firstItems = await scanner.items(
+            from: [firstFile], since: .distantPast, cacheIdentity: "home", parse: parser.parse
+        )
+        let secondItems = await scanner.items(
+            from: [secondFile], since: .distantPast, cacheIdentity: "home", parse: parser.parse
+        )
+        let firstItemsAgain = await scanner.items(
+            from: [firstFile], since: .distantPast, cacheIdentity: "home", parse: parser.parse
+        )
+        XCTAssertEqual(firstItems, [1])
+        XCTAssertEqual(secondItems, [2])
+        XCTAssertEqual(firstItemsAgain, [1])
+        XCTAssertEqual(parser.count, 2)
+        await scanner.waitForPendingWritesForTesting()
+
+        let relaunchedParser = ParseCounter()
+        let relaunched = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let allItems = await relaunched.items(
+            from: [firstFile, secondFile],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: relaunchedParser.parse
+        )
+        XCTAssertEqual(allItems, [1, 2])
+        XCTAssertEqual(relaunchedParser.count, 0)
+    }
+
+    func testStaleIdentityDirectoryIsPruned() async throws {
+        let base = try makeDirectory("IdentityPruning")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test", schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"), writeDebounce: .milliseconds(1)
+        )
+        let file = try makeFile(named: "usage.jsonl", contents: "7", in: base, mtime: Date())
+        let scanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        _ = await scanner.items(from: [file], since: .distantPast, cacheIdentity: "old-home", parse: ParseCounter().parse)
+        await scanner.waitForPendingWritesForTesting()
+
+        let identityDirectory = JSONLScanCachePaths.identityDirectory(
+            persistence: persistence,
+            identity: "old-home"
+        )
+        let old = Date().addingTimeInterval(-JSONLScanCachePaths.staleIdentityRetention - 60)
+        try FileManager.default.setAttributes([.modificationDate: old], ofItemAtPath: identityDirectory.path)
+        await JSONLScanCacheWriter.shared.pruneStaleIdentities(
+            persistence: persistence,
+            before: Date().addingTimeInterval(-JSONLScanCachePaths.staleIdentityRetention)
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: identityDirectory.path))
+    }
+
+    func testConcurrentScansOfSameIdentityParseEachFileOnce() async throws {
+        let base = try makeDirectory("SharedScanner")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let file = try makeFile(named: "usage.jsonl", contents: "7", in: base, mtime: Date())
+        let parser = ParseCounter(delay: 0.03)
+        let scanner = IncrementalJSONLScanner<Int>()
+
+        async let first = scanner.items(
+            from: [file], since: .distantPast, cacheIdentity: "shared-home", parse: parser.parse
+        )
+        async let second = scanner.items(
+            from: [file], since: .distantPast, cacheIdentity: "shared-home", parse: parser.parse
+        )
+
+        let results = await [first, second]
+        XCTAssertEqual(results, [[7], [7]])
+        XCTAssertEqual(parser.count, 1)
+    }
+
+    func testCancelledQueuedScanNeverInvokesItsParser() async throws {
+        let base = try makeDirectory("CancelledQueue")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let file = try makeFile(named: "usage.jsonl", contents: "7", in: base, mtime: Date())
+        let scanner = IncrementalJSONLScanner<Int>()
+        let blockingParser = BlockingParser()
+        let firstTask = Task {
+            await scanner.items(
+                from: [file], since: .distantPast, cacheIdentity: "shared-home", parse: blockingParser.parse
+            )
+        }
+        let startDeadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while !blockingParser.hasStarted, ContinuousClock.now < startDeadline {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        guard blockingParser.hasStarted else {
+            blockingParser.unblock()
+            firstTask.cancel()
+            _ = await firstTask.value
+            XCTFail("the first parser did not start before the timeout")
+            return
+        }
+
+        let queuedParser = ParseCounter()
+        let queuedTask = Task {
+            await scanner.items(
+                from: [file], since: .distantPast, cacheIdentity: "shared-home", parse: queuedParser.parse
+            )
+        }
+        let queueDeadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while await scanner.queuedScanCountForTesting(identity: "shared-home") == 0,
+              ContinuousClock.now < queueDeadline
+        {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        let queuedCount = await scanner.queuedScanCountForTesting(identity: "shared-home")
+        guard queuedCount > 0 else {
+            queuedTask.cancel()
+            blockingParser.unblock()
+            _ = await firstTask.value
+            _ = await queuedTask.value
+            XCTFail("the second scan did not queue before the timeout")
+            return
+        }
+        queuedTask.cancel()
+        blockingParser.unblock()
+
+        let firstResult = await firstTask.value
+        let queuedResult = await queuedTask.value
+        XCTAssertEqual(firstResult, [7])
+        XCTAssertEqual(queuedResult, [])
+        XCTAssertEqual(queuedParser.count, 0)
+    }
+
     func testLimitsConcurrentParsesAndKeepsFileOrder() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("OpenUsageScannerTests-\(UUID().uuidString)", isDirectory: true)
@@ -127,42 +463,31 @@ final class IncrementalJSONLScannerTests: XCTestCase {
 
         XCTAssertEqual(warnings.counts, [])
     }
-}
 
-private final class ConcurrencyProbe: @unchecked Sendable {
-    private let lock = NSLock()
-    private var active = 0
-    private var maximum = 0
-
-    var maximumActive: Int {
-        lock.withLock { maximum }
+    private func makeDirectory(_ suffix: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageScanner\(suffix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
     }
 
-    func begin() {
-        lock.withLock {
-            active += 1
-            maximum = max(maximum, active)
-        }
+    private func makeFile(named name: String, contents: String, in directory: URL, mtime: Date) throws
+        -> JSONLScanning.DiscoveredFile
+    {
+        let url = directory.appendingPathComponent(name)
+        let data = Data(contents.utf8)
+        try data.write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: mtime], ofItemAtPath: url.path)
+        let values = try url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
+        return JSONLScanning.DiscoveredFile(
+            path: url.path,
+            size: try XCTUnwrap(values.fileSize),
+            mtime: try XCTUnwrap(values.contentModificationDate)
+        )
     }
 
-    func end() {
-        lock.withLock {
-            active -= 1
-        }
-    }
-}
-
-private final class WarningRecorder: @unchecked Sendable {
-    private let lock = NSLock()
-    private var recordedCounts: [Int] = []
-
-    var counts: [Int] {
-        lock.withLock { recordedCounts }
-    }
-
-    func record(_ count: Int) {
-        lock.withLock {
-            recordedCounts.append(count)
-        }
+    private func modificationDate(of url: URL) throws -> Date {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return try XCTUnwrap(attributes[.modificationDate] as? Date)
     }
 }

--- a/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
+++ b/Tests/OpenUsageTests/IncrementalJSONLScannerTests.swift
@@ -285,60 +285,6 @@ final class IncrementalJSONLScannerTests: XCTestCase {
         XCTAssertEqual(parser.count, 1)
     }
 
-    func testCancelledQueuedScanNeverInvokesItsParser() async throws {
-        let base = try makeDirectory("CancelledQueue")
-        defer { try? FileManager.default.removeItem(at: base) }
-        let file = try makeFile(named: "usage.jsonl", contents: "7", in: base, mtime: Date())
-        let scanner = IncrementalJSONLScanner<Int>()
-        let blockingParser = BlockingParser()
-        let firstTask = Task {
-            await scanner.items(
-                from: [file], since: .distantPast, cacheIdentity: "shared-home", parse: blockingParser.parse
-            )
-        }
-        let startDeadline = ContinuousClock.now.advanced(by: .seconds(2))
-        while !blockingParser.hasStarted, ContinuousClock.now < startDeadline {
-            try? await Task.sleep(for: .milliseconds(1))
-        }
-        guard blockingParser.hasStarted else {
-            blockingParser.unblock()
-            firstTask.cancel()
-            _ = await firstTask.value
-            XCTFail("the first parser did not start before the timeout")
-            return
-        }
-
-        let queuedParser = ParseCounter()
-        let queuedTask = Task {
-            await scanner.items(
-                from: [file], since: .distantPast, cacheIdentity: "shared-home", parse: queuedParser.parse
-            )
-        }
-        let queueDeadline = ContinuousClock.now.advanced(by: .seconds(2))
-        while await scanner.queuedScanCountForTesting(identity: "shared-home") == 0,
-              ContinuousClock.now < queueDeadline
-        {
-            try? await Task.sleep(for: .milliseconds(1))
-        }
-        let queuedCount = await scanner.queuedScanCountForTesting(identity: "shared-home")
-        guard queuedCount > 0 else {
-            queuedTask.cancel()
-            blockingParser.unblock()
-            _ = await firstTask.value
-            _ = await queuedTask.value
-            XCTFail("the second scan did not queue before the timeout")
-            return
-        }
-        queuedTask.cancel()
-        blockingParser.unblock()
-
-        let firstResult = await firstTask.value
-        let queuedResult = await queuedTask.value
-        XCTAssertEqual(firstResult, [7])
-        XCTAssertEqual(queuedResult, [])
-        XCTAssertEqual(queuedParser.count, 0)
-    }
-
     func testLimitsConcurrentParsesAndKeepsFileOrder() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("OpenUsageScannerTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/OpenUsageTests/JSONLScanCacheStoreTests.swift
+++ b/Tests/OpenUsageTests/JSONLScanCacheStoreTests.swift
@@ -276,6 +276,49 @@ final class JSONLScanCacheStoreTests: XCTestCase {
         XCTAssertEqual(reloadCounter.count, 0)
     }
 
+    func testFlushRetriesDirtyWriteAfterDebouncedFailure() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCacheFlushRetryTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let file = try writeSource(
+            "7",
+            to: base.appendingPathComponent("usage.jsonl"),
+            mtime: Date()
+        )
+        let cacheDirectory = base.appendingPathComponent("cache")
+        try Data("blocks-directory-creation".utf8).write(to: cacheDirectory)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: cacheDirectory,
+            writeDebounce: .milliseconds(1)
+        )
+        let scanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        _ = await scanner.items(
+            from: [file],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: ParseCounter().parse
+        )
+        await scanner.waitForPendingWritesForTesting()
+
+        // The failed debounce has no live task handle now, but its dirty source must still be drained.
+        try FileManager.default.removeItem(at: cacheDirectory)
+        await scanner.flushPendingWrites()
+
+        let reloadCounter = ParseCounter()
+        let reloaded = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let items = await reloaded.items(
+            from: [file],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: reloadCounter.parse
+        )
+        XCTAssertEqual(items, [7])
+        XCTAssertEqual(reloadCounter.count, 0)
+    }
+
     func testParseLimitIsSharedAcrossDifferentIdentities() async throws {
         let base = FileManager.default.temporaryDirectory
             .appendingPathComponent("OpenUsageCachePermitTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/OpenUsageTests/JSONLScanCacheStoreTests.swift
+++ b/Tests/OpenUsageTests/JSONLScanCacheStoreTests.swift
@@ -1,0 +1,434 @@
+import Foundation
+import XCTest
+@testable import OpenUsage
+
+final class JSONLScanCacheStoreTests: XCTestCase {
+    func testWriterMergesDisjointPathUpdatesFromSeparateSnapshots() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCacheWriterTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: base.appendingPathComponent("cache")
+        )
+        let identity = "home"
+        let first = try writeSource(
+            "first",
+            to: base.appendingPathComponent("first.jsonl"),
+            mtime: Date(timeIntervalSince1970: 2_000)
+        )
+        let second = try writeSource(
+            "second",
+            to: base.appendingPathComponent("second.jsonl"),
+            mtime: Date(timeIntervalSince1970: 3_000)
+        )
+        let firstBatch = makeBatch(
+            persistence: persistence,
+            identity: identity,
+            file: first,
+            recordData: Data("first-record".utf8)
+        )
+        let secondBatch = makeBatch(
+            persistence: persistence,
+            identity: identity,
+            file: second,
+            recordData: Data("second-record".utf8)
+        )
+        let firstWriter = JSONLScanCacheWriter()
+        let secondWriter = JSONLScanCacheWriter()
+
+        async let firstCommit = firstWriter.commit(firstBatch)
+        async let secondCommit = secondWriter.commit(secondBatch)
+        _ = try await (firstCommit, secondCommit)
+        let loaded = try firstWriter.load(
+            persistence: persistence,
+            identity: identity,
+            itemType: Int.self
+        )
+        let snapshot = try XCTUnwrap(loaded)
+
+        XCTAssertEqual(Set(snapshot.manifest.files.keys), Set([first.path, second.path]))
+        let firstRecordURL = JSONLScanCachePaths.recordURL(
+            persistence: persistence,
+            identity: identity,
+            fileName: JSONLScanCachePaths.recordFileName(path: first.path)
+        )
+        let secondRecordURL = JSONLScanCachePaths.recordURL(
+            persistence: persistence,
+            identity: identity,
+            fileName: JSONLScanCachePaths.recordFileName(path: second.path)
+        )
+        XCTAssertEqual(try Data(contentsOf: firstRecordURL), Data("first-record".utf8))
+        XCTAssertEqual(try Data(contentsOf: secondRecordURL), Data("second-record".utf8))
+    }
+
+    func testWriterRejectsAStaleUpsertAfterTheSourceChanges() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCacheStaleSourceTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: base.appendingPathComponent("cache")
+        )
+        let sourceURL = base.appendingPathComponent("usage.jsonl")
+        let stale = try writeSource("old", to: sourceURL, mtime: Date(timeIntervalSince1970: 2_000))
+        let staleBatch = makeBatch(
+            persistence: persistence,
+            identity: "home",
+            file: stale,
+            recordData: Data("stale-record".utf8)
+        )
+        _ = try writeSource("newer", to: sourceURL, mtime: Date(timeIntervalSince1970: 3_000))
+
+        let result = try await JSONLScanCacheWriter().commit(staleBatch)
+
+        XCTAssertTrue(result.manifest.files.isEmpty)
+        XCTAssertTrue(result.acceptedUpsertPaths.isEmpty)
+    }
+
+    func testStaleRemovalDoesNotDeleteANewerPathUpdate() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCacheRemovalMergeTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: base.appendingPathComponent("cache")
+        )
+        let sourceURL = base.appendingPathComponent("usage.jsonl")
+        let oldFile = try writeSource("old", to: sourceURL, mtime: Date(timeIntervalSince1970: 2_000))
+        let oldBatch = makeBatch(
+            persistence: persistence,
+            identity: "home",
+            file: oldFile,
+            recordData: Data("old-record".utf8)
+        )
+        let writer = JSONLScanCacheWriter()
+        let oldResult = try await writer.commit(oldBatch)
+        let oldMetadata = try XCTUnwrap(oldResult.manifest.files[oldFile.path])
+
+        let newFile = try writeSource("newer", to: sourceURL, mtime: Date(timeIntervalSince1970: 3_000))
+        let newResult = try await writer.commit(makeBatch(
+            persistence: persistence,
+            identity: "home",
+            file: newFile,
+            recordData: Data("new-record".utf8)
+        ))
+        let newMetadata = try XCTUnwrap(newResult.manifest.files[newFile.path])
+        let staleRemoval = JSONLScanCacheWriteBatch(
+            persistence: persistence,
+            identity: "home",
+            upserts: [:],
+            removals: [oldFile.path: oldMetadata]
+        )
+
+        let result = try await writer.commit(staleRemoval)
+
+        XCTAssertEqual(result.manifest.files[newFile.path], newMetadata)
+        let recordURL = JSONLScanCachePaths.recordURL(
+            persistence: persistence,
+            identity: "home",
+            fileName: newMetadata.recordFileName
+        )
+        XCTAssertEqual(try Data(contentsOf: recordURL), Data("new-record".utf8))
+    }
+
+    func testLoadingAnOldIdentityTouchesItBeforeStalePruning() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCacheLoadTouchTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: base.appendingPathComponent("cache")
+        )
+        let file = try writeSource(
+            "value",
+            to: base.appendingPathComponent("usage.jsonl"),
+            mtime: Date()
+        )
+        let writer = JSONLScanCacheWriter()
+        _ = try await writer.commit(makeBatch(
+            persistence: persistence,
+            identity: "home",
+            file: file,
+            recordData: Data("record".utf8)
+        ))
+        let identityDirectory = JSONLScanCachePaths.identityDirectory(
+            persistence: persistence,
+            identity: "home"
+        )
+        let old = Date().addingTimeInterval(-JSONLScanCachePaths.staleIdentityRetention - 60)
+        try FileManager.default.setAttributes([.modificationDate: old], ofItemAtPath: identityDirectory.path)
+
+        _ = try writer.load(
+            persistence: persistence,
+            identity: "home",
+            itemType: Int.self
+        )
+        await writer.pruneStaleIdentities(
+            persistence: persistence,
+            before: Date().addingTimeInterval(-JSONLScanCachePaths.staleIdentityRetention)
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: identityDirectory.path))
+    }
+
+    func testFreshScannerCanPersistAfterAnotherScannerHasWrittenRepeatedly() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCacheGenerationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let sourceURL = base.appendingPathComponent("usage.jsonl")
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"),
+            writeDebounce: .milliseconds(1)
+        )
+        let firstScanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let baseDate = Date(timeIntervalSince1970: 10_000)
+
+        for (index, contents) in ["1", "22", "333"].enumerated() {
+            let file = try writeSource(
+                contents,
+                to: sourceURL,
+                mtime: baseDate.addingTimeInterval(Double(index))
+            )
+            let scanned = await firstScanner.items(
+                from: [file],
+                since: .distantPast,
+                cacheIdentity: "home",
+                parse: ParseCounter().parse
+            )
+            XCTAssertEqual(scanned, [try XCTUnwrap(Int(contents))])
+            await firstScanner.waitForPendingWritesForTesting()
+        }
+
+        let finalFile = try writeSource(
+            "4444",
+            to: sourceURL,
+            mtime: baseDate.addingTimeInterval(3)
+        )
+        let freshScanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let finalItems = await freshScanner.items(
+            from: [finalFile],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: ParseCounter().parse
+        )
+        XCTAssertEqual(finalItems, [4444])
+        await freshScanner.waitForPendingWritesForTesting()
+
+        let reloadCounter = ParseCounter()
+        let reloaded = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let items = await reloaded.items(
+            from: [finalFile],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: reloadCounter.parse
+        )
+        XCTAssertEqual(items, [4444])
+        XCTAssertEqual(reloadCounter.count, 0)
+    }
+
+    func testFlushPendingWritesBypassesTheDebounceForOneShotProcesses() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCacheFlushTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let file = try writeSource(
+            "7",
+            to: base.appendingPathComponent("usage.jsonl"),
+            mtime: Date()
+        )
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"),
+            writeDebounce: .seconds(60)
+        )
+        let scanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        _ = await scanner.items(
+            from: [file],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: ParseCounter().parse
+        )
+
+        await scanner.flushPendingWrites()
+
+        let reloadCounter = ParseCounter()
+        let reloaded = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let items = await reloaded.items(
+            from: [file],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: reloadCounter.parse
+        )
+        XCTAssertEqual(items, [7])
+        XCTAssertEqual(reloadCounter.count, 0)
+    }
+
+    func testParseLimitIsSharedAcrossDifferentIdentities() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCachePermitTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let now = Date()
+        let firstFiles = try makeIntegerFiles(range: 0..<8, prefix: "a", in: base, mtime: now)
+        let secondFiles = try makeIntegerFiles(range: 8..<16, prefix: "b", in: base, mtime: now)
+        let scanner = IncrementalJSONLScanner<Int>(maxConcurrentParses: 3)
+        let probe = ConcurrencyProbe()
+        let parse: @Sendable (Data) -> [Int]? = { data in
+            probe.begin()
+            defer { probe.end() }
+            Thread.sleep(forTimeInterval: 0.01)
+            return String(data: data, encoding: .utf8).flatMap(Int.init).map { [$0] }
+        }
+
+        async let first = scanner.items(
+            from: firstFiles,
+            since: .distantPast,
+            cacheIdentity: "home-a",
+            parse: parse
+        )
+        async let second = scanner.items(
+            from: secondFiles,
+            since: .distantPast,
+            cacheIdentity: "home-b",
+            parse: parse
+        )
+        let results = await (first, second)
+
+        XCTAssertEqual(results.0, Array(0..<8))
+        XCTAssertEqual(results.1, Array(8..<16))
+        XCTAssertLessThanOrEqual(probe.maximumActive, 3)
+    }
+
+    func testStaleLocalEvictionCannotRemoveANewerExternalRecord() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageCacheExternalUpdateTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"),
+            writeDebounce: .milliseconds(1)
+        )
+        let identity = "home"
+        let baseDate = Date(timeIntervalSince1970: 10_000)
+        let primaryURL = base.appendingPathComponent("primary.jsonl")
+        let originalPrimary = try writeSource("1", to: primaryURL, mtime: baseDate)
+        let firstScanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        _ = await firstScanner.items(
+            from: [originalPrimary],
+            since: .distantPast,
+            cacheIdentity: identity,
+            parse: ParseCounter().parse
+        )
+        await firstScanner.waitForPendingWritesForTesting()
+
+        let updatedPrimary = try writeSource(
+            "2",
+            to: primaryURL,
+            mtime: baseDate.addingTimeInterval(10)
+        )
+        let externalScanner = IncrementalJSONLScanner<Int>(persistence: persistence)
+        _ = await externalScanner.items(
+            from: [updatedPrimary],
+            since: .distantPast,
+            cacheIdentity: identity,
+            parse: ParseCounter().parse
+        )
+        await externalScanner.waitForPendingWritesForTesting()
+
+        let secondary = try writeSource(
+            "20",
+            to: base.appendingPathComponent("secondary.jsonl"),
+            mtime: baseDate.addingTimeInterval(20)
+        )
+        _ = await firstScanner.items(
+            from: [secondary],
+            since: .distantPast,
+            cacheIdentity: identity,
+            parse: ParseCounter().parse
+        )
+        await firstScanner.waitForPendingWritesForTesting()
+        _ = await firstScanner.items(
+            from: [secondary],
+            since: baseDate.addingTimeInterval(5),
+            cacheIdentity: identity,
+            parse: ParseCounter().parse
+        )
+        await firstScanner.waitForPendingWritesForTesting()
+
+        let reloadCounter = ParseCounter()
+        let reloaded = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let items = await reloaded.items(
+            from: [updatedPrimary, secondary],
+            since: .distantPast,
+            cacheIdentity: identity,
+            parse: reloadCounter.parse
+        )
+        XCTAssertEqual(items, [2, 20])
+        XCTAssertEqual(reloadCounter.count, 0)
+    }
+
+    private func makeBatch(
+        persistence: JSONLScanCachePersistence,
+        identity: String,
+        file: JSONLScanning.DiscoveredFile,
+        recordData: Data
+    ) -> JSONLScanCacheWriteBatch {
+        let metadata = JSONLScanCacheFileMetadata(
+            size: file.size,
+            mtime: file.mtime,
+            recordFileName: JSONLScanCachePaths.recordFileName(path: file.path)
+        )
+        return JSONLScanCacheWriteBatch(
+            persistence: persistence,
+            identity: identity,
+            upserts: [file.path: JSONLScanCacheUpsert(metadata: metadata, recordData: recordData)],
+            removals: [:]
+        )
+    }
+
+    private func writeSource(
+        _ contents: String,
+        to url: URL,
+        mtime: Date
+    ) throws -> JSONLScanning.DiscoveredFile {
+        let data = Data(contents.utf8)
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.modificationDate: mtime], ofItemAtPath: url.path)
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return JSONLScanning.DiscoveredFile(
+            path: url.path,
+            size: try XCTUnwrap(attributes[.size] as? NSNumber).intValue,
+            mtime: try XCTUnwrap(attributes[.modificationDate] as? Date)
+        )
+    }
+
+    private func makeIntegerFiles(
+        range: Range<Int>,
+        prefix: String,
+        in directory: URL,
+        mtime: Date
+    ) throws -> [JSONLScanning.DiscoveredFile] {
+        try range.map { value in
+            try writeSource(
+                String(value),
+                to: directory.appendingPathComponent("\(prefix)-\(value).jsonl"),
+                mtime: mtime
+            )
+        }
+    }
+}

--- a/Tests/OpenUsageTests/JSONLScannerCancellationTests.swift
+++ b/Tests/OpenUsageTests/JSONLScannerCancellationTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import XCTest
+@testable import OpenUsage
+
+final class JSONLScannerCancellationTests: XCTestCase {
+    func testCancelledQueuedScanReturnsNilAndNeverInvokesItsParser() async throws {
+        let base = try makeDirectory("Queue")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let file = try makeIntegerFile(in: base)
+        let scanner = IncrementalJSONLScanner<Int>()
+        let blockingParser = BlockingParser()
+        let firstTask = Task {
+            await scanner.items(
+                from: [file], since: .distantPast, cacheIdentity: "shared-home", parse: blockingParser.parse
+            )
+        }
+        guard await waitUntil({ blockingParser.hasStarted }) else {
+            blockingParser.unblock()
+            firstTask.cancel()
+            _ = await firstTask.value
+            return XCTFail("the first parser did not start before the timeout")
+        }
+
+        let queuedParser = ParseCounter()
+        let queuedTask = Task {
+            await scanner.items(
+                from: [file], since: .distantPast, cacheIdentity: "shared-home", parse: queuedParser.parse
+            )
+        }
+        guard await waitUntil({ await scanner.queuedScanCountForTesting(identity: "shared-home") > 0 }) else {
+            queuedTask.cancel()
+            blockingParser.unblock()
+            _ = await firstTask.value
+            _ = await queuedTask.value
+            return XCTFail("the second scan did not queue before the timeout")
+        }
+        queuedTask.cancel()
+        blockingParser.unblock()
+
+        let firstResult = await firstTask.value
+        let queuedResult = await queuedTask.value
+        XCTAssertEqual(firstResult, [7])
+        XCTAssertNil(queuedResult)
+        XCTAssertEqual(queuedParser.count, 0)
+    }
+
+    func testCancelledClaudeScanIsNotAnAuthoritativeEmptyHistory() async throws {
+        let now = Date()
+        let home = try ClaudeLogFixture.makeHome(files: [
+            "project/session.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: OpenUsageISO8601.string(from: now),
+                input: 10,
+                output: 5,
+                costUSD: 0.25
+            )
+        ])
+        defer { try? FileManager.default.removeItem(at: home) }
+        let file = try XCTUnwrap(JSONLScanning.jsonlFiles(under: home.appendingPathComponent("projects")).first)
+        let incremental = IncrementalJSONLScanner<ClaudeLogUsageScanner.Entry>()
+        let blockingParser = BlockingClaudeParser()
+        let firstTask = Task {
+            await incremental.items(
+                from: [file],
+                since: .distantPast,
+                cacheIdentity: "shared-home",
+                parse: blockingParser.parse
+            )
+        }
+        guard await waitUntil({ blockingParser.hasStarted }) else {
+            blockingParser.unblock()
+            firstTask.cancel()
+            _ = await firstTask.value
+            return XCTFail("the first parser did not start before the timeout")
+        }
+
+        let scanner = ClaudeLogUsageScanner(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": home.path]),
+            homeDirectory: { home },
+            incrementalScanner: incremental,
+            cacheIdentityOverride: "shared-home"
+        )
+        let cancelledTask = Task {
+            await scanner.scan(now: now, pricing: TestPricing.bundled)
+        }
+        guard await waitUntil({ await incremental.queuedScanCountForTesting(identity: "shared-home") > 0 }) else {
+            cancelledTask.cancel()
+            blockingParser.unblock()
+            _ = await firstTask.value
+            _ = await cancelledTask.value
+            return XCTFail("the Claude scan did not queue before the timeout")
+        }
+        cancelledTask.cancel()
+        blockingParser.unblock()
+
+        _ = await firstTask.value
+        let cancelledResult = await cancelledTask.value
+        XCTAssertNil(cancelledResult)
+    }
+
+    func testCancellationDuringParseReturnsNilWithoutPersistingPartialCache() async throws {
+        let base = try makeDirectory("ActiveParse")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let first = try makeIntegerFile(named: "first.jsonl", value: 1, in: base)
+        let second = try makeIntegerFile(named: "second.jsonl", value: 2, in: base)
+        let persistence = JSONLScanCachePersistence(
+            namespace: "test",
+            schemaVersion: 1,
+            directory: base.appendingPathComponent("cache"),
+            writeDebounce: .milliseconds(1)
+        )
+        let scanner = IncrementalJSONLScanner<Int>(maxConcurrentParses: 1, persistence: persistence)
+        let blockingParser = BlockingParser()
+        let task = Task {
+            await scanner.items(
+                from: [first, second],
+                since: .distantPast,
+                cacheIdentity: "home",
+                parse: blockingParser.parse
+            )
+        }
+        guard await waitUntil({ blockingParser.hasStarted }) else {
+            blockingParser.unblock()
+            task.cancel()
+            _ = await task.value
+            return XCTFail("the parser did not start before the timeout")
+        }
+        task.cancel()
+        blockingParser.unblock()
+
+        let cancelledResult = await task.value
+        XCTAssertNil(cancelledResult)
+        await scanner.waitForPendingWritesForTesting()
+
+        let reloadCounter = ParseCounter()
+        let reloaded = IncrementalJSONLScanner<Int>(persistence: persistence)
+        let reloadedItems = await reloaded.items(
+            from: [first, second],
+            since: .distantPast,
+            cacheIdentity: "home",
+            parse: reloadCounter.parse
+        )
+        XCTAssertEqual(reloadedItems, [1, 2])
+        XCTAssertEqual(reloadCounter.count, 2)
+    }
+
+    private func waitUntil(
+        _ condition: @escaping @Sendable () async -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while ContinuousClock.now < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return await condition()
+    }
+
+    private func makeDirectory(_ suffix: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenUsageScannerCancellation\(suffix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func makeIntegerFile(
+        named name: String = "usage.jsonl",
+        value: Int = 7,
+        in directory: URL
+    ) throws -> JSONLScanning.DiscoveredFile {
+        let url = directory.appendingPathComponent(name)
+        try Data(String(value).utf8).write(to: url)
+        let values = try url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
+        return JSONLScanning.DiscoveredFile(
+            path: url.path,
+            size: try XCTUnwrap(values.fileSize),
+            mtime: try XCTUnwrap(values.contentModificationDate)
+        )
+    }
+}
+
+private final class BlockingClaudeParser: @unchecked Sendable {
+    private let lock = NSLock()
+    private var started = false
+    private let release = DispatchSemaphore(value: 0)
+
+    var hasStarted: Bool {
+        lock.withLock { started }
+    }
+
+    func parse(_ data: Data) -> [ClaudeLogUsageScanner.Entry]? {
+        lock.withLock { started = true }
+        release.wait()
+        return ClaudeLogUsageScanner.parseFile(data)
+    }
+
+    func unblock() {
+        release.signal()
+    }
+}

--- a/Tests/OpenUsageTests/JSONLScannerTestSupport.swift
+++ b/Tests/OpenUsageTests/JSONLScannerTestSupport.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+final class ConcurrencyProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var active = 0
+    private var maximum = 0
+
+    var maximumActive: Int {
+        lock.withLock { maximum }
+    }
+
+    func begin() {
+        lock.withLock {
+            active += 1
+            maximum = max(maximum, active)
+        }
+    }
+
+    func end() {
+        lock.withLock {
+            active -= 1
+        }
+    }
+}
+
+final class WarningRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedCounts: [Int] = []
+
+    var counts: [Int] {
+        lock.withLock { recordedCounts }
+    }
+
+    func record(_ count: Int) {
+        lock.withLock {
+            recordedCounts.append(count)
+        }
+    }
+}
+
+final class ParseCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let delay: TimeInterval
+    private var recordedCount = 0
+
+    init(delay: TimeInterval = 0) {
+        self.delay = delay
+    }
+
+    var count: Int {
+        lock.withLock { recordedCount }
+    }
+
+    func parse(_ data: Data) -> [Int]? {
+        lock.withLock { recordedCount += 1 }
+        if delay > 0 { Thread.sleep(forTimeInterval: delay) }
+        return String(data: data, encoding: .utf8).flatMap(Int.init).map { [$0] }
+    }
+}
+
+final class BlockingParser: @unchecked Sendable {
+    private let lock = NSLock()
+    private var started = false
+    private let release = DispatchSemaphore(value: 0)
+
+    var hasStarted: Bool {
+        lock.withLock { started }
+    }
+
+    func parse(_ data: Data) -> [Int]? {
+        lock.withLock { started = true }
+        release.wait()
+        return String(data: data, encoding: .utf8).flatMap(Int.init).map { [$0] }
+    }
+
+    func unblock() {
+        release.signal()
+    }
+}

--- a/Tests/OpenUsageTests/StaleWhileRevalidateTests.swift
+++ b/Tests/OpenUsageTests/StaleWhileRevalidateTests.swift
@@ -241,6 +241,114 @@ final class StaleWhileRevalidateTests: XCTestCase {
         XCTAssertEqual(store.errorMessage(for: provider.id), "Not signed in")
     }
 
+    func testCancelledRefreshKeepsLastGoodHistoryAndSkipsPublication() async throws {
+        let provider = Self.testProvider
+        let descriptor = Self.descriptor(provider, id: "test.alpha", metric: "Alpha")
+        let defaults = makeUserDefaults("cancelled-history")
+        let history = ProviderUsageHistory(
+            series: DailyUsageSeries(daily: [
+                DailyUsageEntry(date: "2026-07-17", totalTokens: 400, costUSD: 4)
+            ])
+        )
+        let runtime = BlockingProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                plan: "Last good",
+                lines: [.progress(label: "Alpha", used: 40, limit: 100, format: .percent)],
+                usageHistory: history
+            )
+        )
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots")
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: cache,
+            defaults: defaults
+        )
+        _ = await store.refresh(providerID: provider.id, force: true)
+        var historyChangeCount = 0
+        store.onLocalHistoryChanged = { historyChangeCount += 1 }
+
+        runtime.snapshot = ProviderSnapshot(
+            providerID: provider.id,
+            displayName: provider.displayName,
+            plan: "Partial cancelled result",
+            lines: [.progress(label: "Alpha", used: 0, limit: 100, format: .percent)],
+            usageHistory: ProviderUsageHistory(series: DailyUsageSeries(daily: []))
+        )
+        runtime.blockNextRefresh = true
+        let task = Task {
+            await store.refresh(providerID: provider.id, force: true)
+        }
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while !runtime.isWaiting, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        guard runtime.isWaiting else {
+            runtime.resume()
+            task.cancel()
+            _ = await task.value
+            return XCTFail("the provider refresh did not suspend before the timeout")
+        }
+        task.cancel()
+        runtime.resume()
+
+        let outcome = await task.value
+        guard case .skipped = outcome else {
+            return XCTFail("a canceled provider refresh must be skipped")
+        }
+        let retained = try XCTUnwrap(store.localSnapshots[provider.id])
+        XCTAssertEqual(retained.plan, "Last good")
+        XCTAssertEqual(retained.usageHistory, history)
+        XCTAssertEqual(historyChangeCount, 0)
+        XCTAssertFalse(store.refreshingProviderIDs.contains(provider.id))
+        XCTAssertEqual(cache.loadSnapshots(providerIDs: [provider.id])[provider.id]?.plan, "Last good")
+    }
+
+    func testCompletedEmptyHistoryStillClearsLastGoodHistory() async throws {
+        let provider = Self.testProvider
+        let descriptor = Self.descriptor(provider, id: "test.alpha", metric: "Alpha")
+        let defaults = makeUserDefaults("completed-empty-history")
+        let runtime = MutableProviderRuntime(
+            provider: provider,
+            descriptors: [descriptor],
+            snapshot: ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                plan: "With history",
+                lines: [.progress(label: "Alpha", used: 40, limit: 100, format: .percent)],
+                usageHistory: ProviderUsageHistory(
+                    series: DailyUsageSeries(daily: [
+                        DailyUsageEntry(date: "2026-07-17", totalTokens: 400, costUSD: 4)
+                    ])
+                )
+            )
+        )
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [runtime],
+            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots"),
+            defaults: defaults
+        )
+        _ = await store.refresh(providerID: provider.id, force: true)
+
+        runtime.snapshot = ProviderSnapshot(
+            providerID: provider.id,
+            displayName: provider.displayName,
+            plan: "Completed empty scan",
+            lines: [.progress(label: "Alpha", used: 50, limit: 100, format: .percent)],
+            usageHistory: ProviderUsageHistory(series: DailyUsageSeries(daily: []))
+        )
+        _ = await store.refresh(providerID: provider.id, force: true)
+
+        let refreshed = try XCTUnwrap(store.localSnapshots[provider.id])
+        XCTAssertEqual(refreshed.plan, "Completed empty scan")
+        XCTAssertEqual(refreshed.usageHistory?.series.daily, [])
+    }
+
     // MARK: - Fixtures
 
     private static let testProvider = Provider(
@@ -301,5 +409,36 @@ private final class MutableProviderRuntime: ProviderRuntime {
 
     func refresh() async -> ProviderSnapshot {
         snapshot
+    }
+}
+
+@MainActor
+private final class BlockingProviderRuntime: ProviderRuntime {
+    let provider: Provider
+    let widgetDescriptors: [WidgetDescriptor]
+    var snapshot: ProviderSnapshot
+    var blockNextRefresh = false
+    private(set) var isWaiting = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    init(provider: Provider, descriptors: [WidgetDescriptor], snapshot: ProviderSnapshot) {
+        self.provider = provider
+        self.widgetDescriptors = descriptors
+        self.snapshot = snapshot
+    }
+
+    func refresh() async -> ProviderSnapshot {
+        if blockNextRefresh {
+            blockNextRefresh = false
+            isWaiting = true
+            await withCheckedContinuation { continuation = $0 }
+            isWaiting = false
+        }
+        return snapshot
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/Tests/OpenUsageTests/TestSupport.swift
+++ b/Tests/OpenUsageTests/TestSupport.swift
@@ -72,14 +72,19 @@ enum ClaudeLogFixture {
     static func scanner(home: URL?) -> ClaudeLogUsageScanner {
         ClaudeLogUsageScanner(
             environment: FakeEnvironment(home.map { ["CLAUDE_CONFIG_DIR": $0.path] } ?? [:]),
-            homeDirectory: { FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-claude-home") }
+            homeDirectory: { FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-claude-home") },
+            incrementalScanner: IncrementalJSONLScanner<ClaudeLogUsageScanner.Entry>()
         )
     }
 
     /// A scanner whose *user home* is the fixture from `makeUserHome` — exercises the default
     /// `~/.claude` root plus Cowork session discovery, with no `CLAUDE_CONFIG_DIR` override.
     static func scanner(userHome: URL) -> ClaudeLogUsageScanner {
-        ClaudeLogUsageScanner(environment: FakeEnvironment([:]), homeDirectory: { userHome })
+        ClaudeLogUsageScanner(
+            environment: FakeEnvironment([:]),
+            homeDirectory: { userHome },
+            incrementalScanner: IncrementalJSONLScanner<ClaudeLogUsageScanner.Entry>()
+        )
     }
 
     /// One Claude Code usage line in the modern log shape. Pass `nil` to omit a field.
@@ -137,7 +142,8 @@ enum CodexLogFixture {
     static func scanner(home: URL?) -> CodexLogUsageScanner {
         CodexLogUsageScanner(
             environment: FakeEnvironment(home.map { ["CODEX_HOME": $0.path] } ?? [:]),
-            homeDirectory: { FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-codex-home") }
+            homeDirectory: { FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-codex-home") },
+            incrementalScanner: IncrementalJSONLScanner<CodexLogUsageScanner.Event>()
         )
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,13 @@ Because every provider produces the same normalized `MetricLine` shapes, the UI 
 way and doesn't need to know provider-specific details. To add one, see
 [Adding a provider](adding-a-provider.md).
 
+Claude, Codex, and pi share `IncrementalJSONLScanner` for local JSONL history. Its per-file parsed events
+are cached by path, size, and modification time in a versioned Application Support store, partitioned by
+provider/home identity. Provider instances reading the same home share one scanner actor, which avoids
+duplicate parsing across cards; the disk store provides the reuse across process launches. Scans drop
+source-file records as their modification dates leave the requested history window, while aggregation and
+pricing still run on every refresh from the cached events.
+
 ## Stores
 
 The UI reads from a few observable stores:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -33,6 +33,12 @@ If a local usage log exists but cannot be read, OpenUsage writes one warning and
 refresh. It does not repeat the warning every five minutes; it warns again only if the file recovers
 and later becomes unreadable again.
 
+Any provider refresh that takes 10 seconds or longer writes a Warning-level `[refresh]` line with the
+provider ID, elapsed milliseconds, and threshold. This is visible at the default Info setting, so a
+slow local-log scan or network call can be identified from a normal support log without reproducing it
+with Debug enabled. The warning is diagnostic only: other provider cards still update independently,
+and the slow provider is allowed to finish.
+
 ## Subsystem tags
 
 Every line is prefixed with a bracketed tag so the log is easy to grep:

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -37,6 +37,14 @@ Desktop's rotating refresh token and never modifies Desktop's config, cookies, o
 
 Besides the provider API calls the vendor's own tools would make, OpenUsage fetches public [model price lists](pricing.md) about once an hour (from `raw.githubusercontent.com`, `models.dev`, and this project's GitHub Pages). These are plain downloads of public data — they carry no usage, log, or account information, and they run regardless of the Share Anonymous Usage setting. The spend tiles are computed from local CLI logs entirely on your Mac; no log data ever leaves it.
 
+To avoid re-reading unchanged Claude, Codex, and pi logs after every relaunch, OpenUsage keeps their
+parsed usage events in `~/Library/Application Support/OpenUsage/log-scan-cache/`. These records contain
+the usage metadata needed for local totals, including any per-event cost already recorded by a provider,
+but not raw JSONL lines or conversation text. They are private to your macOS account and are never sent
+to PostHog, a provider, or iCloud. Old source-file records are dropped as the scan window advances, and
+identity caches that have not been used for 35 days are removed. OpenUsage's pricing engine runs after
+the cache is read, so its computed aggregates and totals are not persisted in this cache.
+
 If you explicitly turn on [iCloud Sync](icloud-sync.md), OpenUsage writes normalized daily tokens,
 spend, and model totals to its private iCloud container so your own Macs can show one combined summary.
 Credentials, account limits, provider responses, and raw logs are never written there. This is separate

--- a/docs/refreshing.md
+++ b/docs/refreshing.md
@@ -2,7 +2,7 @@
 
 ## When data updates
 
-- All enabled providers refresh together: once at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Opening the popover does not start a second automatic pass. Providers fetch in parallel — one slow provider doesn't delay the others.
+- All enabled providers refresh together: once at launch, then every 5 minutes (a fixed cadence — there's no setting for it). Opening the popover does not start a second automatic pass. Providers fetch in parallel, so fast cards update without waiting for a slow one. The batch itself still finishes only after every provider returns; notifications, history sync, and the next five-minute wait begin after that point.
 - Turning a provider on (yourself in Customize, or automatically by first-launch/new-provider detection) fetches it promptly instead of waiting out the interval — even when the change lands in the middle of a refresh that's already running.
 - The Dashboard and Settings footer shows `Next update in Nm`. **Clicking it (or pressing ⌘R while that footer is present)** refreshes immediately, skipping the cache.
 - The one-shot `openusage` command reuses this same persisted cache for five minutes, refreshes missing or stale entries without starting the app, and exits. `openusage --force` runs the same forced provider refresh as ⌘R regardless of cache age.
@@ -16,6 +16,14 @@
 Snapshots are cached on disk and load instantly at launch, so you see your last-known values immediately instead of placeholders — even before the first fetch finishes.
 
 A cached value only counts as *fresh* (skip-a-refresh fresh) when it was fetched **during the current running session**. So a value cached in an earlier session always re-fetches on the first pass after launch — you still see it instantly, but the app never waits out the old interval before getting live numbers. This matters after an update: a new app version refreshes right away instead of showing the previous version's data until its interval lapses. Within a session, a freshly fetched value then counts as fresh for one refresh interval before the next pass re-fetches it.
+
+Claude, Codex, and pi spend history has a separate local-log parse cache under
+`~/Library/Application Support/OpenUsage/log-scan-cache/`. It stores parsed usage events before OpenUsage
+applies model-rate estimates, so pricing updates take effect without re-reading unchanged JSONL. On
+relaunch, an entry is reused only when its path, size, modification time, and parser version still match.
+Same-home cards share parsed data, and changing one source file rewrites only that file's record. Old files
+leave the cache as the history window advances, and identities unused for 35 days are removed. App writes
+are debounced until after refresh; the one-shot CLI drains pending writes before it exits.
 
 ## When a fetch fails
 


### PR DESCRIPTION
## TL;DR

Persist parsed Claude, Codex, and Pi log events per source file, so unchanged histories are reused after relaunch instead of being parsed from scratch. Writes remain incremental, and provider refreshes taking 10 seconds or longer now leave a support-visible warning.

Closes #1015

## What was happening

- The local JSONL cache lived only in memory, so every process launch repeated the full scan; a large Codex history could take roughly two minutes cold despite subsequent in-process scans taking seconds.
- Same-home provider instances could duplicate parsing, and normal support logs did not clearly identify which provider held up a refresh.

## What this changes

- Adds a versioned Application Support cache keyed by provider identity, source path, size, modification time, and parser schema; changing one source rewrites only that file's parsed record.
- Shares scanner actors across same-home cards, serializes matching scans, and applies one scanner-wide read limit across distinct identities.
- Merges app and CLI updates safely under a cross-process lock, validates stale writes against the source file, publishes records atomically, and uses private file permissions.
- Debounces app writes off the refresh path while explicitly flushing pending writes before the one-shot CLI exits.
- Prunes files as they leave the history window, removes identities unused for 35 days, and documents the cache lifecycle and privacy properties.
- Logs a warning-level refresh diagnostic when any provider takes at least 10 seconds.

## Heads-up

- The first scan after this ships is still cold because no persisted cache exists yet; later launches reuse it.
- Cached records contain parsed usage metadata, including provider-recorded per-event cost, but never raw JSONL lines, conversation text, or OpenUsage's computed pricing totals.
- Persisted event-shape or parser-semantics changes must bump that provider's cache schema version.

## Tests

- `swift test`: 1,200 app tests passed (3 skipped), plus 4 CLI tests and 3 Swift Testing checks.
- `script/build_and_run.sh verify`: signed release-mode development build rebuilt, launched, and remained running.
- Manual cold/warm relaunch against local usage logs: Codex improved from 3.55s to 1.40s and Claude from 5.58s to 1.25s after the persisted cache was available.
- Focused regressions cover relaunch reuse, stat/schema invalidation, per-file writes, pruning, same-home sharing, cancellation, cross-process merging, stale-write protection, scanner-wide concurrency limits, CLI flushing, and slow-refresh warnings.
