### PR TITLE
Fix background CPU: gate periodic TimelineViews on popover visibility

### DIFF
--- a/Sources/OpenUsage/Support/PartyMode.swift
+++ b/Sources/OpenUsage/Support/PartyMode.swift
@@ -15,12 +15,15 @@ extension EnvironmentValues {
     }
 }
 
-/// Whether the hosting popover is currently on-screen. The easter-egg animation loops read this to
-/// **mount** their `TimelineView(.animation)` clocks only while the popover is visible and drop to a
-/// static frame when it isn't, so a closed popover with the egg still active runs no display link and
-/// spends no CPU. Default `false`, so the windowless ShareCard export and any non-popover host never
-/// mount the loops. Seeded from `PopoverTransparencyStore.popoverShown`, which `StatusItemController`
-/// flips at its `showPanel`/`hidePanel` chokepoints.
+/// Whether the hosting popover is currently on-screen. The easter-egg animation loops, plus any clock-
+/// driven text (footer countdown, per-row reset ticks, iCloud "Updated Xm ago" labels), read this to
+/// **mount** their `TimelineView` clocks only while the popover is visible and drop to a static frame
+/// when it isn't. This matters because `NSHostingView` drives `TimelineView` with a plain `NSTimer`, not
+/// a display link tied to on-screen state — hiding the panel via `orderOut` alone never pauses it, so an
+/// ungated clock ticks (and re-lays-out the whole hosted tree) forever in the background. Default
+/// `false`, so the windowless ShareCard export and any non-popover host never mount the loops. Seeded
+/// from `PopoverTransparencyStore.popoverShown`, which `StatusItemController` flips at its
+/// `showPanel`/`hidePanel` chokepoints.
 ///
 /// This is a STRUCTURAL mount gate (`if shown { TimelineView } else { static }`), deliberately NOT the
 /// reverted `TimelineView(.animation(paused: !shown))` overload (commit 1ef9c4e): that overload froze
@@ -63,6 +66,32 @@ struct VisibilityGatedTimeline<Content: View>: View {
         } else {
             content(Date().timeIntervalSinceReferenceDate)
                 .transition(.identity)
+        }
+    }
+}
+
+/// The `.periodic(from:by:)` counterpart to `VisibilityGatedTimeline`, for countdown/tick text (footer
+/// "next update in", per-row reset countdowns, "Updated Xm ago" labels) rather than continuous animation.
+/// Same STRUCTURAL mount gate and the same reason it exists: `NSHostingView` schedules `.periodic` via a
+/// plain `NSTimer`, so nothing about hiding the panel with `orderOut` stops it on its own — unmounting is
+/// what actually silences the timer. Shows a single static frame (now) while hidden.
+struct VisibilityGatedPeriodicTimeline<Content: View>: View {
+    @Environment(\.popoverIsVisible) private var shown
+    private let interval: TimeInterval
+    private let content: (Date) -> Content
+
+    init(every interval: TimeInterval, @ViewBuilder content: @escaping (Date) -> Content) {
+        self.interval = interval
+        self.content = content
+    }
+
+    var body: some View {
+        if shown {
+            TimelineView(.periodic(from: .now, by: interval)) { timeline in
+                content(timeline.date)
+            }
+        } else {
+            content(Date())
         }
     }
 }

--- a/Sources/OpenUsage/Views/ICloudSyncSettingsSection.swift
+++ b/Sources/OpenUsage/Views/ICloudSyncSettingsSection.swift
@@ -89,8 +89,8 @@ struct ICloudSyncSettingsSection: View {
                             .fixedSize()
                     }
                 }
-                TimelineView(.periodic(from: .now, by: 60)) { context in
-                    Text("Updated \(relativeAge(document.updatedAt, now: context.date))")
+                VisibilityGatedPeriodicTimeline(every: 60) { now in
+                    Text("Updated \(relativeAge(document.updatedAt, now: now))")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)

--- a/Sources/OpenUsage/Views/PopoverFooter.swift
+++ b/Sources/OpenUsage/Views/PopoverFooter.swift
@@ -68,9 +68,9 @@ struct PopoverFooter: View {
         Button {
             refreshNow()
         } label: {
-            TimelineView(.periodic(from: .now, by: 1)) { context in
+            VisibilityGatedPeriodicTimeline(every: 1) { now in
                 HStack(spacing: 5) {
-                    Text(updateStatusText(now: context.date))
+                    Text(updateStatusText(now: now))
                         .monospacedDigit()
                         .contentTransition(.numericText())
                     if isUpdating {

--- a/Sources/OpenUsage/Views/WidgetRowView.swift
+++ b/Sources/OpenUsage/Views/WidgetRowView.swift
@@ -48,11 +48,14 @@ struct WidgetRowView: View {
     var body: some View {
         // A row with a concrete reset date derives time-sensitive state (reset countdown, pace marker,
         // "Runs out in …") from the current clock, so it re-renders on a 30s tick — the cadence the
-        // original app uses — instead of waiting for the next data refresh. TimelineView only schedules
-        // ticks while the popover is actually visible. Rows without a reset date are static.
+        // original app uses — instead of waiting for the next data refresh.
+        // `VisibilityGatedPeriodicTimeline` only mounts that tick while the popover is on-screen (see
+        // `PartyMode.swift`); a plain `TimelineView` here would keep ticking, and re-laying-out this row,
+        // forever after the panel is hidden, since `orderOut` alone doesn't pause it. Rows without a
+        // reset date are static.
         Group {
             if data.resetsAt != nil || !data.expiriesAt.isEmpty {
-                TimelineView(.periodic(from: .now, by: 30)) { _ in
+                VisibilityGatedPeriodicTimeline(every: 30) { _ in
                     rowContent
                 }
             } else {


### PR DESCRIPTION
## TL;DR
The app was burning steady background CPU (~5%) with just the tray icon showing and no window open, because several `TimelineView` clocks kept ticking after the popover was hidden. This gates them so they stop when the popover isn't visible.

## What was happening
- `StatusItemController` hides the panel via `panel.orderOut(nil)` without tearing down the hosted SwiftUI tree, so the view graph stays fully mounted and alive in the background.
- `PopoverFooter`'s 1s countdown, `WidgetRowView`'s 30s reset-tick, and `ICloudSyncSettingsSection`'s 60s "Updated Xm ago" label each used a raw `TimelineView(.periodic(...))` with no visibility gate.
- `NSHostingView` drives `.periodic` schedules with a plain `NSTimer`, not a display link tied to on-screen state — so hiding the panel with `orderOut` never paused these timers.
- Every tick forced a full `NSHostingView.layout()` pass (visible in an Instruments/`sample` trace as deep, repeated `sizeThatFits`/`StackLayout` recursion and `CA::Transaction::commit()` work), even with nothing on screen.

## What this changes
- Adds `VisibilityGatedPeriodicTimeline` in `PartyMode.swift` — the `.periodic` counterpart to the existing `VisibilityGatedTimeline` already used to gate the party-mode egg animation on `\.popoverIsVisible`.
- Switches all three ungated call sites (`PopoverFooter`, `WidgetRowView`, `ICloudSyncSettingsSection`) to it, so each clock structurally unmounts (and its timer actually stops) whenever the popover isn't on-screen, and remounts instantly on reopen.
- Corrects a stale comment in `WidgetRowView.swift` that incorrectly claimed `TimelineView` already paused itself while hidden.

## Heads-up
- Confirmed all three sites are descendants of the `.environment(\.popoverIsVisible, ...)` modifier set in `DashboardView`, so the gate applies correctly in every case (including the Settings screen, which shares the same view tree as the dashboard rather than a separate window).

## Tests
- `swift build` passes clean (only pre-existing, unrelated warnings).
- Manually diagnosed via an idle `sample` profile of the running app showing continuous layout/display-cycle work driven by `NSHostingView.setUpdateTimer` while no window was on screen; recommend re-sampling after this fix to confirm CPU drops to ~0% at idle.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>