### PR TITLE
fix(codex): price codex-auto-review as GPT-5.6 Luna from 2026-07-09

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
@@ -62,7 +62,7 @@ actor CodexLogUsageScanner {
     /// once. The version is the parser schema version; bump it when `Event` semantics change.
     private static let sharedScanner = IncrementalJSONLScanner<Event>(
         logTag: LogTag.plugin("codex"),
-        persistence: JSONLScanCachePersistence(namespace: "codex", schemaVersion: 2)
+        persistence: JSONLScanCachePersistence(namespace: "codex", schemaVersion: 3)
     )
 
     static func flushPersistentCacheWrites() async {

--- a/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
@@ -424,7 +424,14 @@ actor CodexLogUsageScanner {
 
     /// `codex-auto-review` release timeline (newest first), from ccusage's embedded snapshot: a
     /// line dated on/after a release prices as that codex model.
+    ///
+    /// The `gpt-5.6-luna` entry is ours; ccusage's snapshot still stops at gpt-5.5. OpenAI moved
+    /// auto-review onto the GPT-5.6 family when it shipped on 2026-07-09, and the Codex model
+    /// catalog (`~/.codex/models_cache.json`) lists `codex-auto-review` with Luna's exact profile.
+    /// Without this entry every auto-review event since July prices at gpt-5.5 rates, which are 25x
+    /// Luna's across input, cache reads and output alike.
     private static let autoReviewFallbacks: [(releasedOn: String, model: String)] = [
+        ("2026-07-09", "gpt-5.6-luna"),
         ("2026-04-23", "gpt-5.5"),
         ("2026-03-05", "gpt-5.4"),
         ("2026-02-05", "gpt-5.3-codex"),

--- a/Tests/OpenUsageTests/CodexLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/CodexLogUsageScannerTests.swift
@@ -203,6 +203,9 @@ final class CodexLogUsageScannerTests: XCTestCase {
     // MARK: - Auto-review fallbacks
 
     func testAutoReviewSlugMapsToDatedCodexModel() {
+        XCTAssertEqual(CodexLogUsageScanner.autoReviewFallback(at: "2026-08-20T00:00:00Z"), "gpt-5.6-luna")
+        XCTAssertEqual(CodexLogUsageScanner.autoReviewFallback(at: "2026-07-09T00:00:00Z"), "gpt-5.6-luna")
+        XCTAssertEqual(CodexLogUsageScanner.autoReviewFallback(at: "2026-07-08T23:59:59Z"), "gpt-5.5")
         XCTAssertEqual(CodexLogUsageScanner.autoReviewFallback(at: "2026-05-01T00:00:00Z"), "gpt-5.5")
         XCTAssertEqual(CodexLogUsageScanner.autoReviewFallback(at: "2026-03-10T00:00:00Z"), "gpt-5.4")
         XCTAssertEqual(CodexLogUsageScanner.autoReviewFallback(at: "2025-12-25T00:00:00Z"), "gpt-5.2-codex")

--- a/Tests/OpenUsageTests/CodexLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/CodexLogUsageScannerTests.swift
@@ -227,6 +227,20 @@ final class CodexLogUsageScannerTests: XCTestCase {
         XCTAssertEqual(event?.pricingModel, "gpt-5.4")
     }
 
+    func testRecentAutoReviewLinesUseLunaPricing() {
+        let lines = [
+            CodexLogFixture.turnContext(timestamp: "2026-08-20T08:00:00.000Z", model: "codex-auto-review"),
+            CodexLogFixture.tokenCount(
+                timestamp: "2026-08-20T08:01:00.000Z",
+                last: CodexLogFixture.usage(input: 10, output: 5)
+            )
+        ].joined(separator: "\n")
+
+        let event = CodexLogUsageScanner.parseFile(Data(lines.utf8)).first
+        XCTAssertEqual(event?.model, "codex-auto-review")
+        XCTAssertEqual(event?.pricingModel, "gpt-5.6-luna")
+    }
+
     // MARK: - Child-session replay (subagents and forks)
 
     /// Epoch seconds of the child sessions' creation instant used across the replay tests.


### PR DESCRIPTION
## TL;DR

Codex auto-review usage has been priced 25x too high since July: the dated fallback table still maps `codex-auto-review` to gpt-5.5, but OpenAI moved auto-review onto GPT-5.6 Luna. This adds the missing entry.

## What was happening

- `codex-auto-review` is an internal slug, so `CodexLogUsageScanner` maps it to a real model by date to estimate cost. That table is copied from ccusage's snapshot and its newest entry was `2026-04-23 -> gpt-5.5`.
- OpenAI shipped the GPT-5.6 family on 2026-07-09 and moved auto-review onto it (the Codex CLI migration landed in openai/codex#33173). The Codex model catalog on disk (`~/.codex/models_cache.json`) now lists `codex-auto-review` with Luna's exact profile: same `multi_agent_version: v1`, same reasoning levels with no `ultra`, same 872k max context. Sol and Terra both differ on those fields.
- gpt-5.5 bills $5.00 input / $0.50 cache read / $30.00 output per million. Luna bills $0.20 / $0.02 / $1.20 — exactly one twenty-fifth on all three, so the error is a flat 25x on every auto-review event since July.
- On one real local day this read **$20.92 for 10M tokens where the true cost is about $0.86**, and it inflated auto-review's share of the day from ~2% to 30%. Token counts were never affected; they are measured.
- ccusage has not fixed this upstream. Their issue #1589 asks for it and a community PR was auto-closed by their contributor bot, so mirroring the snapshot unchanged would keep the bug.

## What this changes

- Adds `("2026-07-09", "gpt-5.6-luna")` to the top of `autoReviewFallbacks`.
- Documents in the doc comment that this entry is ours rather than ccusage's, with the reason, so the next person syncing the snapshot does not delete it.
- Adds boundary assertions to `testAutoReviewSlugMapsToDatedCodexModel`: today and the release date resolve to Luna, the day before still resolves to gpt-5.5.

## Heads-up

- **The date has some slack.** GPT-5.6 launched 2026-07-09, the Codex CLI migration merged 07-14, and one write-up puts the switch at 07-30. I used 07-09 to match what ccusage's own open issue proposes, so we stay easy to reconcile if they ever merge it. If auto-review actually switched later, events in that window now price low instead of high, and the window is at most three weeks in the past.
- **Luna over Terra.** Two GitHub issues from earlier in August show the catalog mapping `codex-auto-review` to Terra. A catalog fetched today shows Luna's profile instead, so those describe an older state. If it turns out to be Terra, the rates are 2.5x rather than 25x lower and only this one line changes.
- **The table is the fragile part.** A hardcoded date list needs an edit every time OpenAI reassigns the slug, and it has now been stale for five weeks twice over. Reading the variant out of `models_cache.json` at scan time would be self-maintaining. That is a design change, so it is not in this PR.
- No pricing data was needed: `gpt-5.6-luna` already carries $0.20 / $0.02 / $1.20 in `pricing_supplement.json`, matching OpenAI's live pricing page, and the supplement is consulted before the public catalogs.

## Tests

- `swift test` — 1289 tests, 3 skipped, 0 failures.
- Verified against real logs: summing today's `codex-auto-review` events under `~/.codex/sessions/2026/08/20/` gives 10.08M tokens (3.58M uncached input, 6.49M cached, 7.7k output). Priced at gpt-5.5 that is $21.39, which matches the $20.92 the tile showed once session dedup is applied — confirming the fallback was the live path, not a coincidence.
- Built and launched the dev bundle with `script/build_and_run.sh`.

No screenshots: the change corrects a number in an existing tile and touches no UI.
