### PR TITLE
fix: skip unchanged status-item image applies

### DIFF
--- a/Sources/OpenUsage/App/StatusItemImageUpdater.swift
+++ b/Sources/OpenUsage/App/StatusItemImageUpdater.swift
@@ -7,10 +7,26 @@ import Observation
 /// `withObservationTracking`'s `onChange` is one-shot, so each render re-arms it. After the first change,
 /// the next render waits briefly so a burst of snapshot writes collapses into one render with the latest
 /// values — avoiding enough repeated work to make the menu-bar item disappear during a busy refresh.
+/// Unchanged memoized images are not re-applied: setting the same `NSImage` still costs a WindowServer
+/// redraw.
 @MainActor
 final class StatusItemImageUpdater {
+    /// Applies a status-item image only when the instance changed. The renderer memoizes by content,
+    /// so an identical instance means the button already shows this render — an unconditional set
+    /// still costs a full status-item redraw through WindowServer on macOS 26+.
+    struct ApplyGate {
+        private var lastApplied: NSImage?
+
+        mutating func apply(_ image: NSImage, using apply: (NSImage) -> Void) {
+            guard image !== lastApplied else { return }
+            lastApplied = image
+            apply(image)
+        }
+    }
+
     private let container: AppContainer
     private let apply: (NSImage) -> Void
+    private var applyGate = ApplyGate()
 
     /// - Parameter apply: sets the rendered image onto the status-item button.
     init(container: AppContainer, apply: @escaping (NSImage) -> Void) {
@@ -27,7 +43,7 @@ final class StatusItemImageUpdater {
                 self?.scheduleDelayedUpdate()
             }
         }
-        apply(image)
+        applyGate.apply(image, using: apply)
     }
 
     /// The observation callback fires only once until `update()` reads and re-arms it. Waiting here lets

--- a/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
+++ b/Sources/OpenUsage/Support/MenuBarStripRenderer.swift
@@ -7,10 +7,11 @@ import SwiftUI
 /// outside the `label:` view builder (an `ImageRenderer` inline there throws obscure errors).
 @MainActor
 enum MenuBarStripRenderer {
-    /// Last render, memoized on (content, style). The label view re-evaluates on every snapshot
+    /// Last render, memoized on (content, style). The observation loop re-renders on every snapshot
     /// write — several times per refresh pass — but the strip's visible content rarely changes.
-    /// Returning the same `NSImage` instance lets SwiftUI skip the status-item update, and keeps
-    /// `ImageRenderer` (which retains a little memory per run on macOS) to actual visual changes.
+    /// Returning the same `NSImage` instance lets `StatusItemImageUpdater` skip the status-item set
+    /// (an unconditional set still costs a WindowServer redraw), and keeps `ImageRenderer` (which
+    /// retains a little memory per run on macOS) to actual visual changes.
     private static var lastRender: (content: MenuBarContent, style: MenuBarStyle, image: NSImage?)?
 
     /// The strip image for the given content and style, or `nil` when the content renders nothing

--- a/Tests/OpenUsageTests/MenuBarStripMemoTests.swift
+++ b/Tests/OpenUsageTests/MenuBarStripMemoTests.swift
@@ -2,8 +2,9 @@ import XCTest
 @testable import OpenUsage
 
 /// Covers the strip renderer's single-entry memo (#18): equal (content, style) inputs return the
-/// previously rendered `NSImage` instance — so the hundreds of label re-evaluations between real
-/// data changes never re-run `ImageRenderer` — while a changed value or style renders fresh.
+/// previously rendered `NSImage` instance — so the hundreds of observation-loop re-renders between
+/// real data changes never re-run `ImageRenderer`, and `StatusItemImageUpdater` can skip `apply`
+/// on that same instance — while a changed value or style renders fresh.
 @MainActor
 final class MenuBarStripMemoTests: XCTestCase {
     func testEqualContentReturnsSameImageInstance() throws {
@@ -23,6 +24,32 @@ final class MenuBarStripMemoTests: XCTestCase {
         let text = try XCTUnwrap(MenuBarStripRenderer.image(for: content, style: .text))
         let bars = try XCTUnwrap(MenuBarStripRenderer.image(for: content, style: .bars))
         XCTAssertNotIdentical(text, bars)
+    }
+
+    func testUnchangedMemoizedImageIsNotApplied() throws {
+        var applied: [NSImage] = []
+        var gate = StatusItemImageUpdater.ApplyGate()
+        let first = try XCTUnwrap(MenuBarStripRenderer.image(for: makeContent(value: "42%"), style: .text))
+        let second = try XCTUnwrap(MenuBarStripRenderer.image(for: makeContent(value: "42%"), style: .text))
+        gate.apply(first, using: { applied.append($0) })
+        gate.apply(second, using: { applied.append($0) })
+        XCTAssertIdentical(first, second)
+        XCTAssertEqual(applied.count, 1)
+        XCTAssertIdentical(applied[0], first)
+    }
+
+    func testChangedImageIsApplied() throws {
+        var applied: [NSImage] = []
+        var gate = StatusItemImageUpdater.ApplyGate()
+        let first = try XCTUnwrap(MenuBarStripRenderer.image(for: makeContent(value: "42%"), style: .text))
+        let changed = try XCTUnwrap(MenuBarStripRenderer.image(for: makeContent(value: "43%"), style: .text))
+        gate.apply(first, using: { applied.append($0) })
+        gate.apply(changed, using: { applied.append($0) })
+        gate.apply(changed, using: { applied.append($0) })
+        XCTAssertNotIdentical(first, changed)
+        XCTAssertEqual(applied.count, 2)
+        XCTAssertIdentical(applied[0], first)
+        XCTAssertIdentical(applied[1], changed)
     }
 
     private func makeContent(value: String) -> MenuBarContent {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1039.

## TL;DR

The menu-bar strip no longer re-applies a memoized `NSImage` to the status item when the instance has not changed, so unchanged renders skip the WindowServer redraw.

## What was happening

- `MenuBarStripRenderer.image(for:)` already memos by content and returns the same `NSImage` instance when the strip has not changed.
- `StatusItemImageUpdater.update()` still called `apply(image)` on every observation-driven render, including cache hits.
- Setting the same image on the status-item button still costs a full status-item redraw through WindowServer (especially expensive on macOS 27 beta).

## What this changes

- `update()` remembers the last applied instance and skips `apply` when it is unchanged.
- The 50ms observation coalesce is left alone. Widening it to 250ms would cap the loop at 4 Hz but also delay real strip changes (including the screen-share privacy swap) — a product/UX tradeoff, not required for the redundant-apply bug.
- `MenuBarStripMemoTests` now covers the skip-apply gate against the existing memoized-instance contract.

## Heads-up

- Closed draft PR #1038 also widened the coalesce window 50ms → 250ms. This PR takes only the skip-apply half on purpose.
- No visual change: the strip still updates immediately when the memoized instance changes.

## Tests

- Added `testUnchangedMemoizedImageIsNotApplied` and `testChangedImageIsApplied` on the existing `MenuBarStripMemoTests` path.
- This environment is Linux, so `swift test` could not be run locally. CI on `macos-26` is the compile/test gate.

## Screenshots

Not applicable — no visual change; this only skips redundant status-item image sets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-468176f1-68e9-4f74-92a4-bc79bf6392c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-468176f1-68e9-4f74-92a4-bc79bf6392c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

