### PR TITLE
feat(pricing): price Cursor Grok 4.6 and correct Grok 4.5 Fast output

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
-  "updated_at": "2026-08-11",
+  "updated_at": "2026-08-13",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -61,7 +61,20 @@
       "input_per_million": 4.0,
       "cache_write_per_million": 4.0,
       "cache_read_per_million": 1.0,
-      "output_per_million": 18.0
+      "output_per_million": 12.0
+    },
+    "grok-4.6": {
+      "$comment": "Cursor + SpaceXAI first-party model. Cache write not published separately; defaults to input. Cursor lists a 50% launch discount for one week starting 2026-08-12; rates below are the numbers on the pricing table as of 2026-08-13.",
+      "input_per_million": 2.0,
+      "cache_write_per_million": 2.0,
+      "cache_read_per_million": 0.5,
+      "output_per_million": 6.0
+    },
+    "grok-4.6-fast": {
+      "input_per_million": 4.0,
+      "cache_write_per_million": 4.0,
+      "cache_read_per_million": 1.0,
+      "output_per_million": 12.0
     },
     "kimi-k2.7-code": {
       "$comment": "Cursor's published Kimi K2.7 Code rates. Public catalogs disagree (some bare keys are $0), so this override wins.",
@@ -158,6 +171,9 @@
     { "pattern": "^composer-2\\.5$", "canonical": "composer-2.5" },
     { "pattern": "^composer-2\\.5-fast$", "canonical": "composer-2.5-fast" },
     { "pattern": "^github_bugbot$", "canonical": "github_bugbot" },
+    { "pattern": "^(?:cursor-)?grok-4\\.6-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.6-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.6(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.6-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.6(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.6" },
     { "pattern": "^(?:cursor-)?grok-4\\.5-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5-fast" },
     { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.5-fast" },
     { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5" },
@@ -232,6 +248,8 @@
     { "pattern": "(?i)^Composer 2\\.5 \\(Auto[^)]*\\)$", "canonical": "composer-2.5" },
     { "pattern": "(?i)^Composer 2 Fast \\(Auto[^)]*\\)$", "canonical": "composer-2-fast" },
     { "pattern": "(?i)^Composer 2 \\(Auto[^)]*\\)$", "canonical": "composer-2" },
+    { "pattern": "(?i)^(?:Cursor )?Grok 4\\.6 Fast \\(Auto[^)]*\\)$", "canonical": "grok-4.6-fast" },
+    { "pattern": "(?i)^(?:Cursor )?Grok 4\\.6 \\(Auto[^)]*\\)$", "canonical": "grok-4.6" },
     { "pattern": "(?i)^(?:Cursor )?Grok 4\\.5 Fast \\(Auto[^)]*\\)$", "canonical": "grok-4.5-fast" },
     { "pattern": "(?i)^(?:Cursor )?Grok 4\\.5 \\(Auto[^)]*\\)$", "canonical": "grok-4.5" },
     { "pattern": "(?i)^(?:Claude )?Haiku 4\\.5 \\(Auto[^)]*\\)$", "canonical": "claude-haiku-4-5" },

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -52,6 +52,8 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-high")?.inputPerMillion, 4)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-high-fast")?.inputPerMillion, 4)
         XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-high-fast")?.inputPerMillion, 4)
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.6-high")?.inputPerMillion, 2)
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.6-high-fast")?.inputPerMillion, 4)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2p5")?.inputPerMillion, 0.6)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2.7-code")?.inputPerMillion, 0.95)
         XCTAssertEqual(pricing.resolve(model: "kimi-k2p7")?.inputPerMillion, 0.95)
@@ -178,6 +180,8 @@ final class PricingBundledResourceTests: XCTestCase {
             "Composer 2.5 (Auto)": "composer-2.5",
             "Composer 2.5 Fast (Auto)": "composer-2.5-fast",
             "Composer 2 (Auto Balanced)": "composer-2",
+            "Grok 4.6 (Auto Intelligence)": "grok-4.6",
+            "Cursor Grok 4.6 Fast (Auto)": "grok-4.6-fast",
             "Grok 4.5 (Auto Intelligence)": "grok-4.5",
             "Cursor Grok 4.5 Fast (Auto)": "grok-4.5-fast",
             "GPT-5.5 (Auto)": "gpt-5.5",
@@ -291,7 +295,7 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(fast.inputPerMillion, 4.0)
         XCTAssertEqual(fast.cacheWritePerMillion, 4.0)
         XCTAssertEqual(fast.cacheReadPerMillion, 1.0)
-        XCTAssertEqual(fast.outputPerMillion, 18.0)
+        XCTAssertEqual(fast.outputPerMillion, 12.0)
         // Cursor CSV uses fast-before-effort (`grok-4.5-fast-high`); also accept effort-before-fast.
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-high"), fast)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-medium"), fast)
@@ -302,6 +306,33 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-high-fast"), fast)
         XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-fast-high"), fast)
         XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.5-high"), standard)
+    }
+
+    /// Grok 4.6 (Cursor + SpaceXAI first-party): same published table rates as Grok 4.5, with
+    /// effort slugs and the `cursor-` CSV prefix collapsing to the same entries.
+    func testGrok46PricingAndAliases() throws {
+        let pricing = Self.pricing
+        let standard = try XCTUnwrap(pricing.resolve(model: "grok-4.6-high"))
+        XCTAssertEqual(standard.inputPerMillion, 2.0)
+        XCTAssertEqual(standard.cacheWritePerMillion, 2.0)
+        XCTAssertEqual(standard.cacheReadPerMillion, 0.5)
+        XCTAssertEqual(standard.outputPerMillion, 6.0)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.6"), standard)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.6-low"), standard)
+
+        let fast = try XCTUnwrap(pricing.resolve(model: "grok-4.6-fast"))
+        XCTAssertEqual(fast.inputPerMillion, 4.0)
+        XCTAssertEqual(fast.cacheWritePerMillion, 4.0)
+        XCTAssertEqual(fast.cacheReadPerMillion, 1.0)
+        XCTAssertEqual(fast.outputPerMillion, 12.0)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.6-fast-high"), fast)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.6-high-fast"), fast)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.6-xhigh"), standard)
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.6-high-fast"), fast)
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.6-fast-high"), fast)
+        XCTAssertEqual(pricing.resolve(model: "cursor-grok-4.6-high"), standard)
+        XCTAssertEqual(pricing.supplement.canonicalName(for: "cursor-grok-4.6-high"), "grok-4.6")
+        XCTAssertEqual(pricing.supplement.canonicalName(for: "cursor-grok-4.6-high-fast"), "grok-4.6-fast")
     }
 
     /// Kimi K2.7 Code: Cursor's published rates override messy public-catalog entries.


### PR DESCRIPTION
## TL;DR

Prices Cursor Grok 4.6 (and Fast) so `cursor-grok-4.6-high` / `cursor-grok-4.6-high-fast` stop showing as unknown models, and corrects Grok 4.5 Fast output to Cursor's published $12/M.

## What was happening

- Cursor's usage export now emits `cursor-grok-4.6-high` and `cursor-grok-4.6-high-fast`. Neither LiteLLM, models.dev, nor the supplement had those keys, so those rows were left out of spend and the Today tile showed the unknown-model warning.
- Cursor's [models & pricing](https://cursor.com/docs/models-and-pricing.md) page now lists Grok 4.5 Fast output at **$12**/M. The supplement still had **$18**/M.

## What this changes

Source: [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md) (fetched 2026-08-13). Rates are USD per million tokens. Cache write is unpublished on the page, so it defaults to the input rate (same as Grok 4.5).

**New pricing**

| Key | Input | Cache write | Cache read | Output |
| --- | ---: | ---: | ---: | ---: |
| `grok-4.6` | $2 | $2 | $0.50 | $6 |
| `grok-4.6-fast` | $4 | $4 | $1 | $12 |

**Price correction**

| Key | Field | Was | Now |
| --- | --- | ---: | ---: |
| `grok-4.5-fast` | output | $18 | $12 |

**New aliases** (fast rules before base; optional `cursor-` prefix; effort suffixes `low`/`medium`/`high`/`xhigh`)

- `cursor-grok-4.6-high` → `grok-4.6`
- `cursor-grok-4.6-high-fast` / `cursor-grok-4.6-fast-high` → `grok-4.6-fast`
- Router labels `Grok 4.6 (Auto …)` / `Cursor Grok 4.6 Fast (Auto …)` → the matching key

`updated_at` bumped to `2026-08-13`.

## Heads-up

- Cursor notes a **50% launch discount** for Grok 4.6 for one week starting 2026-08-12. The table numbers above are the ones on the page today (same as Grok 4.5). If those are already discounted, rates may rise after ~2026-08-19 — we'll need another supplement bump if the table changes.
- Left alone on purpose: GPT-5.6 Terra/Luna (OpenAI preview rates already in the supplement; not Cursor-native) and Gemini 3.6 Flash (new Google API model — catalogs should pick it up; no alias until a real slug shows up).

## Tests

- Supplement JSON/regex validation passed.
- `swift test --filter "ModelPricing|PricingBundledResource"` — 58 tests, 0 failures (including new `testGrok46PricingAndAliases` covering the exact CSV slugs from the warning).


Made with [Cursor](https://cursor.com)