### PR TITLE
fix(pricing): price Gemini 3.7 Flash and refresh GPT-5.6 rates

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
@@ -578,8 +578,8 @@ actor CodexLogUsageScanner {
         case "gpt-5.5": return (10, 45, 1)
         case "gpt-5.5-pro": return (60, 270, 60)
         case "gpt-5.6-sol": return (10, 45, 1)
-        case "gpt-5.6-terra": return (5, 22.5, 0.5)
-        case "gpt-5.6-luna": return (2, 9, 0.2)
+        case "gpt-5.6-terra": return (4, 18, 0.4)
+        case "gpt-5.6-luna": return (0.4, 1.8, 0.04)
         default: return nil
         }
     }

--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries; https://developers.openai.com/api/docs/models/daybreak-blue-latest and https://developers.openai.com/api/docs/pricing for Daybreak aliases and rates.",
-  "updated_at": "2026-08-13T08:06:24Z",
+  "updated_at": "2026-08-14T12:55:21Z",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -126,23 +126,37 @@
       "output_per_million": 22.5
     },
     "gpt-5.6-sol": {
-      "$comment": "OpenAI's GPT-5.6 preview pricing. Its public catalogs have not added these models yet.",
+      "$comment": "OpenAI GPT-5.6 official rates (developers.openai.com/api/docs/pricing) and Cursor's Other Models table. Public catalogs have not added these models yet.",
       "input_per_million": 5.0,
       "cache_write_per_million": 6.25,
       "cache_read_per_million": 0.5,
       "output_per_million": 30.0
     },
     "gpt-5.6-terra": {
-      "input_per_million": 2.5,
-      "cache_write_per_million": 3.125,
-      "cache_read_per_million": 0.25,
-      "output_per_million": 15.0
+      "input_per_million": 2.0,
+      "cache_write_per_million": 2.5,
+      "cache_read_per_million": 0.2,
+      "output_per_million": 12.0
     },
     "gpt-5.6-luna": {
-      "input_per_million": 1.0,
-      "cache_write_per_million": 1.25,
-      "cache_read_per_million": 0.1,
-      "output_per_million": 6.0
+      "input_per_million": 0.2,
+      "cache_write_per_million": 0.25,
+      "cache_read_per_million": 0.02,
+      "output_per_million": 1.2
+    },
+    "gemini-3.6-flash": {
+      "$comment": "Google Gemini 3.6 Flash. Bundled LiteLLM/models.dev snapshots do not carry it yet; Cursor and LiteLLM agree on these API rates. Cache write is unpublished, so it defaults to input.",
+      "input_per_million": 1.5,
+      "cache_write_per_million": 1.5,
+      "cache_read_per_million": 0.15,
+      "output_per_million": 7.5
+    },
+    "gemini-3.7-flash": {
+      "$comment": "Google Gemini 3.7 Flash introductory API rate. Cursor's table lists output at $3.50; Google and LiteLLM publish $3.75, which is the API rate Cursor bills. Cache write is unpublished, so it defaults to input.",
+      "input_per_million": 0.75,
+      "cache_write_per_million": 0.75,
+      "cache_read_per_million": 0.075,
+      "output_per_million": 3.75
     }
   },
   "fast_multipliers": {
@@ -155,9 +169,9 @@
     "gpt-5.3-codex": 2.0,
     "gpt-5.4": 2.0,
     "gpt-5.5": 2.5,
-    "gpt-5.6-sol": 2.5,
-    "gpt-5.6-terra": 2.5,
-    "gpt-5.6-luna": 2.5
+    "gpt-5.6-sol": 2.0,
+    "gpt-5.6-terra": 2.0,
+    "gpt-5.6-luna": 2.0
   },
   "alias_rules": [
     { "pattern": "^agent_review$", "canonical": "gpt-5.4" },
@@ -198,12 +212,13 @@
     { "pattern": "^claude-opus-5(?:\\[1m\\])?(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-5" },
     { "pattern": "^claude-fable-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-fable-5" },
     { "pattern": "^claude-sonnet-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-sonnet-5" },
-    { "pattern": "^gemini-2\\.5-flash$", "canonical": "gemini-2.5-flash" },
-    { "pattern": "^gemini-3-flash(?:-preview)?$", "canonical": "gemini-3-flash-preview" },
-    { "pattern": "^gemini-3\\.5-flash(?:-preview)?$", "canonical": "gemini-3.5-flash" },
-    { "pattern": "^gemini-3-pro-preview$", "canonical": "gemini-3-pro-preview" },
-    { "pattern": "^gemini-3\\.1-pro$", "canonical": "gemini-3.1-pro-preview" },
-    { "pattern": "^gemini-3\\.1-pro-preview$", "canonical": "gemini-3.1-pro-preview" },
+    { "pattern": "^gemini-2\\.5-flash(?:-(?:low|medium|high|xhigh))?$", "canonical": "gemini-2.5-flash" },
+    { "pattern": "^gemini-3-flash(?:-preview)?(?:-(?:low|medium|high|xhigh))?$", "canonical": "gemini-3-flash-preview" },
+    { "pattern": "^gemini-3\\.5-flash(?:-preview)?(?:-(?:low|medium|high|xhigh))?$", "canonical": "gemini-3.5-flash" },
+    { "pattern": "^gemini-3\\.6-flash(?:-preview)?(?:-(?:low|medium|high|xhigh))?$", "canonical": "gemini-3.6-flash" },
+    { "pattern": "^gemini-3\\.7-flash(?:-preview)?(?:-(?:low|medium|high|xhigh))?$", "canonical": "gemini-3.7-flash" },
+    { "pattern": "^gemini-3-pro-preview(?:-(?:low|medium|high|xhigh))?$", "canonical": "gemini-3-pro-preview" },
+    { "pattern": "^gemini-3\\.1-pro(?:-preview)?(?:-(?:low|medium|high|xhigh))?$", "canonical": "gemini-3.1-pro-preview" },
     { "pattern": "^gpt-5(?:-(?:low|high))?-fast$", "canonical": "gpt-5-fast" },
     { "pattern": "^gpt-5(?:-(?:low|high))?$", "canonical": "gpt-5" },
     { "pattern": "^gpt-5\\.1(?:-(?:low|high))?-fast$", "canonical": "gpt-5-fast" },
@@ -263,6 +278,8 @@
     { "pattern": "(?i)^GPT-5\\.6 Terra \\(Auto[^)]*\\)$", "canonical": "gpt-5.6-terra" },
     { "pattern": "(?i)^GPT-5\\.6 Luna \\(Auto[^)]*\\)$", "canonical": "gpt-5.6-luna" },
     { "pattern": "(?i)^Gemini 3\\.1 Pro \\(Auto[^)]*\\)$", "canonical": "gemini-3.1-pro-preview" },
+    { "pattern": "(?i)^Gemini 3\\.6 Flash \\(Auto[^)]*\\)$", "canonical": "gemini-3.6-flash" },
+    { "pattern": "(?i)^Gemini 3\\.7 Flash \\(Auto[^)]*\\)$", "canonical": "gemini-3.7-flash" },
     { "pattern": "(?i)^GLM 5\\.2 \\(Auto[^)]*\\)$", "canonical": "glm-5.2" },
     { "pattern": "(?i)^Kimi K3 \\(Auto[^)]*\\)$", "canonical": "kimi-k3" }
   ]

--- a/Tests/OpenUsageTests/CodexLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/CodexLogUsageScannerTests.swift
@@ -637,8 +637,8 @@ final class CodexLogUsageScannerTests: XCTestCase {
             ("gpt-5.5", 2.55),
             ("gpt-5.5-pro-20260423", 20.7),
             ("gpt-5.6-sol", 2.55),
-            ("gpt-5.6-terra", 1.275),
-            ("gpt-5.6-luna", 0.51)
+            ("gpt-5.6-terra", 1.02),
+            ("gpt-5.6-luna", 0.102)
         ]
 
         for (model, expected) in expectedCosts {

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -42,11 +42,14 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(pricing.resolve(model: "claude-4.6-opus-max-thinking-fast")?.inputPerMillion, 30)
         XCTAssertEqual(pricing.resolve(model: "gpt-5.5-xhigh-fast")?.inputPerMillion, 12.5)
         XCTAssertEqual(pricing.resolve(model: "gpt-5.6-sol-ultra")?.inputPerMillion, 5)
-        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-sol-ultra-fast")?.inputPerMillion, 12.5)
-        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-terra-high")?.inputPerMillion, 2.5)
-        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-terra-high-fast")?.inputPerMillion, 6.25)
-        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-luna")?.inputPerMillion, 1)
-        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-luna-fast")?.inputPerMillion, 2.5)
+        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-sol-ultra-fast")?.inputPerMillion, 10)
+        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-terra-high")?.inputPerMillion, 2)
+        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-terra-high-fast")?.inputPerMillion, 4)
+        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-luna")?.inputPerMillion, 0.2)
+        XCTAssertEqual(pricing.resolve(model: "gpt-5.6-luna-fast")?.inputPerMillion, 0.4)
+        XCTAssertEqual(pricing.resolve(model: "gemini-3.6-flash-high")?.inputPerMillion, 1.5)
+        XCTAssertEqual(pricing.resolve(model: "gemini-3.7-flash-high")?.inputPerMillion, 0.75)
+        XCTAssertEqual(pricing.resolve(model: "gemini-3.7-flash-high")?.outputPerMillion, 3.75)
         XCTAssertEqual(pricing.resolve(model: "grok-4-20-thinking")?.inputPerMillion, 2)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5")?.inputPerMillion, 2)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-fast-high")?.inputPerMillion, 4)
@@ -192,6 +195,8 @@ final class PricingBundledResourceTests: XCTestCase {
             "GPT-5.6 Sol (Auto Cost)": "gpt-5.6-sol",
             "GPT-5.6 Luna (Auto)": "gpt-5.6-luna",
             "Gemini 3.1 Pro (Auto Balanced)": "gemini-3.1-pro-preview",
+            "Gemini 3.6 Flash (Auto)": "gemini-3.6-flash",
+            "Gemini 3.7 Flash (Auto Balanced)": "gemini-3.7-flash",
             "GLM 5.2 (Auto)": "glm-5.2",
             "Kimi K3 (Auto Intelligence)": "kimi-k3"
         ]
@@ -217,32 +222,32 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(sol.cacheReadPerMillion, 0.5)
         XCTAssertEqual(sol.outputPerMillion, 30.0)
         let solFast = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-sol-ultra-fast"))
-        XCTAssertEqual(solFast.inputPerMillion, 12.5)
-        XCTAssertEqual(solFast.cacheWritePerMillion, 15.625)
-        XCTAssertEqual(solFast.cacheReadPerMillion, 1.25)
-        XCTAssertEqual(solFast.outputPerMillion, 75.0)
+        XCTAssertEqual(solFast.inputPerMillion, 10.0)
+        XCTAssertEqual(solFast.cacheWritePerMillion, 12.5)
+        XCTAssertEqual(solFast.cacheReadPerMillion, 1.0)
+        XCTAssertEqual(solFast.outputPerMillion, 60.0)
 
         let terra = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-terra-high"))
-        XCTAssertEqual(terra.inputPerMillion, 2.5)
-        XCTAssertEqual(terra.cacheWritePerMillion, 3.125)
-        XCTAssertEqual(terra.cacheReadPerMillion, 0.25)
-        XCTAssertEqual(terra.outputPerMillion, 15.0)
+        XCTAssertEqual(terra.inputPerMillion, 2.0)
+        XCTAssertEqual(terra.cacheWritePerMillion, 2.5)
+        XCTAssertEqual(terra.cacheReadPerMillion, 0.2)
+        XCTAssertEqual(terra.outputPerMillion, 12.0)
         let terraFast = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-terra-high-fast"))
-        XCTAssertEqual(terraFast.inputPerMillion, 6.25)
-        XCTAssertEqual(terraFast.cacheWritePerMillion, 7.8125)
-        XCTAssertEqual(terraFast.cacheReadPerMillion, 0.625)
-        XCTAssertEqual(terraFast.outputPerMillion, 37.5)
+        XCTAssertEqual(terraFast.inputPerMillion, 4.0)
+        XCTAssertEqual(terraFast.cacheWritePerMillion, 5.0)
+        XCTAssertEqual(terraFast.cacheReadPerMillion, 0.4)
+        XCTAssertEqual(terraFast.outputPerMillion, 24.0)
 
         let luna = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-luna"))
-        XCTAssertEqual(luna.inputPerMillion, 1.0)
-        XCTAssertEqual(luna.cacheWritePerMillion, 1.25)
-        XCTAssertEqual(luna.cacheReadPerMillion, 0.1)
-        XCTAssertEqual(luna.outputPerMillion, 6.0)
+        XCTAssertEqual(luna.inputPerMillion, 0.2)
+        XCTAssertEqual(luna.cacheWritePerMillion, 0.25)
+        XCTAssertEqual(luna.cacheReadPerMillion, 0.02)
+        XCTAssertEqual(luna.outputPerMillion, 1.2)
         let lunaFast = try XCTUnwrap(pricing.resolve(model: "gpt-5.6-luna-fast"))
-        XCTAssertEqual(lunaFast.inputPerMillion, 2.5)
-        XCTAssertEqual(lunaFast.cacheWritePerMillion, 3.125)
-        XCTAssertEqual(lunaFast.cacheReadPerMillion, 0.25)
-        XCTAssertEqual(lunaFast.outputPerMillion, 15.0)
+        XCTAssertEqual(lunaFast.inputPerMillion, 0.4)
+        XCTAssertEqual(lunaFast.cacheWritePerMillion, 0.5)
+        XCTAssertEqual(lunaFast.cacheReadPerMillion, 0.04)
+        XCTAssertEqual(lunaFast.outputPerMillion, 2.4)
     }
 
     /// Opus 4.7/4.8 fast modes: Cursor's published rates (supplement overrides) win over the


### PR DESCRIPTION
## Approved issue

Maintainer PR — no external issue required.

## TL;DR

Prices the unknown `gemini-3.7-flash-high` Cursor slug (and Gemini 3.6 Flash), and syncs GPT-5.6 Terra/Luna plus their fast multipliers to the current OpenAI/Cursor API rates.

## What was happening

- Cursor CSV now emits `gemini-3.7-flash-high`. No alias stripped the `-high` effort suffix, and the bundled catalogs don't have Gemini 3.6/3.7 yet, so spend tiles showed the unknown-model warning.
- GPT-5.6 Terra and Luna in the supplement still used launch-preview rates. OpenAI and Cursor now publish lower API prices, and Fast mode is 2× (not 2.5×).
- Codex long-context fallbacks for Terra/Luna still used the old 2×/1.5× overlays.

## What this changes

Source: [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md), [OpenAI API pricing](https://developers.openai.com/api/docs/pricing), [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing), live LiteLLM.

**New supplement prices (USD / million tokens)**

| Model | Input | Cache write | Cache read | Output |
| --- | --- | --- | --- | --- |
| `gemini-3.6-flash` | $1.50 | $1.50 | $0.15 | $7.50 |
| `gemini-3.7-flash` | $0.75 | $0.75 | $0.075 | $3.75 |

**GPT-5.6 rate refresh**

| Model | Before | After |
| --- | --- | --- |
| `gpt-5.6-terra` | $2.50 / $3.125 / $0.25 / $15.00 | $2.00 / $2.50 / $0.20 / $12.00 |
| `gpt-5.6-luna` | $1.00 / $1.25 / $0.10 / $6.00 | $0.20 / $0.25 / $0.02 / $1.20 |
| `gpt-5.6-sol` | unchanged | $5.00 / $6.25 / $0.50 / $30.00 |
| GPT-5.6 fast multipliers | 2.5× | 2.0× |

**Aliases**

- `gemini-3.7-flash-high` (and `-low` / `-medium` / `-xhigh`) → `gemini-3.7-flash`
- same effort-suffix coverage for Gemini 2.5 / 3 / 3.5 / 3.6 Flash and 3 / 3.1 Pro
- Cursor Router labels `Gemini 3.6 Flash (Auto…)` and `Gemini 3.7 Flash (Auto…)`

**Codex**

- Long-context overlays: Terra `$4 / $18 / $0.40`, Luna `$0.40 / $1.80 / $0.04` (OpenAI >272k rates)

## Heads-up

- Cursor's table lists Gemini 3.7 Flash output at **$3.50**. Google and LiteLLM publish **$3.75**, which is the API rate Cursor bills. This PR uses $3.75 so the supplement does not override the live catalog with a lower number.
- Bundled LiteLLM/models.dev snapshots still lack 3.6/3.7; the supplement entry is the offline/first-launch fallback. Snapshot refresh is a separate release chore.

## Tests

- Supplement JSON/regex validation
- `swift test --filter "ModelPricing|PricingBundledResource|CodexLogUsageScanner"` — 103 tests, 0 failures

## Screenshots

Not applicable