### PR TITLE
fix(grok): restore spend history from session ledgers

### DIFF
--- a/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
@@ -1,148 +1,180 @@
 import Foundation
 
-/// Builds daily token/cost estimates for Grok from the Grok CLI's local log.
-///
-/// Like the Claude/Codex scanners but simpler: Grok's token data lives in a single global
-/// append-only log, `~/.grok/logs/unified.jsonl`, on `shell.turn.inference_done` lines.
-/// Those lines carry token counts but no model id, so the scanner attributes each row to a model by
-/// tracking the "current model" per CLI process (`pid`) from the model-change events the CLI also
-/// logs. The output is the same `DailyUsageSeries` shape the Claude/Codex spend tiles consume, so it
-/// flows straight through `SpendTileMapper`.
-struct GrokLogUsageScanner: Sendable {
-    var files: TextFileAccessing
-    var environment: EnvironmentReading
-    var homeDirectory: @Sendable () -> URL
-    private let readFailureReporter: UsageLogReadFailureReporter
+/// Builds Grok's daily usage from completed turns in the CLI's durable session transcripts.
+/// `logs/unified.jsonl` is a capped debug log, so it cannot back historical spend or reliable model
+/// attribution. Session `updates.jsonl` files carry both per-model token counts and Grok's own costs.
+actor GrokLogUsageScanner {
+    private let environment: EnvironmentReading
+    private let homeDirectory: @Sendable () -> URL
+    private let scanner: IncrementalJSONLScanner<Entry>
+
+    /// One model's contribution to a completed turn. Event identifiers let copied session transcripts
+    /// deduplicate the same notification without collapsing multiple models within that notification.
+    struct Entry: Codable, Sendable, Equatable {
+        var eventID: String?
+        var timestamp: Date
+        var model: String
+        var tokens: TokenBreakdown
+        var carriedCost: Double?
+    }
+
+    private static let sharedScanner = IncrementalJSONLScanner<Entry>(
+        logTag: LogTag.plugin("grok"),
+        persistence: JSONLScanCachePersistence(namespace: "grok", schemaVersion: 1)
+    )
+
+    static func flushPersistentCacheWrites() async {
+        await sharedScanner.flushPendingWrites()
+    }
 
     init(
-        files: TextFileAccessing = LocalTextFileAccessor(),
         environment: EnvironmentReading = ProcessEnvironmentReader(),
         homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
-        readFailureWarning: UsageLogReadFailureReporter.Warning? = nil
+        incrementalScanner: IncrementalJSONLScanner<Entry>? = nil
     ) {
-        self.files = files
         self.environment = environment
         self.homeDirectory = homeDirectory
-        self.readFailureReporter = UsageLogReadFailureReporter(
-            logTag: LogTag.plugin("grok"),
-            warning: readFailureWarning
-        )
+        self.scanner = incrementalScanner ?? Self.sharedScanner
     }
 
-    /// `~/.grok/logs/unified.jsonl`, or `$GROK_HOME/logs/unified.jsonl` when that env var is set.
-    var logPath: String {
+    /// Scan completed turns under `$GROK_HOME/sessions`, or `~/.grok/sessions` by default.
+    /// Missing transcripts leave the spend tiles unbacked instead of falling back to the debug log.
+    func scan(daysBack: Int = 30, now: Date = Date(), pricing: ModelPricing) async -> LogUsageScan? {
+        let directory = grokHome().appendingPathComponent("sessions", isDirectory: true)
+        let identity = directory.resolvingSymlinksInPath().standardizedFileURL.path
+        let since = JSONLScanning.sinceDate(daysBack: daysBack, now: now)
+        let files = JSONLScanning.jsonlFiles(under: directory)
+            .filter { URL(fileURLWithPath: $0.path).lastPathComponent == "updates.jsonl" }
+
+        guard !files.isEmpty else {
+            _ = await scanner.items(from: [], since: since, cacheIdentity: identity, parse: Self.parseFile)
+            return nil
+        }
+
+        guard let entries = await scanner.items(
+            from: files,
+            since: since,
+            cacheIdentity: identity,
+            parse: Self.parseFile
+        ), !Task.isCancelled else { return nil }
+        return Self.aggregate(entries: Self.dedup(entries), since: since, pricing: pricing)
+    }
+
+    private func grokHome() -> URL {
         if let raw = environment.value(for: "GROK_HOME")?.trimmingCharacters(in: .whitespacesAndNewlines),
            !raw.isEmpty {
-            return expandHome(raw).trimmingTrailingSlashes + "/logs/unified.jsonl"
+            return URL(fileURLWithPath: expandHome(raw))
         }
-        return homeDirectory().appendingPathComponent(".grok/logs/unified.jsonl").path
+        return homeDirectory().appendingPathComponent(".grok", isDirectory: true)
     }
 
-    /// Scan the last `daysBack` days of the log. Returns `nil` when the log is missing/unreadable (the
-    /// spend tiles then render "No data"); returns an empty `daily` when the log exists but has no
-    /// usable token rows in the window.
-    ///
-    /// `async` and nonisolated (this is a plain `Sendable` struct, not `@MainActor`), so the whole-file
-    /// read + parse runs off the main actor when a `@MainActor` provider `await`s it.
-    func scan(daysBack: Int = 30, now: Date = Date(), pricing: ModelPricing) async -> LogUsageScan? {
-        let path = logPath
-        guard files.exists(path) else {
-            await readFailureReporter.update(checkedPaths: [path], failingPaths: [])
-            return nil
+    // MARK: - Session parsing
+
+    static func parseFile(_ data: Data) -> [Entry] {
+        let completedTurnMarker = Data("turn_completed".utf8)
+        var entries: [Entry] = []
+        for line in data.split(separator: UInt8(ascii: "\n")) {
+            guard line.range(of: completedTurnMarker) != nil,
+                  let object = (try? JSONSerialization.jsonObject(with: line)) as? [String: Any]
+            else { continue }
+            entries.append(contentsOf: parseCompletedTurn(object))
         }
-        let text: String
-        do {
-            text = try files.readText(path)
-            await readFailureReporter.update(checkedPaths: [path], failingPaths: [])
-        } catch {
-            await readFailureReporter.update(checkedPaths: [path], failingPaths: [path])
-            return nil
-        }
-        return Self.parse(text, since: JSONLScanning.sinceDate(daysBack: daysBack, now: now), pricing: pricing)
+        return entries
     }
 
-    /// Single chronological pass over the append-only log. Model-carrying events update a per-`pid`
-    /// "current model" (tracked regardless of date, so a session straddling the `since` boundary stays
-    /// attributed); each in-window `inference_done` row is priced against its `pid`'s current model and
-    /// bucketed by local calendar day.
-    static func parse(_ text: String, since: Date, pricing: ModelPricing) -> LogUsageScan {
-        var modelByPID: [Int: String] = [:]
+    private static func parseCompletedTurn(_ object: [String: Any]) -> [Entry] {
+        let params = object["params"] as? [String: Any]
+        let update = (params?["update"] as? [String: Any]) ?? (object["update"] as? [String: Any])
+        guard let update,
+              update["sessionUpdate"] as? String == "turn_completed",
+              let usage = update["usage"] as? [String: Any],
+              let modelUsage = usage["modelUsage"] as? [String: Any],
+              let timestamp = timestamp(in: object, params: params)
+        else { return [] }
+
+        let metadata = (params?["_meta"] as? [String: Any]) ?? (object["_meta"] as? [String: Any])
+        let eventID = (metadata?["eventId"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let topLevelTicks = ProviderParse.number(usage["costUsdTicks"])
+        var entries: [Entry] = []
+
+        for (rawModel, rawUsage) in modelUsage.sorted(by: { $0.key < $1.key }) {
+            let model = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !model.isEmpty,
+                  let values = rawUsage as? [String: Any],
+                  let inputValue = ProviderParse.number(values["inputTokens"]),
+                  inputValue >= 0
+            else { continue }
+
+            let input = Int(inputValue)
+            let cacheRead = min(max(Int(ProviderParse.number(values["cachedReadTokens"]) ?? 0), 0), input)
+            let cacheWrite = min(
+                max(Int(ProviderParse.number(values["cacheCreationTokens"]) ?? 0), 0),
+                input - cacheRead
+            )
+            // Grok reports reasoning as a subset of outputTokens, so it must never be added again.
+            let output = max(Int(ProviderParse.number(values["outputTokens"]) ?? 0), 0)
+            let ticks = ProviderParse.number(values["costUsdTicks"])
+                ?? (modelUsage.count == 1 ? topLevelTicks : nil)
+            let carriedCost = ticks.flatMap { $0 >= 0 ? $0 / 10_000_000_000 : nil }
+
+            entries.append(Entry(
+                eventID: eventID?.isEmpty == false ? eventID : nil,
+                timestamp: timestamp,
+                model: model,
+                tokens: TokenBreakdown(
+                    input: input - cacheRead - cacheWrite,
+                    cacheWrite5m: cacheWrite,
+                    cacheRead: cacheRead,
+                    output: output
+                ),
+                carriedCost: carriedCost
+            ))
+        }
+        return entries
+    }
+
+    private static func timestamp(in object: [String: Any], params: [String: Any]?) -> Date? {
+        for metadata in [params?["_meta"], object["_meta"]] {
+            guard let values = metadata as? [String: Any],
+                  let milliseconds = ProviderParse.number(values["agentTimestampMs"]),
+                  milliseconds > 0
+            else { continue }
+            return Date(timeIntervalSince1970: milliseconds / 1_000)
+        }
+
+        if let seconds = ProviderParse.number(object["timestamp"]), seconds > 0 {
+            return Date(timeIntervalSince1970: seconds)
+        }
+        if let value = object["timestamp"] as? String {
+            return OpenUsageISO8601.date(from: value)
+        }
+        return nil
+    }
+
+    // MARK: - Deduplication and aggregation
+
+    static func dedup(_ entries: [Entry]) -> [Entry] {
+        var seen: Set<String> = []
+        return entries.filter { entry in
+            guard let eventID = entry.eventID else { return true }
+            return seen.insert(eventID + "\0" + entry.model).inserted
+        }
+    }
+
+    static func aggregate(entries: [Entry], since: Date, pricing: ModelPricing) -> LogUsageScan {
         var accumulator = DailyUsageAccumulator()
-
-        text.enumerateLines { line, _ in
-            // Cheap pre-filter before JSON parsing: only model-carrying events and token rows matter
-            // (token rows contain "inference_done"; every model event's `msg` contains "model").
-            guard line.contains("inference_done") || line.contains("model") else { return }
-            guard let data = line.data(using: .utf8),
-                  let object = ProviderParse.jsonObject(data),
-                  let msg = object["msg"] as? String
-            else { return }
-
-            let ctx = object["ctx"] as? [String: Any] ?? [:]
-            let pid = ProviderParse.number(object["pid"]).map { Int($0) }
-
-            if let model = modelID(msg: msg, ctx: ctx) {
-                if let pid { modelByPID[pid] = model }
-                return
-            }
-
-            guard msg == "shell.turn.inference_done",
-                  let promptTokens = ProviderParse.number(ctx["prompt_tokens"]),
-                  let timestamp = (object["ts"] as? String).flatMap(OpenUsageISO8601.date(from:)),
-                  timestamp >= since
-            else { return }
-
-            let completion = Int(ProviderParse.number(ctx["completion_tokens"]) ?? 0)
-            let reasoning = Int(ProviderParse.number(ctx["reasoning_tokens"]) ?? 0)
-            // `cached_prompt_tokens` is a subset of `prompt_tokens`, so total counts prompt once.
-            let cached = min(ProviderParse.number(ctx["cached_prompt_tokens"]) ?? 0, promptTokens)
-            let cacheRead = Int(cached)
-            let inputNoCache = Int(max(0, promptTokens - cached))
-            let output = completion + reasoning
-
-            let day = DailyUsageAccumulator.dayKey(from: timestamp)
-            let totalTokens = Int(promptTokens) + output
-
-            // Grok's token rows lack a model id; attribute via the row's process. Rows that can't be
-            // priced (no attributable model, or a model no source can price) are excluded from every
-            // displayed total — tokens, dollars, the trend, and the model breakdown — because mixing
-            // measured tokens with unpriceable ones makes the figures incoherent. An unknown model's
-            // name lands in `unknownModelsByDay` (the tile's warning triangle), the only place
-            // unpriceable usage surfaces; unattributed rows have no name to warn about.
-            guard let model = pid.flatMap({ modelByPID[$0] }) else { return }
-            let tokenBreakdown = TokenBreakdown(input: inputNoCache, cacheRead: cacheRead, output: output)
-            guard let cost = pricing.estimatedCostDollars(model: model, tokens: tokenBreakdown) else {
-                if totalTokens > 0 {
-                    accumulator.addUnknownModel(day: day, model: model)
+        for entry in entries where entry.timestamp >= since {
+            let day = DailyUsageAccumulator.dayKey(from: entry.timestamp)
+            guard let cost = entry.carriedCost
+                ?? pricing.estimatedCostDollars(model: entry.model, tokens: entry.tokens)
+            else {
+                if entry.tokens.totalTokens > 0 {
+                    accumulator.addUnknownModel(day: day, model: entry.model)
                 }
-                return
+                continue
             }
-            accumulator.add(day: day, tokens: totalTokens, cost: cost, model: model)
+            accumulator.add(day: day, tokens: entry.tokens.totalTokens, cost: cost, model: entry.model)
         }
-
         return accumulator.build()
     }
-
-    /// The model id carried by a model-change event, or `nil` for any other line. The Grok CLI signals
-    /// the active model through several event shapes, all keyed by `pid`.
-    private static func modelID(msg: String, ctx: [String: Any]) -> String? {
-        let raw: Any?
-        switch msg {
-        case "model changed":
-            raw = ctx["model"]
-        case "model catalog: notifying clients":
-            raw = ctx["current_model_id"]
-        case "backend_search: model switch":
-            raw = ctx["model"] ?? ctx["current_model_id"] ?? ctx["model_id"]
-        case "subagent model resolved":
-            raw = ctx["model_id"] ?? ctx["model"]
-        default:
-            return nil
-        }
-        guard let model = (raw as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !model.isEmpty
-        else { return nil }
-        return model
-    }
-
 }

--- a/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
@@ -44,7 +44,7 @@ actor GrokLogUsageScanner {
         let identity = directory.resolvingSymlinksInPath().standardizedFileURL.path
         let since = JSONLScanning.sinceDate(daysBack: daysBack, now: now)
         let files = JSONLScanning.jsonlFiles(under: directory)
-            .filter { URL(fileURLWithPath: $0.path).lastPathComponent == "updates.jsonl" }
+            .filter(Self.isCoordinatorSession)
 
         guard !files.isEmpty else {
             _ = await scanner.items(from: [], since: since, cacheIdentity: identity, parse: Self.parseFile)
@@ -66,6 +66,29 @@ actor GrokLogUsageScanner {
             return URL(fileURLWithPath: expandHome(raw))
         }
         return homeDirectory().appendingPathComponent(".grok", isDirectory: true)
+    }
+
+    /// Coordinator turns already include their subagents, so reading both ledgers would charge every
+    /// child task twice. Older sessions without a summary remain eligible because their kind is unknown.
+    private static func isCoordinatorSession(_ file: JSONLScanning.DiscoveredFile) -> Bool {
+        let fileURL = URL(fileURLWithPath: file.path)
+        guard fileURL.lastPathComponent == "updates.jsonl" else { return false }
+
+        let summaryURL = fileURL.deletingLastPathComponent().appendingPathComponent("summary.json")
+        guard FileManager.default.fileExists(atPath: summaryURL.path) else { return true }
+
+        do {
+            let data = try Data(contentsOf: summaryURL)
+            guard let summary = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                AppLog.warn(LogTag.plugin("grok"), "Session summary is not a JSON object; skipped session")
+                return false
+            }
+            guard let kind = summary["session_kind"] as? String else { return true }
+            return !kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("subagent")
+        } catch {
+            AppLog.warn(LogTag.plugin("grok"), "Could not read session summary; skipped session: \(error.localizedDescription)")
+            return false
+        }
     }
 
     // MARK: - Session parsing

--- a/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokProvider.swift
@@ -42,7 +42,7 @@ final class GrokProvider: ProviderRuntime {
                     estimatedCost: true,
                     sourceNote: "From your Grok logs (estimated)"
                 )
-            // Local spend tiles, estimated from the Grok CLI log (see GrokLogUsageScanner).
+            // Local spend tiles from completed turns in the Grok CLI's session transcripts.
         ] + WidgetDescriptor.spendTiles(provider: provider)
     }
 
@@ -93,8 +93,8 @@ final class GrokProvider: ProviderRuntime {
 
         let plan = await fetchPlanName(accessToken: state.token)
 
-        // Local spend tiles, read natively from the Grok CLI log and priced via the shared pricing
-        // store. `scan` is awaited so its whole-file read + parse runs off the main actor.
+        // Local spend tiles from completed session turns. Recorded Grok costs win when available;
+        // older turns without a carried cost use the shared pricing store.
         var usageHistory: ProviderUsageHistory?
         if let scan = await logUsageScanner.scan(daysBack: 30, now: now(), pricing: await pricing()) {
             usageHistory = ProviderUsageHistory(

--- a/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
+++ b/Sources/OpenUsage/Providers/IncrementalJSONLScanner.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// The `Item`-independent half of the incremental scan machinery: file discovery and the scan-window
-/// lower bound. A non-generic namespace so providers that only need the window math (Grok) share it
-/// without dragging in the generic actor, and so call sites read `JSONLScanning.sinceDate(...)` instead
-/// of `IncrementalJSONLScanner<Entry>.sinceDate(...)`.
+/// lower bound. A non-generic namespace keeps file discovery independent of each provider's parsed
+/// row type and lets call sites read `JSONLScanning.sinceDate(...)`.
 enum JSONLScanning {
     /// A discovered log file plus the stat fields the parse cache is keyed on.
     struct DiscoveredFile: Sendable {
@@ -44,8 +43,8 @@ enum JSONLScanning {
     }
 }
 
-/// The incremental, off-main-actor scan machinery shared by the Claude, Codex, and pi log scanners: discover
-/// `*.jsonl` files, re-parse only those changed since the last scan (a per-file cache keyed by path +
+/// The incremental, off-main-actor scan machinery shared by the Claude, Codex, Grok, and pi log scanners:
+/// discover `*.jsonl` files, re-parse only those changed since the last scan (a per-file cache keyed by path +
 /// size + mtime), and return the parsed items concatenated in file order. Each provider supplies its own
 /// file discovery, per-file parser, and post-parse dedup/aggregation; this owns the cache, the parallel
 /// parse, the mtime-window skip, and (via `JSONLScanning`) the jsonl enumeration so that scaffolding

--- a/Sources/OpenUsage/Providers/JSONLScanCacheCoordination.swift
+++ b/Sources/OpenUsage/Providers/JSONLScanCacheCoordination.swift
@@ -56,6 +56,7 @@ enum PersistentJSONLScanCaches {
     static func flushPendingWrites() async {
         await ClaudeLogUsageScanner.flushPersistentCacheWrites()
         await CodexLogUsageScanner.flushPersistentCacheWrites()
+        await GrokLogUsageScanner.flushPersistentCacheWrites()
         await PiUsageScanner.flushPersistentCacheWrites()
     }
 }

--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries; https://developers.openai.com/api/docs/models/daybreak-blue-latest and https://developers.openai.com/api/docs/pricing for Daybreak aliases and rates.",
-  "updated_at": "2026-08-19T10:51:18Z",
+  "updated_at": "2026-08-24T04:32:07Z",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -187,10 +187,10 @@
     { "pattern": "^github_bugbot$", "canonical": "github_bugbot" },
     { "pattern": "^(?:cursor-)?grok-4[.-]6-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.6-fast" },
     { "pattern": "^(?:cursor-)?grok-4[.-]6(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.6-fast" },
-    { "pattern": "^(?:cursor-)?grok-4[.-]6(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.6" },
+    { "pattern": "^(?:cursor-)?grok-4[.-]6(?:-(?:build|low|medium|high|xhigh))?$", "canonical": "grok-4.6" },
     { "pattern": "^(?:cursor-)?grok-4[.-]5-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5-fast" },
     { "pattern": "^(?:cursor-)?grok-4[.-]5(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.5-fast" },
-    { "pattern": "^(?:cursor-)?grok-4[.-]5(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5" },
+    { "pattern": "^(?:cursor-)?grok-4[.-]5(?:-(?:build|low|medium|high|xhigh))?$", "canonical": "grok-4.5" },
     { "pattern": "^kimi-k2\\.7(?:-code)?$", "canonical": "kimi-k2.7-code" },
     { "pattern": "^kimi-k2p7(?:-code)?$", "canonical": "kimi-k2.7-code" },
     { "pattern": "^kimi-k3(?:-code)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "kimi-k3" },

--- a/Tests/OpenUsageTests/GrokLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/GrokLogUsageScannerTests.swift
@@ -225,6 +225,72 @@ final class GrokLogUsageScannerTests: XCTestCase {
         XCTAssertEqual(usage?.series.daily.map(\.totalTokens), [200, 100])
     }
 
+    func testSkipsSubagentSessionsAlreadyIncludedInCoordinatorTotals() async throws {
+        let coordinator = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-4.6-build",
+            input: 300,
+            costUsdTicks: 30_000_000_000,
+            eventID: "coordinator-turn"
+        )
+        let subagent = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:01:00.000Z",
+            model: "grok-4.6-build",
+            input: 100,
+            costUsdTicks: 10_000_000_000,
+            eventID: "subagent-turn"
+        )
+        let fork = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:02:00.000Z",
+            model: "grok-4.6-build",
+            input: 200,
+            costUsdTicks: 20_000_000_000,
+            eventID: "fork-turn"
+        )
+        let legacy = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T11:00:00.000Z",
+            model: "grok-4.6-build",
+            input: 50,
+            costUsdTicks: 5_000_000_000,
+            eventID: "legacy-turn"
+        )
+        let home = try GrokLogFixture.makeHome(files: [
+            "project/coordinator/updates.jsonl": coordinator,
+            "project/coordinator/summary.json": #"{"session_kind":"coordinator"}"#,
+            "project/coordinator/subagents/worker/updates.jsonl": subagent,
+            "project/coordinator/subagents/worker/summary.json": #"{"session_kind":"subagent"}"#,
+            "project/fork/updates.jsonl": fork,
+            "project/fork/summary.json": #"{"session_kind":"subagent_fork"}"#,
+            "project/legacy/updates.jsonl": legacy
+        ])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let usage = await GrokLogFixture.scanner(home: home).scan(
+            daysBack: 30,
+            now: OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!,
+            pricing: TestPricing.bundled
+        )
+        let day = try XCTUnwrap(usage?.series.daily.first)
+
+        XCTAssertEqual(day.totalTokens, 350, "subagent and fork tokens are already included in their coordinator")
+        XCTAssertEqual(try XCTUnwrap(day.costUSD), 3.5, accuracy: 0.0001)
+    }
+
+    func testSkipsSessionWithMalformedSummaryInsteadOfGuessingItsKind() async throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z", model: "grok-build", input: 1_000
+        )
+        let home = try GrokLogFixture.makeHome(files: [
+            "project/session/updates.jsonl": line,
+            "project/session/summary.json": "{invalid"
+        ])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let usage = await GrokLogFixture.scanner(home: home).scan(pricing: TestPricing.bundled)
+
+        XCTAssertNil(usage)
+    }
+
     func testReadsWhitespaceTrimmedGrokHomeOverride() async throws {
         let line = GrokLogFixture.completedTurn(
             timestamp: "2026-06-10T10:00:00.000Z", model: "grok-build", input: 1_000

--- a/Tests/OpenUsageTests/GrokLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/GrokLogUsageScannerTests.swift
@@ -1,203 +1,360 @@
+import Foundation
 import XCTest
 @testable import OpenUsage
 
 final class GrokLogUsageScannerTests: XCTestCase {
     private let since = OpenUsageISO8601.date(from: "2026-06-01T00:00:00.000Z")!
 
-    func testAttributesTokensToPerProcessModelAndPrices() {
-        // pid 100 is on grok-build, pid 200 on grok-composer-2.5-fast; each token row prices against
-        // its own process's current model.
-        let log = """
-        {"ts":"2026-06-10T09:00:00.000Z","pid":100,"msg":"model catalog: notifying clients","ctx":{"current_model_id":"grok-build"}}
-        {"ts":"2026-06-10T09:00:00.000Z","pid":200,"msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
-        {"ts":"2026-06-10T10:00:00.000Z","pid":100,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"cached_prompt_tokens":0,"completion_tokens":1000000,"reasoning_tokens":0}}
-        {"ts":"2026-06-10T11:00:00.000Z","pid":200,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"cached_prompt_tokens":0,"completion_tokens":1000000,"reasoning_tokens":0}}
-        """
+    func testUsesRecordedPerModelCostAndDoesNotCountReasoningTwice() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-4.6-build",
+            input: 1_000_000,
+            cached: 700_000,
+            output: 50_000,
+            reasoning: 20_000,
+            costUsdTicks: 2_357_158_800,
+            eventID: "turn-1"
+        )
 
-        let usage = GrokLogUsageScanner.parse(log, since: since, pricing: TestPricing.bundled)
+        let usage = scan(line)
+        let day = try XCTUnwrap(usage.series.daily.first)
 
-        let day = usage.series.daily.first { $0.date == "2026-06-10" }
-        XCTAssertEqual(day?.totalTokens, 4_000_000)
-        // grok-build: 1M input @ $1 + 1M output @ $2 = $3. composer-2.5-fast: 1M @ $3 + 1M @ $15 = $18.
-        XCTAssertEqual(day?.costUSD ?? 0, 21.0, accuracy: 0.0001)
-        let models = usage.modelUsage?.daily.first { $0.date == "2026-06-10" }?.models ?? []
-        XCTAssertEqual(Set(models.map(\.model)), Set(["grok-build", "grok-composer-2.5-fast"]))
+        XCTAssertEqual(day.totalTokens, 1_050_000)
+        XCTAssertEqual(try XCTUnwrap(day.costUSD), 0.23571588, accuracy: 0.00000001)
+        XCTAssertEqual(usage.modelUsage?.daily.first?.models.map(\.model), ["grok-4.6-build"])
     }
 
-    func testTracksMidProcessModelSwitch() {
-        let log = """
-        {"ts":"2026-06-12T08:00:00.000Z","pid":7,"msg":"model changed","ctx":{"model":"grok-build"}}
-        {"ts":"2026-06-12T09:00:00.000Z","pid":7,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"cached_prompt_tokens":0,"completion_tokens":0,"reasoning_tokens":0}}
-        {"ts":"2026-06-12T10:00:00.000Z","pid":7,"msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
-        {"ts":"2026-06-12T11:00:00.000Z","pid":7,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"cached_prompt_tokens":0,"completion_tokens":0,"reasoning_tokens":0}}
-        """
+    func testFallsBackToSharedPricingAndSeparatesCacheBuckets() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-4.5-build",
+            input: 1_000_000,
+            cached: 700_000,
+            cacheWrite: 100_000,
+            output: 250_000
+        )
 
-        let usage = GrokLogUsageScanner.parse(log, since: since, pricing: TestPricing.bundled)
+        let day = try XCTUnwrap(scan(line).series.daily.first)
 
-        // First row priced as grok-build ($1/M input), second after the switch as composer-2.5-fast ($3/M).
-        XCTAssertEqual(usage.series.daily.first?.costUSD ?? 0, 4.0, accuracy: 0.0001)
+        // 200k input + 100k cache write at $2/M, 700k cache read at $0.5/M, 250k output at $6/M.
+        XCTAssertEqual(day.totalTokens, 1_250_000)
+        XCTAssertEqual(try XCTUnwrap(day.costUSD), 2.45, accuracy: 0.0001)
     }
 
-    func testUsesCachedReadRateForCachedPromptTokens() {
-        // 800k of the 1M prompt tokens are cache reads (grok-build: $0.2/M read vs $1/M input).
-        let log = """
-        {"ts":"2026-06-12T08:00:00.000Z","pid":1,"msg":"model changed","ctx":{"model":"grok-build"}}
-        {"ts":"2026-06-12T09:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"cached_prompt_tokens":800000,"completion_tokens":0,"reasoning_tokens":0}}
-        """
+    func testSplitsCompletedTurnAcrossModelsWithoutDuplicatingTheEvent() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-4.5-build",
+            input: 100,
+            output: 20,
+            costUsdTicks: 1_000_000_000,
+            eventID: "shared-turn",
+            additionalModels: [
+                "grok-4.6-build": [
+                    "inputTokens": 200,
+                    "outputTokens": 30,
+                    "costUsdTicks": 2_000_000_000
+                ]
+            ]
+        )
 
-        let usage = GrokLogUsageScanner.parse(log, since: since, pricing: TestPricing.bundled)
+        let usage = scan(line)
+        let day = try XCTUnwrap(usage.series.daily.first)
 
-        // 200k input @ $1/M ($0.2) + 800k cache read @ $0.2/M ($0.16) = $0.36.
-        XCTAssertEqual(usage.series.daily.first?.costUSD ?? 0, 0.36, accuracy: 0.0001)
+        XCTAssertEqual(day.totalTokens, 350)
+        XCTAssertEqual(try XCTUnwrap(day.costUSD), 0.3, accuracy: 0.0001)
+        XCTAssertEqual(
+            Set(usage.modelUsage?.daily.first?.models.map(\.model) ?? []),
+            ["grok-4.5-build", "grok-4.6-build"]
+        )
     }
 
-    func testSkipsRowsWithoutTokenFieldsAndOutsideWindow() {
-        let log = """
-        {"ts":"2026-06-10T09:00:00.000Z","pid":1,"msg":"model changed","ctx":{"model":"grok-build"}}
-        {"ts":"2026-05-30T09:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"completion_tokens":0,"reasoning_tokens":0}}
-        {"ts":"2026-06-10T10:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"loop_index":3,"model_elapsed_ms":10}}
-        {"ts":"2026-06-10T11:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":500000,"completion_tokens":0,"reasoning_tokens":0}}
-        """
+    func testSingleModelFallsBackToTurnLevelRecordedCost() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-4.6-build",
+            input: 1_000_000,
+            costUsdTicks: 1_250_000_000,
+            includePerModelCost: false
+        )
 
-        let usage = GrokLogUsageScanner.parse(log, since: since, pricing: TestPricing.bundled)
-
-        // Only the in-window, token-bearing row counts (the pre-window row and the token-less row drop).
-        XCTAssertEqual(usage.series.daily.count, 1)
-        XCTAssertEqual(usage.series.daily.first?.totalTokens, 500_000)
+        let day = try XCTUnwrap(scan(line).series.daily.first)
+        XCTAssertEqual(try XCTUnwrap(day.costUSD), 0.125, accuracy: 0.0001)
     }
 
-    func testUnpricedModelIsExcludedFromTotalsButWarns() {
-        let log = """
-        {"ts":"2026-06-10T09:00:00.000Z","pid":1,"msg":"model changed","ctx":{"model":"grok-unknown-model"}}
-        {"ts":"2026-06-10T10:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"completion_tokens":0,"reasoning_tokens":0}}
-        {"ts":"2026-06-10T11:00:00.000Z","pid":2,"msg":"model changed","ctx":{"model":"grok-build"}}
-        {"ts":"2026-06-10T12:00:00.000Z","pid":2,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":500000,"completion_tokens":0,"reasoning_tokens":0}}
-        """
+    func testRecordedCostAllowsUnknownModelWithoutPricingWarning() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-future-model",
+            input: 500_000,
+            costUsdTicks: 3_000_000_000
+        )
 
-        let usage = GrokLogUsageScanner.parse(log, since: since, pricing: TestPricing.bundled)
+        let usage = scan(line)
 
-        // Unpriceable tokens never enter the displayed totals — they surface only through the
-        // warning triangle, so the tile's tokens and dollars stay coherent.
-        XCTAssertEqual(usage.series.daily.first?.totalTokens, 500_000)
-        XCTAssertNotNil(usage.series.daily.first?.costUSD)
-        XCTAssertEqual(usage.unknownModelsByDay["2026-06-10"], ["grok-unknown-model"])
-        XCTAssertEqual(usage.modelUsage?.daily.first?.models.map(\.model), ["grok-build"])
-    }
-
-    func testUnpricedModelOnlyLeavesDayUnbacked() {
-        let log = """
-        {"ts":"2026-06-10T09:00:00.000Z","pid":1,"msg":"model changed","ctx":{"model":"grok-unknown-model"}}
-        {"ts":"2026-06-10T10:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"completion_tokens":0,"reasoning_tokens":0}}
-        """
-
-        let usage = GrokLogUsageScanner.parse(log, since: since, pricing: TestPricing.bundled)
-
-        // A day with nothing priceable produces no series entry at all (→ "No data"), but the
-        // unknown-model warning still names what was excluded.
-        XCTAssertTrue(usage.series.daily.isEmpty)
-        XCTAssertEqual(usage.unknownModelsByDay["2026-06-10"], ["grok-unknown-model"])
-        XCTAssertEqual(usage.modelUsage?.daily ?? [], [])
-    }
-
-    func testUnattributedRowsAreExcludedWithoutWarning() {
-        let log = """
-        {"ts":"2026-06-10T10:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"completion_tokens":0,"reasoning_tokens":0}}
-        """
-
-        let usage = GrokLogUsageScanner.parse(log, since: since, pricing: TestPricing.bundled)
-
-        // Tokens with no attributable model can't be priced, so they're excluded from every total —
-        // and with no model name to warn about, no unknown-model entry either.
-        XCTAssertTrue(usage.series.daily.isEmpty)
+        let day = try XCTUnwrap(usage.series.daily.first)
+        XCTAssertEqual(try XCTUnwrap(day.costUSD), 0.3, accuracy: 0.0001)
         XCTAssertTrue(usage.unknownModelsByDay.isEmpty)
-        XCTAssertEqual(usage.modelUsage?.daily ?? [], [])
     }
 
-    func testScanReadsGrokHomeOverride() async {
-        let files = FakeFiles([
-            "/custom/grok/logs/unified.jsonl": """
-            {"ts":"2026-06-10T09:00:00.000Z","pid":1,"msg":"model changed","ctx":{"model":"grok-build"}}
-            {"ts":"2026-06-10T10:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"completion_tokens":0,"reasoning_tokens":0}}
-            """
+    func testUnknownModelWithoutRecordedCostIsExcludedAndWarns() {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-future-model",
+            input: 500_000
+        )
+
+        let usage = scan(line)
+
+        XCTAssertTrue(usage.series.daily.isEmpty)
+        XCTAssertEqual(usage.unknownModelsByDay["2026-06-10"], ["grok-future-model"])
+    }
+
+    func testZeroRecordedCostStillCountsMeasuredTokens() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-future-model",
+            input: 500,
+            costUsdTicks: 0
+        )
+
+        let day = try XCTUnwrap(scan(line).series.daily.first)
+
+        XCTAssertEqual(day.totalTokens, 500)
+        XCTAssertEqual(day.costUSD, 0)
+    }
+
+    func testPrefersMillisecondAgentTimestampOverCoarseOuterTimestamp() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-09T10:00:00.000Z",
+            model: "grok-build",
+            input: 1_000,
+            agentTimestampMs: 1_781_089_200_456
+        )
+
+        let entry = try XCTUnwrap(GrokLogUsageScanner.parseFile(Data(line.utf8)).first)
+
+        XCTAssertEqual(entry.timestamp.timeIntervalSince1970, 1_781_089_200.456, accuracy: 0.0001)
+    }
+
+    func testParsesUnixSecondTimestamps() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-build",
+            input: 1_000,
+            numericTimestamp: true
+        )
+
+        XCTAssertEqual(try XCTUnwrap(scan(line).series.daily.first).date, "2026-06-10")
+    }
+
+    func testParsesTopLevelUpdateEnvelope() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-build",
+            input: 1_000,
+            nested: false
+        )
+
+        XCTAssertEqual(try XCTUnwrap(scan(line).series.daily.first).totalTokens, 1_000)
+    }
+
+    func testSkipsIncompleteMalformedAndOutOfWindowTurns() throws {
+        let incomplete = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-build",
+            input: 1_000,
+            sessionUpdate: "turn_started"
+        )
+        let stale = GrokLogFixture.completedTurn(
+            timestamp: "2026-05-30T10:00:00.000Z",
+            model: "grok-build",
+            input: 2_000
+        )
+        let completed = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-build",
+            input: 3_000
+        )
+
+        let usage = scan([incomplete, "{broken turn_completed", stale, completed].joined(separator: "\n"))
+
+        XCTAssertEqual(try XCTUnwrap(usage.series.daily.first).totalTokens, 3_000)
+    }
+
+    func testCopiedEventIDsAreCountedOnce() throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z",
+            model: "grok-build",
+            input: 1_000,
+            eventID: "duplicate-event"
+        )
+
+        let usage = scan([line, line].joined(separator: "\n"))
+
+        XCTAssertEqual(try XCTUnwrap(usage.series.daily.first).totalTokens, 1_000)
+    }
+
+    func testRecursivelyScansSessionLedgersAndIgnoresOtherJSONLFiles() async throws {
+        let first = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z", model: "grok-build", input: 100, eventID: "copied-turn"
+        )
+        let second = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-11T10:00:00.000Z", model: "grok-build", input: 200
+        )
+        let ignored = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-12T10:00:00.000Z", model: "grok-build", input: 300
+        )
+        let home = try GrokLogFixture.makeHome(files: [
+            "project-a/session-a/updates.jsonl": first,
+            "project-b/session-b/updates.jsonl": second,
+            "project-b/session-b/debug.jsonl": ignored,
+            "project-c/copied-session/updates.jsonl": first
         ])
-        let scanner = GrokLogUsageScanner(
-            files: files,
-            environment: FakeEnvironment(["GROK_HOME": "/custom/grok"]),
-            homeDirectory: { URL(fileURLWithPath: "/home/ignored") }
+        defer { try? FileManager.default.removeItem(at: home) }
+        let scanner = GrokLogFixture.scanner(home: home)
+
+        let usage = await scanner.scan(
+            daysBack: 30,
+            now: OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!,
+            pricing: TestPricing.bundled
         )
 
-        let usage = await scanner.scan(daysBack: 30, now: OpenUsageISO8601.date(from: "2026-06-18T00:00:00.000Z")!, pricing: TestPricing.bundled)
-
-        XCTAssertEqual(usage?.series.daily.first?.totalTokens, 1_000_000)
+        XCTAssertEqual(usage?.series.daily.map(\.date), ["2026-06-11", "2026-06-10"])
+        XCTAssertEqual(usage?.series.daily.map(\.totalTokens), [200, 100])
     }
 
-    func testScanReturnsNilWhenLogMissing() async {
-        let warnings = GrokWarningRecorder()
-        let scanner = GrokLogUsageScanner(
-            files: FakeFiles(),
-            environment: FakeEnvironment(),
-            homeDirectory: { URL(fileURLWithPath: "/home/none") },
-            readFailureWarning: warnings.record
+    func testReadsWhitespaceTrimmedGrokHomeOverride() async throws {
+        let line = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z", model: "grok-build", input: 1_000
         )
+        let home = try GrokLogFixture.makeHome(files: ["project/session/updates.jsonl": line])
+        defer { try? FileManager.default.removeItem(at: home) }
+        let scanner = GrokLogUsageScanner(
+            environment: FakeEnvironment(["GROK_HOME": "  \(home.path)  "]),
+            homeDirectory: { URL(fileURLWithPath: "/home/ignored") },
+            incrementalScanner: IncrementalJSONLScanner<GrokLogUsageScanner.Entry>()
+        )
+
+        let usage = await scanner.scan(
+            daysBack: 30,
+            now: OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!,
+            pricing: TestPricing.bundled
+        )
+
+        XCTAssertEqual(usage?.series.daily.first?.totalTokens, 1_000)
+    }
+
+    func testReturnsNilWhenSessionLedgersAreMissing() async {
+        let scanner = GrokLogFixture.scanner(home: nil)
 
         let usage = await scanner.scan(pricing: TestPricing.bundled)
+
         XCTAssertNil(usage)
-        XCTAssertEqual(warnings.counts, [])
     }
 
-    func testUnreadableLogWarnsOnceUntilItRecovers() async {
-        let path = "/custom/grok/logs/unified.jsonl"
-        let files = FailingTextFiles(path: path)
-        let warnings = GrokWarningRecorder()
-        let scanner = GrokLogUsageScanner(
-            files: files,
-            environment: FakeEnvironment(["GROK_HOME": "/custom/grok"]),
-            homeDirectory: { URL(fileURLWithPath: "/home/ignored") },
-            readFailureWarning: warnings.record
+    func testDoesNotFallBackToTheDebugLogWhenSessionsAreMissing() async throws {
+        let home = try GrokLogFixture.makeHome(files: [:])
+        defer { try? FileManager.default.removeItem(at: home) }
+        let logs = home.appendingPathComponent("logs", isDirectory: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        try "debug log content".write(
+            to: logs.appendingPathComponent("unified.jsonl"),
+            atomically: true,
+            encoding: .utf8
         )
 
-        _ = await scanner.scan(pricing: TestPricing.bundled)
-        _ = await scanner.scan(pricing: TestPricing.bundled)
-        XCTAssertEqual(warnings.counts, [1])
+        let usage = await GrokLogFixture.scanner(home: home).scan(pricing: TestPricing.bundled)
 
-        files.shouldFail = false
-        _ = await scanner.scan(pricing: TestPricing.bundled)
-        files.shouldFail = true
-        _ = await scanner.scan(pricing: TestPricing.bundled)
-        XCTAssertEqual(warnings.counts, [1, 1])
+        XCTAssertNil(usage)
+    }
+
+    private func scan(_ text: String) -> LogUsageScan {
+        let entries = GrokLogUsageScanner.parseFile(Data(text.utf8))
+        return GrokLogUsageScanner.aggregate(
+            entries: GrokLogUsageScanner.dedup(entries),
+            since: since,
+            pricing: TestPricing.bundled
+        )
     }
 }
 
-private final class GrokWarningRecorder: @unchecked Sendable {
-    private let lock = NSLock()
-    private var recordedCounts: [Int] = []
-
-    var counts: [Int] { lock.withLock { recordedCounts } }
-
-    func record(_ count: Int) {
-        lock.withLock { recordedCounts.append(count) }
-    }
-}
-
-private final class FailingTextFiles: TextFileAccessing, @unchecked Sendable {
-    let path: String
-    var shouldFail = true
-
-    init(path: String) {
-        self.path = path
+enum GrokLogFixture {
+    static func makeHome(files: [String: String]) throws -> URL {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openusage-grok-\(UUID().uuidString)", isDirectory: true)
+        let sessions = home.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
+        for (relativePath, contents) in files {
+            let file = sessions.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try contents.write(to: file, atomically: true, encoding: .utf8)
+        }
+        return home
     }
 
-    func exists(_ path: String) -> Bool { path == self.path }
-
-    func readText(_ path: String) throws -> String {
-        if shouldFail { throw TestError.unreadable }
-        return ""
+    static func scanner(home: URL?) -> GrokLogUsageScanner {
+        GrokLogUsageScanner(
+            environment: FakeEnvironment(home.map { ["GROK_HOME": $0.path] } ?? [:]),
+            homeDirectory: {
+                FileManager.default.temporaryDirectory.appendingPathComponent("openusage-no-grok-home")
+            },
+            incrementalScanner: IncrementalJSONLScanner<GrokLogUsageScanner.Entry>()
+        )
     }
 
-    func writeText(_ path: String, _ text: String) throws {}
-    func remove(_ path: String) throws {}
+    static func completedTurn(
+        timestamp: String,
+        model: String,
+        input: Int,
+        cached: Int = 0,
+        cacheWrite: Int = 0,
+        output: Int = 0,
+        reasoning: Int = 0,
+        costUsdTicks: Int? = nil,
+        eventID: String? = nil,
+        agentTimestampMs: Int? = nil,
+        numericTimestamp: Bool = false,
+        nested: Bool = true,
+        includePerModelCost: Bool = true,
+        additionalModels: [String: [String: Int]] = [:],
+        sessionUpdate: String = "turn_completed"
+    ) -> String {
+        var modelValues: [String: Int] = [
+            "inputTokens": input,
+            "cachedReadTokens": cached,
+            "cacheCreationTokens": cacheWrite,
+            "outputTokens": output,
+            "reasoningTokens": reasoning
+        ]
+        if let costUsdTicks, includePerModelCost {
+            modelValues["costUsdTicks"] = costUsdTicks
+        }
+        var models = additionalModels
+        models[model] = modelValues
 
-    private enum TestError: Error {
-        case unreadable
+        var usage: [String: Any] = ["inputTokens": input, "outputTokens": output, "modelUsage": models]
+        if let costUsdTicks { usage["costUsdTicks"] = costUsdTicks }
+        let update: [String: Any] = ["sessionUpdate": sessionUpdate, "usage": usage]
+        var metadata: [String: Any] = [:]
+        if let eventID { metadata["eventId"] = eventID }
+        if let agentTimestampMs { metadata["agentTimestampMs"] = agentTimestampMs }
+
+        let parsedTimestamp = OpenUsageISO8601.date(from: timestamp)!
+        var object: [String: Any] = [
+            "timestamp": numericTimestamp ? Int(parsedTimestamp.timeIntervalSince1970) : timestamp
+        ]
+        if nested {
+            var params: [String: Any] = ["sessionId": "session-1", "update": update]
+            if !metadata.isEmpty { params["_meta"] = metadata }
+            object["params"] = params
+            object["method"] = "session/update"
+        } else {
+            object["update"] = update
+            if !metadata.isEmpty { object["_meta"] = metadata }
+        }
+
+        return String(decoding: try! JSONSerialization.data(withJSONObject: object), as: UTF8.self)
     }
 }

--- a/Tests/OpenUsageTests/GrokProviderTests.swift
+++ b/Tests/OpenUsageTests/GrokProviderTests.swift
@@ -211,25 +211,30 @@ final class GrokProviderTests: XCTestCase {
         XCTAssertNil(snapshot.errorCategory)
     }
 
-    func testRefreshAppendsLocalSpendTilesFromLog() async {
+    func testRefreshAppendsLocalSpendTilesFromSessions() async throws {
         let now = OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!
-        // grok-build: 1M input @ $1 = $1.00 today; composer-2.5-fast: 1M output @ $15 = $15.00 yesterday.
-        let log = """
-        {"ts":"2026-06-18T09:00:00.000Z","pid":1,"msg":"model changed","ctx":{"model":"grok-build"}}
-        {"ts":"2026-06-18T10:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"cached_prompt_tokens":0,"completion_tokens":0,"reasoning_tokens":0}}
-        {"ts":"2026-06-17T09:00:00.000Z","pid":2,"msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
-        {"ts":"2026-06-17T10:00:00.000Z","pid":2,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":0,"cached_prompt_tokens":0,"completion_tokens":1000000,"reasoning_tokens":0}}
-        """
-        let scanner = GrokLogUsageScanner(
-            files: FakeFiles(["/home/test/.grok/logs/unified.jsonl": log]),
-            environment: FakeEnvironment(),
-            homeDirectory: { URL(fileURLWithPath: "/home/test") }
-        )
+        let home = try GrokLogFixture.makeHome(files: [
+            "project/today/updates.jsonl": GrokLogFixture.completedTurn(
+                timestamp: "2026-06-18T10:00:00.000Z",
+                model: "grok-4.6-build",
+                input: 1_000_000,
+                costUsdTicks: 10_000_000_000
+            ),
+            "project/yesterday/updates.jsonl": GrokLogFixture.completedTurn(
+                timestamp: "2026-06-17T10:00:00.000Z",
+                model: "grok-4.5-build",
+                input: 0,
+                output: 1_000_000,
+                costUsdTicks: 150_000_000_000
+            )
+        ])
+        defer { try? FileManager.default.removeItem(at: home) }
+        let scanner = GrokLogFixture.scanner(home: home)
         let provider = makeProvider(httpClient: RecordingHTTPClient(handler: Self.defaultRoutes), scanner: scanner, now: now)
 
         let snapshot = await provider.refresh()
 
-        // Existing credit lines stay; the three spend tiles are appended from the local log.
+        // Existing credit lines stay; the three spend tiles use Grok's recorded session costs.
         XCTAssertEqual(progress(snapshot.lines, "Weekly limit")?.used, 99)
         XCTAssertEqual(values(snapshot.lines, "Today"),
                        [MetricValue(number: 1.0, kind: .dollars, estimated: true), MetricValue(number: 1_000_000, kind: .count, label: "tokens")])
@@ -239,22 +244,23 @@ final class GrokProviderTests: XCTestCase {
                        [MetricValue(number: 16.0, kind: .dollars, estimated: true), MetricValue(number: 2_000_000, kind: .count, label: "tokens")])
     }
 
-    func testPeriodWithoutUsageLeavesTileUnbacked() async {
-        // Regression for the reported "Today 0" bug: the log exists and has yesterday's usage, but no
-        // inference ran today. An idle today is "No data" (no backing line), never a fabricated
+    func testPeriodWithoutUsageLeavesTileUnbacked() async throws {
+        // Regression for the reported "Today 0" bug: a session has yesterday's usage, but no
+        // turn completed today. An idle today is "No data" (no backing line), never a fabricated
         // "$0.00 · 0 tokens" that contradicts a live session. "No data" is also what a missing/unreadable
-        // log produces — the two cases collapse to the same honest read.
+        // session produces — the two cases collapse to the same honest read.
         let now = OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!
-        // Only yesterday (06-17) has an inference row; today (06-18) has none.
-        let log = """
-        {"ts":"2026-06-17T09:00:00.000Z","pid":2,"msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
-        {"ts":"2026-06-17T10:00:00.000Z","pid":2,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":0,"cached_prompt_tokens":0,"completion_tokens":1000000,"reasoning_tokens":0}}
-        """
-        let scanner = GrokLogUsageScanner(
-            files: FakeFiles(["/home/test/.grok/logs/unified.jsonl": log]),
-            environment: FakeEnvironment(),
-            homeDirectory: { URL(fileURLWithPath: "/home/test") }
-        )
+        let home = try GrokLogFixture.makeHome(files: [
+            "project/session/updates.jsonl": GrokLogFixture.completedTurn(
+                timestamp: "2026-06-17T10:00:00.000Z",
+                model: "grok-4.5-build",
+                input: 0,
+                output: 1_000_000,
+                costUsdTicks: 150_000_000_000
+            )
+        ])
+        defer { try? FileManager.default.removeItem(at: home) }
+        let scanner = GrokLogFixture.scanner(home: home)
         let provider = makeProvider(httpClient: RecordingHTTPClient(handler: Self.defaultRoutes), scanner: scanner, now: now)
 
         let snapshot = await provider.refresh()
@@ -265,20 +271,19 @@ final class GrokProviderTests: XCTestCase {
         XCTAssertNotNil(values(snapshot.lines, "Last 30 Days"))
     }
 
-    func testRefreshAppendsUsageTrendFromLog() async {
+    func testRefreshAppendsUsageTrendFromSessions() async throws {
         let now = OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!
-        // 1M input today (06-18), 1M output yesterday (06-17).
-        let log = """
-        {"ts":"2026-06-18T09:00:00.000Z","pid":1,"msg":"model changed","ctx":{"model":"grok-build"}}
-        {"ts":"2026-06-18T10:00:00.000Z","pid":1,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":1000000,"cached_prompt_tokens":0,"completion_tokens":0,"reasoning_tokens":0}}
-        {"ts":"2026-06-17T09:00:00.000Z","pid":2,"msg":"model changed","ctx":{"model":"grok-composer-2.5-fast"}}
-        {"ts":"2026-06-17T10:00:00.000Z","pid":2,"msg":"shell.turn.inference_done","ctx":{"prompt_tokens":0,"cached_prompt_tokens":0,"completion_tokens":1000000,"reasoning_tokens":0}}
-        """
-        let scanner = GrokLogUsageScanner(
-            files: FakeFiles(["/home/test/.grok/logs/unified.jsonl": log]),
-            environment: FakeEnvironment(),
-            homeDirectory: { URL(fileURLWithPath: "/home/test") }
+        let today = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-18T10:00:00.000Z", model: "grok-build", input: 1_000_000
         )
+        let yesterday = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-17T10:00:00.000Z", model: "grok-composer-2.5-fast", input: 0, output: 1_000_000
+        )
+        let home = try GrokLogFixture.makeHome(files: [
+            "project/session/updates.jsonl": [today, yesterday].joined(separator: "\n")
+        ])
+        defer { try? FileManager.default.removeItem(at: home) }
+        let scanner = GrokLogFixture.scanner(home: home)
         let provider = makeProvider(httpClient: RecordingHTTPClient(handler: Self.defaultRoutes), scanner: scanner, now: now)
 
         let snapshot = await provider.refresh()
@@ -292,11 +297,11 @@ final class GrokProviderTests: XCTestCase {
         XCTAssertEqual(points[29].value, 1_000_000, "yesterday's tokens land on the second-to-last bar")
     }
 
-    func testRefreshWithoutLogAppendsNoUsageTrend() async {
+    func testRefreshWithoutSessionsAppendsNoUsageTrend() async {
         let provider = makeProvider(httpClient: RecordingHTTPClient(handler: Self.defaultRoutes))
 
         let snapshot = await provider.refresh()
-        XCTAssertNil(snapshot.lines.first(where: { $0.label == "Usage Trend" }), "no log means no trend chart")
+        XCTAssertNil(snapshot.lines.first(where: { $0.label == "Usage Trend" }), "no sessions means no trend chart")
     }
 
     /// The stock happy-path routes: the captured weekly credits config and the plan name.
@@ -328,7 +333,7 @@ final class GrokProviderTests: XCTestCase {
     }
 
     private func noLogScanner() -> GrokLogUsageScanner {
-        GrokLogUsageScanner(files: FakeFiles(), environment: FakeEnvironment(), homeDirectory: { URL(fileURLWithPath: "/home/none") })
+        GrokLogFixture.scanner(home: nil)
     }
 
     private func values(_ lines: [MetricLine], _ label: String) -> [MetricValue]? {

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -300,6 +300,7 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(standard.cacheReadPerMillion, 0.5)
         XCTAssertEqual(standard.outputPerMillion, 6.0)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5"), standard)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.5-build"), standard)
         XCTAssertEqual(pricing.resolve(model: "grok-4.5-low"), standard)
 
         let fast = try XCTUnwrap(pricing.resolve(model: "grok-4.5-fast"))
@@ -331,6 +332,7 @@ final class PricingBundledResourceTests: XCTestCase {
         XCTAssertEqual(standard.cacheReadPerMillion, 0.5)
         XCTAssertEqual(standard.outputPerMillion, 6.0)
         XCTAssertEqual(pricing.resolve(model: "grok-4.6"), standard)
+        XCTAssertEqual(pricing.resolve(model: "grok-4.6-build"), standard)
         XCTAssertEqual(pricing.resolve(model: "grok-4.6-low"), standard)
 
         let fast = try XCTUnwrap(pricing.resolve(model: "grok-4.6-fast"))

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,6 +1,6 @@
 # Model Pricing
 
-How OpenUsage turns token counts into the estimated dollars on the spend tiles (Claude, Codex, Cursor, Grok). OpenRouter and OpenCode are the exceptions: OpenRouter's API reports billed dollars directly, and OpenCode records its own per-message cost in its local logs, so nothing here applies to them.
+How OpenUsage turns token counts into the estimated dollars on the Claude, Codex, Cursor, and Grok spend tiles. Grok uses the cost recorded in its session logs when available and only estimates older turns without one. OpenRouter and OpenCode do not use these estimates because their sources already report the cost directly.
 
 ## Where prices come from
 
@@ -22,11 +22,11 @@ Log and CSV model names rarely match a catalog key exactly, so resolution tries,
 
 Requests routed by [Cursor Router](https://cursor.com/docs/cursor-router.md) are a special case: instead of a slug, Cursor's export names the model it picked in plain words, like `Opus 5 (Auto Balanced)`. Alias rules map those labels to the same rates as the model itself, so a routed request costs what it would have cost picked by hand. The label stays as written in the model breakdown, so you can still tell which requests the router handled.
 
-A model no source can price is left out of the spend figures entirely — its tokens don't count toward the day's tile, the Usage Trend, or the model breakdown, because a token count next to a dollar figure that ignores part of it would be misleading. Instead, a warning triangle on the affected tiles lists the unpriced models, so you know the figures are incomplete and which model is responsible. A day where *nothing* could be priced reads "No data".
+A model no source can price is left out of the spend figures unless its session already records the actual cost. Otherwise, its tokens don't count toward the day's tile, the Usage Trend, or the model breakdown, because a token count next to a dollar figure that ignores part of it would be misleading. A warning triangle on the affected tiles lists the unpriced models, and a day where nothing could be priced reads "No data".
 
 ## What the estimate includes
 
-Costs are computed per usage event from four token buckets — plain input, cache writes, cache reads, and output — at the model's per-million-token rates, including 1-hour cache-write pricing, long-context tiers, and fast-variant multipliers. Most catalog tiers start above 200k prompt tokens; supported GPT-5.4, GPT-5.5, and GPT-5.6 Codex models switch above 272k input tokens. In either case, the higher rate applies to the whole request. A published cache discount is used when available; Codex cached input falls back to the full input rate when the source publishes no discount. Cursor's export combines many requests into each row, so OpenUsage uses the normal rate there rather than guessing that one request crossed the limit. When a Claude log line carries an explicit `costUSD`, that value is used as-is. Nested Claude advisor usage has no carried cost, so it is priced separately from its tokens using the advisor model. The result is an estimate of API-rate value, not a bill: subscription plans don't charge per token.
+Costs are computed per usage event from four token buckets — plain input, cache writes, cache reads, and output — at the model's per-million-token rates, including 1-hour cache-write pricing, long-context tiers, and fast-variant multipliers. Most catalog tiers start above 200k prompt tokens; supported GPT-5.4, GPT-5.5, and GPT-5.6 Codex models switch above 272k input tokens. In either case, the higher rate applies to the whole request. A published cache discount is used when available; Codex cached input falls back to the full input rate when the source publishes no discount. Cursor's export combines many requests into each row, so OpenUsage uses the normal rate there rather than guessing that one request crossed the limit. When a Claude or Grok session records its own cost, that amount is used as-is. Nested Claude advisor usage has no carried cost, so it is priced separately from its tokens using the advisor model. Estimates represent API-rate value rather than a subscription bill.
 
 ## Privacy
 

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -20,7 +20,7 @@ Sign in once with the Grok CLI (`grok login`); OpenUsage reads the same `~/.grok
 
 ## The spend tiles
 
-Today / Yesterday / Last 30 Days are computed **locally** from completed Grok CLI sessions under `~/.grok/sessions/` (or `$GROK_HOME/sessions/`). OpenUsage uses the cost Grok recorded for each completed turn when available; older turns without a recorded cost are estimated using the shared [model pricing](../pricing.md). Days follow your Mac's local time zone, and each period shows cost and tokens together (`$4.08 · 1.2M tokens`). These amounts are separate from the credits reported by Grok's billing API, and no session data leaves your Mac. A period with no completed usage reads "No data" rather than `$0.00 · 0 tokens`.
+Today / Yesterday / Last 30 Days are computed **locally** from completed Grok CLI sessions under `~/.grok/sessions/` (or `$GROK_HOME/sessions/`). Subagent usage is counted through its parent session, so parallel tasks do not inflate the totals. OpenUsage uses the cost Grok recorded for each completed turn when available; older turns without a recorded cost are estimated using the shared [model pricing](../pricing.md). Days follow your Mac's local time zone, and each period shows cost and tokens together (`$4.08 · 1.2M tokens`). These amounts are separate from the credits reported by Grok's billing API, and no session data leaves your Mac. A period with no completed usage reads "No data" rather than `$0.00 · 0 tokens`.
 
 ## Troubleshooting
 

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -8,7 +8,7 @@ Tracks Grok Build credit usage using the login from the Grok CLI.
 |---|---|
 | Weekly | The shared weekly pool's usage percent (the limit Grok's unified billing enforces), with the weekly reset countdown |
 | Extra Usage | Pay-as-you-go cap as a status (e.g. `2500 cap` or `Disabled`) |
-| Today / Yesterday / Last 30 Days | Local cost and tokens estimated from the Grok CLI log |
+| Today / Yesterday / Last 30 Days | Local cost and tokens from completed Grok CLI sessions |
 
 When Grok reports your subscription tier, OpenUsage shows it beside the provider name.
 
@@ -20,13 +20,13 @@ Sign in once with the Grok CLI (`grok login`); OpenUsage reads the same `~/.grok
 
 ## The spend tiles
 
-Today / Yesterday / Last 30 Days are computed **locally** from the Grok CLI's log (`~/.grok/logs/unified.jsonl`, or `$GROK_HOME/logs/unified.jsonl`) — OpenUsage reads the log directly. Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`), the same as Claude/Codex/Cursor. The dollars are estimated from token counts at public API rates using the shared [model pricing](../pricing.md) (that's the ⓘ); the token counts themselves are measured, and these estimates are separate from the monthly credits the billing API reports. No log data leaves your Mac. A period with no recorded usage reads "No data" rather than a misleading `$0.00 · 0 tokens` — the same as every other spend-tracking provider.
+Today / Yesterday / Last 30 Days are computed **locally** from completed Grok CLI sessions under `~/.grok/sessions/` (or `$GROK_HOME/sessions/`). OpenUsage uses the cost Grok recorded for each completed turn when available; older turns without a recorded cost are estimated using the shared [model pricing](../pricing.md). Days follow your Mac's local time zone, and each period shows cost and tokens together (`$4.08 · 1.2M tokens`). These amounts are separate from the credits reported by Grok's billing API, and no session data leaves your Mac. A period with no completed usage reads "No data" rather than `$0.00 · 0 tokens`.
 
 ## Troubleshooting
 
 - **"Session expired" / auth errors** — run `grok login` again, then refresh.
 - **Weekly shows "No data"** — your account still reports a monthly (non-weekly) period, meaning it hasn't been migrated to Grok's unified weekly billing yet.
-- **Spend tiles show "No data"** — they need the Grok CLI's log at `~/.grok/logs/unified.jsonl`; older CLI versions logged no token counts. Run a Grok CLI session to populate it, then refresh.
+- **Spend tiles show "No data"** — they need completed Grok CLI turns under `~/.grok/sessions/`; a turn that is still running has not been recorded yet. Finish a Grok CLI session, then refresh.
 
 ## Under the hood
 


### PR DESCRIPTION
## TL;DR
Restore complete Grok spend history by scanning durable session ledgers instead of the capped debug log.

## What was happening
- Grok spend tiles and Usage Trend read only `logs/unified.jsonl`, so trimmed debug entries removed historical usage.
- Debug events had no request model, requiring unreliable per-process model attribution.
- Grok CLI session model IDs such as `grok-4.5-build` and `grok-4.6-build` had no pricing aliases.

## What this changes
- Scan `$GROK_HOME/sessions/**/updates.jsonl` and aggregate completed turns using the shared incremental, persistent JSONL cache.
- Prefer recorded per-model `costUsdTicks`, fall back to shared pricing, preserve multi-model attribution, and deduplicate copied event IDs.
- Handle actual `params.update` envelopes, ISO/Unix/millisecond timestamps, cache-read/write buckets, and reasoning tokens without double-counting.
- Add Grok Build pricing aliases, update provider integration and pricing documentation, and replace debug-log fixtures with session-ledger regression coverage.

## Heads-up
- Session records are the only usage source; the capped debug log is intentionally never merged or used as a fallback because doing so would double-count.
- Recorded Grok costs take precedence over public-rate estimates while the existing locally estimated UI labeling remains unchanged.

## Tests
- Full Swift package suite: 1,298 tests passed, three pre-existing skips, zero failures.
- Focused Grok scanner, Grok provider, bundled pricing, and incremental JSONL cache suites: 60 tests passed.
- `git diff --check` passes.

Closes #1126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Grok spend and trend numbers are sourced and priced (new files, cost ticks vs estimates, subagent filtering). Wrong parsing would misreport local usage, but billing API tiles are unchanged.
> 
> **Overview**
> Grok spend tiles and Usage Trend now come from durable CLI session transcripts (`$GROK_HOME/sessions/**/updates.jsonl`) instead of the capped `unified.jsonl` debug log, which dropped history and lacked reliable model IDs.
> 
> `GrokLogUsageScanner` is an incremental JSONL actor like Claude/Codex. It parses completed turns with per-model tokens, prefers Grok’s recorded `costUsdTicks`, falls back to shared pricing, dedupes copied event IDs, and skips subagent ledgers so child work is not double-counted. Missing sessions leave tiles unbacked; the debug log is never a fallback.
> 
> Also aliases `grok-4.5-build` / `grok-4.6-build` to standard Grok 4.5/4.6 rates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4395731c73abcb95a3f854358265f573f96b19e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->