### PR TITLE
fix: restore smooth translucent scrolling

### DIFF
--- a/Sources/OpenUsage/Support/Theme.swift
+++ b/Sources/OpenUsage/Support/Theme.swift
@@ -113,15 +113,10 @@ private struct CardSurfaceModifier: ViewModifier {
                     .fill(Theme.traySurface)
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }
             case .translucent:
-                // Increase Transparency, party, and drunk: the card carries its own frosted
-                // `.regularMaterial` so metric text stays legible over whatever shows through the
-                // behind-window backdrop (the desktop, or the party tint over it), with `.fill.quaternary`
-                // on top preserving the grouped-card hierarchy. HIG: back content-layer surfaces with a
-                // standard material — a bare low-opacity fill over the desktop is the "washed out"
-                // anti-pattern. This is a standard material, not `glassEffect`: Liquid Glass stays in the
-                // chrome layer, not the content cards.
+                // The AppKit backdrop already applies the system blur. A stable translucent surface here
+                // keeps text legible without stacking another live material pass under every card.
                 Theme.cardShape
-                    .fill(.regularMaterial)
+                    .fill(Theme.traySurface.opacity(0.55))
                     .overlay { Theme.cardShape.fill(Theme.cardFill) }
             }
         }

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -29,7 +29,7 @@ time; it also reports unavailable iCloud, loading, write, and malformed-file sta
 | Density | Default / Compact | Default breathes; Compact is a real information-dense mode — text steps down one size, rows and provider sections pull together, and Customize / Settings rows tighten with them. In both, consecutive one-line metrics (Today / Yesterday / …) pull together; Compact pulls harder. |
 | Reduce Animations | Off / On | Off by default. On removes transitions, motion effects, and continuous decorative animation throughout the popover. The app also honors the macOS Reduce Motion accessibility setting. |
 | Time Format | Auto / 12-hour / 24-hour | How exact times read (e.g. "Resets today at 6:38 PM" vs "18:38"). Auto follows the system. |
-| Increase Transparency | Off / On | Off (default) keeps the popover a solid panel. On makes it translucent so your desktop shows through, while keeping the numbers and Options control legible with adaptive frosted surfaces. It pauses automatically when you have the macOS **Reduce Transparency** or **Increase Contrast** accessibility setting turned on (a note explains why), so it never works against those preferences. |
+| Increase Transparency | Off / On | Off (default) keeps the popover a solid panel. On makes it translucent so your desktop shows through, while keeping the numbers and Options control legible with adaptive surfaces. It pauses automatically when you have the macOS **Reduce Transparency** or **Increase Contrast** accessibility setting turned on (a note explains why), so it never works against those preferences. |
 
 ## Usage Display
 


### PR DESCRIPTION
## TL;DR

Restores near-native scrolling cadence when Increase Transparency is enabled by removing the per-card live material pass. The popover still uses its single AppKit vibrancy backdrop, while cards use a stable translucent system surface for legibility.

## What was happening

- Every translucent card rendered its own `.regularMaterial` on top of the full-window `NSVisualEffectView`.
- Scrolling moved several overlapping live blur surfaces at once, making Core Animation the bottleneck even though app-side updates stayed cheap.
- On the built-in 120 Hz display, an Animation Hitches trace measured 62.82 FPS with a 16.65 ms median frame interval.

## What this changes

- Keeps the existing AppKit vibrancy backdrop as the single system blur.
- Replaces each card's nested material with a stable translucent tray surface plus the existing grouped-card fill.
- Updates the Increase Transparency settings documentation to match the implementation.

## Heads-up

- This only affects translucent modes. The default opaque surface is unchanged.
- There is no intended layout or interaction change.

## Tests

- `swift test` — 1,277 tests passed, 3 skipped, 0 failures.
- `CONFIG=debug ./script/build_and_run.sh verify` — dev app built, signed ad hoc, and launched.
- Copied production preferences into `com.robinebers.openusage.dev`, then verified the dashboard and scrolling with Computer Use.
- Instruments Animation Hitches, same 120 Hz input stream:
  - Before: 62.82 FPS; median frame 16.65 ms; p95 20.84 ms.
  - After: 118.01 FPS; median frame 8.33 ms; p95 8.37 ms.

## Screenshots

No intended visual change; verified the translucent dashboard before and after at 320 × 921.

<img width="320" height="921" alt="OpenUsage translucent dashboard after the scrolling fix" src="https://github.com/user-attachments/assets/ac567ed2-ad20-4813-81dd-03a933ca330e" />
