### PR TITLE
Add 'openusage codex --claim-reset' to claim a Codex reset credit from the CLI

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
@@ -12,6 +12,13 @@ enum ResetClaimOutcome: Equatable, Sendable {
     case failed
 }
 
+/// How a claim picks its target from the fresh credit list: the popover carries the exact expiry the
+/// user clicked; the CLI takes whatever claimable credit is next to expire.
+enum ResetCreditPick: Equatable, Sendable {
+    case expiring(at: Date)
+    case nextToExpire
+}
+
 /// Claims a Codex rate-limit reset credit — the app's only provider-API write, so it is deliberately
 /// narrow: one credit per call, always by explicit credit id, guarded by the caller's idempotency key.
 /// The protocol was reverse-engineered from the open-source Codex CLI and verified live once; see
@@ -30,11 +37,11 @@ final class CodexResetClaimService {
     private let usageClient: CodexUsageClient
     private let credentialCandidates: () async -> [Credentials]
     private let refreshAfterClaim: () async -> Void
-    /// The credit id each idempotency key was matched to, kept for the key's retries: if a consume
+    /// The credit each idempotency key was matched to, kept for the key's retries: if a consume
     /// succeeded but its response was lost, the credit is gone from a re-fetched list — a fresh match
     /// would misread the retry as "no longer available" instead of replaying the POST and letting the
-    /// server answer `already_redeemed`. Session-lived, keyed by the popover's per-credit UUIDs.
-    private var matchedCreditIDs: [String: String] = [:]
+    /// server answer `already_redeemed`. Session-lived, keyed by the caller's per-claim UUIDs.
+    private var matchedCredits: [String: (id: String, expiresAt: Date)] = [:]
 
     /// Test seam: injected credential candidates and refresh hook, the same `usageClient` the requests
     /// go through. Candidates are tried in order until one authenticates (see `claim`).
@@ -80,24 +87,38 @@ final class CodexResetClaimService {
     /// Claims the credit expiring at `expiry`. Never throws — every failure mode is logged loudly and
     /// collapsed to an outcome the popover can render.
     func claim(creditExpiringAt expiry: Date, redeemRequestID: String) async -> ResetClaimOutcome {
+        await claim(pick: .expiring(at: expiry), redeemRequestID: redeemRequestID).outcome
+    }
+
+    /// The CLI's entry point (`openusage codex --claim-reset`): claims whatever claimable credit is
+    /// next to expire — the same list fetch, status filter, credential fallback, consume, and refresh
+    /// behavior as the popover's expiry-targeted claim; only the pick differs. Returns the targeted
+    /// credit's expiry so the CLI can report which credit was spent, `nil` when none was targeted.
+    func claimNextAvailableCredit(redeemRequestID: String) async -> (outcome: ResetClaimOutcome, creditExpiresAt: Date?) {
+        await claim(pick: .nextToExpire, redeemRequestID: redeemRequestID)
+    }
+
+    private func claim(
+        pick: ResetCreditPick, redeemRequestID: String
+    ) async -> (outcome: ResetClaimOutcome, creditExpiresAt: Date?) {
         let candidates = await credentialCandidates()
         guard !candidates.isEmpty else {
             AppLog.error(LogTag.plugin("codex"), "reset claim: no usable Codex credentials")
-            return .failed
+            return (.failed, nil)
         }
 
         // A retry of an idempotency key that already matched replays the exact same (key, credit) pair
         // instead of re-matching: after a consume whose response was lost, the credit is no longer in
         // the list, and only the replay lets the server's `already_redeemed` prove the claim landed.
-        let creditID: String
+        let credit: (id: String, expiresAt: Date)
         var preferredCandidates = candidates
-        if let replayID = matchedCreditIDs[redeemRequestID] {
-            creditID = replayID
+        if let replay = matchedCredits[redeemRequestID] {
+            credit = replay
         } else {
-            switch await matchCredit(expiringAt: expiry, candidates: candidates) {
-            case .matched(let id, let authenticated):
-                creditID = id
-                matchedCreditIDs[redeemRequestID] = id
+            switch await matchCredit(pick: pick, candidates: candidates) {
+            case .matched(let matched, let authenticated):
+                credit = matched
+                matchedCredits[redeemRequestID] = matched
                 // Lead with the credential that just authenticated the list fetch. Deduplicate by the
                 // full (token, account) pair — ChatGPT-Account-Id changes what a token is authorized
                 // for, so a same-token candidate with a different account is a distinct fallback.
@@ -105,25 +126,25 @@ final class CodexResetClaimService {
                     $0.accessToken != authenticated.accessToken || $0.accountID != authenticated.accountID
                 }
             case .noCredit:
-                // Not an error: the credit was claimed elsewhere (CLI/web) or expired since the popover
-                // rendered. The refresh reconciles the timeline with reality.
-                AppLog.warn(LogTag.plugin("codex"), "reset claim: no available credit matches the picked expiry")
+                // Not an error: the credit was claimed elsewhere (CLI/web) or expired since it was
+                // listed. The refresh reconciles the timeline with reality.
+                AppLog.warn(LogTag.plugin("codex"), "reset claim: no claimable credit matches the pick")
                 await refreshAfterClaim()
-                return .noCredit
+                return (.noCredit, nil)
             case .failed:
-                return .failed
+                return (.failed, nil)
             }
         }
 
         let outcome = await consume(
-            creditID: creditID, redeemRequestID: redeemRequestID, candidates: preferredCandidates
+            creditID: credit.id, redeemRequestID: redeemRequestID, candidates: preferredCandidates
         )
         if outcome != .failed {
             // The world changed (or turned out different from the snapshot): refresh before returning,
             // so the result banner appears over already-reconciled meters and credit count.
             await refreshAfterClaim()
         }
-        return outcome
+        return (outcome, credit.expiresAt)
     }
 
     /// POSTs the consume, falling back across credential candidates on an auth rejection (401/403).
@@ -165,16 +186,16 @@ final class CodexResetClaimService {
     }
 
     private enum MatchResult {
-        case matched(creditID: String, credentials: Credentials)
+        case matched(credit: (id: String, expiresAt: Date), credentials: Credentials)
         case noCredit
         case failed
     }
 
-    /// Fresh credit list (safe GET) → the id of the credit the user picked, matched by expiry. Tries
-    /// each credential candidate in order, moving on when one is rejected as unauthenticated (401/403)
-    /// — the same fallback the provider's probe applies — so a stale first auth file can't strand the
-    /// claim while the dashboard works off a later one.
-    private func matchCredit(expiringAt expiry: Date, candidates: [Credentials]) async -> MatchResult {
+    /// Fresh credit list (safe GET) → the credit the pick selects. Tries each credential candidate in
+    /// order, moving on when one is rejected as unauthenticated (401/403) — the same fallback the
+    /// provider's probe applies — so a stale first auth file can't strand the claim while the
+    /// dashboard works off a later one.
+    private func matchCredit(pick: ResetCreditPick, candidates: [Credentials]) async -> MatchResult {
         var lastFailure = "no credential candidate authenticated"
         for credentials in candidates {
             let list: HTTPResponse
@@ -194,24 +215,38 @@ final class CodexResetClaimService {
                 AppLog.error(LogTag.plugin("codex"), "reset claim: credit list fetch failed (\(list.statusCode))")
                 return .failed
             }
-            guard let matched = Self.creditID(in: body, expiringAt: expiry) else { return .noCredit }
-            return .matched(creditID: matched, credentials: credentials)
+            guard let matched = Self.credit(in: body, pick: pick) else { return .noCredit }
+            return .matched(credit: matched, credentials: credentials)
         }
         AppLog.error(LogTag.plugin("codex"), "reset claim: \(lastFailure)")
         return .failed
     }
 
-    /// The id of the still-available credit whose `expires_at` matches `expiry` (±1s — the popover's
-    /// dates round-trip through the same ISO-8601 parsing as this list, so a real match is exact; the
-    /// tolerance only absorbs sub-second truncation). Mirrors the mapper's status filter: a credit with
-    /// no `status` counts as available, only an explicit non-"available" state is skipped.
-    static func creditID(in body: [String: Any], expiringAt expiry: Date) -> String? {
+    /// The still-claimable credit the pick selects. Claimable mirrors the mapper's status filter — a
+    /// credit with no `status` counts as available, only an explicit non-"available" state is skipped
+    /// — and requires a parseable `expires_at`, because expiry is the identity a claim matches on.
+    ///
+    /// `.expiring(at:)` matches within ±1s — the popover's dates round-trip through the same ISO-8601
+    /// parsing as this list, so a real match is exact; the tolerance only absorbs sub-second
+    /// truncation. `.nextToExpire` takes the earliest expiry.
+    static func credit(in body: [String: Any], pick: ResetCreditPick) -> (id: String, expiresAt: Date)? {
         guard let credits = body["credits"] as? [[String: Any]] else { return nil }
-        return credits.first { credit in
-            if let status = credit["status"] as? String, status != "available" { return false }
-            guard let date = parseExpiry(credit["expires_at"]) else { return false }
-            return abs(date.timeIntervalSince(expiry)) < 1
-        }?["id"] as? String
+        let claimable: [(id: String, expiresAt: Date)] = credits.compactMap { credit in
+            if let status = credit["status"] as? String, status != "available" { return nil }
+            guard let id = credit["id"] as? String, let date = parseExpiry(credit["expires_at"]) else { return nil }
+            return (id, date)
+        }
+        switch pick {
+        case .expiring(let expiry):
+            return claimable.first { abs($0.expiresAt.timeIntervalSince(expiry)) < 1 }
+        case .nextToExpire:
+            return claimable.min { $0.expiresAt < $1.expiresAt }
+        }
+    }
+
+    /// The expiry-targeted pick, kept as the popover-shaped (and test-covered) surface.
+    static func creditID(in body: [String: Any], expiringAt expiry: Date) -> String? {
+        credit(in: body, pick: .expiring(at: expiry))?.id
     }
 
     /// Collapses a consume response to the popover's outcome. All four protocol codes arrive as HTTP

--- a/Sources/OpenUsage/Services/CodexResetClaimRunner.swift
+++ b/Sources/OpenUsage/Services/CodexResetClaimRunner.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// The claim result the CLI prints: `data` is the compact JSON document for stdout, `status` drives
+/// the exit code, and `warnings` are non-fatal post-claim refresh problems for stderr.
+public struct CodexResetClaimResult: Sendable {
+    public enum Status: String, Sendable {
+        case claimed
+        case nothingToReset = "nothing_to_reset"
+        case noCredit = "no_credit"
+        case failed
+    }
+
+    public let status: Status
+    public let data: Data
+    public let warnings: [String]
+}
+
+/// The CLI's path into the Codex reset-credit claim (`openusage codex --claim-reset`) — the same
+/// `CodexResetClaimService` the app's resets popover uses, so credential fallback, credit matching,
+/// and the idempotency guard can't drift from the app's. Only the pick differs: the popover claims
+/// the credit the user clicked; the CLI claims whatever claimable credit is next to expire. The
+/// service's refresh hook forces a Codex read through `UsageReader`, so the shared snapshot cache
+/// (the app and subsequent CLI reads) reconciles before the process exits.
+@MainActor
+public final class CodexResetClaimRunner {
+    /// Collects failures raised inside the service's post-claim refresh hook — non-fatal for the
+    /// claim itself, surfaced as CLI warnings.
+    @MainActor
+    final class WarningSink {
+        var messages: [String] = []
+    }
+
+    private let service: CodexResetClaimService
+    private let warnings: WarningSink
+    private let makeRedeemRequestID: () -> String
+
+    public convenience init(userDefaults: UserDefaults) {
+        let warnings = WarningSink()
+        let provider = CodexProvider()
+        self.init(
+            service: CodexResetClaimService(
+                authStore: provider.authStore,
+                usageClient: provider.usageClient,
+                refreshAfterClaim: { @MainActor in
+                    do {
+                        let read = try await UsageReader(userDefaults: userDefaults)
+                            .read(providerID: "codex", force: true)
+                        warnings.messages.append(contentsOf: read.warnings)
+                    } catch {
+                        warnings.messages.append("post-claim refresh failed: \(error.localizedDescription)")
+                    }
+                }
+            ),
+            warnings: warnings
+        )
+    }
+
+    /// Test seam: an injected service (whose refresh hook may feed `warnings`) and a deterministic
+    /// idempotency-key generator so the printed JSON is assertable.
+    init(
+        service: CodexResetClaimService,
+        warnings: WarningSink = WarningSink(),
+        makeRedeemRequestID: @escaping () -> String = { UUID().uuidString }
+    ) {
+        self.service = service
+        self.warnings = warnings
+        self.makeRedeemRequestID = makeRedeemRequestID
+    }
+
+    public func claimNextAvailableCredit() async -> CodexResetClaimResult {
+        let redeemRequestID = makeRedeemRequestID()
+        let claim = await service.claimNextAvailableCredit(redeemRequestID: redeemRequestID)
+        let status: CodexResetClaimResult.Status
+        switch claim.outcome {
+        case .success: status = .claimed
+        case .nothingToReset: status = .nothingToReset
+        case .noCredit: status = .noCredit
+        case .failed: status = .failed
+        }
+        return CodexResetClaimResult(
+            status: status,
+            data: Self.encode(
+                status: status, creditExpiresAt: claim.creditExpiresAt, redeemRequestID: redeemRequestID
+            ),
+            warnings: warnings.messages
+        )
+    }
+
+    /// The printed claim document — compact with sorted keys, like the limits JSON. `creditExpiresAt`
+    /// appears only when a credit was actually targeted (on `nothing_to_reset` the targeted credit is
+    /// kept, so "targeted" is deliberately not "spent").
+    private struct WireClaim: Encodable {
+        let schema = "openusage.claim.v1"
+        let provider = "codex"
+        let status: String
+        let creditExpiresAt: String?
+        let redeemRequestID: String
+    }
+
+    static func encode(status: CodexResetClaimResult.Status, creditExpiresAt: Date?, redeemRequestID: String) -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let wire = WireClaim(
+            status: status.rawValue,
+            creditExpiresAt: creditExpiresAt.map(OpenUsageISO8601.string(from:)),
+            redeemRequestID: redeemRequestID
+        )
+        if let data = try? encoder.encode(wire) { return data }
+        // Mirrors LocalLimitsAPI's envelope fallback: a hand-rolled minimal document rather than a crash.
+        return Data(#"{"provider":"codex","schema":"openusage.claim.v1","status":"failed"}"#.utf8)
+    }
+}

--- a/Sources/OpenUsageCLI/CLIArguments.swift
+++ b/Sources/OpenUsageCLI/CLIArguments.swift
@@ -3,6 +3,7 @@ import Foundation
 struct CLIArguments: Equatable, Sendable {
     var providerID: String?
     var force = false
+    var claimReset = false
     var showHelp = false
     var showVersion = false
 
@@ -11,6 +12,7 @@ struct CLIArguments: Equatable, Sendable {
         for argument in arguments {
             switch argument {
             case "--force": parsed.force = true
+            case "--claim-reset": parsed.claimReset = true
             case "-h", "--help": parsed.showHelp = true
             case "-v", "--version": parsed.showVersion = true
             default:

--- a/Sources/OpenUsageCLI/OpenUsageCLI.swift
+++ b/Sources/OpenUsageCLI/OpenUsageCLI.swift
@@ -21,6 +21,29 @@ struct OpenUsageCLI {
             guard let defaults = UserDefaults(suiteName: app.bundleIdentifier) else {
                 throw CLIError.appDefaultsUnavailable
             }
+
+            if arguments.claimReset {
+                guard arguments.providerID == "codex" else {
+                    throw CLIError.usage("--claim-reset claims a Codex reset credit: run 'openusage codex --claim-reset'.")
+                }
+                let claim = await CodexResetClaimRunner(userDefaults: defaults).claimNextAvailableCredit()
+                FileHandle.standardOutput.write(claim.data)
+                FileHandle.standardOutput.write(Data("\n".utf8))
+                claim.warnings.forEach { writeError("warning: \($0)") }
+                switch claim.status {
+                case .claimed, .nothingToReset:
+                    // Exit 0 even when the post-claim refresh warned: the claim itself landed, and a
+                    // non-zero exit would invite scripted retries — a new process is a new idempotency
+                    // key, so a retry could spend a second credit.
+                    break
+                case .noCredit:
+                    exit(3)
+                case .failed:
+                    exit(4)
+                }
+                return
+            }
+
             let result = try await UsageReader(userDefaults: defaults).read(
                 providerID: arguments.providerID,
                 force: arguments.force
@@ -54,12 +77,14 @@ struct OpenUsageCLI {
     }
 
     private static let help = """
-    Usage: openusage [provider] [--force]
+    Usage: openusage [provider] [--force] [--claim-reset]
 
     Read limits through OpenUsage's shared five-minute cache and exit. Output is always JSON.
 
     Options:
-      --force      Refresh even when the shared cache is still fresh
+      --force        Refresh even when the shared cache is still fresh
+      --claim-reset  Spend the next-to-expire Codex rate-limit reset credit (codex only).
+                     Claims immediately, without confirmation — see docs/cli.md before scripting retries
       -v, --version
       -h, --help
     """

--- a/Tests/OpenUsageCLITests/CLIArgumentsTests.swift
+++ b/Tests/OpenUsageCLITests/CLIArgumentsTests.swift
@@ -8,6 +8,13 @@ final class CLIArgumentsTests: XCTestCase {
         XCTAssertTrue(parsed.force)
     }
 
+    func testParsesClaimReset() throws {
+        let parsed = try CLIArguments.parse(["codex", "--claim-reset"])
+        XCTAssertEqual(parsed.providerID, "codex")
+        XCTAssertTrue(parsed.claimReset)
+        XCTAssertFalse(try CLIArguments.parse(["codex"]).claimReset)
+    }
+
     func testRejectsUnknownOptionsAndMultipleProviders() {
         XCTAssertThrowsError(try CLIArguments.parse(["--json"]))
         XCTAssertThrowsError(try CLIArguments.parse(["claude", "codex"]))

--- a/Tests/OpenUsageTests/CodexResetClaimRunnerTests.swift
+++ b/Tests/OpenUsageTests/CodexResetClaimRunnerTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import OpenUsage
+
+/// The CLI-facing claim runner: outcome→status mapping, the printed JSON document, and warning
+/// passthrough from the post-claim refresh hook — through the same stub HTTP client as the service's
+/// own tests (the real endpoint is never touched).
+@MainActor
+final class CodexResetClaimRunnerTests: XCTestCase {
+    private nonisolated static let expiry = Date(timeIntervalSince1970: 1_800_000_000)
+    private nonisolated static let redeemID = "11111111-2222-3333-4444-555555555555"
+
+    private func makeRunner(
+        listBody: Data? = nil,
+        consumeCode: String = "reset",
+        warnings: CodexResetClaimRunner.WarningSink = CodexResetClaimRunner.WarningSink(),
+        refreshAfterClaim: @escaping () async -> Void = {}
+    ) -> CodexResetClaimRunner {
+        let list = listBody ?? Data("""
+        {"credits": [{"id": "RateLimitResetCredit_target", "status": "available",
+                      "expires_at": "\(OpenUsageISO8601.string(from: Self.expiry))"}]}
+        """.utf8)
+        let http = RoutingHTTPClient { request in
+            switch request.url {
+            case CodexUsageClient.resetCreditsURL:
+                return HTTPResponse(statusCode: 200, headers: [:], body: list)
+            case CodexUsageClient.consumeResetCreditURL:
+                return HTTPResponse(statusCode: 200, headers: [:],
+                                    body: Data(#"{"code": "\#(consumeCode)"}"#.utf8))
+            default:
+                XCTFail("unexpected request: \(request.url)")
+                return HTTPResponse(statusCode: 500, headers: [:], body: Data())
+            }
+        }
+        let service = CodexResetClaimService(
+            usageClient: CodexUsageClient(http: http),
+            credentialCandidates: { [("token-123", "acct-456")] },
+            refreshAfterClaim: refreshAfterClaim
+        )
+        return CodexResetClaimRunner(service: service, warnings: warnings, makeRedeemRequestID: { Self.redeemID })
+    }
+
+    func testClaimedResultPrintsCompactSortedJSON() async {
+        let result = await makeRunner().claimNextAvailableCredit()
+
+        XCTAssertEqual(result.status, .claimed)
+        XCTAssertTrue(result.warnings.isEmpty)
+        let expiryString = OpenUsageISO8601.string(from: Self.expiry)
+        XCTAssertEqual(
+            String(decoding: result.data, as: UTF8.self),
+            #"{"creditExpiresAt":"\#(expiryString)","provider":"codex","redeemRequestID":"\#(Self.redeemID)","schema":"openusage.claim.v1","status":"claimed"}"#
+        )
+    }
+
+    func testNoCreditResultOmitsExpiryAndKeepsSchema() async {
+        let result = await makeRunner(listBody: Data(#"{"credits": []}"#.utf8)).claimNextAvailableCredit()
+
+        XCTAssertEqual(result.status, .noCredit)
+        XCTAssertEqual(
+            String(decoding: result.data, as: UTF8.self),
+            #"{"provider":"codex","redeemRequestID":"\#(Self.redeemID)","schema":"openusage.claim.v1","status":"no_credit"}"#
+        )
+    }
+
+    func testNothingToResetMapsToItsOwnStatus() async {
+        let result = await makeRunner(consumeCode: "nothing_to_reset").claimNextAvailableCredit()
+        XCTAssertEqual(result.status, .nothingToReset)
+        XCTAssertTrue(String(decoding: result.data, as: UTF8.self).contains(#""status":"nothing_to_reset""#))
+    }
+
+    func testRefreshHookWarningsSurfaceOnTheResult() async {
+        let warnings = CodexResetClaimRunner.WarningSink()
+        let runner = makeRunner(warnings: warnings, refreshAfterClaim: { @MainActor in
+            warnings.messages.append("post-claim refresh failed: boom")
+        })
+
+        let result = await runner.claimNextAvailableCredit()
+
+        XCTAssertEqual(result.status, .claimed)
+        XCTAssertEqual(result.warnings, ["post-claim refresh failed: boom"])
+    }
+}

--- a/Tests/OpenUsageTests/CodexResetClaimTests.swift
+++ b/Tests/OpenUsageTests/CodexResetClaimTests.swift
@@ -209,6 +209,74 @@ final class CodexResetClaimTests: XCTestCase {
         XCTAssertEqual(refreshes.count, 1)
     }
 
+    // MARK: - Next-to-expire claim (the CLI's pick)
+
+    func testClaimNextAvailableCreditPicksTheEarliestExpiry() async throws {
+        // The stub list carries the target at `expiry` and another credit ~11 days later — the CLI
+        // pick must take the earliest, regardless of list order (the target is listed second).
+        let refreshes = RefreshCounter()
+        let (service, http) = makeService(refreshes: refreshes)
+
+        let claim = await service.claimNextAvailableCredit(redeemRequestID: "redeem-cli")
+
+        XCTAssertEqual(claim.outcome, .success)
+        XCTAssertEqual(claim.creditExpiresAt, Self.expiry, "reports which credit was spent")
+        XCTAssertEqual(refreshes.count, 1, "a successful claim forces a Codex refresh before returning")
+        let consume = try XCTUnwrap(http.requests.last)
+        let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: XCTUnwrap(consume.body)) as? [String: String])
+        XCTAssertEqual(payload["credit_id"], "RateLimitResetCredit_target")
+        XCTAssertEqual(payload["redeem_request_id"], "redeem-cli")
+    }
+
+    func testClaimNextAvailableCreditSkipsUnclaimableCredits() async throws {
+        // The earliest credit is redeemed and another has no expiry at all (unclaimable — expiry is
+        // the identity a claim matches on): the pick must fall through to the later available credit.
+        let listBody = Data("""
+        {"credits": [
+            {"id": "RateLimitResetCredit_redeemed", "status": "redeemed",
+             "expires_at": "\(OpenUsageISO8601.string(from: Self.expiry))"},
+            {"id": "RateLimitResetCredit_bare", "status": "available"},
+            {"id": "RateLimitResetCredit_later", "status": "available",
+             "expires_at": "\(OpenUsageISO8601.string(from: Self.expiry.addingTimeInterval(3600)))"}
+        ], "available_count": 3}
+        """.utf8)
+        let (service, http) = makeService(listBody: listBody)
+
+        let claim = await service.claimNextAvailableCredit(redeemRequestID: "redeem-cli")
+
+        XCTAssertEqual(claim.outcome, .success)
+        XCTAssertEqual(claim.creditExpiresAt, Self.expiry.addingTimeInterval(3600))
+        let consume = try XCTUnwrap(http.requests.last)
+        let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: XCTUnwrap(consume.body)) as? [String: String])
+        XCTAssertEqual(payload["credit_id"], "RateLimitResetCredit_later")
+    }
+
+    func testClaimNextAvailableCreditWithEmptyListIsNoCreditAndRefreshes() async {
+        let refreshes = RefreshCounter()
+        let (service, http) = makeService(
+            listBody: Data(#"{"credits": [], "available_count": 0}"#.utf8),
+            refreshes: refreshes
+        )
+
+        let claim = await service.claimNextAvailableCredit(redeemRequestID: "redeem-cli")
+
+        XCTAssertEqual(claim.outcome, .noCredit)
+        XCTAssertNil(claim.creditExpiresAt)
+        XCTAssertEqual(http.requests.map(\.url), [CodexUsageClient.resetCreditsURL], "no consume POST is ever sent")
+        XCTAssertEqual(refreshes.count, 1, "reconciles a snapshot that may still show credits")
+    }
+
+    func testClaimNextAvailableCreditListFailureIsFailedWithoutRefresh() async {
+        let refreshes = RefreshCounter()
+        let (service, _) = makeService(listStatus: 503, refreshes: refreshes)
+
+        let claim = await service.claimNextAvailableCredit(redeemRequestID: "redeem-cli")
+
+        XCTAssertEqual(claim.outcome, .failed)
+        XCTAssertNil(claim.creditExpiresAt)
+        XCTAssertEqual(refreshes.count, 0, "failures leave the snapshot alone")
+    }
+
     // MARK: - Idempotent replay
 
     func testRetryWithSameKeyReplaysTheConsumeInsteadOfNoCredit() async throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,11 +16,38 @@ snapshot cache. A normal read reuses snapshots less than five minutes old and re
 ones. `--force` is the CLI equivalent of the app's manual refresh: it bypasses that freshness gate and
 writes successful results to the same cache. Credentials are used locally and never appear in the output.
 
+## Claim a Codex Reset Credit
+
+`openusage codex --claim-reset` claims a Codex rate-limit reset credit — the same claim the app offers
+from its resets popover, sharing the app's credential handling and idempotency key handling, so the
+retries *within* one invocation (credential fallback) can never spend a second credit. The command
+fetches the current credit list fresh, claims the credit closest to expiry, refreshes Codex through the
+shared cache so the app and later reads reconcile, and prints a JSON outcome:
+
+```sh
+openusage codex --claim-reset
+# {"creditExpiresAt":"2026-07-19T04:00:00Z","provider":"codex","redeemRequestID":"…","schema":"openusage.claim.v1","status":"claimed"}
+```
+
+`status` is `claimed`, `nothing_to_reset` (usage doesn't need a reset right now — the credit is kept),
+`no_credit` (nothing claimable: already claimed elsewhere or expired), or `failed`. `creditExpiresAt`
+identifies the credit that was targeted and is omitted when none was. Exit codes: `0` for `claimed` and
+`nothing_to_reset`, `3` for `no_credit`, `4` for `failed`. Post-claim refresh problems appear as
+`openusage: warning:` lines on stderr and never change the exit code — the claim already landed.
+
+Each invocation is its own claim with a fresh idempotency key, so don't retry `--claim-reset` blindly in
+a script: a `failed` claim whose request never got an answer may still have landed server-side, and a
+re-run would target the next credit. Re-read the credit list first (`openusage codex --force`) and only
+claim again if a credit you expected gone is still there.
+
+This is the CLI's only write; every other command is read-only.
+
 ## Install on `PATH`
 
 In OpenUsage, open **Settings → Command Line** and click **Install…**. After the standard macOS
 administrator prompt, `openusage` is available globally in new terminal sessions. The installed symlink
 points to the signed helper inside OpenUsage, so in-place app updates also update the command.
 
-Exit codes are `0` for success, `2` for invalid arguments, `3` when a requested provider has no snapshot,
-and `4` when a refresh or local read fails.
+Exit codes are `0` for success, `2` for invalid arguments, `3` when a requested provider has no snapshot
+(or a claim finds no credit), and `4` when a claim, refresh, or local read fails — except a *post-claim*
+refresh problem, which stays a stderr warning.


### PR DESCRIPTION
## Approved issue

Fixes #1006

## TL;DR

Adds `openusage codex --claim-reset`, letting the CLI spend the next-to-expire Codex rate-limit reset credit through the same claim service the app's resets popover uses.

## What was happening

The Codex reset-credit claim only existed in the app's popover — scripts and agent skills (issue #1006) had no way to claim a credit, and the CLI was strictly read-only.

## What this changes

`CodexResetClaimService` gains a `.nextToExpire` pick alongside the popover's expiry-targeted one (same list fetch, status filter, credential fallback, idempotency replay, and post-claim refresh), and a new `CodexResetClaimRunner` wires it into the CLI: `--claim-reset` prints a compact `openusage.claim.v1` JSON outcome, maps `no_credit`/`failed` to exit codes 3/4, keeps post-claim refresh problems as stderr warnings so a landed claim never exits non-zero, and refuses the flag for any provider but codex. docs/cli.md documents the command, exit codes, and why blind scripted retries are unsafe.

## Tests

Full `swift test` suite passes; new coverage for the next-to-expire pick (earliest-expiry selection, skipping unclaimable credits, empty list, list failure), the runner's JSON/warning/status mapping, and `--claim-reset` argument parsing.

## Screenshots

Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a scripted API that consumes provider reset credits; mitigations mirror the app (idempotency per invocation, shared service), but blind retries across runs can spend additional credits.
> 
> **Overview**
> Adds **`openusage codex --claim-reset`**, the CLI’s first write path: it spends the **next-to-expire** claimable Codex rate-limit reset credit using the same **`CodexResetClaimService`** as the app popover.
> 
> **`CodexResetClaimService`** is generalized with **`ResetCreditPick`** (popover: match by expiry; CLI: earliest claimable credit). Idempotency replay now caches **credit id + expiry** per redeem key. **`CodexResetClaimRunner`** maps outcomes to compact **`openusage.claim.v1`** JSON, forces a post-claim Codex refresh via **`UsageReader`**, and surfaces refresh failures as **stderr warnings** without failing exit when the claim succeeded.
> 
> The CLI rejects **`--claim-reset`** for non-codex providers; exit **0** for `claimed` / `nothing_to_reset`, **3** for `no_credit`, **4** for `failed`. **`docs/cli.md`** documents behavior and scripted-retry caveats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dae479ab07fffe66e885ab17794b810008bf811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->