### PR TITLE
fix(openrouter): use current-window spend for Key Limit

### DIFF
--- a/Sources/OpenUsage/Providers/OpenRouter/OpenRouterUsageMapper.swift
+++ b/Sources/OpenUsage/Providers/OpenRouter/OpenRouterUsageMapper.swift
@@ -40,11 +40,14 @@ enum OpenRouterUsageMapper {
         appendSpend(data["usage_weekly"], label: "This Week", into: &lines)
         appendSpend(data["usage_monthly"], label: "This Month", into: &lines)
 
-        // Per-key spend cap, when this key is configured with one.
+        // Per-key spend cap, when this key is configured with one. `usage` is lifetime spend on
+        // the key; `limit_remaining` is what's left in the current window (daily/weekly/monthly
+        // or lifetime), so used = limit - remaining.
         if let limit = ProviderParse.number(data["limit"]), limit > 0 {
+            let remaining = max(0, ProviderParse.number(data["limit_remaining"]) ?? 0)
             lines.append(.progress(
                 label: "Key Limit",
-                used: max(0, ProviderParse.number(data["usage"]) ?? 0),
+                used: max(0, limit - remaining),
                 limit: limit,
                 format: .dollars
             ))

--- a/Tests/OpenUsageTests/OpenRouterProviderTests.swift
+++ b/Tests/OpenUsageTests/OpenRouterProviderTests.swift
@@ -209,7 +209,8 @@ final class OpenRouterUsageMapperTests: XCTestCase {
             "usage_weekly": 1.25,
             "usage_monthly": 4.5,
             "usage": 2,
-            "limit": 5
+            "limit": 5,
+            "limit_remaining": 3
         ])
 
         XCTAssertEqual(mapped.plan, "Pay as you go")
@@ -217,6 +218,20 @@ final class OpenRouterUsageMapperTests: XCTestCase {
         XCTAssertEqual(dollars(mapped.lines, "Today"), 0)
         XCTAssertEqual(dollars(mapped.lines, "This Week"), 1.25)
         XCTAssertEqual(dollars(mapped.lines, "This Month"), 4.5)
+        let keyLimit = try XCTUnwrap(progress(mapped.lines, "Key Limit"))
+        XCTAssertEqual(keyLimit.used, 2)
+        XCTAssertEqual(keyLimit.limit, 5)
+    }
+
+    func testKeyLimitUsesCurrentWindowNotLifetimeUsage() throws {
+        // After a daily/weekly/monthly reset, lifetime `usage` still includes prior windows.
+        // `limit_remaining` is the current window, so used is limit - remaining — not lifetime.
+        let mapped = OpenRouterUsageMapper.keyMetrics(from: [
+            "usage": 12,
+            "limit": 5,
+            "limit_remaining": 3
+        ])
+
         let keyLimit = try XCTUnwrap(progress(mapped.lines, "Key Limit"))
         XCTAssertEqual(keyLimit.used, 2)
         XCTAssertEqual(keyLimit.limit, 5)

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -11,7 +11,7 @@ Tracks your [OpenRouter](https://openrouter.ai) credit balance and spend from yo
 | Today | Spend so far today |
 | This Week | Spend so far this week |
 | This Month | Spend so far this month |
-| Key Limit | Spend against this key's cap — shown only when the key has one configured |
+| Key Limit | Spend in the current limit window against this key's cap — shown only when the key has one configured |
 
 OpenUsage shows the reported tier (such as "Pay as you go" or "Free tier") beside the provider name.
 
@@ -52,8 +52,9 @@ Two REST calls with a `Bearer` token against `https://openrouter.ai/api/v1`:
 
 - `GET /credits` — account-wide `total_credits` and `total_usage`; the Credits meter and Balance come
   from these. Required for a usable snapshot.
-- `GET /key` — best-effort: the tier, daily/weekly/monthly spend, and an optional per-key cap. If this
-  call fails, the balance still renders from `/credits`.
+- `GET /key` — best-effort: the tier, daily/weekly/monthly spend, and an optional per-key cap
+  (`limit` minus `limit_remaining` for the current window). If this call fails, the balance still
+  renders from `/credits`.
 
 A period spend of `$0.00` is shown as a real, measured zero (the API reports it directly) rather than
 "No data". Credit values may be up to ~60 seconds stale on OpenRouter's side.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Approved issue

Fixes #1072

## TL;DR

Key Limit now shows spend in the current OpenRouter limit window (`limit - limit_remaining`) instead of lifetime key spend.

## What was happening

- OpenRouter keys with a daily, weekly, or monthly cap looked exhausted after the first reset.
- `OpenRouterUsageMapper.keyMetrics` set Key Limit `used` from `/key` `usage`, which is lifetime spend on the key.
- The cap (`limit`) is for the current window, so after a reset the meter compared lifetime spend to a freshly reset ceiling.

## What this changes

- Computes Key Limit `used` as `limit - limit_remaining`, the remaining amount OpenRouter reports for the current window.
- Adds a mapper regression test where lifetime `usage` exceeds the cap but the current window still has remaining.
- Updates the OpenRouter provider docs so Key Limit is described as current-window spend.

## Heads-up

- Reset-date extras (`resetsAt` / `periodDurationMs`) from the reporter's fork are intentionally not included; this PR is only the field swap that fixes #1072.

## Tests

- Added `testKeyLimitUsesCurrentWindowNotLifetimeUsage` and updated `testKeyMetricsGivePlanPeriodSpendAndCap` to include `limit_remaining`.
- This environment is Linux and cannot run the macOS-only Swift package; CI on `macos-26` should run `swift test`.

## Screenshots

Not applicable — mapper/docs change only, no visual UI work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1564e637-1ba6-41be-8234-903ae4117131?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1564e637-1ba6-41be-8234-903ae4117131&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

