### PR TITLE
Add Qwen Cloud Token Plan provider

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -18,6 +18,10 @@ final class AppContainer {
     /// `APIKeyManaging`. Each matching Customize provider detail shows an API Key section and writes
     /// changes through the capability. Empty when no installed provider needs a user key.
     let apiKeyProviders: [any APIKeyManaging]
+    /// Providers whose credential is a captured web session (currently Qwen Cloud), conforming to
+    /// `SessionManaging`. Each matching Customize provider detail shows a session card (Sign In /
+    /// Sign Out) beside the API Key card's slot. Empty when no installed provider uses sessions.
+    let sessionProviders: [any SessionManaging]
     /// Quota pace notification preferences (three independent triggers). Drives the Settings section
     /// and is read by `WidgetDataStore.evaluateNotifications`.
     let notificationSettings: NotificationSettingsStore
@@ -82,6 +86,7 @@ final class AppContainer {
         )
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
+        let sessionProviders = providers.compactMap { $0 as? any SessionManaging }
         let enablement = ProviderEnablementStore()
         let notificationSettings = NotificationSettingsStore()
         let layout = LayoutStore(
@@ -126,6 +131,7 @@ final class AppContainer {
         self.registry = registry
         self.enablement = enablement
         self.apiKeyProviders = apiKeyProviders
+        self.sessionProviders = sessionProviders
         self.notificationSettings = notificationSettings
         self.layout = layout
         self.dataStore = dataStore

--- a/Sources/OpenUsage/Providers/ErrorCategory.swift
+++ b/Sources/OpenUsage/Providers/ErrorCategory.swift
@@ -241,3 +241,24 @@ extension AntigravityError: CategorizedError {
         }
     }
 }
+
+extension QwenAuthError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .notSignedIn: .notLoggedIn
+        case .saveFailed, .deleteFailed: .other
+        case .signInCancelled: .other
+        }
+    }
+}
+
+extension QwenUsageError: CategorizedError {
+    var errorCategory: ErrorCategory {
+        switch self {
+        case .connectionFailed: .network
+        case .invalidResponse: .decoding
+        case .requestFailed(let status): ErrorCategory.http(status)
+        case .sessionExpired: .authExpired
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -41,6 +41,7 @@ enum ProviderCatalog {
             GrokProvider(),
             OpenCodeProvider(),
             OpenRouterProvider(),
+            QwenProvider(),
             ZAIProvider()
         ]
         return runtimes

--- a/Sources/OpenUsage/Providers/Qwen/QwenAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Qwen/QwenAuthStore.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// A captured Qwen Cloud console session: the browser cookies that authenticate the billing API
+/// (the load-bearing one is `login_qwencloud_ticket`) plus the plan region.
+struct QwenSession: Hashable, Sendable {
+    var cookies: String
+    var region: String
+}
+
+enum QwenAuthError: Error, LocalizedError, Equatable {
+    case notSignedIn
+    case saveFailed
+    case deleteFailed
+    case signInCancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .notSignedIn:
+            return "Not signed in to Qwen Cloud. Open Qwen in Customize to sign in, or save your browser cookies to ~/.config/openusage/qwen.json."
+        case .saveFailed:
+            return "Couldn't save the Qwen Cloud session."
+        case .deleteFailed:
+            return "Couldn't remove the saved Qwen Cloud session."
+        case .signInCancelled:
+            return "Qwen Cloud sign-in was closed before completing."
+        }
+    }
+}
+
+/// Reads the Qwen Cloud console session OpenUsage uses to call the token-plan billing API. Qwen's
+/// API keys are inference-only — plan usage lives behind the web console's session cookies, so the
+/// credential here is a cookie header captured by the in-app sign-in window (`QwenLoginController`)
+/// or pasted by hand into a config file. The file is the source of truth either way, and a user can
+/// always rotate it by editing the file or signing in again.
+struct QwenAuthStore: Sendable {
+    static let configPath = "~/.config/openusage/qwen.json"
+    /// The token-plan region the billing calls are scoped to. Only the international (Singapore)
+    /// edition is supported in v1; carried in the config so other regions can land without a schema
+    /// change.
+    static let defaultRegion = "ap-southeast-1"
+
+    var files: TextFileAccessing
+
+    init(files: TextFileAccessing = LocalTextFileAccessor()) {
+        self.files = files
+    }
+
+    func loadSession() -> QwenSession? {
+        guard files.exists(Self.configPath),
+              let text = try? files.readText(Self.configPath) else { return nil }
+        return Self.session(fromConfigText: text)
+    }
+
+    /// Persist a captured session (0600 via `LocalTextFileAccessor`). `source` records how the
+    /// cookies arrived ("webView" or "manual") — diagnostic only, never drives behavior.
+    func saveSession(cookies: String, region: String = QwenAuthStore.defaultRegion, source: String) throws {
+        let trimmed = cookies.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw QwenAuthError.saveFailed }
+        let object: [String: Any] = [
+            "cookies": trimmed,
+            "region": region,
+            "source": source,
+            "capturedAt": ISO8601DateFormatter().string(from: Date())
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else { throw QwenAuthError.saveFailed }
+        do {
+            try files.writeText(Self.configPath, text)
+        } catch {
+            AppLog.error(.auth, "save Qwen session to \(Self.configPath) failed: \(error.localizedDescription)")
+            throw QwenAuthError.saveFailed
+        }
+    }
+
+    /// Remove the saved session. A missing file is a no-op. The WebView's own cookie store is left
+    /// intact on purpose: the next sign-in silently recaptures the still-live browser session.
+    func deleteSession() throws {
+        guard files.exists(Self.configPath) else { return }
+        do {
+            try files.remove(Self.configPath)
+        } catch {
+            AppLog.error(.auth, "delete Qwen session at \(Self.configPath) failed: \(error.localizedDescription)")
+            throw QwenAuthError.deleteFailed
+        }
+    }
+
+    /// Accept a JSON object with `cookies` (and optional `region`), or a plain-text file holding only
+    /// the cookie header — so a user who copies the header from DevTools can paste it straight in.
+    static func session(fromConfigText text: String) -> QwenSession? {
+        if let data = text.data(using: .utf8),
+           let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+           let cookies = (object["cookies"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !cookies.isEmpty {
+            let region = (object["region"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .nilIfEmpty ?? defaultRegion
+            return QwenSession(cookies: cookies, region: region)
+        }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains("{") else { return nil }
+        return QwenSession(cookies: trimmed, region: defaultRegion)
+    }
+}

--- a/Sources/OpenUsage/Providers/Qwen/QwenLoginController.swift
+++ b/Sources/OpenUsage/Providers/Qwen/QwenLoginController.swift
@@ -1,0 +1,172 @@
+import AppKit
+import WebKit
+
+/// The app's first interactive sign-in: a small window hosting the real Qwen Cloud sign-in page in
+/// a `WKWebView`. The view rides the **default (persistent, on-disk) website data store** — safe to
+/// share because OpenUsage has no other web surface — so once a user has signed in once, a later
+/// window opens on an already-live session and capture completes without retyping anything, until
+/// the console session itself expires (~30 days).
+///
+/// Capture is poll-driven rather than delegate-driven: every two seconds the store's cookies are
+/// read, and once `login_qwencloud_ticket` appears the session is verified with a live `info.json`
+/// call (the same probe the provider uses) before anything is persisted. Closing the window early
+/// reports `.signInCancelled` (minimizing does NOT — the window is still open); multiple
+/// concurrent `beginSignIn` callers all receive the same outcome.
+@MainActor
+final class QwenLoginController {
+    /// The billing page redirects to the login form when signed out and lands on account content
+    /// when signed in — one URL serves both states.
+    nonisolated static let signInURL = URL(string: "https://home.qwencloud.com/billing/subscription/token-plan-individual")!
+    /// The one cookie the whole billing chain cannot work without (verified empirically: it alone
+    /// authenticates info.json and every gateway call). Its presence is the "login happened"
+    /// signal; the full captured set is still stored for fidelity.
+    nonisolated static let requiredCookieName = "login_qwencloud_ticket"
+    nonisolated static let pollInterval: Duration = .seconds(2)
+
+    /// At most one sign-in window app-wide; the controller pins itself here while active so the
+    /// poll loop and window outlive whoever invoked it.
+    private static var activeSignIn: QwenLoginController?
+
+    private let authStore: QwenAuthStore
+    private let usageClient: QwenUsageClient
+    private var window: NSWindow?
+    private var dataStore: WKWebsiteDataStore?
+    /// Every caller that asked to sign in while this controller is active — drained together in
+    /// `finish`, so a second Sign In click (e.g. the Customize popover reopened mid-sign-in) gets
+    /// its completion instead of hanging its "Signing In…" state forever.
+    private var completions: [@MainActor (Result<QwenSession, Error>) -> Void] = []
+    private var finished = false
+    private var windowClosed = false
+    private var closeObserver: (any NSObjectProtocol)?
+
+    init(authStore: QwenAuthStore = QwenAuthStore(), usageClient: QwenUsageClient = QwenUsageClient()) {
+        self.authStore = authStore
+        self.usageClient = usageClient
+    }
+
+    /// Open the sign-in window (or join the active one). The completion runs exactly once per
+    /// caller on the main actor: `.success` with the persisted session, or a failure
+    /// (cancel / save error).
+    func beginSignIn(completion: @escaping @MainActor (Result<QwenSession, Error>) -> Void) {
+        if let existing = Self.activeSignIn {
+            existing.completions.append(completion)
+            existing.window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        Self.activeSignIn = self
+        completions = [completion]
+
+        let dataStore = WKWebsiteDataStore.default()
+        self.dataStore = dataStore
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = dataStore
+
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 480, height: 640), configuration: configuration)
+        webView.autoresizingMask = [.width, .height]
+
+        let window = NSWindow(
+            contentRect: webView.frame,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Sign in to Qwen Cloud"
+        window.contentView = webView
+        // Center first, then register autosave: on first launch the centered frame gets saved; on
+        // later launches setFrameAutosaveName restores the saved frame and nothing overrides it.
+        window.center()
+        window.setFrameAutosaveName("QwenSignIn")
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        self.window = window
+
+        // Closing the window ends the attempt (miniaturizing does not — isVisible alone can't
+        // tell them apart, so use the close notification).
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.windowClosed = true }
+        }
+
+        webView.load(URLRequest(url: Self.signInURL))
+        Task { [weak self] in await self?.pollForSession() }
+    }
+
+    /// The poll loop: while the window is up, watch for the required cookie, then verify before
+    /// persisting. A verification failure (cookie present but info.json has no secToken yet) simply
+    /// keeps polling. Window closed → cancelled.
+    private func pollForSession() async {
+        while !finished, !windowClosed {
+            try? await Task.sleep(for: Self.pollInterval)
+            guard !finished, !windowClosed, let dataStore else { break }
+            let cookies = await dataStore.httpCookieStore.allCookies()
+            guard let header = Self.cookieHeader(from: cookies) else { continue }
+            guard await verifySession(cookies: header) else { continue }
+            await persist(header: header)
+            return
+        }
+        finish(with: .failure(QwenAuthError.signInCancelled))
+    }
+
+    /// True when the captured cookies authenticate a live info.json probe (yields a secToken).
+    private func verifySession(cookies: String) async -> Bool {
+        do {
+            let response = try await usageClient.fetchInfo(cookies: cookies)
+            guard (200..<300).contains(response.statusCode) else { return false }
+            return QwenUsageMapper.secToken(from: response.body) != nil
+        } catch {
+            return false
+        }
+    }
+
+    private func persist(header: String) async {
+        let session = QwenSession(cookies: header, region: QwenAuthStore.defaultRegion)
+        do {
+            try await loadOffMainActor { [authStore] in
+                try authStore.saveSession(cookies: session.cookies, region: session.region, source: "webView")
+            }
+            finish(with: .success(session))
+        } catch {
+            finish(with: .failure(QwenAuthError.saveFailed))
+        }
+    }
+
+    /// Resolve every waiting caller with the same outcome and tear down.
+    private func finish(with result: Result<QwenSession, Error>) {
+        guard !finished else { return }
+        finished = true
+        if Self.activeSignIn === self { Self.activeSignIn = nil }
+        if let closeObserver { NotificationCenter.default.removeObserver(closeObserver) }
+        self.closeObserver = nil
+        window?.close()
+        window = nil
+        dataStore = nil
+        let completions = self.completions
+        self.completions = []
+        for completion in completions {
+            completion(result)
+        }
+    }
+
+    /// Join the qwencloud console cookies into one `Cookie` header value. Only cookies on a
+    /// qwencloud.com domain are kept, and the result is nil unless the load-bearing
+    /// `login_qwencloud_ticket` is among them — so callers get a single "session ready?" check.
+    nonisolated static func cookieHeader(from cookies: [HTTPCookie]) -> String? {
+        let matching = cookies.filter { isQwenCloudDomain($0.domain) }
+        guard matching.contains(where: { $0.name == requiredCookieName }) else { return nil }
+        return matching
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: "; ")
+    }
+
+    /// qwencloud.com and any subdomain, tolerating the leading-dot spelling.
+    nonisolated static func isQwenCloudDomain(_ domain: String) -> Bool {
+        var host = domain
+        if host.hasPrefix(".") { host.removeFirst() }
+        host = host.lowercased()
+        return host == "qwencloud.com" || host.hasSuffix(".qwencloud.com")
+    }
+}

--- a/Sources/OpenUsage/Providers/Qwen/QwenProvider.swift
+++ b/Sources/OpenUsage/Providers/Qwen/QwenProvider.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// Qwen Cloud Token Plan (individual edition) usage: a rolling 5-hour quota window and a rolling
+/// weekly window, both read from the home.qwencloud.com console API the billing page itself uses.
+/// The API is cookies-only (Qwen API keys are inference-only), so credentials are a browser session
+/// captured by the in-app sign-in window or pasted into `~/.config/openusage/qwen.json`.
+@MainActor
+final class QwenProvider: ProviderRuntime {
+    let provider = Provider(
+        id: "qwen",
+        displayName: "Qwen",
+        icon: .providerMark("qwen"),
+        links: [
+            ProviderLink(label: "Dashboard", url: "https://home.qwencloud.com/billing/subscription/token-plan-individual")
+        ]
+    )
+
+    let authStore: QwenAuthStore
+    let usageClient: QwenUsageClient
+    /// Owns the one-at-a-time sign-in window. The provider is long-lived, so the controller (and
+    /// its pinned active window) survives Customize detail appearances.
+    let loginController: QwenLoginController
+    let now: @Sendable () -> Date
+
+    init(
+        authStore: QwenAuthStore = QwenAuthStore(),
+        usageClient: QwenUsageClient = QwenUsageClient(),
+        loginController: QwenLoginController? = nil,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.authStore = authStore
+        self.usageClient = usageClient
+        self.loginController = loginController ?? QwenLoginController(authStore: authStore, usageClient: usageClient)
+        self.now = now
+    }
+
+    var widgetDescriptors: [WidgetDescriptor] {
+        [
+            .percent(id: "qwen.session", provider: provider, title: "Session",
+                     metricLabel: "5-Hour", isSessionWindow: true)
+                .exportingLimit("session", unit: "percent"),
+            .percent(id: "qwen.weekly", provider: provider, title: "Weekly",
+                     metricLabel: "Weekly")
+                .exportingLimit("weekly", unit: "percent")
+        ]
+    }
+
+    func hasLocalCredentials() async -> Bool {
+        // Same source as `refresh()`: a captured session file.
+        await loadOffMainActor { [authStore] in authStore.loadSession() } != nil
+    }
+
+    func refresh() async -> ProviderSnapshot {
+        guard let session = await loadOffMainActor({ [authStore] in authStore.loadSession() }) else {
+            return ProviderSnapshot.error(provider: provider, error: QwenAuthError.notSignedIn)
+        }
+
+        // The info call is both the sec_token source and the session-liveness probe: dead cookies
+        // surface here as `.sessionExpired` before the billing calls are even attempted.
+        switch await load({ try await usageClient.fetchInfo(cookies: session.cookies) }) {
+        case .authFailure:
+            return ProviderSnapshot.error(provider: provider, error: QwenUsageError.sessionExpired)
+        case .failed(let error):
+            return ProviderSnapshot.error(provider: provider, error: error)
+        case .success(let infoBody):
+            guard let secToken = QwenUsageMapper.secToken(from: infoBody) else {
+                let error: QwenUsageError = QwenUsageMapper.isConsoleLoginFailure(infoBody)
+                    ? .sessionExpired
+                    : .invalidResponse
+                return ProviderSnapshot.error(provider: provider, error: error)
+            }
+            return await refreshUsage(session: session, secToken: secToken)
+        }
+    }
+
+    /// The required usage call plus the best-effort subscription/quota-config decoration (plan
+    /// label + renewal warning). Failures in the optional calls never blank the meters.
+    private func refreshUsage(session: QwenSession, secToken: String) async -> ProviderSnapshot {
+        let usage = await load { [usageClient] in
+            try await usageClient.fetch(.usage, cookies: session.cookies, secToken: secToken, region: session.region)
+        }
+        switch usage {
+        case .authFailure:
+            return ProviderSnapshot.error(provider: provider, error: QwenUsageError.sessionExpired)
+        case .failed(let error):
+            return ProviderSnapshot.error(provider: provider, error: error)
+        case .success(let body):
+            do {
+                let lines = try QwenUsageMapper.mapUsage(body)
+                let subscriptionBody = await loadOptional { [usageClient] in
+                    try await usageClient.fetch(.subscription, cookies: session.cookies, secToken: secToken, region: session.region)
+                }
+                var plan: String?
+                var warning: String?
+                if let subscriptionBody, let info = try? QwenUsageMapper.mapSubscription(subscriptionBody) {
+                    warning = info.renewalWarning
+                    let capsBody = await loadOptional { [usageClient] in
+                        try await usageClient.fetch(.quotaConfig, cookies: session.cookies, secToken: secToken, region: session.region)
+                    }
+                    let caps = capsBody.flatMap { QwenUsageMapper.quotaCaps($0, tierKey: info.tierKey) }
+                    plan = QwenUsageMapper.planLabel(planName: info.planName, caps: caps)
+                }
+                return ProviderSnapshot.make(provider: provider, plan: plan, lines: lines,
+                                             refreshedAt: now(), warning: warning)
+            } catch {
+                return ProviderSnapshot.error(provider: provider, error: error)
+            }
+        }
+    }
+
+    /// Run a required call and classify the outcome: the body on 2xx, an auth failure on 401/403,
+    /// or a typed failure for any other non-2xx or transport error.
+    private func load(_ call: () async throws -> HTTPResponse) async -> CallResult {
+        do {
+            let response = try await call()
+            if response.statusCode == 401 || response.statusCode == 403 { return .authFailure }
+            guard (200..<300).contains(response.statusCode) else {
+                return .failed(.requestFailed(response.statusCode))
+            }
+            return .success(response.body)
+        } catch {
+            return .failed(.connectionFailed)
+        }
+    }
+
+    /// Run an optional call — never throws into the snapshot: any failure just means "no plan
+    /// decoration this refresh".
+    private func loadOptional(_ call: () async throws -> HTTPResponse) async -> Data? {
+        do {
+            let response = try await call()
+            guard (200..<300).contains(response.statusCode) else { return nil }
+            return response.body
+        } catch {
+            return nil
+        }
+    }
+}
+
+private enum CallResult {
+    case success(Data)
+    case authFailure
+    case failed(QwenUsageError)
+}
+
+extension QwenProvider: SessionManaging {
+    var hasSession: Bool { authStore.loadSession() != nil }
+
+    func beginSignIn(completion: @escaping @MainActor (Result<Void, Error>) -> Void) {
+        loginController.beginSignIn { result in
+            completion(result.map { _ in () })
+        }
+    }
+
+    func signOut() throws {
+        try authStore.deleteSession()
+    }
+}

--- a/Sources/OpenUsage/Providers/Qwen/QwenUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Qwen/QwenUsageClient.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Calls the home.qwencloud.com console API — the same internal endpoints the token-plan billing
+/// page uses. API keys cannot reach this data (they are inference-only), so every call carries the
+/// user's captured browser session cookies, and mutating calls additionally carry the `sec_token`
+/// CSRF value fetched from `info.json`.
+struct QwenUsageClient: Sendable {
+    static let infoURL = URL(string: "https://home.qwencloud.com/tool/user/info.json")!
+    static let apiURL = URL(string: "https://cs-data.qwencloud.com/data/api.json")!
+    static let homeOrigin = "https://home.qwencloud.com"
+    static let billingReferer = "https://home.qwencloud.com/billing/subscription/token-plan-individual"
+    /// The console is bot-watched; a plain HTTP client UA trips its defenses, so the calls present
+    /// the same browser identity the captured request used.
+    static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+
+    /// The three personal token-plan endpoints behind the gateway. Raw values are the URL path
+    /// segments; `apiName` is the gateway's `zeldaHttp.apikeyMgr.`-prefixed route.
+    enum Endpoint: String, CaseIterable, Sendable {
+        case usage
+        case subscription
+        case quotaConfig = "quota-config"
+
+        var apiName: String { "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/\(rawValue)" }
+    }
+
+    var http: any HTTPClient
+
+    init(http: any HTTPClient = URLSessionHTTPClient()) {
+        self.http = http
+    }
+
+    /// Session liveness probe and `sec_token` source: `data.secToken` from the user-info endpoint.
+    /// A dead session answers without a token (the provider reads that as `.sessionExpired`).
+    func fetchInfo(cookies: String) async throws -> HTTPResponse {
+        try await http.send(HTTPRequest(
+            method: "GET",
+            url: Self.infoURL,
+            headers: [
+                "Cookie": cookies,
+                "Accept": "application/json, text/plain, */*",
+                "Referer": Self.billingReferer,
+                "User-Agent": Self.userAgent
+            ],
+            timeout: 15
+        ))
+    }
+
+    /// One gateway call (`/data/api.json`) for a token-plan endpoint. The endpoint rides in BOTH
+    /// the query string and the form body's `params` envelope — the captured browser request
+    /// carries it twice, so so do we.
+    func fetch(_ endpoint: Endpoint, cookies: String, secToken: String, region: String) async throws -> HTTPResponse {
+        // Query built by hand (not URLComponents) so the `api` value percent-encodes exactly like
+        // the captured browser request — slashes as %2F. URLComponents would leave them literal.
+        let url = URL(string: "\(Self.apiURL.absoluteString)?product=sfm_bailian&action=IntlBroadScopeAspnGateway&api=\(endpoint.apiName.urlFormEncoded)")!
+        let body = Self.formBody(endpoint: endpoint, secToken: secToken, region: region)
+        return try await http.send(HTTPRequest(
+            method: "POST",
+            url: url,
+            headers: [
+                "Cookie": cookies,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json, text/plain, */*",
+                "Origin": Self.homeOrigin,
+                "Referer": Self.billingReferer,
+                "User-Agent": Self.userAgent
+            ],
+            body: Data(body.utf8),
+            timeout: 15
+        ))
+    }
+
+    /// The `application/x-www-form-urlencoded` body: gateway fields plus the JSON `params` envelope.
+    static func formBody(endpoint: Endpoint, secToken: String, region: String) -> String {
+        [
+            "product=sfm_bailian",
+            "action=IntlBroadScopeAspnGateway",
+            "sec_token=\(secToken.urlFormEncoded)",
+            "region=\(region.urlFormEncoded)",
+            "params=\(paramsEnvelope(apiName: endpoint.apiName).urlFormEncoded)"
+        ].joined(separator: "&")
+    }
+
+    /// The JSON envelope the gateway requires around every call. `cornerstoneParam` is the console's
+    /// static site-identity block — identical for every personal token-plan endpoint (verified
+    /// against a captured browser request). Built as a literal (not JSONSerialization, which would
+    /// escape the slashes in `apiName` as `\/` and diverge from the captured payload byte-for-byte).
+    static func paramsEnvelope(apiName: String) -> String {
+        """
+        {"Api":"\(apiName)","Data":{"cornerstoneParam":{"console":"ONE_CONSOLE",\
+        "consoleSite":"QWENCLOUD","domain":"home.qwencloud.com","productCode":"p_efm",\
+        "protocol":"V2","xsp_lang":"en-US"}},"V":"1.0"}
+        """
+    }
+}
+
+enum QwenUsageError: Error, LocalizedError, Equatable {
+    case connectionFailed
+    case invalidResponse
+    case requestFailed(Int)
+    /// The session cookies no longer authenticate (the gateway reports `ConsoleNeedLogin`, or
+    /// `info.json` stopped returning a `secToken`). The fix is always a fresh sign-in — cookies have
+    /// no programmatic refresh path.
+    case sessionExpired
+
+    var errorDescription: String? {
+        switch self {
+        case .connectionFailed:
+            return ProviderUsageErrorText.connectionFailed
+        case .invalidResponse:
+            return ProviderUsageErrorText.invalidResponse
+        case .requestFailed(let status):
+            return ProviderUsageErrorText.requestFailed(statusCode: status)
+        case .sessionExpired:
+            return "Qwen Cloud session expired. Open Qwen in Customize to sign in again."
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/Qwen/QwenUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Qwen/QwenUsageMapper.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// Maps home.qwencloud.com token-plan payloads into metric lines. All three gateway endpoints share
+/// one envelope — the actual payload sits at `.data.DataV2.data.data` — and report percentages as
+/// fractions of 1.0 with reset times in epoch milliseconds. Pure (no I/O), so it tests against
+/// captured payloads.
+enum QwenUsageMapper {
+    /// A parsed subscription endpoint: the tier key exactly as the API spells it (`specCode`, used
+    /// to look up quota caps), the display name, and — only when auto-renew is off — the warning the
+    /// provider surfaces in the card header.
+    struct SubscriptionInfo: Equatable {
+        var tierKey: String
+        var planName: String
+        var renewalWarning: String?
+    }
+
+    /// Absolute quota caps for one tier, from `quota-config`. The dashboard's own units for these
+    /// numbers aren't published, so they surface in the plan label as bare numbers rather than a
+    /// claimed unit.
+    struct QuotaCaps: Equatable {
+        var fiveHour: Double
+        var weekly: Double
+    }
+
+    /// `data.secToken` from an `info.json` body — the CSRF token every gateway call needs, and the
+    /// session-liveness signal: a dead session answers without one.
+    static func secToken(from body: Data) -> String? {
+        guard let root = ProviderParse.jsonObject(body),
+              let data = root["data"] as? [String: Any] else { return nil }
+        return (data["secToken"] as? String)?.nilIfEmpty
+    }
+
+    /// True when a 2xx body is the gateway's "not logged in" answer (`ConsoleNeedLogin`, or
+    /// `successResponse: false` without a payload) rather than a genuine success or an unrelated
+    /// business error — the provider maps it to `.sessionExpired` instead of a generic failure.
+    static func isConsoleLoginFailure(_ body: Data) -> Bool {
+        guard let root = ProviderParse.jsonObject(body) else { return false }
+        if let code = (root["code"] as? String), code == "ConsoleNeedLogin" { return true }
+        if ((root["data"] as? [String: Any])?["errorCode"] as? String) == "ConsoleNeedLogin" { return true }
+        if (root["successResponse"] as? Bool) == false { return true }
+        return false
+    }
+
+    /// Session (5-hour) + weekly meters from a `usage` payload. A missing percentage is an invalid
+    /// response rather than zero usage; reset times are optional (a missing one just drops the
+    /// countdown).
+    static func mapUsage(_ body: Data) throws -> [MetricLine] {
+        let payload = try innerData(body)
+        return [
+            try percentLine(payload,
+                            percentKey: "per5HourPercentage",
+                            resetKey: "per5HourResetTime",
+                            label: "5-Hour",
+                            periodMs: MetricPeriod.sessionMs),
+            try percentLine(payload,
+                            percentKey: "per1WeekPercentage",
+                            resetKey: "per1WeekResetTime",
+                            label: "Weekly",
+                            periodMs: MetricPeriod.weekMs)
+        ]
+    }
+
+    /// Tier + renewal state from a `subscription` payload.
+    static func mapSubscription(_ body: Data) throws -> SubscriptionInfo {
+        let payload = try innerData(body)
+        guard let tierKey = (payload["specCode"] as? String)?.nilIfEmpty else {
+            throw QwenUsageError.invalidResponse
+        }
+        let planName = tierKey.titleCased(separator: { $0 == "_" || $0 == "-" || $0 == " " })
+        var warning: String?
+        if ProviderParse.bool(payload["autoRenewFlag"]) == false {
+            if let days = ProviderParse.number(payload["remainingDays"]), days >= 0 {
+                let whole = Int(days)
+                warning = "Auto-renew is off — plan ends in \(whole) \(whole == 1 ? "day" : "days")."
+            } else {
+                warning = "Auto-renew is off for this plan."
+            }
+        }
+        return SubscriptionInfo(tierKey: tierKey, planName: planName, renewalWarning: warning)
+    }
+
+    /// The caps entry for one tier key from a `quota-config` payload (`standard`, `lite`, `pro`…),
+    /// or nil when the tier or its numbers are absent — best-effort decoration, never an error.
+    static func quotaCaps(_ body: Data, tierKey: String) -> QuotaCaps? {
+        guard let payload = try? innerData(body),
+              let entry = payload[tierKey] as? [String: Any],
+              let fiveHour = ProviderParse.number(entry["five_hour"]),
+              let weekly = ProviderParse.number(entry["weekly"]),
+              fiveHour >= 0, weekly >= 0 else { return nil }
+        return QuotaCaps(fiveHour: fiveHour, weekly: weekly)
+    }
+
+    /// The header plan label: "Standard" alone, or "Standard · 3,000 / 5h · 10,000 / wk" when the
+    /// quota-config lookup found caps for the tier.
+    static func planLabel(planName: String, caps: QuotaCaps?) -> String {
+        guard let caps else { return planName }
+        return "\(planName) · \(formatCap(caps.fiveHour)) / 5h · \(formatCap(caps.weekly)) / wk"
+    }
+
+    // MARK: - Private
+
+    /// Unwrap `.data.DataV2.data.data` and verify the success markers. Login failures keep an HTTP
+    /// 200 envelope, so they are detected on the way through and surfaced as `.sessionExpired`.
+    private static func innerData(_ body: Data) throws -> [String: Any] {
+        guard let root = ProviderParse.jsonObject(body),
+              let data = root["data"] as? [String: Any] else {
+            throw QwenUsageError.invalidResponse
+        }
+        if (data["errorCode"] as? String) == "ConsoleNeedLogin" {
+            throw QwenUsageError.sessionExpired
+        }
+        guard let dataV2 = data["DataV2"] as? [String: Any],
+              let inner = dataV2["data"] as? [String: Any] else {
+            throw QwenUsageError.invalidResponse
+        }
+        if let code = (inner["code"] as? String), code != "SUCCESS" {
+            throw code == "ConsoleNeedLogin" ? QwenUsageError.sessionExpired : QwenUsageError.invalidResponse
+        }
+        guard let payload = inner["data"] as? [String: Any] else {
+            throw QwenUsageError.invalidResponse
+        }
+        return payload
+    }
+
+    /// One percentage meter. Percentages arrive as fractions of 1.0 (e.g. `0.315` = 31.5%); a
+    /// negative value is malformed, an over-100 result is clamped at the display edge.
+    private static func percentLine(
+        _ payload: [String: Any],
+        percentKey: String,
+        resetKey: String,
+        label: String,
+        periodMs: Int
+    ) throws -> MetricLine {
+        guard let fraction = ProviderParse.number(payload[percentKey]), fraction >= 0 else {
+            throw QwenUsageError.invalidResponse
+        }
+        let resetsAt = ProviderParse.number(payload[resetKey]).map { epochMsToDate($0) }
+        return .progress(
+            label: label,
+            used: ProviderParse.clampPercent(fraction * 100),
+            limit: 100,
+            format: .percent,
+            resetsAt: resetsAt,
+            periodDurationMs: periodMs
+        )
+    }
+
+    /// `12000.0` → "12,000"; whole numbers drop the decimal, nothing else is asserted about units.
+    private static func formatCap(_ value: Double) -> String {
+        if value.rounded() == value {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 0
+            if let text = formatter.string(from: NSNumber(value: value)) { return text }
+        }
+        return String(value)
+    }
+
+    /// Reset times arrive as epoch milliseconds (e.g. `1785353040000`).
+    private static func epochMsToDate(_ ms: Double) -> Date {
+        Date(timeIntervalSince1970: ms / 1000)
+    }
+}

--- a/Sources/OpenUsage/Providers/SessionManagement.swift
+++ b/Sources/OpenUsage/Providers/SessionManagement.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// A `ProviderRuntime` whose credential is a captured web session rather than a static API key
+/// (currently Qwen Cloud — its plan-usage API is cookies-only). The provider's Customize detail
+/// renders a session card (Sign In / Sign Out) instead of the API Key editor; both paths write the
+/// same config file the auth store already reads, so there is no parallel credential storage.
+@MainActor
+protocol SessionManaging: ProviderRuntime {
+    /// Whether a captured session currently exists locally — a file probe, never the network.
+    var hasSession: Bool { get }
+    /// Open the interactive sign-in. The completion runs exactly once on the main actor:
+    /// `.success` when a fresh session was captured and persisted, `.failure` otherwise
+    /// (including `QwenAuthError.signInCancelled` when the window closed early).
+    func beginSignIn(completion: @escaping @MainActor (Result<Void, Error>) -> Void)
+    /// Remove the saved session. The browser-side cookies are kept so the next sign-in can
+    /// recapture a still-live session silently.
+    func signOut() throws
+}

--- a/Sources/OpenUsage/Resources/ProviderIcons/qwen.svg
+++ b/Sources/OpenUsage/Resources/ProviderIcons/qwen.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill="currentColor" d="M50 0 L58.42 29.67 L85.36 14.64 L70.33 41.58 L100 50 L70.33 58.42 L85.36 85.36 L58.42 70.33 L50 100 L41.58 70.33 L14.64 85.36 L29.67 58.42 L0 50 L29.67 41.58 L14.64 14.64 L41.58 29.67 Z"/>
+</svg>

--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -32,6 +32,8 @@ enum DefaultLayout {
         "openrouter.credits", "openrouter.balance",
         "openrouter.today", "openrouter.week", "openrouter.month", "openrouter.keyLimit",
 
+        "qwen.session", "qwen.weekly",
+
         "zai.session", "zai.weekly", "zai.webSearches"
     ]
 
@@ -65,6 +67,7 @@ enum DefaultLayout {
         "cursor.auto", "cursor.api",
         "copilot.premium",
         "openrouter.credits",
+        "qwen.session", "qwen.weekly",
         "zai.session", "zai.weekly"
     ]
 

--- a/Sources/OpenUsage/Support/ProviderIconShape.swift
+++ b/Sources/OpenUsage/Support/ProviderIconShape.swift
@@ -93,6 +93,7 @@ enum ProviderMarks {
         case "grok": return "bolt.fill"
         case "opencode": return "chevron.left.forwardslash.chevron.right"
         case "openrouter": return "point.3.connected.trianglepath.dotted"
+        case "qwen": return "sparkles"
         case "zai": return "z.signal"
         default: return "app.dashed"
         }

--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -36,6 +36,9 @@ struct CustomizeProviderDetailView: View {
                 if let keyProvider = container.apiKeyProviders.first(where: { $0.provider.id == providerID }) {
                     APIKeysSection(provider: keyProvider)
                 }
+                if let sessionProvider = container.sessionProviders.first(where: { $0.provider.id == providerID }) {
+                    SessionSection(provider: sessionProvider)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .animation(Motion.spring, value: layout.expandedMetricIDs)

--- a/Sources/OpenUsage/Views/SessionSection.swift
+++ b/Sources/OpenUsage/Views/SessionSection.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// The per-provider session card shown in a provider's Customize detail when its credential is a
+/// captured web session rather than an API key (currently Qwen Cloud). Mirrors `APIKeysSection`'s
+/// shape: a status-dot row — red when no session is saved, green when one is — with Sign In / Sign
+/// Out. Sign In opens the provider's sign-in window; on a captured session the card clears the
+/// failure backoff and forces a refresh so the dashboard updates immediately.
+struct SessionSection: View {
+    let provider: any SessionManaging
+    @Environment(WidgetDataStore.self) private var dataStore
+    @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
+
+    /// Live status, seeded on appear and re-read after each sign in/out so the dot stays truthful
+    /// without re-reading files on every render.
+    @State private var signedIn = false
+    /// A sign-in window is open; the button reads "Signing In…" and is inert until it resolves.
+    @State private var isSigningIn = false
+    @State private var actionError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: density.headerToCardSpacing) {
+            Text("Cloud Session")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+            VStack(spacing: 0) {
+                sessionRow
+                if let actionError {
+                    Divider()
+                    Text(actionError)
+                        .font(.caption)
+                        .foregroundStyle(Theme.notice)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                        .background(Rectangle().fill(.fill.quinary))
+                }
+            }
+            .cardSurface()
+            .clipShape(Theme.cardShape)
+        }
+        .onAppear { signedIn = provider.hasSession }
+    }
+
+    private var sessionRow: some View {
+        HStack(spacing: 10) {
+            ProviderIcon(source: provider.provider.icon)
+                .frame(width: 18, height: 18)
+            Text(provider.provider.displayName)
+            Spacer(minLength: 8)
+            statusDot
+            if signedIn {
+                Button("Sign Out", action: signOut)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            } else {
+                Button(isSigningIn ? "Signing In…" : "Sign In", action: signIn)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(isSigningIn)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, density.controlRowPadding)
+    }
+
+    /// Binary, like the API key card's: red without a session, green with one.
+    private var statusDot: some View {
+        let color = signedIn ? Color(nsColor: .systemGreen) : Color(nsColor: .systemRed)
+        return Circle().fill(color).frame(width: 6, height: 6)
+    }
+
+    // MARK: - Actions
+
+    private func signIn() {
+        isSigningIn = true
+        actionError = nil
+        provider.beginSignIn { result in
+            isSigningIn = false
+            switch result {
+            case .success:
+                signedIn = true
+                triggerRefresh()
+            case .failure(let error):
+                // Closing the window early is a no-op, not an error worth displaying.
+                if (error as? QwenAuthError) != .signInCancelled {
+                    actionError = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func signOut() {
+        do {
+            try provider.signOut()
+            signedIn = false
+            actionError = nil
+            triggerRefresh()
+        } catch {
+            actionError = error.localizedDescription
+            AppLog.error(.auth, "Qwen session sign-out failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Clear any failure backoff so the wake refresh actually probes the provider, then force a
+    /// refresh so the dashboard shows the new session's data immediately instead of waiting for the
+    /// next 5-minute pass — same pattern the API Key card uses after a save.
+    private func triggerRefresh() {
+        let id = provider.provider.id
+        dataStore.clearFailureBackoff(for: id)
+        Task { await dataStore.refresh(providerID: id, force: true) }
+    }
+}

--- a/Tests/OpenUsageTests/LocalLimitsAPITests.swift
+++ b/Tests/OpenUsageTests/LocalLimitsAPITests.swift
@@ -220,6 +220,7 @@ final class LocalLimitsAPITests: XCTestCase {
             "grok": ["weekly"],
             "opencode": ["session", "weekly", "monthly"],
             "openrouter": ["credits", "balance", "keyLimit"],
+            "qwen": ["session", "weekly"],
             "zai": ["session", "weekly", "webSearches"]
         ]
 

--- a/Tests/OpenUsageTests/QwenProviderTests.swift
+++ b/Tests/OpenUsageTests/QwenProviderTests.swift
@@ -1,0 +1,252 @@
+import XCTest
+@testable import OpenUsage
+
+/// Provider-level tests: a real `QwenProvider` wired to `FakeFiles` (the session config) and a
+/// `RoutingHTTPClient` (canned info.json / api.json responses), with an injected clock. The canned
+/// bodies are the same live captures as `QwenUsageMapperTests`.
+@MainActor
+final class QwenProviderTests: XCTestCase {
+    private nonisolated static let configPath = "~/.config/openusage/qwen.json"
+    private nonisolated static let fixedNow = Date(timeIntervalSince1970: 1_785_350_000)
+
+    private nonisolated static let configJSON = """
+    {"cookies":"login_qwencloud_ticket=abc123; cna=xyz","region":"ap-southeast-1","source":"manual"}
+    """
+
+    /// Routes by URL the way the real endpoints differ: info.json by path, api.json calls by the
+    /// percent-encoded endpoint suffix in the query.
+    private func makeClient(
+        info: (status: Int, body: String)? = (200, QwenUsageMapperTests.infoBody),
+        usage: (status: Int, body: String)? = (200, QwenUsageMapperTests.usageBody),
+        subscription: (status: Int, body: String)? = (200, QwenUsageMapperTests.subscriptionBody),
+        quotaConfig: (status: Int, body: String)? = (200, QwenUsageMapperTests.quotaConfigBody)
+    ) -> RoutingHTTPClient {
+        RoutingHTTPClient { request in
+            let url = request.url.absoluteString
+            func respond(_ canned: (status: Int, body: String)?) -> HTTPResponse {
+                guard let canned else { return HTTPResponse(statusCode: 500, headers: [:], body: Data()) }
+                return HTTPResponse(statusCode: canned.status, headers: [:], body: Data(canned.body.utf8))
+            }
+            if url.contains("tool/user/info.json") { return respond(info) }
+            if url.contains("%2Fusage") { return respond(usage) }
+            if url.contains("%2Fsubscription") { return respond(subscription) }
+            if url.contains("%2Fquota-config") { return respond(quotaConfig) }
+            return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+        }
+    }
+
+    private func makeProvider(
+        config: String? = configJSON,
+        client: RoutingHTTPClient
+    ) -> QwenProvider {
+        var files: [String: String] = [:]
+        if let config { files[Self.configPath] = config }
+        return QwenProvider(
+            authStore: QwenAuthStore(files: FakeFiles(files)),
+            usageClient: QwenUsageClient(http: client),
+            now: { Self.fixedNow }
+        )
+    }
+
+    // MARK: - Happy path
+
+    func testHappyPathMapsMetersPlanAndRenewalWarning() async throws {
+        let provider = makeProvider(client: makeClient())
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(snapshot.providerID, "qwen")
+        XCTAssertEqual(snapshot.refreshedAt, Self.fixedNow)
+        XCTAssertEqual(snapshot.plan, "Standard · 3,000 / 5h · 10,000 / wk")
+        XCTAssertEqual(snapshot.warning, "Auto-renew is off — plan ends in 22 days.")
+
+        XCTAssertEqual(snapshot.lines.count, 2)
+        guard case .progress(let label, let used, _, _, _, _, _)? = snapshot.line(label: "5-Hour") else {
+            return XCTFail("expected the 5-Hour meter")
+        }
+        XCTAssertEqual(label, "5-Hour")
+        XCTAssertEqual(used, 0.10967993005003332 * 100, accuracy: 0.0001)
+        XCTAssertNotNil(snapshot.line(label: "Weekly"))
+    }
+
+    func testHappyPathSendsCookiesAndFormFields() async throws {
+        let client = makeClient()
+        _ = await makeProvider(client: client).refresh()
+
+        // Every request carries the captured cookies.
+        XCTAssertFalse(client.requests.isEmpty)
+        for request in client.requests {
+            XCTAssertEqual(request.headers["Cookie"], "login_qwencloud_ticket=abc123; cna=xyz")
+        }
+
+        // The usage call is a form POST with the gateway fields and the live sec_token.
+        let usageRequest = try client.requests.first {
+            $0.url.absoluteString.contains("%2Fusage")
+        }.unwrap()
+        XCTAssertEqual(usageRequest.method, "POST")
+        let form = String(decoding: usageRequest.body ?? Data(), as: UTF8.self)
+        XCTAssertTrue(form.contains("product=sfm_bailian"))
+        XCTAssertTrue(form.contains("action=IntlBroadScopeAspnGateway"))
+        XCTAssertTrue(form.contains("sec_token=NYOOSBQvO9PGTxFmHt0pT1"))
+        XCTAssertTrue(form.contains("region=ap-southeast-1"))
+        XCTAssertTrue(form.contains("params="))
+        XCTAssertEqual(usageRequest.headers["Content-Type"], "application/x-www-form-urlencoded")
+        XCTAssertEqual(usageRequest.headers["Origin"], "https://home.qwencloud.com")
+    }
+
+    // MARK: - Credential states
+
+    func testMissingConfigReportsNotLoggedIn() async {
+        let provider = makeProvider(config: nil, client: makeClient())
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .notLoggedIn)
+    }
+
+    func testHasLocalCredentialsMirrorsConfigPresence() async {
+        let withConfig = makeProvider(client: makeClient())
+        let withoutConfig = makeProvider(config: nil, client: makeClient())
+        let has = await withConfig.hasLocalCredentials()
+        let hasNot = await withoutConfig.hasLocalCredentials()
+        XCTAssertTrue(has)
+        XCTAssertFalse(hasNot)
+    }
+
+    // MARK: - Session expiry
+
+    func testInfoLoginFailureReportsAuthExpired() async {
+        let deadSession = """
+        {"code":"200","data":{"secToken":null},"successResponse":false}
+        """
+        let provider = makeProvider(client: makeClient(info: (200, deadSession)))
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .authExpired)
+    }
+
+    func testInfoWithoutSecTokenOrFailureMarkerReportsDecoding() async {
+        // A 2xx body that is neither a login failure nor carries a token is malformed — a decoding
+        // error, not an auth expiry (the two surface differently to the user).
+        let oddBody = """
+        {"code":"200","data":{"somethingElse":true},"successResponse":true}
+        """
+        let provider = makeProvider(client: makeClient(info: (200, oddBody)))
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .decoding)
+    }
+
+    func testInfo401ReportsAuthExpired() async {
+        let provider = makeProvider(client: makeClient(info: (401, "{}")))
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .authExpired)
+    }
+
+    func testInfo403ReportsAuthExpired() async {
+        let provider = makeProvider(client: makeClient(info: (403, "{}")))
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .authExpired)
+    }
+
+    func testUsageConsoleNeedLoginReportsAuthExpired() async {
+        let expired = """
+        {"code":"200","data":{"DataV2":{"data":{"code":"ConsoleNeedLogin","data":{}}},"errorCode":""},\
+        "successResponse":true}
+        """
+        let provider = makeProvider(client: makeClient(usage: (200, expired)))
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .authExpired)
+    }
+
+    // MARK: - Failures stay loud
+
+    func testMalformedUsageReportsDecodingInsteadOfZeroMeters() async {
+        let provider = makeProvider(client: makeClient(usage: (200, """
+        {"code":"200","data":{"DataV2":{"data":{"code":"SUCCESS","data":{"unexpected":true}}}}}}
+        """)))
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .decoding)
+        // The error snapshot is a single error badge — never blank meters that read as "0% used".
+        XCTAssertEqual(snapshot.lines.count, 1)
+        XCTAssertTrue(snapshot.lines[0].isError)
+    }
+
+    func testUsage500ReportsHttp5xx() async {
+        let provider = makeProvider(client: makeClient(usage: (500, "boom")))
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .http5xx)
+    }
+
+    func testUsage429ReportsRateLimited() async {
+        let provider = makeProvider(client: makeClient(usage: (429, "slow down")))
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(snapshot.errorCategory, .rateLimited)
+    }
+
+    func testUsageTransportErrorReportsNetwork() async {
+        let client = RoutingHTTPClient { request in
+            let url = request.url.absoluteString
+            if url.contains("%2Fusage") { throw URLError(.notConnectedToInternet) }
+            let body = url.contains("tool/user/info.json")
+                ? QwenUsageMapperTests.infoBody
+                : QwenUsageMapperTests.subscriptionBody
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data(body.utf8))
+        }
+        let snapshot = await makeProvider(client: client).refresh()
+        XCTAssertEqual(snapshot.errorCategory, .network)
+    }
+
+    // MARK: - Best-effort decoration
+
+    func testSubscriptionFailureStillMetersWithoutPlan() async {
+        let provider = makeProvider(client: makeClient(subscription: (500, "x")))
+        let snapshot = await provider.refresh()
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertNil(snapshot.plan)
+        XCTAssertNil(snapshot.warning)
+        XCTAssertEqual(snapshot.lines.count, 2)
+    }
+
+    func testQuotaFailureKeepsBareTierPlan() async {
+        let provider = makeProvider(client: makeClient(quotaConfig: (500, "x")))
+        let snapshot = await provider.refresh()
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(snapshot.plan, "Standard")
+    }
+
+    func testAutoRenewOnMeansNoWarning() async {
+        let sub = """
+        {"code":"200","data":{"DataV2":{"data":{"code":"SUCCESS","data":{"specCode":"pro",\
+        "remainingDays":200,"autoRenewFlag":true,"status":"VALID"}}}},"successResponse":true}
+        """
+        let provider = makeProvider(client: makeClient(subscription: (200, sub), quotaConfig: (500, "x")))
+        let snapshot = await provider.refresh()
+        XCTAssertNil(snapshot.warning)
+        XCTAssertEqual(snapshot.plan, "Pro")
+    }
+
+    // MARK: - SessionManaging
+
+    func testSessionManagingSignOutClearsSession() async throws {
+        let files = FakeFiles([Self.configPath: Self.configJSON])
+        let provider = QwenProvider(
+            authStore: QwenAuthStore(files: files),
+            usageClient: QwenUsageClient(http: makeClient())
+        )
+        let managing: any SessionManaging = provider
+        XCTAssertTrue(managing.hasSession)
+        try managing.signOut()
+        XCTAssertFalse(managing.hasSession)
+    }
+}
+
+private extension Optional {
+    /// Test-only unwrap with a decent failure message.
+    func unwrap(file: StaticString = #filePath, line: UInt = #line) throws -> Wrapped {
+        switch self {
+        case .some(let value): return value
+        case .none:
+            XCTFail("expected a value", file: file, line: line)
+            throw QwenProviderTestError.unwrappedNil
+        }
+    }
+}
+
+private enum QwenProviderTestError: Error { case unwrappedNil }

--- a/Tests/OpenUsageTests/QwenSessionCaptureTests.swift
+++ b/Tests/OpenUsageTests/QwenSessionCaptureTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import OpenUsage
+
+/// Auth-store config handling and the login controller's pure cookie-capture logic (no WebView —
+/// the window itself is manual-validation-only, like every credential UI in the app).
+final class QwenSessionCaptureTests: XCTestCase {
+    private static let configPath = "~/.config/openusage/qwen.json"
+
+    // MARK: - QwenAuthStore.session(fromConfigText:)
+
+    func testJSONConfigWithCookiesAndRegion() {
+        let text = """
+        {"cookies":"login_qwencloud_ticket=abc; cna=xyz","region":"ap-southeast-1","source":"manual"}
+        """
+        let session = QwenAuthStore.session(fromConfigText: text)
+        XCTAssertEqual(session?.cookies, "login_qwencloud_ticket=abc; cna=xyz")
+        XCTAssertEqual(session?.region, "ap-southeast-1")
+    }
+
+    func testJSONConfigDefaultsRegion() {
+        let session = QwenAuthStore.session(fromConfigText: "{\"cookies\":\"login_qwencloud_ticket=abc\"}")
+        XCTAssertEqual(session?.region, "ap-southeast-1")
+    }
+
+    func testJSONConfigWithBlankRegionDefaults() {
+        let session = QwenAuthStore.session(fromConfigText: """
+        {"cookies":"login_qwencloud_ticket=abc","region":"  "}
+        """)
+        XCTAssertEqual(session?.region, "ap-southeast-1")
+    }
+
+    func testPlainTextCookieHeaderIsAccepted() {
+        // A user who copies the cookie header straight from DevTools can paste it as the whole file.
+        let session = QwenAuthStore.session(fromConfigText: "login_qwencloud_ticket=abc; cna=xyz\n")
+        XCTAssertEqual(session?.cookies, "login_qwencloud_ticket=abc; cna=xyz")
+        XCTAssertEqual(session?.region, "ap-southeast-1")
+    }
+
+    func testEmptyAndCookielessInputsAreRejected() {
+        XCTAssertNil(QwenAuthStore.session(fromConfigText: ""))
+        XCTAssertNil(QwenAuthStore.session(fromConfigText: "   \n"))
+        XCTAssertNil(QwenAuthStore.session(fromConfigText: "{\"region\":\"ap-southeast-1\"}"))
+        XCTAssertNil(QwenAuthStore.session(fromConfigText: "{\"cookies\":\"\"}"))
+        // Broken/partial JSON is rejected rather than stored as a cookie string.
+        XCTAssertNil(QwenAuthStore.session(fromConfigText: "login_qwencloud_ticket=x { broken"))
+    }
+
+    // MARK: - QwenUsageClient.paramsEnvelope
+
+    func testParamsEnvelopeCarriesGatewayIdentity() {
+        let envelope = QwenUsageClient.paramsEnvelope(apiName: QwenUsageClient.Endpoint.usage.apiName)
+        // The cornerstone block is the console's site identity — a silent drift here breaks every
+        // call, so pin the values, not just the presence of `params=`.
+        XCTAssertTrue(envelope.contains("\"Api\":\"zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage\""))
+        XCTAssertTrue(envelope.contains("\"domain\":\"home.qwencloud.com\""))
+        XCTAssertTrue(envelope.contains("\"consoleSite\":\"QWENCLOUD\""))
+        XCTAssertTrue(envelope.contains("\"console\":\"ONE_CONSOLE\""))
+        XCTAssertTrue(envelope.contains("\"xsp_lang\":\"en-US\""))
+        XCTAssertTrue(envelope.contains("\"protocol\":\"V2\""))
+        XCTAssertTrue(envelope.contains("\"productCode\":\"p_efm\""))
+        XCTAssertTrue(envelope.contains("\"V\":\"1.0\""))
+    }
+
+    // MARK: - QwenAuthStore file round-trip
+
+    func testSaveAndLoadRoundTrip() throws {
+        let files = FakeFiles()
+        let store = QwenAuthStore(files: files)
+        XCTAssertNil(store.loadSession())
+        try store.saveSession(cookies: "login_qwencloud_ticket=t0k3n", source: "webView")
+        let session = store.loadSession()
+        XCTAssertEqual(session?.cookies, "login_qwencloud_ticket=t0k3n")
+        XCTAssertEqual(session?.region, "ap-southeast-1")
+        // Save writes the documented JSON shape (so hand edits and the app agree).
+        XCTAssertTrue(files.files[Self.configPath]?.contains("\"cookies\"") == true)
+    }
+
+    func testDeleteRemovesSessionAndMissingFileIsNoOp() throws {
+        let files = FakeFiles()
+        let store = QwenAuthStore(files: files)
+        try store.deleteSession() // no file yet — must not throw
+        try store.saveSession(cookies: "login_qwencloud_ticket=t0k3n", source: "manual")
+        try store.deleteSession()
+        XCTAssertNil(store.loadSession())
+    }
+
+    func testSaveRejectsBlankCookies() {
+        let store = QwenAuthStore(files: FakeFiles())
+        XCTAssertThrowsError(try store.saveSession(cookies: "  \n", source: "manual")) { error in
+            XCTAssertEqual(error as? QwenAuthError, .saveFailed)
+        }
+    }
+
+    // MARK: - QwenLoginController.cookieHeader(from:)
+
+    private func cookie(name: String, value: String, domain: String) -> HTTPCookie {
+        HTTPCookie(properties: [
+            .name: name,
+            .value: value,
+            .domain: domain,
+            .path: "/"
+        ])!
+    }
+
+    func testCookieHeaderKeepsQwenCloudCookiesAndRequiresTicket() {
+        let cookies = [
+            cookie(name: "login_qwencloud_ticket", value: "t0k3n", domain: ".qwencloud.com"),
+            cookie(name: "cna", value: "abc", domain: "home.qwencloud.com"),
+            cookie(name: "unrelated", value: "zzz", domain: ".example.com")
+        ]
+        let header = QwenLoginController.cookieHeader(from: cookies)
+        XCTAssertNotNil(header)
+        XCTAssertTrue(header!.contains("login_qwencloud_ticket=t0k3n"))
+        XCTAssertTrue(header!.contains("cna=abc"))
+        XCTAssertFalse(header!.contains("unrelated"))
+    }
+
+    func testCookieHeaderWithoutTicketIsNil() {
+        let cookies = [cookie(name: "cna", value: "abc", domain: ".qwencloud.com")]
+        XCTAssertNil(QwenLoginController.cookieHeader(from: cookies))
+    }
+
+    func testCookieHeaderEmptySetIsNil() {
+        XCTAssertNil(QwenLoginController.cookieHeader(from: []))
+    }
+
+    func testDomainMatching() {
+        XCTAssertTrue(QwenLoginController.isQwenCloudDomain("qwencloud.com"))
+        XCTAssertTrue(QwenLoginController.isQwenCloudDomain(".qwencloud.com"))
+        XCTAssertTrue(QwenLoginController.isQwenCloudDomain("home.qwencloud.com"))
+        XCTAssertTrue(QwenLoginController.isQwenCloudDomain("cs-data.qwencloud.com"))
+        XCTAssertFalse(QwenLoginController.isQwenCloudDomain("example.com"))
+        XCTAssertFalse(QwenLoginController.isQwenCloudDomain("notqwencloud.com"))
+    }
+}

--- a/Tests/OpenUsageTests/QwenUsageMapperTests.swift
+++ b/Tests/OpenUsageTests/QwenUsageMapperTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+@testable import OpenUsage
+
+/// Mapper tests against payloads captured live from the home.qwencloud.com console API
+/// (2026-07-29), trimmed of request IDs. The live bodies carry fields we don't map (`instanceCode`,
+/// `addon_quota`, `ret`…), which exercises the unknown-field tolerance the mapper must keep.
+final class QwenUsageMapperTests: XCTestCase {
+    // MARK: - Fixtures
+
+    static let infoBody = """
+    {"requestId":"1a61679d","code":"200","data":{"sessionExpireTimeStamp":1787052662982,\
+    "secToken":"NYOOSBQvO9PGTxFmHt0pT1","sessionCreateTimeStamp":1784460662982},\
+    "httpStatusCode":null,"successResponse":true}
+    """
+
+    static let usageBody = """
+    {"code":"200","data":{"DataV2":{"ret":["SUCCESS::OK"],"data":{"msg":"Success.","code":"SUCCESS",\
+    "data":{"per5HourPercentage":0.10967993005003332,"per1WeekResetTime":1785802380000,\
+    "per5HourResetTime":1785353040000,"per1WeekPercentage":0.31521579342249},\
+    "requestId":"348ae586","success":true}},"success":true,"httpStatus":200,"errorCode":"",\
+    "api":"zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/usage","errorMsg":""},\
+    "httpStatusCode":"200","requestId":"348ae586","successResponse":true}
+    """
+
+    static let subscriptionBody = """
+    {"code":"200","data":{"DataV2":{"ret":["SUCCESS::OK"],"data":{"msg":"Success.","code":"SUCCESS",\
+    "data":{"instanceCode":"sfm_tokenplansolo_public_intl-sg-o514vonhtcx","specCode":"standard",\
+    "remainingDays":22,"startTime":1784590251000,"endTime":1787328000000,"autoRenewFlag":false,\
+    "status":"VALID"},"requestId":"3eb648f6","success":true}},"success":true,"httpStatus":200,\
+    "errorCode":"","api":"zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/subscription","errorMsg":""},\
+    "httpStatusCode":"200","requestId":"3eb648f6","successResponse":true}
+    """
+
+    static let quotaConfigBody = """
+    {"code":"200","data":{"DataV2":{"ret":["SUCCESS::OK"],"data":{"msg":"Success.","code":"SUCCESS",\
+    "data":{"standard":{"five_hour":3000.0,"weekly":10000.0},"addon_quota":{"extrabundle":20000.0},\
+    "lite":{"five_hour":700.0,"weekly":2500.0},"pro":{"five_hour":12000.0,"weekly":40000.0}},\
+    "requestId":"88da1775","success":true}},"success":true,"httpStatus":200,"errorCode":"",\
+    "api":"zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/quota-config","errorMsg":""},\
+    "httpStatusCode":"200","requestId":"88da1775","successResponse":true}
+    """
+
+    /// Wraps an inner payload in the gateway envelope so tests can vary just the payload.
+    static func envelope(innerCode: String = "SUCCESS", payloadJSON: String, errorCode: String = "") -> String {
+        """
+        {"code":"200","data":{"DataV2":{"data":{"msg":"x","code":"\(innerCode)",\
+        "data":\(payloadJSON),"success":true}},"success":true,"httpStatus":200,"errorCode":"\(errorCode)"}\
+        ,"httpStatusCode":"200","successResponse":true}
+        """
+    }
+
+    // MARK: - secToken / login-failure detection
+
+    func testSecTokenExtraction() {
+        XCTAssertEqual(QwenUsageMapper.secToken(from: Data(Self.infoBody.utf8)), "NYOOSBQvO9PGTxFmHt0pT1")
+    }
+
+    func testSecTokenMissingOnDeadSession() {
+        let body = """
+        {"code":"200","data":{"sessionExpireTimeStamp":null,"secToken":null},\
+        "successResponse":false}
+        """
+        XCTAssertNil(QwenUsageMapper.secToken(from: Data(body.utf8)))
+        XCTAssertTrue(QwenUsageMapper.isConsoleLoginFailure(Data(body.utf8)))
+    }
+
+    func testConsoleNeedLoginCodeIsLoginFailure() {
+        let body = """
+        {"code":"ConsoleNeedLogin","data":null,"successResponse":false}
+        """
+        XCTAssertTrue(QwenUsageMapper.isConsoleLoginFailure(Data(body.utf8)))
+    }
+
+    // MARK: - usage
+
+    func testUsageMapsBothWindowsWithResetDates() throws {
+        let lines = try QwenUsageMapper.mapUsage(Data(Self.usageBody.utf8))
+        XCTAssertEqual(lines.count, 2)
+
+        guard case .progress(let sessionLabel, let sessionUsed, let sessionLimit, let sessionFormat,
+                             let sessionResets, let sessionPeriod, _) = lines[0] else {
+            return XCTFail("expected a progress line for the 5-hour window")
+        }
+        XCTAssertEqual(sessionLabel, "5-Hour")
+        XCTAssertEqual(sessionUsed, 0.10967993005003332 * 100, accuracy: 0.0001)
+        XCTAssertEqual(sessionLimit, 100)
+        XCTAssertEqual(sessionFormat, .percent)
+        XCTAssertEqual(sessionResets, Date(timeIntervalSince1970: 1785353040000.0 / 1000))
+        XCTAssertEqual(sessionPeriod, MetricPeriod.sessionMs)
+
+        guard case .progress(let weeklyLabel, let weeklyUsed, _, _, let weeklyResets, let weeklyPeriod, _) = lines[1] else {
+            return XCTFail("expected a progress line for the weekly window")
+        }
+        XCTAssertEqual(weeklyLabel, "Weekly")
+        XCTAssertEqual(weeklyUsed, 0.31521579342249 * 100, accuracy: 0.0001)
+        XCTAssertEqual(weeklyResets, Date(timeIntervalSince1970: 1785802380000.0 / 1000))
+        XCTAssertEqual(weeklyPeriod, MetricPeriod.weekMs)
+    }
+
+    func testUsageOverFullClampsToOneHundred() throws {
+        let body = Self.envelope(payloadJSON: """
+        {"per5HourPercentage":1.4,"per5HourResetTime":1785353040000,\
+        "per1WeekPercentage":0.5,"per1WeekResetTime":1785802380000}
+        """)
+        let lines = try QwenUsageMapper.mapUsage(Data(body.utf8))
+        guard case .progress(_, let used, _, _, _, _, _) = lines[0] else {
+            return XCTFail("expected progress")
+        }
+        XCTAssertEqual(used, 100)
+    }
+
+    func testUsageMissingPercentageIsInvalidNotZero() {
+        let body = Self.envelope(payloadJSON: """
+        {"per5HourResetTime":1785353040000,"per1WeekPercentage":0.5,"per1WeekResetTime":1785802380000}
+        """)
+        XCTAssertThrowsError(try QwenUsageMapper.mapUsage(Data(body.utf8))) { error in
+            XCTAssertEqual(error as? QwenUsageError, .invalidResponse)
+        }
+    }
+
+    func testUsageNegativePercentageIsInvalid() {
+        let body = Self.envelope(payloadJSON: """
+        {"per5HourPercentage":-0.1,"per5HourResetTime":1785353040000,\
+        "per1WeekPercentage":0.5,"per1WeekResetTime":1785802380000}
+        """)
+        XCTAssertThrowsError(try QwenUsageMapper.mapUsage(Data(body.utf8))) { error in
+            XCTAssertEqual(error as? QwenUsageError, .invalidResponse)
+        }
+    }
+
+    func testUsageMissingResetStillMaps() throws {
+        let body = Self.envelope(payloadJSON: """
+        {"per5HourPercentage":0.25,"per1WeekPercentage":0.5,"per1WeekResetTime":1785802380000}
+        """)
+        let lines = try QwenUsageMapper.mapUsage(Data(body.utf8))
+        guard case .progress(_, _, _, _, let resets, _, _) = lines[0] else {
+            return XCTFail("expected progress")
+        }
+        XCTAssertNil(resets)
+    }
+
+    func testGatewayLoginFailureSurfacesAsSessionExpired() {
+        let body = Self.envelope(innerCode: "ConsoleNeedLogin", payloadJSON: "{}")
+        XCTAssertThrowsError(try QwenUsageMapper.mapUsage(Data(body.utf8))) { error in
+            XCTAssertEqual(error as? QwenUsageError, .sessionExpired)
+        }
+    }
+
+    func testGatewayErrorCodeLoginFailureSurfacesAsSessionExpired() {
+        let body = Self.envelope(payloadJSON: "{}", errorCode: "ConsoleNeedLogin")
+        XCTAssertThrowsError(try QwenUsageMapper.mapUsage(Data(body.utf8))) { error in
+            XCTAssertEqual(error as? QwenUsageError, .sessionExpired)
+        }
+    }
+
+    func testNonSuccessInnerCodeIsInvalidResponse() {
+        let body = Self.envelope(innerCode: "SOMETHING_ELSE", payloadJSON: "{}")
+        XCTAssertThrowsError(try QwenUsageMapper.mapUsage(Data(body.utf8))) { error in
+            XCTAssertEqual(error as? QwenUsageError, .invalidResponse)
+        }
+    }
+
+    func testGarbageBodyIsInvalidResponse() {
+        XCTAssertThrowsError(try QwenUsageMapper.mapUsage(Data("<html>nope</html>".utf8))) { error in
+            XCTAssertEqual(error as? QwenUsageError, .invalidResponse)
+        }
+    }
+
+    // MARK: - subscription
+
+    func testSubscriptionWithoutAutoRenewProducesWarning() throws {
+        let info = try QwenUsageMapper.mapSubscription(Data(Self.subscriptionBody.utf8))
+        XCTAssertEqual(info.tierKey, "standard")
+        XCTAssertEqual(info.planName, "Standard")
+        XCTAssertEqual(info.renewalWarning, "Auto-renew is off — plan ends in 22 days.")
+    }
+
+    func testSubscriptionWithAutoRenewHasNoWarning() throws {
+        let body = Self.envelope(payloadJSON: """
+        {"specCode":"pro","remainingDays":200,"autoRenewFlag":true,"status":"VALID"}
+        """)
+        let info = try QwenUsageMapper.mapSubscription(Data(body.utf8))
+        XCTAssertEqual(info.planName, "Pro")
+        XCTAssertNil(info.renewalWarning)
+    }
+
+    func testSubscriptionMissingSpecIsInvalid() {
+        let body = Self.envelope(payloadJSON: """
+        {"remainingDays":22,"autoRenewFlag":false}
+        """)
+        XCTAssertThrowsError(try QwenUsageMapper.mapSubscription(Data(body.utf8))) { error in
+            XCTAssertEqual(error as? QwenUsageError, .invalidResponse)
+        }
+    }
+
+    // MARK: - quota-config
+
+    func testQuotaCapsForKnownTier() {
+        let caps = QwenUsageMapper.quotaCaps(Data(Self.quotaConfigBody.utf8), tierKey: "standard")
+        XCTAssertEqual(caps, QwenUsageMapper.QuotaCaps(fiveHour: 3000, weekly: 10000))
+    }
+
+    func testQuotaCapsForUnknownTierIsNil() {
+        XCTAssertNil(QwenUsageMapper.quotaCaps(Data(Self.quotaConfigBody.utf8), tierKey: "mega"))
+    }
+
+    func testQuotaCapsNegativeValuesAreNil() {
+        let body = Self.envelope(payloadJSON: """
+        {"standard":{"five_hour":-1,"weekly":10000.0}}
+        """)
+        XCTAssertNil(QwenUsageMapper.quotaCaps(Data(body.utf8), tierKey: "standard"))
+    }
+
+    func testPlanLabelWithAndWithoutCaps() {
+        let caps = QwenUsageMapper.QuotaCaps(fiveHour: 3000, weekly: 10000)
+        XCTAssertEqual(QwenUsageMapper.planLabel(planName: "Standard", caps: caps),
+                       "Standard · 3,000 / 5h · 10,000 / wk")
+        XCTAssertEqual(QwenUsageMapper.planLabel(planName: "Standard", caps: nil), "Standard")
+    }
+}

--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -1,0 +1,64 @@
+# Qwen
+
+Tracks [Qwen Cloud](https://home.qwencloud.com) Token Plan (individual edition) usage quotas — the
+rolling 5-hour and weekly windows shown on the plan's billing page.
+
+## What it tracks
+
+| Metric | Meaning |
+|---|---|
+| Session | 5-hour rolling window usage (percentage) |
+| Weekly | 7-day rolling window usage (percentage) |
+
+When Qwen reports your plan tier, OpenUsage shows it beside the provider name (with the tier's
+quota numbers when available). If auto-renew is off, an amber notice warns how many days the plan
+has left.
+
+## Where credentials come from
+
+Qwen API keys are inference-only — plan usage lives behind the web console, authenticated by your
+browser session. OpenUsage captures that session once, in-app:
+
+1. **Sign in from the app** — open Qwen in **Customize**, click **Sign In**, and log in to
+   qwencloud.com in the window that opens. OpenUsage verifies the session and stores the needed
+   cookies in `~/.config/openusage/qwen.json` (readable only by your user).
+2. **Or paste cookies by hand** — copy the `Cookie` header from your browser's DevTools on the
+   billing page and save it to `~/.config/openusage/qwen.json`:
+
+```json
+{"cookies":"login_qwencloud_ticket=…; cna=…"}
+```
+
+The sign-in window keeps its own browser state, so after one sign-in, signing in again later
+recaptures the still-live session without retyping anything. Sessions last roughly 30 days; when
+yours expires, the card shows an error and Sign In works the same way. Nothing leaves your Mac
+except the same calls qwencloud.com's own billing page makes.
+
+## Setup
+
+1. Subscribe to the [Qwen Token Plan](https://home.qwencloud.com/billing/subscription/token-plan-individual).
+2. Open **Customize → Qwen**, click **Sign In**, and log in.
+3. Qwen appears on the dashboard and (after you star a metric) the menu bar on the next refresh.
+
+## Under the hood
+
+The same internal endpoints qwencloud.com's billing page uses (stable in practice):
+
+- `GET https://home.qwencloud.com/tool/user/info.json` — session check and the `sec_token` every
+  other call carries.
+- `POST https://cs-data.qwencloud.com/data/api.json` three times — `usage` (the meters),
+  `subscription` (plan tier + renewal, best-effort), and `quota-config` (per-tier quota numbers,
+  best-effort; a failure here doesn't blank the meters).
+
+Percentages arrive as fractions of 1.0 and reset times as epoch milliseconds. Missing required
+usage values are reported as an invalid response instead of being shown as zero. Only the
+international (Singapore) plan edition is supported; the region is carried in the config file so
+others can be added later.
+
+## Troubleshooting
+
+- **"Not signed in to Qwen Cloud"** — sign in from Customize → Qwen, or save your cookies to the
+  config file.
+- **"Qwen Cloud session expired"** — normal after ~30 days; sign in again from Customize → Qwen.
+- **Sign-in window won't complete** — qwencloud.com occasionally challenges automated browsers;
+  log in normally in the window (it's a real browser view), or fall back to pasting cookies.


### PR DESCRIPTION
## Approved issue

_Draft PR — no approved issue yet. Will open one via the new-provider template and link it before requesting review._

## TL;DR

Adds a `qwen` provider that tracks Qwen Cloud Token Plan (individual edition) usage: the rolling 5-hour and weekly quota windows shown on the plan's billing page, with reset countdowns, plan tier, and an auto-renew warning.

## What was happening

OpenUsage had no Qwen provider — Token Plan usage was only visible on the qwencloud.com billing page. The plan's data is unreachable with API keys (they are inference-only; verified by probing the gateway), so the existing "read a credential the provider's CLI already stored" pattern could not apply: the billing API is browser-session-cookie-only, exactly the calls the billing page itself makes.

## What this changes

- New `Sources/OpenUsage/Providers/Qwen/` module (`ProviderRuntime`): auth store (`~/.config/openusage/qwen.json`, 0600), usage client (`home.qwencloud.com/tool/user/info.json` for the session probe + `sec_token`, then three `cs-data.qwencloud.com/data/api.json` calls: `usage` (required), `subscription` and `quota-config` (best-effort)), pure mapper verified against live-captured payloads.
- New `SessionManaging` protocol (sibling of `APIKeyManaging`) + a Sign In / Sign Out session card in the provider's Customize detail, and `QwenLoginController`: the app's first interactive sign-in — a WKWebView window on the persistent website data store, so after one login, later sign-ins silently recapture the live session. A hand-pasted cookie file works too (headless fallback).
- Widgets: Session (5h) and Weekly percent meters with reset countdowns; plan label with tier quota numbers; amber header warning when auto-renew is off.
- Registration in `ProviderCatalog`/`AppContainer`/`DefaultLayout`, arc-free `qwen.svg` mark, `docs/providers/qwen.md`, and tests.

## Heads-up

- **First interactive sign-in in the app.** The codebase ethos is "never ask the user for a token," but Qwen exposes no local credential to read (inference keys can't reach billing data — verified). The WebView captures only what the console itself sets, verifies the session with a live `info.json` call before persisting, stores cookies 0600, and never logs them. The provider is fully functional with just the config file, so the WebView layer is removable if unwanted.
- **Size:** ~1,552 insertions including tests (608 lines). If the 1,000-line policy applies, happy to split into an implementation+docs PR (~944) and a tests PR (~608) — guidance welcome.
- **Metric placement defaults** (enabled: session+weekly; pinned: session+weekly following the Z.ai precedent; both Always Visible) are provisional pending owner confirmation per AGENTS.md.
- **International (Singapore) edition only**; the region is carried in the config so other editions can follow. The console API is internal/unversioned, so decoding is strict (failures surface as categorized errors, never silent zero meters) and tests pin the real payload shapes.

## Tests

- `swift test`: 1,328 tests pass (3 pre-existing skips), including 40+ new tests — mapper tests against live-captured payloads (unknown-field tolerance, login-failure envelopes, clamping), provider tests with `RoutingHTTPClient`/`FakeFiles` (happy path, expired session, decode/HTTP/rate-limit/transport failures, best-effort degradation, `SessionManaging` round-trip), and pure-function tests for the cookie capture.
- Verified in a local `build_and_run.sh` build against a real Token Plan account: fresh install auto-enabled the provider via `hasLocalCredentials()`, refresh logged `qwen ok`, and the local HTTP API reported live Session/Weekly meters with correct reset times.

## Screenshots

Will attach before marking ready: menu-bar widgets, the Customize session card, and the sign-in window.
