### PR TITLE
Fix Settings transitions and honor Reduce Animations

### DIFF
--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -62,6 +62,9 @@ final class StatusItemController: NSObject {
         let hosting = NSHostingController(
             rootView: AnyView(
                 DashboardView()
+                    // Own the preference outside `DashboardView` so the view can read the resolved
+                    // value while deciding whether to mount its two-page transition structure.
+                    .reduceAnimationsWhenRequested()
                     .environment(container)
                     .environment(container.layout)
                     .environment(container.dataStore)
@@ -215,7 +218,9 @@ final class StatusItemController: NSObject {
             }
         }
         let mode: PopoverBackdropView.Mode = style.surfaceTreatment == .opaque ? .opaque : .translucent
-        if hasAppliedTransparency {
+        let shouldAnimate = hasAppliedTransparency && !ReduceAnimationsSetting.isEnabled
+        hasAppliedTransparency = true
+        if shouldAnimate {
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.55
                 context.allowsImplicitAnimation = true
@@ -223,7 +228,6 @@ final class StatusItemController: NSObject {
                 backdrop.setMode(mode, animated: true)
             }
         } else {
-            hasAppliedTransparency = true
             panel.alphaValue = style.windowAlpha
             backdrop.setMode(mode, animated: false)
         }

--- a/Sources/OpenUsage/Stores/LaunchAtLoginSetting.swift
+++ b/Sources/OpenUsage/Stores/LaunchAtLoginSetting.swift
@@ -9,13 +9,19 @@ final class LaunchAtLoginSetting {
     static let failureMessage = "macOS wouldn't update Launch at Login. Check System Settings → Login Items."
 
     private(set) var isEnabled: Bool
+    private(set) var isLoading = true
     private(set) var errorMessage: String?
 
-    private let currentStatus: () -> Bool
+    private let loadStatus: @Sendable () async -> Bool
     private let setSystemEnabled: (Bool) throws -> Void
 
     init(
-        currentStatus: @escaping () -> Bool = { SMAppService.mainApp.status == .enabled },
+        initialStatus: Bool = false,
+        loadStatus: @escaping @Sendable () async -> Bool = {
+            await Task.detached(priority: .userInitiated) {
+                SMAppService.mainApp.status == .enabled
+            }.value
+        },
         setEnabled: @escaping (Bool) throws -> Void = { enabled in
             if enabled {
                 try SMAppService.mainApp.register()
@@ -24,23 +30,31 @@ final class LaunchAtLoginSetting {
             }
         }
     ) {
-        self.currentStatus = currentStatus
+        self.loadStatus = loadStatus
         self.setSystemEnabled = setEnabled
-        self.isEnabled = currentStatus()
+        self.isEnabled = initialStatus
+    }
+
+    /// `SMAppService.status` is an XPC-backed synchronous call that can take hundreds of milliseconds.
+    /// The loader performs it away from the main actor so opening Settings never waits on that round trip.
+    func refreshStatus() async {
+        isEnabled = await loadStatus()
+        isLoading = false
     }
 
     func update(to enabled: Bool) {
         guard enabled != isEnabled else { return }
+        let previousValue = isEnabled
         do {
             try setSystemEnabled(enabled)
-            isEnabled = currentStatus()
+            isEnabled = enabled
             errorMessage = nil
         } catch {
             AppLog.error(
                 .config,
                 "Launch at Login \(enabled ? "register" : "unregister") failed: \(error.localizedDescription)"
             )
-            isEnabled = currentStatus()
+            isEnabled = previousValue
             errorMessage = Self.failureMessage
         }
     }

--- a/Sources/OpenUsage/Stores/ReduceAnimationsSetting.swift
+++ b/Sources/OpenUsage/Stores/ReduceAnimationsSetting.swift
@@ -1,0 +1,23 @@
+import AppKit
+import Foundation
+
+/// App-specific motion preference. It supplements macOS Reduce Motion so either choice can request
+/// the same reduced-animation behavior throughout the SwiftUI tree and the AppKit panel bridge.
+enum ReduceAnimationsSetting {
+    static let key = "reduceAnimations"
+    static let fallback = false
+
+    static func resolve(appPreference: Bool, systemReduceMotion: Bool) -> Bool {
+        appPreference || systemReduceMotion
+    }
+
+    /// Live value for imperative AppKit animation sites. SwiftUI reads the same two inputs through
+    /// `@AppStorage` and `accessibilityReduceMotion` in `ReduceAnimationsModifier`.
+    @MainActor
+    static var isEnabled: Bool {
+        resolve(
+            appPreference: UserDefaults.standard.bool(forKey: key),
+            systemReduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        )
+    }
+}

--- a/Sources/OpenUsage/Support/Animations.swift
+++ b/Sources/OpenUsage/Support/Animations.swift
@@ -4,9 +4,42 @@ import SwiftUI
 enum Motion {
     static let spring = Animation.spring(response: 0.42, dampingFraction: 0.80)
     static let modeSwitch = Animation.easeInOut(duration: 0.18)
+
+    /// The single transaction policy behind Reduce Animations. `disablesAnimations` prevents inner
+    /// `.animation` modifiers from restoring motion after this root policy clears an explicit animation.
+    static func applyReduction(to transaction: inout Transaction, enabled: Bool) {
+        guard enabled else { return }
+        transaction.animation = nil
+        transaction.disablesAnimations = true
+    }
+}
+
+private struct ReduceAnimationsKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var reduceAnimations: Bool {
+        get { self[ReduceAnimationsKey.self] }
+        set { self[ReduceAnimationsKey.self] = newValue }
+    }
 }
 
 extension View {
+    /// Applies the app preference at the popover root. The transaction catches explicit and implicit
+    /// SwiftUI animations; the environment value also reaches the time-driven easter-egg gate. macOS
+    /// Reduce Motion remains authoritative even when the app toggle is off.
+    func reduceAnimationsWhenRequested() -> some View {
+        modifier(ReduceAnimationsModifier())
+    }
+
+    /// Applies an already-resolved motion policy. Separate SwiftUI hosts (for example AppKit-owned
+    /// hover popovers) use this to receive the same environment value and transaction clamp as the
+    /// dashboard root.
+    func animationReduction(_ enabled: Bool) -> some View {
+        modifier(AnimationReductionModifier(enabled: enabled))
+    }
+
     /// The macOS "denied" idiom: a brief horizontal shake, like the login window on a wrong
     /// password. Increment `trigger` to play one shake; repeats re-shake so a second blocked
     /// click still gets feedback while the label is already showing.
@@ -16,6 +49,55 @@ extension View {
     /// otherwise they replay an old shake every time they appear.
     func denyShake(trigger: Int, shakeOnAppear: Bool = false) -> some View {
         modifier(DenyShakeModifier(trigger: trigger, shakeOnAppear: shakeOnAppear))
+    }
+}
+
+private struct ReduceAnimationsModifier: ViewModifier {
+    @AppStorage(ReduceAnimationsSetting.key) private var appPreference = ReduceAnimationsSetting.fallback
+    @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
+
+    private var shouldReduceAnimations: Bool {
+        ReduceAnimationsSetting.resolve(
+            appPreference: appPreference,
+            systemReduceMotion: systemReduceMotion
+        )
+    }
+
+    func body(content: Content) -> some View {
+        content.animationReduction(shouldReduceAnimations)
+    }
+}
+
+private struct AnimationReductionModifier: ViewModifier {
+    let enabled: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .environment(\.reduceAnimations, enabled)
+            .transaction { transaction in
+                Motion.applyReduction(to: &transaction, enabled: enabled)
+            }
+    }
+}
+
+/// Keeps an in-flight status visible without mounting an indeterminate spinner clock when motion is
+/// reduced. The static symbol deliberately matches the existing iCloud sync affordance.
+struct MotionAwareProgressView: View {
+    var controlSize: ControlSize = .small
+
+    @Environment(\.reduceAnimations) private var reduceAnimations
+
+    @ViewBuilder
+    var body: some View {
+        if reduceAnimations {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: 12, height: 12)
+        } else {
+            ProgressView()
+                .controlSize(controlSize)
+        }
     }
 }
 

--- a/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
+++ b/Sources/OpenUsage/Support/LiquidGlassFallbacks.swift
@@ -50,20 +50,8 @@ extension View {
     /// as Liquid Glass. In the readable translucent modes, `reinforced` adds that same adaptive frosted
     /// material and hairline under Liquid Glass so a light desktop cannot erase the capsule boundary.
     /// macOS 15 always gets the frosted material shape with a hairline border (no glass there).
-    @ViewBuilder
-    func interactiveGlass(in shape: some InsettableShape, reinforced: Bool = false) -> some View {
-        if #available(macOS 26, *) {
-            if reinforced {
-                background(.regularMaterial, in: shape)
-                    .overlay { shape.strokeBorder(.separator, lineWidth: 0.5) }
-                    .glassEffect(.regular.interactive(), in: shape)
-            } else {
-                glassEffect(.regular.interactive(), in: shape)
-            }
-        } else {
-            background(.regularMaterial, in: shape)
-                .overlay { shape.strokeBorder(.separator, lineWidth: 0.5) }
-        }
+    func interactiveGlass<Shape: InsettableShape>(in shape: Shape, reinforced: Bool = false) -> some View {
+        modifier(MotionAwareInteractiveGlassModifier(shape: shape, reinforced: reinforced))
     }
 
     /// Liquid Glass surface for a full chrome bar (the footer / top bar) on macOS 26+, a frosted
@@ -127,6 +115,41 @@ extension View {
             scrollEdgeEffectStyle(.soft, for: .bottom)
         } else {
             self
+        }
+    }
+}
+
+private struct MotionAwareInteractiveGlassModifier<Shape: InsettableShape>: ViewModifier {
+    let shape: Shape
+    let reinforced: Bool
+    @Environment(\.reduceAnimations) private var reduceAnimations
+
+    /// Liquid Glass owns its hover/press scale and shimmer outside the view's normal transaction. Swap
+    /// only that interactive variant for static system glass when either Reduce Animations source is on.
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            if reinforced {
+                if reduceAnimations {
+                    content
+                        .background(.regularMaterial, in: shape)
+                        .overlay { shape.strokeBorder(.separator, lineWidth: 0.5) }
+                        .glassEffect(.regular, in: shape)
+                } else {
+                    content
+                        .background(.regularMaterial, in: shape)
+                        .overlay { shape.strokeBorder(.separator, lineWidth: 0.5) }
+                        .glassEffect(.regular.interactive(), in: shape)
+                }
+            } else if reduceAnimations {
+                content.glassEffect(.regular, in: shape)
+            } else {
+                content.glassEffect(.regular.interactive(), in: shape)
+            }
+        } else {
+            content
+                .background(.regularMaterial, in: shape)
+                .overlay { shape.strokeBorder(.separator, lineWidth: 0.5) }
         }
     }
 }

--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -16,11 +16,12 @@ extension EnvironmentValues {
 }
 
 /// Whether the hosting popover is currently on-screen. The easter-egg animation loops read this to
-/// **mount** their `TimelineView(.animation)` clocks only while the popover is visible and drop to a
-/// static frame when it isn't, so a closed popover with the egg still active runs no display link and
-/// spends no CPU. Default `false`, so the windowless ShareCard export and any non-popover host never
-/// mount the loops. Seeded from `PopoverTransparencyStore.popoverShown`, which `StatusItemController`
-/// flips at its `showPanel`/`hidePanel` chokepoints.
+/// **mount** their `TimelineView(.animation)` clocks only while the popover is visible and motion is
+/// allowed, and drop to a static frame otherwise. A closed popover or reduced-motion preference with
+/// the egg still active therefore runs no display link and spends no animation work. Default `false`,
+/// so the windowless ShareCard export and any non-popover host never mount the loops. Seeded from
+/// `PopoverTransparencyStore.popoverShown`, which `StatusItemController` flips at its
+/// `showPanel`/`hidePanel` chokepoints.
 ///
 /// This is a STRUCTURAL mount gate (`if shown { TimelineView } else { static }`), deliberately NOT the
 /// reverted `TimelineView(.animation(paused: !shown))` overload (commit 1ef9c4e): that overload froze
@@ -40,14 +41,16 @@ extension EnvironmentValues {
 }
 
 /// Renders time-driven `content(t)` under a live `TimelineView(.animation)` while the popover is
-/// on-screen, and at a single static frame (the current instant, matching the live clock's first frame)
-/// when it's hidden — so no display link ticks behind a closed popover, yet the look doesn't snap off on
-/// close. This is the shared home of the STRUCTURAL mount gate every easter-egg loop uses; it is
+/// on-screen and motion is allowed, and at a single static frame otherwise — so no display link ticks
+/// behind a closed popover or under Reduce Animations, yet the look doesn't disappear. Reduced motion
+/// uses the calm baseline (`t == 0`); a merely hidden popover keeps its current-looking phase. This is
+/// the shared home of the STRUCTURAL mount gate every easter-egg loop uses; it is
 /// deliberately NOT the reverted `TimelineView(.animation(paused:))` overload (see `\.popoverIsVisible`).
 /// Both branches carry `.transition(.identity)` so toggling the egg crossfades via the surrounding
 /// `.animation`, never a hard cut. `t` is `timeIntervalSinceReferenceDate`.
 struct VisibilityGatedTimeline<Content: View>: View {
     @Environment(\.popoverIsVisible) private var shown
+    @Environment(\.reduceAnimations) private var reduceAnimations
     private let content: (TimeInterval) -> Content
 
     init(@ViewBuilder content: @escaping (TimeInterval) -> Content) {
@@ -55,15 +58,32 @@ struct VisibilityGatedTimeline<Content: View>: View {
     }
 
     var body: some View {
-        if shown {
+        switch MotionTimelineMode.resolve(popoverShown: shown, reduceAnimations: reduceAnimations) {
+        case .live:
             TimelineView(.animation) { timeline in
                 content(timeline.date.timeIntervalSinceReferenceDate)
             }
             .transition(.identity)
-        } else {
+        case .currentStatic:
             content(Date().timeIntervalSinceReferenceDate)
                 .transition(.identity)
+        case .baselineStatic:
+            content(0)
+                .transition(.identity)
         }
+    }
+}
+
+/// Structural policy for continuous decorative motion. Kept pure so the no-display-link guarantee is
+/// regression-testable without mounting a SwiftUI host.
+enum MotionTimelineMode: Equatable {
+    case live
+    case currentStatic
+    case baselineStatic
+
+    static func resolve(popoverShown: Bool, reduceAnimations: Bool) -> Self {
+        if reduceAnimations { return .baselineStatic }
+        return popoverShown ? .live : .currentStatic
     }
 }
 

--- a/Sources/OpenUsage/Views/CopyFeedbackButton.swift
+++ b/Sources/OpenUsage/Views/CopyFeedbackButton.swift
@@ -2,8 +2,9 @@ import SwiftUI
 
 /// The shared screenshot-copy control used by dashboard headers. The glyph stays compact, but the
 /// button owns a larger pointer target; a successful copy swaps it for a green, bouncing checkmark
-/// before returning to the copy symbol. Keeping the state and timer here makes every copy action use
-/// the same feedback instead of rebuilding the interaction at each call site.
+/// before returning to the copy symbol (the bounce is omitted under Reduce Animations). Keeping the
+/// state and timer here makes every copy action use the same feedback instead of rebuilding the
+/// interaction at each call site.
 struct CopyFeedbackButton: View {
     let accessibilityLabel: String
     var isRevealed = true
@@ -11,6 +12,7 @@ struct CopyFeedbackButton: View {
 
     @State private var copied = false
     @State private var resetTask: Task<Void, Never>?
+    @Environment(\.reduceAnimations) private var reduceAnimations
 
     var body: some View {
         Button {
@@ -27,7 +29,7 @@ struct CopyFeedbackButton: View {
             Image(systemName: copied ? "checkmark" : "doc.on.doc")
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(copied ? Color.green : Color.secondary)
-                .symbolEffect(.bounce, value: copied)
+                .symbolEffect(.bounce, value: reduceAnimations ? false : copied)
                 .frame(width: 28, height: 28)
                 .contentShape(Rectangle())
         }

--- a/Sources/OpenUsage/Views/DashboardView.swift
+++ b/Sources/OpenUsage/Views/DashboardView.swift
@@ -21,6 +21,7 @@ struct DashboardView: View {
     @Environment(WidgetDataStore.self) private var dataStore
     @Environment(PopoverTransparencyStore.self) private var transparency
     @Environment(UpdaterController.self) private var updater
+    @Environment(\.reduceAnimations) private var reduceAnimations
     @State private var reorderLift: ReorderLift?
     /// The panel height SwiftUI drives — the single animation clock. `PanelHeightModifier` follows it
     /// frame-by-frame onto the AppKit panel, so the window resize rides the same spring as the screen
@@ -174,6 +175,18 @@ struct DashboardView: View {
             // page offset so the screens slide between modes on one spring.
             .onChange(of: layout.screenSlideID) { _, id in
                 guard id != 0 else { return }
+                if reduceAnimations {
+                    // Snap as one structural update. Mounting the normal two-page pager for even one
+                    // frame would pair the destination header with the outgoing screen; scheduling the
+                    // spring would also keep that stale structure alive until its delayed completion.
+                    animatedSlideID = id
+                    slideProgress = 1
+                    if let target = heightCoordinator.target(for: layout.screen) {
+                        didEstablishHeight = true
+                        animatedHeight = target
+                    }
+                    return
+                }
                 slideProgress = 0
                 animatedSlideID = id
                 let destination = layout.screen
@@ -293,8 +306,25 @@ struct DashboardView: View {
 
     /// True from the moment `layout.screen` changes until the slide reaches the incoming screen.
     private var isSliding: Bool {
-        layout.screenSlideID != 0
-            && (layout.screenSlideID != animatedSlideID || slideProgress < 1)
+        Self.screenTransitionIsActive(
+            reduceAnimations: reduceAnimations,
+            screenSlideID: layout.screenSlideID,
+            animatedSlideID: animatedSlideID,
+            slideProgress: slideProgress
+        )
+    }
+
+    /// Reduced motion never mounts the outgoing + incoming pager together: destination chrome and
+    /// content must replace the old screen atomically instead of exposing the pager's setup frame.
+    static func screenTransitionIsActive(
+        reduceAnimations: Bool,
+        screenSlideID: Int,
+        animatedSlideID: Int,
+        slideProgress: CGFloat
+    ) -> Bool {
+        !reduceAnimations
+            && screenSlideID != 0
+            && (screenSlideID != animatedSlideID || slideProgress < 1)
     }
 
     /// One page at rest (the current screen); the two involved screens in left-to-right rank order

--- a/Sources/OpenUsage/Views/ICloudSyncSettingsSection.swift
+++ b/Sources/OpenUsage/Views/ICloudSyncSettingsSection.swift
@@ -25,8 +25,7 @@ struct ICloudSyncSettingsSection: View {
                 HStack(spacing: 7) {
                     Text("Sync Across Macs")
                     if sync.enabled, sync.isSyncing, sync.serviceError == nil {
-                        ProgressView()
-                            .controlSize(.small)
+                        MotionAwareProgressView(controlSize: .small)
                             .transition(.scale(scale: 0.8).combined(with: .opacity))
                             .accessibilityLabel("Syncing usage history")
                     }

--- a/Sources/OpenUsage/Views/PopoverFooter.swift
+++ b/Sources/OpenUsage/Views/PopoverFooter.swift
@@ -74,8 +74,7 @@ struct PopoverFooter: View {
                         .monospacedDigit()
                         .contentTransition(.numericText())
                     if isUpdating {
-                        ProgressView()
-                            .controlSize(.mini)
+                        MotionAwareProgressView(controlSize: .mini)
                     }
                 }
             }

--- a/Sources/OpenUsage/Views/ProviderSectionHeader.swift
+++ b/Sources/OpenUsage/Views/ProviderSectionHeader.swift
@@ -83,8 +83,7 @@ struct ProviderSectionHeader: View {
                 }
             }
             if refreshing {
-                ProgressView()
-                    .controlSize(.mini)
+                MotionAwareProgressView(controlSize: .mini)
                     .accessibilityLabel("Refreshing")
             } else if let warning {
                 Image(systemName: "exclamationmark.triangle.fill")

--- a/Sources/OpenUsage/Views/RateLimitResetsDetail.swift
+++ b/Sources/OpenUsage/Views/RateLimitResetsDetail.swift
@@ -328,7 +328,7 @@ struct RateLimitResetsDetail: View {
                 .font(.system(size: density.supportingPointSize))
                 .foregroundStyle(.secondary)
             Spacer(minLength: 8)
-            ProgressView().controlSize(.small)
+            MotionAwareProgressView(controlSize: .small)
         }
         .frame(height: nodeHeight)
     }

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -20,6 +20,7 @@ struct SettingsScreen: View {
     @AppStorage(AppearanceSetting.key) private var appearance = AppearanceSetting.system
     @AppStorage(TimeFormatSetting.key) private var timeFormat = TimeFormatSetting.auto
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @AppStorage(ReduceAnimationsSetting.key) private var reduceAnimations = ReduceAnimationsSetting.fallback
     @AppStorage(LogLevelSetting.key) private var logLevel = LogLevelSetting.fallback
     /// Surfaced under the Advanced rows when copying the path or revealing the file fails.
     @State private var logActionError: String?
@@ -39,164 +40,17 @@ struct SettingsScreen: View {
     }
 
     private var content: some View {
-        @Bindable var store = container.dataStore
-        @Bindable var layout = container.layout
-        @Bindable var updater = updater
-        @Bindable var transparency = container.transparency
-        @Bindable var privacy = container.privacy
-        @Bindable var notifications = container.notificationSettings
         // Same section rhythm as the dashboard and Customize (all read the density setting).
-        return VStack(alignment: .leading, spacing: density.sectionSpacing) {
-            section("General") {
-                // The dashboard's cross-provider Total Spend card; at least one enabled spend-capable
-                // provider must exist, so this toggle can't conjure it up alone.
-                row("Show Total Spend") {
-                    Toggle("", isOn: $showTotalSpend)
-                        .settingsSwitchStyle()
-                }
-                row("Launch at Login") {
-                    Toggle("", isOn: Binding(
-                        get: { launchAtLogin.isEnabled },
-                        set: { launchAtLogin.update(to: $0) }
-                    ))
-                        .settingsSwitchStyle()
-                }
-                if let launchAtLoginError = launchAtLogin.errorMessage {
-                    inlineNotice(launchAtLoginError)
-                }
-                // Click-to-record field; its ⓧ clears the combo and disables the shortcut.
-                row("Global Shortcut") {
-                    ShortcutRecorderField(name: .togglePopover)
-                        .hoverTooltip("Open OpenUsage from anywhere")
-                }
-            }
+        VStack(alignment: .leading, spacing: density.sectionSpacing) {
+            generalSection
             ICloudSyncSettingsSection(sync: container.iCloudSync)
-            section("Appearance") {
-                row("Icon Style") {
-                    picker($layout.menuBarStyle, options: MenuBarStyle.allCases, label: \.label)
-                }
-                row("Theme") {
-                    picker($appearance, options: AppearanceSetting.allCases, label: \.label)
-                        // NSApp-level so the popover panel restyles too (it ignores preferredColorScheme).
-                        .onChange(of: appearance) {
-                            AppearanceSetting.applyCurrent()
-                        }
-                }
-                row("Density") {
-                    picker($density, options: DensitySetting.allCases, label: \.label)
-                }
-                row("Time Format") {
-                    picker($timeFormat, options: TimeFormatSetting.allCases, label: \.label)
-                }
-                // Translucent popover the proper way (behind-window vibrancy, text stays legible). It
-                // yields to the system accessibility settings, and to the party easter egg while that's
-                // running (the egg drives the look) — either way, see the paused notice below.
-                row("Increase Transparency") {
-                    Toggle("", isOn: $transparency.increaseTransparency)
-                        .settingsSwitchStyle()
-                        // Party mode owns the look while it's active, so disable (dim) the toggle to show
-                        // it has no effect right now — its stored value resumes once the egg is exited.
-                        .disabled(transparency.secretCodeActive)
-                }
-                // Egg first: while Party runs it overrides the toggle regardless of the system flags, so
-                // its notice takes precedence over the accessibility one.
-                if transparency.secretCodeActive {
-                    inlineNotice("Party mode is on, so this stays paused.")
-                } else if transparency.isPaused {
-                    inlineNotice("macOS Reduce Transparency or Increase Contrast is on, so this stays paused.")
-                }
-                // Both rows surface only after the secret code has been entered. Party Mode is the egg's
-                // own switch: turning it off (like re-typing the code) exits the egg and hides both rows,
-                // dropping back to the base state. Drunk Mode escalates the readable party into the woozy,
-                // barely-readable state and back — turning it off stays in the party (4 → 3), while turning
-                // Party Mode off from there clears Drunk Mode too (4 → base).
-                if transparency.secretCodeActive {
-                    row("Party Mode") {
-                        Toggle("", isOn: $transparency.partyModeActive)
-                            .settingsSwitchStyle()
-                    }
-                    row("Drunk Mode") {
-                        Toggle("", isOn: $transparency.drunkMode)
-                            .settingsSwitchStyle()
-                    }
-                    // The egg yields to the accessibility flags too: when one is on the panel stays
-                    // opaque, so explain why the party looks normal rather than leaving it a mystery.
-                    if transparency.partyPaused {
-                        inlineNotice("macOS Reduce Transparency or Increase Contrast is on, so the party stays paused.")
-                    }
-                }
-            }
-            section("Usage Display") {
-                row("Show Usage As") {
-                    picker($store.meterStyle, options: WidgetDisplayMode.allCases, label: \.label)
-                }
-                row("Reset Times") {
-                    picker($store.resetDisplayMode, options: ResetDisplayMode.allCases, label: \.label)
-                }
-                // Off (default) leaves pacing on yellow and red only. On also surfaces projection
-                // and the even-pace tick on blue rows.
-                row("Always Show Pacing") {
-                    Toggle("", isOn: $store.alwaysShowPacing)
-                        .settingsSwitchStyle()
-                        .hoverTooltip("Show how you're pacing on every metric, not just ones near their limit")
-                }
-            }
+            appearanceSection
+            usageDisplaySection
             notificationsSection
-            section("Privacy") {
-                row("Hide From Screen Share") {
-                    Toggle("", isOn: $privacy.hideUsageWhileScreenSharing)
-                        .settingsSwitchStyle()
-                }
-                Text("While your screen is shared or recorded, the menu bar shows “OpenUsage” instead of your usage.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                row("Share Anonymous Usage") {
-                    Toggle("", isOn: Binding(
-                        get: { container.telemetry.isEnabled },
-                        set: { container.telemetry.setEnabled($0) }
-                    ))
-                    .settingsSwitchStyle()
-                }
-                // Plain-language disclosure of exactly what leaves the machine — coarse counts and
-                // error types only, never account details or usage values.
-                Text("Shares anonymous usage counts and error types to help improve OpenUsage. No account details, credentials, or usage values are sent.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 8)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            privacySection
             commandLineSection
             advancedSection
-            // Visible whenever the updater is active (only the signed release build ships a feed; the
-            // dev build and a bare `swift run`, with no feed, hide this).
-            if updater.isActive {
-                section("Updates") {
-                    row("Update Automatically") {
-                        Toggle("", isOn: $updater.automaticallyChecksForUpdates)
-                            .settingsSwitchStyle()
-                    }
-                    row("Beta Updates") {
-                        Toggle("", isOn: $updater.betaChannelEnabled)
-                            .settingsSwitchStyle()
-                            .hoverTooltip("Receive pre-release builds before they ship to everyone")
-                    }
-                    // No version label here — the footer already shows it. The frame goes on the label so
-                    // the glass background stretches the full row width instead of hugging the text.
-                    // (Glass on macOS 26+, bordered fallback on macOS 15.)
-                    Button { updater.checkForUpdates() } label: {
-                        Text("Check for Updates…").frame(maxWidth: .infinity)
-                    }
-                    .glassButtonStyle()
-                    .controlSize(.regular)
-                    .disabled(!updater.canCheckForUpdates)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, density.controlRowPadding)
-                }
-            }
+            updatesSection
             // Mirror of the Customize cross-link — the layout controls live on the other screen.
             ScreenCrossLinkRow(
                 systemImage: "slider.horizontal.3",
@@ -207,10 +61,186 @@ struct SettingsScreen: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
-        .task { await refreshNotificationsAuth() }
+        .task {
+            async let launchAtLoginStatus: Void = launchAtLogin.refreshStatus()
+            async let notificationsAuth: Void = refreshNotificationsAuth()
+            _ = await (launchAtLoginStatus, notificationsAuth)
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             commandLineTool.refreshStatus()
             Task { await refreshNotificationsAuth() }
+        }
+    }
+
+    private var generalSection: some View {
+        section("General") {
+            // The dashboard's cross-provider Total Spend card; at least one enabled spend-capable
+            // provider must exist, so this toggle can't conjure it up alone.
+            row("Show Total Spend") {
+                Toggle("", isOn: $showTotalSpend)
+                    .settingsSwitchStyle()
+            }
+            row("Launch at Login") {
+                Toggle("", isOn: Binding(
+                    get: { launchAtLogin.isEnabled },
+                    set: { launchAtLogin.update(to: $0) }
+                ))
+                    .settingsSwitchStyle()
+                    .disabled(launchAtLogin.isLoading)
+            }
+            if let launchAtLoginError = launchAtLogin.errorMessage {
+                inlineNotice(launchAtLoginError)
+            }
+            // Click-to-record field; its ⓧ clears the combo and disables the shortcut.
+            row("Global Shortcut") {
+                ShortcutRecorderField(name: .togglePopover)
+                    .hoverTooltip("Open OpenUsage from anywhere")
+            }
+        }
+    }
+
+    private var appearanceSection: some View {
+        @Bindable var layout = container.layout
+        @Bindable var transparency = container.transparency
+        return section("Appearance") {
+            row("Icon Style") {
+                picker($layout.menuBarStyle, options: MenuBarStyle.allCases, label: \.label)
+            }
+            row("Theme") {
+                picker($appearance, options: AppearanceSetting.allCases, label: \.label)
+                    // NSApp-level so the popover panel restyles too (it ignores preferredColorScheme).
+                    .onChange(of: appearance) {
+                        AppearanceSetting.applyCurrent()
+                    }
+            }
+            row("Density") {
+                picker($density, options: DensitySetting.allCases, label: \.label)
+            }
+            row("Reduce Animations") {
+                Toggle("", isOn: $reduceAnimations)
+                    .settingsSwitchStyle()
+            }
+            row("Time Format") {
+                picker($timeFormat, options: TimeFormatSetting.allCases, label: \.label)
+            }
+            // Translucent popover the proper way (behind-window vibrancy, text stays legible). It
+            // yields to the system accessibility settings, and to the party easter egg while that's
+            // running (the egg drives the look) — either way, see the paused notice below.
+            row("Increase Transparency") {
+                Toggle("", isOn: $transparency.increaseTransparency)
+                    .settingsSwitchStyle()
+                    // Party mode owns the look while it's active, so disable (dim) the toggle to show
+                    // it has no effect right now — its stored value resumes once the egg is exited.
+                    .disabled(transparency.secretCodeActive)
+            }
+            // Egg first: while Party runs it overrides the toggle regardless of the system flags, so
+            // its notice takes precedence over the accessibility one.
+            if transparency.secretCodeActive {
+                inlineNotice("Party mode is on, so this stays paused.")
+            } else if transparency.isPaused {
+                inlineNotice("macOS Reduce Transparency or Increase Contrast is on, so this stays paused.")
+            }
+            // Both rows surface only after the secret code has been entered. Party Mode is the egg's
+            // own switch: turning it off (like re-typing the code) exits the egg and hides both rows,
+            // dropping back to the base state. Drunk Mode escalates the readable party into the woozy,
+            // barely-readable state and back — turning it off stays in the party (4 → 3), while turning
+            // Party Mode off from there clears Drunk Mode too (4 → base).
+            if transparency.secretCodeActive {
+                row("Party Mode") {
+                    Toggle("", isOn: $transparency.partyModeActive)
+                        .settingsSwitchStyle()
+                }
+                row("Drunk Mode") {
+                    Toggle("", isOn: $transparency.drunkMode)
+                        .settingsSwitchStyle()
+                }
+                // The egg yields to the accessibility flags too: when one is on the panel stays
+                // opaque, so explain why the party looks normal rather than leaving it a mystery.
+                if transparency.partyPaused {
+                    inlineNotice("macOS Reduce Transparency or Increase Contrast is on, so the party stays paused.")
+                }
+            }
+        }
+    }
+
+    private var usageDisplaySection: some View {
+        @Bindable var store = container.dataStore
+        return section("Usage Display") {
+            row("Show Usage As") {
+                picker($store.meterStyle, options: WidgetDisplayMode.allCases, label: \.label)
+            }
+            row("Reset Times") {
+                picker($store.resetDisplayMode, options: ResetDisplayMode.allCases, label: \.label)
+            }
+            // Off (default) leaves pacing on yellow and red only. On also surfaces projection
+            // and the even-pace tick on blue rows.
+            row("Always Show Pacing") {
+                Toggle("", isOn: $store.alwaysShowPacing)
+                    .settingsSwitchStyle()
+                    .hoverTooltip("Show how you're pacing on every metric, not just ones near their limit")
+            }
+        }
+    }
+
+    private var privacySection: some View {
+        @Bindable var privacy = container.privacy
+        return section("Privacy") {
+            row("Hide From Screen Share") {
+                Toggle("", isOn: $privacy.hideUsageWhileScreenSharing)
+                    .settingsSwitchStyle()
+            }
+            Text("While your screen is shared or recorded, the menu bar shows “OpenUsage” instead of your usage.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            row("Share Anonymous Usage") {
+                Toggle("", isOn: Binding(
+                    get: { container.telemetry.isEnabled },
+                    set: { container.telemetry.setEnabled($0) }
+                ))
+                .settingsSwitchStyle()
+            }
+            // Plain-language disclosure of exactly what leaves the machine — coarse counts and
+            // error types only, never account details or usage values.
+            Text("Shares anonymous usage counts and error types to help improve OpenUsage. No account details, credentials, or usage values are sent.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private var updatesSection: some View {
+        @Bindable var updater = updater
+        // Visible whenever the updater is active (only the signed release build ships a feed; the
+        // dev build and a bare `swift run`, with no feed, hide this).
+        if updater.isActive {
+            section("Updates") {
+                row("Update Automatically") {
+                    Toggle("", isOn: $updater.automaticallyChecksForUpdates)
+                        .settingsSwitchStyle()
+                }
+                row("Beta Updates") {
+                    Toggle("", isOn: $updater.betaChannelEnabled)
+                        .settingsSwitchStyle()
+                        .hoverTooltip("Receive pre-release builds before they ship to everyone")
+                }
+                // No version label here — the footer already shows it. The frame goes on the label so
+                // the glass background stretches the full row width instead of hugging the text.
+                // (Glass on macOS 26+, bordered fallback on macOS 15.)
+                Button { updater.checkForUpdates() } label: {
+                    Text("Check for Updates…").frame(maxWidth: .infinity)
+                }
+                .glassButtonStyle()
+                .controlSize(.regular)
+                .disabled(!updater.canCheckForUpdates)
+                .padding(.horizontal, 12)
+                .padding(.vertical, density.controlRowPadding)
+            }
         }
     }
 

--- a/Sources/OpenUsage/Views/UsageSparkline.swift
+++ b/Sources/OpenUsage/Views/UsageSparkline.swift
@@ -11,6 +11,7 @@ struct UsageSparkline: View {
     private let points: [MetricChartPoint]
 
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @Environment(\.reduceAnimations) private var reduceAnimations
     @State private var hover = HoverPopoverState()
 
     /// Widest the bar strip grows to, and a floor so it can't collapse to a sliver next to a long title.
@@ -53,8 +54,10 @@ struct UsageSparkline: View {
                 // Dismissing from outside (click-away) removes the detail view without an `.ended`
                 // hover event, so a plain assignment would strand `overDetail == true` and block
                 // future hides — reset the whole hover state instead.
-                .popover(isPresented: Binding(get: { hover.isPresented }, set: { if !$0 { hover.dismiss() } }),
-                         arrowEdge: .top) {
+                .motionAwareHoverPopover(
+                    isPresented: Binding(get: { hover.isPresented }, set: { if !$0 { hover.dismiss() } }),
+                    reduceAnimations: reduceAnimations
+                ) {
                     UsageTrendDetail(title: data.title, points: points, note: data.chartNote) { inside in
                         hover.detailHover(inside)
                     }

--- a/Sources/OpenUsage/Views/UsageTrendPopoverPresenter.swift
+++ b/Sources/OpenUsage/Views/UsageTrendPopoverPresenter.swift
@@ -1,0 +1,143 @@
+import AppKit
+import SwiftUI
+
+extension View {
+    /// SwiftUI does not expose the backing `NSPopover.animates` flag, so reduced motion crosses the
+    /// AppKit boundary only for presentation. The normal path stays on SwiftUI's standard popover.
+    func motionAwareHoverPopover<PopoverContent: View>(
+        isPresented: Binding<Bool>,
+        reduceAnimations: Bool,
+        @ViewBuilder content: @escaping () -> PopoverContent
+    ) -> some View {
+        modifier(MotionAwareHoverPopoverModifier(
+            isPresented: isPresented,
+            reduceAnimations: reduceAnimations,
+            popoverContent: content
+        ))
+    }
+}
+
+private struct MotionAwareHoverPopoverModifier<PopoverContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let reduceAnimations: Bool
+    @ViewBuilder let popoverContent: () -> PopoverContent
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if reduceAnimations {
+            content.background {
+                ReducedMotionPopoverPresenter(
+                    isPresented: $isPresented,
+                    reduceAnimations: reduceAnimations,
+                    popoverContent: popoverContent
+                )
+            }
+        } else {
+            content.popover(isPresented: $isPresented, arrowEdge: .top, content: popoverContent)
+        }
+    }
+}
+
+/// An invisible anchor that owns the one AppKit presentation detail SwiftUI does not expose:
+/// `NSPopover.animates`. SwiftUI remains the source of truth through `isPresented`.
+private struct ReducedMotionPopoverPresenter<PopoverContent: View>: NSViewRepresentable {
+    @Binding var isPresented: Bool
+    let reduceAnimations: Bool
+    @ViewBuilder let popoverContent: () -> PopoverContent
+
+    func makeCoordinator() -> ReducedMotionPopoverController {
+        ReducedMotionPopoverController(isPresented: $isPresented)
+    }
+
+    func makeNSView(context: Context) -> PopoverAnchorView {
+        let view = PopoverAnchorView()
+        view.onWindowChange = { [weak coordinator = context.coordinator, weak view] in
+            guard let view else { return }
+            coordinator?.synchronize(with: view)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: PopoverAnchorView, context: Context) {
+        context.coordinator.isPresented = $isPresented
+        context.coordinator.update(
+            content: AnyView(popoverContent()),
+            reduceAnimations: reduceAnimations,
+            anchor: nsView
+        )
+    }
+
+    static func dismantleNSView(_ nsView: PopoverAnchorView, coordinator: ReducedMotionPopoverController) {
+        nsView.onWindowChange = nil
+        coordinator.dismissWithoutUpdatingBinding()
+    }
+
+    @MainActor
+    final class PopoverAnchorView: NSView {
+        var onWindowChange: (() -> Void)?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            onWindowChange?()
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            nil
+        }
+    }
+}
+
+/// Owns the AppKit objects and delegate lifecycle outside the generic SwiftUI representable.
+@MainActor
+final class ReducedMotionPopoverController: NSObject, NSPopoverDelegate {
+    var isPresented: Binding<Bool>
+    let popover: NSPopover
+
+    private let host = NSHostingController(rootView: AnyView(EmptyView()))
+    private var ignoreNextClose = false
+
+    init(isPresented: Binding<Bool>) {
+        self.isPresented = isPresented
+        self.popover = NSPopover()
+        super.init()
+        popover.animates = false
+        popover.behavior = .transient
+        popover.contentViewController = host
+        popover.delegate = self
+    }
+
+    func update(content: AnyView, reduceAnimations: Bool, anchor: NSView) {
+        host.rootView = AnyView(content.animationReduction(reduceAnimations))
+        host.view.layoutSubtreeIfNeeded()
+        let size = host.view.fittingSize
+        if size.width > 0, size.height > 0 {
+            popover.contentSize = size
+        }
+        synchronize(with: anchor)
+    }
+
+    func synchronize(with anchor: NSView) {
+        guard isPresented.wrappedValue else {
+            if popover.isShown { popover.performClose(nil) }
+            return
+        }
+        guard anchor.window != nil, !popover.isShown else { return }
+        popover.show(relativeTo: anchor.bounds, of: anchor, preferredEdge: .minY)
+    }
+
+    func dismissWithoutUpdatingBinding() {
+        guard popover.isShown else { return }
+        ignoreNextClose = true
+        popover.performClose(nil)
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        if ignoreNextClose {
+            ignoreNextClose = false
+            return
+        }
+        if isPresented.wrappedValue {
+            isPresented.wrappedValue = false
+        }
+    }
+}

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -25,6 +25,7 @@ struct WidgetRowView: View {
     var condensedTop: Bool = false
 
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @Environment(\.reduceAnimations) private var reduceAnimations
     @State private var modelHover = HoverPopoverState()
     /// Backs the resets popover's claim flow; `nil` outside the live dashboard (previews, share
     /// renders), which renders the timeline read-only.
@@ -355,14 +356,14 @@ struct WidgetRowView: View {
                     modelHover.inlineHover(false)
                 }
             }
-            .popover(
+            .motionAwareHoverPopover(
                 isPresented: Binding(
                     get: { hasHoverPopover && modelHover.isPresented },
                     // A click-outside dismiss removes the detail view without an `.ended` hover event,
                     // so a plain assignment would strand `overDetail == true` and block future hides.
                     set: { if !$0 { modelHover.dismiss() } }
                 ),
-                arrowEdge: .top
+                reduceAnimations: reduceAnimations
             ) {
                 if let breakdown = data.modelBreakdown {
                     ModelUsageDetail(title: data.title, breakdown: breakdown) { inside in

--- a/Tests/OpenUsageTests/LaunchAtLoginSettingTests.swift
+++ b/Tests/OpenUsageTests/LaunchAtLoginSettingTests.swift
@@ -7,7 +7,7 @@ final class LaunchAtLoginSettingTests: XCTestCase {
         let systemEnabled = false
         var requestedValues: [Bool] = []
         let setting = LaunchAtLoginSetting(
-            currentStatus: { systemEnabled },
+            initialStatus: systemEnabled,
             setEnabled: { enabled in
                 requestedValues.append(enabled)
                 throw TestError.rejected
@@ -25,7 +25,7 @@ final class LaunchAtLoginSettingTests: XCTestCase {
         var systemEnabled = false
         var shouldFail = true
         let setting = LaunchAtLoginSetting(
-            currentStatus: { systemEnabled },
+            initialStatus: systemEnabled,
             setEnabled: { enabled in
                 if shouldFail { throw TestError.rejected }
                 systemEnabled = enabled
@@ -38,6 +38,21 @@ final class LaunchAtLoginSettingTests: XCTestCase {
 
         XCTAssertTrue(setting.isEnabled)
         XCTAssertNil(setting.errorMessage)
+    }
+
+    func testStatusLoadsAfterInitialization() async {
+        let setting = LaunchAtLoginSetting(
+            loadStatus: { true },
+            setEnabled: { _ in }
+        )
+
+        XCTAssertFalse(setting.isEnabled)
+        XCTAssertTrue(setting.isLoading)
+
+        await setting.refreshStatus()
+
+        XCTAssertTrue(setting.isEnabled)
+        XCTAssertFalse(setting.isLoading)
     }
 
     private enum TestError: Error {

--- a/Tests/OpenUsageTests/ReduceAnimationsSettingTests.swift
+++ b/Tests/OpenUsageTests/ReduceAnimationsSettingTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import SwiftUI
+@testable import OpenUsage
+
+@MainActor
+final class ReduceAnimationsSettingTests: XCTestCase {
+    func testMotionStaysEnabledWithoutEitherPreference() {
+        XCTAssertFalse(ReduceAnimationsSetting.resolve(appPreference: false, systemReduceMotion: false))
+    }
+
+    func testAppPreferenceReducesAnimations() {
+        XCTAssertTrue(ReduceAnimationsSetting.resolve(appPreference: true, systemReduceMotion: false))
+    }
+
+    func testSystemPreferenceReducesAnimations() {
+        XCTAssertTrue(ReduceAnimationsSetting.resolve(appPreference: false, systemReduceMotion: true))
+    }
+
+    func testPersistenceKeyAndFallbackStayStable() {
+        XCTAssertEqual(ReduceAnimationsSetting.key, "reduceAnimations")
+        XCTAssertFalse(ReduceAnimationsSetting.fallback)
+    }
+
+    func testReducedAnimationsClearsAndLocksTheRootTransaction() {
+        var transaction = Transaction(animation: .linear(duration: 1))
+
+        Motion.applyReduction(to: &transaction, enabled: true)
+
+        XCTAssertNil(transaction.animation)
+        XCTAssertTrue(transaction.disablesAnimations)
+    }
+
+    func testNormalMotionLeavesTheRootTransactionUntouched() {
+        var transaction = Transaction(animation: .linear(duration: 1))
+
+        Motion.applyReduction(to: &transaction, enabled: false)
+
+        XCTAssertNotNil(transaction.animation)
+        XCTAssertFalse(transaction.disablesAnimations)
+    }
+
+    func testReducedAnimationsNeverMountsScreenTransitionPager() {
+        XCTAssertFalse(DashboardView.screenTransitionIsActive(
+            reduceAnimations: true,
+            screenSlideID: 2,
+            animatedSlideID: 1,
+            slideProgress: 0
+        ))
+    }
+
+    func testNormalMotionKeepsScreenTransitionPagerUntilCompletion() {
+        XCTAssertTrue(DashboardView.screenTransitionIsActive(
+            reduceAnimations: false,
+            screenSlideID: 2,
+            animatedSlideID: 1,
+            slideProgress: 0
+        ))
+        XCTAssertFalse(DashboardView.screenTransitionIsActive(
+            reduceAnimations: false,
+            screenSlideID: 2,
+            animatedSlideID: 2,
+            slideProgress: 1
+        ))
+    }
+
+    func testContinuousMotionUsesBaselineWhenAnimationsAreReduced() {
+        XCTAssertEqual(
+            MotionTimelineMode.resolve(popoverShown: true, reduceAnimations: true),
+            .baselineStatic
+        )
+        XCTAssertEqual(
+            MotionTimelineMode.resolve(popoverShown: false, reduceAnimations: true),
+            .baselineStatic
+        )
+    }
+
+    func testContinuousMotionOnlyRunsWhileVisibleWithoutReduction() {
+        XCTAssertEqual(
+            MotionTimelineMode.resolve(popoverShown: true, reduceAnimations: false),
+            .live
+        )
+        XCTAssertEqual(
+            MotionTimelineMode.resolve(popoverShown: false, reduceAnimations: false),
+            .currentStatic
+        )
+    }
+}

--- a/Tests/OpenUsageTests/UsageTrendPopoverTests.swift
+++ b/Tests/OpenUsageTests/UsageTrendPopoverTests.swift
@@ -1,0 +1,18 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class UsageTrendPopoverTests: XCTestCase {
+    func testReducedMotionPopoverDisablesPresentationAnimation() {
+        var isPresented = false
+        let controller = ReducedMotionPopoverController(isPresented: Binding(
+            get: { isPresented },
+            set: { isPresented = $0 }
+        ))
+
+        XCTAssertFalse(controller.popover.animates)
+        XCTAssertEqual(controller.popover.behavior, .transient)
+    }
+}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -27,6 +27,7 @@ time; it also reports unavailable iCloud, loading, write, and malformed-file sta
 | Icon Style | Text / Bars | How starred metrics render in the menu bar. See [Menu bar](menu-bar.md). |
 | Theme | System / Light / Dark | App-wide appearance override for the popover. |
 | Density | Default / Compact | Default breathes; Compact is a real information-dense mode — text steps down one size, rows and provider sections pull together, and Customize / Settings rows tighten with them. In both, consecutive one-line metrics (Today / Yesterday / …) pull together; Compact pulls harder. |
+| Reduce Animations | Off / On | Off by default. On removes transitions, motion effects, and continuous decorative animation throughout the popover. The app also honors the macOS Reduce Motion accessibility setting. |
 | Time Format | Auto / 12-hour / 24-hour | How exact times read (e.g. "Resets today at 6:38 PM" vs "18:38"). Auto follows the system. |
 | Increase Transparency | Off / On | Off (default) keeps the popover a solid panel. On makes it translucent so your desktop shows through, while keeping the numbers and Options control legible with adaptive frosted surfaces. It pauses automatically when you have the macOS **Reduce Transparency** or **Increase Contrast** accessibility setting turned on (a note explains why), so it never works against those preferences. |
 


### PR DESCRIPTION
## TL;DR

Makes the in-popover Settings screen open promptly and applies Reduce Animations consistently across SwiftUI transitions, AppKit popovers, progress indicators, and time-driven effects.

## What was happening

- Opening Settings waited on a synchronous launch-at-login status lookup, causing a visible delay.
- The dashboard and Settings screen briefly coexisted during navigation, so the new header pushed the existing content down before the transition completed.
- Reduce Animations did not cover several independent motion sources, including hover popovers, indeterminate progress indicators, glass interactions, and timeline-driven effects.
- The separate Usage Trend hosting root did not inherit the dashboard animation-reduction policy.

## What this changes

- Loads launch-at-login status asynchronously and keeps the Settings transition responsive.
- Adds a shared reduction policy that combines the app preference with the macOS accessibility setting.
- Disables page transitions, panel crossfades, time-driven effects, interactive glass motion, symbol effects, and indeterminate spinner clocks when motion is reduced.
- Uses a shared AppKit-backed hover-popover presenter so Usage Trend, model breakdown, and reset-credit popovers can open and close without animation.
- Propagates the reduction policy into the separate popover hosting root.
- Adds regression coverage and documents the setting.

## Heads-up

The reduced-motion hover-popover path uses an AppKit-owned NSPopover because SwiftUI does not expose its animation flag.

## Tests

- `swift test` — 1,216 XCTest tests passed, 3 skipped; 3 Swift Testing tests passed.
- `CONFIG=debug ./script/build_and_run.sh verify` — debug app rebuilt, relaunched, and verified.

## Screenshots

Not applicable: this changes transition timing and motion behavior without changing the static layout.