### PR TITLE
Stop redundant status-item redraws; cap the strip render loop at 4 Hz

### DIFF
--- a/Sources/OpenUsage/App/StatusItemImageUpdater.swift
+++ b/Sources/OpenUsage/App/StatusItemImageUpdater.swift
@@ -11,6 +11,10 @@ import Observation
 final class StatusItemImageUpdater {
     private let container: AppContainer
     private let apply: (NSImage) -> Void
+    /// Last image handed to `apply`; the renderer memoizes by content, so an identical instance means
+    /// the button already shows this render — skip the set (an unconditional set still costs a full
+    /// status-item redraw round-trip through WindowServer on macOS 26+).
+    private var lastApplied: NSImage?
 
     /// - Parameter apply: sets the rendered image onto the status-item button.
     init(container: AppContainer, apply: @escaping (NSImage) -> Void) {
@@ -27,14 +31,18 @@ final class StatusItemImageUpdater {
                 self?.scheduleDelayedUpdate()
             }
         }
+        guard image !== lastApplied else { return }
+        lastApplied = image
         apply(image)
     }
 
     /// The observation callback fires only once until `update()` reads and re-arms it. Waiting here lets
-    /// any immediately-following writes land first; the eventual render then reads their latest values.
+    /// any immediately-following writes land first and caps the loop at ~4 Hz — the old 50ms window
+    /// let bursty observation churn drive it at up to 20 Hz, which macOS 27 beta's status-item redraw
+    /// path amplified into sustained CPU burn.
     private func scheduleDelayedUpdate() {
         Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(50))
+            try? await Task.sleep(for: .milliseconds(250))
             guard !Task.isCancelled else { return }
             self?.update()
         }


### PR DESCRIPTION
Fixes #1039.

## TL;DR

The menu-bar strip re-rendered and re-applied its image far more often than the visible content changed; macOS 27 beta's status-item redraw path turns that into 40-60% sustained CPU. This skips the redundant applies and caps the observation loop at 4 Hz. Measured ~50% → 3.5% on an M1 Max running 26A5388g.

## What was happening

- `StatusItemImageUpdater.update()` called `apply(image)` unconditionally — even when the memoized renderer returned the *same* `NSImage` instance. Setting the same image still costs a full status-item redraw round-trip through WindowServer.
- The observation re-render waited only 50ms, so bursty snapshot writes could drive the loop at up to 20 Hz.
- A 3s spindump showed the main thread's cpu time dominated by the `com.apple.CoreGraphics.RemoteContexts` queue (repeated strip draws), with `NSEventThread` pulling a matching WindowServer event storm. Stable macOS tolerates the redundant sets cheaply, which is why this never surfaced before.
- Part of the burn traces further down into an OS regression: with an accessibility-customized cursor color, macOS 26+ re-renders the cursor image in-process on every `NSCursor set`, in every app. That one is Apple's bug (being filed separately) — but the redundant redraws here amplified it, and they're wasted work on any OS.

## What this changes

- `update()` remembers the last applied instance and skips `apply` when it hasn't changed. Pure redundancy elimination; behavior identical everywhere.
- The coalesce window widens 50ms → 250ms, capping the observation-driven loop at 4 Hz.

## Heads-up

- A real strip change (including the screen-share privacy swap) can now lag by up to 250ms — imperceptible in practice, but it's a bound the old code didn't have.

## Tests

- `swift test --filter MenuBar` — 42 tests green; the dedup leans on the memoized-instance contract already covered by `MenuBarStripMemoTests`.
- Verified live per AGENTS.md: killed the running app, `script/build_and_run.sh run`, measured 60s cputime deltas — sustained ~50% before, 3.5% after.

## Screenshots

No visual change — the strip renders identically; this only removes redundant redraws and caps their frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
