### PR TITLE
Account-first Phase 0: shell-environment snapshot + the plan

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -52,6 +52,9 @@ final class AppContainer {
     /// The new-provider credential-detection pass (see `NewProviderSeeder`); `nil` unless this launch is
     /// the first with a provider the install has never seen.
     private let newProviderTask: Task<Void, Never>?
+    /// Persists a fresh `ShellEnvironmentSnapshot` once the login-shell capture completes, so the next
+    /// launch can read shell-exported facts (provider home overrides) even when its own capture is slow.
+    private let shellEnvironmentSnapshotTask: Task<Void, Never>
 
     /// `isFreshInstall` must be captured by the caller BEFORE `SettingsMigrator.migrate()` runs (the
     /// migrator's schema stamp makes the defaults domain non-empty). See `AppDelegate`.
@@ -60,6 +63,9 @@ final class AppContainer {
         // profile (e.g. OPENROUTER_API_KEY) resolve in a Finder/Dock-launched build, not only when
         // run from a terminal. Warmed here so the first refresh finds the cache ready.
         LoginShellEnvironment.shared.prewarm()
+        // Once the capture lands, persist its identity-relevant facts so the NEXT launch has them
+        // even if that launch's own capture is slow (see `ShellEnvironmentSnapshot`).
+        self.shellEnvironmentSnapshotTask = ShellEnvironmentSnapshotStore(defaults: .standard).startRefreshTask()
 
         let providers = ProviderCatalog.make()
         let registry = WidgetRegistry.from(providers)
@@ -205,6 +211,7 @@ final class AppContainer {
         refreshTask.cancel()
         seedTask?.cancel()
         newProviderTask?.cancel()
+        shellEnvironmentSnapshotTask.cancel()
     }
 
     /// Re-runs first-launch credential detection on demand — the enablement half of the Customize

--- a/Sources/OpenUsage/Services/LoginShellEnvironment.swift
+++ b/Sources/OpenUsage/Services/LoginShellEnvironment.swift
@@ -51,10 +51,29 @@ final class LoginShellEnvironment: @unchecked Sendable {
 
     /// Spawn the capture eagerly off the main thread so the first provider refresh (and any UI read)
     /// finds the cache already warm and never blocks on the subprocess. Safe to call more than once.
+    /// `.userInitiated`, not `.utility`: launch-time readers depend on this cache, and under
+    /// cold-launch CPU contention a utility-priority spawn regularly lost the race against the first
+    /// provider refresh — which then resolved shell-exported keys as absent for the whole pass.
     func prewarm() {
-        Task.detached(priority: .utility) { [weak self] in
+        Task.detached(priority: .userInitiated) { [weak self] in
             _ = self?.capturedEnvironment()
         }
+    }
+
+    /// Whether a capture has completed AND yielded a plausible environment. A real login shell always
+    /// exports at least `PATH`/`HOME`, so an empty capture means the spawn or parse failed — callers
+    /// must not persist facts (like "no overrides exported") derived from it.
+    var capturedSuccessfully: Bool {
+        !(cachedSnapshot() ?? [:]).isEmpty
+    }
+
+    /// Off-main only: make sure the one-time capture has actually run (spawning it now if the prewarm
+    /// never completed), then report whether it succeeded. The post-launch snapshot task uses this so
+    /// a launch whose prewarm was slow still persists fresh facts for the next launch.
+    func ensureCaptured() -> Bool {
+        guard !Thread.isMainThread else { return capturedSuccessfully }
+        _ = capturedEnvironment()
+        return capturedSuccessfully
     }
 
     private func cachedSnapshot() -> [String: String]? {

--- a/Sources/OpenUsage/Services/ShellEnvironmentSnapshot.swift
+++ b/Sources/OpenUsage/Services/ShellEnvironmentSnapshot.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// The login-shell facts account-identity resolution depends on (provider home overrides and OAuth
+/// endpoint switches), persisted after every successful shell capture. Shell exports change ~never
+/// between launches, so when the login shell is too slow to warm before a launch-time read, the
+/// reader can run against the previous launch's snapshot instead of mistaking an exported override
+/// for "not set". Only a genuinely first launch (no snapshot yet) has nothing to fall back on.
+struct ShellEnvironmentSnapshot: Codable, Equatable, Sendable {
+    /// Identity-relevant, non-secret configuration variables. Secrets (API keys, tokens) must never
+    /// be added here — the snapshot lives in UserDefaults as plain text.
+    static let capturedKeys = [
+        "CLAUDE_CONFIG_DIR", "CODEX_HOME", "XDG_CONFIG_HOME",
+        "USER_TYPE", "USE_LOCAL_OAUTH", "USE_STAGING_OAUTH",
+        "CLAUDE_LOCAL_OAUTH_API_BASE", "CLAUDE_CODE_CUSTOM_OAUTH_URL",
+    ]
+
+    /// Captured values. A key absent here was verifiably NOT exported at capture time — that absence
+    /// is a cached fact too, and pins "no override" even if a late-finishing warm would disagree.
+    var values: [String: String]
+    var capturedAt: Date
+
+    /// Values for every captured key as the (warm) login-shell layer reports them, or `nil` when the
+    /// capture failed — a real login shell always exports PATH/HOME, so an empty capture means the
+    /// spawn or parse failed and its "facts" must not be persisted.
+    static func current(
+        shellEnvironment: LoginShellEnvironment = .shared,
+        capturedAt: Date = Date()
+    ) -> ShellEnvironmentSnapshot? {
+        guard shellEnvironment.capturedSuccessfully else { return nil }
+        var values: [String: String] = [:]
+        for key in capturedKeys {
+            if let value = shellEnvironment.value(for: key) { values[key] = value }
+        }
+        return ShellEnvironmentSnapshot(values: values, capturedAt: capturedAt)
+    }
+}
+
+/// UserDefaults persistence for the snapshot (`openusage.shellEnvSnapshot.v1`). A class so the
+/// post-launch refresh task can carry it across actors; UserDefaults itself is thread-safe.
+final class ShellEnvironmentSnapshotStore: @unchecked Sendable {
+    static let storageKey = "openusage.shellEnvSnapshot.v1"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    func load() -> ShellEnvironmentSnapshot? {
+        guard let data = defaults.data(forKey: Self.storageKey) else { return nil }
+        guard let snapshot = try? JSONDecoder().decode(ShellEnvironmentSnapshot.self, from: data) else {
+            AppLog.warn(.config, "shell-environment snapshot was undecodable; discarding it")
+            defaults.removeObject(forKey: Self.storageKey)
+            return nil
+        }
+        return snapshot
+    }
+
+    func save(_ snapshot: ShellEnvironmentSnapshot) {
+        guard let data = try? JSONEncoder().encode(snapshot) else {
+            AppLog.error(.config, "failed to encode shell-environment snapshot; keeping the previous one")
+            return
+        }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+
+    /// Wait (off-main, bounded by the capture's own subprocess timeout) for the login-shell capture
+    /// kicked off by `prewarm()`, then persist a fresh snapshot of its facts. A failed capture
+    /// persists nothing — the previous snapshot's facts stay in place. Callers retain the task and
+    /// cancel it on teardown.
+    func startRefreshTask(shellEnvironment: LoginShellEnvironment = .shared) -> Task<Void, Never> {
+        Task.detached(priority: .utility) { [self] in
+            guard shellEnvironment.ensureCaptured(),
+                  let snapshot = ShellEnvironmentSnapshot.current(shellEnvironment: shellEnvironment)
+            else {
+                AppLog.warn(.config, "login-shell capture failed; keeping the previous shell-environment snapshot")
+                return
+            }
+            let previous = load()
+            save(snapshot)
+            if let previous, previous.values != snapshot.values {
+                AppLog.info(.config, "shell-environment snapshot changed since the last capture; launch-time readers pick it up next launch")
+            }
+        }
+    }
+}

--- a/Tests/OpenUsageTests/ShellEnvironmentSnapshotTests.swift
+++ b/Tests/OpenUsageTests/ShellEnvironmentSnapshotTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class ShellEnvironmentSnapshotTests: XCTestCase {
+    func testStoreRoundtripsSnapshot() {
+        let defaults = makeScratchDefaults()
+        let store = ShellEnvironmentSnapshotStore(defaults: defaults)
+        let snapshot = ShellEnvironmentSnapshot(
+            values: ["CLAUDE_CONFIG_DIR": "~/.claude-work", "XDG_CONFIG_HOME": "~/.config"],
+            capturedAt: Date(timeIntervalSince1970: 1_752_800_000)
+        )
+
+        store.save(snapshot)
+
+        XCTAssertEqual(store.load(), snapshot)
+    }
+
+    func testUndecodableSnapshotIsDiscarded() {
+        let defaults = makeScratchDefaults()
+        defaults.set(Data("not json".utf8), forKey: ShellEnvironmentSnapshotStore.storageKey)
+        let store = ShellEnvironmentSnapshotStore(defaults: defaults)
+
+        XCTAssertNil(store.load())
+        XCTAssertNil(defaults.data(forKey: ShellEnvironmentSnapshotStore.storageKey))
+    }
+
+    func testCurrentIsNilWhenCaptureFailed() {
+        // An empty capture means the spawn or parse failed (a real login shell always exports
+        // PATH/HOME) — its "facts" must not be persisted as a snapshot.
+        let shellEnvironment = LoginShellEnvironment(runner: FixedRunner(stdout: "no markers"))
+        XCTAssertFalse(shellEnvironment.ensureCapturedForTesting(), "an empty capture must report failure")
+        XCTAssertNil(ShellEnvironmentSnapshot.current(shellEnvironment: shellEnvironment))
+    }
+
+    func testCurrentCapturesOnlyDeclaredKeys() {
+        let stdout = [
+            "__OPENUSAGE_ENV_BEGIN__",
+            "CLAUDE_CONFIG_DIR=~/.claude-work",
+            "OPENROUTER_API_KEY=sk-or-secret",
+            "PATH=/usr/bin",
+            "__OPENUSAGE_ENV_END__",
+        ].joined(separator: "\0")
+        let shellEnvironment = LoginShellEnvironment(runner: FixedRunner(stdout: stdout))
+        XCTAssertTrue(shellEnvironment.ensureCapturedForTesting())
+
+        let snapshot = ShellEnvironmentSnapshot.current(shellEnvironment: shellEnvironment)
+
+        // Only the declared non-secret keys land in the snapshot — never API keys or tokens.
+        XCTAssertEqual(snapshot?.values, ["CLAUDE_CONFIG_DIR": "~/.claude-work"])
+    }
+
+    func testRefreshTaskPersistsSnapshotAfterCapture() async {
+        let defaults = makeScratchDefaults()
+        let store = ShellEnvironmentSnapshotStore(defaults: defaults)
+        let stdout = [
+            "__OPENUSAGE_ENV_BEGIN__", "CODEX_HOME=/tmp/codex-home", "PATH=/usr/bin", "__OPENUSAGE_ENV_END__",
+        ].joined(separator: "\0")
+        let shellEnvironment = LoginShellEnvironment(runner: FixedRunner(stdout: stdout))
+
+        await store.startRefreshTask(shellEnvironment: shellEnvironment).value
+
+        XCTAssertEqual(store.load()?.values, ["CODEX_HOME": "/tmp/codex-home"])
+    }
+
+    func testRefreshTaskKeepsPreviousSnapshotWhenCaptureFails() async {
+        let defaults = makeScratchDefaults()
+        let store = ShellEnvironmentSnapshotStore(defaults: defaults)
+        let previous = ShellEnvironmentSnapshot(values: ["CODEX_HOME": "/tmp/old"], capturedAt: Date())
+        store.save(previous)
+        let shellEnvironment = LoginShellEnvironment(runner: FixedRunner(stdout: "capture failed"))
+
+        await store.startRefreshTask(shellEnvironment: shellEnvironment).value
+
+        XCTAssertEqual(store.load(), previous)
+    }
+
+    private func makeScratchDefaults() -> UserDefaults {
+        let suiteName = "OpenUsageTests.ShellEnvironmentSnapshot.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return defaults
+    }
+}
+
+private final class FixedRunner: ProcessRunning, @unchecked Sendable {
+    let stdout: String
+
+    init(stdout: String) { self.stdout = stdout }
+
+    func run(executable: String, arguments: [String], environment: [String: String], timeout: TimeInterval) throws -> ProcessResult {
+        ProcessResult(exitCode: 0, stdout: stdout, stderr: "")
+    }
+}
+
+private extension LoginShellEnvironment {
+    /// Force the capture from the test's (main) thread by hopping off-main, since `ensureCaptured`
+    /// refuses to spawn on the main thread.
+    func ensureCapturedForTesting() -> Bool {
+        let done = DispatchSemaphore(value: 0)
+        var result = false
+        DispatchQueue.global().async {
+            result = self.ensureCaptured()
+            done.signal()
+        }
+        done.wait()
+        return result
+    }
+}

--- a/docs/research/account-first-plan.md
+++ b/docs/research/account-first-plan.md
@@ -1,0 +1,130 @@
+# Account-First Multi-Account Plan
+
+The execution plan for multi-account Claude/Codex support, replacing the closed PR #1014
+(branch `claude/provider-management-ux-780d96`, continued on `agent/multi-account-cli-pr1014`).
+Those branches stay alive as **cherry-pick material** — most of their auth-store scoping, discovery
+internals, swap timeline, iCloud remapping, and ~4k test lines port into the phases below.
+
+## Why the restart
+
+PR #1014 keyed the default card by *location* (the default home) and every extra account by
+*identity*. Review traced nearly every P1 bug to that split: the default card's identity is mutable,
+so the branch accreted ~1.5–2k lines of guard machinery (same-account folds, duplicate suppression,
+launch gating, history withholding) defending a structural flaw — guards its own follow-up plan
+would then delete. Since none of it ever shipped, no user has state that needs the staged
+migrate-shadow-flip choreography. This plan flips to the account-first model **before** any
+multi-account discovery ships, so the guards never get written.
+
+## Target model
+
+Every card is an **account**: an opaque identity key with a stable record id minted at creation.
+Places an account is signed in are **sources** (default home, config dir, cswap vault slot,
+Desktop/Cowork, Codex home) attached to its record. "Default" is a badge on a source
+(`holdsDefaultSource`) used for the bare-id alias, CLI resolution, and attribution — never a key,
+never live sort order. A swap re-points source edges; cards, history, layout, and pins never move.
+An unresolved source claims no account. A card whose sources are all absent renders a calm
+signed-out state with a Remove affordance (tombstone; rescans never resurrect it).
+
+### The migration-killing decision
+
+The account occupying the default home at conversion time **keeps the bare id (`claude`, `codex`)
+as its permanent record id**. Ids are opaque, so nothing is special about the shape. Every existing
+install migrates by doing nothing: layout keys, pins, history bindings, snapshot cache entries, and
+third-party API consumers keep working untouched. If the user later swaps accounts at the default
+home, the new account mints `claude@<hash8>` and takes the default badge; the old card stays under
+its old id. The bare id doubles as the family **alias**: requests for `claude` resolve through
+`ProviderCardResolver` (badge holder → sole enabled family card → family empty state) and the HTTP
+API echoes the requested id.
+
+## Phases
+
+Each phase is one PR, shipped to the **beta channel** and soaked before the next starts. Docs and
+tests land in-slice (repo policy). Estimated source LOC excludes tests.
+
+### Phase 0 — Standalone reliability (no model change, ~300 LOC)
+
+- Shell-environment snapshot: discovery-grade env facts survive a slow login shell
+  (cherry-pick `22c8e97`).
+- File splits along provider seams where they help review (`c96fc75`, as needed).
+- Exit: beta with zero behavior change beyond launch reliability.
+
+### Phase 1 — Account-first core, single account per family (~800 LOC)
+
+- `ProviderAccountsStore` (`openusage.providerAccounts.v1`): account records with id, family,
+  identityKey, label, sources (+ badge), tombstone. Port from `e052ef9`, dropping the
+  shadow-comparison half — the registry is authoritative from day one.
+- Default-home identity reading for Claude and Codex (the proven slice of discovery — **no
+  candidate scanning yet**). Resolved identity attaches the default source; unresolved leaves the
+  family rendering its current state.
+- Cards render from account records. With exactly one account per family this is pixel-identical
+  to today, so the structural flip ships invisibly.
+- `ProviderCardResolver` wired through the one-shot CLI and local HTTP API (port from `e052ef9`).
+- Snapshot-cache identity stamp (v9): cached values remember the producing account; a swap between
+  launches discards the stale entry instead of painting it under the new account (port `fef9ad0`).
+- Signed-out rendering + "Remove Account…" (context menu, tombstone in the store) — cheap while
+  the model is small.
+- Exit: beta soak; logs confirm identity-resolution rates in the wild; existing users see nothing.
+
+### Phase 2 — Claude multi-account: config-dir discovery (~1,200 LOC)
+
+- Candidate scan (dot-dirs at `~`, dirs under `~/.config`), identity-extraction-is-validation,
+  support-trail log lines. Port the discovery internals; **omit** fold/suppression plumbing — a
+  candidate naming a known account just attaches as another source/log root on that record, so
+  duplicate cards are structurally impossible.
+- New account → new record → new card named by account label ("Claude — Sunstory"); layout seeded
+  from `DefaultLayout.translatedForInstances` (pins never seeded).
+- Scoped `ClaudeAuthStore` (per-config-dir keychain names), per-account spend from each home's logs.
+- iCloud identity routing: `PeerHistoryRemapper`, account-identity matching, v1-peer histories to a
+  family bucket rendered as device-labeled remote-only slices. Required the moment two accounts can
+  exist.
+- Exit: beta soak with real multi-config-dir users; lifecycle test suite re-targeted green.
+
+### Phase 3 — Claude: Cowork / Desktop accounts (~500 LOC)
+
+- Cowork sandbox walk with per-sandbox identity; sandboxes matching an existing account attach as
+  its log roots; a distinct account becomes one Desktop-backed card (org-pinned identity, Safe
+  Storage credentials).
+- Purely a new source kind on the existing model.
+
+### Phase 4 — Claude: cswap (~500 LOC)
+
+- Vault slot discovery: each parked slot is a source of its account; the active slot is whoever
+  holds the default badge.
+- Switch-log timeline partitions the shared home's spend logs per account.
+- A swap is the badge moving between records — no suppression, no restart requirement. A
+  mid-process swap marks the source stale; reconcile next launch.
+
+### Phase 5 — Codex multi-account + per-card resets (~700 LOC)
+
+- **5a:** `CODEX_HOME` candidate scan with the strict identity rule — `tokens.account_id` or the
+  id_token's ChatGPT account claim; a credential file that can't name its account never becomes a
+  card (port `93e741e`). Scoped auth stores, per-identity log-root grouping, and the
+  `CodexResetClaimRouter` (port `b6be1b1`) so every account's row claims its own reset credits from
+  day one.
+- **5b (separate if needed):** keyring-mode homes — an unverified keyring source claims no account
+  until the one-time post-launch account-scoped read binds it (`CodexHomeIdentityCache`). The
+  nichest slice; keeping it out of 5a keeps 5a simple.
+
+### Phase 6 — Attribution polish (small)
+
+- Pi spend attribution routed through the resolver to the badge holder.
+- Family-keyed telemetry rollups (`accounts_per_family` gauge).
+- Total Spend family grouping/tinting if still wanted (see `c6a63eb` on the old branch for why
+  plain size order won before).
+
+## Owner decisions (lock before the phase that needs them)
+
+1. **Bare id as the first account's record id** — the plan assumes yes (kills all migration).
+2. Label fallback when an account has no email/org name: short hash vs ordinal ("Claude 2").
+3. Newly discovered accounts seed enabled (PR #1014 behavior) or disabled.
+4. Remove-button placement: context-menu-first (assumed), Customize section later.
+
+## Verification
+
+- Per phase: `swift build` + full `swift test`; new suites land with their phase.
+- Live: `script/build_and_run.sh`, then `~/Library/Logs/OpenUsage/OpenUsage.log` — discovery trail,
+  identity resolution, and (Phase 1+) account-registry lines.
+- Beta release per phase via the release-swift skill; soak before the next phase merges.
+- CLI/API: `openusage claude` (alias) and `openusage claude@<hash>` (direct);
+  `curl 127.0.0.1:6736/v1/usage/claude` echoes the requested id.
+- iCloud: two-machine check once Phase 2 lands (migrated writer + old reader and inverse).


### PR DESCRIPTION
## TL;DR

First slice of the account-first multi-account plan (replacing closed #1014): the plan document itself, plus launch groundwork — the login shell's identity-relevant exports are now persisted so a slow shell can never hide them from a later launch.

## What was happening

- PR #1014 keyed the default Claude/Codex card by *location* and extras by *identity*; review traced nearly every P1 bug to that split, and it accreted ~2k lines of guard machinery. It never shipped, so we restarted with an account-first model — the full reasoning and phase breakdown live in the new `docs/research/account-first-plan.md`.
- The login-shell environment capture runs at utility priority and can lose the cold-launch race. Anything at launch that needs shell-exported facts (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, OAuth endpoint switches) would see them as "not set" for that launch.

## What this changes

- Adds `docs/research/account-first-plan.md` — the phased execution plan every later PR links back to.
- Adds `ShellEnvironmentSnapshot` + store: after every successful login-shell capture, the declared non-secret, identity-relevant keys are persisted to UserDefaults. A key absent from the snapshot is a cached fact too ("verifiably not exported").
- `LoginShellEnvironment` gains `capturedSuccessfully` (an empty capture = failed spawn/parse, never "no exports") and `ensureCaptured()`; the prewarm moves from utility to userInitiated priority.
- `AppContainer` starts a post-capture task each launch that refreshes the snapshot once the shell warms.

## Heads-up

- Nothing reads the snapshot yet — the consumer is Phase 1's launch-time account-identity read (PR follows this one). Shipping the writer first means Phase 1 lands on machines that already have a snapshot.
- Secrets can never enter the snapshot: only the fixed `capturedKeys` list is persisted.

## Tests

- New `ShellEnvironmentSnapshotTests` (roundtrip, undecodable discard, failed-capture nil, secret-key exclusion, refresh-task persist/keep-previous).
- Full suite: 1210 tests green. Local Bugbot review: no findings.

Made with [Cursor](https://cursor.com)