### PR TITLE
Price Claude Opus 5 in the pricing supplement

### DIFF
--- a/Sources/OpenUsage/Pricing/PricingSupplement.swift
+++ b/Sources/OpenUsage/Pricing/PricingSupplement.swift
@@ -8,6 +8,8 @@ struct PricingSupplement: Sendable {
     /// Models priced directly by the supplement (highest-precedence source).
     let pricing: [String: ModelRates]
     /// Base-model -> fast-variant multiplier, for `-fast` slugs whose catalogs carry no `fast` field.
+    /// Also applied to the base model's own rates, so requests flagged fast by the scanner (rather
+    /// than by a `-fast` slug) bill at the fast rate.
     let fastMultipliers: [String: Double]
     let aliasRules: [AliasRule]
     let updatedAt: String?
@@ -76,7 +78,10 @@ extension PricingSupplement {
                 outputPerMillion: entry.outputPerMillion,
                 cacheWritePerMillion: entry.cacheWritePerMillion ?? entry.inputPerMillion,
                 cacheReadPerMillion: entry.cacheReadPerMillion ?? entry.inputPerMillion * 0.1,
-                cacheReadIsExplicit: entry.cacheReadPerMillion != nil
+                cacheReadIsExplicit: entry.cacheReadPerMillion != nil,
+                // Carry the declared multiplier onto the entry itself: scanners that flag fast mode
+                // on the request (Claude's `speed` field) price the base slug, never a `-fast` one.
+                fastMultiplier: file.fastMultipliers?[model] ?? 1
             )
         }
         var rules: [AliasRule] = []

--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
-  "updated_at": "2026-07-14",
+  "updated_at": "2026-07-24",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -84,6 +84,20 @@
       "cache_read_per_million": 1.0,
       "output_per_million": 50.0
     },
+    "claude-opus-5": {
+      "$comment": "Claude Opus 5 launch pricing (Anthropic Opus-tier rates: $5/$25, 1.25x 5m cache write, 0.1x cache read). LiteLLM, models.dev, and Cursor have not listed the model yet, so it would otherwise show as an unpriced model.",
+      "input_per_million": 5.0,
+      "cache_write_per_million": 6.25,
+      "cache_read_per_million": 0.5,
+      "output_per_million": 25.0
+    },
+    "claude-opus-5-fast": {
+      "$comment": "Opus 5 fast mode: 2x the Opus 5 base rate, the same fast multiplier Anthropic and Cursor apply to Opus 4.8 fast mode.",
+      "input_per_million": 10.0,
+      "cache_write_per_million": 12.5,
+      "cache_read_per_million": 1.0,
+      "output_per_million": 50.0
+    },
     "claude-4-sonnet-1m": {
       "$comment": "Cursor's long-context Sonnet 4 tier: the whole request bills at the >200k rate.",
       "input_per_million": 6.0,
@@ -154,6 +168,8 @@
     { "pattern": "^claude-opus-4-7(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-4-7" },
     { "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-opus-4-8-fast" },
     { "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-4-8" },
+    { "pattern": "^claude-opus-5(?:\\[1m\\])?(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-opus-5-fast" },
+    { "pattern": "^claude-opus-5(?:\\[1m\\])?(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-5" },
     { "pattern": "^claude-fable-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-fable-5" },
     { "pattern": "^claude-sonnet-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-sonnet-5" },
     { "pattern": "^gemini-2\\.5-flash$", "canonical": "gemini-2.5-flash" },

--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -126,6 +126,7 @@
     }
   },
   "fast_multipliers": {
+    "claude-opus-5": 2.0,
     "gpt-5": 2.0,
     "gpt-5.1-codex": 2.0,
     "gpt-5.1-codex-max": 2.0,

--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -85,14 +85,14 @@
       "output_per_million": 50.0
     },
     "claude-opus-5": {
-      "$comment": "Claude Opus 5 launch pricing (Anthropic Opus-tier rates: $5/$25, 1.25x 5m cache write, 0.1x cache read). LiteLLM, models.dev, and Cursor have not listed the model yet, so it would otherwise show as an unpriced model.",
+      "$comment": "Claude Opus 5 launch pricing per anthropic.com/news/claude-opus-5: $5 input / $25 output per million, plus the standard Anthropic cache multipliers (1.25x 5m cache write, 0.1x cache read). LiteLLM, models.dev, and Cursor have not listed the model yet, so it would otherwise show as an unpriced model.",
       "input_per_million": 5.0,
       "cache_write_per_million": 6.25,
       "cache_read_per_million": 0.5,
       "output_per_million": 25.0
     },
     "claude-opus-5-fast": {
-      "$comment": "Opus 5 fast mode: 2x the Opus 5 base rate, the same fast multiplier Anthropic and Cursor apply to Opus 4.8 fast mode.",
+      "$comment": "Opus 5 fast mode: the launch announcement prices it at twice the Opus 5 base rate, matching the fast multiplier already used for Opus 4.8.",
       "input_per_million": 10.0,
       "cache_write_per_million": 12.5,
       "cache_read_per_million": 1.0,

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -120,6 +120,20 @@ final class PricingBundledResourceTests: XCTestCase {
         let opus48 = try XCTUnwrap(pricing.resolve(model: "claude-opus-4-8"))
         XCTAssertEqual(opus5.inputPerMillion, opus48.inputPerMillion)
         XCTAssertEqual(opus5.outputPerMillion, opus48.outputPerMillion)
+        XCTAssertEqual(opus5.fastMultiplier, opus48.fastMultiplier)
+    }
+
+    /// Claude logs signal fast mode with a `speed` field while the model stays `claude-opus-5`, so
+    /// the base entry itself must carry the 2x multiplier — the `-fast` slug is never involved.
+    func testClaudeOpus5FastModeBillsAtTwiceBaseRate() throws {
+        let pricing = Self.pricing
+        let opus5 = try XCTUnwrap(pricing.resolve(model: "claude-opus-5"))
+        XCTAssertEqual(opus5.fastMultiplier, 2.0)
+
+        let tokens = TokenBreakdown(input: 1_000_000, cacheWrite5m: 1_000_000, cacheRead: 1_000_000, output: 1_000_000)
+        var fastTokens = tokens
+        fastTokens.isFast = true
+        XCTAssertEqual(opus5.costDollars(for: fastTokens), opus5.costDollars(for: tokens) * 2, accuracy: 0.000_001)
     }
 
     func testGPT56PricingAndAliases() throws {

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -101,6 +101,27 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(sonnet5.outputPerMillion, sonnet46.outputPerMillion)
     }
 
+    /// Claude Opus 5: standard Opus-tier rates from the supplement (no public catalog lists it yet),
+    /// with the `[1m]`, thinking/effort, and fast slug variants resolving to the right entry.
+    func testClaudeOpus5PricingAndAliases() throws {
+        let pricing = Self.pricing
+        let opus5 = try XCTUnwrap(pricing.resolve(model: "claude-opus-5"))
+        XCTAssertEqual(opus5.inputPerMillion, 5.0)
+        XCTAssertEqual(opus5.cacheWritePerMillion, 6.25)
+        XCTAssertEqual(opus5.cacheReadPerMillion, 0.5)
+        XCTAssertEqual(opus5.outputPerMillion, 25.0)
+        XCTAssertEqual(pricing.resolve(model: "claude-opus-5[1m]"), opus5)
+        XCTAssertEqual(pricing.resolve(model: "claude-opus-5-thinking-xhigh"), opus5)
+
+        let opus5Fast = try XCTUnwrap(pricing.resolve(model: "claude-opus-5-thinking-high-fast"))
+        XCTAssertEqual(opus5Fast.inputPerMillion, opus5.inputPerMillion * 2)
+        XCTAssertEqual(opus5Fast.outputPerMillion, opus5.outputPerMillion * 2)
+
+        let opus48 = try XCTUnwrap(pricing.resolve(model: "claude-opus-4-8"))
+        XCTAssertEqual(opus5.inputPerMillion, opus48.inputPerMillion)
+        XCTAssertEqual(opus5.outputPerMillion, opus48.outputPerMillion)
+    }
+
     func testGPT56PricingAndAliases() throws {
         let pricing = Self.pricing
         let sol = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-sol-ultra"))


### PR DESCRIPTION
**TL;DR** — Claude Opus 5 shows up in Claude logs but no public pricing catalog lists it yet, so its spend was dropped and the tiles showed an unknown-model warning. This adds Opus 5 (and its fast mode) to the pricing supplement.

**What was happening**

- Claude logs now carry `claude-opus-5` (and the `claude-opus-5[1m]` long-context variant).
- None of the three pricing sources knows the model: the live LiteLLM feed, live models.dev, and Cursor's models & pricing page all still stop at Opus 4.8 / Fable 5.
- A model no source can price is left out of the spend figures entirely, so Opus 5 tokens didn't count toward the day's tile, the Usage Trend, or the model breakdown — and the affected tiles carried the "Unknown model found - claude-opus-5" warning triangle.

**What this changes**

- Adds a `claude-opus-5` supplement entry at Anthropic's Opus-tier rates: $5 input / $6.25 5m cache write / $0.50 cache read / $25 output per million tokens — identical to Opus 4.8.
- Adds `claude-opus-5-fast` at 2x the base rate ($10 / $12.50 / $1.00 / $50), the same fast multiplier applied to Opus 4.8 fast mode.
- Adds alias rules covering the slug variants: `claude-opus-5[1m]`, `-thinking`, and the effort suffixes (`low`/`medium`/`high`/`xhigh`/`max`), each with a `-fast` counterpart.
- Makes `PricingSupplement.decode` carry the top-level `fast_multipliers` map onto the base model's own rates, and declares `claude-opus-5: 2.0` there. Claude logs flag fast mode with a `speed` field while the model slug stays `claude-opus-5`, so the base entry's multiplier — not the `-fast` slug — is what prices those requests; supplement entries previously always decoded with a multiplier of 1, which would have billed native fast-mode Opus 5 at half the real rate. (Opus 4.8 avoids this only because LiteLLM's entry carries `"fast": 2.0`.) Codex is unaffected — it overrides `fastMultiplier` with its own service-tier value.
- Bumps `updated_at`, so merging republishes the supplement to gh-pages and installed apps pick the prices up within about an hour — no release needed.

**Heads-up**

- The `[1m]` alias is load-bearing rather than cosmetic. Supplement lookups are exact-match only; `claude-opus-4-8[1m]` prices today only because it fuzzy-matches the LiteLLM key. With no catalog entry for Opus 5 to fuzzy-match against, the 1M-context slug would stay unpriced without an explicit alias.
- The rates are confirmed by the launch announcement ([anthropic.com/news/claude-opus-5](https://www.anthropic.com/news/claude-opus-5)): "$5 per million input tokens", "$25 per million output tokens", and fast mode "available at twice Opus 5's base price". The announcement publishes no cache or long-context tiers, so the entries use Anthropic's standard cache multipliers (1.25x 5m write, 0.1x read) and no >200k tier — identical to how Opus 4.8 is priced in LiteLLM today. Worth a re-check if a long-context tier is announced later.
- Once LiteLLM or models.dev add the model, the supplement entry keeps winning (it is the highest-precedence layer). If their rates ever diverge from these, delete the entry and let the public catalogs take over.

**Tests**

- New `testClaudeOpus5PricingAndAliases` in `PricingBundledResourceTests` asserts the base rates, that `claude-opus-5[1m]` and `claude-opus-5-thinking-xhigh` resolve to the same entry, that fast mode is 2x base, and that Opus 5 matches Opus 4.8.
- New `testClaudeOpus5FastModeBillsAtTwiceBaseRate` covers the request-flagged fast path (`speed: "fast"` on the base slug), plus a `fastMultiplier` parity assertion against Opus 4.8.
- `swift test` — 1281 tests, 0 failures.

