### PR TITLE
Use the newer of the cached and bundled pricing supplement

### DIFF
--- a/Sources/OpenUsage/Pricing/ModelPricingStore.swift
+++ b/Sources/OpenUsage/Pricing/ModelPricingStore.swift
@@ -103,23 +103,55 @@ actor ModelPricingStore {
         )
     }
 
+    /// Whichever of the fetched cache and the bundled resource carries the newer `updated_at`. The
+    /// cache can't simply win: an app update ships a newer bundled supplement while an older cache is
+    /// still on disk, and the feed is only re-read once an hour — so a cache-always-wins rule hides
+    /// freshly shipped rates for that hour, and forever for anyone who can't reach the feed.
     private func loadSupplement() -> PricingSupplement {
-        if let cached = readCache(.supplement) {
-            do {
-                return try PricingSupplement.decode(from: cached)
-            } catch {
-                AppLog.warn("pricing", "cached supplement unreadable, using bundled: \(error.localizedDescription)")
-            }
-        }
-        guard let bundled = bundledData("pricing_supplement") else {
-            AppLog.error("pricing", "bundled pricing_supplement.json missing")
+        let cached = decodedCachedSupplement()
+        let bundled = decodedBundledSupplement()
+        switch (cached, bundled) {
+        case (let cached?, let bundled?):
+            // Bundled wins only when strictly newer, so the usual case (a feed ahead of the shipped
+            // file, or the two in step) keeps serving the cache.
+            return Self.isNewer(bundled.updatedAt, than: cached.updatedAt) ? bundled : cached
+        case (let cached?, nil):
+            return cached
+        case (nil, let bundled?):
+            return bundled
+        case (nil, nil):
             return PricingSupplement()
+        }
+    }
+
+    /// `updated_at` is a zero-padded ISO date, so lexicographic order is chronological. A missing
+    /// date counts as oldest — an undated file never displaces a dated one.
+    private static func isNewer(_ lhs: String?, than rhs: String?) -> Bool {
+        guard let lhs else { return false }
+        guard let rhs else { return true }
+        return lhs > rhs
+    }
+
+    private func decodedCachedSupplement() -> PricingSupplement? {
+        guard let data = readCache(.supplement) else { return nil }
+        do {
+            return try PricingSupplement.decode(from: data)
+        } catch {
+            AppLog.warn("pricing", "cached supplement unreadable, using bundled: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func decodedBundledSupplement() -> PricingSupplement? {
+        guard let data = bundledData("pricing_supplement") else {
+            AppLog.error("pricing", "bundled pricing_supplement.json missing")
+            return nil
         }
         do {
-            return try PricingSupplement.decode(from: bundled)
+            return try PricingSupplement.decode(from: data)
         } catch {
             AppLog.error("pricing", "bundled pricing_supplement.json unreadable: \(error.localizedDescription)")
-            return PricingSupplement()
+            return nil
         }
     }
 

--- a/Tests/OpenUsageTests/ModelPricingStoreTests.swift
+++ b/Tests/OpenUsageTests/ModelPricingStoreTests.swift
@@ -154,6 +154,64 @@ final class ModelPricingStoreTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "fetched-model")?.inputPerMillion, 5)
     }
 
+    /// An app update ships a newer bundled supplement while the cache from the previous version is
+    /// still on disk. The shipped rates must win until the feed catches up — otherwise a fix that
+    /// merged and shipped stays invisible, permanently for anyone who can't reach the feed.
+    func testNewerBundledSupplementBeatsOlderCache() async throws {
+        try writeSupplementCache(updatedAt: "2026-01-01", autoInput: 9)
+
+        let store = makeStoreWithBundledSupplement(updatedAt: "2026-06-01", autoInput: 4)
+        let pricing = await store.current()
+        XCTAssertEqual(pricing.resolve(model: "auto")?.inputPerMillion, 4)
+    }
+
+    /// The usual case: the feed runs ahead of the shipped file, so the cache keeps winning.
+    func testNewerCachedSupplementBeatsOlderBundled() async throws {
+        try writeSupplementCache(updatedAt: "2026-06-01", autoInput: 9)
+
+        let store = makeStoreWithBundledSupplement(updatedAt: "2026-01-01", autoInput: 4)
+        let pricing = await store.current()
+        XCTAssertEqual(pricing.resolve(model: "auto")?.inputPerMillion, 9)
+    }
+
+    /// An undated file never displaces a dated one, in either direction.
+    func testUndatedSupplementNeverDisplacesDatedOne() async throws {
+        try writeSupplementCache(updatedAt: nil, autoInput: 9)
+
+        let datedBundle = await makeStoreWithBundledSupplement(updatedAt: "2026-06-01", autoInput: 4).current()
+        XCTAssertEqual(datedBundle.resolve(model: "auto")?.inputPerMillion, 4)
+
+        try writeSupplementCache(updatedAt: "2026-06-01", autoInput: 9)
+        let undatedBundle = await makeStoreWithBundledSupplement(updatedAt: nil, autoInput: 4).current()
+        XCTAssertEqual(undatedBundle.resolve(model: "auto")?.inputPerMillion, 9)
+    }
+
+    private static func supplementJSON(updatedAt: String?, autoInput: Double) -> String {
+        let dateField = updatedAt.map { "\"updated_at\": \"\($0)\", " } ?? ""
+        return """
+        {\(dateField)"pricing": {"auto": {"input_per_million": \(autoInput), "output_per_million": 6.0}},
+         "fast_multipliers": {}, "alias_rules": []}
+        """
+    }
+
+    private func writeSupplementCache(updatedAt: String?, autoInput: Double) throws {
+        try Data(Self.supplementJSON(updatedAt: updatedAt, autoInput: autoInput).utf8)
+            .write(to: tempDir.appendingPathComponent("supplement.json"), options: .atomic)
+    }
+
+    /// A store whose bundled supplement carries `updatedAt`, with the network dead so only the
+    /// cache-vs-bundled choice is under test.
+    private func makeStoreWithBundledSupplement(updatedAt: String?, autoInput: Double) -> ModelPricingStore {
+        let json = Self.supplementJSON(updatedAt: updatedAt, autoInput: autoInput)
+        return ModelPricingStore(
+            http: RoutingHTTPClient(handler: { _ in throw URLError(.notConnectedToInternet) }),
+            cacheDirectory: tempDir,
+            bundledData: { name in
+                name == "pricing_supplement" ? Data(json.utf8) : Self.bundledFixtures(name)
+            }
+        )
+    }
+
     func testFailureRetryIntervalPreventsHammering() async throws {
         let counter = OSAllocatedUnfairLockedCounter()
         let (store, _) = makeStore(handler: { _ in

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -14,6 +14,8 @@ The app ships with bundled snapshots of all three, so pricing works offline and 
 
 Because the supplement is published to GitHub Pages on merge, a pricing correction reaches installed apps within about an hour — no app update needed.
 
+Updating the app also works. The supplement carries an `updated_at` date, and the app uses whichever of the cached and bundled copies is newer, so a build shipping fresher rates applies them straight away instead of waiting on the cache to expire. That matters most offline: without it, an old cache would shadow the shipped rates for as long as the feed stayed unreachable.
+
 ## How a model name resolves
 
 Log and CSV model names rarely match a catalog key exactly, so resolution tries, in order: supplement alias rules, exact key match, fast-variant handling (a `-fast` suffix resolves the base model and applies its fast multiplier), then fuzzy matching — provider prefixes (`anthropic/`, `xai/`, …), dated suffixes (`claude-sonnet-4` ↔ `claude-sonnet-4-20250514`), and separator differences (`grok-4-3` ↔ `grok-4.3`). Fast variants without an explicit price or model-specific multiplier stay unpriced instead of silently using the standard-speed rate.


### PR DESCRIPTION
## TL;DR

The cached pricing supplement beat the bundled one unconditionally, so a build shipping newer rates was ignored until the next successful fetch — and forever for anyone who can't reach the feed. Now the two are compared by the `updated_at` they already carry, and the newer wins.

## What was happening

- `loadSupplement()` returned the on-disk cache whenever one existed and never looked at the bundled resource. There was no age comparison in either direction.
- Sources refetch about once an hour, so right after an app update the previous version's cache shadowed the newly shipped supplement for up to that long.
- Worse offline: the cache is only replaced on a successful `200`. If the feed is unreachable — no network, restricted network, gh-pages down — a stale cache outranked a freshly shipped bundled file **indefinitely**. A pricing fix could merge, ship, and install, and still not apply.
- Hit in practice: after #1087 merged, a local build with Kimi K3 and the Cursor Router rules baked in still showed `Unknown models found — Opus 5 (Auto Balanced), kimi-k3-max`, because a July 14 cache was winning.
- Note the contrast with `loadCatalog()` right below it, which merges bundled with cache so snapshot-only models survive. Only the supplement was all-or-nothing.

## What this changes

- `loadSupplement()` decodes both copies and returns the one with the newer `updated_at`. `PricingSupplement.updatedAt` was already parsed and unused, so nothing new needed decoding.
- Bundled wins only when **strictly** newer, so the normal case — the feed ahead of the shipped file, or the two in step — keeps serving the cache exactly as before.
- A missing `updated_at` counts as oldest, so an undated file never displaces a dated one in either direction.
- Decoding is split into `decodedCachedSupplement()` / `decodedBundledSupplement()`, keeping the existing log levels: a bad cache warns and falls back, a bad bundled resource is an error.

## Tests

Three cases added to `ModelPricingStoreTests`, all against a real on-disk cache with the network dead so only the cache-vs-bundled choice is exercised:

- newer bundled beats older cache (the regression),
- newer cache beats older bundled (the common case still works),
- an undated file never displaces a dated one, in both directions.

Full suite green: 1300 tests, 0 failures.

## Heads-up

- `updated_at` is compared lexicographically. That's correct for the zero-padded ISO dates the file uses and stays correct for a full ISO 8601 timestamp, but it would silently misbehave on a non-ISO format. Worth remembering if the field's shape ever changes.
- The LiteLLM and models.dev catalogs are untouched — they carry no `updated_at`, and their merge already preserves bundled entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to supplement selection logic with clear fallbacks and new unit tests; no auth, network protocol, or catalog merge changes.
> 
> **Overview**
> **Pricing supplement loading** no longer treats the on-disk cache as authoritative whenever it exists. `loadSupplement()` decodes both the cached and bundled `pricing_supplement.json` and returns whichever has the **newer** `updated_at` (lexicographic compare; missing date counts as oldest). Bundled wins only when strictly newer, so the normal case—feed-ahead cache—stays unchanged.
> 
> Decoding is split into `decodedCachedSupplement()` / `decodedBundledSupplement()` with the same warn/error behavior as before. **Docs** note that app updates can apply shipped supplement rates immediately, including when offline.
> 
> **Tests** cover newer bundled vs older cache, newer cache vs older bundled, and undated vs dated supplements (network disabled so only the merge rule is exercised).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c11d762c9538e4d5d770ab3b58c85436073a872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->