### PR TITLE
Account-first Phase 2b: one name resolver for card titles

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -78,8 +78,7 @@ final class AppContainer {
 
         let providers = ProviderCatalog.make(
             claudeCards: accountAssembly.claudeCards,
-            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName
+            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots
         )
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
@@ -95,7 +94,8 @@ final class AppContainer {
             isProviderEnabled: { [enablement] in enablement.isEnabled($0) },
             orderedDescriptors: { [layout] in layout.visiblePlaced.compactMap { layout.descriptor(for: $0) } },
             notificationSettings: { notificationSettings },
-            providerIdentityKeys: accountAssembly.identityKeysByCard
+            providerIdentityKeys: accountAssembly.identityKeysByCard,
+            resolveDisplayName: { [accounts] in accounts.resolvedDisplayName(cardID: $0) }
         )
         let iCloudSync = ICloudUsageSyncStore(dataStore: dataStore)
         // Re-enabling a provider should fetch it promptly, so clear any leftover failure backoff before
@@ -204,7 +204,7 @@ final class AppContainer {
         self.telemetry = telemetry
         self.transparency = PopoverTransparencyStore()
         self.privacy = MenuBarPrivacyStore()
-        self.localAPI = LocalUsageServer(state: { [layout, enablement, dataStore] in
+        self.localAPI = LocalUsageServer(state: { [layout, enablement, dataStore, accounts] in
             LocalUsageAPI.State(
                 enabledOrderedIDs: layout.orderedProviderIDs().filter { enablement.isEnabled($0) },
                 knownIDs: Set(registry.providers.map(\.id)),
@@ -212,6 +212,9 @@ final class AppContainer {
                 limitDescriptors: registry.limitDescriptorsByProvider,
                 errors: dataStore.providerErrors
             )
+            // API output is human-read too: resolve card titles at respond time so renames show,
+            // exactly like every UI surface.
+            .resolvingDisplayNames(accounts.resolvedDisplayNamesByCardID)
         })
         self.refreshTask = Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry)
         localAPI.start()
@@ -228,26 +231,13 @@ final class AppContainer {
         shellEnvironmentSnapshotTask.cancel()
     }
 
-    /// The name a card renders under right now. Live: a rename in the account registry wins over
-    /// the name baked into the `Provider` at launch, so card titles update without a relaunch.
-    /// Non-account providers (no record) keep their static display name.
+    /// The name a card renders under right now — the app-side face of the one resolver
+    /// (`ProviderAccountRecord.resolvedDisplayName`). Live: a rename in the account registry
+    /// re-titles the card everywhere without a relaunch. Non-account providers (no record) keep
+    /// their static display name; `Provider.displayName` itself only ever carries the derived
+    /// default, so the fallback can never be a stale rename.
     func displayName(for provider: Provider) -> String {
-        guard let record = accounts.records.first(where: { $0.id == provider.id }) else {
-            return provider.displayName
-        }
-        if let custom = record.customLabel?.nilIfEmpty { return custom }
-        // A rename was cleared mid-session: fall back to the derived name rather than the
-        // launch-baked one, which may itself carry the just-cleared rename.
-        return derivedDisplayName(for: record)
-    }
-
-    /// The name a card carries without a rename — the Customize name field's placeholder, and the
-    /// fallback once a rename is cleared: the stock family name for the default card, the
-    /// account-label-derived name for an extra card.
-    func derivedDisplayName(for record: ProviderAccountRecord) -> String {
-        ProviderAccountID.isAccountCard(record.id)
-            ? ClaudeAccountCard.displayName(customLabel: nil, label: record.label, id: record.id)
-            : ProviderAccountID.family(of: record.id).capitalized
+        accounts.resolvedDisplayName(cardID: provider.id) ?? provider.displayName
     }
 
     /// Whether the card has an account record a rename can attach to (accounts-model families only,

--- a/Sources/OpenUsage/App/StatusItemImageUpdater.swift
+++ b/Sources/OpenUsage/App/StatusItemImageUpdater.swift
@@ -52,7 +52,8 @@ final class StatusItemImageUpdater {
         }
         let content = MenuBarContentBuilder.build(
             groups: container.layout.pinnedGroups,
-            data: { container.dataStore.data(for: $0) }
+            data: { container.dataStore.data(for: $0) },
+            title: { container.displayName(for: $0) }
         )
         return MenuBarStripRenderer.image(for: content, style: container.layout.menuBarStyle)
             ?? MenuBarIcon.image

--- a/Sources/OpenUsage/Models/MenuBarContent.swift
+++ b/Sources/OpenUsage/Models/MenuBarContent.swift
@@ -58,13 +58,19 @@ enum MenuBarContentBuilder {
     /// The strip is dynamic: a pinned metric without data is dropped (one of two pins renders alone at
     /// full size), and a provider with no data-carrying pins contributes no icon at all. Pins are
     /// membership; the strip shows whatever subset is real right now.
-    static func build(groups: [ProviderMetrics], data: (WidgetDescriptor) -> WidgetData) -> MenuBarContent {
+    /// `title` resolves each provider's card title (the VoiceOver summary is a human-facing name, so
+    /// the caller passes the account-registry resolver); defaults to the baked derived name.
+    static func build(
+        groups: [ProviderMetrics],
+        data: (WidgetDescriptor) -> WidgetData,
+        title: (Provider) -> String = { $0.displayName }
+    ) -> MenuBarContent {
         let resolvedGroups = groups.compactMap { group -> MenuBarContent.Group? in
             let metrics = group.metrics.map { resolve($0, data($0)) }.filter(\.hasData)
             guard !metrics.isEmpty else { return nil }
             return MenuBarContent.Group(
                 providerID: group.provider.id,
-                displayName: group.provider.displayName,
+                displayName: title(group.provider),
                 icon: group.provider.icon,
                 metrics: metrics
             )

--- a/Sources/OpenUsage/Models/ProviderSnapshot.swift
+++ b/Sources/OpenUsage/Models/ProviderSnapshot.swift
@@ -3,7 +3,11 @@ import Foundation
 /// Latest normalized output for one provider refresh.
 struct ProviderSnapshot: Hashable, Sendable, Codable {
     let providerID: String
-    let displayName: String
+    /// The card title at refresh time — always the baked DERIVED name (renames never reach the
+    /// cache or iCloud). The CLI/API boundary re-resolves it against the account registry at
+    /// respond time (`LocalUsageAPI.State.resolvingDisplayNames`), so human-facing output carries
+    /// renames without persisting them.
+    var displayName: String
     var plan: String?
     var lines: [MetricLine]
     var refreshedAt: Date

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -12,15 +12,17 @@ enum ProviderCatalog {
     static func make(
         defaults: UserDefaults = .standard,
         claudeCards: [ClaudeAccountCard] = [],
-        defaultClaudeExtraLogRoots: [URL] = [],
-        defaultClaudeDisplayName: String? = nil
+        defaultClaudeExtraLogRoots: [URL] = []
     ) -> [ProviderRuntime] {
         // Default provider order (see AGENTS.md "## Providers"): the three established providers first,
         // then every other provider alphabetically by display name. Account cards slot in right after
         // their family's default card.
+        //
+        // Every baked `Provider.displayName` here is the DERIVED default — renames live only in the
+        // account registry and are resolved at render time (`ProviderAccountRecord.resolvedDisplayName`),
+        // so a baked name can never be a stale copy of one.
         var runtimes: [ProviderRuntime] = []
         runtimes.append(ClaudeProvider(
-            provider: ClaudeProvider.makeProvider(displayName: defaultClaudeDisplayName ?? "Claude"),
             // Once extra Claude cards exist, an unpinned Desktop fallback could borrow a login that
             // belongs to one of them — fetching that account's usage onto the default card. Desktop
             // returns as its own properly-pinned source kind in Phase 3.

--- a/Sources/OpenUsage/Services/LocalUsageAPI.swift
+++ b/Sources/OpenUsage/Services/LocalUsageAPI.swift
@@ -28,6 +28,22 @@ enum LocalUsageAPI {
         func matchingCardIDs(for token: String) -> [String] {
             knownIDs.filter { $0 == token || ProviderAccountID.family(of: $0) == token }.sorted()
         }
+
+        /// A copy whose snapshots carry live card titles: `titles` maps card id → resolved title
+        /// (from the account registry, so renames show). Applied where the state is captured — the
+        /// snapshots themselves always store the derived name, so a rename never persists into the
+        /// cache or iCloud. Cards without an entry keep their baked name.
+        func resolvingDisplayNames(_ titles: [String: String]) -> State {
+            guard !titles.isEmpty else { return self }
+            var state = self
+            state.snapshots = snapshots.mapValues { snapshot in
+                guard let title = titles[snapshot.providerID] else { return snapshot }
+                var snapshot = snapshot
+                snapshot.displayName = title
+                return snapshot
+            }
+            return state
+        }
     }
 
     struct Response: Equatable, Sendable {

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -7,6 +7,9 @@ struct ClaudeAccountCard: Equatable, Sendable {
     /// The account's stable record id (`claude@ab12cd34`) — the card id everywhere: layout, cache,
     /// CLI/API matching.
     var id: String
+    /// The DERIVED card name (`ProviderAccountRecord.derivedDisplayName`) baked into the launch
+    /// `Provider`. Never a rename: renames live only in the account registry and are resolved at
+    /// render time, so a baked name can never be a stale copy of one.
     var displayName: String
     /// The config dir the card's credentials and spend logs are pinned to.
     var configDirPath: String
@@ -14,20 +17,6 @@ struct ClaudeAccountCard: Equatable, Sendable {
     var keychainLiteral: String
     /// Same-account additional config dirs (rare): extra spend-log roots, never extra credentials.
     var extraLogRoots: [URL] = []
-
-    /// The card name: the user's rename, else "Claude — <org or email>" from the account label,
-    /// else the record id itself (owner decision 2: short-hash fallback, one rename away from good).
-    static func displayName(customLabel: String?, label: String?, id: String) -> String {
-        if let customLabel = customLabel?.nilIfEmpty { return customLabel }
-        guard let label = label?.nilIfEmpty else { return id }
-        // Labels are our own "email (Org Name)" format — prefer the org for a short card title.
-        if label.hasSuffix(")"), let open = label.lastIndex(of: "(") {
-            let org = label[label.index(after: open)..<label.index(before: label.endIndex)]
-                .trimmingCharacters(in: .whitespaces)
-            if !org.isEmpty { return "Claude — \(org)" }
-        }
-        return "Claude — \(label)"
-    }
 }
 
 /// The launch-time account pass: read which account is signed in at each family's default home,
@@ -45,8 +34,6 @@ struct ProviderAccountAssembly {
     /// Same-account custom config dirs discovered for the DEFAULT card's login: extra spend-log
     /// roots for the default scanner, never extra credentials.
     var defaultClaudeExtraLogRoots: [URL] = []
-    /// The default Claude card's rename, when the badge-holder record carries one.
-    var defaultClaudeDisplayName: String?
 
     /// `waitsForLoginShell`: true for the menu-bar app (a Finder/Dock launch inherits no shell
     /// exports, so the pass leans on the login-shell layers), false for the one-shot CLI (a terminal
@@ -213,9 +200,7 @@ struct ProviderAccountAssembly {
             guard let primary = account.dirs.first else { continue }
             claudeCards.append(ClaudeAccountCard(
                 id: record.id,
-                displayName: ClaudeAccountCard.displayName(
-                    customLabel: record.customLabel, label: record.label, id: record.id
-                ),
+                displayName: record.derivedDisplayName,
                 configDirPath: primary.anchorPath,
                 keychainLiteral: primary.keychainLiteral,
                 extraLogRoots: account.dirs.dropFirst().map { URL(fileURLWithPath: $0.anchorPath) }
@@ -225,12 +210,10 @@ struct ProviderAccountAssembly {
         }
         claudeCards.sort { $0.id < $1.id }
 
-        let defaultClaudeRename = records.first { $0.id == "claude" }?.customLabel?.nilIfEmpty
         return ProviderAccountAssembly(
             identityKeysByCard: identityKeys,
             claudeCards: claudeCards,
-            defaultClaudeExtraLogRoots: defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: defaultClaudeRename
+            defaultClaudeExtraLogRoots: defaultClaudeExtraLogRoots
         )
     }
 }

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -60,8 +60,7 @@ public struct UsageReader {
         let providers = providersOverride ?? ProviderCatalog.make(
             defaults: defaults,
             claudeCards: accountAssembly.claudeCards,
-            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName
+            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots
         )
         let registry = WidgetRegistry.from(providers)
         let knownIDs = Set(registry.providers.map(\.id))
@@ -132,6 +131,10 @@ public struct UsageReader {
                 .compactMap { id in errors[id].map { "\(id): \($0)" } }
         }
 
+        // CLI output is human-read: resolve card titles against the persisted account registry so
+        // renames show, matching the app's UI and HTTP API. Injected-provider tests use their own
+        // defaults suite, so this is a no-op there.
+        let accountTitles = ProviderAccountsStore(defaults: defaults).resolvedDisplayNamesByCardID
         let state = LocalUsageAPI.State(
             enabledOrderedIDs: enabledOrderedIDs,
             knownIDs: knownIDs,
@@ -139,6 +142,7 @@ public struct UsageReader {
             limitDescriptors: registry.limitDescriptorsByProvider,
             errors: errors
         )
+        .resolvingDisplayNames(accountTitles)
         let path = requestedToken.map { "/v1/limits/\($0)" } ?? "/v1/limits"
         let response = LocalUsageAPI.respond(method: "GET", path: path, state: state)
         guard let data = response.body else {

--- a/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
@@ -78,10 +78,29 @@ struct ProviderAccountRecord: Codable, Equatable, Sendable {
     /// Set by a future "Remove Account…". A tombstoned account is never resurrected by rescans.
     var removedTombstone: Bool = false
 
-    /// The name the card renders under: the user's rename, else the account's own label
-    /// ("email (Org Name)"), else the record id itself (`claude@ab12cd34` — owner decision 2).
-    var displayLabel: String {
-        customLabel?.nilIfEmpty ?? label?.nilIfEmpty ?? id
+    /// The name a card carries without a rename: the stock family name for the bare card, a
+    /// "Claude — <org or email>" derived from the account label for an extra card, or the record id
+    /// itself when the account has no label (owner decision 2: short-hash fallback, one rename away
+    /// from good). Never contains `customLabel` — this is what gets baked into the launch
+    /// `Provider`, and baking a rename there is how stale-name bugs are born.
+    var derivedDisplayName: String {
+        guard ProviderAccountID.isAccountCard(id) else { return family.capitalized }
+        guard let label = label?.nilIfEmpty else { return id }
+        // Labels are our own "email (Org Name)" format — prefer the org for a short card title.
+        if label.hasSuffix(")"), let open = label.lastIndex(of: "(") {
+            let org = label[label.index(after: open)..<label.index(before: label.endIndex)]
+                .trimmingCharacters(in: .whitespaces)
+            if !org.isEmpty { return "\(family.capitalized) — \(org)" }
+        }
+        return "\(family.capitalized) — \(label)"
+    }
+
+    /// THE name resolver — the single place a rename becomes a card title. Everything that shows a
+    /// card name to a human resolves through this at render time (directly or via
+    /// `AppContainer.displayName(for:)`); `Provider.displayName` only ever carries the derived
+    /// default.
+    var resolvedDisplayName: String {
+        customLabel?.nilIfEmpty ?? derivedDisplayName
     }
 }
 
@@ -177,6 +196,19 @@ final class ProviderAccountsStore {
             persist()
         }
         return records
+    }
+
+    /// The resolved card title for a card id, or `nil` when the card has no account record (a
+    /// non-account provider keeps its static `Provider.displayName`). The lookup half of the one
+    /// name resolver — see `ProviderAccountRecord.resolvedDisplayName`.
+    func resolvedDisplayName(cardID: String) -> String? {
+        records.first { $0.id == cardID }?.resolvedDisplayName
+    }
+
+    /// Card id → resolved title for every record — the map the CLI/API boundary applies to its
+    /// snapshots (`LocalUsageAPI.State.resolvingDisplayNames`).
+    var resolvedDisplayNamesByCardID: [String: String] {
+        Dictionary(uniqueKeysWithValues: records.map { ($0.id, $0.resolvedDisplayName) })
     }
 
     /// Stores a user rename for a card; `nil` or blank clears it back to the derived name.

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -36,6 +36,10 @@ final class WidgetDataStore {
     /// producer, and launch loads only paint an entry whose stamp matches. A card absent here has an
     /// unresolved identity this launch (or isn't account-aware) — its cache behaves as it always did.
     private let providerIdentityKeys: [String: String]
+    /// The live card title for a card id, `nil` for non-account providers — the account-registry
+    /// name resolver, injected by `AppContainer` so notification titles carry renames. `nil`
+    /// (tests, the one-shot CLI) falls back to the baked derived name.
+    private let resolveDisplayName: (@MainActor (String) -> String?)?
     /// Where a fired milestone is delivered: `(idPrefix, title, subtitle, body) -> Bool`. The Bool is
     /// whether it was actually delivered (authorized + scheduled); on false the caller leaves the
     /// milestone un-marked so it retries next pass. Injected so tests can record posts without a live
@@ -123,7 +127,8 @@ final class WidgetDataStore {
         slowProviderRefreshThreshold: TimeInterval = WidgetDataStore.defaultSlowProviderRefreshThreshold,
         notificationSettings: (@MainActor () -> NotificationSettingsStore)? = nil,
         postNotification: (@MainActor (String, String, String, String) async -> Bool)? = nil,
-        providerIdentityKeys: [String: String] = [:]
+        providerIdentityKeys: [String: String] = [:],
+        resolveDisplayName: (@MainActor (String) -> String?)? = nil
     ) {
         precondition(slowProviderRefreshThreshold >= 0)
         self.registry = registry
@@ -141,6 +146,7 @@ final class WidgetDataStore {
                 await AppNotifications.shared.post(idPrefix: idPrefix, title: title, subtitle: subtitle, body: body)
             }
         self.providerIdentityKeys = providerIdentityKeys
+        self.resolveDisplayName = resolveDisplayName
         self.meterStyle = defaults.enumValue(forKey: Self.meterStyleKey, default: .remaining)
         self.resetDisplayMode = defaults.enumValue(forKey: Self.resetDisplayModeKey, default: .relative)
         self.alwaysShowPacing = defaults.bool(forKey: Self.alwaysShowPacingKey)
@@ -234,7 +240,9 @@ final class WidgetDataStore {
             metrics: metrics,
             toggles: toggles,
             now: now,
-            providerName: { [providersByID] id in providersByID[id]?.provider.displayName ?? id },
+            providerName: { [providersByID, resolveDisplayName] id in
+                resolveDisplayName?(id) ?? providersByID[id]?.provider.displayName ?? id
+            },
             post: postNotification
         )
     }

--- a/Sources/OpenUsage/Support/TotalSpendAggregator.swift
+++ b/Sources/OpenUsage/Support/TotalSpendAggregator.swift
@@ -65,6 +65,10 @@ enum TotalSpendMetric: String, CaseIterable, Identifiable, Sendable {
 /// plus whether the dollars are a local estimate (log-scanned providers) or measured (Cursor's CSV).
 struct TotalSpendSlice: Identifiable, Equatable {
     let provider: Provider
+    /// The card title, resolved by the aggregation's caller through the one name resolver — so the
+    /// legend, the ranking tie-break, and the share-card export (which renders outside the SwiftUI
+    /// environment and can't resolve for itself) all show the same live name.
+    let title: String
     let amountUSD: Double
     let tokenCount: Double
     let estimated: Bool
@@ -82,6 +86,8 @@ struct TotalSpendSlice: Identifiable, Equatable {
 /// and ranks the legend, plus the formatted value surfaces read through `MetricFormatter`.
 struct TotalSpendProjectedSlice: Identifiable, Equatable {
     let provider: Provider
+    /// The already-resolved card title (see `TotalSpendSlice.title`) — what the legend renders.
+    let title: String
     let displayAmount: Double
     let estimated: Bool
 
@@ -129,11 +135,16 @@ struct TotalSpend: Equatable {
 
         let ranked = included.sorted { lhs, rhs in
             if lhs.display != rhs.display { return lhs.display > rhs.display }
-            return lhs.slice.provider.displayName.localizedStandardCompare(rhs.slice.provider.displayName) == .orderedAscending
+            return lhs.slice.title.localizedStandardCompare(rhs.slice.title) == .orderedAscending
         }
 
         let projected = ranked.map {
-            TotalSpendProjectedSlice(provider: $0.slice.provider, displayAmount: $0.display, estimated: $0.slice.estimated)
+            TotalSpendProjectedSlice(
+                provider: $0.slice.provider,
+                title: $0.slice.title,
+                displayAmount: $0.display,
+                estimated: $0.slice.estimated
+            )
         }
 
         let center: Double
@@ -163,10 +174,14 @@ struct TotalSpend: Equatable {
 enum TotalSpendAggregator {
     /// The total for one period across `providers` (pass them in display order; ties keep it).
     /// Slices keep provider display order input only as a stable traversal; metric projection re-ranks.
+    /// `title` resolves each provider's card title — the live card passes the account-registry
+    /// resolver so slices carry renames; the default is the baked derived name for callers without
+    /// registry access (tests).
     static func total(
         for period: TotalSpendPeriod,
         providers: [Provider],
-        snapshots: [String: ProviderSnapshot]
+        snapshots: [String: ProviderSnapshot],
+        title: (Provider) -> String = { $0.displayName }
     ) -> TotalSpend {
         let slices = providers.compactMap { provider -> TotalSpendSlice? in
             guard let snapshot = snapshots[provider.id],
@@ -182,6 +197,7 @@ enum TotalSpendAggregator {
 
             return TotalSpendSlice(
                 provider: provider,
+                title: title(provider),
                 amountUSD: max(amount, 0),
                 tokenCount: max(tokens, 0),
                 estimated: dollars.contains(where: \.estimated)

--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -209,7 +209,7 @@ private struct CardNameSection: View {
     }
 
     private var placeholder: String {
-        record.map { container.derivedDisplayName(for: $0) } ?? ""
+        record?.derivedDisplayName ?? ""
     }
 
     private func commit() {

--- a/Sources/OpenUsage/Views/TotalSpendCard.swift
+++ b/Sources/OpenUsage/Views/TotalSpendCard.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct TotalSpendCard: View {
     @Environment(LayoutStore.self) private var layout
     @Environment(WidgetDataStore.self) private var dataStore
+    @Environment(AppContainer.self) private var container
     @Environment(\.colorScheme) private var colorScheme
     @Namespace private var pickerNamespace
 
@@ -37,7 +38,7 @@ struct TotalSpendCard: View {
 
     private var total: TotalSpend {
         // Accounts that live only on other Macs (synced, no card here) count toward the total and
-        // get their own legend slice ("Claude · Mac mini") — the number should be the whole truth
+        // get their own legend slice ("claude@ab12cd34") — the number should be the whole truth
         // even when a login isn't set up on this machine.
         var aggregatedProviders = providers
         var aggregatedSnapshots = dataStore.snapshots
@@ -45,7 +46,14 @@ struct TotalSpendCard: View {
             aggregatedProviders.append(entry.provider)
             aggregatedSnapshots[entry.provider.id] = entry.snapshot
         }
-        return TotalSpendAggregator.total(for: period, providers: aggregatedProviders, snapshots: aggregatedSnapshots)
+        // Titles resolve here — the one place with registry access — so the legend AND the share
+        // export (rendered outside the environment) carry live renames.
+        return TotalSpendAggregator.total(
+            for: period,
+            providers: aggregatedProviders,
+            snapshots: aggregatedSnapshots,
+            title: { container.displayName(for: $0) }
+        )
     }
 
     private var projection: TotalSpendProjection {
@@ -113,7 +121,7 @@ struct TotalSpendCard: View {
     /// hardcoded list, so disabling a provider (or a new spend provider shipping) can't make the
     /// tooltip lie about what the total reflects.
     private var infoTooltip: String {
-        let names = providers.map(\.displayName)
+        let names = providers.map { container.displayName(for: $0) }
         return "Only includes \(names.formatted(.list(type: .and)))."
     }
 
@@ -341,7 +349,7 @@ struct TotalSpendRingContent: View {
             Circle()
                 .fill(TotalSpendPalette.color(for: slice.provider.id))
                 .frame(width: 8, height: 8)
-            Text(slice.provider.displayName)
+            Text(slice.title)
                 .font(.system(size: density.supportingPointSize))
                 .foregroundStyle(.primary)
                 .lineLimit(1)

--- a/Tests/OpenUsageTests/LocalUsageAPITests.swift
+++ b/Tests/OpenUsageTests/LocalUsageAPITests.swift
@@ -129,6 +129,21 @@ final class LocalUsageAPITests: XCTestCase {
         XCTAssertEqual(Set(providers.keys), ["claude", "claude@ab12cd34"])
     }
 
+    func testResolvedTitlesOverrideSnapshotDisplayNamesAtTheBoundary() throws {
+        // Snapshots always store the derived name; the boundary re-resolves against the account
+        // registry so API/CLI output carries renames without ever persisting them.
+        let state = makeState().resolvingDisplayNames(["claude": "Claude Team"])
+
+        let response = LocalUsageAPI.respond(method: "GET", path: "/v1/usage", state: state)
+        let array = try XCTUnwrap(try json(response.body) as? [[String: Any]])
+        XCTAssertEqual(array.first { $0["providerId"] as? String == "claude" }?["displayName"] as? String, "Claude Team")
+        XCTAssertEqual(
+            array.first { $0["providerId"] as? String == "cursor" }?["displayName"] as? String,
+            "Cursor",
+            "cards without a record keep their baked name"
+        )
+    }
+
     func testMethodAndRouteErrors() throws {
         let state = makeState()
 

--- a/Tests/OpenUsageTests/MenuBarContentTests.swift
+++ b/Tests/OpenUsageTests/MenuBarContentTests.swift
@@ -87,6 +87,17 @@ final class MenuBarContentTests: XCTestCase {
         XCTAssertEqual(content.accessibilityText, "A Session 41%, Weekly 12%")
     }
 
+    func testAccessibilityTextUsesTheResolvedTitle() {
+        // The VoiceOver summary is a human-facing name, so it goes through the caller's resolver
+        // (the account registry) instead of the baked provider name.
+        let content = MenuBarContentBuilder.build(
+            groups: [group("a", percent("a.m1", "Session", 41))],
+            data: { $0.sample },
+            title: { _ in "Claude Team" }
+        )
+        XCTAssertEqual(content.accessibilityText, "Claude Team Session 41%")
+    }
+
     func testTrayLabelsShortenLongTimeWindows() {
         let content = MenuBarContentBuilder.build(
             groups: [group("a", percent("a.today", "Today", 5), percent("a.month", "Last 30 Days", 80))],

--- a/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
@@ -205,7 +205,7 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         )
     }
 
-    func testARenamedRecordDrivesTheCardDisplayName() throws {
+    func testARenameNeverBakesIntoTheCardOnlyTheResolverCarriesIt() throws {
         let defaults = makeScratchDefaults()
         let store = ProviderAccountsStore(defaults: defaults)
         let observer = DefaultAccountObserver(
@@ -230,12 +230,16 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         XCTAssertEqual(first.claudeCards.first?.displayName, cardID, "no label → the short-hash id fallback")
         store.rename(cardID: cardID, to: "Work Max")
 
+        let reloadedStore = ProviderAccountsStore(defaults: defaults)
         let second = ProviderAccountAssembly.make(
             observer: observer,
-            accountsStore: ProviderAccountsStore(defaults: defaults),
+            accountsStore: reloadedStore,
             claudeDiscovery: discovery
         )
-        XCTAssertEqual(second.claudeCards.first?.displayName, "Work Max")
+        // The baked card name stays the DERIVED default — a rename lives only in the registry and
+        // is resolved at render time, so a baked name can never be a stale copy of it.
+        XCTAssertEqual(second.claudeCards.first?.displayName, cardID)
+        XCTAssertEqual(reloadedStore.resolvedDisplayName(cardID: cardID), "Work Max")
     }
 
     func testNothingObservedLeavesRegistryAndKeysEmpty() {

--- a/Tests/OpenUsageTests/ProviderAccountsStoreTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountsStoreTests.swift
@@ -126,11 +126,12 @@ final class ProviderAccountsStoreTests: XCTestCase {
 
         store.rename(cardID: "claude", to: "  Work  ")
         XCTAssertEqual(store.records[0].customLabel, "Work", "renames are trimmed")
+        XCTAssertEqual(store.records[0].resolvedDisplayName, "Work", "the resolver surfaces the rename")
         XCTAssertEqual(ProviderAccountsStore(defaults: defaults).records[0].customLabel, "Work", "renames persist")
 
         store.rename(cardID: "claude", to: "   ")
         XCTAssertNil(store.records[0].customLabel, "a blank rename clears back to the derived name")
-        XCTAssertEqual(store.records[0].displayLabel, "a@example.com")
+        XCTAssertEqual(store.records[0].resolvedDisplayName, "Claude", "the bare card derives the stock family name")
 
         store.rename(cardID: "missing", to: "X")
         XCTAssertEqual(store.records.count, 1, "renaming an unknown card is a no-op")

--- a/Tests/OpenUsageTests/TotalSpendAggregatorTests.swift
+++ b/Tests/OpenUsageTests/TotalSpendAggregatorTests.swift
@@ -50,6 +50,25 @@ final class TotalSpendAggregatorTests: XCTestCase {
         XCTAssertEqual(spend.centerValue, 9.75, accuracy: 0.0001)
     }
 
+    func testSlicesCarryTheCallerResolvedTitleThroughProjection() {
+        // The caller (the live card, with registry access) resolves each slice's title once; the
+        // legend and the share export both read that resolved string, so a mid-session rename can
+        // never show on one and not the other.
+        let snapshots = [
+            "claude": snapshot(claude, lines: [spendLine("Today", dollars: 2.50)]),
+            "cursor": snapshot(cursor, lines: [spendLine("Today", dollars: 7.25)])
+        ]
+
+        let total = TotalSpendAggregator.total(
+            for: .today,
+            providers: [claude, cursor],
+            snapshots: snapshots,
+            title: { $0.id == "claude" ? "Claude Team" : $0.displayName }
+        )
+
+        XCTAssertEqual(total.projection(for: .cost).slices.map(\.title), ["Cursor", "Claude Team"])
+    }
+
     func testProviderWithoutPeriodLineIsExcludedNotZero() {
         let snapshots = [
             "claude": snapshot(claude, lines: [spendLine("Today", dollars: 1.00)]),

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -52,7 +52,7 @@ Rows with a reset date tick every 30 seconds, so countdowns and pace stay live b
 ## Right-click menus
 
 Every row: **Hide · Star for menu bar / Unstar · Refresh \<provider\> · Customize…** (Customize opens straight to that provider's metrics.)
-Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on in Customize. Customize opens straight to that provider's metrics.) plus **Share Screenshot** (see below). Claude and Codex cards also offer **Rename…** — give the card any name you like (handy with multiple accounts); leave the field empty to go back to the default name.
+Provider headers: **Hide \<provider\> · Refresh \<provider\> · Customize…** (Hide turns the whole provider off; turn it back on in Customize. Customize opens straight to that provider's metrics.) plus **Share Screenshot** (see below). Claude and Codex cards also offer **Rename…** — give the card any name you like (handy with multiple accounts); leave the field empty to go back to the default name. The name follows the card everywhere it's shown: the dashboard, the Total Spend legend, share screenshots, notifications, and the CLI/API output.
 
 ## Share
 

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -168,6 +168,8 @@ Line types are `progress`, `text`, `badge`, and `barChart`. A `barChart` line ca
 
 The in-app model breakdown shown when hovering spend rows is not included in this API yet. Spend rows continue to serialize as the same `text` lines so existing local integrations keep their current shape.
 
+In both response shapes, `displayName` is the card's current name — if you renamed a card in the app, the rename shows here too. Match on `providerId` (or the envelope key), never on the name.
+
 ## Errors
 
 ```json

--- a/docs/research/account-first-plan.md
+++ b/docs/research/account-first-plan.md
@@ -83,9 +83,23 @@ tests land in-slice (repo policy). Estimated source LOC excludes tests.
   renders only while one of its sources is still found on this computer.
 - Scoped `ClaudeAuthStore` (per-config-dir keychain names), per-account spend from each home's logs.
 - iCloud identity routing: `PeerHistoryRemapper`, account-identity matching, v1-peer histories to a
-  family bucket rendered as device-labeled remote-only slices. Required the moment two accounts can
-  exist.
+  family bucket rendered as remote-only Total Spend slices named by account code (`claude@ab12cd34`).
+  Required the moment two accounts can exist.
 - Exit: beta soak with real multi-config-dir users; lifecycle test suite re-targeted green.
+- *Shipped as #1030.*
+
+### Phase 2b — One name resolver (~150 LOC)
+
+- Follow-up to Phase 2's rename feature: name resolution had no single seam — some surfaces read
+  the rename live from the registry, others (Total Spend legend, share export, menu bar
+  accessibility, notifications, CLI/API) showed the name baked into the `Provider` at launch, so a
+  mid-session rename drifted between surfaces.
+- The rule: `Provider.displayName` only ever carries the *derived* default; a rename lives solely
+  in the account registry (`ProviderAccountRecord.resolvedDisplayName`) and is resolved at render
+  time. Renames are never baked at launch and never persist into the snapshot cache or iCloud.
+- Total Spend slices carry a caller-resolved title (so the live legend and the
+  outside-the-environment share render agree); menu bar VoiceOver text, quota notifications, and
+  the CLI/HTTP API resolve through the same registry at their boundaries.
 
 ### Phase 3 — Claude: Cowork / Desktop accounts (~500 LOC)
 


### PR DESCRIPTION
## TL;DR

A renamed card now shows its name everywhere — including the Total Spend legend, share exports, notifications, and the CLI/API — because name resolution was consolidated into one seam: renames live only in the account registry and are resolved at render time, never baked into the launch `Provider`.

## What was happening

- A card's name lived in two places: the immutable `Provider` value created at launch (which had the rename baked in), and the live rename in the account registry.
- Surfaces that read the baked value — the Total Spend legend most visibly — kept showing the old name after a mid-session rename, while the card header updated immediately. The two only re-agreed after a relaunch.
- Every new surface had to remember which name source it was on. That's a standing bug generator: "surface X shows the launch name."

## What this changes

- **The rule:** `Provider.displayName` only ever carries the *derived* default (stock family name, or "Claude — Org" from the account label). A rename lives solely in `ProviderAccountRecord` and is resolved at render time through one resolver (`resolvedDisplayName`, surfaced app-side as `AppContainer.displayName(for:)`). A baked name can never be a stale copy of a rename, because it never contains one.
- **Total Spend:** slices carry a caller-resolved `title`, so the live legend and the share-card export (which renders outside the SwiftUI environment) always show the same name. The ranking tie-break uses it too.
- **Stop baking:** `ProviderCatalog`/`ProviderAccountAssembly` no longer inject renames into the launch `Provider` (dropped `defaultClaudeDisplayName` and the `customLabel` half of extra-card naming).
- **Straggler audit:** menu bar VoiceOver text, quota-notification titles, and CLI/HTTP API `displayName` now resolve through the registry at their boundaries. Snapshots (cache, iCloud) keep storing only the derived name — renames never persist outside the registry.
- Docs: plan doc gains the Phase 2b section; dashboard and HTTP API docs note where renames show.

## Heads-up

- `/v1/usage` and `/v1/limits` `displayName` now reflects renames. Matching stays by `providerId`; the docs now say to never match on the name.
- The one-shot CLI reads the same persisted registry, so `openusage` output shows renames too.

## Tests

- New: aggregator title-threading, menu-bar resolved-title accessibility text, API boundary rename resolution.
- Re-pinned: assembly test now asserts a rename is *never* baked (only the resolver carries it); store test pins the derived-name fallback after a cleared rename.
- Full suite: 1279 tests, 0 failures. Live run verified via `./script/build_and_run.sh verify`.

Made with [Cursor](https://cursor.com)