### PR TITLE
Add Reset All Settings with confirmation

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyboardShortcuts
 import Observation
 
 /// Composition root: owns the (constant) registry and the (mutable) stores, injected
@@ -220,6 +221,40 @@ final class AppContainer {
     @discardableResult
     func reseedEnabledProviders() -> Task<Void, Never> {
         FirstRunSeeder.reseed(providers: providers, enablement: enablement)
+    }
+
+    /// The Settings "Reset All Settings" action: restores every user preference the container owns to
+    /// its default (see `docs/settings.md` § Reset). Composes the Customize reset (`resetToDefault` +
+    /// provider reseed) with the Settings-only preferences. Deliberately untouched: telemetry (the
+    /// opt-out choice and install id stay independent of settings changes — see the `TelemetryStore`
+    /// note above), the iCloud sync device identity, provider credentials, and cached usage snapshots.
+    /// Launch at Login and the Sparkle update preferences live outside the container; the Settings
+    /// screen resets those alongside this call.
+    func resetAllSettings() {
+        layout.resetToDefault()
+        // The menu-bar Icon Style is a Settings preference, not part of the Customize layout reset.
+        layout.menuBarStyle = .text
+        reseedEnabledProviders()
+        dataStore.resetDisplaySettings()
+        notificationSettings.resetToDefaults()
+        transparency.resetToDefaults()
+        privacy.hideUsageWhileScreenSharing = false
+        // Same as flipping the Settings toggle off: stops syncing and removes this Mac's document
+        // from the shared iCloud container (peers keep their own history).
+        iCloudSync.enabled = false
+        // Removing an `@AppStorage` key restores its declared default; the Settings screen's
+        // `@AppStorage` properties observe the change. New settings must be added here.
+        for key in [
+            AppearanceSetting.key, TimeFormatSetting.key, DensitySetting.key,
+            LogLevelSetting.key, TotalSpendSetting.key,
+            TotalSpendSetting.periodKey, TotalSpendSetting.metricKey,
+        ] {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        KeyboardShortcuts.reset(.togglePopover)
+        AppearanceSetting.applyCurrent()
+        AppLog.reloadLevel()
+        AppLog.info(.config, "All settings reset to defaults")
     }
 
     /// Drives live updates: refresh on launch, then again every refresh interval. Each pass honors the

--- a/Sources/OpenUsage/App/UpdaterController.swift
+++ b/Sources/OpenUsage/App/UpdaterController.swift
@@ -100,6 +100,15 @@ final class UpdaterController {
         AppLog.info(.updates, "started (feed present)")
     }
 
+    /// Restores the update preferences to their defaults — the Settings "Reset All Settings" path:
+    /// stable channel, automatic checks on (the release Info.plist ships `SUEnableAutomaticChecks`
+    /// true). A dormant updater (dev build, no feed) has no auto-check state to restore; the
+    /// pass-through setter is a no-op there.
+    func resetToDefaults() {
+        betaChannelEnabled = false
+        automaticallyChecksForUpdates = true
+    }
+
     /// User-initiated check. Shows Sparkle's standard UI (progress, release notes, install prompt).
     func checkForUpdates() {
         guard let controller else { return }

--- a/Sources/OpenUsage/Stores/NotificationSettingsStore.swift
+++ b/Sources/OpenUsage/Stores/NotificationSettingsStore.swift
@@ -51,4 +51,11 @@ final class NotificationSettingsStore {
     /// first trigger is turned on) and whether the Settings permission notice should show. Turning all
     /// three off silences everything.
     var anyEnabled: Bool { underTenPercent || healthyToClose || closeToRunningOut }
+
+    /// Restores all three triggers to their default (off) — the Settings "Reset All Settings" path.
+    func resetToDefaults() {
+        underTenPercent = false
+        healthyToClose = false
+        closeToRunningOut = false
+    }
 }

--- a/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
+++ b/Sources/OpenUsage/Stores/PopoverTransparencyStore.swift
@@ -88,6 +88,14 @@ final class PopoverTransparencyStore {
         AppLog.info(.statusItem, "Too-much-transparency egg \(active ? "enabled" : "disabled")")
     }
 
+    /// Restores the transparency preference to its default (off) and exits the easter egg — the
+    /// Settings "Reset All Settings" path. Without the egg exit, a reset during Party/Drunk Mode
+    /// would keep overriding the freshly-reset preference with the party look.
+    func resetToDefaults() {
+        setSecretCode(false)
+        increaseTransparency = false
+    }
+
     /// Flips the on-screen flag from `StatusItemController`'s show/hide chokepoints. Guards on change so a
     /// redundant set doesn't churn observers. Orthogonal to `effectiveStyle` (it never enters `resolve`),
     /// so toggling it re-renders only the SwiftUI egg's mount gate, never the AppKit backdrop crossfade.

--- a/Sources/OpenUsage/Stores/TotalSpendSetting.swift
+++ b/Sources/OpenUsage/Stores/TotalSpendSetting.swift
@@ -5,4 +5,8 @@ import Foundation
 /// per-provider spend rows it aggregates stay wherever the user put them.
 enum TotalSpendSetting {
     static let key = "showTotalSpend"
+    /// The card's selected period (Today / Yesterday / 30 Days), persisted by `TotalSpendCard`.
+    static let periodKey = "openusage.totalSpend.period"
+    /// The card's selected metric (Cost / Cost/MTok / Tokens), persisted by `TotalSpendCard`.
+    static let metricKey = "openusage.totalSpend.metric"
 }

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -103,6 +103,15 @@ final class WidgetDataStore {
         didSet { defaults.set(alwaysShowPacing, forKey: Self.alwaysShowPacingKey) }
     }
 
+    /// Restores the Usage Display preferences (meter style, reset-time format, always-show-pacing) to
+    /// their defaults — the Settings "Reset All Settings" path. Cached usage snapshots are data, not
+    /// settings, and stay untouched.
+    func resetDisplaySettings() {
+        meterStyle = .remaining
+        resetDisplayMode = .relative
+        alwaysShowPacing = false
+    }
+
     init(
         registry: WidgetRegistry,
         providers: [ProviderRuntime],

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -29,6 +29,14 @@ struct SettingsScreen: View {
     /// System Settings after re-enabling).
     private enum NotificationsAuthState { case authorized, denied, notDetermined }
     @State private var notificationsAuth: NotificationsAuthState = .authorized
+    /// Gates the destructive Reset All Settings action behind a confirmation alert. View-local state:
+    /// leaving the Settings screen (or the popover closing, which resets the screen to the dashboard)
+    /// unmounts this view and drops a pending confirmation with it.
+    @State private var isPresentingResetConfirm = false
+    /// Remounts `ShortcutRecorderField` after a reset. The field seeds its chip from the
+    /// KeyboardShortcuts store only on appear (the store isn't observable), so without a fresh
+    /// identity the still-mounted Settings screen would keep showing the cleared shortcut.
+    @State private var shortcutFieldGeneration = 0
 
     /// Fills the region the dashboard's pinned footer leaves. Same scroller treatment as Customize:
     /// the overlay scroller stays (the scroll edge effect needs it) but is invisible.
@@ -67,6 +75,7 @@ struct SettingsScreen: View {
                 // Click-to-record field; its ⓧ clears the combo and disables the shortcut.
                 row("Global Shortcut") {
                     ShortcutRecorderField(name: .togglePopover)
+                        .id(shortcutFieldGeneration)
                         .hoverTooltip("Open OpenUsage from anywhere")
                 }
             }
@@ -350,9 +359,9 @@ struct SettingsScreen: View {
 
     // MARK: - Advanced (logging)
 
-    /// Log-level control plus copy/reveal buttons for the file log. The file lives at a fixed path
-    /// (`~/Library/Logs/OpenUsage/OpenUsage.log`); raising the level here applies live (no restart) and
-    /// persists across launches. Default Info, Debug is opt-in.
+    /// Log-level control plus copy/reveal buttons for the file log, and the Reset All Settings row.
+    /// The file lives at a fixed path (`~/Library/Logs/OpenUsage/OpenUsage.log`); raising the level
+    /// here applies live (no restart) and persists across launches. Default Info, Debug is opt-in.
     private var advancedSection: some View {
         section("Advanced") {
             row("Log Level") {
@@ -379,6 +388,32 @@ struct SettingsScreen: View {
             }
             if let logActionError {
                 inlineNotice(logActionError)
+            }
+            // The Settings-wide destructive reset (issue #602). Red label, confirmation alert;
+            // confirming restores every preference to its default — the container-owned stores plus
+            // the two view-scoped ones (Launch at Login lives in the system's login-item registry,
+            // the update preferences on the updater controller).
+            Button {
+                isPresentingResetConfirm = true
+            } label: {
+                Text("Reset All Settings…")
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity)
+            }
+            .glassButtonStyle()
+            .controlSize(.regular)
+            .padding(.horizontal, 12)
+            .padding(.vertical, density.controlRowPadding)
+            .alert("Reset All Settings?", isPresented: $isPresentingResetConfirm) {
+                Button("Reset", role: .destructive) {
+                    withAnimation(Motion.spring) { container.resetAllSettings() }
+                    launchAtLogin.update(to: false)
+                    updater.resetToDefaults()
+                    shortcutFieldGeneration += 1
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Restores every setting and customization to its default and turns providers back on for the tools you have installed. If iCloud sync is on, it turns off and this Mac's synced history is removed. This cannot be undone.")
             }
         }
     }

--- a/Sources/OpenUsage/Views/TotalSpendCard.swift
+++ b/Sources/OpenUsage/Views/TotalSpendCard.swift
@@ -15,9 +15,9 @@ struct TotalSpendCard: View {
     @Namespace private var pickerNamespace
 
     /// The selected period survives popover closes and relaunches, like the meter-style toggles.
-    @AppStorage("openusage.totalSpend.period") private var periodRawValue = TotalSpendPeriod.today.rawValue
+    @AppStorage(TotalSpendSetting.periodKey) private var periodRawValue = TotalSpendPeriod.today.rawValue
     /// The selected metric (Cost / Cost/MTok / Tokens) survives the same way.
-    @AppStorage("openusage.totalSpend.metric") private var metricRawValue = TotalSpendMetric.cost.rawValue
+    @AppStorage(TotalSpendSetting.metricKey) private var metricRawValue = TotalSpendMetric.cost.rawValue
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
 
     private var period: TotalSpendPeriod {

--- a/Tests/OpenUsageTests/NotificationSettingsStoreTests.swift
+++ b/Tests/OpenUsageTests/NotificationSettingsStoreTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class NotificationSettingsStoreTests: XCTestCase {
+    func testResetToDefaultsTurnsAllTriggersOffAndPersists() {
+        let suiteName = "OpenUsageTests.notification-settings-reset.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = NotificationSettingsStore(defaults: defaults)
+        store.underTenPercent = true
+        store.healthyToClose = true
+        store.closeToRunningOut = true
+
+        store.resetToDefaults()
+
+        XCTAssertFalse(store.anyEnabled)
+        // A second store on the same suite must load the defaults back, not the pre-reset values.
+        let reloaded = NotificationSettingsStore(defaults: defaults)
+        XCTAssertFalse(reloaded.underTenPercent)
+        XCTAssertFalse(reloaded.healthyToClose)
+        XCTAssertFalse(reloaded.closeToRunningOut)
+    }
+}

--- a/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
+++ b/Tests/OpenUsageTests/PopoverTransparencyStoreTests.swift
@@ -245,4 +245,20 @@ final class PopoverTransparencyStoreTests: XCTestCase {
         XCTAssertTrue(store.popoverShown)
         XCTAssertFalse(PopoverTransparencyStore(defaults: defaults).popoverShown, "not persisted")
     }
+
+    func testResetToDefaultsTurnsOffTransparencyAndExitsTheEgg() {
+        let defaults = makeDefaults("reset")
+        let store = PopoverTransparencyStore(defaults: defaults)
+        store.increaseTransparency = true
+        store.toggleSecretCode()
+        store.drunkMode = true
+
+        store.resetToDefaults()
+
+        XCTAssertFalse(store.increaseTransparency)
+        XCTAssertFalse(store.secretCodeActive, "reset exits the egg so it can't override the reset look")
+        XCTAssertFalse(store.drunkMode)
+        // A fresh store reading the same defaults sees the reset value.
+        XCTAssertFalse(PopoverTransparencyStore(defaults: defaults).increaseTransparency)
+    }
 }

--- a/Tests/OpenUsageTests/WidgetDataStoreTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreTests.swift
@@ -669,6 +669,27 @@ final class WidgetDataStoreTests: XCTestCase {
         XCTAssertEqual(store.data(for: descriptor).valueText, "20%")
     }
 
+    func testResetDisplaySettingsRestoresDefaultsAndPersists() {
+        let provider = Provider(id: "test", displayName: "Test", icon: .providerMark("codex"))
+        let registry = WidgetRegistry(providers: [provider], descriptors: [])
+        let defaults = makeUserDefaults("reset-display-settings")
+        let store = WidgetDataStore(registry: registry, providers: [], defaults: defaults)
+        store.meterStyle = .used
+        store.resetDisplayMode = .absolute
+        store.alwaysShowPacing = true
+
+        store.resetDisplaySettings()
+
+        XCTAssertEqual(store.meterStyle, .remaining)
+        XCTAssertEqual(store.resetDisplayMode, .relative)
+        XCTAssertFalse(store.alwaysShowPacing)
+        // A second store on the same suite must load the defaults back, not the pre-reset values.
+        let reloaded = WidgetDataStore(registry: registry, providers: [], defaults: defaults)
+        XCTAssertEqual(reloaded.meterStyle, .remaining)
+        XCTAssertEqual(reloaded.resetDisplayMode, .relative)
+        XCTAssertFalse(reloaded.alwaysShowPacing)
+    }
+
     private func makeUserDefaults(_ name: String) -> UserDefaults {
         let suiteName = "OpenUsageTests.\(name).\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -66,8 +66,13 @@ All three alerts default off. The first time you turn one on, OpenUsage asks for
 | Log Level | Error / Warning / Info / Debug | How much detail the app writes to its log file. Defaults to Info and persists across launches; raise to Debug while reproducing a problem. Applies immediately. |
 | Copy Log Path | button | Copies the log file path (`~/Library/Logs/OpenUsage/OpenUsage.log`) to the clipboard. |
 | Reveal in Finder | button | Opens a Finder window with the log file selected. |
+| Reset All Settings… | button | Restores every setting to its default, behind a confirmation alert. |
 
 See [Logging](logging.md) for the full behavior: subsystem tags, the file size cap, and the guarantee that secrets are never written.
+
+**Reset All Settings…** restores every setting on this screen to its default — appearance, usage display, notifications, privacy, log level, the global shortcut (cleared), Launch at Login (turned off), iCloud sync (turned off), and the update preferences (stable channel, automatic checks on) — and also resets all customization, exactly like Customize's Reset All: default layout, order, and menu-bar stars, with providers turned back on for the tools you have installed. The reset cannot be undone.
+
+Not touched: provider logins and API keys, cached usage data, and your Share Anonymous Usage choice. Turning iCloud sync off as part of the reset works exactly like flipping its toggle off: this Mac's synced history is removed from the shared iCloud data, and your other Macs keep their own.
 
 ## Updates
 


### PR DESCRIPTION
**TL;DR** — Adds a Reset All Settings button (red, behind a confirmation) to Settings → Advanced, restoring every setting and customization to its default. Closes #602.

## What was happening

- There was no way to return OpenUsage to its defaults short of deleting preferences by hand.

## What this changes

- A red "Reset All Settings…" row in Settings → Advanced, guarded by a confirmation alert.
- Confirming restores appearance, usage display, notifications, privacy, log level, the global shortcut, Launch at Login, update preferences, and runs the full Customize reset with provider re-detection — live, no relaunch.
- iCloud sync turns off exactly like its toggle: this Mac's synced history is removed; other Macs keep theirs.
- Not touched: provider credentials, cached usage data, the Share Anonymous Usage choice.

## Heads-up

- The shortcut recorder field is remounted after a reset (its chip only reads the store on appear).

## Tests

- Unit tests for each store's new reset method; full suite green.
- Verified end-to-end in a dev build: toggles flipped → reset → defaults restored live, confirmed in the defaults domain.

## Screenshots

<img width="320" height="1049" alt="shipped-b-red" src="https://github.com/user-attachments/assets/facc6fc2-2af9-46cd-9439-3c01e37f457b" />

<img width="320" height="1049" alt="shipped-b-alert" src="https://github.com/user-attachments/assets/57bf514a-da5e-45af-ba4d-dca89845126b" />
