### PR TITLE
fix(copilot): show personal credits on org-managed seats

### DIFF
--- a/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
@@ -76,13 +76,15 @@ final class CopilotProvider: ProviderRuntime {
 
             let mapped = try CopilotUsageMapper.map(response)
 
-            // An org-managed (token-based-billing) seat has no per-seat quota, so the real usage lives
-            // in the org's billing. Look it up there — best-effort: an org admin sees Org Credits /
-            // Org Spend, everyone else keeps the plan-only card as before. Gated on the mapper's
-            // explicit flag, never on `lines` being empty (issue #839).
+            // An org-managed (token-based-billing) seat has no per-seat percent meter, so the real
+            // usage lives in the org's billing. Look it up there — best-effort: an org admin sees
+            // Org Credits / Org Spend, everyone else keeps the plan-only card as before. Gated on
+            // the mapper's explicit flag, never on `lines` being empty (issue #839). Appended rather
+            // than replacing: `mapped.lines` can already carry the user's own personal Credits count
+            // (issue #1094), which must survive alongside whatever the org lookup adds.
             var lines = mapped.lines
             if mapped.isOrgManagedSeat {
-                lines = await orgBillingLines(token: token.value)
+                lines += await orgBillingLines(token: token.value)
             }
 
             return ProviderSnapshot.make(provider: provider, plan: mapped.plan, lines: lines, refreshedAt: now())

--- a/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotProvider.swift
@@ -39,7 +39,7 @@ final class CopilotProvider: ProviderRuntime {
     var widgetDescriptors: [WidgetDescriptor] {
         [
             .percent(id: "copilot.premium", provider: provider, title: "Credits")
-                .exportingLimit("premiumCredits", unit: "percent"),
+                .exportingLimit("premiumCredits", unit: "credits", source: .progressOrValue(kind: .count)),
             .values(id: "copilot.extra", provider: provider, title: "Extra Usage", selection: .kind(.count))
                 .exportingLimit("extraUsage", unit: "count", source: .value(kind: .count)),
             .values(id: "copilot.orgCredits", provider: provider, title: "Org Credits", selection: .kind(.count))

--- a/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/Copilot/CopilotUsageMapper.swift
@@ -3,11 +3,14 @@ import Foundation
 struct CopilotMappedUsage: Equatable, Sendable {
     var plan: String?
     var lines: [MetricLine]
-    /// True for an org-managed (token-based-billing) seat whose response carried no usable per-seat
-    /// meters — the signal that the real usage lives in *organization* billing, where the provider
+    /// True for an org-managed (token-based-billing) seat whose response carried no *percent* per-seat
+    /// meter — the signal that the real usage lives in *organization* billing, where the provider
     /// should look next. Kept as an explicit flag so the org lookup is never gated on the incidental
     /// shape of `lines` (see issue #839: a placeholder `overage_permitted` used to sneak an
-    /// "Extra Usage: 0" row in and block the lookup).
+    /// "Extra Usage: 0" row in and block the lookup). `lines` isn't necessarily empty when this is
+    /// `true`: the same placeholder can still carry the user's own `credits_used`, shown as a personal
+    /// Credits count (issue #1094) — the provider must merge that with any org-billing lines rather
+    /// than replace it.
     var isOrgManagedSeat: Bool = false
 }
 
@@ -18,8 +21,9 @@ struct CopilotMappedUsage: Equatable, Sendable {
 /// `chat`/`completions` as the `-1` "unlimited" sentinel (suppressed); free plans carry real `chat` and
 /// `completions` counts — either inside `quota_snapshots` (current) or, on older responses, as
 /// `limited_user_quotas` against `monthly_quotas`. Zero-entitlement placeholder snapshots — what GitHub
-/// returns for Copilot Business token-based-billing seats — carry no real signal and are suppressed
-/// rather than rendered as a misleading "0% used" bar.
+/// returns for Copilot Business token-based-billing seats — have no percent allotment and are not
+/// rendered as a misleading "0% used" bar. The same bucket can still carry a personal `credits_used`
+/// count (issue #1094), which is shown as unbounded Credits.
 enum CopilotUsageMapper {
     static let periodMs = MetricPeriod.monthMs
 
@@ -66,15 +70,20 @@ enum CopilotUsageMapper {
             appendIfPresent(&lines, limitedLine(label: "Completions", remaining: limited?["completions"], total: monthly?["completions"], resetsAt: resetsAt))
         }
 
-        // Copilot Business / token-based-billing seats expose no per-seat quota — a legitimate empty
-        // state, not a failure. Surface the plan with empty meters (the tiles read "No data") so the
-        // dashboard still identifies the plan, instead of a loud error that drops it. A genuinely empty
-        // or garbled payload (no token-based-billing marker) is a real problem and fails loudly.
+        // Copilot Business / token-based-billing seats expose no per-seat percent quota — a legitimate
+        // empty state, not a failure. Surface the plan (and a personal Credits count when
+        // `credits_used` is present) so the dashboard still identifies the plan, instead of a loud
+        // error that drops it. A genuinely empty or garbled payload (no token-based-billing marker)
+        // is a real problem and fails loudly.
         guard !lines.isEmpty else {
-            if ProviderParse.bool(body["token_based_billing"]) == true {
-                return CopilotMappedUsage(plan: plan, lines: [], isOrgManagedSeat: true)
+            guard ProviderParse.bool(body["token_based_billing"]) == true else {
+                throw CopilotUsageError.quotaUnavailable
             }
-            throw CopilotUsageError.quotaUnavailable
+            return CopilotMappedUsage(
+                plan: plan,
+                lines: personalCreditsLines(premium),
+                isOrgManagedSeat: true
+            )
         }
 
         return CopilotMappedUsage(plan: plan, lines: lines)
@@ -116,6 +125,21 @@ enum CopilotUsageMapper {
             resetsAt: resetsAt,
             periodDurationMs: periodMs
         )
+    }
+
+    /// Personal `credits_used` on an org-managed zero-entitlement placeholder. Used only after the
+    /// percent-based lines all come back empty. There's no allotment to show a percentage against, so
+    /// a real positive count is shown as unbounded Credits instead of leaving the card empty.
+    /// Extra Usage stays suppressed here: the placeholder can carry `overage_permitted: true` with
+    /// no included pool (issue #839). A zero or missing `credits_used` stays "No data".
+    private static func personalCreditsLines(_ raw: Any?) -> [MetricLine] {
+        guard let snapshot = raw as? [String: Any],
+              let creditsUsed = ProviderParse.number(snapshot["credits_used"]),
+              creditsUsed > 0
+        else {
+            return []
+        }
+        return [.values(label: "Credits", values: [MetricValue(number: creditsUsed, kind: .count)])]
     }
 
     /// "Extra Usage" — premium interactions consumed beyond the included Credits pool. Surfaced only once

--- a/Tests/OpenUsageTests/CopilotProviderTests.swift
+++ b/Tests/OpenUsageTests/CopilotProviderTests.swift
@@ -318,6 +318,47 @@ final class CopilotUsageMapperTests: XCTestCase {
         XCTAssertFalse(paid.isOrgManagedSeat)
     }
 
+    func testShowsPersonalCreditsUsedOnOrgManagedPlaceholder() throws {
+        // The exact shape reported in issue #1094: org-managed seat, zero entitlement, but
+        // `premium_interactions.credits_used` carries the user's own real per-seat consumption.
+        let body: [String: Any] = [
+            "copilot_plan": "business",
+            "token_based_billing": true,
+            "quota_snapshots": [
+                "chat": ["unlimited": true, "token_based_billing": true, "credits_used": 0, "entitlement": 0, "percent_remaining": 100.0],
+                "completions": ["unlimited": true, "token_based_billing": true, "credits_used": 0, "entitlement": 0, "percent_remaining": 100.0],
+                "premium_interactions": [
+                    "unlimited": true, "token_based_billing": true, "credits_used": 2111, "entitlement": 0,
+                    "overage_permitted": true, "percent_remaining": 100.0
+                ]
+            ]
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertEqual(mapped.plan, "Business")
+        XCTAssertEqual(countValue(mapped.lines, "Credits"), 2111)
+        XCTAssertNil(mapped.lines.first(where: { $0.label == "Extra Usage" }))
+        XCTAssertTrue(mapped.isOrgManagedSeat)
+    }
+
+    func testUnusedOrgManagedSeatStillShowsNoData() throws {
+        // A genuinely unused seat (`credits_used` 0 or absent) must not regress to showing "0" — it
+        // stays empty, same as `testTokenBasedBillingReturnsPlanWithoutMeters`.
+        let body: [String: Any] = [
+            "copilot_plan": "business",
+            "token_based_billing": true,
+            "quota_snapshots": [
+                "premium_interactions": ["entitlement": 0, "remaining": 0, "credits_used": 0]
+            ]
+        ]
+
+        let mapped = try CopilotUsageMapper.map(body: body)
+
+        XCTAssertTrue(mapped.lines.isEmpty)
+        XCTAssertTrue(mapped.isOrgManagedSeat)
+    }
+
     func testThrowsQuotaUnavailableWhenEmpty() {
         XCTAssertThrowsError(try CopilotUsageMapper.map(body: ["copilot_plan": "pro"])) { error in
             XCTAssertEqual(error as? CopilotUsageError, .quotaUnavailable)
@@ -474,6 +515,44 @@ final class CopilotProviderTests: XCTestCase {
         XCTAssertNil(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey))
     }
 
+    func testOrgManagedSeatWithPersonalCreditsShowsThemDespiteForbiddenOrgBilling() async {
+        // A plain org member (403 on org billing, issue #1094) must still see their own credit
+        // consumption from the user-scoped endpoint instead of a fully empty card.
+        let forbidden = HTTPResponse(statusCode: 403, headers: [:], body: Data())
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makeBusinessPlaceholderBodyWithPersonalCredits(2111))),
+            ("/user/orgs", okJSON([["login": "acme"]])),
+            ("/orgs/acme/settings/billing/usage/summary", forbidden)
+        ])
+        let defaults = freshDefaults()
+        let provider = makeOrgProvider(http: http, defaults: defaults)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertNil(snapshot.errorCategory)
+        XCTAssertEqual(snapshot.plan, "Business")
+        XCTAssertEqual(countValue(snapshot.lines, "Credits"), 2111)
+        XCTAssertNil(defaults.string(forKey: CopilotProvider.billingOrgDefaultsKey))
+    }
+
+    func testOrgManagedSeatWithPersonalCreditsAlsoKeepsOrgBillingLinesForAdmins() async {
+        // An org owner/billing manager gets both: their own personal Credits count, plus the org-wide
+        // Org Credits / Org Spend rows — the merge must not drop either side (issue #1094 vs #839).
+        let http = routedClient([
+            ("/copilot_internal/user", ok(makeBusinessPlaceholderBodyWithPersonalCredits(2111))),
+            ("/user/orgs", okJSON([["login": "acme"]])),
+            ("/orgs/acme/settings/billing/usage/summary", ok(makeOrgSummaryBody()))
+        ])
+        let defaults = freshDefaults()
+        let provider = makeOrgProvider(http: http, defaults: defaults)
+
+        let snapshot = await provider.refresh()
+
+        XCTAssertEqual(countValue(snapshot.lines, "Credits"), 2111)
+        XCTAssertEqual(orgCount(snapshot.lines, "Org Credits") ?? -1, 298.698546, accuracy: 0.0001)
+        XCTAssertNil(snapshot.lines.first(where: { $0.label == "Extra Usage" }))
+    }
+
     func testUsesCachedOrgWithoutReprobing() async {
         let http = routedClient([
             ("/copilot_internal/user", ok(makeBusinessPlaceholderBody())),
@@ -614,6 +693,18 @@ private func makeBusinessPlaceholderBody() -> [String: Any] {
             "premium_interactions": bucket("premium_interactions", overagePermitted: true)
         ]
     ]
+}
+
+/// The org-managed placeholder body from issue #1094: same shape as `makeBusinessPlaceholderBody`, but
+/// the premium bucket carries a real `credits_used` — the user's own per-seat consumption.
+private func makeBusinessPlaceholderBodyWithPersonalCredits(_ creditsUsed: Double) -> [String: Any] {
+    var body = makeBusinessPlaceholderBody()
+    var quota = body["quota_snapshots"] as! [String: Any]
+    var premium = quota["premium_interactions"] as! [String: Any]
+    premium["credits_used"] = creditsUsed
+    quota["premium_interactions"] = premium
+    body["quota_snapshots"] = quota
+    return body
 }
 
 /// The org billing usage summary from issue #839: one Copilot AI-unit item, fully covered by the

--- a/Tests/OpenUsageTests/LocalLimitsAPITests.swift
+++ b/Tests/OpenUsageTests/LocalLimitsAPITests.swift
@@ -170,6 +170,50 @@ final class LocalLimitsAPITests: XCTestCase {
         XCTAssertNil(resource["utilization"])
     }
 
+    @MainActor
+    func testCopilotPremiumCreditsExportsPersonalCountAndPaidPercent() throws {
+        let credits = CopilotProvider().widgetDescriptors.first { $0.id == "copilot.premium" }!
+        let personal = ProviderSnapshot(
+            providerID: "copilot",
+            displayName: "Copilot",
+            plan: "Business",
+            lines: [.values(label: "Credits", values: [MetricValue(number: 2111, kind: .count)])],
+            refreshedAt: fetchedAt
+        )
+        let paid = ProviderSnapshot(
+            providerID: "copilot",
+            displayName: "Copilot",
+            plan: "Pro",
+            lines: [.progress(label: "Credits", used: 59, limit: 100, format: .percent)],
+            refreshedAt: fetchedAt
+        )
+
+        func resource(in snapshot: ProviderSnapshot) throws -> [String: Any] {
+            let state = LocalUsageAPI.State(
+                enabledOrderedIDs: ["copilot"],
+                knownIDs: ["copilot"],
+                snapshots: ["copilot": snapshot],
+                limitDescriptors: ["copilot": [credits]],
+                generatedAt: generatedAt
+            )
+            let root = try json(LocalUsageAPI.respond(method: "GET", path: "/v1/limits", state: state).body)
+            let providers = try XCTUnwrap(root["providers"] as? [String: Any])
+            let copilot = try XCTUnwrap(providers["copilot"] as? [String: Any])
+            let resources = try XCTUnwrap(copilot["resources"] as? [String: Any])
+            return try XCTUnwrap(resources["premiumCredits"] as? [String: Any])
+        }
+
+        let count = try resource(in: personal)
+        XCTAssertEqual(count["used"] as? Double, 2111)
+        XCTAssertEqual(count["unit"] as? String, "credits")
+        XCTAssertNil(count["limit"])
+
+        let percent = try resource(in: paid)
+        XCTAssertEqual(percent["used"] as? Double, 59)
+        XCTAssertEqual(percent["unit"] as? String, "percent")
+        XCTAssertEqual(percent["limit"] as? Double, 100)
+    }
+
     func testProgressResourceUnitFollowsRuntimeMetricFormat() throws {
         let provider = Provider(id: "cursor", displayName: "Cursor", icon: .providerMark("cursor"))
         let total = WidgetDescriptor.percent(

--- a/docs/local-http-api.md
+++ b/docs/local-http-api.md
@@ -97,7 +97,9 @@ the app and CLI; `stale` says whether that instant has passed. Refresh failures 
 `{"providerId":"…","message":"…"}` while a last-good provider snapshot remains available.
 For bounded progress resources, `unit` follows the provider's live metric format. For example, Cursor
 `totalUsage` is `percent` on percentage-based plans, `requests` on request-based Enterprise plans, and
-`usd` when Cursor reports a dollar pool. OpenCode `session`, `weekly`, and `monthly` are `percent`.
+`usd` when Cursor reports a dollar pool. Copilot `premiumCredits` is `percent` on paid plans and a
+`credits` count on org-managed seats that only report personal `credits_used`. OpenCode `session`,
+`weekly`, and `monthly` are `percent`.
 
 ### Public resources
 

--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -6,22 +6,22 @@ Tracks your GitHub Copilot quota using a GitHub token that Copilot tooling alrea
 
 | Metric | Meaning |
 |---|---|
-| Credits | Share of your monthly AI-credit allotment used (the headline meter) |
+| Credits | Share of your monthly AI-credit allotment used (the headline meter). On org-managed seats with no allotment, a plain count of your own credits used this cycle |
 | Extra Usage | Premium interactions used beyond your included credits, once extra spend is enabled |
 | Org Credits | AI credits your whole organization used this month (org-managed Business/Enterprise seats) |
 | Org Spend | Dollars your organization was billed for AI credits beyond the included pool |
 | Chat | Chat-message quota used |
 | Completions | Code-completion quota used |
 
-Credits and Extra Usage are Always Visible by default; Org Credits, Org Spend, Chat, and Completions start in On Demand behind the card's caret. Each meter shows percent used and, when the response includes one, a countdown to the next reset. The plan name (Pro, Business, Free, …) shows next to the provider.
+Credits and Extra Usage are Always Visible by default; Org Credits, Org Spend, Chat, and Completions start in On Demand behind the card's caret. Percent meters show percent used and, when the response includes one, a countdown to the next reset. The plan name (Pro, Business, Free, …) shows next to the provider.
 
 Since June 2026 GitHub Copilot bills all plans by **AI credits**, so what each account shows differs by plan:
 
 - **Paid plans** meter the credit pool — so you see Credits (and Extra Usage if you've turned on additional spend). Chat and completions are unlimited on paid plans, so those rows read "No data".
 - **Free plans** have no credits, so Credits reads "No data"; instead you see your fixed Chat and Completions counts under the caret.
-- **Org-managed seats (Copilot Business / Enterprise assigned by an organization)** return no per-seat quota, so the personal meters have nothing to show. OpenUsage then looks the usage up in the organization's billing instead: it lists your organizations, finds the one whose billing reports Copilot AI-credit usage, and shows **Org Credits** (credits the whole org used this month) and **Org Spend** (dollars billed beyond the included pool). Two caveats:
-  - The numbers are **organization-wide**, not your personal share — GitHub doesn't expose per-seat usage.
-  - Reading an org's billing requires you to be an **org owner or billing manager**. Regular members keep the previous behavior: the plan shows, the meters read "No data".
+- **Org-managed seats (Copilot Business / Enterprise assigned by an organization)** return no per-seat percent quota. If the response's `premium_interactions` bucket carries a real `credits_used` count, OpenUsage shows it as **Credits** — a plain count, not a percentage, since this bucket's `entitlement` is 0 (no allotment to divide by). This is your *own* consumption and needs no special access. OpenUsage also looks the usage up in the organization's billing: it lists your organizations, finds the one whose billing reports Copilot AI-credit usage, and shows **Org Credits** (credits the whole org used this month) and **Org Spend** (dollars billed beyond the included pool). Two caveats there:
+  - The Org Credits/Org Spend numbers are **organization-wide**, not your personal share — GitHub doesn't expose per-seat usage through that API.
+  - Reading an org's billing requires you to be an **org owner or billing manager**. Regular members don't get Org Credits/Org Spend, but still see their own Credits count when the response carries one; if it doesn't, the meters read "No data".
 - Org Credits is shown as a plain count, not a percentage: the billing API reports usage only, never the org's credit allotment, and OpenUsage doesn't fabricate a denominator.
 
 A dollar credit figure (e.g. "$12 of $15 used") isn't shown: GitHub only exposes that through its logged-in web billing page, which would require reading browser cookies — OpenUsage does not do that. Editors like VS Code show the same credit *percentage* from this endpoint, not a dollar amount.
@@ -49,7 +49,7 @@ Using Copilot in a supported editor is enough on its own — the editor writes t
 
 - **"Sign in to GitHub Copilot…"** — no token was found. Sign in to Copilot in your editor, or run `gh auth login`.
 - **"GitHub token invalid or expired"** — the token was rejected (401/403). Re-authenticate with `gh auth login`.
-- **Meters show "No data" but the plan is shown** — expected on an org-managed Copilot Business/Enterprise seat when you aren't an owner or billing manager of the org (GitHub doesn't expose per-seat quota, and org billing is admin-only). If you *are* an org admin and still see no Org Credits, make sure your token can list your orgs — the GitHub CLI token from `gh auth login` can; some editor-plugin tokens can't.
+- **Meters show "No data" but the plan is shown** — expected on an org-managed Copilot Business/Enterprise seat whose response carries no personal `credits_used` and, if you aren't an org owner or billing manager, no org billing access either (GitHub doesn't expose per-seat quota otherwise, and org billing is admin-only). If you *are* an org admin and still see no Org Credits, make sure your token can list your orgs — the GitHub CLI token from `gh auth login` can; some editor-plugin tokens can't.
 
 ## Under the hood
 


### PR DESCRIPTION
## Approved issue

Fixes #1094

## TL;DR

Org-managed Copilot Business seats now show the user's own `credits_used` as a Credits count, instead of a fully empty card when org billing is off-limits.

## What was happening

- `/copilot_internal/user` reports `premium_interactions.entitlement: 0` on token-based-billing seats.
- The mapper dropped that bucket, then fell back to org billing.
- Regular org members get 403/404 on org billing, so Credits and Extra Usage read "No data".
- The same user response now carries a real `credits_used` (personal consumption, no admin rights needed).

## What this changes

- When percent meters come back empty on an org-managed seat, a positive `credits_used` is shown as unbounded **Credits**.
- Unused seats (`credits_used` 0 or missing) still read "No data".
- Org billing lines are appended, not replaced, so admins keep personal Credits plus Org Credits / Org Spend.
- Extra Usage stays suppressed on the placeholder (`overage_permitted: true` with no included pool) so #839 does not regress.
- Updates `docs/providers/copilot.md`.

## Heads-up

- Credits is still the existing Always Visible row — percent on paid plans, a plain count on this org-managed fallback.
- Left the `GET /orgs/{org}/settings/billing/ai_credit/usage` migration out of scope.

## Tests

- `swift test --filter Copilot` — 43 passed, including the #1094 live-shape fixture and the #839 Extra Usage: 0 regression.
- `CONFIG=debug ./script/build_and_run.sh verify` — dev app rebuilt and launched.

## Screenshots

Not applicable — mapping change; the Credits row uses the existing unbounded-count treatment.

Made with [Cursor](https://cursor.com)