### PR TITLE
fix: restore Z.ai credit quota limits

### DIFF
--- a/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/ZAI/ZAIUsageMapper.swift
@@ -2,8 +2,10 @@ import Foundation
 
 /// Builds metric lines from the Z.ai `/api/monitor/usage/quota/limit` payload and the plan name from
 /// `/api/biz/subscription/list`. Ports and extends the legacy Tauri plugin's mapping:
-/// - a `TOKENS_LIMIT` entry whose window is sub-daily (`unit: 3`, hours) is the 5-hour session meter,
-/// - a `TOKENS_LIMIT` entry whose window is multi-day (`unit: 6`, weeks) is the weekly meter,
+/// - a `CREDIT_LIMIT` (or legacy `TOKENS_LIMIT`) entry whose window is sub-daily (`unit: 3`, hours)
+///   is the 5-hour session meter,
+/// - a `CREDIT_LIMIT` (or legacy `TOKENS_LIMIT`) entry whose window is multi-day (`unit: 6`, weeks)
+///   is the weekly meter,
 /// - a `TIME_LIMIT` entry (`unit: 5`, monthly) is the web-search/reader count meter (used / limit).
 ///
 /// Both endpoints are undocumented internal APIs used by Z.ai's own subscription UI; the response
@@ -61,10 +63,14 @@ enum ZAIUsageMapper {
         var lines: [MetricLine] = []
         var sawRecognizedLimit = false
 
-        // Split the TOKENS_LIMIT entries by window length: a sub-daily window is the session meter,
-        // a multi-day window is the weekly meter. Z.ai reports both, and both are percentage meters.
-        let tokenLimits = limits.filter { ($0["type"] as? String) == "TOKENS_LIMIT" || ($0["name"] as? String) == "TOKENS_LIMIT" }
-        for entry in tokenLimits {
+        // Split the percentage quota entries by window length: a sub-daily window is the session
+        // meter, and a multi-day window is the weekly meter. Current responses call these
+        // CREDIT_LIMIT; older plans used TOKENS_LIMIT for the same shape.
+        let percentageLimits = limits.filter {
+            let type = ($0["type"] as? String) ?? ($0["name"] as? String)
+            return type == "CREDIT_LIMIT" || type == "TOKENS_LIMIT"
+        }
+        for entry in percentageLimits {
             guard let window = try classifyTokenWindow(entry) else { continue }
             sawRecognizedLimit = true
             switch window {
@@ -100,10 +106,11 @@ enum ZAIUsageMapper {
 
     // MARK: - Private
 
-    /// How a `TOKENS_LIMIT` entry's window maps to a meter. Z.ai encodes the window as a `(unit, number)`
-    /// pair: `unit: 3` is hours (session), `unit: 6` is weeks (weekly), `unit: 5` is months. A sub-daily
-    /// window is the session meter; a multi-day window is the weekly meter. Unknown units are ignored
-    /// so a future Z.ai window cannot hide meters whose units OpenUsage still understands.
+    /// How a percentage quota entry's window maps to a meter. Z.ai encodes the window as a
+    /// `(unit, number)` pair: `unit: 3` is hours (session), `unit: 6` is weeks (weekly), `unit: 5` is
+    /// months. A sub-daily window is the session meter; a multi-day window is the weekly meter.
+    /// Unknown units are ignored so a future Z.ai window cannot hide meters whose units OpenUsage
+    /// still understands.
     private enum TokenWindow {
         case session(periodMs: Int)
         case weekly(periodMs: Int)
@@ -136,7 +143,7 @@ enum ZAIUsageMapper {
         return .weekly(periodMs: periodMs)
     }
 
-    /// A percentage meter (Session or Weekly) from a `TOKENS_LIMIT` entry.
+    /// A percentage meter (Session or Weekly) from a credit/token quota entry.
     private static func percentLine(_ entry: [String: Any], label: String, periodMs: Int) throws -> MetricLine {
         guard let rawPercentage = ProviderParse.number(entry["percentage"]) else {
             throw ZAIUsageError.invalidResponse

--- a/Tests/OpenUsageTests/ZAILiveResponseMappingTests.swift
+++ b/Tests/OpenUsageTests/ZAILiveResponseMappingTests.swift
@@ -15,6 +15,15 @@ final class ZAILiveResponseMappingTests: XCTestCase {
     ],"level":"pro"},"success":true}
     """#
 
+    // Captured from a GLM Coding Lite plan on 2026-08-13. Z.ai renamed the percentage quota type
+    // from TOKENS_LIMIT to CREDIT_LIMIT and no longer includes reset time for the active 5-hour window.
+    private let liveCreditQuota = #"""
+    {"code":200,"msg":"Operation successful","data":{"limits":[
+      {"type":"CREDIT_LIMIT","unit":3,"number":5,"usage":2000,"currentValue":0,"remaining":2000,"percentage":0},
+      {"type":"CREDIT_LIMIT","unit":6,"number":1,"usage":10000,"currentValue":9855,"remaining":145,"percentage":98,"nextResetTime":1786685679998}
+    ],"level":"lite"},"success":true}
+    """#
+
     private let liveSubscription = #"""
     {"code":200,"msg":"Operation successful","data":[{"productName":"GLM Coding Pro","status":"VALID","nextRenewTime":"2026-07-29","billingCycle":"monthly","inCurrentPeriod":true}],"success":true}
     """#
@@ -38,6 +47,18 @@ final class ZAILiveResponseMappingTests: XCTestCase {
         let web = try XCTUnwrap(progress(mapped.lines, "Web Searches"))
         XCTAssertEqual(web.used, 0, accuracy: 0.001)
         XCTAssertEqual(web.limit, 1000, accuracy: 0.001)
+    }
+
+    func testMapsCurrentCreditLimitResponseToSessionAndWeekly() throws {
+        let mapped = try ZAIUsageMapper.map(quotaBody: Data(liveCreditQuota.utf8), subscriptionBody: nil)
+
+        let session = try XCTUnwrap(progress(mapped.lines, "Session"))
+        XCTAssertEqual(session.used, 0, accuracy: 0.001)
+        XCTAssertEqual(session.periodDurationMs, 5 * 60 * 60 * 1000)
+
+        let weekly = try XCTUnwrap(progress(mapped.lines, "Weekly"))
+        XCTAssertEqual(weekly.used, 98, accuracy: 0.001)
+        XCTAssertEqual(weekly.periodDurationMs, 7 * 24 * 60 * 60 * 1000)
     }
 
     private func progress(_ lines: [MetricLine], _ label: String) -> (used: Double, limit: Double, periodDurationMs: Int?)? {

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -45,10 +45,11 @@ Two undocumented internal endpoints Z.ai's own subscription UI uses (stable in p
   blank the meters).
 - `GET https://api.z.ai/api/monitor/usage/quota/limit` — the quota meters.
 
-The quota response carries a `limits` array. Each `TOKENS_LIMIT` entry is a token window; its
-window length decides which meter it feeds (sub-daily → Session, multi-day → Weekly), while a
-`TIME_LIMIT` entry is the monthly web-search count. Reset times come back as epoch milliseconds.
-Missing required usage values are reported as an invalid response instead of being shown as zero.
+The quota response carries a `limits` array. Each `CREDIT_LIMIT` entry (called `TOKENS_LIMIT` in
+older responses) is a percentage quota window; its window length decides which meter it feeds
+(sub-daily → Session, multi-day → Weekly), while a `TIME_LIMIT` entry is the monthly web-search
+count. Reset times come back as epoch milliseconds. Missing required usage values are reported as
+an invalid response instead of being shown as zero.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## TL;DR

Restore Z.ai Session and Weekly meters after the quota API renamed percentage limits from `TOKENS_LIMIT` to `CREDIT_LIMIT`.

## What was happening

- Z.ai refreshes completed successfully, so the log reported `zai ok`.
- Current GLM Coding Lite responses label both percentage quota windows as `CREDIT_LIMIT`.
- The mapper only recognized the older `TOKENS_LIMIT` name and returned a successful no-data snapshot, leaving both meters blank.

## What this changes

- Recognizes current `CREDIT_LIMIT` and legacy `TOKENS_LIMIT` entries as the same percentage quota shape.
- Keeps the existing window-based Session and Weekly classification.
- Adds an anonymized live-response regression fixture for the current GLM Coding Lite payload.
- Updates the Z.ai provider documentation with both response names.

## Heads-up

- These are undocumented endpoints used by Z.ai's own subscription UI, so the live-response fixture intentionally preserves only the structural fields consumed by the mapper.

## Tests

- `swift test --filter ZAI` — 42 passed.
- `swift test` — 1,278 XCTest tests passed, 3 skipped; 3 Swift Testing tests passed.
- `CONFIG=debug ./script/build_and_run.sh verify` — dev app rebuilt, launched, and verified.
- Live API + UI — Session rendered as 100% left and Weekly as 2% left instead of `No data`.

## Screenshots

Verified in the dev build with the production settings copied into the dev defaults domain:

![Z.ai Session and Weekly limits](https://raw.githubusercontent.com/robinebers/openusage/codex/zai-credit-limits-assets/openusage-zai-credit-limits.png)