### PR TITLE
Account-first Phase 3: Claude Cowork / Desktop accounts

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -78,7 +78,9 @@ final class AppContainer {
 
         let providers = ProviderCatalog.make(
             claudeCards: accountAssembly.claudeCards,
-            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots
+            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
+            defaultClaudeCoworkRoots: accountAssembly.defaultClaudeCoworkRoots,
+            defaultClaudeOrganization: accountAssembly.defaultClaudeOrganization
         )
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -156,14 +156,19 @@ struct ClaudeOAuthConfig: Hashable, Sendable {
 }
 
 /// Which login a `ClaudeAuthStore` is allowed to see. `.standard` is the default card —
-/// byte-identical to the store's historical behavior. `.configDir` backs an extra account card and
-/// deliberately has no cross-account, environment-token, or Desktop fallback: the card can only ever
-/// read the one login it was created for.
+/// byte-identical to the store's historical behavior. The scoped cases back extra account cards and
+/// deliberately have no cross-account or environment-token fallback: a card can only ever read the
+/// one login it was created for.
 enum ClaudeCredentialScope: Hashable, Sendable {
     case standard
     /// One extra `CLAUDE_CONFIG_DIR` home. `keychainLiteral` is the literal string whose hash names
     /// the keychain item (Claude Code hashes the env value as typed — `~/…` vs absolute differ).
+    /// No Desktop fallback: that login belongs to another card.
     case configDir(path: String, keychainLiteral: String)
+    /// Claude Desktop only (a Cowork login distinct from the CLI login). `organization` pins the
+    /// read to that org's cached token — plans are org-scoped (a Team org next to a personal Max
+    /// org), so the card must never follow Desktop's *active* org.
+    case desktopOnly(organization: String)
 }
 
 struct ClaudeAuthStore: Sendable {
@@ -181,11 +186,15 @@ struct ClaudeAuthStore: Sendable {
     var desktop: ClaudeDesktopAuthStore
     var now: @Sendable () -> Date
     let scope: ClaudeCredentialScope
-    /// Whether the `.standard` store may fall back to Claude Desktop's credentials. On by default
-    /// (the historical behavior); the catalog turns it OFF once extra Claude account cards exist,
-    /// because the Desktop login could belong to any of them — borrowing it unpinned could fetch one
-    /// account's usage onto another account's card. Desktop-backed cards return properly in Phase 3.
-    let allowsDesktopFallback: Bool
+    /// The `.standard` card's Desktop fallback pins to this org once extra Claude cards exist (the
+    /// default account's own org, parsed from its identity key) — an unpinned fallback could borrow
+    /// a Desktop login that belongs to one of the other cards, fetching that account's usage onto
+    /// the default card.
+    let standardDesktopOrganization: String?
+    /// Whether the `.standard` store may fall back to Desktop's *active* org when no org pin is
+    /// known. On by default (the historical single-account behavior); the catalog turns it OFF once
+    /// extra Claude account cards exist, so without a pin the fallback is disabled rather than blind.
+    let allowsUnpinnedStandardDesktopFallback: Bool
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
@@ -193,7 +202,8 @@ struct ClaudeAuthStore: Sendable {
         keychain: KeychainAccessing = SecurityKeychainAccessor(),
         desktop: ClaudeDesktopAuthStore? = nil,
         scope: ClaudeCredentialScope = .standard,
-        allowsDesktopFallback: Bool = true,
+        standardDesktopOrganization: String? = nil,
+        allowsUnpinnedStandardDesktopFallback: Bool = true,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.environment = environment
@@ -201,7 +211,8 @@ struct ClaudeAuthStore: Sendable {
         self.keychain = keychain
         self.desktop = desktop ?? ClaudeDesktopAuthStore(files: files, now: now)
         self.scope = scope
-        self.allowsDesktopFallback = allowsDesktopFallback
+        self.standardDesktopOrganization = standardDesktopOrganization?.nilIfEmpty?.lowercased()
+        self.allowsUnpinnedStandardDesktopFallback = allowsUnpinnedStandardDesktopFallback
         self.now = now
     }
 
@@ -218,9 +229,21 @@ struct ClaudeAuthStore: Sendable {
         var desktopStatus: ClaudeDesktopCredentialStatus = .notChecked
         // A working CLI login remains the source of truth and avoids a second Keychain prompt. Desktop
         // is a fallback for people who only use the native app (or whose stored CLI login lacks profile
-        // scope), never a competing account source. A `.configDir` card never consults Desktop at all —
-        // that login belongs to another card.
-        let desktopAllowed = scope == .standard && allowsDesktopFallback
+        // scope), never a competing account source. Scoped cards are stricter: a `.configDir` card
+        // never consults Desktop at all (that login belongs to another card), and a `.desktopOnly`
+        // card consults nothing else — always pinned to its own org.
+        let desktopAllowed: Bool
+        var desktopOrganization: String?
+        switch scope {
+        case .standard:
+            desktopAllowed = standardDesktopOrganization != nil || allowsUnpinnedStandardDesktopFallback
+            desktopOrganization = standardDesktopOrganization
+        case .desktopOnly(let organization):
+            desktopAllowed = true
+            desktopOrganization = organization
+        case .configDir:
+            desktopAllowed = false
+        }
         if forceDesktopFallback, !desktopAllowed {
             // Tell the provider there is no safe Desktop candidate so it preserves the original CLI
             // auth error instead of converting it to a generic "not logged in" result.
@@ -230,7 +253,7 @@ struct ClaudeAuthStore: Sendable {
             $0.hasUsableAccessToken && liveUsageAvailability($0) == .available
         }
         if desktopAllowed, forceDesktopFallback || !hasUsableCLILogin {
-            let result = desktop.load(allowInteraction: allowDesktopInteraction)
+            let result = desktop.load(allowInteraction: allowDesktopInteraction, organization: desktopOrganization)
             desktopStatus = result.status
             if let oauth = result.oauth {
                 stored.insert(ClaudeCredentialState(
@@ -263,6 +286,11 @@ struct ClaudeAuthStore: Sendable {
             return keychainServiceCandidates().contains {
                 keychain.genericPasswordExists(service: $0) == true
             }
+        case .desktopOnly(let organization):
+            // `allowInteraction: false` can never raise a dialog: a not-yet-granted Safe Storage key
+            // read comes back as `.permissionRequired`, which still proves a Desktop login exists.
+            let status = desktop.load(allowInteraction: false, organization: organization).status
+            return status == .available || status == .permissionRequired || status == .stale
         }
     }
 
@@ -454,6 +482,8 @@ struct ClaudeAuthStore: Sendable {
             // Exactly this card's item — never the bare default service, which is another account's
             // login.
             return ["\(base)-\(hashSuffix(keychainLiteral))"]
+        case .desktopOnly:
+            return []
         case .standard:
             if let configDir = claudeHomeOverride() {
                 return ["\(base)-\(hashSuffix(configDir))", base]
@@ -475,6 +505,8 @@ struct ClaudeAuthStore: Sendable {
     /// later expiry (the #738 regression from ranking purely by expiry). The source kind (never the
     /// token) is logged so a "locked out" report can be diagnosed from which source was chosen.
     private func orderedStoredCandidates() -> [ClaudeCredentialState] {
+        // A desktop-only card has no CLI sources at all.
+        if case .desktopOnly = scope { return [] }
         var candidates: [ClaudeCredentialState] = []
         if let keychain = loadKeychainCredentials() { candidates.append(keychain) }
         if let file = loadFileCredentials() { candidates.append(file) }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeCoworkDiscovery.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeCoworkDiscovery.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Launch-time identity walk over Cowork's session sandboxes (the `.claude` dirs the Claude desktop
+/// app creates per session, see `ClaudeLogUsageScanner.coworkClaudeDirs`).
+///
+/// Each sandbox carries its own `.claude.json`, which names the account that ran the session. The
+/// walk only reads those identity files — no keychain, no credential files — so it can never raise
+/// a permission dialog or block launch. Routing is the assembly's job: sandboxes naming the default
+/// account stay on the default card, sandboxes naming a known config-dir account attach as its log
+/// roots, and a distinct account becomes one Desktop-backed card.
+struct ClaudeCoworkDiscovery {
+    /// One Cowork session sandbox and the account it names, when it names one.
+    struct Sandbox: Equatable, Sendable {
+        /// The session's `.claude` dir (a spend-log root: it holds `projects/**/*.jsonl`).
+        var root: URL
+        /// `nil` when the sandbox's identity file is missing or names no account — such a sandbox
+        /// stays on the default card, exactly where the built-in walk has always put it.
+        var identityKey: String?
+        var label: String?
+        /// The account's org UUID (lowercased) — the pin a Desktop-backed card reads credentials
+        /// under. Claude Desktop caches tokens per org, so an account without one can't get a card.
+        var organization: String?
+    }
+
+    struct Result: Sendable {
+        var sandboxes: [Sandbox] = []
+        /// The support trail (token-free and email-free): identity hashes and paths only.
+        var notes: [String] = []
+    }
+
+    var files: TextFileAccessing
+    var homeDirectory: @Sendable () -> URL
+    /// The sandbox walk, injectable for tests; defaults to the scanner's own walk so discovery and
+    /// spend scanning can never see different sandbox sets.
+    var listSandboxes: @Sendable (URL) -> [URL]
+    /// Wall-clock budget; on overrun the scan returns what it has (and the next launch resumes).
+    var timeBudget: TimeInterval
+    var now: @Sendable () -> Date
+
+    init(
+        files: TextFileAccessing = LocalTextFileAccessor(),
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        listSandboxes: @escaping @Sendable (URL) -> [URL] = { ClaudeLogUsageScanner.coworkClaudeDirs(home: $0) },
+        timeBudget: TimeInterval = 0.4,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.files = files
+        self.homeDirectory = homeDirectory
+        self.listSandboxes = listSandboxes
+        self.timeBudget = timeBudget
+        self.now = now
+    }
+
+    func run() -> Result {
+        let started = now()
+        var result = Result()
+        for root in listSandboxes(homeDirectory()) {
+            if now().timeIntervalSince(started) > timeBudget {
+                result.notes.append("cowork sandbox scan hit its \(Int(timeBudget * 1000))ms budget; finishing with partial results")
+                break
+            }
+            result.sandboxes.append(sandbox(at: root, notes: &result.notes))
+        }
+        return result
+    }
+
+    private func sandbox(at root: URL, notes: inout [String]) -> Sandbox {
+        let identityText: String?
+        do {
+            identityText = try files.readTextIfPresent(root.path + "/.claude.json")
+        } catch {
+            notes.append("cowork sandbox \(logPath(root.path)): identity file unreadable → kept on the default card")
+            return Sandbox(root: root)
+        }
+        guard let identityText,
+              let parsed = try? JSONDecoder().decode(
+                  DefaultAccountObserver.ClaudeStateFile.self, from: Data(identityText.utf8)
+              ),
+              let account = parsed.oauthAccount,
+              let key = DefaultAccountObserver.claudeIdentityKey(account)
+        else {
+            // No identity = a sandbox the default login produced before identity files existed, or
+            // one mid-creation. The built-in walk has always counted these on the default card.
+            return Sandbox(root: root)
+        }
+        return Sandbox(
+            root: root,
+            identityKey: key,
+            label: DefaultAccountObserver.claudeIdentityLabel(account),
+            organization: account.organizationUuid?.nilIfEmpty?.lowercased()
+        )
+    }
+
+    /// Log-safe path: the home prefix is folded to `~` so support logs don't carry the username.
+    private func logPath(_ path: String) -> String {
+        let home = homeDirectory().path
+        guard path.hasPrefix(home + "/") else { return path }
+        return "~" + path.dropFirst(home.count)
+    }
+}

--- a/Sources/OpenUsage/Providers/Claude/ClaudeCoworkDiscovery.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeCoworkDiscovery.swift
@@ -26,6 +26,11 @@ struct ClaudeCoworkDiscovery {
         var sandboxes: [Sandbox] = []
         /// The support trail (token-free and email-free): identity hashes and paths only.
         var notes: [String] = []
+        /// True when the walk hit its time budget before visiting every sandbox. A partial list
+        /// must not drive routing — a missed non-default sandbox would silently bleed into the
+        /// default card, and a partial partition would drop default spend — so the assembly skips
+        /// the whole cowork pass this launch and retries next launch.
+        var truncated = false
     }
 
     var files: TextFileAccessing
@@ -33,7 +38,8 @@ struct ClaudeCoworkDiscovery {
     /// The sandbox walk, injectable for tests; defaults to the scanner's own walk so discovery and
     /// spend scanning can never see different sandbox sets.
     var listSandboxes: @Sendable (URL) -> [URL]
-    /// Wall-clock budget; on overrun the scan returns what it has (and the next launch resumes).
+    /// Wall-clock budget; on overrun the scan returns what it has, flagged `truncated` so the
+    /// assembly knows the list is not the whole truth (and retries next launch).
     var timeBudget: TimeInterval
     var now: @Sendable () -> Date
 
@@ -56,7 +62,8 @@ struct ClaudeCoworkDiscovery {
         var result = Result()
         for root in listSandboxes(homeDirectory()) {
             if now().timeIntervalSince(started) > timeBudget {
-                result.notes.append("cowork sandbox scan hit its \(Int(timeBudget * 1000))ms budget; finishing with partial results")
+                result.notes.append("cowork sandbox scan hit its \(Int(timeBudget * 1000))ms budget → skipping cowork routing this launch")
+                result.truncated = true
                 break
             }
             result.sandboxes.append(sandbox(at: root, notes: &result.notes))

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
@@ -123,7 +123,10 @@ struct ClaudeDesktopAuthStore: Sendable {
         return Self.cookieRelativePaths.contains { files.exists(path($0)) }
     }
 
-    func load(allowInteraction: Bool) -> ClaudeDesktopCredentialResult {
+    /// `organization` pins the read to one org's cached token (a Desktop-backed account card for a
+    /// non-active Desktop org, e.g. a Team org alongside a personal Max org). `nil` keeps the default
+    /// behavior: resolve the app's currently active organization and use its token.
+    func load(allowInteraction: Bool, organization: String? = nil) -> ClaudeDesktopCredentialResult {
         guard hasCredentialMaterial() else {
             return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
         }
@@ -132,14 +135,20 @@ struct ClaudeDesktopAuthStore: Sendable {
             guard let key = try safeStorageKey(allowInteraction: allowInteraction) else {
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
             }
-            guard let activeOrg = try loadActiveOrganization(key: key),
-                  let caches = try loadCaches(key: key)
-            else {
+            let targetOrganization: String
+            if let organization {
+                targetOrganization = organization.lowercased()
+            } else if let activeOrg = try loadActiveOrganization(key: key) {
+                targetOrganization = activeOrg
+            } else {
+                return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
+            }
+            guard let caches = try loadCaches(key: key) else {
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
             }
 
             let selection = Self.selectCredential(
-                activeOrganization: activeOrg,
+                activeOrganization: targetOrganization,
                 v2: caches.v2,
                 v1: caches.v1,
                 now: now()

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
@@ -267,18 +267,21 @@ struct ClaudeDesktopAuthStore: Sendable {
         now: Date
     ) -> Selection {
         let normalizedOrg = activeOrganization.lowercased()
-        let v2Candidates = candidates(in: v2, organization: normalizedOrg, now: now)
-        if let best = v2Candidates.available.max(by: { $0.rank < $1.rank }) {
-            return .available(best.oauth)
-        }
+        let v2Candidates = candidates(in: v2, organization: normalizedOrg, now: now, isCurrentGeneration: true)
 
+        // A v2 key (live or tombstoned) always speaks for its v1 twin, but the two generations
+        // compete in ONE ranked pool. Short-circuiting on "any live v2 entry" once let a
+        // profile-only v2 leftover (carrying stale tier metadata) beat the current full-scope
+        // login whose live token existed only in v1 — token quality must outrank cache
+        // generation, with generation only breaking quality ties.
         let v2Keys = Set(v2?.keys ?? Dictionary<String, Any>().keys)
         let v1Candidates = candidates(
             in: v1?.filter { !v2Keys.contains($0.key) },
             organization: normalizedOrg,
-            now: now
+            now: now,
+            isCurrentGeneration: false
         )
-        if let best = v1Candidates.available.max(by: { $0.rank < $1.rank }) {
+        if let best = (v2Candidates.available + v1Candidates.available).max(by: { $0.rank < $1.rank }) {
             return .available(best.oauth)
         }
         if v2Candidates.sawStale || v1Candidates.sawStale { return .stale }
@@ -297,12 +300,15 @@ struct ClaudeDesktopAuthStore: Sendable {
         var clientID: String
         var scopes: [String]
         var expiresAt: Double
+        /// `true` for the v2 cache, Desktop's current generation.
+        var isCurrentGeneration: Bool
 
         /// Selection order mirrors Desktop's own resolution instead of raw expiry: production client
         /// with full scopes first, then any full-scope entry over bare `user:profile` leftovers, then
-        /// scope richness, with expiry only as the final tiebreak. A stale wrong-tier token with a
-        /// longer TTL must not outrank the current login.
-        var rank: (Int, Int, Int, Double) {
+        /// scope richness, then the newer cache generation, with expiry only as the final tiebreak.
+        /// A stale wrong-tier token with a longer TTL must not outrank the current login, and a
+        /// newer-generation entry must not outrank a better-quality older one.
+        var rank: (Int, Int, Int, Int, Double) {
             let hasFullScope = scopes.contains(ClaudeDesktopAuthStore.usageScope)
                 && scopes.contains(ClaudeDesktopAuthStore.inferenceScope)
             let isProductionClient = clientID == ClaudeDesktopAuthStore.productionClientID
@@ -310,6 +316,7 @@ struct ClaudeDesktopAuthStore: Sendable {
                 isProductionClient && hasFullScope ? 1 : 0,
                 hasFullScope ? 1 : 0,
                 scopes.count,
+                isCurrentGeneration ? 1 : 0,
                 expiresAt
             )
         }
@@ -318,7 +325,8 @@ struct ClaudeDesktopAuthStore: Sendable {
     private static func candidates(
         in cache: [String: Any]?,
         organization: String,
-        now: Date
+        now: Date,
+        isCurrentGeneration: Bool
     ) -> (available: [Candidate], sawStale: Bool, sawInvalid: Bool) {
         guard let cache else { return ([], false, false) }
         var available: [Candidate] = []
@@ -358,7 +366,8 @@ struct ClaudeDesktopAuthStore: Sendable {
                 oauth: oauth,
                 clientID: parsedKey.clientID,
                 scopes: parsedKey.scopes,
-                expiresAt: expiresAt
+                expiresAt: expiresAt,
+                isCurrentGeneration: isCurrentGeneration
             ))
         }
         return (available, sawStale, sawInvalid)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -37,6 +37,12 @@ actor ClaudeLogUsageScanner {
     /// logs belong to the account that produced them, not this card), the account's partition of the
     /// walk otherwise. `nil` keeps the built-in walk byte-identical (a machine where every sandbox
     /// belongs to the default login).
+    ///
+    /// A partition is frozen at launch by design: a sandbox created afterwards routes on the next
+    /// launch. The live-walk alternative (subtract known-foreign roots) would count the OTHER
+    /// account's brand-new sessions on this card until relaunch — the exact bleed the partition
+    /// exists to prevent. Missing-until-relaunch is the safer failure. Files inside known sandboxes
+    /// still update live on every refresh.
     private let coworkRootsOverride: [URL]?
 
     /// One parsed usage line. Token buckets are pre-normalized into `TokenBreakdown`; dedup fields

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -33,6 +33,11 @@ actor ClaudeLogUsageScanner {
     /// Same-account custom config dirs appended to the DEFAULT card's standard roots, so spend the
     /// user's own login produced in a side home still counts on its card.
     private let additionalRoots: [URL]
+    /// When set, replaces the built-in Cowork sandbox walk: `[]` for scoped account cards (Cowork
+    /// logs belong to the account that produced them, not this card), the account's partition of the
+    /// walk otherwise. `nil` keeps the built-in walk byte-identical (a machine where every sandbox
+    /// belongs to the default login).
+    private let coworkRootsOverride: [URL]?
 
     /// One parsed usage line. Token buckets are pre-normalized into `TokenBreakdown`; dedup fields
     /// ride along so the global dedup pass can run over cached entries.
@@ -66,7 +71,8 @@ actor ClaudeLogUsageScanner {
         incrementalScanner: IncrementalJSONLScanner<Entry>? = nil,
         cacheIdentityOverride: String? = nil,
         rootsOverride: [URL]? = nil,
-        additionalRoots: [URL] = []
+        additionalRoots: [URL] = [],
+        coworkRootsOverride: [URL]? = nil
     ) {
         precondition(cacheIdentityOverride?.isEmpty != true)
         // A scoped root set must carry its own parse-source identity, or its cache records would
@@ -78,6 +84,7 @@ actor ClaudeLogUsageScanner {
         self.cacheIdentityOverride = cacheIdentityOverride
         self.rootsOverride = rootsOverride
         self.additionalRoots = additionalRoots
+        self.coworkRootsOverride = coworkRootsOverride
     }
 
     /// Scan the last `daysBack` days of Claude logs. Returns `nil` when no Claude data directory or
@@ -143,7 +150,15 @@ actor ClaudeLogUsageScanner {
         let roots = Set(configuredRoots.map { $0.resolvingSymlinksInPath().standardizedFileURL.path })
             .sorted()
             .joined(separator: "\n")
-        return "home=\(home)\nroots=\(roots)"
+        // The built-in Cowork walk deliberately leaves no mark here (session roots come and go; a new
+        // session must extend the same cache, and existing installs keep their warm cache). A cowork
+        // PARTITION does mark it: the same physical roots parsed under a different sandbox split must
+        // not share whole-file records with the unpartitioned identity.
+        guard let coworkRootsOverride else { return "home=\(home)\nroots=\(roots)" }
+        let cowork = Set(coworkRootsOverride.map { $0.resolvingSymlinksInPath().standardizedFileURL.path })
+            .sorted()
+            .joined(separator: ",")
+        return "home=\(home)\nroots=\(roots)\ncowork=\(cowork)"
     }
 
     // MARK: - Root and file discovery
@@ -192,8 +207,14 @@ actor ClaudeLogUsageScanner {
             addIfValid(home.appendingPathComponent(".claude"))
         }
 
-        for sandbox in Self.coworkClaudeDirs(home: homeDirectory()) {
-            addIfValid(sandbox)
+        if let coworkRootsOverride {
+            // The default card's partition of the Cowork walk once another account's sandboxes
+            // exist — that account's sessions must not bleed into this card's spend.
+            for sandbox in coworkRootsOverride { addIfValid(sandbox) }
+        } else {
+            for sandbox in Self.coworkClaudeDirs(home: homeDirectory()) {
+                addIfValid(sandbox)
+            }
         }
         // Same-account custom config dirs (default card only): the user's own spend in a side home.
         for root in additionalRoots {
@@ -207,7 +228,9 @@ actor ClaudeLogUsageScanner {
     /// (plus an `agent/local_*` variant one level deeper). Each holds the same `projects/**/*.jsonl`
     /// session logs as `~/.claude`, so they scan as additional roots. The walk is bounded to those
     /// known levels — session dirs contain full sandbox homes we must not recurse into.
-    private static func coworkClaudeDirs(home: URL) -> [URL] {
+    /// Internal because `ClaudeCoworkDiscovery` walks the very same dirs for per-sandbox identity —
+    /// one walk, so discovery and the scanner can never see different sandbox sets.
+    static func coworkClaudeDirs(home: URL) -> [URL] {
         let base = home
             .appendingPathComponent("Library/Application Support/Claude/local-agent-mode-sessions")
 

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -25,13 +25,14 @@ enum ProviderCatalog {
         // so a baked name can never be a stale copy of one.
         var runtimes: [ProviderRuntime] = []
         runtimes.append(ClaudeProvider(
-            // Once extra Claude cards exist, an unpinned Desktop fallback could borrow a login that
-            // belongs to one of them — fetching that account's usage onto the default card. With the
-            // default account's own org known, the fallback stays available pinned to that org;
-            // otherwise it is disabled rather than blind.
+            // Once ANOTHER Claude account is known on this machine — an extra card, or a cowork
+            // partition from an account that earned no card (no org pin) — an unpinned Desktop
+            // fallback could follow that account's active org, fetching its usage onto the default
+            // card. With the default account's own org known, the fallback stays available pinned
+            // to that org; otherwise it is disabled rather than blind.
             authStore: ClaudeAuthStore(
                 standardDesktopOrganization: defaultClaudeOrganization,
-                allowsUnpinnedStandardDesktopFallback: claudeCards.isEmpty
+                allowsUnpinnedStandardDesktopFallback: claudeCards.isEmpty && defaultClaudeCoworkRoots == nil
             ),
             logUsageScanner: ClaudeLogUsageScanner(
                 additionalRoots: defaultClaudeExtraLogRoots,

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -12,7 +12,9 @@ enum ProviderCatalog {
     static func make(
         defaults: UserDefaults = .standard,
         claudeCards: [ClaudeAccountCard] = [],
-        defaultClaudeExtraLogRoots: [URL] = []
+        defaultClaudeExtraLogRoots: [URL] = [],
+        defaultClaudeCoworkRoots: [URL]? = nil,
+        defaultClaudeOrganization: String? = nil
     ) -> [ProviderRuntime] {
         // Default provider order (see AGENTS.md "## Providers"): the three established providers first,
         // then every other provider alphabetically by display name. Account cards slot in right after
@@ -24,10 +26,17 @@ enum ProviderCatalog {
         var runtimes: [ProviderRuntime] = []
         runtimes.append(ClaudeProvider(
             // Once extra Claude cards exist, an unpinned Desktop fallback could borrow a login that
-            // belongs to one of them — fetching that account's usage onto the default card. Desktop
-            // returns as its own properly-pinned source kind in Phase 3.
-            authStore: ClaudeAuthStore(allowsDesktopFallback: claudeCards.isEmpty),
-            logUsageScanner: ClaudeLogUsageScanner(additionalRoots: defaultClaudeExtraLogRoots)
+            // belongs to one of them — fetching that account's usage onto the default card. With the
+            // default account's own org known, the fallback stays available pinned to that org;
+            // otherwise it is disabled rather than blind.
+            authStore: ClaudeAuthStore(
+                standardDesktopOrganization: defaultClaudeOrganization,
+                allowsUnpinnedStandardDesktopFallback: claudeCards.isEmpty
+            ),
+            logUsageScanner: ClaudeLogUsageScanner(
+                additionalRoots: defaultClaudeExtraLogRoots,
+                coworkRootsOverride: defaultClaudeCoworkRoots
+            )
         ))
         for card in claudeCards {
             runtimes.append(claudeAccountRuntime(card: card))
@@ -47,17 +56,21 @@ enum ProviderCatalog {
     }
 
     /// An extra Claude account card: same provider machinery, credentials and logs pinned to one
-    /// login. The scanner's parse cache is partitioned per card so distinct homes never share
-    /// records.
+    /// login (a config-dir home, or Claude Desktop's org-pinned cache for a Cowork account). The
+    /// scanner's parse cache is partitioned per card so distinct homes never share records.
     private static func claudeAccountRuntime(card: ClaudeAccountCard) -> ClaudeProvider {
-        ClaudeProvider(
+        let scope: ClaudeCredentialScope = switch card.credential {
+        case .configDir(let path, let keychainLiteral):
+            .configDir(path: path, keychainLiteral: keychainLiteral)
+        case .desktop(let organization):
+            .desktopOnly(organization: organization)
+        }
+        return ClaudeProvider(
             provider: ClaudeProvider.makeProvider(id: card.id, displayName: card.displayName),
-            authStore: ClaudeAuthStore(
-                scope: .configDir(path: card.configDirPath, keychainLiteral: card.keychainLiteral)
-            ),
+            authStore: ClaudeAuthStore(scope: scope),
             logUsageScanner: ClaudeLogUsageScanner(
                 cacheIdentityOverride: "claude-account:\(card.id)",
-                rootsOverride: [URL(fileURLWithPath: card.configDirPath)] + card.extraLogRoots
+                rootsOverride: card.logRoots
             )
         )
     }

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -1,9 +1,21 @@
 import Foundation
 
-/// One extra Claude account card to build this launch: a custom-config-dir login found on this
-/// computer whose account is distinct from the default card's. Cards render only while their source
-/// is found (owner decision 4) — a record with no finding this launch simply builds no card.
+/// One extra Claude account card to build this launch: a login found on this computer whose account
+/// is distinct from the default card's — a custom-config-dir login, or a Claude Desktop (Cowork)
+/// login. Cards render only while their source is found (owner decision 4) — a record with no
+/// finding this launch simply builds no card.
 struct ClaudeAccountCard: Equatable, Sendable {
+    /// Where the card's credentials come from (its spend logs are `logRoots`, kept separate —
+    /// a Desktop-backed card's logs are Cowork sandboxes, not a credential home).
+    enum Credential: Equatable, Sendable {
+        /// One custom `CLAUDE_CONFIG_DIR` home; `keychainLiteral` names the dir's keychain item
+        /// (see `ClaudeCredentialScope.configDir`).
+        case configDir(path: String, keychainLiteral: String)
+        /// Claude Desktop's Safe Storage cache, pinned to this org's token
+        /// (see `ClaudeCredentialScope.desktopOnly`).
+        case desktop(organization: String)
+    }
+
     /// The account's stable record id (`claude@ab12cd34`) — the card id everywhere: layout, cache,
     /// CLI/API matching.
     var id: String
@@ -11,12 +23,10 @@ struct ClaudeAccountCard: Equatable, Sendable {
     /// `Provider`. Never a rename: renames live only in the account registry and are resolved at
     /// render time, so a baked name can never be a stale copy of one.
     var displayName: String
-    /// The config dir the card's credentials and spend logs are pinned to.
-    var configDirPath: String
-    /// The literal string whose hash names the dir's keychain item (see `ClaudeCredentialScope`).
-    var keychainLiteral: String
-    /// Same-account additional config dirs (rare): extra spend-log roots, never extra credentials.
-    var extraLogRoots: [URL] = []
+    var credential: Credential
+    /// Every spend-log root the card scans: its config dir(s), plus any Cowork sandboxes this
+    /// account produced.
+    var logRoots: [URL]
 }
 
 /// The launch-time account pass: read which account is signed in at each family's default home,
@@ -34,6 +44,20 @@ struct ProviderAccountAssembly {
     /// Same-account custom config dirs discovered for the DEFAULT card's login: extra spend-log
     /// roots for the default scanner, never extra credentials.
     var defaultClaudeExtraLogRoots: [URL] = []
+    /// Set only when another account's Cowork sandboxes exist: the default card's partition of the
+    /// Cowork walk (that account's sessions must not bleed into the default card's spend). `nil`
+    /// keeps the scanner's built-in walk byte-identical.
+    var defaultClaudeCoworkRoots: [URL]?
+
+    /// The default Claude account's org UUID, parsed from its identity key (`uuid|org`) — the pin
+    /// the default card's Desktop fallback reads under once other Claude cards exist. `nil` when
+    /// the default identity is unresolved or the account has no org.
+    var defaultClaudeOrganization: String? {
+        guard let key = identityKeysByCard["claude"],
+              let separator = key.firstIndex(of: "|")
+        else { return nil }
+        return String(key[key.index(after: separator)...]).nilIfEmpty
+    }
 
     /// `waitsForLoginShell`: true for the menu-bar app (a Finder/Dock launch inherits no shell
     /// exports, so the pass leans on the login-shell layers), false for the one-shot CLI (a terminal
@@ -74,7 +98,8 @@ struct ProviderAccountAssembly {
             observer: DefaultAccountObserver(),
             accountsStore: accountsStore ?? ProviderAccountsStore(defaults: defaults),
             families: families,
-            claudeDiscovery: ClaudeConfigDirDiscovery()
+            claudeDiscovery: ClaudeConfigDirDiscovery(),
+            coworkDiscovery: ClaudeCoworkDiscovery()
         )
     }
 
@@ -95,7 +120,8 @@ struct ProviderAccountAssembly {
         observer: DefaultAccountObserver,
         accountsStore: ProviderAccountsStore,
         families: Set<String> = ProviderAccountID.families,
-        claudeDiscovery: ClaudeConfigDirDiscovery? = nil
+        claudeDiscovery: ClaudeConfigDirDiscovery? = nil,
+        coworkDiscovery: ClaudeCoworkDiscovery? = nil
     ) -> ProviderAccountAssembly {
         var identityKeys: [String: String] = [:]
         var observations: [ProviderAccountsStore.AccountObservation] = []
@@ -125,58 +151,129 @@ struct ProviderAccountAssembly {
             }
         }
 
-        // Extra Claude logins in custom config dirs. Guarded on the default read: when a default
-        // login clearly EXISTS but can't be named (`unresolved`), accepting candidates could render
-        // the very account the default card shows as a second card — skip them this launch instead.
-        // A machine with no default login at all keeps accepting: there is nothing to duplicate,
-        // and a custom-dir-only login should still get its card.
-        var foundClaudeAccounts: [(identityKey: String, label: String?, dirs: [ClaudeConfigDirDiscovery.Finding])] = []
+        // Extra Claude logins in custom config dirs and Cowork sandboxes. Guarded on the default
+        // read: when a default login clearly EXISTS but can't be named (`unresolved`), accepting
+        // candidates could render the very account the default card shows as a second card — skip
+        // them this launch instead. A machine with no default login at all keeps accepting: there
+        // is nothing to duplicate, and a custom-dir-only login should still get its card.
+        var plannedCards: [PlannedClaudeCard] = []
         var defaultClaudeExtraLogRoots: [URL] = []
+        var defaultClaudeCoworkRoots: [URL]?
         let claudeOutcome = outcomes.first { $0.family == "claude" }?.outcome
-        if let claudeDiscovery, let claudeOutcome {
+        var claudeCandidatesAllowed = false
+        if let claudeOutcome {
             if case .unresolved = claudeOutcome {
                 AppLog.info(.config, "discovery: claude default login present but its identity is unreadable → skipping extra-account candidates this launch")
             } else {
-                let defaultKey = identityKeys["claude"]
-                let scan = claudeDiscovery.run()
-                for note in scan.notes {
-                    AppLog.info(.config, "discovery: \(note)")
+                claudeCandidatesAllowed = true
+            }
+        }
+        if let claudeDiscovery, claudeCandidatesAllowed {
+            let defaultKey = identityKeys["claude"]
+            let scan = claudeDiscovery.run()
+            for note in scan.notes {
+                AppLog.info(.config, "discovery: \(note)")
+            }
+            var order: [String] = []
+            var grouped: [String: [ClaudeConfigDirDiscovery.Finding]] = [:]
+            for finding in scan.findings {
+                if grouped[finding.identityKey] == nil { order.append(finding.identityKey) }
+                grouped[finding.identityKey, default: []].append(finding)
+            }
+            for identityKey in order {
+                let findings = grouped[identityKey] ?? []
+                let sources = findings.map {
+                    ProviderAccountSource(
+                        kind: .configDir,
+                        anchor: $0.anchorPath,
+                        holdsDefaultSource: false,
+                        keychainLiteral: $0.keychainLiteral
+                    )
                 }
-                var order: [String] = []
-                var grouped: [String: [ClaudeConfigDirDiscovery.Finding]] = [:]
-                for finding in scan.findings {
-                    if grouped[finding.identityKey] == nil { order.append(finding.identityKey) }
-                    grouped[finding.identityKey, default: []].append(finding)
-                }
-                for identityKey in order {
-                    let findings = grouped[identityKey] ?? []
-                    let sources = findings.map {
-                        ProviderAccountSource(
-                            kind: .configDir,
-                            anchor: $0.anchorPath,
-                            holdsDefaultSource: false,
-                            keychainLiteral: $0.keychainLiteral
-                        )
+                if identityKey == defaultKey {
+                    // Same account as the default card: its dirs are extra spend-log roots on
+                    // that card, never a second card — duplicate cards are structurally
+                    // impossible because identity routes the source to the existing record.
+                    defaultClaudeExtraLogRoots += findings.map { URL(fileURLWithPath: $0.anchorPath) }
+                    if let index = observations.firstIndex(where: { $0.family == "claude" && $0.identityKey == identityKey }) {
+                        observations[index].sources += sources
                     }
-                    if identityKey == defaultKey {
-                        // Same account as the default card: its dirs are extra spend-log roots on
-                        // that card, never a second card — duplicate cards are structurally
-                        // impossible because identity routes the source to the existing record.
-                        defaultClaudeExtraLogRoots += findings.map { URL(fileURLWithPath: $0.anchorPath) }
-                        if let index = observations.firstIndex(where: { $0.family == "claude" && $0.identityKey == identityKey }) {
-                            observations[index].sources += sources
-                        }
-                        AppLog.info(.config, "discovery: \(findings.count) config dir(s) fold onto the default claude card (same account)")
-                    } else {
-                        observations.append(ProviderAccountsStore.AccountObservation(
-                            family: "claude",
-                            identityKey: identityKey,
-                            label: findings.first?.label,
-                            sources: sources
-                        ))
-                        foundClaudeAccounts.append((identityKey, findings.first?.label, findings))
-                    }
+                    AppLog.info(.config, "discovery: \(findings.count) config dir(s) fold onto the default claude card (same account)")
+                } else {
+                    guard let primary = findings.first else { continue }
+                    observations.append(ProviderAccountsStore.AccountObservation(
+                        family: "claude",
+                        identityKey: identityKey,
+                        label: primary.label,
+                        sources: sources
+                    ))
+                    plannedCards.append(PlannedClaudeCard(
+                        identityKey: identityKey,
+                        credential: .configDir(path: primary.anchorPath, keychainLiteral: primary.keychainLiteral),
+                        logRoots: findings.map { URL(fileURLWithPath: $0.anchorPath) }
+                    ))
                 }
+            }
+        }
+
+        // Cowork sandboxes: identity comes from each session sandbox's own `.claude.json`.
+        // Sandboxes naming the default login (the overwhelmingly common case) stay exactly where
+        // they are today — on the default card. Sandboxes naming an account already found in a
+        // config dir become that card's extra log roots. A distinct account becomes ONE
+        // Desktop-backed card (org-pinned Safe Storage credentials) with its sandboxes as the
+        // card's spend logs. The moment any non-default sandbox exists, the default card's walk is
+        // partitioned so another account's sessions can't bleed into its spend.
+        if let coworkDiscovery, claudeCandidatesAllowed {
+            let defaultKey = identityKeys["claude"]
+            let scan = coworkDiscovery.run()
+            for note in scan.notes {
+                AppLog.info(.config, "discovery: \(note)")
+            }
+            var defaultBucket: [URL] = []
+            var order: [String] = []
+            var grouped: [String: [ClaudeCoworkDiscovery.Sandbox]] = [:]
+            for sandbox in scan.sandboxes {
+                guard let key = sandbox.identityKey, key != defaultKey else {
+                    // An unidentified sandbox counts on the default card, exactly where the
+                    // built-in walk has always put it.
+                    defaultBucket.append(sandbox.root)
+                    continue
+                }
+                if grouped[key] == nil { order.append(key) }
+                grouped[key, default: []].append(sandbox)
+            }
+            for identityKey in order {
+                let sandboxes = grouped[identityKey] ?? []
+                let roots = sandboxes.map(\.root)
+                if let index = plannedCards.firstIndex(where: { $0.identityKey == identityKey }) {
+                    // The account already has a card from its config dir; its sandboxes are just
+                    // more of its spend logs.
+                    plannedCards[index].logRoots += roots
+                    AppLog.info(.config, "discovery: \(roots.count) cowork sandbox(es) attach to an existing claude account card as log roots")
+                    continue
+                }
+                guard let organization = sandboxes.compactMap(\.organization).first else {
+                    // Desktop caches tokens per org; without the pin the card could only read
+                    // Desktop's ACTIVE org, which may be a different account's usage pool.
+                    AppLog.info(.config, "discovery: cowork account \(ProviderAccountID.make(family: "claude", identityKey: identityKey)) has no organization pin → skipped Desktop-backed card")
+                    continue
+                }
+                let label = sandboxes.compactMap(\.label).first
+                observations.append(ProviderAccountsStore.AccountObservation(
+                    family: "claude",
+                    identityKey: identityKey,
+                    label: label,
+                    sources: [ProviderAccountSource(kind: .desktop, anchor: nil, holdsDefaultSource: false)]
+                ))
+                plannedCards.append(PlannedClaudeCard(
+                    identityKey: identityKey,
+                    credential: .desktop(organization: organization),
+                    logRoots: roots
+                ))
+            }
+            if !order.isEmpty {
+                defaultClaudeCoworkRoots = defaultBucket
+                AppLog.info(.config, "discovery: cowork partition — default keeps \(defaultBucket.count) sandbox dir(s), \(order.count) other account(s) found")
             }
         }
 
@@ -185,35 +282,42 @@ struct ProviderAccountAssembly {
         // The extra-card build plan: one card per distinct account found this launch, under its
         // reconciled record id.
         var claudeCards: [ClaudeAccountCard] = []
-        for account in foundClaudeAccounts {
-            guard let record = records.first(where: { $0.family == "claude" && $0.identityKey == account.identityKey }) else {
+        for planned in plannedCards {
+            guard let record = records.first(where: { $0.family == "claude" && $0.identityKey == planned.identityKey }) else {
                 continue
             }
             guard record.id != "claude" else {
-                // The bare record's account has moved out of the default home into a config dir
-                // while another login occupies the default. The bare CARD is the default home's
+                // The bare record's account has moved out of the default home into a side login
+                // while another account occupies the default. The bare CARD is the default home's
                 // runtime, so this record can't render under its own id this launch. Proper swap
                 // support re-points this in Phase 4; until then the parked account stays hidden.
-                AppLog.warn(.config, "discovery: the claude record's account now lives in a config dir; its card is unavailable until swap support lands")
+                AppLog.warn(.config, "discovery: the claude record's account now lives outside the default home; its card is unavailable until swap support lands")
                 continue
             }
-            guard let primary = account.dirs.first else { continue }
             claudeCards.append(ClaudeAccountCard(
                 id: record.id,
                 displayName: record.derivedDisplayName,
-                configDirPath: primary.anchorPath,
-                keychainLiteral: primary.keychainLiteral,
-                extraLogRoots: account.dirs.dropFirst().map { URL(fileURLWithPath: $0.anchorPath) }
+                credential: planned.credential,
+                logRoots: planned.logRoots
             ))
-            identityKeys[record.id] = account.identityKey
-            AppLog.info(.config, "accounts: extra claude card \(record.id) from \(account.dirs.count) config dir(s)")
+            identityKeys[record.id] = planned.identityKey
+            let kind = if case .desktop = planned.credential { "desktop (cowork)" } else { "config dir" }
+            AppLog.info(.config, "accounts: extra claude card \(record.id) — \(kind), \(planned.logRoots.count) log root(s)")
         }
         claudeCards.sort { $0.id < $1.id }
 
         return ProviderAccountAssembly(
             identityKeysByCard: identityKeys,
             claudeCards: claudeCards,
-            defaultClaudeExtraLogRoots: defaultClaudeExtraLogRoots
+            defaultClaudeExtraLogRoots: defaultClaudeExtraLogRoots,
+            defaultClaudeCoworkRoots: defaultClaudeCoworkRoots
         )
+    }
+
+    /// One distinct account's card plan before reconciliation assigns its record id.
+    private struct PlannedClaudeCard {
+        var identityKey: String
+        var credential: ClaudeAccountCard.Credential
+        var logRoots: [URL]
     }
 }

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -190,12 +190,12 @@ struct ProviderAccountAssembly {
                         keychainLiteral: $0.keychainLiteral
                     )
                 }
-                if identityKey == defaultKey {
+                if let defaultKey, sameClaudeAccount(identityKey, defaultKey) {
                     // Same account as the default card: its dirs are extra spend-log roots on
                     // that card, never a second card — duplicate cards are structurally
                     // impossible because identity routes the source to the existing record.
                     defaultClaudeExtraLogRoots += findings.map { URL(fileURLWithPath: $0.anchorPath) }
-                    if let index = observations.firstIndex(where: { $0.family == "claude" && $0.identityKey == identityKey }) {
+                    if let index = observations.firstIndex(where: { $0.family == "claude" && $0.identityKey == defaultKey }) {
                         observations[index].sources += sources
                     }
                     AppLog.info(.config, "discovery: \(findings.count) config dir(s) fold onto the default claude card (same account)")
@@ -232,10 +232,15 @@ struct ProviderAccountAssembly {
             var defaultBucket: [URL] = []
             var order: [String] = []
             var grouped: [String: [ClaudeCoworkDiscovery.Sandbox]] = [:]
-            for sandbox in scan.sandboxes {
-                guard let key = sandbox.identityKey, key != defaultKey else {
-                    // An unidentified sandbox counts on the default card, exactly where the
-                    // built-in walk has always put it.
+            // A truncated walk saw only some sandboxes; routing on it could partition away default
+            // spend or miss a non-default sandbox entirely. Skip the pass — the built-in walk stays
+            // byte-identical this launch, and the next launch retries.
+            for sandbox in scan.truncated ? [] : scan.sandboxes {
+                guard let key = sandbox.identityKey,
+                      !(defaultKey.map { sameClaudeAccount(key, $0) } ?? false)
+                else {
+                    // An unidentified or default-account sandbox counts on the default card,
+                    // exactly where the built-in walk has always put it.
                     defaultBucket.append(sandbox.root)
                     continue
                 }
@@ -245,7 +250,7 @@ struct ProviderAccountAssembly {
             for identityKey in order {
                 let sandboxes = grouped[identityKey] ?? []
                 let roots = sandboxes.map(\.root)
-                if let index = plannedCards.firstIndex(where: { $0.identityKey == identityKey }) {
+                if let index = plannedCards.firstIndex(where: { sameClaudeAccount($0.identityKey, identityKey) }) {
                     // The account already has a card from its config dir; its sandboxes are just
                     // more of its spend logs.
                     plannedCards[index].logRoots += roots
@@ -312,6 +317,19 @@ struct ProviderAccountAssembly {
             defaultClaudeExtraLogRoots: defaultClaudeExtraLogRoots,
             defaultClaudeCoworkRoots: defaultClaudeCoworkRoots
         )
+    }
+
+    /// Whether two Claude identity keys (`uuid` or `uuid|org`) name the same login. An identity
+    /// file sometimes omits the org half (older files, files written mid-login), so a bare-uuid
+    /// key still names the same account as a `uuid|org` key with the same uuid — org presence
+    /// must never split one login into two cards. Two keys with DIFFERENT orgs stay distinct:
+    /// same user, separate usage pools.
+    static func sameClaudeAccount(_ lhs: String, _ rhs: String) -> Bool {
+        if lhs == rhs { return true }
+        let lhsParts = lhs.split(separator: "|", maxSplits: 1)
+        let rhsParts = rhs.split(separator: "|", maxSplits: 1)
+        guard lhsParts.first == rhsParts.first else { return false }
+        return lhsParts.count == 1 || rhsParts.count == 1
     }
 
     /// One distinct account's card plan before reconciliation assigns its record id.

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -60,7 +60,9 @@ public struct UsageReader {
         let providers = providersOverride ?? ProviderCatalog.make(
             defaults: defaults,
             claudeCards: accountAssembly.claudeCards,
-            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots
+            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
+            defaultClaudeCoworkRoots: accountAssembly.defaultClaudeCoworkRoots,
+            defaultClaudeOrganization: accountAssembly.defaultClaudeOrganization
         )
         let registry = WidgetRegistry.from(providers)
         let knownIDs = Set(registry.providers.map(\.id))

--- a/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
@@ -44,6 +44,10 @@ struct ProviderAccountSource: Codable, Equatable, Sendable {
         case defaultHome
         /// A custom Claude config dir (a `CLAUDE_CONFIG_DIR` home kept besides the default).
         case configDir
+        /// A Claude Desktop login (a Cowork account distinct from every CLI login), credentialed
+        /// from Desktop's org-pinned Safe Storage cache. No anchor path — the login lives in
+        /// Desktop's own container, and its Cowork sandboxes are log roots, not credential homes.
+        case desktop
     }
 
     var kind: Kind

--- a/Tests/OpenUsageTests/ClaudeCoworkDiscoveryTests.swift
+++ b/Tests/OpenUsageTests/ClaudeCoworkDiscoveryTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import OpenUsage
+
+/// The Cowork sandbox identity walk: each session's `.claude` dir names its account (or doesn't).
+/// Routing is the assembly's job — see `ProviderAccountAssemblyTests`.
+final class ClaudeCoworkDiscoveryTests: XCTestCase {
+    private let sandboxA = URL(fileURLWithPath: "/Users/dev/Library/Application Support/Claude/local-agent-mode-sessions/g/s/local_1/.claude")
+    private let sandboxB = URL(fileURLWithPath: "/Users/dev/Library/Application Support/Claude/local-agent-mode-sessions/g/s/local_2/.claude")
+
+    private func makeDiscovery(files: [String: String], sandboxes: [URL]) -> ClaudeCoworkDiscovery {
+        ClaudeCoworkDiscovery(
+            files: FakeFiles(files),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") },
+            listSandboxes: { _ in sandboxes }
+        )
+    }
+
+    func testReadsIdentityLabelAndOrganizationPerSandbox() throws {
+        let discovery = makeDiscovery(
+            files: [
+                sandboxA.path + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "emailAddress": "work@example.com", "organizationUuid": "ORG-2", "organizationName": "Sunstory"}}"#,
+            ],
+            sandboxes: [sandboxA]
+        )
+
+        let result = discovery.run()
+
+        let sandbox = try XCTUnwrap(result.sandboxes.first)
+        XCTAssertEqual(result.sandboxes.count, 1)
+        XCTAssertEqual(sandbox.root, sandboxA)
+        XCTAssertEqual(sandbox.identityKey, "acct-2|org-2")
+        XCTAssertEqual(sandbox.label, "work@example.com (Sunstory)")
+        XCTAssertEqual(sandbox.organization, "org-2")
+    }
+
+    func testASandboxWithoutAnIdentityFileStillReportsItsRoot() {
+        // No identity = the sandbox stays on the default card; the root must still be reported so
+        // the assembly can keep it in the default card's partition.
+        let discovery = makeDiscovery(files: [:], sandboxes: [sandboxA, sandboxB])
+
+        let result = discovery.run()
+
+        XCTAssertEqual(result.sandboxes.map(\.root), [sandboxA, sandboxB])
+        XCTAssertEqual(result.sandboxes.compactMap(\.identityKey), [])
+    }
+
+    func testAnIdentityFileNamingNoAccountCountsAsUnidentified() {
+        let discovery = makeDiscovery(
+            files: [sandboxA.path + "/.claude.json": #"{"oauthAccount": {}}"#],
+            sandboxes: [sandboxA]
+        )
+
+        let result = discovery.run()
+
+        XCTAssertEqual(result.sandboxes.first?.identityKey, nil)
+    }
+}

--- a/Tests/OpenUsageTests/ClaudeCoworkDiscoveryTests.swift
+++ b/Tests/OpenUsageTests/ClaudeCoworkDiscoveryTests.swift
@@ -44,6 +44,22 @@ final class ClaudeCoworkDiscoveryTests: XCTestCase {
         XCTAssertEqual(result.sandboxes.compactMap(\.identityKey), [])
     }
 
+    func testHittingTheTimeBudgetFlagsTheResultTruncated() {
+        let roots = [sandboxA, sandboxB]
+        let discovery = ClaudeCoworkDiscovery(
+            files: FakeFiles([:]),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") },
+            listSandboxes: { _ in roots },
+            timeBudget: -1
+        )
+
+        let result = discovery.run()
+
+        XCTAssertTrue(result.truncated, "the assembly needs to know the list is not the whole truth")
+        XCTAssertTrue(result.sandboxes.isEmpty)
+        XCTAssertEqual(result.notes.count, 1)
+    }
+
     func testAnIdentityFileNamingNoAccountCountsAsUnidentified() {
         let discovery = makeDiscovery(
             files: [sandboxA.path + "/.claude.json": #"{"oauthAccount": {}}"#],

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -103,6 +103,74 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         XCTAssertEqual(oauth.accessToken, "full-scope-token")
     }
 
+    func testOrganizationPinReadsThatOrgsTokenNotTheActiveOrgs() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization): tokenEntry("active-org-token", expiresIn: 3_600),
+                cacheKey(organization: otherOrganization): tokenEntry("pinned-org-token", expiresIn: 3_600)
+            ]
+        )
+
+        let result = fixture.store.load(allowInteraction: false, organization: otherOrganization)
+
+        XCTAssertEqual(result.status, .available)
+        XCTAssertEqual(result.oauth?.accessToken, "pinned-org-token")
+    }
+
+    func testDesktopOnlyScopeLoadsExactlyItsPinnedOrg() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization): tokenEntry("active-org-token", expiresIn: 3_600),
+                cacheKey(organization: otherOrganization): tokenEntry("cowork-org-token", expiresIn: 3_600)
+            ]
+        )
+        let now = now
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(),
+            files: fixture.files,
+            keychain: FakeKeychain(),
+            desktop: fixture.store,
+            scope: .desktopOnly(organization: otherOrganization),
+            now: { now }
+        )
+
+        let load = authStore.loadCredentialSet()
+
+        XCTAssertEqual(load.candidates.map(\.oauth.accessToken), ["cowork-org-token"])
+        XCTAssertEqual(load.candidates.first?.source, .desktop)
+        XCTAssertEqual(load.desktopStatus, .available)
+    }
+
+    func testStandardStorePinsDesktopFallbackInsteadOfFollowingAnotherCardsActiveOrg() throws {
+        // Desktop's ACTIVE org is another card's account (a Cowork login). The default card's
+        // fallback must read its own org's token, never follow the active org.
+        let fixture = try makeFixture(
+            activeOrganization: otherOrganization,
+            v2: [
+                cacheKey(organization: organization): tokenEntry("default-org-token", expiresIn: 3_600),
+                cacheKey(organization: otherOrganization): tokenEntry("cowork-card-token", expiresIn: 3_600)
+            ]
+        )
+        let now = now
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: fixture.files,
+            keychain: FakeKeychain(),
+            desktop: fixture.store,
+            standardDesktopOrganization: organization,
+            allowsUnpinnedStandardDesktopFallback: false,
+            now: { now }
+        )
+
+        let load = authStore.loadCredentialSet()
+
+        XCTAssertEqual(load.candidates.first?.oauth.accessToken, "default-org-token")
+        XCTAssertFalse(load.candidates.contains { $0.oauth.accessToken == "cowork-card-token" })
+        XCTAssertEqual(load.desktopStatus, .available)
+    }
+
     func testBackgroundReadDoesNotPromptButManualReadCan() throws {
         let fixture = try makeFixture(
             activeOrganization: organization,

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -103,6 +103,61 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         XCTAssertEqual(oauth.accessToken, "full-scope-token")
     }
 
+    func testALiveFullScopeV1EntryOutranksAWeakLiveV2Leftover() throws {
+        // The real-world shape that showed a Max 20x account as "Max 5x": v2 holds the current
+        // login only as an EXPIRED entry plus a live profile-only leftover with stale 5x tier
+        // metadata, while v1 still holds the login's live full-scope token. Short-circuiting on
+        // "any live v2 entry" picked the 5x leftover; quality must outrank cache generation.
+        let productionClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+        let selection = ClaudeDesktopAuthStore.selectCredential(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization, clientID: productionClientID):
+                    tokenEntry("expired-20x-token", expiresIn: -3_600, rateLimitTier: "default_claude_max_20x"),
+                cacheKey(organization: organization, scopes: "user:profile"):
+                    tokenEntry("stale-5x-token", expiresIn: 86_400, rateLimitTier: "default_claude_max_5x"),
+            ],
+            v1: [
+                cacheKey(
+                    organization: organization,
+                    clientID: productionClientID,
+                    scopes: "user:profile user:inference user:sessions"
+                ):
+                    tokenEntry("current-20x-token", expiresIn: 30_000_000, rateLimitTier: "default_claude_max_20x"),
+            ],
+            now: now
+        )
+
+        guard case .available(let oauth) = selection else {
+            return XCTFail("expected an available credential, got \(selection)")
+        }
+        XCTAssertEqual(oauth.accessToken, "current-20x-token")
+        XCTAssertEqual(oauth.rateLimitTier, "default_claude_max_20x")
+    }
+
+    func testEqualQualityTokensTiebreakToTheNewerCacheGeneration() throws {
+        // Same client, same scope set (different order → distinct cache keys, so the v1 entry is
+        // not filtered as a twin). The v1 entry even lives longer; the newer generation must win
+        // the tie — but only the tie.
+        let selection = ClaudeDesktopAuthStore.selectCredential(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization, scopes: "user:profile user:inference"):
+                    tokenEntry("v2-token", expiresIn: 1_800),
+            ],
+            v1: [
+                cacheKey(organization: organization, scopes: "user:inference user:profile"):
+                    tokenEntry("v1-token", expiresIn: 86_400),
+            ],
+            now: now
+        )
+
+        guard case .available(let oauth) = selection else {
+            return XCTFail("expected an available credential, got \(selection)")
+        }
+        XCTAssertEqual(oauth.accessToken, "v2-token")
+    }
+
     func testOrganizationPinReadsThatOrgsTokenNotTheActiveOrgs() throws {
         let fixture = try makeFixture(
             activeOrganization: organization,

--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
@@ -561,6 +561,50 @@ final class ClaudeLogUsageScannerTests: XCTestCase {
         XCTAssertEqual(scan.series.daily[0].costUSD ?? 0, 0.25, accuracy: 1e-9)
     }
 
+    func testCoworkRootsOverrideReplacesTheBuiltInWalk() async throws {
+        // Two sandboxes on disk, but the partition hands this scanner only the first — the other
+        // belongs to a different account's card and must not count here.
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let home = try ClaudeLogFixture.makeUserHome(
+            claudeFiles: [
+                "project-a/terminal.jsonl": ClaudeLogFixture.usageLine(
+                    timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
+                    messageID: "msg-terminal", requestID: "req-terminal"
+                )
+            ],
+            coworkSessions: [
+                "group-1/sub-1/local_mine": [
+                    "workspace/session.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 10, output: 5, costUSD: 0.05,
+                        messageID: "msg-mine", requestID: "req-mine"
+                    )
+                ],
+                "group-1/sub-1/local_theirs": [
+                    "workspace/session.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 90_000, output: 10, costUSD: 9.99,
+                        messageID: "msg-theirs", requestID: "req-theirs"
+                    )
+                ]
+            ]
+        )
+        let mine = home.appendingPathComponent(
+            "Library/Application Support/Claude/local-agent-mode-sessions/group-1/sub-1/local_mine/.claude"
+        )
+        let scanner = ClaudeLogUsageScanner(
+            environment: FakeEnvironment([:]),
+            homeDirectory: { home },
+            incrementalScanner: IncrementalJSONLScanner<Entry>(),
+            coworkRootsOverride: [mine]
+        )
+
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+        XCTAssertEqual(scan.series.daily.count, 1)
+        XCTAssertEqual(scan.series.daily[0].totalTokens, 165, "terminal + own sandbox only; the other account's sandbox is excluded")
+        XCTAssertEqual(scan.series.daily[0].costUSD ?? 0, 0.30, accuracy: 1e-9)
+    }
+
     func testScanAcceptsProjectsDirItselfInConfigDir() async throws {
         let now = Date()
         let home = try ClaudeLogFixture.makeHome(files: [

--- a/Tests/OpenUsageTests/ClaudeScopedAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeScopedAuthStoreTests.swift
@@ -91,6 +91,22 @@ final class ClaudeScopedAuthStoreTests: XCTestCase {
         XCTAssertTrue(load.candidates.isEmpty)
     }
 
+    @MainActor
+    func testACoworkPartitionAloneDisablesTheUnpinnedDesktopFallback() throws {
+        // A distinct Cowork account can exist WITHOUT earning a card (no org pin, so no
+        // Desktop-backed card is safe to build). Another account is still known on the machine,
+        // so the default card's unpinned Desktop fallback must drop all the same — Desktop's
+        // active org may be that account's usage pool.
+        let partitioned = ProviderCatalog.make(defaultClaudeCoworkRoots: [])
+        let claude = try XCTUnwrap(partitioned.compactMap { $0 as? ClaudeProvider }.first)
+        XCTAssertFalse(claude.authStore.allowsUnpinnedStandardDesktopFallback)
+
+        // Control: a machine with no other account known keeps the fallback.
+        let alone = ProviderCatalog.make()
+        let defaultClaude = try XCTUnwrap(alone.compactMap { $0 as? ClaudeProvider }.first)
+        XCTAssertTrue(defaultClaude.authStore.allowsUnpinnedStandardDesktopFallback)
+    }
+
     func testDesktopOnlyStoreHasNoCLISourcesAndNeverInheritsTheEnvironmentToken() {
         let store = ClaudeAuthStore(
             environment: FakeEnvironment(["CLAUDE_CODE_OAUTH_TOKEN": "ambient-token"]),

--- a/Tests/OpenUsageTests/ClaudeScopedAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeScopedAuthStoreTests.swift
@@ -75,18 +75,38 @@ final class ClaudeScopedAuthStoreTests: XCTestCase {
         XCTAssertFalse(bare.hasCredentialFootprint())
     }
 
-    func testStandardStoreDropsDesktopFallbackWhileExtraCardsExist() {
-        // With no CLI login and Desktop disallowed (extra Claude cards exist), the load reports
-        // `.notFound` instead of consulting Desktop — the caller keeps the honest CLI error.
+    func testStandardStoreDropsDesktopFallbackWhileExtraCardsExistAndNoOrgPinIsKnown() {
+        // With no CLI login, no org pin, and the unpinned fallback disallowed (extra Claude cards
+        // exist), the load reports `.notFound` instead of consulting Desktop — the caller keeps the
+        // honest CLI error.
         let store = ClaudeAuthStore(
             environment: FakeEnvironment([:]),
             files: FakeFiles([:]),
             keychain: ServiceKeychain(),
-            allowsDesktopFallback: false
+            allowsUnpinnedStandardDesktopFallback: false
         )
 
         let load = store.loadCredentialSet(forceDesktopFallback: true)
         XCTAssertEqual(load.desktopStatus, .notFound)
         XCTAssertTrue(load.candidates.isEmpty)
+    }
+
+    func testDesktopOnlyStoreHasNoCLISourcesAndNeverInheritsTheEnvironmentToken() {
+        let store = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CODE_OAUTH_TOKEN": "ambient-token"]),
+            files: FakeFiles([
+                // Every CLI credential on the machine must stay invisible to a Desktop-backed card.
+                "~/.claude/.credentials.json": #"{"claudeAiOauth": {"accessToken": "default-at"}}"#,
+            ]),
+            keychain: ServiceKeychain(),
+            scope: .desktopOnly(organization: "11111111-2222-3333-4444-555555555555")
+        )
+
+        XCTAssertEqual(store.keychainServiceCandidates(), [])
+        // No Desktop material in this fixture, so the load ends up empty — the point is that no CLI
+        // or environment candidate leaked in, and Desktop WAS consulted (status is not .notChecked).
+        let load = store.loadCredentialSet()
+        XCTAssertTrue(load.candidates.isEmpty)
+        XCTAssertEqual(load.desktopStatus, .notFound)
     }
 }

--- a/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
@@ -105,7 +105,8 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         XCTAssertEqual(assembly.claudeCards.count, 1)
         XCTAssertTrue(card.id.hasPrefix("claude@"), "a config-dir account never claims the bare id")
         XCTAssertEqual(card.displayName, "Claude — Sunstory")
-        XCTAssertEqual(card.configDirPath, "/Users/dev/.claude-work")
+        XCTAssertEqual(card.credential, .configDir(path: "/Users/dev/.claude-work", keychainLiteral: "/Users/dev/.claude-work"))
+        XCTAssertEqual(card.logRoots.map(\.path), ["/Users/dev/.claude-work"])
         XCTAssertEqual(assembly.identityKeysByCard["claude"], "acct-1")
         XCTAssertEqual(assembly.identityKeysByCard[card.id], "acct-2")
         // The registry recorded both: the default holder under the bare id, the extra account with
@@ -202,6 +203,149 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         XCTAssertTrue(
             card.id.hasPrefix("claude@"),
             "the bare id stays reserved for a future default-home login even when it is free"
+        )
+    }
+
+    // MARK: - Cowork sandboxes
+
+    private let coworkBase = "/Users/dev/Library/Application Support/Claude/local-agent-mode-sessions/g/s"
+
+    private func makeCoworkDiscovery(
+        files: [String: String],
+        sandboxes: [String]
+    ) -> ClaudeCoworkDiscovery {
+        ClaudeCoworkDiscovery(
+            files: FakeFiles(files),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") },
+            listSandboxes: { _ in sandboxes.map { URL(fileURLWithPath: $0) } }
+        )
+    }
+
+    private func makeDefaultResolvedObserver() -> DefaultAccountObserver {
+        DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([
+                "/Users/dev/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
+            ]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+    }
+
+    func testDefaultAccountSandboxesLeaveTheBuiltInCoworkWalkUntouched() {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let sandbox = "\(coworkBase)/local_1/.claude"
+        let cowork = makeCoworkDiscovery(
+            files: [sandbox + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#],
+            sandboxes: [sandbox]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
+        )
+
+        XCTAssertTrue(assembly.claudeCards.isEmpty)
+        XCTAssertNil(assembly.defaultClaudeCoworkRoots, "no partition — the scanner's built-in walk stays byte-identical")
+    }
+
+    func testADistinctCoworkAccountBecomesOneDesktopBackedCardAndPartitionsTheWalk() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let mine = "\(coworkBase)/local_1/.claude"
+        let theirsA = "\(coworkBase)/local_2/.claude"
+        let theirsB = "\(coworkBase)/local_3/.claude"
+        let identity = #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2", "organizationName": "Sunstory"}}"#
+        let cowork = makeCoworkDiscovery(
+            files: [
+                mine + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
+                theirsA + "/.claude.json": identity,
+                theirsB + "/.claude.json": identity,
+            ],
+            sandboxes: [mine, theirsA, theirsB]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
+        )
+
+        let card = try XCTUnwrap(assembly.claudeCards.first)
+        XCTAssertEqual(assembly.claudeCards.count, 1, "several sandboxes of one account are ONE card")
+        XCTAssertEqual(card.credential, .desktop(organization: "org-2"))
+        XCTAssertEqual(card.displayName, "Claude — Sunstory")
+        XCTAssertEqual(card.logRoots.map(\.path), [theirsA, theirsB])
+        XCTAssertEqual(assembly.identityKeysByCard[card.id], "acct-2|org-2")
+        XCTAssertEqual(assembly.defaultClaudeCoworkRoots?.map(\.path), [mine], "the default card keeps exactly its own sandboxes")
+        let record = try XCTUnwrap(store.records.first { $0.id == card.id })
+        XCTAssertEqual(record.sources.map(\.kind), [.desktop])
+    }
+
+    func testCoworkSandboxesOfAConfigDirAccountAttachAsItsLogRoots() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let sandbox = "\(coworkBase)/local_1/.claude"
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2"}}"#,
+                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-work"]
+        )
+        let cowork = makeCoworkDiscovery(
+            files: [sandbox + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2"}}"#],
+            sandboxes: [sandbox]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: makeDefaultResolvedObserver(),
+            accountsStore: store,
+            claudeDiscovery: discovery,
+            coworkDiscovery: cowork
+        )
+
+        let card = try XCTUnwrap(assembly.claudeCards.first)
+        XCTAssertEqual(assembly.claudeCards.count, 1, "the sandbox joins the config-dir card instead of minting a second one")
+        XCTAssertEqual(card.credential, .configDir(path: "/Users/dev/.claude-work", keychainLiteral: "/Users/dev/.claude-work"))
+        XCTAssertEqual(card.logRoots.map(\.path), ["/Users/dev/.claude-work", sandbox])
+        XCTAssertEqual(assembly.defaultClaudeCoworkRoots?.map(\.path), [], "the other account's sandbox leaves the default walk")
+    }
+
+    func testADistinctCoworkAccountWithoutAnOrgPinGetsNoCardButStaysOutOfTheDefaultWalk() {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let sandbox = "\(coworkBase)/local_1/.claude"
+        let cowork = makeCoworkDiscovery(
+            // An account UUID but no org: Desktop caches tokens per org, so there is no safe
+            // credential pin for a card.
+            files: [sandbox + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-3"}}"#],
+            sandboxes: [sandbox]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
+        )
+
+        XCTAssertTrue(assembly.claudeCards.isEmpty)
+        XCTAssertEqual(
+            assembly.defaultClaudeCoworkRoots?.map(\.path), [],
+            "another account's sessions must still not bleed into the default card's spend"
+        )
+        XCTAssertEqual(store.records.count, 1, "only the default account has a record")
+    }
+
+    func testAnUnidentifiedSandboxStaysOnTheDefaultCardEvenWhenAPartitionExists() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let nameless = "\(coworkBase)/local_1/.claude"
+        let theirs = "\(coworkBase)/local_2/.claude"
+        let cowork = makeCoworkDiscovery(
+            files: [theirs + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2"}}"#],
+            sandboxes: [nameless, theirs]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
+        )
+
+        XCTAssertEqual(assembly.claudeCards.count, 1)
+        XCTAssertEqual(
+            assembly.defaultClaudeCoworkRoots?.map(\.path), [nameless],
+            "a sandbox naming no account keeps counting on the default card, as the built-in walk always has"
         )
     }
 

--- a/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
@@ -349,6 +349,99 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         )
     }
 
+    func testASandboxMissingItsOrgHalfStillCountsAsTheDefaultAccount() {
+        // Identity files sometimes omit the org (older files, files written mid-login). Same
+        // account uuid = same login: the sandbox must stay on the default card, not become a
+        // phantom second account that partitions the walk.
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([
+                "/Users/dev/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1", "organizationUuid": "ORG-1"}}"#,
+            ]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+        let sandbox = "\(coworkBase)/local_1/.claude"
+        let cowork = makeCoworkDiscovery(
+            files: [sandbox + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#],
+            sandboxes: [sandbox]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: store, coworkDiscovery: cowork
+        )
+
+        XCTAssertTrue(assembly.claudeCards.isEmpty)
+        XCTAssertNil(assembly.defaultClaudeCoworkRoots, "no partition — same login, org half or not")
+    }
+
+    func testASandboxCarryingAnOrgTheBareDefaultKeyLacksStillCountsAsTheDefaultAccount() {
+        // The mirror case: the DEFAULT identity file is the one missing its org half.
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let sandbox = "\(coworkBase)/local_1/.claude"
+        let cowork = makeCoworkDiscovery(
+            files: [sandbox + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1", "organizationUuid": "ORG-1"}}"#],
+            sandboxes: [sandbox]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
+        )
+
+        XCTAssertTrue(assembly.claudeCards.isEmpty)
+        XCTAssertNil(assembly.defaultClaudeCoworkRoots)
+    }
+
+    func testATruncatedCoworkScanSkipsRoutingThisLaunch() {
+        // A partial sandbox list must not drive routing: a missed non-default sandbox would bleed
+        // into the default card, and a partial partition would drop default spend. The pass skips
+        // wholesale and the next launch retries.
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let theirs = "\(coworkBase)/local_1/.claude"
+        let cowork = ClaudeCoworkDiscovery(
+            files: FakeFiles([theirs + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2"}}"#]),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") },
+            listSandboxes: { _ in [URL(fileURLWithPath: theirs)] },
+            timeBudget: -1
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
+        )
+
+        XCTAssertTrue(assembly.claudeCards.isEmpty)
+        XCTAssertNil(assembly.defaultClaudeCoworkRoots, "no partition from a partial walk — the built-in walk stays byte-identical")
+    }
+
+    func testAConfigDirMissingItsOrgHalfFoldsOntoTheDefaultCard() throws {
+        // The same one-login-two-key-shapes rule applies to config dirs: a dir whose identity file
+        // omits the org must fold onto the default card, never mint a duplicate.
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([
+                "/Users/dev/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1", "organizationUuid": "ORG-1"}}"#,
+            ]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+        let discovery = makeDiscovery(
+            files: [
+                "/Users/dev/.claude-side/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
+                "/Users/dev/.claude-side/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-1"}}"#,
+            ],
+            subdirectories: ["/Users/dev/.claude-side"]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: store, claudeDiscovery: discovery
+        )
+
+        XCTAssertTrue(assembly.claudeCards.isEmpty)
+        XCTAssertEqual(assembly.defaultClaudeExtraLogRoots.map(\.path), ["/Users/dev/.claude-side"])
+    }
+
     func testARenameNeverBakesIntoTheCardOnlyTheResolverCarriesIt() throws {
         let defaults = makeScratchDefaults()
         let store = ProviderAccountsStore(defaults: defaults)

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -64,6 +64,10 @@ short trail in the log file:
 - `account identity read skipped for claude, codex: login shell cold and no shell-environment
   snapshot exists yet` — a first launch raced a slow login shell, so the named families were left
   unread this launch; every later launch has a persisted snapshot to fall back on.
+- `discovery: …` — the extra-login scan's decision trail: every accepted or skipped config-dir
+  candidate and Cowork sandbox, same-account folds, and the Cowork partition (which sandboxes stay
+  on the default card). Identity hashes and paths only, never emails or tokens — a "my account
+  didn't show up" report is diagnosable from these lines alone.
 
 ## Tips
 

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -50,6 +50,14 @@ card, with its own limits, plan, and spend tiles read from that home. A custom d
 account as your main login doesn't become a second card — its session logs simply count into the main
 card's spend tiles.
 
+Cowork sessions are account-aware too. Each Cowork session folder records which account ran it: sessions
+from your main login keep counting on the main card, and sessions from an account that already has a
+config-dir card count on that card. If Claude Desktop is signed into a *different* account than the CLI,
+its Cowork sessions become their own card, backed read-only by Desktop's login (same Safe Storage read
+as above, pinned to that account's organization so it never borrows another card's token) — with that
+account's limits, plan, and its Cowork sessions as the card's spend. Signing Desktop out again makes
+the card disappear the same way a deleted config dir does.
+
 Extra cards are named from the account ("Claude — Acme Corp"); right-click a card and choose **Rename…**
 (or use the Name field in Customize) to call it whatever you like. A card only shows while its login is
 still found on this Mac — log it out or delete the dir and the card disappears, keeping its

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -56,7 +56,9 @@ config-dir card count on that card. If Claude Desktop is signed into a *differen
 its Cowork sessions become their own card, backed read-only by Desktop's login (same Safe Storage read
 as above, pinned to that account's organization so it never borrows another card's token) — with that
 account's limits, plan, and its Cowork sessions as the card's spend. Signing Desktop out again makes
-the card disappear the same way a deleted config dir does.
+the card disappear the same way a deleted config dir does. Which session belongs to which account is
+decided once at launch; a Cowork session started after that keeps counting live within its card, but a
+session from a *newly appearing* account is sorted onto the right card on the next launch.
 
 Extra cards are named from the account ("Claude — Acme Corp"); right-click a card and choose **Rename…**
 (or use the Name field in Customize) to call it whatever you like. A card only shows while its login is


### PR DESCRIPTION
## TL;DR

Cowork sessions become account-aware: each sandbox names the account that ran it, and a Claude Desktop login distinct from every CLI login gets its own card — backed read-only by Desktop's org-pinned Safe Storage credentials, with its Cowork sessions as the card's spend.

## What was happening

- The Claude card counted **every** Cowork sandbox on the machine, no matter which account ran the session — a Desktop signed into a different account silently bled its spend into the default card.
- A Claude Desktop login with no CLI counterpart was invisible: no card, no limits, no spend.
- The Desktop Safe Storage fallback always followed Desktop's *active* org, which becomes wrong the moment more than one Claude account exists on the machine.

## What this changes

- **`ClaudeCoworkDiscovery` (new):** a launch-time walk over Cowork's session sandboxes that reads each sandbox's own `.claude.json` identity file (no keychain, no credentials, 400ms budget). The walk itself is shared with the spend scanner, so discovery and scanning can never see different sandbox sets.
- **Assembly routing:** sandboxes naming the default account stay exactly where they've always been; sandboxes naming a known config-dir account attach as that card's extra log roots; a distinct account becomes **one** Desktop-backed card. The moment any non-default sandbox exists, the default card's Cowork walk is partitioned so another account's sessions can't bleed into its spend.
- **Org-pinned Desktop credentials:** `ClaudeDesktopAuthStore.load` accepts an organization pin; a Desktop-backed card reads exactly its account's cached token, never Desktop's active org. New `ClaudeCredentialScope.desktopOnly(organization:)`.
- **Default card stays safe:** once extra Claude cards exist, the default card's Desktop fallback is pinned to its own org (parsed from its identity key) — or disabled when that org is unknown — instead of blindly borrowing whatever org Desktop has active.
- **`ClaudeLogUsageScanner`:** gains `coworkRootsOverride` to scan an explicit sandbox set (the partition); cache identity includes the partition so changing it invalidates correctly.
- New `.desktop` source kind on account records; Desktop-backed cards reuse the whole existing account-card pipeline (layout, rename, iCloud identity, CLI/API matching).

## Heads-up

- Signing Desktop out removes the card the same way a deleted config dir does (owner decision: cards render only while their source is found).
- A distinct Cowork account with no org pin gets no card (Desktop caches tokens per org, so an unpinned read could fetch another account's usage) — but its sandboxes still stay out of the default card's spend.
- Sandboxes with no identity file (pre-identity sessions, mid-creation) keep counting on the default card, exactly as the built-in walk always has.

## Tests

- 13 new tests: sandbox identity reading, all four assembly routing paths (default / fold-onto-config-dir-card / distinct-account card / no-org-pin skip), org-pinned Desktop load, `.desktopOnly` scope, pinned standard fallback, and the scanner partition.
- Full suite: 1292 tests pass.
- Live run on this machine: default-only setup unchanged (no sandboxes from other accounts → no partition, byte-identical walk).

Made with [Cursor](https://cursor.com)