### PR TITLE
Account-first Phase 2: Claude multi-account from custom config dirs

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -40,6 +40,9 @@ final class AppContainer {
     /// provider were ever removed from the registry. Injected into the view tree via
     /// `\.codexResetClaim`.
     let codexResetClaim: CodexResetClaimService?
+    /// The account registry the launch pass reconciled. The UI observes it live: a rename
+    /// (`customLabel`) re-titles the card everywhere without a relaunch.
+    let accounts: ProviderAccountsStore
     /// The provider runtimes, kept so on-demand credential detection (the Customize "Reset All" reseed)
     /// can re-probe `hasLocalCredentials()` the same way first-run seeding does.
     private let providers: [ProviderRuntime]
@@ -69,7 +72,9 @@ final class AppContainer {
         // The launch account pass: which account is signed in at each family's default home, plus
         // the config-dir scan for extra Claude logins. Feeds the snapshot cache's account stamp,
         // reconciles the account registry, and hands the catalog its extra-card build plan.
-        let accountAssembly = ProviderAccountAssembly.make(waitsForLoginShell: true)
+        let accounts = ProviderAccountsStore()
+        let accountAssembly = ProviderAccountAssembly.make(accountsStore: accounts, waitsForLoginShell: true)
+        self.accounts = accounts
 
         let providers = ProviderCatalog.make(
             claudeCards: accountAssembly.claudeCards,
@@ -221,6 +226,34 @@ final class AppContainer {
         seedTask?.cancel()
         newProviderTask?.cancel()
         shellEnvironmentSnapshotTask.cancel()
+    }
+
+    /// The name a card renders under right now. Live: a rename in the account registry wins over
+    /// the name baked into the `Provider` at launch, so card titles update without a relaunch.
+    /// Non-account providers (no record) keep their static display name.
+    func displayName(for provider: Provider) -> String {
+        guard let record = accounts.records.first(where: { $0.id == provider.id }) else {
+            return provider.displayName
+        }
+        if let custom = record.customLabel?.nilIfEmpty { return custom }
+        // A rename was cleared mid-session: fall back to the derived name rather than the
+        // launch-baked one, which may itself carry the just-cleared rename.
+        return derivedDisplayName(for: record)
+    }
+
+    /// The name a card carries without a rename — the Customize name field's placeholder, and the
+    /// fallback once a rename is cleared: the stock family name for the default card, the
+    /// account-label-derived name for an extra card.
+    func derivedDisplayName(for record: ProviderAccountRecord) -> String {
+        ProviderAccountID.isAccountCard(record.id)
+            ? ClaudeAccountCard.displayName(customLabel: nil, label: record.label, id: record.id)
+            : ProviderAccountID.family(of: record.id).capitalized
+    }
+
+    /// Whether the card has an account record a rename can attach to (accounts-model families only,
+    /// and only once the account's identity has been observed at least once).
+    func canRename(_ providerID: String) -> Bool {
+        accounts.records.contains { $0.id == providerID }
     }
 
     /// Re-runs first-launch credential detection on demand — the enablement half of the Customize

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -66,11 +66,16 @@ final class AppContainer {
         // Once the capture lands, persist its identity-relevant facts so the NEXT launch has them
         // even if that launch's own capture is slow (see `ShellEnvironmentSnapshot`).
         self.shellEnvironmentSnapshotTask = ShellEnvironmentSnapshotStore(defaults: .standard).startRefreshTask()
-        // The launch account pass: which account is signed in at each family's default home. Feeds
-        // the snapshot cache's account stamp and reconciles the account registry.
+        // The launch account pass: which account is signed in at each family's default home, plus
+        // the config-dir scan for extra Claude logins. Feeds the snapshot cache's account stamp,
+        // reconciles the account registry, and hands the catalog its extra-card build plan.
         let accountAssembly = ProviderAccountAssembly.make(waitsForLoginShell: true)
 
-        let providers = ProviderCatalog.make()
+        let providers = ProviderCatalog.make(
+            claudeCards: accountAssembly.claudeCards,
+            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
+            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName
+        )
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
         let enablement = ProviderEnablementStore()

--- a/Sources/OpenUsage/Models/UsageHistoryDocument.swift
+++ b/Sources/OpenUsage/Models/UsageHistoryDocument.swift
@@ -2,13 +2,23 @@ import Foundation
 
 /// One Mac's presentation-free usage history in the private iCloud container.
 struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
-    static let currentSchema = "openusage.history.v1"
+    /// v2 adds account cards (`claude@ab12cd34`) and the `identities` map that lets peers match
+    /// histories by ACCOUNT instead of by card id — the same account can be the default card on one
+    /// Mac and an extra card on another. v1 documents stay readable (no identities → the legacy
+    /// same-card-id merge); v1 readers reject v2 documents with their designed "update OpenUsage"
+    /// message.
+    static let currentSchema = "openusage.history.v2"
+    static let legacySchemaV1 = "openusage.history.v1"
 
     var schema: String = currentSchema
     var deviceID: String
     var deviceName: String
     var updatedAt: Date
     var providers: [String: ProviderUsageHistory]
+    /// Card id → stable account identity key (see `ProviderAccountID`), for every card whose
+    /// identity this Mac knows. Absent on v1 documents. Contains no emails or names — identity keys
+    /// are opaque account/organization identifiers.
+    var identities: [String: String]?
 
     var id: String { deviceID }
 
@@ -24,13 +34,19 @@ struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
     }
 
     func validate() throws {
-        guard schema == Self.currentSchema else { throw UsageHistoryDocumentError.unsupportedSchema }
+        guard schema == Self.currentSchema || schema == Self.legacySchemaV1 else {
+            throw UsageHistoryDocumentError.unsupportedSchema
+        }
+        // v1 card ids are bare provider ids; v2 additionally carries account cards (`claude@ab12cd34`).
+        let idPattern = schema == Self.legacySchemaV1
+            ? #"^[a-z0-9][a-z0-9-]*$"#
+            : #"^[a-z0-9][a-z0-9@-]*$"#
         guard !deviceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !deviceName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { throw UsageHistoryDocumentError.invalidDevice }
 
         for (providerID, history) in providers {
-            guard providerID.range(of: #"^[a-z0-9][a-z0-9-]*$"#, options: .regularExpression) != nil else {
+            guard providerID.range(of: idPattern, options: .regularExpression) != nil else {
                 throw UsageHistoryDocumentError.invalidProvider(providerID)
             }
             var seriesDays: Set<String> = []

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -155,6 +155,17 @@ struct ClaudeOAuthConfig: Hashable, Sendable {
     var clientID: String
 }
 
+/// Which login a `ClaudeAuthStore` is allowed to see. `.standard` is the default card —
+/// byte-identical to the store's historical behavior. `.configDir` backs an extra account card and
+/// deliberately has no cross-account, environment-token, or Desktop fallback: the card can only ever
+/// read the one login it was created for.
+enum ClaudeCredentialScope: Hashable, Sendable {
+    case standard
+    /// One extra `CLAUDE_CONFIG_DIR` home. `keychainLiteral` is the literal string whose hash names
+    /// the keychain item (Claude Code hashes the env value as typed — `~/…` vs absolute differ).
+    case configDir(path: String, keychainLiteral: String)
+}
+
 struct ClaudeAuthStore: Sendable {
     private static let defaultClaudeHome = "~/.claude"
     private static let credentialFileName = ".credentials.json"
@@ -169,18 +180,28 @@ struct ClaudeAuthStore: Sendable {
     var keychain: KeychainAccessing
     var desktop: ClaudeDesktopAuthStore
     var now: @Sendable () -> Date
+    let scope: ClaudeCredentialScope
+    /// Whether the `.standard` store may fall back to Claude Desktop's credentials. On by default
+    /// (the historical behavior); the catalog turns it OFF once extra Claude account cards exist,
+    /// because the Desktop login could belong to any of them — borrowing it unpinned could fetch one
+    /// account's usage onto another account's card. Desktop-backed cards return properly in Phase 3.
+    let allowsDesktopFallback: Bool
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
         files: TextFileAccessing = LocalTextFileAccessor(),
         keychain: KeychainAccessing = SecurityKeychainAccessor(),
         desktop: ClaudeDesktopAuthStore? = nil,
+        scope: ClaudeCredentialScope = .standard,
+        allowsDesktopFallback: Bool = true,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.environment = environment
         self.files = files
         self.keychain = keychain
         self.desktop = desktop ?? ClaudeDesktopAuthStore(files: files, now: now)
+        self.scope = scope
+        self.allowsDesktopFallback = allowsDesktopFallback
         self.now = now
     }
 
@@ -197,11 +218,18 @@ struct ClaudeAuthStore: Sendable {
         var desktopStatus: ClaudeDesktopCredentialStatus = .notChecked
         // A working CLI login remains the source of truth and avoids a second Keychain prompt. Desktop
         // is a fallback for people who only use the native app (or whose stored CLI login lacks profile
-        // scope), never a competing account source.
+        // scope), never a competing account source. A `.configDir` card never consults Desktop at all —
+        // that login belongs to another card.
+        let desktopAllowed = scope == .standard && allowsDesktopFallback
+        if forceDesktopFallback, !desktopAllowed {
+            // Tell the provider there is no safe Desktop candidate so it preserves the original CLI
+            // auth error instead of converting it to a generic "not logged in" result.
+            desktopStatus = .notFound
+        }
         let hasUsableCLILogin = stored.contains {
             $0.hasUsableAccessToken && liveUsageAvailability($0) == .available
         }
-        if forceDesktopFallback || !hasUsableCLILogin {
+        if desktopAllowed, forceDesktopFallback || !hasUsableCLILogin {
             let result = desktop.load(allowInteraction: allowDesktopInteraction)
             desktopStatus = result.status
             if let oauth = result.oauth {
@@ -222,7 +250,26 @@ struct ClaudeAuthStore: Sendable {
         loadCredentialSet().candidates
     }
 
+    /// Whether this scoped card's login leaves any local footprint, checked without ever reading a
+    /// keychain secret — safe for the every-launch seeding probe (`NewProviderSeeder`), which must
+    /// never raise a permission dialog. The `.standard` card keeps its richer
+    /// `loadCredentialSet`-based probe in `ClaudeProvider.hasLocalCredentials`.
+    func hasCredentialFootprint() -> Bool {
+        switch scope {
+        case .standard:
+            return !loadCredentialSet().candidates.isEmpty
+        case .configDir:
+            if files.exists(credentialsPath()) { return true }
+            return keychainServiceCandidates().contains {
+                keychain.genericPasswordExists(service: $0) == true
+            }
+        }
+    }
+
     private func applyingEnvironmentToken(to stored: [ClaudeCredentialState]) -> [ClaudeCredentialState] {
+        // An ambient env token describes the DEFAULT login's environment; a scoped card must never
+        // inherit it (that would leak one account's token into another account's card).
+        guard case .standard = scope else { return stored }
         guard let envAccessToken = envText("CLAUDE_CODE_OAUTH_TOKEN") else {
             return stored
         }
@@ -330,36 +377,52 @@ struct ClaudeAuthStore: Sendable {
     }
 
     private func resolveOAuthEndpoints() -> ResolvedOAuthEndpoints {
+        Self.resolveOAuthEndpoints(environment: environment)
+    }
+
+    private static func resolveOAuthEndpoints(environment: EnvironmentReading) -> ResolvedOAuthEndpoints {
         var baseAPI = Self.prodBaseAPIURL
         var refreshURL = Self.prodRefreshURL
         var clientID = Self.prodClientID
         var suffix = ""
 
-        let isAntUser = envText("USER_TYPE") == "ant"
-        if isAntUser, envFlag("USE_LOCAL_OAUTH") {
-            let base = (envText("CLAUDE_LOCAL_OAUTH_API_BASE") ?? "http://localhost:8000").trimmingTrailingSlashes
+        let isAntUser = envText(environment, "USER_TYPE") == "ant"
+        if isAntUser, envFlag(environment, "USE_LOCAL_OAUTH") {
+            let base = (envText(environment, "CLAUDE_LOCAL_OAUTH_API_BASE") ?? "http://localhost:8000").trimmingTrailingSlashes
             baseAPI = base
             refreshURL = "\(base)/v1/oauth/token"
             clientID = Self.nonProdClientID
             suffix = "-local-oauth"
-        } else if isAntUser, envFlag("USE_STAGING_OAUTH") {
+        } else if isAntUser, envFlag(environment, "USE_STAGING_OAUTH") {
             baseAPI = "https://api-staging.anthropic.com"
             refreshURL = "https://platform.staging.ant.dev/v1/oauth/token"
             clientID = Self.nonProdClientID
             suffix = "-staging-oauth"
         }
 
-        if let custom = envText("CLAUDE_CODE_CUSTOM_OAUTH_URL") {
+        if let custom = envText(environment, "CLAUDE_CODE_CUSTOM_OAUTH_URL") {
             let base = custom.trimmingTrailingSlashes
             baseAPI = base
             refreshURL = "\(base)/v1/oauth/token"
             suffix = "-custom-oauth"
         }
-        if let override = envText("CLAUDE_CODE_OAUTH_CLIENT_ID") {
+        if let override = envText(environment, "CLAUDE_CODE_OAUTH_CLIENT_ID") {
             clientID = override
         }
 
         return ResolvedOAuthEndpoints(baseAPI: baseAPI, refreshURL: refreshURL, clientID: clientID, suffix: suffix)
+    }
+
+    /// The keychain service names as this environment's Claude Code writes them — the single source
+    /// both the scoped store and config-dir DISCOVERY build from, so a non-prod OAuth setup (local/
+    /// staging/custom, which suffixes the service) can never make discovery probe one name while
+    /// refresh reads another.
+    static func baseKeychainServiceName(environment: EnvironmentReading) -> String {
+        "\(keychainServicePrefix)\(resolveOAuthEndpoints(environment: environment).suffix)-credentials"
+    }
+
+    static func scopedKeychainServiceName(forConfigDirLiteral literal: String, environment: EnvironmentReading) -> String {
+        "\(baseKeychainServiceName(environment: environment))-\(hashSuffix(literal))"
     }
 
     // baseAPI/refreshURL can derive from user-set env vars (CLAUDE_CODE_CUSTOM_OAUTH_URL,
@@ -386,10 +449,17 @@ struct ClaudeAuthStore: Sendable {
         // Only needs the file suffix, which never fails — keep this off the throwing URL path so
         // credential loading stays forgiving even when a custom OAuth URL is malformed.
         let base = "\(Self.keychainServicePrefix)\(resolveOAuthEndpoints().suffix)-credentials"
-        if let configDir = claudeHomeOverride() {
-            return ["\(base)-\(hashSuffix(configDir))", base]
+        switch scope {
+        case .configDir(_, let keychainLiteral):
+            // Exactly this card's item — never the bare default service, which is another account's
+            // login.
+            return ["\(base)-\(hashSuffix(keychainLiteral))"]
+        case .standard:
+            if let configDir = claudeHomeOverride() {
+                return ["\(base)-\(hashSuffix(configDir))", base]
+            }
+            return [base]
         }
-        return [base]
     }
 
     static func parseCredentials(_ text: String) -> ClaudeCredentialsFile? {
@@ -471,10 +541,17 @@ struct ClaudeAuthStore: Sendable {
     }
 
     private func credentialsPath() -> String {
-        "\(envText("CLAUDE_CONFIG_DIR") ?? Self.defaultClaudeHome)/\(Self.credentialFileName)"
+        if case .configDir(let path, _) = scope {
+            return "\(path)/\(Self.credentialFileName)"
+        }
+        return "\(envText("CLAUDE_CONFIG_DIR") ?? Self.defaultClaudeHome)/\(Self.credentialFileName)"
     }
 
     private func envText(_ name: String) -> String? {
+        Self.envText(environment, name)
+    }
+
+    private static func envText(_ environment: EnvironmentReading, _ name: String) -> String? {
         guard let value = environment.value(for: name)?.trimmingCharacters(in: .whitespacesAndNewlines),
               !value.isEmpty
         else {
@@ -484,11 +561,19 @@ struct ClaudeAuthStore: Sendable {
     }
 
     private func envFlag(_ name: String) -> Bool {
-        guard let value = envText(name)?.lowercased() else { return false }
+        Self.envFlag(environment, name)
+    }
+
+    private static func envFlag(_ environment: EnvironmentReading, _ name: String) -> Bool {
+        guard let value = envText(environment, name)?.lowercased() else { return false }
         return !["0", "false", "no", "off"].contains(value)
     }
 
     private func hashSuffix(_ value: String) -> String {
+        Self.hashSuffix(value)
+    }
+
+    private static func hashSuffix(_ value: String) -> String {
         let normalized = value.precomposedStringWithCanonicalMapping
         let digest = SHA256.hash(data: Data(normalized.utf8))
         return String(digest.map { String(format: "%02x", $0) }.joined().prefix(8))

--- a/Sources/OpenUsage/Providers/Claude/ClaudeConfigDirDiscovery.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeConfigDirDiscovery.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+/// Launch-time scan for EXTRA Claude logins in custom config dirs — the homes a user points
+/// `CLAUDE_CONFIG_DIR` at besides the default (`~/.claude` / `$XDG_CONFIG_HOME/claude`).
+///
+/// Runs synchronously inside the launch account pass under a small time budget, and reads **no
+/// keychain secrets** — credential presence is checked from file existence and attributes-only
+/// keychain probes, so discovery can never raise a macOS permission dialog or block launch.
+///
+/// Shape rules: candidates are dot-dirs at `~` and dirs under `~/.config` — bounded, never temp dirs
+/// or project trees. A candidate only counts when it carries Claude's exact credential shape AND
+/// names its account (identity read from the home itself). Identity-extraction-is-validation: that
+/// routing, not name matching, is what keeps toys, forks, and sandbox homes out.
+struct ClaudeConfigDirDiscovery {
+    /// One accepted custom-config-dir login. Whether it becomes its own card or attaches to an
+    /// existing account's record is the assembly's call, not discovery's.
+    struct Finding: Equatable, Sendable {
+        var identityKey: String
+        var label: String?
+        /// The expanded config-dir path (the card's credential home and its spend-log root).
+        var anchorPath: String
+        /// The literal string whose hash names the dir's keychain item (see `ClaudeCredentialScope`).
+        var keychainLiteral: String
+    }
+
+    struct Result: Sendable {
+        var findings: [Finding] = []
+        /// The support trail: one line per notable decision (near-miss rejections, folds), emitted to
+        /// the log so a "my account didn't show up" report is diagnosable from a default log.
+        /// Token-free and email-free by construction — identity hashes, kinds, and paths only.
+        var notes: [String] = []
+    }
+
+    var environment: EnvironmentReading
+    var files: TextFileAccessing
+    var keychain: KeychainAccessing
+    var homeDirectory: @Sendable () -> URL
+    var listSubdirectories: @Sendable (URL) -> [URL]
+    /// Wall-clock budget; on overrun the scan returns what it has (and the next launch resumes).
+    var timeBudget: TimeInterval
+    var now: @Sendable () -> Date
+
+    init(
+        environment: EnvironmentReading = ProcessEnvironmentReader(),
+        files: TextFileAccessing = LocalTextFileAccessor(),
+        keychain: KeychainAccessing = SecurityKeychainAccessor(),
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        listSubdirectories: @escaping @Sendable (URL) -> [URL] = Self.filesystemSubdirectories,
+        timeBudget: TimeInterval = 0.4,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.environment = environment
+        self.files = files
+        self.keychain = keychain
+        self.homeDirectory = homeDirectory
+        self.listSubdirectories = listSubdirectories
+        self.timeBudget = timeBudget
+        self.now = now
+    }
+
+    func run() -> Result {
+        let started = now()
+        var result = Result()
+        let excluded = Set(defaultClaudeConfigDirs().map(canonical))
+
+        for candidate in candidateDirectories() {
+            if now().timeIntervalSince(started) > timeBudget {
+                result.notes.append("claude config-dir scan hit its \(Int(timeBudget * 1000))ms budget; finishing with partial results")
+                break
+            }
+            guard !excluded.contains(canonical(candidate.path)) else { continue }
+            if let finding = claudeCandidate(at: candidate, notes: &result.notes) {
+                result.findings.append(finding)
+            }
+        }
+        return result
+    }
+
+    // MARK: - Candidates
+
+    /// Dot-dirs at `~` plus dirs under `~/.config`, in stable path order.
+    private func candidateDirectories() -> [URL] {
+        let home = homeDirectory()
+        var candidates = listSubdirectories(home).filter { $0.lastPathComponent.hasPrefix(".") }
+        candidates += listSubdirectories(home.appendingPathComponent(".config"))
+        return candidates.sorted { $0.path < $1.path }
+    }
+
+    private static func filesystemSubdirectories(of url: URL) -> [URL] {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: []
+        )) ?? []
+        return contents.filter {
+            (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+        }
+    }
+
+    private func claudeCandidate(at url: URL, notes: inout [String]) -> Finding? {
+        // Pre-gate: only dirs that carry an identity file at all enter the trail — everything else
+        // is a random dot-dir and stays out of the log. (A custom config dir keeps its state INSIDE
+        // the dir; only the default `~/.claude` keeps it next door at `~/.claude.json`, and the
+        // default homes are excluded before this runs.)
+        guard let identityText = try? files.readTextIfPresent(url.path + "/.claude.json") else {
+            return nil
+        }
+        guard let parsed = try? JSONDecoder().decode(
+                  DefaultAccountObserver.ClaudeStateFile.self, from: Data(identityText.utf8)
+              ),
+              let account = parsed.oauthAccount,
+              let key = DefaultAccountObserver.claudeIdentityKey(account)
+        else {
+            notes.append("claude candidate \(logPath(url.path)): identity file present but names no account → skipped")
+            return nil
+        }
+
+        // Credential shape: the dir's own `.credentials.json`, or its *computed* keychain item.
+        // Claude Code hashes the literal CLAUDE_CONFIG_DIR string, so every plausible spelling of
+        // this path is probed (attributes only — no secret, no prompt).
+        let fileBacked = (try? files.readTextIfPresent(url.path + "/.credentials.json"))
+            .flatMap { $0 }
+            .flatMap { ClaudeAuthStore.parseCredentials($0) }?
+            .claudeAiOauth?.accessToken?.nilIfEmpty != nil
+
+        var matchedLiteral: String?
+        let literals = keychainLiterals(for: url)
+        for literal in literals {
+            let service = ClaudeAuthStore.scopedKeychainServiceName(
+                forConfigDirLiteral: literal,
+                environment: environment
+            )
+            if keychain.genericPasswordExists(service: service) == true {
+                matchedLiteral = literal
+                break
+            }
+        }
+        guard fileBacked || matchedLiteral != nil else {
+            notes.append("claude candidate \(logPath(url.path)): identity \(hash8(key)) but no credential (no .credentials.json, no keychain item for \(literals.count) path spellings) → skipped")
+            return nil
+        }
+
+        notes.append("claude candidate \(logPath(url.path)): accepted (\(hash8(key)), \(fileBacked ? "file" : "keychain") credential)")
+        return Finding(
+            identityKey: key,
+            label: DefaultAccountObserver.claudeIdentityLabel(account),
+            anchorPath: url.path,
+            keychainLiteral: matchedLiteral ?? url.path
+        )
+    }
+
+    /// Every plausible spelling Claude Code might have hashed for this dir's keychain item: the path
+    /// as listed, symlink-resolved, and each with the home prefix swapped for `~` (users export
+    /// `CLAUDE_CONFIG_DIR=~/x` and `=/Users/me/x` interchangeably).
+    private func keychainLiterals(for url: URL) -> [String] {
+        let home = homeDirectory()
+        let homePaths = Array(Set([home.path, home.resolvingSymlinksInPath().path]))
+        var candidates = [url.path, url.resolvingSymlinksInPath().path]
+        for candidate in candidates {
+            for homePath in homePaths where candidate.hasPrefix(homePath + "/") {
+                let suffix = candidate.dropFirst(homePath.count)
+                candidates += homePaths.map { $0 + suffix }
+            }
+        }
+        var literals: [String] = []
+        for candidate in candidates {
+            literals.append(candidate)
+            for homePath in homePaths where candidate.hasPrefix(homePath + "/") {
+                literals.append("~" + candidate.dropFirst(homePath.count))
+            }
+        }
+        var seen = Set<String>()
+        return literals.filter { seen.insert($0).inserted }
+    }
+
+    // MARK: - Default homes (the exclusion set)
+
+    /// The default card's config dirs: every `CLAUDE_CONFIG_DIR` entry when set, else the scanner's
+    /// standard resolution (`$XDG_CONFIG_HOME/claude`, then `~/.claude`).
+    private func defaultClaudeConfigDirs() -> [String] {
+        if let raw = environment.value(for: "CLAUDE_CONFIG_DIR")?
+            .trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
+            let dirs = raw.split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            if !dirs.isEmpty { return dirs.map(expandTilde) }
+        }
+        let home = homeDirectory()
+        let xdg = environment.value(for: "XDG_CONFIG_HOME")?.nilIfEmpty.map(expandTilde)
+            ?? home.appendingPathComponent(".config").path
+        return [xdg + "/claude", home.appendingPathComponent(".claude").path]
+    }
+
+    // MARK: - Path helpers
+
+    private func expandTilde(_ path: String) -> String {
+        guard path == "~" || path.hasPrefix("~/") else { return path }
+        return homeDirectory().path + String(path.dropFirst(1))
+    }
+
+    private func canonical(_ path: String) -> String {
+        URL(fileURLWithPath: expandTilde(path)).resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    /// Log-safe path: the home prefix is folded to `~` so support logs don't carry the username.
+    private func logPath(_ path: String) -> String {
+        let home = homeDirectory().path
+        guard path.hasPrefix(home + "/") else { return path }
+        return "~" + path.dropFirst(home.count)
+    }
+
+    private func hash8(_ identityKey: String) -> String {
+        String(ProviderAccountID.make(family: "claude", identityKey: identityKey).dropFirst("claude@".count))
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -26,6 +26,13 @@ actor ClaudeLogUsageScanner {
     /// Scoped provider instances pass their stable parse-source identity here. Account or time filters
     /// over the same physical roots deliberately pass the same value and share whole-file records.
     private let cacheIdentityOverride: String?
+    /// Extra account cards pin the scan to exactly their config dir(s), replacing the standard
+    /// resolution (env override, XDG, `~/.claude`, Cowork sandboxes) entirely — another account's
+    /// logs must never bleed into a scoped card. `nil` keeps the standard walk byte-identical.
+    private let rootsOverride: [URL]?
+    /// Same-account custom config dirs appended to the DEFAULT card's standard roots, so spend the
+    /// user's own login produced in a side home still counts on its card.
+    private let additionalRoots: [URL]
 
     /// One parsed usage line. Token buckets are pre-normalized into `TokenBreakdown`; dedup fields
     /// ride along so the global dedup pass can run over cached entries.
@@ -57,13 +64,20 @@ actor ClaudeLogUsageScanner {
         environment: EnvironmentReading = ProcessEnvironmentReader(),
         homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
         incrementalScanner: IncrementalJSONLScanner<Entry>? = nil,
-        cacheIdentityOverride: String? = nil
+        cacheIdentityOverride: String? = nil,
+        rootsOverride: [URL]? = nil,
+        additionalRoots: [URL] = []
     ) {
         precondition(cacheIdentityOverride?.isEmpty != true)
+        // A scoped root set must carry its own parse-source identity, or its cache records would
+        // collide with the default card's under the standard identity.
+        precondition(rootsOverride == nil || cacheIdentityOverride != nil)
         self.environment = environment
         self.homeDirectory = homeDirectory
         self.scanner = incrementalScanner ?? Self.sharedScanner
         self.cacheIdentityOverride = cacheIdentityOverride
+        self.rootsOverride = rootsOverride
+        self.additionalRoots = additionalRoots
     }
 
     /// Scan the last `daysBack` days of Claude logs. Returns `nil` when no Claude data directory or
@@ -150,6 +164,13 @@ actor ClaudeLogUsageScanner {
             roots.append(url)
         }
 
+        // A scoped card scans exactly its own config dir(s) — no env resolution, no Cowork walk
+        // (sandboxes belong to the default login until Phase 3 attributes them per account).
+        if let rootsOverride {
+            for root in rootsOverride { addIfValid(root) }
+            return roots
+        }
+
         if let raw = environment.value(for: "CLAUDE_CONFIG_DIR")?.trimmingCharacters(in: .whitespacesAndNewlines),
            !raw.isEmpty {
             for part in raw.split(separator: ",").map({ $0.trimmingCharacters(in: .whitespaces) }) where !part.isEmpty {
@@ -173,6 +194,10 @@ actor ClaudeLogUsageScanner {
 
         for sandbox in Self.coworkClaudeDirs(home: homeDirectory()) {
             addIfValid(sandbox)
+        }
+        // Same-account custom config dirs (default card only): the user's own spend in a side home.
+        for root in additionalRoots {
+            addIfValid(root)
         }
         return roots
     }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -3,15 +3,22 @@ import Foundation
 
 @MainActor
 final class ClaudeProvider: ProviderRuntime {
-    let provider = Provider(
-        id: "claude",
-        displayName: "Claude",
-        icon: .providerMark("claude"),
-        links: [
-            .init(label: "Status", url: "https://status.anthropic.com/"),
-            .init(label: "Dashboard", url: "https://claude.ai/settings/usage")
-        ]
-    )
+    /// The default card's identity. Extra account cards inject their own `Provider` with an
+    /// `@`-suffixed id and an account-derived display name; everything else about the runtime is
+    /// identical.
+    static func makeProvider(id: String = "claude", displayName: String = "Claude") -> Provider {
+        Provider(
+            id: id,
+            displayName: displayName,
+            icon: .providerMark("claude"),
+            links: [
+                .init(label: "Status", url: "https://status.anthropic.com/"),
+                .init(label: "Dashboard", url: "https://claude.ai/settings/usage")
+            ]
+        )
+    }
+
+    let provider: Provider
 
     let authStore: ClaudeAuthStore
     let usageClient: ClaudeUsageClient
@@ -30,12 +37,14 @@ final class ClaudeProvider: ProviderRuntime {
     private static let rateLimitCooldown: TimeInterval = 5 * 60
 
     init(
+        provider: Provider = ClaudeProvider.makeProvider(),
         authStore: ClaudeAuthStore = ClaudeAuthStore(),
         usageClient: ClaudeUsageClient = ClaudeUsageClient(),
         logUsageScanner: ClaudeLogUsageScanner = ClaudeLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
         pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
     ) {
+        self.provider = provider
         self.authStore = authStore
         self.usageClient = usageClient
         self.logUsageScanner = logUsageScanner
@@ -45,15 +54,15 @@ final class ClaudeProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "claude.session", provider: provider, title: "Session", isSessionWindow: true)
+            .percent(id: "\(provider.id).session", provider: provider, title: "Session", isSessionWindow: true)
                 .exportingLimit("session", unit: "percent"),
-            .percent(id: "claude.weekly", provider: provider, title: "Weekly")
+            .percent(id: "\(provider.id).weekly", provider: provider, title: "Weekly")
                 .exportingLimit("weekly", unit: "percent"),
-            .percent(id: "claude.sonnet", provider: provider, title: "Sonnet")
+            .percent(id: "\(provider.id).sonnet", provider: provider, title: "Sonnet")
                 .exportingLimit("sonnet", unit: "percent"),
-            .percent(id: "claude.fable", provider: provider, title: "Fable")
+            .percent(id: "\(provider.id).fable", provider: provider, title: "Fable")
                 .exportingLimit("fable", unit: "percent"),
-            .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent")
+            .boundedDollars(id: "\(provider.id).extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent")
                 .exportingLimit("extraUsage", unit: "usd", source: .progressOrValue(kind: .dollars)),
             .usageTrend(provider: provider)
                 .exportingHistory(
@@ -65,6 +74,12 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     func hasLocalCredentials() async -> Bool {
+        // Scoped cards answer from footprints only (file existence / keychain attributes) so the
+        // every-launch seeding probe can never raise a keychain dialog for an account the user
+        // hasn't granted yet. The secret read happens on the first refresh.
+        if authStore.scope != .standard {
+            return await loadOffMainActor { [authStore] in authStore.hasCredentialFootprint() }
+        }
         // Never trigger another app's Keychain prompt during first-run detection. Encrypted Desktop
         // material still counts as a local login; the first manual refresh requests access if needed.
         let load = await loadOffMainActor { [authStore] in authStore.loadCredentialSet() }

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -4,11 +4,33 @@ import Foundation
 /// their runtimes here so credentials, refresh behavior, pricing, and normalization can never drift.
 @MainActor
 enum ProviderCatalog {
-    static func make(defaults: UserDefaults = .standard) -> [ProviderRuntime] {
+    /// `claudeCards` carries the extra Claude account cards found by the launch account pass
+    /// (`ProviderAccountAssembly`). Each becomes an ordinary runtime inserted right after the default
+    /// Claude card, with credentials and usage logs pinned to exactly its own config dir. The empty
+    /// default keeps the historical single-card set for focused tests and callers that intentionally
+    /// skip the account pass.
+    static func make(
+        defaults: UserDefaults = .standard,
+        claudeCards: [ClaudeAccountCard] = [],
+        defaultClaudeExtraLogRoots: [URL] = [],
+        defaultClaudeDisplayName: String? = nil
+    ) -> [ProviderRuntime] {
         // Default provider order (see AGENTS.md "## Providers"): the three established providers first,
-        // then every other provider alphabetically by display name.
-        [
-            ClaudeProvider(),
+        // then every other provider alphabetically by display name. Account cards slot in right after
+        // their family's default card.
+        var runtimes: [ProviderRuntime] = []
+        runtimes.append(ClaudeProvider(
+            provider: ClaudeProvider.makeProvider(displayName: defaultClaudeDisplayName ?? "Claude"),
+            // Once extra Claude cards exist, an unpinned Desktop fallback could borrow a login that
+            // belongs to one of them — fetching that account's usage onto the default card. Desktop
+            // returns as its own properly-pinned source kind in Phase 3.
+            authStore: ClaudeAuthStore(allowsDesktopFallback: claudeCards.isEmpty),
+            logUsageScanner: ClaudeLogUsageScanner(additionalRoots: defaultClaudeExtraLogRoots)
+        ))
+        for card in claudeCards {
+            runtimes.append(claudeAccountRuntime(card: card))
+        }
+        runtimes += [
             CodexProvider(),
             CursorProvider(),
             AntigravityProvider(),
@@ -19,5 +41,22 @@ enum ProviderCatalog {
             OpenRouterProvider(),
             ZAIProvider()
         ]
+        return runtimes
+    }
+
+    /// An extra Claude account card: same provider machinery, credentials and logs pinned to one
+    /// login. The scanner's parse cache is partitioned per card so distinct homes never share
+    /// records.
+    private static func claudeAccountRuntime(card: ClaudeAccountCard) -> ClaudeProvider {
+        ClaudeProvider(
+            provider: ClaudeProvider.makeProvider(id: card.id, displayName: card.displayName),
+            authStore: ClaudeAuthStore(
+                scope: .configDir(path: card.configDirPath, keychainLiteral: card.keychainLiteral)
+            ),
+            logUsageScanner: ClaudeLogUsageScanner(
+                cacheIdentityOverride: "claude-account:\(card.id)",
+                rootsOverride: [URL(fileURLWithPath: card.configDirPath)] + card.extraLogRoots
+            )
+        )
     }
 }

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Matches synced peer histories to this Mac's cards by ACCOUNT identity instead of by card id.
+///
+/// The same account can be the default card on one Mac and an extra account card on another (which
+/// login holds a family's default home differs per machine), so card ids don't travel: a peer's
+/// `claude` entry may belong to the account this Mac shows as `claude@ab12cd34`, and vice versa. v2
+/// documents carry a per-card identity map that makes the match exact; v1 documents (no identities)
+/// keep the legacy same-card-id merge for bare ids. Peer accounts with no card on this Mac at all
+/// become `remoteOnly` entries — surfaced in Total Spend only, never as ghost cards.
+enum PeerHistoryRemapper {
+    struct Remapped {
+        /// Peer histories addressed to a LOCAL card id, ready for the same-id day merge.
+        var histories: [(cardID: String, history: ProviderUsageHistory)] = []
+        /// Peer accounts with no local card, keyed by identity.
+        var remoteOnly: [RemoteOnlyHistory] = []
+    }
+
+    struct RemoteOnlyHistory {
+        var identityKey: String
+        var family: String
+        var deviceNames: [String]
+        var histories: [ProviderUsageHistory]
+    }
+
+    /// `localIdentityByCardID` is this Mac's card → identity map (the launch account pass's
+    /// `identityKeysByCard`).
+    static func remap(
+        documents: [UsageHistoryDocument],
+        localIdentityByCardID: [String: String]
+    ) -> Remapped {
+        // Invert to identity → card, preferring the bare (default) card when an identity appears on
+        // two local cards at once (transiently possible around a swap).
+        var localCardByIdentity: [String: String] = [:]
+        for (cardID, identity) in localIdentityByCardID.sorted(by: { $0.key < $1.key }) {
+            if let existing = localCardByIdentity[identity], !ProviderAccountID.isAccountCard(existing) {
+                continue
+            }
+            if ProviderAccountID.isAccountCard(cardID), localCardByIdentity[identity] != nil {
+                continue
+            }
+            localCardByIdentity[identity] = cardID
+        }
+
+        var result = Remapped()
+        var remoteByIdentity: [String: RemoteOnlyHistory] = [:]
+        func collectRemoteOnly(identity: String, family: String, deviceName: String, history: ProviderUsageHistory) {
+            var entry = remoteByIdentity[identity] ?? RemoteOnlyHistory(
+                identityKey: identity, family: family, deviceNames: [], histories: []
+            )
+            if !entry.deviceNames.contains(deviceName) {
+                entry.deviceNames.append(deviceName)
+            }
+            entry.histories.append(history)
+            remoteByIdentity[identity] = entry
+        }
+
+        for document in UsageHistoryDocument.newestByDevice(documents) {
+            for (peerCardID, history) in document.providers.sorted(by: { $0.key < $1.key }) {
+                let family = ProviderAccountID.family(of: peerCardID)
+                if let identity = document.identities?[peerCardID] {
+                    if let localCard = localCardByIdentity[identity] {
+                        result.histories.append((localCard, history))
+                    } else {
+                        collectRemoteOnly(identity: identity, family: family, deviceName: document.deviceName, history: history)
+                    }
+                    continue
+                }
+                // No identity recorded (v1 document, or a card this peer couldn't identify): bare
+                // ids keep the legacy same-card-id merge; account-card ids still match when this Mac
+                // has the same identity-derived card id, else they're remote-only.
+                if !ProviderAccountID.isAccountCard(peerCardID) || localIdentityByCardID[peerCardID] != nil {
+                    result.histories.append((peerCardID, history))
+                } else {
+                    collectRemoteOnly(identity: peerCardID, family: family, deviceName: document.deviceName, history: history)
+                }
+            }
+        }
+
+        result.remoteOnly = remoteByIdentity.values.sorted { $0.identityKey < $1.identityKey }
+        return result
+    }
+}

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -61,6 +61,13 @@ enum PeerHistoryRemapper {
                 if let identity = document.identities?[peerCardID] {
                     if let localCard = localCardByIdentity[identity] {
                         result.histories.append((localCard, history))
+                    } else if !ProviderAccountID.isAccountCard(peerCardID), localIdentityByCardID[peerCardID] == nil {
+                        // The peer named its bare card's account, but this Mac's own bare card has
+                        // an UNRESOLVED identity this launch — we can't prove a mismatch, so keep
+                        // the legacy same-card-id merge rather than splitting what is most likely
+                        // the same account into a separate Total Spend slice. A genuinely different
+                        // account separates on the next launch that resolves the local identity.
+                        result.histories.append((peerCardID, history))
                     } else {
                         collectRemoteOnly(identity: identity, family: family, deviceName: document.deviceName, history: history)
                     }

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -19,6 +19,10 @@ enum PeerHistoryRemapper {
     struct RemoteOnlyHistory {
         var identityKey: String
         var family: String
+        /// The account's identity-derived card id (`claude@ab12cd34`) — the same id the account
+        /// gets as a card on any Mac it's signed in on. Names the Total Spend slice, so several
+        /// remote-only accounts from one device stay tellable apart.
+        var cardID: String
         var deviceNames: [String]
         var histories: [ProviderUsageHistory]
     }
@@ -44,9 +48,9 @@ enum PeerHistoryRemapper {
 
         var result = Remapped()
         var remoteByIdentity: [String: RemoteOnlyHistory] = [:]
-        func collectRemoteOnly(identity: String, family: String, deviceName: String, history: ProviderUsageHistory) {
+        func collectRemoteOnly(identity: String, family: String, cardID: String, deviceName: String, history: ProviderUsageHistory) {
             var entry = remoteByIdentity[identity] ?? RemoteOnlyHistory(
-                identityKey: identity, family: family, deviceNames: [], histories: []
+                identityKey: identity, family: family, cardID: cardID, deviceNames: [], histories: []
             )
             if !entry.deviceNames.contains(deviceName) {
                 entry.deviceNames.append(deviceName)
@@ -69,17 +73,31 @@ enum PeerHistoryRemapper {
                         // account separates on the next launch that resolves the local identity.
                         result.histories.append((peerCardID, history))
                     } else {
-                        collectRemoteOnly(identity: identity, family: family, deviceName: document.deviceName, history: history)
+                        collectRemoteOnly(
+                            identity: identity,
+                            family: family,
+                            cardID: ProviderAccountID.make(family: family, identityKey: identity),
+                            deviceName: document.deviceName,
+                            history: history
+                        )
                     }
                     continue
                 }
                 // No identity recorded (v1 document, or a card this peer couldn't identify): bare
                 // ids keep the legacy same-card-id merge; account-card ids still match when this Mac
-                // has the same identity-derived card id, else they're remote-only.
+                // has the same identity-derived card id, else they're remote-only. The peer's card
+                // id doubles as both the grouping key and the display id — it IS the account's
+                // identity-derived id, just minted on the peer.
                 if !ProviderAccountID.isAccountCard(peerCardID) || localIdentityByCardID[peerCardID] != nil {
                     result.histories.append((peerCardID, history))
                 } else {
-                    collectRemoteOnly(identity: peerCardID, family: family, deviceName: document.deviceName, history: history)
+                    collectRemoteOnly(
+                        identity: peerCardID,
+                        family: family,
+                        cardID: peerCardID,
+                        deviceName: document.deviceName,
+                        history: history
+                    )
                 }
             }
         }

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -20,10 +20,9 @@ enum PeerHistoryRemapper {
         var identityKey: String
         var family: String
         /// The account's identity-derived card id (`claude@ab12cd34`) — the same id the account
-        /// gets as a card on any Mac it's signed in on. Names the Total Spend slice, so several
-        /// remote-only accounts from one device stay tellable apart.
+        /// gets as a card on any Mac it's signed in on. Names the Total Spend slice; which Mac the
+        /// spend came from is deliberately not part of the name (irrelevant to the total).
         var cardID: String
-        var deviceNames: [String]
         var histories: [ProviderUsageHistory]
     }
 
@@ -48,13 +47,10 @@ enum PeerHistoryRemapper {
 
         var result = Remapped()
         var remoteByIdentity: [String: RemoteOnlyHistory] = [:]
-        func collectRemoteOnly(identity: String, family: String, cardID: String, deviceName: String, history: ProviderUsageHistory) {
+        func collectRemoteOnly(identity: String, family: String, cardID: String, history: ProviderUsageHistory) {
             var entry = remoteByIdentity[identity] ?? RemoteOnlyHistory(
-                identityKey: identity, family: family, cardID: cardID, deviceNames: [], histories: []
+                identityKey: identity, family: family, cardID: cardID, histories: []
             )
-            if !entry.deviceNames.contains(deviceName) {
-                entry.deviceNames.append(deviceName)
-            }
             entry.histories.append(history)
             remoteByIdentity[identity] = entry
         }
@@ -77,7 +73,6 @@ enum PeerHistoryRemapper {
                             identity: identity,
                             family: family,
                             cardID: ProviderAccountID.make(family: family, identityKey: identity),
-                            deviceName: document.deviceName,
                             history: history
                         )
                     }
@@ -91,13 +86,7 @@ enum PeerHistoryRemapper {
                 if !ProviderAccountID.isAccountCard(peerCardID) || localIdentityByCardID[peerCardID] != nil {
                     result.histories.append((peerCardID, history))
                 } else {
-                    collectRemoteOnly(
-                        identity: peerCardID,
-                        family: family,
-                        cardID: peerCardID,
-                        deviceName: document.deviceName,
-                        history: history
-                    )
+                    collectRemoteOnly(identity: peerCardID, family: family, cardID: peerCardID, history: history)
                 }
             }
         }

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -50,8 +50,14 @@ struct ProviderAccountAssembly {
 
     /// `waitsForLoginShell`: true for the menu-bar app (a Finder/Dock launch inherits no shell
     /// exports, so the pass leans on the login-shell layers), false for the one-shot CLI (a terminal
-    /// launch's process environment already carries the user's exports).
-    static func make(defaults: UserDefaults = .standard, waitsForLoginShell: Bool) -> ProviderAccountAssembly {
+    /// launch's process environment already carries the user's exports). The app passes its own
+    /// `accountsStore` so the registry the pass reconciles is the same instance the UI observes for
+    /// renames; the CLI omits it and gets a throwaway.
+    static func make(
+        defaults: UserDefaults = .standard,
+        accountsStore: ProviderAccountsStore? = nil,
+        waitsForLoginShell: Bool
+    ) -> ProviderAccountAssembly {
         // The identity read needs the login shell's exports (CLAUDE_CONFIG_DIR/CODEX_HOME name the
         // default homes), and it reads them through the very same reader the provider auth stores
         // use — `ProcessEnvironmentReader`, which pins identity-relevant keys to the persisted
@@ -79,7 +85,7 @@ struct ProviderAccountAssembly {
         }
         return make(
             observer: DefaultAccountObserver(),
-            accountsStore: ProviderAccountsStore(defaults: defaults),
+            accountsStore: accountsStore ?? ProviderAccountsStore(defaults: defaults),
             families: families,
             claudeDiscovery: ClaudeConfigDirDiscovery()
         )
@@ -105,7 +111,7 @@ struct ProviderAccountAssembly {
         claudeDiscovery: ClaudeConfigDirDiscovery? = nil
     ) -> ProviderAccountAssembly {
         var identityKeys: [String: String] = [:]
-        var observations: [ProviderAccountsStore.Observation] = []
+        var observations: [ProviderAccountsStore.AccountObservation] = []
 
         let outcomes: [(family: String, outcome: DefaultAccountObserver.Outcome)] = [
             ("claude", { observer.observeClaude() }),
@@ -117,7 +123,7 @@ struct ProviderAccountAssembly {
             switch outcome {
             case .resolved(let identityKey, let label, let anchor):
                 identityKeys[family] = identityKey
-                observations.append(ProviderAccountsStore.Observation(
+                observations.append(ProviderAccountsStore.AccountObservation(
                     family: family,
                     identityKey: identityKey,
                     label: label,
@@ -175,7 +181,7 @@ struct ProviderAccountAssembly {
                         }
                         AppLog.info(.config, "discovery: \(findings.count) config dir(s) fold onto the default claude card (same account)")
                     } else {
-                        observations.append(ProviderAccountsStore.Observation(
+                        observations.append(ProviderAccountsStore.AccountObservation(
                             family: "claude",
                             identityKey: identityKey,
                             label: findings.first?.label,

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -1,14 +1,52 @@
 import Foundation
 
+/// One extra Claude account card to build this launch: a custom-config-dir login found on this
+/// computer whose account is distinct from the default card's. Cards render only while their source
+/// is found (owner decision 4) — a record with no finding this launch simply builds no card.
+struct ClaudeAccountCard: Equatable, Sendable {
+    /// The account's stable record id (`claude@ab12cd34`) — the card id everywhere: layout, cache,
+    /// CLI/API matching.
+    var id: String
+    var displayName: String
+    /// The config dir the card's credentials and spend logs are pinned to.
+    var configDirPath: String
+    /// The literal string whose hash names the dir's keychain item (see `ClaudeCredentialScope`).
+    var keychainLiteral: String
+    /// Same-account additional config dirs (rare): extra spend-log roots, never extra credentials.
+    var extraLogRoots: [URL] = []
+
+    /// The card name: the user's rename, else "Claude — <org or email>" from the account label,
+    /// else the record id itself (owner decision 2: short-hash fallback, one rename away from good).
+    static func displayName(customLabel: String?, label: String?, id: String) -> String {
+        if let customLabel = customLabel?.nilIfEmpty { return customLabel }
+        guard let label = label?.nilIfEmpty else { return id }
+        // Labels are our own "email (Org Name)" format — prefer the org for a short card title.
+        if label.hasSuffix(")"), let open = label.lastIndex(of: "(") {
+            let org = label[label.index(after: open)..<label.index(before: label.endIndex)]
+                .trimmingCharacters(in: .whitespaces)
+            if !org.isEmpty { return "Claude — \(org)" }
+        }
+        return "Claude — \(label)"
+    }
+}
+
 /// The launch-time account pass: read which account is signed in at each family's default home,
-/// reconcile the account registry, and expose the per-card identity map that the snapshot cache's
-/// account stamp consumes. Runs once per launch (app) or per invocation (one-shot CLI); a mid-run
-/// swap is caught on the next launch.
+/// scan for extra Claude logins in custom config dirs, reconcile the account registry, and expose
+/// what the rest of launch consumes — the per-card identity map (snapshot-cache account stamp) and
+/// the extra-card build plan (`ProviderCatalog`). Runs once per launch (app) or per invocation
+/// (one-shot CLI); a mid-run swap is caught on the next launch.
 @MainActor
 struct ProviderAccountAssembly {
-    /// Card id → the account identity signed in there this launch. Phase 1 observes only default
-    /// homes, so the keys are the bare family ids; a family whose identity didn't resolve is absent.
+    /// Card id → the account identity signed in there this launch. A card whose identity didn't
+    /// resolve is absent.
     let identityKeysByCard: [String: String]
+    /// Extra Claude account cards found on this computer this launch, in stable id order.
+    var claudeCards: [ClaudeAccountCard] = []
+    /// Same-account custom config dirs discovered for the DEFAULT card's login: extra spend-log
+    /// roots for the default scanner, never extra credentials.
+    var defaultClaudeExtraLogRoots: [URL] = []
+    /// The default Claude card's rename, when the badge-holder record carries one.
+    var defaultClaudeDisplayName: String?
 
     /// `waitsForLoginShell`: true for the menu-bar app (a Finder/Dock launch inherits no shell
     /// exports, so the pass leans on the login-shell layers), false for the one-shot CLI (a terminal
@@ -42,7 +80,8 @@ struct ProviderAccountAssembly {
         return make(
             observer: DefaultAccountObserver(),
             accountsStore: ProviderAccountsStore(defaults: defaults),
-            families: families
+            families: families,
+            claudeDiscovery: ClaudeConfigDirDiscovery()
         )
     }
 
@@ -54,14 +93,16 @@ struct ProviderAccountAssembly {
         "codex": "CODEX_HOME",
     ]
 
-    /// The environment-independent core, separated so tests inject a fixed observer and scratch
-    /// store. `families` limits the pass to the families whose home facts are readable this launch
-    /// (see `make(defaults:waitsForLoginShell:)`); a family left out is simply not observed —
-    /// no identity key, no reconciliation, exactly as if the pass never ran for it.
+    /// The environment-independent core, separated so tests inject a fixed observer, discovery, and
+    /// scratch store. `families` limits the pass to the families whose home facts are readable this
+    /// launch (see `make(defaults:waitsForLoginShell:)`); a family left out is simply not observed —
+    /// no identity key, no reconciliation, exactly as if the pass never ran for it. `claudeDiscovery`
+    /// is skipped alongside the claude family (its exclusion set needs the same home facts).
     static func make(
         observer: DefaultAccountObserver,
         accountsStore: ProviderAccountsStore,
-        families: Set<String> = ProviderAccountID.families
+        families: Set<String> = ProviderAccountID.families,
+        claudeDiscovery: ClaudeConfigDirDiscovery? = nil
     ) -> ProviderAccountAssembly {
         var identityKeys: [String: String] = [:]
         var observations: [ProviderAccountsStore.Observation] = []
@@ -91,7 +132,99 @@ struct ProviderAccountAssembly {
             }
         }
 
-        accountsStore.reconcile(with: observations)
-        return ProviderAccountAssembly(identityKeysByCard: identityKeys)
+        // Extra Claude logins in custom config dirs. Guarded on the default read: when a default
+        // login clearly EXISTS but can't be named (`unresolved`), accepting candidates could render
+        // the very account the default card shows as a second card — skip them this launch instead.
+        // A machine with no default login at all keeps accepting: there is nothing to duplicate,
+        // and a custom-dir-only login should still get its card.
+        var foundClaudeAccounts: [(identityKey: String, label: String?, dirs: [ClaudeConfigDirDiscovery.Finding])] = []
+        var defaultClaudeExtraLogRoots: [URL] = []
+        let claudeOutcome = outcomes.first { $0.family == "claude" }?.outcome
+        if let claudeDiscovery, let claudeOutcome {
+            if case .unresolved = claudeOutcome {
+                AppLog.info(.config, "discovery: claude default login present but its identity is unreadable → skipping extra-account candidates this launch")
+            } else {
+                let defaultKey = identityKeys["claude"]
+                let scan = claudeDiscovery.run()
+                for note in scan.notes {
+                    AppLog.info(.config, "discovery: \(note)")
+                }
+                var order: [String] = []
+                var grouped: [String: [ClaudeConfigDirDiscovery.Finding]] = [:]
+                for finding in scan.findings {
+                    if grouped[finding.identityKey] == nil { order.append(finding.identityKey) }
+                    grouped[finding.identityKey, default: []].append(finding)
+                }
+                for identityKey in order {
+                    let findings = grouped[identityKey] ?? []
+                    let sources = findings.map {
+                        ProviderAccountSource(
+                            kind: .configDir,
+                            anchor: $0.anchorPath,
+                            holdsDefaultSource: false,
+                            keychainLiteral: $0.keychainLiteral
+                        )
+                    }
+                    if identityKey == defaultKey {
+                        // Same account as the default card: its dirs are extra spend-log roots on
+                        // that card, never a second card — duplicate cards are structurally
+                        // impossible because identity routes the source to the existing record.
+                        defaultClaudeExtraLogRoots += findings.map { URL(fileURLWithPath: $0.anchorPath) }
+                        if let index = observations.firstIndex(where: { $0.family == "claude" && $0.identityKey == identityKey }) {
+                            observations[index].sources += sources
+                        }
+                        AppLog.info(.config, "discovery: \(findings.count) config dir(s) fold onto the default claude card (same account)")
+                    } else {
+                        observations.append(ProviderAccountsStore.Observation(
+                            family: "claude",
+                            identityKey: identityKey,
+                            label: findings.first?.label,
+                            sources: sources
+                        ))
+                        foundClaudeAccounts.append((identityKey, findings.first?.label, findings))
+                    }
+                }
+            }
+        }
+
+        let records = accountsStore.reconcile(with: observations)
+
+        // The extra-card build plan: one card per distinct account found this launch, under its
+        // reconciled record id.
+        var claudeCards: [ClaudeAccountCard] = []
+        for account in foundClaudeAccounts {
+            guard let record = records.first(where: { $0.family == "claude" && $0.identityKey == account.identityKey }) else {
+                continue
+            }
+            guard record.id != "claude" else {
+                // The bare record's account has moved out of the default home into a config dir
+                // while another login occupies the default. The bare CARD is the default home's
+                // runtime, so this record can't render under its own id this launch. Proper swap
+                // support re-points this in Phase 4; until then the parked account stays hidden.
+                AppLog.warn(.config, "discovery: the claude record's account now lives in a config dir; its card is unavailable until swap support lands")
+                continue
+            }
+            guard let primary = account.dirs.first else { continue }
+            claudeCards.append(ClaudeAccountCard(
+                id: record.id,
+                displayName: ClaudeAccountCard.displayName(
+                    customLabel: record.customLabel, label: record.label, id: record.id
+                ),
+                configDirPath: primary.anchorPath,
+                keychainLiteral: primary.keychainLiteral,
+                extraLogRoots: account.dirs.dropFirst().map { URL(fileURLWithPath: $0.anchorPath) }
+            ))
+            identityKeys[record.id] = account.identityKey
+            AppLog.info(.config, "accounts: extra claude card \(record.id) from \(account.dirs.count) config dir(s)")
+        }
+        claudeCards.sort { $0.id < $1.id }
+
+        let defaultClaudeRename = records.first { $0.id == "claude" }?.customLabel?.nilIfEmpty
+        return ProviderAccountAssembly(
+            identityKeysByCard: identityKeys,
+            claudeCards: claudeCards,
+            defaultClaudeExtraLogRoots: defaultClaudeExtraLogRoots,
+            defaultClaudeDisplayName: defaultClaudeRename
+        )
     }
 }

--- a/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
+++ b/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
@@ -9,20 +9,41 @@ enum UsageHistoryAggregator {
         descriptors: [String: UsageHistoryDescriptor],
         now: Date = Date()
     ) -> [String: ProviderUsageHistory] {
+        var pairs: [(String, ProviderUsageHistory)] = []
+        for document in UsageHistoryDocument.newestByDevice(peerDocuments) {
+            for (providerID, history) in document.providers {
+                pairs.append((providerID, history))
+            }
+        }
+        return merged(localSnapshots: localSnapshots, peerHistories: pairs, descriptors: descriptors, now: now)
+    }
+
+    /// The identity-remapped variant: peers arrive as (LOCAL card id, history) pairs — see
+    /// `PeerHistoryRemapper` — so the same account merges into the same card regardless of which Mac
+    /// calls it the default and which shows it as an extra account card.
+    static func merged(
+        localSnapshots: [String: ProviderSnapshot],
+        peerHistories: [(String, ProviderUsageHistory)],
+        descriptors: [String: UsageHistoryDescriptor],
+        now: Date = Date()
+    ) -> [String: ProviderUsageHistory] {
         var inputs: [String: [ProviderUsageHistory]] = [:]
-        let peerDocuments = UsageHistoryDocument.newestByDevice(peerDocuments)
         for (providerID, descriptor) in descriptors where descriptor.scope == .machineLocal {
             if let local = localSnapshots[providerID]?.usageHistory {
                 inputs[providerID, default: []].append(local)
             }
-            for document in peerDocuments {
-                if let peer = document.providers[providerID] {
-                    inputs[providerID, default: []].append(peer)
-                }
+            for (peerID, history) in peerHistories where peerID == providerID {
+                inputs[providerID, default: []].append(history)
             }
         }
         let includedDays = UsageHistoryWindow.dayKeys(through: now)
         return inputs.mapValues { merge($0, includedDays: includedDays) }
+    }
+
+    /// Day-sum several histories into one — the same merge the per-card path uses, exposed for
+    /// remote-only accounts (histories synced from other Macs with no local card).
+    static func mergeHistories(_ histories: [ProviderUsageHistory], now: Date = Date()) -> ProviderUsageHistory {
+        merge(histories, includedDays: UsageHistoryWindow.dayKeys(through: now))
     }
 
     private static func merge(

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -37,13 +37,11 @@ public struct UsageReader {
     }
 
     public func read(providerID requestedProviderID: String? = nil, force: Bool = false) async throws -> UsageReadResult {
-        let providers = providersOverride ?? ProviderCatalog.make(defaults: defaults)
-        let registry = WidgetRegistry.from(providers)
-        let knownIDs = Set(registry.providers.map(\.id))
-        let enablement = ProviderEnablementStore(defaults: defaults)
         // The launch account pass (see `ProviderAccountAssembly`): resolves each family's default
         // account so cached snapshots are guarded — and refreshed ones stamped — with the correct
-        // account. Skipped when a test injects its own providers — they have no real homes to read.
+        // account, and finds the extra Claude cards the catalog must build (the CLI must know the
+        // same card set as the app, or family matching would answer differently between the two).
+        // Skipped when a test injects its own providers — they have no real homes to read.
         //
         // Warm the login-shell capture FIRST (off-main, one bounded subprocess). Identity-relevant
         // keys are pinned to the persisted shell-environment snapshot, but a CLI spawned without the
@@ -59,6 +57,15 @@ public struct UsageReader {
         let accountAssembly = providersOverride == nil
             ? ProviderAccountAssembly.make(defaults: defaults, waitsForLoginShell: false)
             : ProviderAccountAssembly(identityKeysByCard: [:])
+        let providers = providersOverride ?? ProviderCatalog.make(
+            defaults: defaults,
+            claudeCards: accountAssembly.claudeCards,
+            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
+            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName
+        )
+        let registry = WidgetRegistry.from(providers)
+        let knownIDs = Set(registry.providers.map(\.id))
+        let enablement = ProviderEnablementStore(defaults: defaults)
         // A requested id names cards by plain string matching — an exact card id, or a family id
         // naming all of that family's cards — mirroring the local HTTP API exactly (see
         // `LocalUsageAPI.State.matchingCardIDs`). Never resolved from runtime state: the same

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -68,6 +68,25 @@ enum DefaultLayout {
         "zai.session", "zai.weekly"
     ]
 
+    /// Account-card-aware default list: for every extra account card in the registry
+    /// (`claude@ab12cd34`), the family's entries are re-prefixed onto the card and appended, so a
+    /// newly discovered account seeds the same metric set (and caret split) as its family's default
+    /// card. Pins are deliberately NOT translated — an extra account never claims menu-bar space by
+    /// default. `migrationBaselineMetricIDs` is deliberately NOT translated either: account-card ids
+    /// must always read as never-offered so their defaults seed the first time the card appears.
+    static func translatedForAccountCards(_ ids: [String], providerIDs: [String]) -> [String] {
+        let accountCardIDs = providerIDs.filter(ProviderAccountID.isAccountCard)
+        guard !accountCardIDs.isEmpty else { return ids }
+        var result = ids
+        for cardID in accountCardIDs {
+            let prefix = ProviderAccountID.family(of: cardID) + "."
+            for id in ids where id.hasPrefix(prefix) {
+                result.append("\(cardID).\(id.dropFirst(prefix.count))")
+            }
+        }
+        return result
+    }
+
     /// Metrics placed in the per-provider On Demand section on a fresh install. This is
     /// membership, not enablement: optional disabled rows like Sonnet or Cursor Requests/Credits are
     /// listed here so if the user enables them later they appear below the caret by default.

--- a/Sources/OpenUsage/Stores/LayoutBootstrap.swift
+++ b/Sources/OpenUsage/Stores/LayoutBootstrap.swift
@@ -36,7 +36,11 @@ enum LayoutBootstrap {
         defaults: LayoutDefaultSet
     ) -> LayoutInitialState {
         let hasStoredLayout = persistence.hasStoredLayout
-        let savedPlaced = persistence.loadPlaced()?.filter { registry.descriptor(id: $0.descriptorID) != nil }
+        // Keep widgets whose provider is absent from this launch's registry (an account card whose
+        // login wasn't found this launch). They remain invisible because rendering resolves through
+        // the live registry, but carrying the tombstones through unrelated layout writes lets the
+        // card recover its enabled state when its account returns.
+        let savedPlaced = persistence.loadPlaced()
         let startingPlaced = savedPlaced ?? defaults.metricIDs
             .filter { registry.descriptor(id: $0) != nil }
             .map { PlacedWidget(descriptorID: $0) }
@@ -54,17 +58,20 @@ enum LayoutBootstrap {
         } ?? LayoutOrdering.defaultMetricOrder(registry: registry)
 
         // An existing value — including an empty array from a user who unpinned everything — wins.
-        let pinnedMetricIDs = Set(
-            (persistence.loadPins() ?? defaults.pinnedMetricIDs)
-                .filter { registry.descriptor(id: $0) != nil }
-        )
+        // Unknown saved ids are retained as invisible tombstones for temporarily absent account cards.
+        let pinnedMetricIDs: Set<String>
+        if let savedPins = persistence.loadPins() {
+            pinnedMetricIDs = Set(savedPins)
+        } else {
+            pinnedMetricIDs = Set(defaults.pinnedMetricIDs.filter { registry.descriptor(id: $0) != nil })
+        }
 
         // Expanded membership is a fresh-install default only. Existing layouts that predate the feature
         // keep every familiar metric above the caret unless the user later moves one.
         var shouldPersistExpanded = false
         var expandedMetricIDs: Set<String>
         if let savedExpanded = persistence.loadExpandedMetrics() {
-            expandedMetricIDs = Set(savedExpanded.filter { registry.descriptor(id: $0) != nil })
+            expandedMetricIDs = Set(savedExpanded)
         } else if hasStoredLayout {
             expandedMetricIDs = []
         } else {
@@ -72,9 +79,7 @@ enum LayoutBootstrap {
             shouldPersistExpanded = true
         }
 
-        let expandedProviderIDs = Set(
-            (persistence.loadExpandedProviders() ?? []).filter { registry.provider(id: $0) != nil }
-        )
+        let expandedProviderIDs = Set(persistence.loadExpandedProviders() ?? [])
 
         // A newly-shipped default metric is new to an existing user, so it may safely start below the
         // caret when that is its declared default. Metrics they already had are never silently hidden.
@@ -94,9 +99,16 @@ enum LayoutBootstrap {
             registry.descriptor(id: id) != nil && !expandedNow.contains(id) && !placedIDs.contains(id)
         }
         let savedOnEnable = persistence.loadExpandOnEnable()
-        let defaultExpandedOnEnableIDs = Set(
-            (savedOnEnable ?? defaults.expandedMetricIDs).filter(isExpandOnEnableCandidate)
-        )
+        let defaultExpandedOnEnableIDs: Set<String>
+        if let savedOnEnable {
+            // Known metrics still have to be valid candidates, but an unknown id may belong to a
+            // temporarily absent account card and must survive until its descriptor returns.
+            defaultExpandedOnEnableIDs = Set(savedOnEnable.filter { id in
+                registry.descriptor(id: id) == nil || isExpandOnEnableCandidate(id)
+            })
+        } else {
+            defaultExpandedOnEnableIDs = Set(defaults.expandedMetricIDs.filter(isExpandOnEnableCandidate))
+        }
 
         return LayoutInitialState(
             placed: seededResult.placed,
@@ -138,8 +150,12 @@ enum LayoutBootstrap {
         let seededDefaults: Set<String>
         var shouldPersistSeededDefaults = false
         if let saved = persistence.loadSeededDefaults() {
-            seededDefaults = Set(LayoutOrdering.knownMetricIDs(saved, registry: registry))
-            shouldPersistSeededDefaults = seededDefaults != Set(saved)
+            // Keep markers for metrics whose provider is absent from this launch's registry (an
+            // account card whose login wasn't found). Pruning them would make a default metric the
+            // user disabled look newly introduced when the card returns, so startup would turn it
+            // back on. Permanently removed metric ids are harmless tombstones and can stay here.
+            seededDefaults = Set(saved)
+            shouldPersistSeededDefaults = seededDefaults.count != saved.count
         } else if hasStoredLayout {
             seededDefaults = Set(LayoutOrdering.knownMetricIDs(defaults.migrationBaselineMetricIDs, registry: registry))
             shouldPersistSeededDefaults = true
@@ -188,11 +204,20 @@ enum LayoutOrdering {
         _ saved: [String: [String]],
         registry: WidgetRegistry
     ) -> [String: [String]] {
-        var fallback = defaultMetricOrder(registry: registry)
+        // Start with every saved provider so a temporarily absent account card keeps its ordering
+        // entry. For providers present now, deduplicate the saved sequence (including unknown metric
+        // tombstones) and append newly introduced live metrics; `LayoutStore` filters this persisted
+        // superset through the live registry before rendering.
+        var fallback = saved
         for provider in registry.providers {
             let valid = registry.descriptors(for: provider.id).map(\.id)
             if let savedIDs = saved[provider.id] {
-                fallback[provider.id] = normalizedMetricIDs(savedIDs, validIDs: valid)
+                var seen = Set<String>()
+                var retained = savedIDs.filter { seen.insert($0).inserted }
+                retained.append(contentsOf: valid.filter { seen.insert($0).inserted })
+                fallback[provider.id] = retained
+            } else {
+                fallback[provider.id] = valid
             }
         }
         return fallback

--- a/Sources/OpenUsage/Stores/LayoutStore+Customization.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore+Customization.swift
@@ -17,7 +17,8 @@ extension LayoutStore {
     }
 
     func isMetricEnabled(_ descriptorID: String) -> Bool {
-        placed.contains { $0.descriptorID == descriptorID }
+        registry.descriptor(id: descriptorID) != nil
+            && placed.contains { $0.descriptorID == descriptorID }
     }
 
     /// Whether any enabled provider ships the local spend tiles — the capability gate for the
@@ -159,8 +160,25 @@ extension LayoutStore {
         recordingUndoStep {
             let shown = customizeGroups.map(\.provider.id)
             guard let next = Self.reordered(shown, dragged: dragged, target: target) else { return false }
-            let rest = orderedProviderIDs().filter { !next.contains($0) }
-            providerOrder = next + rest
+            // Reorder only the visible slots in the raw persisted sequence. Unknown ids may be
+            // account cards absent from this launch's registry, and disabled providers are hidden
+            // from `customizeGroups`; both keep their exact positions while the visible ids move
+            // around them.
+            let shownSet = Set(shown)
+            var replacements = next.makeIterator()
+            var rebuilt: [String] = []
+            for providerID in providerOrder {
+                if shownSet.contains(providerID) {
+                    if let replacement = replacements.next() { rebuilt.append(replacement) }
+                } else {
+                    rebuilt.append(providerID)
+                }
+            }
+            while let replacement = replacements.next() { rebuilt.append(replacement) }
+            for providerID in orderedProviderIDs() where !rebuilt.contains(providerID) {
+                rebuilt.append(providerID)
+            }
+            providerOrder = rebuilt
             persistProviderOrder()
             syncPlacedOrder()
             return true

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -123,19 +123,24 @@ final class LayoutStore {
         self.registry = registry
         let persistence = LayoutPersistence(defaults: defaults, storageKey: storageKey)
         self.persistence = persistence
-        self.defaultMetricIDs = defaultMetricIDs
+        // Extra account cards seed their family's default metric set (and caret split); pins and the
+        // migration baseline are deliberately never translated (see `translatedForAccountCards`).
+        let registryProviderIDs = registry.providers.map(\.id)
+        let translatedMetricIDs = DefaultLayout.translatedForAccountCards(defaultMetricIDs, providerIDs: registryProviderIDs)
+        let translatedExpandedIDs = DefaultLayout.translatedForAccountCards(defaultExpandedMetricIDs, providerIDs: registryProviderIDs)
+        self.defaultMetricIDs = translatedMetricIDs
         self.defaultPinnedMetricIDs = defaultPinnedMetricIDs
-        self.defaultExpandedMetricIDs = defaultExpandedMetricIDs
+        self.defaultExpandedMetricIDs = translatedExpandedIDs
         self.isProviderEnabled = isProviderEnabled
 
         let initial = LayoutBootstrap.load(
             registry: registry,
             persistence: persistence,
             defaults: LayoutDefaultSet(
-                metricIDs: defaultMetricIDs,
+                metricIDs: translatedMetricIDs,
                 migrationBaselineMetricIDs: migrationBaselineMetricIDs,
                 pinnedMetricIDs: defaultPinnedMetricIDs,
-                expandedMetricIDs: defaultExpandedMetricIDs
+                expandedMetricIDs: translatedExpandedIDs
             )
         )
         placed = initial.placed
@@ -154,7 +159,7 @@ final class LayoutStore {
     }
 
     func isProviderExpanded(_ providerID: String) -> Bool {
-        expandedProviderIDs.contains(providerID)
+        registry.provider(id: providerID) != nil && expandedProviderIDs.contains(providerID)
     }
 
     @discardableResult
@@ -263,7 +268,9 @@ final class LayoutStore {
     /// column, so a third would not fit the menu bar height.
     static let maxPinsPerProvider = 2
 
-    func isPinned(_ descriptorID: String) -> Bool { pinnedMetricIDs.contains(descriptorID) }
+    func isPinned(_ descriptorID: String) -> Bool {
+        registry.descriptor(id: descriptorID) != nil && pinnedMetricIDs.contains(descriptorID)
+    }
 
     func pinnedCount(forProvider providerID: String) -> Int {
         pinnedMetricIDs.count { registry.descriptor(id: $0)?.providerID == providerID }

--- a/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import Observation
 
 /// Card-id helpers for the account-first model. The account occupying a family's default home when
 /// first observed keeps the bare family id (`claude`, `codex`) as its permanent record id — that is
@@ -11,9 +12,14 @@ enum ProviderAccountID {
 
     /// `claude@ab12cd34` — a stable, non-reversible id derived from the account's identity key.
     static func make(family: String, identityKey: String) -> String {
+        "\(family)@\(hash8(identityKey))"
+    }
+
+    /// The 8-hex-char identity digest card ids are built from, exposed for other identity-derived
+    /// ids (the iCloud remote-only pseudo providers).
+    static func hash8(_ identityKey: String) -> String {
         let digest = SHA256.hash(data: Data(identityKey.lowercased().utf8))
-        let hash8 = digest.prefix(4).map { String(format: "%02x", $0) }.joined()
-        return "\(family)@\(hash8)"
+        return digest.prefix(4).map { String(format: "%02x", $0) }.joined()
     }
 
     /// The family a card id belongs to: `claude@ab12cd34` → `claude`, bare ids map to themselves.
@@ -80,10 +86,11 @@ struct ProviderAccountRecord: Codable, Equatable, Sendable {
 }
 
 /// The account-first registry (`openusage.providerAccounts.v1`). Reconciled at every launch from the
-/// default-home identity reads; authoritative from day one — there is no parallel card model to drift
-/// from. With a single account per family (all Phase 1 can observe), the registry is bookkeeping the
-/// UI doesn't consult yet; multi-account rendering (Phase 2+) reads cards straight from these records.
+/// default-home identity reads and the config-dir scan; authoritative from day one — there is no
+/// parallel card model to drift from. Extra account cards render straight from these records, and
+/// the UI observes it live for renames (`customLabel`).
 @MainActor
+@Observable
 final class ProviderAccountsStore {
     static let storageKey = "openusage.providerAccounts.v1"
 
@@ -105,7 +112,8 @@ final class ProviderAccountsStore {
     }
 
     /// One account observed this launch, before reconciliation assigns (or re-finds) its record id.
-    struct Observation {
+    /// (Named to avoid colliding with the `Observation` module the `@Observable` macro expands into.)
+    struct AccountObservation {
         var family: String
         var identityKey: String
         var label: String?
@@ -118,7 +126,7 @@ final class ProviderAccountsStore {
     /// — an account that went unobserved (logged out, unreadable identity) is simply left as it was,
     /// except that a newly observed default-home holder takes the default badge off every sibling.
     @discardableResult
-    func reconcile(with observations: [Observation]) -> [ProviderAccountRecord] {
+    func reconcile(with observations: [AccountObservation]) -> [ProviderAccountRecord] {
         var updated = records
         var changed = false
 
@@ -194,7 +202,7 @@ final class ProviderAccountsStore {
     /// account observed at the family's DEFAULT home may claim the bare id — that id's runtime reads
     /// the default home, so handing it to a custom-config-dir account would point the existing card
     /// at a login it can't read.
-    private static func availableID(for observation: Observation, in records: [ProviderAccountRecord]) -> String {
+    private static func availableID(for observation: AccountObservation, in records: [ProviderAccountRecord]) -> String {
         let observedAtDefaultHome = observation.sources.contains { $0.kind == .defaultHome }
         if observedAtDefaultHome, !records.contains(where: { $0.id == observation.family }) {
             return observation.family

--- a/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
@@ -20,6 +20,12 @@ enum ProviderAccountID {
     static func family(of cardID: String) -> String {
         cardID.firstIndex(of: "@").map { String(cardID[..<$0]) } ?? cardID
     }
+
+    /// Whether a card id names an extra account card (`claude@ab12cd34`) rather than a bare
+    /// provider id.
+    static func isAccountCard(_ cardID: String) -> Bool {
+        cardID.contains("@")
+    }
 }
 
 /// One place an account is signed in. "Default" is a badge on a source (`holdsDefaultSource`), never
@@ -30,12 +36,24 @@ struct ProviderAccountSource: Codable, Equatable, Sendable {
     enum Kind: String, Codable, Sendable {
         /// The provider's standard home for this machine (`~/.claude`, `~/.codex`, env override).
         case defaultHome
+        /// A custom Claude config dir (a `CLAUDE_CONFIG_DIR` home kept besides the default).
+        case configDir
     }
 
     var kind: Kind
     /// Canonical home path the source was observed at.
     var anchor: String?
     var holdsDefaultSource: Bool
+    /// `configDir` only: the literal string whose hash names the source's keychain item (Claude Code
+    /// hashes `CLAUDE_CONFIG_DIR` exactly as typed, so `~/x` and its absolute spelling differ).
+    var keychainLiteral: String?
+
+    init(kind: Kind, anchor: String?, holdsDefaultSource: Bool, keychainLiteral: String? = nil) {
+        self.kind = kind
+        self.anchor = anchor
+        self.holdsDefaultSource = holdsDefaultSource
+        self.keychainLiteral = keychainLiteral
+    }
 }
 
 /// An account as the account-first model sees it: opaque identity key, stable record id minted at
@@ -47,9 +65,18 @@ struct ProviderAccountRecord: Codable, Equatable, Sendable {
     var family: String
     var identityKey: String
     var label: String?
+    /// A user-chosen card name (Rename in the card's context menu / Customize). Wins over `label`
+    /// and the id-derived fallback; never touched by reconciliation.
+    var customLabel: String?
     var sources: [ProviderAccountSource]
     /// Set by a future "Remove Account…". A tombstoned account is never resurrected by rescans.
     var removedTombstone: Bool = false
+
+    /// The name the card renders under: the user's rename, else the account's own label
+    /// ("email (Org Name)"), else the record id itself (`claude@ab12cd34` — owner decision 2).
+    var displayLabel: String {
+        customLabel?.nilIfEmpty ?? label?.nilIfEmpty ?? id
+    }
 }
 
 /// The account-first registry (`openusage.providerAccounts.v1`). Reconciled at every launch from the
@@ -144,6 +171,15 @@ final class ProviderAccountsStore {
         return records
     }
 
+    /// Stores a user rename for a card; `nil` or blank clears it back to the derived name.
+    func rename(cardID: String, to name: String?) {
+        guard let index = records.firstIndex(where: { $0.id == cardID }) else { return }
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        guard records[index].customLabel != trimmed else { return }
+        records[index].customLabel = trimmed
+        persist()
+    }
+
     /// The record currently holding a family's default badge, if any.
     func defaultBadgeHolder(family: String) -> ProviderAccountRecord? {
         records.first { record in
@@ -154,9 +190,15 @@ final class ProviderAccountsStore {
     }
 
     /// The bare family id when free (the migration-killing rule: the first account observed at the
-    /// default home IS the existing card), else an identity-derived `family@<hash8>` id.
+    /// default home IS the existing card), else an identity-derived `family@<hash8>` id. Only an
+    /// account observed at the family's DEFAULT home may claim the bare id — that id's runtime reads
+    /// the default home, so handing it to a custom-config-dir account would point the existing card
+    /// at a login it can't read.
     private static func availableID(for observation: Observation, in records: [ProviderAccountRecord]) -> String {
-        if !records.contains(where: { $0.id == observation.family }) { return observation.family }
+        let observedAtDefaultHome = observation.sources.contains { $0.kind == .defaultHome }
+        if observedAtDefaultHome, !records.contains(where: { $0.id == observation.family }) {
+            return observation.family
+        }
         let derived = ProviderAccountID.make(family: observation.family, identityKey: observation.identityKey)
         guard records.contains(where: { $0.id == derived }) else { return derived }
         // A hash-prefix collision between two distinct identities of one family; salt until free.

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -474,11 +474,14 @@ final class WidgetDataStore {
             let device = entry.deviceNames.count == 1
                 ? entry.deviceNames[0]
                 : "\(entry.deviceNames.count) other Macs"
-            // The stock family name, not the local family card's display name — that card is a
-            // DIFFERENT account (possibly renamed), and this slice shouldn't inherit its rename.
+            // The slice is named by the account's identity-derived card id ("claude@ab12cd34 ·
+            // Mac mini") — unique per account, so several remote-only accounts from one device stay
+            // tellable apart, and it's the exact id the account's card gets the day it's signed in
+            // here (and the id the CLI/API answer to on the Mac that has it). The pseudo provider id
+            // stays distinct from real card ids so a slice can never collide with a live card.
             let provider = Provider(
                 id: "\(entry.family)@peer-\(ProviderAccountID.hash8(entry.identityKey))",
-                displayName: "\(entry.family.capitalized) · \(device)",
+                displayName: "\(entry.cardID) · \(device)",
                 icon: familyProvider.icon
             )
             let empty = ProviderSnapshot(

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -88,6 +88,9 @@ final class WidgetDataStore {
     /// Wired by `ICloudUsageSyncStore`; debounced there so a concurrent provider batch produces one file.
     @ObservationIgnored var onLocalHistoryChanged: (@MainActor () -> Void)?
     @ObservationIgnored private var peerHistoryDocuments: [UsageHistoryDocument] = []
+    /// Accounts synced from other Macs that have NO card here: surfaced in Total Spend only (their
+    /// synthesized snapshots carry the usual Today/Yesterday/Last 30 Days lines), never as cards.
+    private(set) var remoteOnlySpend: [(provider: Provider, snapshot: ProviderSnapshot)] = []
 
     /// Global meter style: whether every bounded tile (and the menu-bar value) renders as "used" or
     /// "left/remaining". Persisted so the choice survives relaunch; defaults to `.remaining`.
@@ -379,23 +382,33 @@ final class WidgetDataStore {
 
     func localHistoryDocument(deviceID: String, deviceName: String, updatedAt: Date = Date()) -> UsageHistoryDocument {
         var providers: [String: ProviderUsageHistory] = [:]
+        var identities: [String: String] = [:]
+        // Every machine-local card syncs — account cards included. Their ids are identity-derived,
+        // so they mean the same account on every Mac; the identities map additionally lets peers
+        // match a default card's history to whatever card that account is over there (see
+        // `PeerHistoryRemapper`).
         for (providerID, descriptor) in registry.historyDescriptorsByProvider
         where descriptor.scope == .machineLocal && isProviderEnabled(providerID) {
             if let history = localSnapshots[providerID]?.usageHistory {
                 providers[providerID] = history
+                if let identity = providerIdentityKeys[providerID] {
+                    identities[providerID] = identity
+                }
             }
         }
         return UsageHistoryDocument(
             deviceID: deviceID,
             deviceName: deviceName,
             updatedAt: updatedAt,
-            providers: providers
+            providers: providers,
+            identities: identities.isEmpty ? nil : identities
         )
     }
 
     private func rebuildRenderedSnapshots() {
         guard !peerHistoryDocuments.isEmpty else {
             snapshots = localSnapshots
+            remoteOnlySpend = []
             return
         }
         let renderDate = now()
@@ -404,10 +417,22 @@ final class WidgetDataStore {
         ) { result, entry in
             if isProviderEnabled(entry.key) { result[entry.key] = entry.value }
         }
+        // Match peers by account identity, not card id — the same account can be the default card
+        // on one Mac and an extra account card on another. Whatever matches no local card at all
+        // becomes a Total Spend-only remote entry below.
+        let remapped = PeerHistoryRemapper.remap(
+            documents: peerHistoryDocuments,
+            localIdentityByCardID: providerIdentityKeys
+        )
         let merged = UsageHistoryAggregator.merged(
             localSnapshots: localSnapshots,
-            peerDocuments: peerHistoryDocuments,
+            peerHistories: remapped.histories,
             descriptors: enabledDescriptors,
+            now: renderDate
+        )
+        remoteOnlySpend = Self.renderRemoteOnlySpend(
+            remapped.remoteOnly,
+            registry: registry,
             now: renderDate
         )
         var rendered = localSnapshots
@@ -429,6 +454,47 @@ final class WidgetDataStore {
             )
         }
         snapshots = rendered
+    }
+
+    /// Synthesize Total Spend entries for accounts that exist only on other Macs: a pseudo provider
+    /// (family icon, "Claude · Mac mini" name) plus a snapshot carrying the standard spend-tile
+    /// lines, rendered from the merged remote history by the same renderer real cards use.
+    private static func renderRemoteOnlySpend(
+        _ remoteOnly: [PeerHistoryRemapper.RemoteOnlyHistory],
+        registry: WidgetRegistry,
+        now: Date
+    ) -> [(provider: Provider, snapshot: ProviderSnapshot)] {
+        remoteOnly.compactMap { entry in
+            guard let familyProvider = registry.provider(id: entry.family),
+                  let descriptor = registry.historyDescriptorsByProvider[entry.family]
+            else { return nil }
+            let history = UsageHistoryAggregator.mergeHistories(entry.histories, now: now)
+            guard !history.series.daily.isEmpty else { return nil }
+
+            let device = entry.deviceNames.count == 1
+                ? entry.deviceNames[0]
+                : "\(entry.deviceNames.count) other Macs"
+            // The stock family name, not the local family card's display name — that card is a
+            // DIFFERENT account (possibly renamed), and this slice shouldn't inherit its rename.
+            let provider = Provider(
+                id: "\(entry.family)@peer-\(ProviderAccountID.hash8(entry.identityKey))",
+                displayName: "\(entry.family.capitalized) · \(device)",
+                icon: familyProvider.icon
+            )
+            let empty = ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [],
+                refreshedAt: now
+            )
+            let snapshot = UsageHistorySnapshotRenderer.render(
+                local: empty,
+                history: history,
+                descriptor: descriptor,
+                now: now
+            )
+            return (provider, snapshot)
+        }
     }
 
     /// The provider's latest refresh error, or `nil` when its last refresh succeeded.

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -471,17 +471,15 @@ final class WidgetDataStore {
             let history = UsageHistoryAggregator.mergeHistories(entry.histories, now: now)
             guard !history.series.daily.isEmpty else { return nil }
 
-            let device = entry.deviceNames.count == 1
-                ? entry.deviceNames[0]
-                : "\(entry.deviceNames.count) other Macs"
-            // The slice is named by the account's identity-derived card id ("claude@ab12cd34 ·
-            // Mac mini") — unique per account, so several remote-only accounts from one device stay
-            // tellable apart, and it's the exact id the account's card gets the day it's signed in
-            // here (and the id the CLI/API answer to on the Mac that has it). The pseudo provider id
-            // stays distinct from real card ids so a slice can never collide with a live card.
+            // The slice is named by the account's identity-derived card id ("claude@ab12cd34") —
+            // unique per account, and the exact id the account's card gets the day it's signed in
+            // here (and the id the CLI/API answer to on the Mac that has it). Which Mac the spend
+            // came from is irrelevant to the total, so it's not part of the name. The pseudo
+            // provider id stays distinct from real card ids so a slice can never collide with a
+            // live card.
             let provider = Provider(
                 id: "\(entry.family)@peer-\(ProviderAccountID.hash8(entry.identityKey))",
-                displayName: "\(entry.cardID) · \(device)",
+                displayName: entry.cardID,
                 icon: familyProvider.icon
             )
             let empty = ProviderSnapshot(

--- a/Sources/OpenUsage/Stores/WidgetRegistry.swift
+++ b/Sources/OpenUsage/Stores/WidgetRegistry.swift
@@ -45,13 +45,25 @@ struct WidgetRegistry: Sendable {
     }
 
     /// Saved order filtered to installed providers, with newly introduced providers appended in the
-    /// canonical registry order. Shared by the dashboard, local API, and one-shot CLI.
+    /// canonical registry order — except account cards (`claude@ab12cd34`), which slot in right
+    /// after their family's group so a newly discovered account appears next to its siblings
+    /// instead of at the end of the dashboard. Shared by the dashboard, local API, and one-shot CLI.
     func orderedProviderIDs(savedOrder: [String]) -> [String] {
         let defaults = providers.map(\.id)
         let known = Set(defaults)
         let saved = savedOrder.filter { known.contains($0) }
         let savedIDs = Set(saved)
-        return saved + defaults.filter { !savedIDs.contains($0) }
+        var result = saved
+        for id in defaults where !savedIDs.contains(id) {
+            let family = ProviderAccountID.family(of: id)
+            if ProviderAccountID.isAccountCard(id),
+               let anchor = result.lastIndex(where: { ProviderAccountID.family(of: $0) == family }) {
+                result.insert(id, at: result.index(after: anchor))
+            } else {
+                result.append(id)
+            }
+        }
+        return result
     }
 
     var limitDescriptorsByProvider: [String: [WidgetDescriptor]] {

--- a/Sources/OpenUsage/Support/ShareCardRenderer.swift
+++ b/Sources/OpenUsage/Support/ShareCardRenderer.swift
@@ -63,12 +63,15 @@ enum ShareCardRenderer {
     /// rows read density via `@AppStorage`, so the saved value is swapped to `.regular` for the duration
     /// of the render and restored on exit (synchronously), keeping the exported card consistent without
     /// disturbing the live popover.
+    /// `displayName` carries the live card title (a rename can land mid-session, after the
+    /// `Provider`'s own name was baked at launch); `nil` falls back to the baked name.
     @discardableResult
     static func share(
         group: ProviderGroup,
         dataStore: WidgetDataStore,
         layout: LayoutStore,
-        appearance: ColorScheme
+        appearance: ColorScheme,
+        displayName: String? = nil
     ) -> Bool {
         let isExpanded = layout.isProviderExpanded(group.provider.id)
         let alwaysRows = group.alwaysShownWidgets.compactMap { widget -> WidgetData? in
@@ -85,7 +88,8 @@ enum ShareCardRenderer {
             plan: dataStore.plan(for: group.provider.id),
             rows: rows,
             appearance: appearance,
-            expandBoundaryIndex: isExpanded ? alwaysRows.count : nil
+            expandBoundaryIndex: isExpanded ? alwaysRows.count : nil,
+            displayNameOverride: displayName
         )
         return renderAndCopy(view, label: group.provider.id, layout: layout)
     }

--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -28,6 +28,9 @@ struct CustomizeProviderDetailView: View {
     var body: some View {
         if let group = layout.customizeDetail(for: providerID) {
             VStack(alignment: .leading, spacing: density.sectionSpacing) {
+                if container.canRename(providerID) {
+                    CardNameSection(providerID: providerID)
+                }
                 metricSections(group)
                     .simultaneousGesture(metricDragGesture())
                 if let keyProvider = container.apiKeyProviders.first(where: { $0.provider.id == providerID }) {
@@ -167,6 +170,50 @@ struct CustomizeProviderDetailView: View {
     private func makeLift(metricID: String, value: DragGesture.Value) -> ReorderLift? {
         let title = layout.customizeDetail(for: providerID)?.metrics.first { $0.id == metricID }?.title ?? ""
         return ReorderLift.make(id: metricID, payload: .customizeMetric(title: title), value: value, frames: rowFrames)
+    }
+}
+
+/// The card-name editor shown at the top of an account card's Customize detail (Claude/Codex cards
+/// with an account record). The field holds the user's rename; the placeholder shows the derived
+/// name the card falls back to, so clearing the field reads as "back to the default". Commits on
+/// Return and when focus leaves the field — never per keystroke, so half-typed names don't persist.
+private struct CardNameSection: View {
+    let providerID: String
+    @Environment(AppContainer.self) private var container
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    @State private var draft = ""
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
+            Text("Name")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+            TextField(placeholder, text: $draft)
+                .textFieldStyle(.plain)
+                .focused($isFocused)
+                .onSubmit { commit() }
+                .padding(.horizontal, 12)
+                .padding(.vertical, density.controlRowPadding)
+                .cardSurface()
+        }
+        .onAppear { draft = record?.customLabel ?? "" }
+        .onChange(of: isFocused) { _, focused in
+            if !focused { commit() }
+        }
+    }
+
+    private var record: ProviderAccountRecord? {
+        container.accounts.records.first { $0.id == providerID }
+    }
+
+    private var placeholder: String {
+        record.map { container.derivedDisplayName(for: $0) } ?? ""
+    }
+
+    private func commit() {
+        container.accounts.rename(cardID: providerID, to: draft)
     }
 }
 

--- a/Sources/OpenUsage/Views/HeaderView.swift
+++ b/Sources/OpenUsage/Views/HeaderView.swift
@@ -23,6 +23,7 @@ import SwiftUI
 /// and fire while the menu is open, so the monitor and the items never double-fire. ⌘Q (Quit) is
 /// unowned elsewhere, so it rides its menu item directly.
 struct HeaderView: View {
+    @Environment(AppContainer.self) private var container
     @Environment(LayoutStore.self) private var layout
     @Environment(WidgetDataStore.self) private var dataStore
     @Environment(UpdaterController.self) private var updater
@@ -132,7 +133,7 @@ struct HeaderView: View {
                     .disabled(true)
             } else {
                 ForEach(groups) { group in
-                    Button(group.provider.displayName) { shareCard(group) }
+                    Button(container.displayName(for: group.provider)) { shareCard(group) }
                 }
             }
         } label: {
@@ -150,7 +151,8 @@ struct HeaderView: View {
             group: group,
             dataStore: dataStore,
             layout: layout,
-            appearance: colorScheme
+            appearance: colorScheme,
+            displayName: container.displayName(for: group.provider)
         )
     }
 

--- a/Sources/OpenUsage/Views/PopoverTopBar.swift
+++ b/Sources/OpenUsage/Views/PopoverTopBar.swift
@@ -10,6 +10,9 @@ struct PopoverTopBar: View {
 
     @Binding var isPresentingResetAllConfirm: Bool
 
+    /// Read for the live card name, so a renamed card's Customize detail title follows the rename.
+    @Environment(AppContainer.self) private var container
+
     @ViewBuilder
     var body: some View {
         switch layout.screen {
@@ -43,7 +46,9 @@ struct PopoverTopBar: View {
     }
 
     private var customizeTitle: String {
-        layout.customizeProviderID.flatMap { layout.provider(id: $0)?.displayName } ?? "Customize"
+        layout.customizeProviderID.flatMap { id in
+            layout.provider(id: id).map { container.displayName(for: $0) }
+        } ?? "Customize"
     }
 
     private func customizeBack() {
@@ -102,7 +107,7 @@ struct PopoverTopBar: View {
         .glassButtonStyle()
         .buttonBorderShape(.circle)
         .controlSize(.large)
-        .hoverTooltip("Reset \(layout.provider(id: providerID)?.displayName ?? providerID)")
+        .hoverTooltip("Reset \(layout.provider(id: providerID).map { container.displayName(for: $0) } ?? providerID)")
         .accessibilityLabel("Reset")
     }
 

--- a/Sources/OpenUsage/Views/ProviderListRow.swift
+++ b/Sources/OpenUsage/Views/ProviderListRow.swift
@@ -15,6 +15,8 @@ struct ProviderListRow<Handle: View>: View {
     var onOpen: () -> Void = {}
 
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    /// Read for the live card name, so a rename re-titles the Customize row without a relaunch.
+    @Environment(AppContainer.self) private var container
 
     var body: some View {
         HStack(spacing: 10) {
@@ -29,7 +31,7 @@ struct ProviderListRow<Handle: View>: View {
                 ProviderIcon(source: provider.icon)
                     .frame(width: 18, height: 18)
                 VStack(alignment: .leading, spacing: 0) {
-                    Text(provider.displayName)
+                    Text(container.displayName(for: provider))
                         .font(.system(size: density.headerPointSize, weight: .semibold))
                         .foregroundStyle(.primary)
                         .lineLimit(1)
@@ -54,7 +56,7 @@ struct ProviderListRow<Handle: View>: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Open \(provider.displayName)")
+            .accessibilityLabel("Open \(container.displayName(for: provider))")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, density.controlRowPadding)

--- a/Sources/OpenUsage/Views/ProviderSectionHeader.swift
+++ b/Sources/OpenUsage/Views/ProviderSectionHeader.swift
@@ -28,6 +28,9 @@ struct ProviderSectionHeader: View {
     /// Header type and icon track the density setting like the rows do, so Compact shrinks the
     /// whole section anatomy — not just the rows under it.
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+    /// Read for the live card name: a rename lands in the account registry and re-titles the header
+    /// without a relaunch (the `Provider`'s own name is baked at launch).
+    @Environment(AppContainer.self) private var container
     /// Party easter egg: pulse the provider mark. Off by default everywhere else.
     @Environment(\.popoverPartyMode) private var partyMode
     @State private var isHovered = false
@@ -61,7 +64,7 @@ struct ProviderSectionHeader: View {
                 // Name + plan keep their width and stay on one line; under width pressure (a long plan
                 // name like "Super Grok Heavy") the lower-priority stale tag truncates first instead of
                 // wrapping the name to a second line.
-                Text(provider.displayName)
+                Text(container.displayName(for: provider))
                     .font(.system(size: density.headerPointSize, weight: .semibold))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
@@ -96,7 +99,7 @@ struct ProviderSectionHeader: View {
             Spacer(minLength: 8)
             if let onCopyScreenshot {
                 CopyFeedbackButton(
-                    accessibilityLabel: "Copy \(provider.displayName) Screenshot",
+                    accessibilityLabel: "Copy \(container.displayName(for: provider)) Screenshot",
                     isRevealed: isHovered,
                     action: onCopyScreenshot
                 )

--- a/Sources/OpenUsage/Views/ShareCardView.swift
+++ b/Sources/OpenUsage/Views/ShareCardView.swift
@@ -20,6 +20,10 @@ struct ShareCardView: View {
     /// neighbor-aware condensing treats the expand caret as a hard boundary the way the live dashboard
     /// does. `nil` when the provider is collapsed (no expanded section).
     var expandBoundaryIndex: Int? = nil
+    /// The live card title when it differs from the launch-baked `provider.displayName` (a rename can
+    /// land mid-session). Passed explicitly — this view renders in an `ImageRenderer`, outside the
+    /// app's environment, so it can't read the account registry itself.
+    var displayNameOverride: String? = nil
 
     /// Authored card width in points. The renderer multiplies this by `ShareCardRenderer.scale` for the
     /// PNG's pixel width; the height is whatever the rows add up to (flexible).
@@ -42,7 +46,7 @@ struct ShareCardView: View {
             ProviderIcon(source: provider.icon, inset: 0.04)
                 .frame(width: 22, height: 22)
             HStack(alignment: .firstTextBaseline, spacing: 6) {
-                Text(provider.displayName)
+                Text(displayNameOverride ?? provider.displayName)
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.primary)
                     .lineLimit(1)

--- a/Sources/OpenUsage/Views/TotalSpendCard.swift
+++ b/Sources/OpenUsage/Views/TotalSpendCard.swift
@@ -36,7 +36,16 @@ struct TotalSpendCard: View {
     }
 
     private var total: TotalSpend {
-        TotalSpendAggregator.total(for: period, providers: providers, snapshots: dataStore.snapshots)
+        // Accounts that live only on other Macs (synced, no card here) count toward the total and
+        // get their own legend slice ("Claude · Mac mini") — the number should be the whole truth
+        // even when a login isn't set up on this machine.
+        var aggregatedProviders = providers
+        var aggregatedSnapshots = dataStore.snapshots
+        for entry in dataStore.remoteOnlySpend {
+            aggregatedProviders.append(entry.provider)
+            aggregatedSnapshots[entry.provider.id] = entry.snapshot
+        }
+        return TotalSpendAggregator.total(for: period, providers: aggregatedProviders, snapshots: aggregatedSnapshots)
     }
 
     private var projection: TotalSpendProjection {

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -93,7 +93,11 @@ struct WidgetGroupedListView: View {
             // whose identity has been observed at least once.
             if container.canRename(group.provider.id) {
                 Button("Rename…") {
-                    renameDraft = name
+                    // Seed with the STORED rename (empty when none), not the derived title —
+                    // confirming an untouched field must stay "no rename", not freeze the derived
+                    // name into a custom label that future account-label updates can't refresh.
+                    renameDraft = container.accounts.records
+                        .first { $0.id == group.provider.id }?.customLabel ?? ""
                     renameCardID = group.provider.id
                 }
             }

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -20,6 +20,9 @@ struct WidgetGroupedListView: View {
     @State private var rowFrames: [String: CGRect] = [:]
     @State private var activeProviderID: String?
     @State private var activeMetricID: String?
+    /// The card the "Rename…" alert is currently editing; `nil` when the alert is closed.
+    @State private var renameCardID: String?
+    @State private var renameDraft = ""
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
     var body: some View {
@@ -33,6 +36,25 @@ struct WidgetGroupedListView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .onPreferenceChange(ReorderFramePreferenceKey.self) { rowFrames = $0 }
         .animation(Motion.spring, value: layout.displayGroups.map(\.provider.id))
+        .alert("Rename Card", isPresented: isRenamePresented) {
+            TextField("Name", text: $renameDraft)
+            Button("Rename") {
+                if let renameCardID {
+                    // A cleared field resets the card back to its derived name.
+                    container.accounts.rename(cardID: renameCardID, to: renameDraft)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Leave the name empty to go back to the default.")
+        }
+    }
+
+    private var isRenamePresented: Binding<Bool> {
+        Binding(
+            get: { renameCardID != nil },
+            set: { if !$0 { renameCardID = nil } }
+        )
     }
 
     private func section(_ group: ProviderGroup) -> some View {
@@ -57,14 +79,23 @@ struct WidgetGroupedListView: View {
         .padding(.horizontal, 8)
         .highPriorityGesture(providerDragGesture(for: group))
         .contextMenu {
+            let name = container.displayName(for: group.provider)
             // Hides the whole provider section (the Customize provider list brings it back). Mirrors
             // the per-metric "Hide" but one level up, so the verb order reads the same on a header as a row.
-            Button("Hide \(group.provider.displayName)") {
+            Button("Hide \(name)") {
                 container.enablement.setEnabled(false, for: group.provider.id)
             }
             Divider()
-            Button("Refresh \(group.provider.displayName)") {
+            Button("Refresh \(name)") {
                 Task { await dataStore.refresh(providerID: group.provider.id, force: true) }
+            }
+            // Renaming needs an account record to write to, so it only shows on account-model cards
+            // whose identity has been observed at least once.
+            if container.canRename(group.provider.id) {
+                Button("Rename…") {
+                    renameDraft = name
+                    renameCardID = group.provider.id
+                }
             }
             Button("Customize…") {
                 openCustomize(for: group.provider.id)
@@ -85,7 +116,8 @@ struct WidgetGroupedListView: View {
             group: group,
             dataStore: dataStore,
             layout: layout,
-            appearance: colorScheme
+            appearance: colorScheme,
+            displayName: container.displayName(for: group.provider)
         )
     }
 
@@ -259,7 +291,7 @@ struct WidgetGroupedListView: View {
         }
         Divider()
         if let provider = layout.provider(id: providerID) {
-            Button("Refresh \(provider.displayName)") {
+            Button("Refresh \(container.displayName(for: provider))") {
                 Task { await dataStore.refresh(providerID: providerID, force: true) }
             }
         }

--- a/Tests/OpenUsageTests/AntigravityLayoutTests.swift
+++ b/Tests/OpenUsageTests/AntigravityLayoutTests.swift
@@ -46,10 +46,10 @@ final class AntigravityLayoutTests: XCTestCase {
                        "a metric the user already lived with is never silently tucked away")
     }
 
-    func testSavedGeminiFlashStateIsFilteredEverywhere() {
-        // `antigravity.geminiFlash` no longer exists (owner-approved: its layout state drops with no
-        // migration). Every load path filters unknown IDs against the registry, so stale saved state
-        // self-heals.
+    func testSavedGeminiFlashStateStaysInvisibleWhileItsTombstonesAreRetained() {
+        // `antigravity.geminiFlash` no longer exists, so live registry lookups keep it out of the UI.
+        // Its saved state remains as a harmless tombstone because an unknown descriptor can also be a
+        // temporarily absent account card, whose customization must return on the next launch.
         let defaults = makeDefaults("FlashFilter")
         saveStored([
             PlacedWidget(descriptorID: "antigravity.geminiPro"),
@@ -66,8 +66,13 @@ final class AntigravityLayoutTests: XCTestCase {
 
         XCTAssertFalse(store.isMetricEnabled("antigravity.geminiFlash"))
         XCTAssertFalse(store.orderedSupportedMetrics(for: "antigravity").map(\.id).contains("antigravity.geminiFlash"))
-        // The saved pin set is respected exactly (dead ID dropped, no weekly pin auto-added).
-        XCTAssertEqual(store.pinnedMetricIDs, ["antigravity.geminiPro"])
+        XCTAssertFalse(store.isPinned("antigravity.geminiFlash"), "the dead pin stays invisible")
+        XCTAssertTrue(
+            store.pinnedMetricIDs.contains("antigravity.geminiFlash"),
+            "…but its tombstone is retained for a possible return"
+        )
+        XCTAssertTrue(store.isPinned("antigravity.geminiPro"))
+        XCTAssertFalse(store.isPinned("antigravity.geminiWeekly"), "an existing pin set gains no new defaults")
     }
 
     func testAbsentPinsKeyAdoptsGeminiWeeklyPinOnUpgrade() {

--- a/Tests/OpenUsageTests/ClaudeConfigDirDiscoveryTests.swift
+++ b/Tests/OpenUsageTests/ClaudeConfigDirDiscoveryTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import OpenUsage
+
+/// The config-dir candidate rules: identity-extraction-is-validation plus the exact credential
+/// shape, with the default homes excluded. Everything runs on fakes — no real filesystem/keychain.
+final class ClaudeConfigDirDiscoveryTests: XCTestCase {
+    private let home = URL(fileURLWithPath: "/Users/dev")
+
+    private func makeDiscovery(
+        environment: [String: String] = [:],
+        files: [String: String],
+        keychainServices: [String: String] = [:],
+        subdirectories: [String] = []
+    ) -> ClaudeConfigDirDiscovery {
+        ClaudeConfigDirDiscovery(
+            environment: FakeEnvironment(environment),
+            files: FakeFiles(files),
+            keychain: ServiceKeychain(values: keychainServices),
+            homeDirectory: { [home] in home },
+            listSubdirectories: { [home] url in
+                subdirectories
+                    .map { URL(fileURLWithPath: $0) }
+                    .filter { $0.deletingLastPathComponent().path == url.path }
+                    .filter { _ in url.path.hasPrefix(home.path) }
+            }
+        )
+    }
+
+    func testAcceptsADirWithIdentityAndFileCredential() throws {
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "emailAddress": "work@example.com", "organizationName": "Sunstory"}}"#,
+                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-work"]
+        )
+
+        let result = discovery.run()
+
+        let finding = try XCTUnwrap(result.findings.first)
+        XCTAssertEqual(result.findings.count, 1)
+        XCTAssertEqual(finding.identityKey, "acct-2")
+        XCTAssertEqual(finding.label, "work@example.com (Sunstory)")
+        XCTAssertEqual(finding.anchorPath, "/Users/dev/.claude-work")
+    }
+
+    func testAcceptsAKeychainBackedDirThroughItsScopedServiceName() throws {
+        // Claude Code hashes the literal CLAUDE_CONFIG_DIR string; the `~` spelling must be probed
+        // alongside the absolute one, and the matched literal is what the scoped store reuses.
+        let literal = "~/.claude-alt"
+        let service = ClaudeAuthStore.scopedKeychainServiceName(
+            forConfigDirLiteral: literal, environment: FakeEnvironment([:])
+        )
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-alt/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-3"}}"#,
+            ],
+            keychainServices: [service: "present"],
+            subdirectories: ["/Users/dev/.claude-alt"]
+        )
+
+        let result = discovery.run()
+
+        let finding = try XCTUnwrap(result.findings.first)
+        XCTAssertEqual(finding.identityKey, "acct-3")
+        XCTAssertEqual(finding.keychainLiteral, literal)
+    }
+
+    func testRejectsIdentityWithoutCredentialAndCredentialWithoutIdentity() {
+        let discovery = makeDiscovery(
+            files: [
+                // Identity but no credential shape: a toy/fork state file.
+                "/Users/dev/.claude-toy/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-4"}}"#,
+                // Credential but no identity: can't be routed to an account, must not become a card.
+                "/Users/dev/.claude-anon/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-5"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-toy", "/Users/dev/.claude-anon"]
+        )
+
+        let result = discovery.run()
+
+        XCTAssertTrue(result.findings.isEmpty)
+        XCTAssertEqual(result.notes.count, 1, "the near-miss with an identity enters the support trail")
+    }
+
+    func testExcludesTheDefaultHomesIncludingTheEnvOverride() {
+        let files = [
+            "/Users/dev/.claude-main/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-MAIN"}}"#,
+            "/Users/dev/.claude-main/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at"}}"#,
+            "/Users/dev/.config/claude/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-XDG"}}"#,
+            "/Users/dev/.config/claude/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at"}}"#,
+        ]
+        let discovery = makeDiscovery(
+            environment: ["CLAUDE_CONFIG_DIR": "~/.claude-main"],
+            files: files,
+            subdirectories: ["/Users/dev/.claude-main", "/Users/dev/.config/claude"]
+        )
+
+        // The env-named home is the default card's and is excluded; the XDG dir is then a genuinely
+        // separate home and a legitimate candidate.
+        XCTAssertEqual(discovery.run().findings.map(\.identityKey), ["acct-xdg"])
+
+        // Without the override, XDG is a default home again and the env-named dir is the candidate.
+        let withoutOverride = makeDiscovery(
+            files: files,
+            subdirectories: ["/Users/dev/.claude-main", "/Users/dev/.config/claude"]
+        )
+        XCTAssertEqual(withoutOverride.run().findings.map(\.identityKey), ["acct-main"])
+    }
+}

--- a/Tests/OpenUsageTests/ClaudeScopedAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeScopedAuthStoreTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import OpenUsage
+
+/// The `.configDir` credential scope: an extra account card may only ever see its own login —
+/// its own credentials file and its own computed keychain item, with no Desktop, environment-token,
+/// or default-service fallback.
+final class ClaudeScopedAuthStoreTests: XCTestCase {
+    private let scope = ClaudeCredentialScope.configDir(
+        path: "/Users/dev/.claude-work",
+        keychainLiteral: "~/.claude-work"
+    )
+
+    func testScopedStoreReadsOnlyItsOwnCredentialSources() throws {
+        let scopedService = ClaudeAuthStore.scopedKeychainServiceName(
+            forConfigDirLiteral: "~/.claude-work", environment: FakeEnvironment([:])
+        )
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([
+                // Another account's default-home file must stay invisible to the scoped card.
+                "~/.claude/.credentials.json": #"{"claudeAiOauth": {"accessToken": "default-at"}}"#,
+                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "work-at"}}"#,
+            ]),
+            keychain: ServiceKeychain(),
+            scope: scope
+        )
+
+        XCTAssertEqual(store.keychainServiceCandidates(), [scopedService], "never the bare default service")
+        let load = store.loadCredentialSet()
+        XCTAssertEqual(load.candidates.map(\.oauth.accessToken), ["work-at"])
+        XCTAssertEqual(load.desktopStatus, .notChecked, "a config-dir card never consults Desktop")
+    }
+
+    func testScopedStoreNeverInheritsTheAmbientEnvironmentToken() {
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CODE_OAUTH_TOKEN": "ambient-token"]),
+            files: FakeFiles([
+                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "work-at"}}"#,
+            ]),
+            keychain: ServiceKeychain(),
+            scope: scope
+        )
+
+        let candidates = store.loadCredentialSet().candidates
+        XCTAssertEqual(candidates.map(\.oauth.accessToken), ["work-at"])
+        XCTAssertFalse(candidates.contains { $0.source == .environment })
+    }
+
+    func testFootprintProbeSeesFileAndKeychainShapesWithoutReadingSecrets() {
+        let scopedService = ClaudeAuthStore.scopedKeychainServiceName(
+            forConfigDirLiteral: "~/.claude-work", environment: FakeEnvironment([:])
+        )
+        let fileBacked = ClaudeAuthStore(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles(["/Users/dev/.claude-work/.credentials.json": "{}"]),
+            keychain: ServiceKeychain(),
+            scope: scope
+        )
+        XCTAssertTrue(fileBacked.hasCredentialFootprint())
+
+        let keychainBacked = ClaudeAuthStore(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([:]),
+            keychain: ServiceKeychain(values: [scopedService: "present"]),
+            scope: scope
+        )
+        XCTAssertTrue(keychainBacked.hasCredentialFootprint())
+
+        let bare = ClaudeAuthStore(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([:]),
+            keychain: ServiceKeychain(),
+            scope: scope
+        )
+        XCTAssertFalse(bare.hasCredentialFootprint())
+    }
+
+    func testStandardStoreDropsDesktopFallbackWhileExtraCardsExist() {
+        // With no CLI login and Desktop disallowed (extra Claude cards exist), the load reports
+        // `.notFound` instead of consulting Desktop — the caller keeps the honest CLI error.
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([:]),
+            keychain: ServiceKeychain(),
+            allowsDesktopFallback: false
+        )
+
+        let load = store.loadCredentialSet(forceDesktopFallback: true)
+        XCTAssertEqual(load.desktopStatus, .notFound)
+        XCTAssertTrue(load.candidates.isEmpty)
+    }
+}

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -780,6 +780,71 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(store.pinnedMetricIDs, expected)
     }
 
+    func testProviderReorderPreservesAnAbsentAccountCardSlot() {
+        let defaults = makeDefaults("ReorderAbsentAccountCard")
+        let storageKey = "layout"
+        let hidden = "claude@hidden"
+        LayoutPersistence(defaults: defaults, storageKey: storageKey).saveProviderOrder([
+            "claude", hidden, "cursor",
+        ])
+        let store = LayoutStore(registry: .mock, defaults: defaults, storageKey: storageKey)
+
+        XCTAssertTrue(store.reorderProvider(dragged: "cursor", target: "claude"))
+
+        XCTAssertEqual(Array(store.providerOrder.prefix(3)), ["cursor", hidden, "claude"])
+        XCTAssertEqual(
+            LayoutPersistence(defaults: defaults, storageKey: storageKey).loadProviderOrder()?.contains(hidden),
+            true,
+            "the absent card keeps its slot for the launch it returns on"
+        )
+    }
+
+    func testTranslatedDefaultsSeedAnAccountCardTheFirstTimeItAppears() {
+        // An existing user's layout predates the account card entirely; when the card first enters
+        // the registry, its family's default metrics seed for it (enabled), because translated ids
+        // are never part of the seeded-defaults baseline.
+        let claude = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let work = Provider(id: "claude@work", displayName: "Claude — Work", icon: .providerMark("claude"))
+        func descriptor(_ id: String, _ provider: Provider) -> WidgetDescriptor {
+            WidgetDescriptor(
+                id: id,
+                providerID: provider.id,
+                metricLabel: id,
+                sample: WidgetData(title: id, icon: provider.icon, kind: .percent, used: 0, limit: 100)
+            )
+        }
+        let registry = WidgetRegistry(
+            providers: [claude, work],
+            descriptors: [
+                descriptor("claude.session", claude),
+                descriptor("claude.sonnet", claude),
+                descriptor("claude@work.session", work),
+                descriptor("claude@work.sonnet", work),
+            ]
+        )
+        let defaults = makeDefaults("AccountCardSeeding")
+        saveStored([PlacedWidget(descriptorID: "claude.session")], forKey: "layout", in: defaults)
+        defaults.set(["claude.session", "claude.sonnet"], forKey: "layout.seededDefaults")
+
+        let store = LayoutStore(
+            registry: registry,
+            defaults: defaults,
+            storageKey: "layout",
+            defaultMetricIDs: ["claude.session"],
+            defaultExpandedMetricIDs: ["claude.sonnet"]
+        )
+
+        XCTAssertTrue(store.isMetricEnabled("claude@work.session"))
+        XCTAssertFalse(
+            store.isMetricEnabled("claude.sonnet"),
+            "the family's own disabled default stays exactly as the user left it"
+        )
+        XCTAssertTrue(
+            store.defaultExpandedOnEnableIDs.contains("claude@work.sonnet"),
+            "the caret split translates with the metric set"
+        )
+    }
+
     func testResetToDefaultRestoresProviderOrderAndMarksDefaultsSeeded() {
         let defaults = makeDefaults("ResetSeeded")
         let store = LayoutStore(

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -1010,14 +1010,17 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertTrue(store.expandedMetricIDs.contains("claude.weekly"))
     }
 
-    func testInvalidPersistedExpandedIDsAreDropped() {
+    func testUnknownPersistedExpandedIDsAreRetainedAsInvisibleTombstones() {
         let defaults = makeDefaults("InvalidExpand")
         saveStored([PlacedWidget(descriptorID: "claude.session")], forKey: "layout", in: defaults)
         defaults.set(["claude.session", "missing.metric"], forKey: "layout.expandedMetrics")
 
         let store = LayoutStore(registry: .mock, defaults: defaults, storageKey: "layout")
         XCTAssertTrue(store.expandedMetricIDs.contains("claude.session"))
-        XCTAssertFalse(store.expandedMetricIDs.contains("missing.metric"))
+        XCTAssertTrue(
+            store.expandedMetricIDs.contains("missing.metric"),
+            "unknown state stays persisted so a temporarily absent account card can recover it"
+        )
     }
 
     func testDisplayGroupsPartitionEnabledMetrics() {

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+@testable import OpenUsage
+
+/// Identity-keyed iCloud matching: the same account merges into the same card across Macs regardless
+/// of which machine calls it the default and which shows it as an extra account card, and accounts
+/// with no local card surface as remote-only Total Spend entries.
+@MainActor
+final class PeerHistoryIdentityTests: XCTestCase {
+    private let teamKey = "uuid-me|org-team"
+    private let maxKey = "uuid-me|org-max"
+
+    func testDocumentV2AllowsAccountCardsAndV1StaysStrict() throws {
+        var v2 = makeDocument(providers: [
+            "claude": history(day: "2026-07-16", tokens: 10, cost: 1),
+            "claude@ab12cd34": history(day: "2026-07-16", tokens: 20, cost: 2),
+        ], identities: ["claude": maxKey, "claude@ab12cd34": teamKey])
+        XCTAssertNoThrow(try v2.validate())
+
+        v2.schema = UsageHistoryDocument.legacySchemaV1
+        XCTAssertThrowsError(try v2.validate()) // account-card ids are a v2 concept
+
+        let v1 = UsageHistoryDocument(
+            schema: UsageHistoryDocument.legacySchemaV1,
+            deviceID: "d", deviceName: "n", updatedAt: Date(),
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: nil
+        )
+        XCTAssertNoThrow(try v1.validate())
+    }
+
+    func testRemapMatchesAccountsAcrossDefaultAndExtraCardRoles() {
+        // The mini↔MacBook case: mini's DEFAULT card is the Team account (claude), its extra card is
+        // Max. This Mac is the mirror image (default = Max, extra = Team). Every peer history must
+        // land on the LOCAL card with the same account.
+        let miniDoc = makeDocument(
+            deviceName: "Mac mini",
+            providers: [
+                "claude": history(day: "2026-07-16", tokens: 100, cost: 502.34),
+                "claude@b2d3867d": history(day: "2026-07-16", tokens: 90, cost: 494.27),
+            ],
+            identities: ["claude": teamKey, "claude@b2d3867d": maxKey]
+        )
+        let localMap = ["claude": maxKey, "claude@f15456b0": teamKey]
+
+        let remapped = PeerHistoryRemapper.remap(documents: [miniDoc], localIdentityByCardID: localMap)
+
+        XCTAssertTrue(remapped.remoteOnly.isEmpty)
+        let byCard = Dictionary(grouping: remapped.histories, by: { $0.cardID })
+        XCTAssertEqual(byCard["claude"]?.first?.history.series.daily.first?.costUSD, 494.27, "mini's Max spend belongs to this Mac's default (Max) card")
+        XCTAssertEqual(byCard["claude@f15456b0"]?.first?.history.series.daily.first?.costUSD, 502.34, "mini's Team spend belongs to this Mac's Team card")
+    }
+
+    func testRemapCollectsRemoteOnlyAccounts() {
+        let doc = makeDocument(
+            deviceName: "Mac mini",
+            providers: ["claude@ab12cd34": history(day: "2026-07-16", tokens: 50, cost: 42)],
+            identities: ["claude@ab12cd34": "uuid-other|org-x"]
+        )
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [doc],
+            localIdentityByCardID: ["claude": maxKey]
+        )
+        XCTAssertTrue(remapped.histories.isEmpty)
+        XCTAssertEqual(remapped.remoteOnly.count, 1)
+        XCTAssertEqual(remapped.remoteOnly.first?.family, "claude")
+        XCTAssertEqual(remapped.remoteOnly.first?.deviceNames, ["Mac mini"])
+    }
+
+    func testRemapLegacyV1DocumentKeepsSameCardMerge() {
+        let v1 = UsageHistoryDocument(
+            schema: UsageHistoryDocument.legacySchemaV1,
+            deviceID: "d", deviceName: "old Mac", updatedAt: Date(),
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: nil
+        )
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [v1],
+            localIdentityByCardID: ["claude": maxKey]
+        )
+        XCTAssertEqual(remapped.histories.first?.cardID, "claude")
+        XCTAssertTrue(remapped.remoteOnly.isEmpty)
+    }
+
+    func testLocalDocumentPublishesAccountCardsWithIdentities() {
+        let registry = makeRegistry()
+        // Preload the cache; the store's init adopts cached snapshots as its local set. The entries
+        // carry the same account stamp the store is launched with, or the swap guard discards them.
+        let cache = scratchCache()
+        cache.store(
+            snapshot(providerID: "claude", history: history(day: "2026-07-16", tokens: 10, cost: 1)),
+            producedByIdentityKey: maxKey
+        )
+        cache.store(
+            snapshot(providerID: "claude@f15456b0", history: history(day: "2026-07-16", tokens: 20, cost: 2)),
+            producedByIdentityKey: teamKey
+        )
+        let dataStore = WidgetDataStore(
+            registry: registry,
+            providers: [],
+            cache: cache,
+            defaults: makeScratchDefaults("PublishDoc"),
+            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
+        )
+
+        let document = dataStore.localHistoryDocument(deviceID: "dev", deviceName: "This Mac")
+        XCTAssertEqual(document.schema, UsageHistoryDocument.currentSchema)
+        XCTAssertNotNil(document.providers["claude@f15456b0"], "account cards sync now")
+        XCTAssertEqual(document.identities?["claude"], maxKey)
+        XCTAssertEqual(document.identities?["claude@f15456b0"], teamKey)
+        XCTAssertNoThrow(try document.validate())
+    }
+
+    func testRemoteOnlyAccountFeedsTotalSpend() {
+        let registry = makeRegistry()
+        let dataStore = WidgetDataStore(
+            registry: registry,
+            providers: [],
+            cache: scratchCache(),
+            defaults: makeScratchDefaults("RemoteTotal"),
+            providerIdentityKeys: ["claude": maxKey]
+        )
+        let today = dayKey(Date())
+        let doc = makeDocument(
+            deviceName: "Mac mini",
+            providers: ["claude@ab12cd34": history(day: today, tokens: 1_000_000, cost: 42)],
+            identities: ["claude@ab12cd34": "uuid-other|org-x"]
+        )
+        dataStore.setPeerHistoryDocuments([doc], ownDeviceID: "this-mac")
+
+        XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
+        let entry = dataStore.remoteOnlySpend[0]
+        XCTAssertEqual(entry.provider.displayName, "Claude · Mac mini")
+
+        let total = TotalSpendAggregator.total(
+            for: .today,
+            providers: [entry.provider],
+            snapshots: [entry.provider.id: entry.snapshot]
+        )
+        XCTAssertEqual(total.slices.count, 1)
+        XCTAssertEqual(total.slices[0].amountUSD, 42, accuracy: 0.001)
+    }
+
+    func testClearingPeersDropsRemoteOnlyEntries() {
+        let dataStore = WidgetDataStore(
+            registry: makeRegistry(),
+            providers: [],
+            cache: scratchCache(),
+            defaults: makeScratchDefaults("ClearPeers"),
+            providerIdentityKeys: ["claude": maxKey]
+        )
+        let doc = makeDocument(
+            deviceName: "Mac mini",
+            providers: ["claude@ab12cd34": history(day: dayKey(Date()), tokens: 10, cost: 1)],
+            identities: ["claude@ab12cd34": "uuid-other|org-x"]
+        )
+        dataStore.setPeerHistoryDocuments([doc], ownDeviceID: "this-mac")
+        XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
+
+        dataStore.clearPeerHistoryDocuments()
+        XCTAssertTrue(dataStore.remoteOnlySpend.isEmpty, "sync off returns Total Spend to local-only")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeRegistry() -> WidgetRegistry {
+        let claude = ClaudeProvider.makeProvider()
+        let extraCard = ClaudeProvider.makeProvider(id: "claude@f15456b0", displayName: "Claude — Team")
+        let descriptors = [
+            WidgetDescriptor.usageTrend(provider: claude)
+                .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test"),
+            WidgetDescriptor.usageTrend(provider: extraCard)
+                .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test"),
+        ]
+        return WidgetRegistry(providers: [claude, extraCard], descriptors: descriptors)
+    }
+
+    private func scratchCache() -> ProviderSnapshotCache {
+        ProviderSnapshotCache(userDefaults: makeScratchDefaults("Cache"), storageKey: "snapshots", ttl: 600)
+    }
+
+    private func makeScratchDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.PeerIdentity.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return defaults
+    }
+
+    private func makeDocument(
+        deviceName: String = "Peer",
+        providers: [String: ProviderUsageHistory],
+        identities: [String: String]?
+    ) -> UsageHistoryDocument {
+        UsageHistoryDocument(
+            deviceID: UUID().uuidString,
+            deviceName: deviceName,
+            updatedAt: Date(),
+            providers: providers,
+            identities: identities
+        )
+    }
+
+    private func history(day: String, tokens: Int, cost: Double) -> ProviderUsageHistory {
+        ProviderUsageHistory(
+            series: DailyUsageSeries(daily: [DailyUsageEntry(date: day, totalTokens: tokens, costUSD: cost)]),
+            modelUsage: nil,
+            unknownModelsByDay: [:]
+        )
+    }
+
+    private func snapshot(providerID: String, history: ProviderUsageHistory) -> ProviderSnapshot {
+        var snapshot = ProviderSnapshot(
+            providerID: providerID,
+            displayName: providerID,
+            lines: [],
+            refreshedAt: Date()
+        )
+        snapshot.usageHistory = history
+        return snapshot
+    }
+
+    private func dayKey(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -64,6 +64,11 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertEqual(remapped.remoteOnly.count, 1)
         XCTAssertEqual(remapped.remoteOnly.first?.family, "claude")
         XCTAssertEqual(remapped.remoteOnly.first?.deviceNames, ["Mac mini"])
+        XCTAssertEqual(
+            remapped.remoteOnly.first?.cardID,
+            ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"),
+            "the slice id is the same id the account's card gets on any Mac it's signed in on"
+        )
     }
 
     func testUnresolvedLocalIdentityKeepsTheBareCardMergeInsteadOfDoubleCounting() {
@@ -145,7 +150,8 @@ final class PeerHistoryIdentityTests: XCTestCase {
 
         XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
         let entry = dataStore.remoteOnlySpend[0]
-        XCTAssertEqual(entry.provider.displayName, "Claude · Mac mini")
+        let expectedCardID = ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x")
+        XCTAssertEqual(entry.provider.displayName, "\(expectedCardID) · Mac mini")
 
         let total = TotalSpendAggregator.total(
             for: .today,
@@ -154,6 +160,38 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
         XCTAssertEqual(total.slices.count, 1)
         XCTAssertEqual(total.slices[0].amountUSD, 42, accuracy: 0.001)
+    }
+
+    func testSeveralRemoteOnlyAccountsFromOneDeviceStayTellableApart() {
+        // Many accounts on the mini, none on this Mac: each must keep its own slice with its own
+        // identity-derived name — never several identical "Claude · Mac mini" legend rows.
+        let dataStore = WidgetDataStore(
+            registry: makeRegistry(),
+            providers: [],
+            cache: scratchCache(),
+            defaults: makeScratchDefaults("ManyRemote"),
+            providerIdentityKeys: ["claude": maxKey]
+        )
+        let today = dayKey(Date())
+        let doc = makeDocument(
+            deviceName: "Mac mini",
+            providers: [
+                "claude@11111111": history(day: today, tokens: 10, cost: 1),
+                "claude@22222222": history(day: today, tokens: 20, cost: 2),
+            ],
+            identities: [
+                "claude@11111111": "uuid-a|org-a",
+                "claude@22222222": "uuid-b|org-b",
+            ]
+        )
+        dataStore.setPeerHistoryDocuments([doc], ownDeviceID: "this-mac")
+
+        XCTAssertEqual(dataStore.remoteOnlySpend.count, 2)
+        let names = Set(dataStore.remoteOnlySpend.map(\.provider.displayName))
+        XCTAssertEqual(names.count, 2, "every remote-only account carries a unique display name")
+        for name in names {
+            XCTAssertTrue(name.hasPrefix("claude@") && name.hasSuffix(" · Mac mini"), "unexpected slice name: \(name)")
+        }
     }
 
     func testClearingPeersDropsRemoteOnlyEntries() {

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -66,6 +66,22 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertEqual(remapped.remoteOnly.first?.deviceNames, ["Mac mini"])
     }
 
+    func testUnresolvedLocalIdentityKeepsTheBareCardMergeInsteadOfDoubleCounting() {
+        // The peer named its bare card's account, but this Mac's own bare-card identity didn't
+        // resolve this launch (no local map entry). A mismatch can't be proven, so the history must
+        // stay on the same-id card — going remote-only would ADD a Total Spend slice on top of the
+        // local card's own spend for what is most likely the same account.
+        let doc = makeDocument(
+            deviceName: "Mac mini",
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: ["claude": teamKey]
+        )
+        let remapped = PeerHistoryRemapper.remap(documents: [doc], localIdentityByCardID: [:])
+
+        XCTAssertEqual(remapped.histories.first?.cardID, "claude")
+        XCTAssertTrue(remapped.remoteOnly.isEmpty)
+    }
+
     func testRemapLegacyV1DocumentKeepsSameCardMerge() {
         let v1 = UsageHistoryDocument(
             schema: UsageHistoryDocument.legacySchemaV1,

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -63,7 +63,6 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertTrue(remapped.histories.isEmpty)
         XCTAssertEqual(remapped.remoteOnly.count, 1)
         XCTAssertEqual(remapped.remoteOnly.first?.family, "claude")
-        XCTAssertEqual(remapped.remoteOnly.first?.deviceNames, ["Mac mini"])
         XCTAssertEqual(
             remapped.remoteOnly.first?.cardID,
             ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"),
@@ -151,7 +150,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
         let entry = dataStore.remoteOnlySpend[0]
         let expectedCardID = ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x")
-        XCTAssertEqual(entry.provider.displayName, "\(expectedCardID) · Mac mini")
+        XCTAssertEqual(entry.provider.displayName, expectedCardID, "the slice is named by the account code alone — the source Mac is irrelevant")
 
         let total = TotalSpendAggregator.total(
             for: .today,
@@ -190,7 +189,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
         let names = Set(dataStore.remoteOnlySpend.map(\.provider.displayName))
         XCTAssertEqual(names.count, 2, "every remote-only account carries a unique display name")
         for name in names {
-            XCTAssertTrue(name.hasPrefix("claude@") && name.hasSuffix(" · Mac mini"), "unexpected slice name: \(name)")
+            XCTAssertTrue(name.hasPrefix("claude@"), "unexpected slice name: \(name)")
         }
     }
 

--- a/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
@@ -61,6 +61,183 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         XCTAssertNil(store.defaultBadgeHolder(family: "claude"), "an out-of-pass family must not be reconciled")
     }
 
+    private func makeDiscovery(
+        files: [String: String],
+        subdirectories: [String]
+    ) -> ClaudeConfigDirDiscovery {
+        ClaudeConfigDirDiscovery(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles(files),
+            keychain: ServiceKeychain(),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") },
+            listSubdirectories: { url in
+                subdirectories
+                    .map { URL(fileURLWithPath: $0) }
+                    .filter { $0.deletingLastPathComponent().path == url.path }
+            }
+        )
+    }
+
+    func testADistinctConfigDirAccountMintsAHashedRecordAndAnExtraCard() throws {
+        let defaults = makeScratchDefaults()
+        let store = ProviderAccountsStore(defaults: defaults)
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([
+                "/Users/dev/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1", "emailAddress": "dev@example.com"}}"#,
+            ]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "emailAddress": "work@example.com", "organizationName": "Sunstory"}}"#,
+                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-work"]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: store, claudeDiscovery: discovery
+        )
+
+        let card = try XCTUnwrap(assembly.claudeCards.first)
+        XCTAssertEqual(assembly.claudeCards.count, 1)
+        XCTAssertTrue(card.id.hasPrefix("claude@"), "a config-dir account never claims the bare id")
+        XCTAssertEqual(card.displayName, "Claude — Sunstory")
+        XCTAssertEqual(card.configDirPath, "/Users/dev/.claude-work")
+        XCTAssertEqual(assembly.identityKeysByCard["claude"], "acct-1")
+        XCTAssertEqual(assembly.identityKeysByCard[card.id], "acct-2")
+        // The registry recorded both: the default holder under the bare id, the extra account with
+        // its config-dir source.
+        let record = try XCTUnwrap(store.records.first { $0.id == card.id })
+        XCTAssertEqual(record.sources.map(\.kind), [.configDir])
+        XCTAssertEqual(record.label, "work@example.com (Sunstory)")
+        XCTAssertTrue(assembly.defaultClaudeExtraLogRoots.isEmpty)
+    }
+
+    func testASameAccountConfigDirFoldsOntoTheDefaultCardAsALogRoot() throws {
+        let defaults = makeScratchDefaults()
+        let store = ProviderAccountsStore(defaults: defaults)
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([
+                "/Users/dev/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
+            ]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-side/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
+                "/Users/dev/.claude-side/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-1"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-side"]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: store, claudeDiscovery: discovery
+        )
+
+        XCTAssertTrue(assembly.claudeCards.isEmpty, "one account never renders as two cards")
+        XCTAssertEqual(assembly.defaultClaudeExtraLogRoots.map(\.path), ["/Users/dev/.claude-side"])
+        let record = try XCTUnwrap(store.defaultBadgeHolder(family: "claude"))
+        XCTAssertEqual(record.id, "claude")
+        XCTAssertEqual(Set(record.sources.map(\.kind)), [.defaultHome, .configDir])
+    }
+
+    func testAnUnresolvedDefaultLoginSkipsCandidatesThisLaunch() {
+        let defaults = makeScratchDefaults()
+        let store = ProviderAccountsStore(defaults: defaults)
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([
+                // Credentials exist but the state file names no account → unresolved, footprint present.
+                "/Users/dev/.claude/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-1"}}"#,
+            ]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2"}}"#,
+                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-work"]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: store, claudeDiscovery: discovery
+        )
+
+        XCTAssertTrue(
+            assembly.claudeCards.isEmpty,
+            "with a nameless default login, an accepted candidate could be that very account — skip"
+        )
+        XCTAssertTrue(store.records.isEmpty)
+    }
+
+    func testNoDefaultLoginStillAcceptsAConfigDirOnlyAccount() throws {
+        let defaults = makeScratchDefaults()
+        let store = ProviderAccountsStore(defaults: defaults)
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([:]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2"}}"#,
+                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-work"]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: store, claudeDiscovery: discovery
+        )
+
+        let card = try XCTUnwrap(assembly.claudeCards.first)
+        XCTAssertTrue(
+            card.id.hasPrefix("claude@"),
+            "the bare id stays reserved for a future default-home login even when it is free"
+        )
+    }
+
+    func testARenamedRecordDrivesTheCardDisplayName() throws {
+        let defaults = makeScratchDefaults()
+        let store = ProviderAccountsStore(defaults: defaults)
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([:]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2"}}"#,
+                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-work"]
+        )
+
+        // First pass creates the record; the user then renames it.
+        let first = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: store, claudeDiscovery: discovery
+        )
+        let cardID = try XCTUnwrap(first.claudeCards.first?.id)
+        XCTAssertEqual(first.claudeCards.first?.displayName, cardID, "no label → the short-hash id fallback")
+        store.rename(cardID: cardID, to: "Work Max")
+
+        let second = ProviderAccountAssembly.make(
+            observer: observer,
+            accountsStore: ProviderAccountsStore(defaults: defaults),
+            claudeDiscovery: discovery
+        )
+        XCTAssertEqual(second.claudeCards.first?.displayName, "Work Max")
+    }
+
     func testNothingObservedLeavesRegistryAndKeysEmpty() {
         let defaults = makeScratchDefaults()
         let store = ProviderAccountsStore(defaults: defaults)

--- a/Tests/OpenUsageTests/ProviderAccountsStoreTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountsStoreTests.swift
@@ -16,8 +16,8 @@ final class ProviderAccountsStoreTests: XCTestCase {
         identityKey: String,
         label: String? = nil,
         anchor: String = "/Users/dev/.claude"
-    ) -> ProviderAccountsStore.Observation {
-        ProviderAccountsStore.Observation(
+    ) -> ProviderAccountsStore.AccountObservation {
+        ProviderAccountsStore.AccountObservation(
             family: family,
             identityKey: identityKey,
             label: label,
@@ -117,6 +117,36 @@ final class ProviderAccountsStoreTests: XCTestCase {
         defaults.set(Data("not json".utf8), forKey: ProviderAccountsStore.storageKey)
 
         XCTAssertTrue(ProviderAccountsStore(defaults: defaults).records.isEmpty)
+    }
+
+    func testRenamePersistsAndAClearedNameFallsBackToTheDerivedOne() {
+        let defaults = makeScratchDefaults()
+        let store = ProviderAccountsStore(defaults: defaults)
+        store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a", label: "a@example.com")])
+
+        store.rename(cardID: "claude", to: "  Work  ")
+        XCTAssertEqual(store.records[0].customLabel, "Work", "renames are trimmed")
+        XCTAssertEqual(ProviderAccountsStore(defaults: defaults).records[0].customLabel, "Work", "renames persist")
+
+        store.rename(cardID: "claude", to: "   ")
+        XCTAssertNil(store.records[0].customLabel, "a blank rename clears back to the derived name")
+        XCTAssertEqual(store.records[0].displayLabel, "a@example.com")
+
+        store.rename(cardID: "missing", to: "X")
+        XCTAssertEqual(store.records.count, 1, "renaming an unknown card is a no-op")
+    }
+
+    func testReconcileNeverTouchesACustomLabel() {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a", label: "old")])
+        store.rename(cardID: "claude", to: "Work")
+
+        let records = store.reconcile(with: [
+            defaultHomeObservation(family: "claude", identityKey: "acct-a", label: "new"),
+        ])
+
+        XCTAssertEqual(records[0].label, "new")
+        XCTAssertEqual(records[0].customLabel, "Work", "rescans update the label but never the rename")
     }
 
     func testFamilyHelperSplitsCardIDs() {

--- a/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
@@ -17,7 +17,7 @@ final class UsageHistoryDocumentTests: XCTestCase {
 
     func testRejectsUnsupportedSchemaInvalidValuesAndImpossibleDates() {
         var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
-        document.schema = "openusage.history.v2"
+        document.schema = "openusage.history.v3"
         XCTAssertThrowsError(try document.validate()) { error in
             XCTAssertEqual(error as? UsageHistoryDocumentError, .unsupportedSchema)
         }

--- a/Tests/OpenUsageTests/WidgetRegistryTests.swift
+++ b/Tests/OpenUsageTests/WidgetRegistryTests.swift
@@ -15,6 +15,25 @@ final class WidgetRegistryTests: XCTestCase {
         )
     }
 
+    func testNewAccountCardsSlotInAfterTheirFamilyGroup() {
+        let registry = WidgetRegistry(
+            providers: [provider("claude"), provider("claude@ab12cd34"), provider("codex"), provider("cursor")],
+            descriptors: []
+        )
+
+        // The saved order predates the account card: it appears right after the claude group, not
+        // at the end of the dashboard; a genuinely new provider still appends.
+        XCTAssertEqual(
+            registry.orderedProviderIDs(savedOrder: ["codex", "claude"]),
+            ["codex", "claude", "claude@ab12cd34", "cursor"]
+        )
+        // With no family sibling in the saved order, the card appends like any new provider.
+        XCTAssertEqual(
+            registry.orderedProviderIDs(savedOrder: ["codex"]),
+            ["codex", "claude", "claude@ab12cd34", "cursor"]
+        )
+    }
+
     func testLookupsReturnExpectedEntries() {
         let claude = provider("claude")
         let codex = provider("codex")

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -52,7 +52,7 @@ Rows with a reset date tick every 30 seconds, so countdowns and pace stay live b
 ## Right-click menus
 
 Every row: **Hide · Star for menu bar / Unstar · Refresh \<provider\> · Customize…** (Customize opens straight to that provider's metrics.)
-Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on in Customize. Customize opens straight to that provider's metrics.) plus **Share Screenshot** (see below).
+Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on in Customize. Customize opens straight to that provider's metrics.) plus **Share Screenshot** (see below). Claude and Codex cards also offer **Rename…** — give the card any name you like (handy with multiple accounts); leave the field empty to go back to the default name.
 
 ## Share
 
@@ -73,7 +73,7 @@ Open Customize from the footer's **Options** menu (or press **Return**). It's a 
 
 The **provider list** shows every provider with a switch to turn it on or off, a count of its metrics, and a chevron into its detail. Turn a provider off and it stays in the list, greyed — its metrics hide from the dashboard and menu bar but keep their setup for when you turn it back on. Drag enabled providers by their grip to reorder; tap a row to open its detail. On a fresh install only the providers detected on your Mac start on (see "First launch" above); this list is where you add the rest.
 
-A provider's **detail** has a back button and provider-specific Reset control in its top bar, followed by two metric sections: **Always Visible** (shown on the dashboard card) and **On Demand** (tucked behind the card's caret). Each metric row has a drag grip, its name, an always-visible star for the menu bar, and an on/off switch. Drag a metric into the other card—or onto one of that card's rows—to move it between Always Visible and On Demand. An empty card shows a dashed **Drag metrics here** target. You can star up to two metrics per provider. OpenRouter and Z.ai also show an **API Key** section here, where you can add, replace, reveal, or clear that provider's key.
+A provider's **detail** has a back button and provider-specific Reset control in its top bar. Claude and Codex cards start with a **Name** field — the same rename the card's right-click menu offers; clear it to go back to the default name. Then come two metric sections: **Always Visible** (shown on the dashboard card) and **On Demand** (tucked behind the card's caret). Each metric row has a drag grip, its name, an always-visible star for the menu bar, and an on/off switch. Drag a metric into the other card—or onto one of that card's rows—to move it between Always Visible and On Demand. An empty card shows a dashed **Drag metrics here** target. You can star up to two metrics per provider. OpenRouter and Z.ai also show an **API Key** section here, where you can add, replace, reveal, or clear that provider's key.
 
 Drag-reorder also works directly on the dashboard — drag a row within its provider, drag it across the caret boundary while the card is open, or drag a provider header to reorder sections. On a Force Touch trackpad you'll feel a light tap each time the dragged item snaps into a new slot.
 

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -32,9 +32,12 @@ the same card everywhere, even when one Mac shows it as the main card and anothe
 card.
 
 An account you use on another Mac but have no login for here doesn't become a card: it appears as its
-own slice in **Total Spend** ("Claude · Mac mini"), so the number at the top is the whole truth across
-your Macs. The moment you log that account in locally, its card appears with the full cross-machine
-history already attached.
+own slice in **Total Spend**, named by its account code and the Mac it lives on ("claude@ab12cd34 ·
+Mac mini") — so the number at the top is the whole truth across your Macs, and several such accounts
+from one Mac stay tellable apart. That code is the same id the account's card carries on any Mac it's
+signed in on (the synced file holds no emails or names to label it with). The moment you log that
+account in locally, its card appears — under that same id — with the full cross-machine history
+already attached.
 
 Macs running an older OpenUsage read their own format but report this Mac's newer file as "update
 OpenUsage" — update both sides to sync multi-account machines.

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -32,12 +32,11 @@ the same card everywhere, even when one Mac shows it as the main card and anothe
 card.
 
 An account you use on another Mac but have no login for here doesn't become a card: it appears as its
-own slice in **Total Spend**, named by its account code and the Mac it lives on ("claude@ab12cd34 ·
-Mac mini") — so the number at the top is the whole truth across your Macs, and several such accounts
-from one Mac stay tellable apart. That code is the same id the account's card carries on any Mac it's
-signed in on (the synced file holds no emails or names to label it with). The moment you log that
-account in locally, its card appears — under that same id — with the full cross-machine history
-already attached.
+own slice in **Total Spend**, named by its account code ("claude@ab12cd34") — so the number at the top
+is the whole truth across your Macs, and several such accounts stay tellable apart. That code is the
+same id the account's card carries on any Mac it's signed in on (the synced file holds no emails or
+names to label it with). The moment you log that account in locally, its card appears — under that
+same id — with the full cross-machine history already attached.
 
 Macs running an older OpenUsage read their own format but report this Mac's newer file as "update
 OpenUsage" — update both sides to sync multi-account machines.

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -24,6 +24,21 @@ This Mac updates its file after a five-minute refresh batch, a manual refresh, o
 change. iCloud delivery is eventually consistent, so another Mac can take longer than five minutes to
 receive it, especially while offline. Downloaded changes reload immediately when macOS reports them.
 
+## Multiple accounts across Macs
+
+Histories match by **account**, not by card name. Each Mac's file records which account every card
+belongs to (an opaque account/organization identifier — never an email), so the same account merges into
+the same card everywhere, even when one Mac shows it as the main card and another as an extra account
+card.
+
+An account you use on another Mac but have no login for here doesn't become a card: it appears as its
+own slice in **Total Spend** ("Claude · Mac mini"), so the number at the top is the whole truth across
+your Macs. The moment you log that account in locally, its card appears with the full cross-machine
+history already attached.
+
+Macs running an older OpenUsage read their own format but report this Mac's newer file as "update
+OpenUsage" — update both sides to sync multi-account machines.
+
 Settings lists each valid device file with the time that Mac generated it. To remove a Mac from the
 combined summary, turn sync off on that Mac; this deletes its file from iCloud. Turning sync off also
 stops that Mac from reading peers and immediately returns every surface there to local-only spend.

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -42,6 +42,22 @@ If one source holds an expired or "locked out" token, OpenUsage falls back to th
 
 Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the Claude Code session logs under `~/.claude/projects/` (or `$CLAUDE_CONFIG_DIR`) itself — no external tools needed. Symlinks are followed, so a projects folder linked into a synced location (say, a Dropbox folder) is read all the same. Claude usage from the [pi](https://github.com/earendil-works/pi) coding agent counts too: OpenUsage reads pi's session logs under `~/.pi/agent/sessions/` (or `$PI_CODING_AGENT_SESSION_DIR`) and folds any Claude usage there into the same tiles and trend, so a Claude sub driven through pi still shows up here. pi records its own per-message cost, so those dollars come straight from pi rather than being re-estimated. Cowork (the Claude desktop app's agent mode) counts too: it writes the same logs into per-session folders under `~/Library/Application Support/Claude/local-agent-mode-sessions/`, and OpenUsage scans those as well, so desktop agent sessions show up in the tiles alongside terminal ones. Persisted `claude -p` runs count as well. Runs made with `--no-session-persistence` cannot appear because Claude deliberately writes no session log for OpenUsage to read. Advisor work recorded inside a message is counted once under the advisor's own model; the parent's main-model totals are kept separate, and ordinary iteration details are not counted again. A log's recorded fast or standard speed controls its price; OpenUsage does not infer speed from the event date. Days are grouped in your Mac's local time zone, so they line up with your own calendar. Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`); a day with no usage reads **No data** rather than a misleading `$0.00 · 0 tokens` — the same as every other spend-tracking provider. The live Session and Weekly meters are unaffected. The dollars are estimated from token counts at API rates (that's the ⓘ) using the shared [model pricing](../pricing.md); the token counts themselves are measured. No log data leaves your Mac.
 
+## Multiple accounts
+
+If you keep more than one Claude login on this Mac using custom config dirs (separate `CLAUDE_CONFIG_DIR`
+homes, each with its own sign-in), OpenUsage finds them at launch and gives each **account** its own
+card, with its own limits, plan, and spend tiles read from that home. A custom dir signed into the same
+account as your main login doesn't become a second card — its session logs simply count into the main
+card's spend tiles.
+
+Extra cards are named from the account ("Claude — Acme Corp"); right-click a card and choose **Rename…**
+(or use the Name field in Customize) to call it whatever you like. A card only shows while its login is
+still found on this Mac — log it out or delete the dir and the card disappears, keeping its
+customization and history for if it returns. Turn a card off like any provider in Customize.
+
+In the [CLI](../cli.md) and [local API](../local-http-api.md), extra cards appear under ids like
+`claude@ab12cd34`; requesting `claude` returns every Claude card.
+
 ## Troubleshooting
 
 - **"Not logged in"** — run `claude` and sign in, then refresh.

--- a/docs/research/account-first-plan.md
+++ b/docs/research/account-first-plan.md
@@ -22,8 +22,10 @@ Places an account is signed in are **sources** (default home, config dir, cswap 
 Desktop/Cowork, Codex home) attached to its record. "Default" is a badge on a source
 (`holdsDefaultSource`) used for the bare-id alias, CLI resolution, and attribution — never a key,
 never live sort order. A swap re-points source edges; cards, history, layout, and pins never move.
-An unresolved source claims no account. A card whose sources are all absent renders a calm
-signed-out state with a Remove affordance (tombstone; rescans never resurrect it).
+An unresolved source claims no account. A card renders only while at least one of its sources is
+found on this computer; when every source is gone the card stops rendering, and its record, layout,
+and history are retained so the card reattaches if the login reappears (owner decision 4 — no
+Remove affordance yet).
 
 ### The migration-killing decision
 
@@ -65,9 +67,9 @@ tests land in-slice (repo policy). Estimated source LOC excludes tests.
   array — made now, before multi-account ships, instead of aliasing forever.
 - Snapshot-cache identity stamp (v9): cached values remember the producing account; a swap between
   launches discards the stale entry instead of painting it under the new account (port `fef9ad0`).
-- Signed-out rendering + "Remove Account…" (context menu, tombstone in the store) — cheap while
-  the model is small.
 - Exit: beta soak; logs confirm identity-resolution rates in the wild; existing users see nothing.
+- *Shipped as #1026 + #1027 (v0.7.7-beta.1). Signed-out rendering and "Remove Account…" were cut
+  entirely per owner decision 4.*
 
 ### Phase 2 — Claude multi-account: config-dir discovery (~1,200 LOC)
 
@@ -75,8 +77,10 @@ tests land in-slice (repo policy). Estimated source LOC excludes tests.
   support-trail log lines. Port the discovery internals; **omit** fold/suppression plumbing — a
   candidate naming a known account just attaches as another source/log root on that record, so
   duplicate cards are structurally impossible.
-- New account → new record → new card named by account label ("Claude — Sunstory"); layout seeded
-  from `DefaultLayout.translatedForInstances` (pins never seeded).
+- New account → new record → new card named by account label ("Claude — Sunstory"), falling back
+  to the short-hash id; user rename in the card's context menu and in Customize. Cards seed
+  enabled; layout seeded from `DefaultLayout.translatedForInstances` (pins never seeded). A card
+  renders only while one of its sources is still found on this computer.
 - Scoped `ClaudeAuthStore` (per-config-dir keychain names), per-account spend from each home's logs.
 - iCloud identity routing: `PeerHistoryRemapper`, account-identity matching, v1-peer histories to a
   family bucket rendered as device-labeled remote-only slices. Required the moment two accounts can
@@ -116,12 +120,17 @@ tests land in-slice (repo policy). Estimated source LOC excludes tests.
 - Total Spend family grouping/tinting if still wanted (see `c6a63eb` on the old branch for why
   plain size order won before).
 
-## Owner decisions (lock before the phase that needs them)
+## Owner decisions (locked 2026-07-19)
 
-1. **Bare id as the first account's record id** — the plan assumes yes (kills all migration).
-2. Label fallback when an account has no email/org name: short hash vs ordinal ("Claude 2").
-3. Newly discovered accounts seed enabled (PR #1014 behavior) or disabled.
-4. Remove-button placement: context-menu-first (assumed), Customize section later.
+1. **Bare id as the first account's record id** — yes (kills all migration).
+2. Label fallback when an account has no email/org name: the short-hash record id
+   (`claude@ab12cd34`) — paired with a user rename, offered in the card's context menu and in
+   Customize, so an ugly fallback is one click from a good name.
+3. Newly discovered accounts seed **enabled** (PR #1014 behavior).
+4. **No "Remove Account…" yet.** Only accounts found on this computer render as cards; a card whose
+   account is no longer found anywhere simply stops rendering (its record, layout, and history are
+   retained and reattach if the login reappears). Unwanted cards are handled by the existing
+   per-provider disable. Tombstones stay schema-only until a later phase needs true removal.
 
 ## Verification
 


### PR DESCRIPTION
## TL;DR

Claude logins kept in custom config dirs now get their own dashboard cards — each with its own limits, plan, and spend — plus a card rename (right-click + Customize) and identity-keyed iCloud matching so the same account merges into the same card across Macs.

## What was happening

- OpenUsage only ever showed ONE Claude card: the login at the default home (`~/.claude` / `CLAUDE_CONFIG_DIR`). A second account kept in a separate config dir was invisible.
- The Phase 1 account registry recorded accounts but nothing rendered from it yet.
- iCloud sync matched histories by card id, which doesn't travel: the same account can be the default card on one Mac and an extra card on another, so cross-machine spend could merge into the wrong card (and extra cards didn't sync at all).

## What this changes

- **Config-dir discovery (launch-time):** scans dot-dirs at `~` and dirs under `~/.config` for Claude homes with both an identity and a credential (file or scoped keychain item). A dir signed into the *same* account as the default card folds in as an extra spend-log root; a *distinct* account mints a record (`claude@ab12cd34`) and renders as its own card.
- **Scoped auth:** each extra card's `ClaudeAuthStore` reads only its own config dir + its dir-hashed keychain item — never the default home, desktop fallback, or ambient env token. The default card drops the Desktop fallback while extra cards exist, so credentials can't cross-match.
- **Cards render only while found (owner decision 4):** a card whose login disappears stops rendering; its layout, pins, and history are retained as tombstones and reattach when it returns. New cards seed enabled with translated defaults (owner decision 3) and slot in right after their family group.
- **Rename (owner decision 2):** cards are named from the account label ("Claude — Acme Corp", short-hash fallback); **Rename…** in the card's right-click menu and a **Name** field in Customize store a custom label in the account registry, re-titling the card live everywhere (header, menus, Customize, share cards).
- **iCloud identity routing:** history documents move to v2 — account cards sync, and an identities map (card id → opaque identity key, no emails) lets `PeerHistoryRemapper` re-address peer histories to the local card with the same account. Peer accounts with no local card become Total Spend-only slices named by their account code ("claude@ab12cd34 · Mac mini" — the same id the account's card carries wherever it IS signed in, so several remote-only accounts from one Mac stay tellable apart), never ghost cards. v1 files stay readable; v1 readers see their designed "update OpenUsage" message.

## Heads-up

- The bare `claude` id stays reserved for the account observed at the default home; an account that moved from the default home into a config dir while another login occupies the default stays hidden until swap support (Phase 4).
- When the local default identity is unresolved, discovery skips candidates for that launch (can't prove a candidate isn't the default account), and peer bare-card histories keep the legacy same-id merge (can't prove a mismatch → no double-count).
- Cowork/Desktop accounts (Phase 3), cswap (Phase 4), and Codex multi-account (Phase 5) are intentionally out of scope.

## Tests

- `swift test`: 1275 tests green. New suites: `ClaudeConfigDirDiscoveryTests`, `ClaudeScopedAuthStoreTests`, `PeerHistoryIdentityTests`; expanded `ProviderAccountAssemblyTests`, `ProviderAccountsStoreTests`, `LayoutStoreTests`, `WidgetRegistryTests`.
- Live run on this Mac: default identity resolves and the config-dir scan runs clean with no candidates — correct for this machine, whose second account is parked in claude-swap's vault (Phase 4 scope), not a config-dir login. The accept/fold paths are covered by the discovery/assembly suites; a real two-config-dir soak still needs a machine (or a hand-made second dir) with two live logins.
- Local Bugbot review done; both findings fixed with regression tests.

Made with [Cursor](https://cursor.com)

