### PR TITLE
fix(pricing): alias grok-proxy to Grok Build

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries; https://developers.openai.com/api/docs/models/daybreak-blue-latest and https://developers.openai.com/api/docs/pricing for Daybreak aliases and rates.",
-  "updated_at": "2026-08-14T12:55:21Z",
+  "updated_at": "2026-08-19T10:51:18Z",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -229,6 +229,7 @@
     { "pattern": "^grok-build-0\\.1$", "canonical": "grok-build-0.1" },
     { "pattern": "^grok-code-fast-1$", "canonical": "grok-build-0.1" },
     { "pattern": "^grok-build$", "canonical": "grok-build-0.1" },
+    { "pattern": "^grok-proxy$", "canonical": "grok-build-0.1" },
     { "pattern": "^grok-composer-2\\.5-fast$", "canonical": "composer-2.5-fast" },
     { "pattern": "^gpt-5\\.1-codex-max(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "gpt-5.1-codex-max-fast" },
     { "pattern": "^gpt-5\\.1-codex-max(?:-(?:low|medium|high|xhigh))?$", "canonical": "gpt-5.1-codex-max" },

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -285,6 +285,8 @@ final class PricingBundledResourceTests: XCTestCase {
     func testGrokCLIModelAliases() {
         let pricing = Self.pricing
         XCTAssertEqual(pricing.resolve(model: "grok-build")?.inputPerMillion, 1)
+        // grok-proxy is the recent Grok Build CLI log slug for the same model.
+        XCTAssertEqual(pricing.resolve(model: "grok-proxy"), pricing.resolve(model: "grok-build-0.1"))
         XCTAssertEqual(pricing.resolve(model: "grok-composer-2.5-fast")?.inputPerMillion, 3)
     }
 


### PR DESCRIPTION
## TL;DR

Alias the Grok CLI log slug `grok-proxy` to `grok-build-0.1` so recent Grok Build usage shows up in spend tiles and Total Spend.

## What was happening

- `GrokLogUsageScanner` attributes `inference_done` rows via the last model id seen for that PID.
- Unpriced models are dropped from every spend total (warning triangle only).
- `grok-build` and `grok-code-fast-1` already alias to `grok-build-0.1`. Recent Grok Build CLI sessions log `grok-proxy` instead, so Today/Yesterday (and Total Spend for those days) went empty while Weekly quota still worked. Older `grok-build` days still filled Last 30 Days.

## What this changes

- Add supplement alias `grok-proxy` → `grok-build-0.1` (same rates as `grok-build`: $1 input / $2 output per million).
- Extend `testGrokCLIModelAliases` so `grok-proxy` resolves to the same rates as `grok-build-0.1`.
- Bump `updated_at` so installed apps pick the feed up within about an hour. No app release needed.

## Heads-up

- Grok 4.5/4.6 sessions still log those ids, not `grok-proxy`. This only affects Grok Build CLI users whose logs switched slugs.
- If `grok-proxy` ever becomes a generic proxy id for other models, this alias would underprice those rows.

## Tests

- Supplement JSON/alias validation
- `PricingBundledResourceTests/testGrokCLIModelAliases`

Fixes #1119

Made with [Cursor](https://cursor.com)