### PR TITLE
Multi-account 2/4: account-safe iCloud history synchronization

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -102,6 +102,11 @@ final class AppContainer {
             orderedDescriptors: { [layout] in layout.visiblePlaced.compactMap { layout.descriptor(for: $0) } },
             notificationSettings: { notificationSettings },
             providerIdentityKeys: accountAssembly.identityKeysByCard,
+            knownAccountIdentitiesByFamily: accounts.records.reduce(into: [:]) { identities, record in
+                identities[record.family, default: []].formUnion(
+                    [record.identityKey] + (record.identityAliases ?? [])
+                )
+            },
             resolveDisplayName: { [accounts] in accounts.resolvedDisplayName(cardID: $0) }
         )
         let iCloudSync = ICloudUsageSyncStore(dataStore: dataStore)

--- a/Sources/OpenUsage/Models/UsageHistoryDocument.swift
+++ b/Sources/OpenUsage/Models/UsageHistoryDocument.swift
@@ -2,13 +2,23 @@ import Foundation
 
 /// One Mac's presentation-free usage history in the private iCloud container.
 struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
-    static let currentSchema = "openusage.history.v1"
+    /// v2 adds account cards (`claude@ab12cd34`) and the `identities` map that lets peers match
+    /// histories by ACCOUNT instead of by card id — the same account can be the default card on one
+    /// Mac and an extra card on another. v1 documents stay readable (no identities → the legacy
+    /// same-card-id merge); v1 readers reject v2 documents with their designed "update OpenUsage"
+    /// message.
+    static let currentSchema = "openusage.history.v2"
+    static let legacySchemaV1 = "openusage.history.v1"
 
     var schema: String = currentSchema
     var deviceID: String
     var deviceName: String
     var updatedAt: Date
     var providers: [String: ProviderUsageHistory]
+    /// Card id → stable account identity key (see `ProviderAccountID`), for every card whose
+    /// identity this Mac knows. Absent on v1 documents. Contains no emails or names — identity keys
+    /// are opaque account/organization identifiers.
+    var identities: [String: String]?
 
     var id: String { deviceID }
 
@@ -24,13 +34,19 @@ struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
     }
 
     func validate() throws {
-        guard schema == Self.currentSchema else { throw UsageHistoryDocumentError.unsupportedSchema }
+        guard schema == Self.currentSchema || schema == Self.legacySchemaV1 else {
+            throw UsageHistoryDocumentError.unsupportedSchema
+        }
+        // v1 card ids are bare provider ids; v2 additionally carries account cards (`claude@ab12cd34`).
+        let idPattern = schema == Self.legacySchemaV1
+            ? #"^[a-z0-9][a-z0-9-]*$"#
+            : #"^[a-z0-9][a-z0-9@-]*$"#
         guard !deviceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !deviceName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { throw UsageHistoryDocumentError.invalidDevice }
 
         for (providerID, history) in providers {
-            guard providerID.range(of: #"^[a-z0-9][a-z0-9-]*$"#, options: .regularExpression) != nil else {
+            guard providerID.range(of: idPattern, options: .regularExpression) != nil else {
                 throw UsageHistoryDocumentError.invalidProvider(providerID)
             }
             var seriesDays: Set<String> = []

--- a/Sources/OpenUsage/Models/UsageHistoryDocument.swift
+++ b/Sources/OpenUsage/Models/UsageHistoryDocument.swift
@@ -4,9 +4,8 @@ import Foundation
 struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
     /// v2 adds account cards (`claude@ab12cd34`) and the `identities` map that lets peers match
     /// histories by ACCOUNT instead of by card id — the same account can be the default card on one
-    /// Mac and an extra card on another. v1 documents stay readable (no identities → the legacy
-    /// same-card-id merge); v1 readers reject v2 documents with their designed "update OpenUsage"
-    /// message.
+    /// Mac and an extra card on another. Legacy account histories without ownership proof stay
+    /// readable but are quarantined; non-account provider histories still merge normally.
     static let currentSchema = "openusage.history.v2"
     static let legacySchemaV1 = "openusage.history.v1"
 
@@ -40,14 +39,37 @@ struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
         // v1 card ids are bare provider ids; v2 additionally carries account cards (`claude@ab12cd34`).
         let idPattern = schema == Self.legacySchemaV1
             ? #"^[a-z0-9][a-z0-9-]*$"#
-            : #"^[a-z0-9][a-z0-9@-]*$"#
+            : #"^[a-z0-9][a-z0-9-]*(?:@[a-f0-9]{8})?$"#
         guard !deviceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !deviceName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { throw UsageHistoryDocumentError.invalidDevice }
 
+        if schema == Self.legacySchemaV1, identities != nil {
+            throw UsageHistoryDocumentError.invalidIdentity("legacy schema")
+        }
+
+        var identitiesByFamily: [String: Set<String>] = [:]
+        for (providerID, identity) in identities ?? [:] {
+            let family = ProviderAccountID.family(of: providerID)
+            guard providers[providerID] != nil,
+                  ProviderAccountID.families.contains(family),
+                  !identity.isEmpty,
+                  identity.rangeOfCharacter(from: .whitespacesAndNewlines.union(.controlCharacters)) == nil,
+                  !identity.contains("/"), !identity.contains("\\")
+            else { throw UsageHistoryDocumentError.invalidIdentity(providerID) }
+            guard identitiesByFamily[family, default: []].insert(identity).inserted else {
+                throw UsageHistoryDocumentError.duplicateIdentity(providerID)
+            }
+        }
+
         for (providerID, history) in providers {
             guard providerID.range(of: idPattern, options: .regularExpression) != nil else {
                 throw UsageHistoryDocumentError.invalidProvider(providerID)
+            }
+            if ProviderAccountID.isAccountCard(providerID) {
+                guard ProviderAccountID.families.contains(ProviderAccountID.family(of: providerID)),
+                      identities?[providerID] != nil
+                else { throw UsageHistoryDocumentError.invalidIdentity(providerID) }
             }
             var seriesDays: Set<String> = []
             for day in history.series.daily {
@@ -116,6 +138,8 @@ enum UsageHistoryDocumentError: Error, LocalizedError, Equatable {
     case unsupportedSchema
     case invalidDevice
     case invalidProvider(String)
+    case invalidIdentity(String)
+    case duplicateIdentity(String)
     case invalidDay(String)
     case duplicateDay(String)
     case duplicateModel(String)
@@ -126,6 +150,8 @@ enum UsageHistoryDocumentError: Error, LocalizedError, Equatable {
         case .unsupportedSchema: "This Mac wrote a newer usage-history format. Update OpenUsage."
         case .invalidDevice: "The synced Mac identity is invalid."
         case .invalidProvider: "The synced provider identifier is invalid."
+        case .invalidIdentity: "The synced account identity is invalid."
+        case .duplicateIdentity: "The synced account identity appears more than once."
         case .invalidDay: "The synced history contains an invalid date."
         case .duplicateDay: "The synced history contains the same date more than once."
         case .duplicateModel: "The synced history contains the same model more than once."

--- a/Sources/OpenUsage/Models/UsageHistoryDocument.swift
+++ b/Sources/OpenUsage/Models/UsageHistoryDocument.swift
@@ -57,7 +57,7 @@ struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
                   identity.rangeOfCharacter(from: .whitespacesAndNewlines.union(.controlCharacters)) == nil,
                   !identity.contains("/"), !identity.contains("\\")
             else { throw UsageHistoryDocumentError.invalidIdentity(providerID) }
-            guard identitiesByFamily[family, default: []].insert(identity).inserted else {
+            guard identitiesByFamily[family, default: []].insert(identity.lowercased()).inserted else {
                 throw UsageHistoryDocumentError.duplicateIdentity(providerID)
             }
         }

--- a/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexAuthStore.swift
@@ -41,6 +41,13 @@ struct CodexAuthState: Hashable, Sendable {
     var hasUsableAccessToken: Bool {
         auth.tokens?.accessToken?.isEmpty == false
     }
+
+    var accountIdentityKey: String? {
+        auth.tokens?.accountID?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+            ?? auth.tokens?.idToken.flatMap {
+                DefaultAccountObserver.chatGPTAccountID(inIDTokenPayload: ProviderParse.jwtPayload($0))
+            }
+    }
 }
 
 enum CodexAuthError: Error, LocalizedError, Equatable {
@@ -217,4 +224,3 @@ private extension CodexAuthState.Source {
         return false
     }
 }
-

--- a/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexLogUsageScanner.swift
@@ -107,7 +107,7 @@ actor CodexLogUsageScanner {
     // MARK: - Discovery
 
     /// `CODEX_HOME` entries (comma-separated) when set, else `~/.codex` — same as ccusage.
-    private func codexHomes() -> [URL] {
+    func codexHomes() -> [URL] {
         if let raw = environment.value(for: "CODEX_HOME")?.trimmingCharacters(in: .whitespacesAndNewlines),
            !raw.isEmpty {
             return raw.split(separator: ",")

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -19,6 +19,7 @@ final class CodexProvider: ProviderRuntime, AccountIdentityReporting {
     let now: @Sendable () -> Date
     let pricing: @Sendable () async -> ModelPricing
     private(set) var verifiedAccountIdentityKey: String?
+    private(set) var isAccountHistorySafeToExport = false
 
     init(
         authStore: CodexAuthStore = CodexAuthStore(),
@@ -147,8 +148,11 @@ final class CodexProvider: ProviderRuntime, AccountIdentityReporting {
         // the shared pricing store, merged with Codex usage that happened inside pi (attributed back
         // here). Both scans run on their scanner actors, off the main actor.
         let pricing = await pricing()
-        let nativeScan = await logUsageScanner.scan(now: now(), pricing: pricing)
-        let piScan = await PiUsageScanner.shared.scan(cardID: provider.id, now: now(), pricing: pricing)
+        isAccountHistorySafeToExport = await logRootsBelong(to: authState)
+        let nativeScan = isAccountHistorySafeToExport
+            ? await logUsageScanner.scan(now: now(), pricing: pricing) : nil
+        let piScan = isAccountHistorySafeToExport
+            ? await PiUsageScanner.shared.scan(cardID: provider.id, now: now(), pricing: pricing) : nil
         var usageHistory: ProviderUsageHistory?
         // Cancellation can land between the native and pi scans. Treat the pair as one unit so a
         // partial result cannot replace the last-good combined history in WidgetDataStore.
@@ -243,6 +247,21 @@ final class CodexProvider: ProviderRuntime, AccountIdentityReporting {
                 .caseInsensitiveCompare(identity) == .orderedSame
             else { throw CodexAuthError.tokenConflict }
         }
+    }
+
+    private func logRootsBelong(to state: CodexAuthState) async -> Bool {
+        guard let identity = state.accountIdentityKey else { return true }
+        for home in await logUsageScanner.codexHomes() {
+            let authPath = home.appendingPathComponent("auth.json").path
+            guard authStore.files.exists(authPath) else { continue }
+            guard authStore.loadAuth(at: authPath)?.accountIdentityKey?
+                .caseInsensitiveCompare(identity) == .orderedSame
+            else {
+                AppLog.warn(.config, "codex logs belong to another or unresolved account; history quarantined")
+                return false
+            }
+        }
+        return true
     }
 
     private func refreshAccessToken(authState: inout CodexAuthState, refreshToken: String) async throws -> String {

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @MainActor
-final class CodexProvider: ProviderRuntime {
+final class CodexProvider: ProviderRuntime, AccountIdentityReporting {
     let provider = Provider(
         id: "codex",
         displayName: "Codex",
@@ -15,19 +15,23 @@ final class CodexProvider: ProviderRuntime {
     let authStore: CodexAuthStore
     let usageClient: CodexUsageClient
     let logUsageScanner: CodexLogUsageScanner
+    let expectedIdentityKey: String?
     let now: @Sendable () -> Date
     let pricing: @Sendable () async -> ModelPricing
+    private(set) var verifiedAccountIdentityKey: String?
 
     init(
         authStore: CodexAuthStore = CodexAuthStore(),
         usageClient: CodexUsageClient = CodexUsageClient(),
         logUsageScanner: CodexLogUsageScanner = CodexLogUsageScanner(),
+        expectedIdentityKey: String? = nil,
         now: @escaping @Sendable () -> Date = Date.init,
         pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
     ) {
         self.authStore = authStore
         self.usageClient = usageClient
         self.logUsageScanner = logUsageScanner
+        self.expectedIdentityKey = expectedIdentityKey
         self.now = now
         self.pricing = pricing
     }
@@ -64,11 +68,11 @@ final class CodexProvider: ProviderRuntime {
         // usable access token counts (see `hasUsableAccessToken`) — an API-key-only auth.json can't
         // serve the usage API, so seeding it on would just show an error row.
         let fileCandidates = authStore.loadAuthCandidates()
-        if fileCandidates.contains(where: \.hasUsableAccessToken) {
+        if fileCandidates.contains(where: { $0.hasUsableAccessToken && belongsToExpectedAccount($0) }) {
             return true
         }
         let keychain = await loadOffMainActor { [authStore] in authStore.loadKeychainAuth() }
-        return keychain?.hasUsableAccessToken == true
+        return keychain.map { $0.hasUsableAccessToken && belongsToExpectedAccount($0) } == true
     }
 
     func refresh() async -> ProviderSnapshot {
@@ -101,6 +105,7 @@ final class CodexProvider: ProviderRuntime {
     }
 
     private func probe(authState initialState: CodexAuthState) async throws -> ProviderSnapshot {
+        try verifyAccountOwnership(initialState)
         var authState = initialState
         guard var accessToken = authState.auth.tokens?.accessToken, !accessToken.isEmpty else {
             if authState.auth.apiKey?.isEmpty == false {
@@ -115,6 +120,7 @@ final class CodexProvider: ProviderRuntime {
             // an already-rotated refresh_token and trip `refresh_token_reused` (issue #516).
             if let live = reloadLiveAuth(source: authState.source),
                let liveToken = live.auth.tokens?.accessToken, !liveToken.isEmpty {
+                try verifyAccountOwnership(live)
                 authState = live
                 accessToken = liveToken
             }
@@ -128,6 +134,7 @@ final class CodexProvider: ProviderRuntime {
         }
 
         let response = try await fetchUsageWithRetry(accessToken: accessToken, authState: &authState)
+        try verifyAccountOwnership(authState, checkingCurrentSource: true)
         // The access token may have rotated during the usage fetch's refresh-and-retry; read the live one.
         let currentToken = authState.auth.tokens?.accessToken ?? accessToken
         let resetCredits = await fetchResetCreditsBestEffort(
@@ -164,6 +171,8 @@ final class CodexProvider: ProviderRuntime {
         }
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)
+        try verifyAccountOwnership(authState, checkingCurrentSource: true)
+        verifiedAccountIdentityKey = authState.accountIdentityKey?.lowercased()
         return ProviderSnapshot.make(
             provider: provider,
             plan: mapped.plan,
@@ -222,6 +231,20 @@ final class CodexProvider: ProviderRuntime {
         }
     }
 
+    private func belongsToExpectedAccount(_ state: CodexAuthState) -> Bool {
+        guard let expectedIdentityKey else { return true }
+        return state.accountIdentityKey?.caseInsensitiveCompare(expectedIdentityKey) == .orderedSame
+    }
+
+    private func verifyAccountOwnership(_ state: CodexAuthState, checkingCurrentSource: Bool = false) throws {
+        guard belongsToExpectedAccount(state) else { throw CodexAuthError.tokenConflict }
+        if checkingCurrentSource, let identity = state.accountIdentityKey {
+            guard reloadLiveAuth(source: state.source)?.accountIdentityKey?
+                .caseInsensitiveCompare(identity) == .orderedSame
+            else { throw CodexAuthError.tokenConflict }
+        }
+    }
+
     private func refreshAccessToken(authState: inout CodexAuthState, refreshToken: String) async throws -> String {
         let response = try await usageClient.refreshToken(refreshToken)
         authState.auth.tokens?.accessToken = response.accessToken
@@ -232,6 +255,7 @@ final class CodexProvider: ProviderRuntime {
             authState.auth.tokens?.idToken = idToken
         }
         authState.auth.lastRefresh = OpenUsageISO8601.string(from: now())
+        try verifyAccountOwnership(authState, checkingCurrentSource: true)
         // Fail loudly: a swallowed save strands the rotated token on disk (next launch re-refreshes /
         // can surface a false "token expired"). The refreshed token works for this session, so log and
         // continue. This is also the only call site of authStore.save, so a genuinely undecodable

--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -253,7 +253,11 @@ final class CodexProvider: ProviderRuntime, AccountIdentityReporting {
         guard let identity = state.accountIdentityKey else { return true }
         for home in await logUsageScanner.codexHomes() {
             let authPath = home.appendingPathComponent("auth.json").path
-            guard authStore.files.exists(authPath) else { continue }
+            guard authStore.files.exists(authPath) else {
+                if case .keychain = state.source { continue }
+                AppLog.warn(.config, "codex logs have no credential proving their account; history quarantined")
+                return false
+            }
             guard authStore.loadAuth(at: authPath)?.accountIdentityKey?
                 .caseInsensitiveCompare(identity) == .orderedSame
             else {

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -52,7 +52,7 @@ enum ProviderCatalog {
         }
         runtimes.sort { $0.provider.id == "claude" && $1.provider.id != "claude" }
         runtimes += [
-            CodexProvider(),
+            CodexProvider(expectedIdentityKey: claudeIdentityKeys["codex"]),
             CursorProvider(),
             AntigravityProvider(),
             CopilotProvider(defaults: defaults),

--- a/Sources/OpenUsage/Providers/ProviderRuntime.swift
+++ b/Sources/OpenUsage/Providers/ProviderRuntime.swift
@@ -38,6 +38,11 @@ protocol ProviderRuntime: AnyObject {
     func hasLocalCredentials() async -> Bool
 }
 
+@MainActor
+protocol AccountIdentityReporting: AnyObject {
+    var verifiedAccountIdentityKey: String? { get }
+}
+
 /// Run a blocking, `Sendable` credential load off the MainActor.
 ///
 /// Auth stores read credentials via the `security` (keychain) and `sqlite3` CLIs, whose `ProcessRunner`

--- a/Sources/OpenUsage/Providers/ProviderRuntime.swift
+++ b/Sources/OpenUsage/Providers/ProviderRuntime.swift
@@ -41,6 +41,11 @@ protocol ProviderRuntime: AnyObject {
 @MainActor
 protocol AccountIdentityReporting: AnyObject {
     var verifiedAccountIdentityKey: String? { get }
+    var isAccountHistorySafeToExport: Bool { get }
+}
+
+extension AccountIdentityReporting {
+    var isAccountHistorySafeToExport: Bool { true }
 }
 
 /// Run a blocking, `Sendable` credential load off the MainActor.

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Matches synced peer histories to this Mac's cards by ACCOUNT identity instead of by card id.
+///
+/// The same account can be the default card on one Mac and an extra account card on another (which
+/// login holds a family's default home differs per machine), so card ids don't travel: a peer's
+/// `claude` entry may belong to the account this Mac shows as `claude@ab12cd34`, and vice versa. v2
+/// documents carry a per-card identity map that makes the match exact; v1 documents (no identities)
+/// keep the legacy same-card-id merge for bare ids. Peer accounts with no card on this Mac at all
+/// become `remoteOnly` entries — surfaced in Total Spend only, never as ghost cards.
+enum PeerHistoryRemapper {
+    struct Remapped {
+        /// Peer histories addressed to a LOCAL card id, ready for the same-id day merge.
+        var histories: [(cardID: String, history: ProviderUsageHistory)] = []
+        /// Peer accounts with no local card, keyed by identity.
+        var remoteOnly: [RemoteOnlyHistory] = []
+    }
+
+    struct RemoteOnlyHistory {
+        var identityKey: String
+        var family: String
+        var deviceNames: [String]
+        var histories: [ProviderUsageHistory]
+    }
+
+    /// `localIdentityByCardID` is this Mac's card → identity map (the launch account pass's
+    /// `identityKeysByCard`).
+    static func remap(
+        documents: [UsageHistoryDocument],
+        localIdentityByCardID: [String: String]
+    ) -> Remapped {
+        // Invert to identity → card, preferring the bare (default) card when an identity appears on
+        // two local cards at once (transiently possible around a swap).
+        var localCardByIdentity: [String: String] = [:]
+        for (cardID, identity) in localIdentityByCardID.sorted(by: { $0.key < $1.key }) {
+            if let existing = localCardByIdentity[identity], !ProviderAccountID.isAccountCard(existing) {
+                continue
+            }
+            if ProviderAccountID.isAccountCard(cardID), localCardByIdentity[identity] != nil {
+                continue
+            }
+            localCardByIdentity[identity] = cardID
+        }
+
+        var result = Remapped()
+        var remoteByIdentity: [String: RemoteOnlyHistory] = [:]
+        func collectRemoteOnly(identity: String, family: String, deviceName: String, history: ProviderUsageHistory) {
+            var entry = remoteByIdentity[identity] ?? RemoteOnlyHistory(
+                identityKey: identity, family: family, deviceNames: [], histories: []
+            )
+            if !entry.deviceNames.contains(deviceName) {
+                entry.deviceNames.append(deviceName)
+            }
+            entry.histories.append(history)
+            remoteByIdentity[identity] = entry
+        }
+
+        for document in UsageHistoryDocument.newestByDevice(documents) {
+            for (peerCardID, history) in document.providers.sorted(by: { $0.key < $1.key }) {
+                let family = ProviderAccountID.family(of: peerCardID)
+                if let identity = document.identities?[peerCardID] {
+                    if let localCard = localCardByIdentity[identity] {
+                        result.histories.append((localCard, history))
+                    } else {
+                        collectRemoteOnly(identity: identity, family: family, deviceName: document.deviceName, history: history)
+                    }
+                    continue
+                }
+                // No identity recorded (v1 document, or a card this peer couldn't identify): bare
+                // ids keep the legacy same-card-id merge; account-card ids still match when this Mac
+                // has the same identity-derived card id, else they're remote-only.
+                if !ProviderAccountID.isAccountCard(peerCardID) || localIdentityByCardID[peerCardID] != nil {
+                    result.histories.append((peerCardID, history))
+                } else {
+                    collectRemoteOnly(identity: peerCardID, family: family, deviceName: document.deviceName, history: history)
+                }
+            }
+        }
+
+        result.remoteOnly = remoteByIdentity.values.sorted { $0.identityKey < $1.identityKey }
+        return result
+    }
+}

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -25,6 +25,7 @@ enum PeerHistoryRemapper {
         var identityKey: String
         var family: String
         var cardID: String
+        var deviceName: String
         var histories: [ProviderUsageHistory]
     }
 
@@ -96,6 +97,7 @@ enum PeerHistoryRemapper {
                     identityKey: identity,
                     family: family,
                     cardID: ProviderAccountID.make(family: family, identityKey: identity),
+                    deviceName: document.deviceName,
                     histories: []
                 )
                 entry.histories.append(history)

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -39,7 +39,8 @@ enum PeerHistoryRemapper {
     static func remap(
         documents: [UsageHistoryDocument],
         localIdentityByCardID: [String: String],
-        localAccountCardIDs: Set<String>
+        localAccountCardIDs: Set<String>,
+        knownAccountIdentitiesByFamily: [String: Set<String>] = [:]
     ) -> Remapped {
         struct AccountKey: Hashable {
             let family: String
@@ -51,19 +52,51 @@ enum PeerHistoryRemapper {
             }
         }
 
+        var knownIdentities = knownAccountIdentitiesByFamily
+        for (cardID, identity) in localIdentityByCardID {
+            knownIdentities[ProviderAccountID.family(of: cardID), default: []].insert(identity)
+        }
+        for document in documents {
+            for (cardID, identity) in document.identities ?? [:] {
+                knownIdentities[ProviderAccountID.family(of: cardID), default: []].insert(identity)
+            }
+        }
+        func parsedClaudeIdentity(_ identity: String) -> (user: String, organization: String?)? {
+            let parts = identity.lowercased().split(separator: "|", omittingEmptySubsequences: false)
+            guard (1...2).contains(parts.count), parts.allSatisfy({ !$0.isEmpty }) else { return nil }
+            return (String(parts[0]), parts.count == 2 ? String(parts[1]) : nil)
+        }
+        func accountKey(family: String, identity: String) -> AccountKey? {
+            guard family == "claude", let parsed = parsedClaudeIdentity(identity) else {
+                return AccountKey(family: family, identity: identity)
+            }
+            let organizations = Set((knownIdentities[family] ?? []).compactMap {
+                parsedClaudeIdentity($0).flatMap { $0.user == parsed.user ? $0.organization : nil }
+            })
+            guard parsed.organization != nil || organizations.count <= 1 else { return nil }
+            let organization = parsed.organization ?? organizations.first
+            return AccountKey(family: family, identity: organization.map { "\(parsed.user)|\($0)" } ?? parsed.user)
+        }
+
         var localCards: [AccountKey: [String]] = [:]
+        var ambiguousLocalUsers = Set<String>()
         for (cardID, identity) in localIdentityByCardID where !identity.isEmpty {
             let family = ProviderAccountID.family(of: cardID)
             guard ProviderAccountID.families.contains(family) else { continue }
-            localCards[AccountKey(family: family, identity: identity), default: []].append(cardID)
+            guard let key = accountKey(family: family, identity: identity) else {
+                if let parsed = parsedClaudeIdentity(identity) { ambiguousLocalUsers.insert(parsed.user) }
+                continue
+            }
+            localCards[key, default: []].append(cardID)
         }
         var result = Remapped()
         var remoteAccounts: [AccountKey: RemoteOnlyHistory] = [:]
 
         for document in UsageHistoryDocument.newestByDevice(documents) {
             let peerIdentityCounts = Dictionary(
-                (document.identities ?? [:]).map { cardID, identity in
-                    (AccountKey(family: ProviderAccountID.family(of: cardID), identity: identity), 1)
+                (document.identities ?? [:]).compactMap { cardID, identity in
+                    accountKey(family: ProviderAccountID.family(of: cardID), identity: identity)
+                        .map { ($0, 1) }
                 },
                 uniquingKeysWith: +
             )
@@ -79,7 +112,10 @@ enum PeerHistoryRemapper {
                     result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .missingPeerIdentity))
                     continue
                 }
-                let key = AccountKey(family: family, identity: identity)
+                guard let key = accountKey(family: family, identity: identity) else {
+                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .ambiguousPeerIdentity))
+                    continue
+                }
                 guard peerIdentityCounts[key] == 1 else {
                     result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .ambiguousPeerIdentity))
                     continue
@@ -91,6 +127,12 @@ enum PeerHistoryRemapper {
                     continue
                 }
                 if matches.count > 1 {
+                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .ambiguousLocalIdentity))
+                    continue
+                }
+                if family == "claude", let parsed = parsedClaudeIdentity(identity),
+                   ambiguousLocalUsers.contains(parsed.user)
+                {
                     result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .ambiguousLocalIdentity))
                     continue
                 }

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -25,8 +25,15 @@ enum PeerHistoryRemapper {
         var identityKey: String
         var family: String
         var cardID: String
-        var deviceName: String
+        var deviceNamesByID: [String: String]
         var histories: [ProviderUsageHistory]
+
+        var displayName: String {
+            let deviceLabel = deviceNamesByID.count == 1
+                ? deviceNamesByID.values.first ?? "Another Mac"
+                : "\(deviceNamesByID.count) Macs"
+            return "\(family.capitalized) · \(deviceLabel)"
+        }
     }
 
     static func remap(
@@ -97,9 +104,10 @@ enum PeerHistoryRemapper {
                     identityKey: identity,
                     family: family,
                     cardID: ProviderAccountID.make(family: family, identityKey: identity),
-                    deviceName: document.deviceName,
+                    deviceNamesByID: [:],
                     histories: []
                 )
+                entry.deviceNamesByID[document.deviceID] = document.deviceName
                 entry.histories.append(history)
                 remoteAccounts[key] = entry
             }

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -1,83 +1,111 @@
 import Foundation
 
-/// Matches synced peer histories to this Mac's cards by ACCOUNT identity instead of by card id.
-///
-/// The same account can be the default card on one Mac and an extra account card on another (which
-/// login holds a family's default home differs per machine), so card ids don't travel: a peer's
-/// `claude` entry may belong to the account this Mac shows as `claude@ab12cd34`, and vice versa. v2
-/// documents carry a per-card identity map that makes the match exact; v1 documents (no identities)
-/// keep the legacy same-card-id merge for bare ids. Peer accounts with no card on this Mac at all
-/// become `remoteOnly` entries — surfaced in Total Spend only, never as ghost cards.
+/// Account histories merge only when both Macs prove the same provider-family/account identity.
 enum PeerHistoryRemapper {
     struct Remapped {
-        /// Peer histories addressed to a LOCAL card id, ready for the same-id day merge.
         var histories: [(cardID: String, history: ProviderUsageHistory)] = []
-        /// Peer accounts with no local card, keyed by identity.
         var remoteOnly: [RemoteOnlyHistory] = []
+        var quarantined: [QuarantinedHistory] = []
+    }
+
+    struct QuarantinedHistory {
+        enum Reason: Equatable {
+            case missingPeerIdentity
+            case ambiguousPeerIdentity
+            case unresolvedLocalIdentity
+            case ambiguousLocalIdentity
+        }
+
+        var cardID: String
+        var family: String
+        var reason: Reason
     }
 
     struct RemoteOnlyHistory {
         var identityKey: String
         var family: String
-        var deviceNames: [String]
+        var cardID: String
         var histories: [ProviderUsageHistory]
     }
 
-    /// `localIdentityByCardID` is this Mac's card → identity map (the launch account pass's
-    /// `identityKeysByCard`).
     static func remap(
         documents: [UsageHistoryDocument],
-        localIdentityByCardID: [String: String]
+        localIdentityByCardID: [String: String],
+        localAccountCardIDs: Set<String>? = nil
     ) -> Remapped {
-        // Invert to identity → card, preferring the bare (default) card when an identity appears on
-        // two local cards at once (transiently possible around a swap).
-        var localCardByIdentity: [String: String] = [:]
-        for (cardID, identity) in localIdentityByCardID.sorted(by: { $0.key < $1.key }) {
-            if let existing = localCardByIdentity[identity], !ProviderAccountID.isAccountCard(existing) {
-                continue
-            }
-            if ProviderAccountID.isAccountCard(cardID), localCardByIdentity[identity] != nil {
-                continue
-            }
-            localCardByIdentity[identity] = cardID
+        struct AccountKey: Hashable {
+            let family: String
+            let identity: String
         }
+
+        var localCards: [AccountKey: [String]] = [:]
+        for (cardID, identity) in localIdentityByCardID where !identity.isEmpty {
+            let family = ProviderAccountID.family(of: cardID)
+            guard ProviderAccountID.families.contains(family) else { continue }
+            localCards[AccountKey(family: family, identity: identity), default: []].append(cardID)
+        }
+        let knownCardIDs = localAccountCardIDs ?? Set(localIdentityByCardID.keys)
 
         var result = Remapped()
-        var remoteByIdentity: [String: RemoteOnlyHistory] = [:]
-        func collectRemoteOnly(identity: String, family: String, deviceName: String, history: ProviderUsageHistory) {
-            var entry = remoteByIdentity[identity] ?? RemoteOnlyHistory(
-                identityKey: identity, family: family, deviceNames: [], histories: []
-            )
-            if !entry.deviceNames.contains(deviceName) {
-                entry.deviceNames.append(deviceName)
-            }
-            entry.histories.append(history)
-            remoteByIdentity[identity] = entry
-        }
+        var remoteAccounts: [AccountKey: RemoteOnlyHistory] = [:]
 
         for document in UsageHistoryDocument.newestByDevice(documents) {
+            let peerIdentityCounts = Dictionary(
+                (document.identities ?? [:]).map { cardID, identity in
+                    (AccountKey(family: ProviderAccountID.family(of: cardID), identity: identity), 1)
+                },
+                uniquingKeysWith: +
+            )
             for (peerCardID, history) in document.providers.sorted(by: { $0.key < $1.key }) {
                 let family = ProviderAccountID.family(of: peerCardID)
-                if let identity = document.identities?[peerCardID] {
-                    if let localCard = localCardByIdentity[identity] {
-                        result.histories.append((localCard, history))
-                    } else {
-                        collectRemoteOnly(identity: identity, family: family, deviceName: document.deviceName, history: history)
-                    }
+
+                guard ProviderAccountID.families.contains(family) else {
+                    result.histories.append((peerCardID, history))
                     continue
                 }
-                // No identity recorded (v1 document, or a card this peer couldn't identify): bare
-                // ids keep the legacy same-card-id merge; account-card ids still match when this Mac
-                // has the same identity-derived card id, else they're remote-only.
-                if !ProviderAccountID.isAccountCard(peerCardID) || localIdentityByCardID[peerCardID] != nil {
-                    result.histories.append((peerCardID, history))
-                } else {
-                    collectRemoteOnly(identity: peerCardID, family: family, deviceName: document.deviceName, history: history)
+
+                guard let identity = document.identities?[peerCardID], !identity.isEmpty else {
+                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .missingPeerIdentity))
+                    continue
                 }
+                let key = AccountKey(family: family, identity: identity)
+                guard peerIdentityCounts[key] == 1 else {
+                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .ambiguousPeerIdentity))
+                    continue
+                }
+
+                let matches = localCards[key] ?? []
+                if matches.count == 1 {
+                    result.histories.append((matches[0], history))
+                    continue
+                }
+                if matches.count > 1 {
+                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .ambiguousLocalIdentity))
+                    continue
+                }
+
+                let familyCards = knownCardIDs.filter { ProviderAccountID.family(of: $0) == family }
+                guard familyCards.contains(where: { localIdentityByCardID[$0] != nil }),
+                      !familyCards.contains(where: { localIdentityByCardID[$0] == nil })
+                else {
+                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .unresolvedLocalIdentity))
+                    continue
+                }
+
+                var entry = remoteAccounts[key] ?? RemoteOnlyHistory(
+                    identityKey: identity,
+                    family: family,
+                    cardID: ProviderAccountID.make(family: family, identityKey: identity),
+                    histories: []
+                )
+                entry.histories.append(history)
+                remoteAccounts[key] = entry
             }
         }
 
-        result.remoteOnly = remoteByIdentity.values.sorted { $0.identityKey < $1.identityKey }
+        result.remoteOnly = remoteAccounts.values.sorted {
+            ($0.family, $0.identityKey) < ($1.family, $1.identityKey)
+        }
         return result
     }
 }

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -39,11 +39,16 @@ enum PeerHistoryRemapper {
     static func remap(
         documents: [UsageHistoryDocument],
         localIdentityByCardID: [String: String],
-        localAccountCardIDs: Set<String>? = nil
+        localAccountCardIDs: Set<String>
     ) -> Remapped {
         struct AccountKey: Hashable {
             let family: String
             let identity: String
+
+            init(family: String, identity: String) {
+                self.family = family
+                self.identity = identity.lowercased()
+            }
         }
 
         var localCards: [AccountKey: [String]] = [:]
@@ -52,8 +57,6 @@ enum PeerHistoryRemapper {
             guard ProviderAccountID.families.contains(family) else { continue }
             localCards[AccountKey(family: family, identity: identity), default: []].append(cardID)
         }
-        let knownCardIDs = localAccountCardIDs ?? Set(localIdentityByCardID.keys)
-
         var result = Remapped()
         var remoteAccounts: [AccountKey: RemoteOnlyHistory] = [:]
 
@@ -92,18 +95,16 @@ enum PeerHistoryRemapper {
                     continue
                 }
 
-                let familyCards = knownCardIDs.filter { ProviderAccountID.family(of: $0) == family }
-                guard familyCards.contains(where: { localIdentityByCardID[$0] != nil }),
-                      !familyCards.contains(where: { localIdentityByCardID[$0] == nil })
-                else {
+                let familyCards = localAccountCardIDs.filter { ProviderAccountID.family(of: $0) == family }
+                if familyCards.contains(where: { localIdentityByCardID[$0] == nil }) {
                     result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .unresolvedLocalIdentity))
                     continue
                 }
 
                 var entry = remoteAccounts[key] ?? RemoteOnlyHistory(
-                    identityKey: identity,
+                    identityKey: key.identity,
                     family: family,
-                    cardID: ProviderAccountID.make(family: family, identityKey: identity),
+                    cardID: ProviderAccountID.make(family: family, identityKey: key.identity),
                     deviceNamesByID: [:],
                     histories: []
                 )

--- a/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
+++ b/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
@@ -9,20 +9,41 @@ enum UsageHistoryAggregator {
         descriptors: [String: UsageHistoryDescriptor],
         now: Date = Date()
     ) -> [String: ProviderUsageHistory] {
+        var pairs: [(String, ProviderUsageHistory)] = []
+        for document in UsageHistoryDocument.newestByDevice(peerDocuments) {
+            for (providerID, history) in document.providers {
+                pairs.append((providerID, history))
+            }
+        }
+        return merged(localSnapshots: localSnapshots, peerHistories: pairs, descriptors: descriptors, now: now)
+    }
+
+    /// The identity-remapped variant: peers arrive as (LOCAL card id, history) pairs — see
+    /// `PeerHistoryRemapper` — so the same account merges into the same card regardless of which Mac
+    /// calls it the default and which shows it as an extra account card.
+    static func merged(
+        localSnapshots: [String: ProviderSnapshot],
+        peerHistories: [(String, ProviderUsageHistory)],
+        descriptors: [String: UsageHistoryDescriptor],
+        now: Date = Date()
+    ) -> [String: ProviderUsageHistory] {
         var inputs: [String: [ProviderUsageHistory]] = [:]
-        let peerDocuments = UsageHistoryDocument.newestByDevice(peerDocuments)
         for (providerID, descriptor) in descriptors where descriptor.scope == .machineLocal {
             if let local = localSnapshots[providerID]?.usageHistory {
                 inputs[providerID, default: []].append(local)
             }
-            for document in peerDocuments {
-                if let peer = document.providers[providerID] {
-                    inputs[providerID, default: []].append(peer)
-                }
+            for (peerID, history) in peerHistories where peerID == providerID {
+                inputs[providerID, default: []].append(history)
             }
         }
         let includedDays = UsageHistoryWindow.dayKeys(through: now)
         return inputs.mapValues { merge($0, includedDays: includedDays) }
+    }
+
+    /// Day-sum several histories into one — the same merge the per-card path uses, exposed for
+    /// remote-only accounts (histories synced from other Macs with no local card).
+    static func mergeHistories(_ histories: [ProviderUsageHistory], now: Date = Date()) -> ProviderUsageHistory {
+        merge(histories, includedDays: UsageHistoryWindow.dayKeys(through: now))
     }
 
     private static func merge(

--- a/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
+++ b/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
@@ -1,26 +1,10 @@
 import Foundation
 
 enum UsageHistoryAggregator {
-    /// Combines only providers explicitly declared machine-local. Account-wide histories such as
-    /// Cursor are left out even if a malformed or future file contains them.
-    static func merged(
-        localSnapshots: [String: ProviderSnapshot],
-        peerDocuments: [UsageHistoryDocument],
-        descriptors: [String: UsageHistoryDescriptor],
-        now: Date = Date()
-    ) -> [String: ProviderUsageHistory] {
-        var pairs: [(String, ProviderUsageHistory)] = []
-        for document in UsageHistoryDocument.newestByDevice(peerDocuments) {
-            for (providerID, history) in document.providers {
-                pairs.append((providerID, history))
-            }
-        }
-        return merged(localSnapshots: localSnapshots, peerHistories: pairs, descriptors: descriptors, now: now)
-    }
-
-    /// The identity-remapped variant: peers arrive as (LOCAL card id, history) pairs — see
+    /// Peers arrive as verified (local card id, history) pairs from
     /// `PeerHistoryRemapper` — so the same account merges into the same card regardless of which Mac
-    /// calls it the default and which shows it as an extra account card.
+    /// calls it the default and which shows it as an extra account card. Account-wide histories are
+    /// never combined, even when an invalid peer document includes one.
     static func merged(
         localSnapshots: [String: ProviderSnapshot],
         peerHistories: [(String, ProviderUsageHistory)],

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -386,9 +386,7 @@ final class WidgetDataStore {
         if let reporter = provider as? any AccountIdentityReporting {
             let previousIdentity = providerIdentityKeys[providerID]?.lowercased()
             let verifiedIdentity = reporter.verifiedAccountIdentityKey?.lowercased()
-            if verifiedIdentity == nil || verifiedIdentity != previousIdentity
-                || !reporter.isAccountHistorySafeToExport
-            {
+            if verifiedIdentity == nil || verifiedIdentity != previousIdentity {
                 if localSnapshots.removeValue(forKey: providerID) != nil {
                     AppLog.warn(.config, "accounts: \(providerID) ownership changed; previous history discarded")
                 }
@@ -430,7 +428,9 @@ final class WidgetDataStore {
         localSnapshots[providerID] = snapshot
         // Stamp the write with the card's launch-resolved account identity; nil (no stamp) for
         // non-account providers and for cards whose identity didn't resolve this launch.
-        cache.store(snapshot, producedByIdentityKey: providerIdentityKeys[providerID])
+        if (provider as? any AccountIdentityReporting)?.isAccountHistorySafeToExport != false {
+            cache.store(snapshot, producedByIdentityKey: providerIdentityKeys[providerID])
+        }
         rebuildRenderedSnapshots()
         if notifyHistoryChange { onLocalHistoryChanged?() }
         AppLog.info(.refresh, "\(providerID) ok (\(durationMs)ms)")

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -530,7 +530,7 @@ final class WidgetDataStore {
 
             let provider = Provider(
                 id: "\(entry.family)@peer-\(ProviderAccountID.hash8(entry.identityKey))",
-                displayName: entry.cardID,
+                displayName: "\(entry.family.capitalized) · \(entry.deviceName)",
                 icon: familyProvider.icon
             )
             let empty = ProviderSnapshot(

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -37,7 +37,8 @@ final class WidgetDataStore {
     /// `ProviderAccountAssembly`. Drives the snapshot cache's account stamp: writes record the
     /// producer, and launch loads only paint an entry whose stamp matches. A card absent here has an
     /// unresolved identity this launch (or isn't account-aware) — its cache behaves as it always did.
-    private let providerIdentityKeys: [String: String]
+    @ObservationIgnored private var providerIdentityKeys: [String: String]
+    @ObservationIgnored private var knownAccountIdentitiesByFamily: [String: Set<String>]
     /// The live card title for a card id, `nil` for non-account providers — the account-registry
     /// name resolver, injected by `AppContainer` so notification titles carry renames. `nil`
     /// (tests, the one-shot CLI) falls back to the baked derived name.
@@ -151,6 +152,7 @@ final class WidgetDataStore {
         notificationSettings: (@MainActor () -> NotificationSettingsStore)? = nil,
         postNotification: (@MainActor (String, String, String, String) async -> Bool)? = nil,
         providerIdentityKeys: [String: String] = [:],
+        knownAccountIdentitiesByFamily: [String: Set<String>] = [:],
         resolveDisplayName: (@MainActor (String) -> String?)? = nil
     ) {
         precondition(slowProviderRefreshThreshold >= 0)
@@ -171,6 +173,11 @@ final class WidgetDataStore {
                 await AppNotifications.shared.post(idPrefix: idPrefix, title: title, subtitle: subtitle, body: body)
             }
         self.providerIdentityKeys = providerIdentityKeys
+        var knownIdentities = knownAccountIdentitiesByFamily.mapValues { Set($0.map { $0.lowercased() }) }
+        for (cardID, identity) in providerIdentityKeys {
+            knownIdentities[ProviderAccountID.family(of: cardID), default: []].insert(identity.lowercased())
+        }
+        self.knownAccountIdentitiesByFamily = knownIdentities
         self.resolveDisplayName = resolveDisplayName
         self.meterStyle = defaults.enumValue(forKey: Self.meterStyleKey, default: .remaining)
         self.resetDisplayMode = defaults.enumValue(forKey: Self.resetDisplayModeKey, default: .relative)
@@ -362,6 +369,20 @@ final class WidgetDataStore {
         }
         // Recovered: drop any backoff so the provider resumes the normal cadence immediately.
         failureRetryAfter[providerID] = nil
+        if let reporter = provider as? any AccountIdentityReporting {
+            let previousIdentity = providerIdentityKeys[providerID]?.lowercased()
+            let verifiedIdentity = reporter.verifiedAccountIdentityKey?.lowercased()
+            if verifiedIdentity == nil || verifiedIdentity != previousIdentity {
+                if localSnapshots.removeValue(forKey: providerID) != nil {
+                    AppLog.warn(.config, "accounts: \(providerID) ownership changed; previous history discarded")
+                }
+            }
+            providerIdentityKeys[providerID] = verifiedIdentity
+            if let verifiedIdentity {
+                knownAccountIdentitiesByFamily[ProviderAccountID.family(of: providerID), default: []]
+                    .insert(verifiedIdentity)
+            }
+        }
         // A provider can refresh its live limits successfully while its optional local log/CSV scan
         // produces no result. Keep only the last-good normalized history in that case; the new plan,
         // limits, warnings, and timestamp still win. A non-nil empty history remains authoritative and
@@ -438,6 +459,12 @@ final class WidgetDataStore {
                         AppLog.warn(.config, "sync: omitting unresolved account history for \(providerID)")
                         continue
                     }
+                    if providerID == "codex",
+                       knownAccountIdentitiesByFamily["codex", default: []].count > 1
+                    {
+                        AppLog.warn(.config, "sync: omitting Codex history shared by multiple accounts")
+                        continue
+                    }
                     identities[providerID] = identity.lowercased()
                 }
                 providers[providerID] = history
@@ -475,7 +502,8 @@ final class WidgetDataStore {
         let remapped = PeerHistoryRemapper.remap(
             documents: peerHistoryDocuments,
             localIdentityByCardID: providerIdentityKeys,
-            localAccountCardIDs: localAccountCardIDs
+            localAccountCardIDs: localAccountCardIDs,
+            knownAccountIdentitiesByFamily: knownAccountIdentitiesByFamily
         )
         if !remapped.quarantined.isEmpty {
             AppLog.warn(.config, "sync: quarantined \(remapped.quarantined.count) unverified peer account histories")

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -438,7 +438,7 @@ final class WidgetDataStore {
                         AppLog.warn(.config, "sync: omitting unresolved account history for \(providerID)")
                         continue
                     }
-                    identities[providerID] = identity
+                    identities[providerID] = identity.lowercased()
                 }
                 providers[providerID] = history
             }
@@ -467,10 +467,15 @@ final class WidgetDataStore {
         // Match peers by account identity, not card id — the same account can be the default card
         // on one Mac and an extra account card on another. Whatever matches no local card at all
         // becomes a Total Spend-only remote entry below.
+        var localAccountCardIDs = Set(providerIdentityKeys.keys)
+        localAccountCardIDs.formUnion(registry.providers.lazy.map(\.id).filter(ProviderAccountID.isAccountCard))
+        localAccountCardIDs.formUnion(localSnapshots.compactMap { cardID, snapshot in
+            snapshot.usageHistory == nil ? nil : cardID
+        })
         let remapped = PeerHistoryRemapper.remap(
             documents: peerHistoryDocuments,
             localIdentityByCardID: providerIdentityKeys,
-            localAccountCardIDs: Set(registry.providers.map(\.id))
+            localAccountCardIDs: localAccountCardIDs
         )
         if !remapped.quarantined.isEmpty {
             AppLog.warn(.config, "sync: quarantined \(remapped.quarantined.count) unverified peer account histories")

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -52,6 +52,7 @@ final class WidgetDataStore {
     private static let meterStyleKey = "meterStyle"
     private static let resetDisplayModeKey = "resetDisplayMode"
     private static let alwaysShowPacingKey = "alwaysShowPacing"
+    private static let verifiedAccountIdentitiesKey = "openusage.verifiedProviderAccountIdentities.v1"
     /// How long a provider that just failed is skipped before the loop will probe it again. A failed
     /// refresh isn't cached, so — unlike a success, which the snapshot cache gates for an interval —
     /// nothing else stops the loop from re-probing a broken provider (logged-out Devin/Grok especially)
@@ -176,6 +177,19 @@ final class WidgetDataStore {
         var knownIdentities = knownAccountIdentitiesByFamily.mapValues { Set($0.map { $0.lowercased() }) }
         for (cardID, identity) in providerIdentityKeys {
             knownIdentities[ProviderAccountID.family(of: cardID), default: []].insert(identity.lowercased())
+        }
+        let verifiedIdentities = defaults.dictionary(forKey: Self.verifiedAccountIdentitiesKey)
+            as? [String: [String]] ?? [:]
+        for (family, identities) in verifiedIdentities {
+            knownIdentities[family, default: []].formUnion(identities.map { $0.lowercased() })
+        }
+        for provider in registry.providers {
+            let family = ProviderAccountID.family(of: provider.id)
+            if ProviderAccountID.families.contains(family),
+               let identity = cache.producedByIdentityKey(providerID: provider.id)
+            {
+                knownIdentities[family, default: []].insert(identity.lowercased())
+            }
         }
         self.knownAccountIdentitiesByFamily = knownIdentities
         self.resolveDisplayName = resolveDisplayName
@@ -381,8 +395,18 @@ final class WidgetDataStore {
             }
             providerIdentityKeys[providerID] = verifiedIdentity
             if let verifiedIdentity {
-                knownAccountIdentitiesByFamily[ProviderAccountID.family(of: providerID), default: []]
-                    .insert(verifiedIdentity)
+                let family = ProviderAccountID.family(of: providerID)
+                knownAccountIdentitiesByFamily[family, default: []].insert(verifiedIdentity)
+                var persisted = defaults.dictionary(forKey: Self.verifiedAccountIdentitiesKey)
+                    as? [String: [String]] ?? [:]
+                var verified = Set(persisted[family, default: []].map { $0.lowercased() })
+                if let cached = cache.producedByIdentityKey(providerID: providerID) {
+                    verified.insert(cached.lowercased())
+                }
+                if verified.insert(verifiedIdentity).inserted || persisted[family] == nil {
+                    persisted[family] = verified.sorted()
+                    defaults.set(persisted, forKey: Self.verifiedAccountIdentitiesKey)
+                }
             }
         }
         // A provider can refresh its live limits successfully while its optional local log/CSV scan

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -372,7 +372,9 @@ final class WidgetDataStore {
         if let reporter = provider as? any AccountIdentityReporting {
             let previousIdentity = providerIdentityKeys[providerID]?.lowercased()
             let verifiedIdentity = reporter.verifiedAccountIdentityKey?.lowercased()
-            if verifiedIdentity == nil || verifiedIdentity != previousIdentity {
+            if verifiedIdentity == nil || verifiedIdentity != previousIdentity
+                || !reporter.isAccountHistorySafeToExport
+            {
                 if localSnapshots.removeValue(forKey: providerID) != nil {
                     AppLog.warn(.config, "accounts: \(providerID) ownership changed; previous history discarded")
                 }
@@ -455,6 +457,12 @@ final class WidgetDataStore {
         where descriptor.scope == .machineLocal && isProviderEnabled(providerID) {
             if let history = localSnapshots[providerID]?.usageHistory {
                 if ProviderAccountID.families.contains(ProviderAccountID.family(of: providerID)) {
+                    if let reporter = providersByID[providerID] as? any AccountIdentityReporting,
+                       !reporter.isAccountHistorySafeToExport
+                    {
+                        AppLog.warn(.config, "sync: omitting account history with unverified log ownership")
+                        continue
+                    }
                     guard let identity = providerIdentityKeys[providerID] else {
                         AppLog.warn(.config, "sync: omitting unresolved account history for \(providerID)")
                         continue

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -484,8 +484,15 @@ final class WidgetDataStore {
                     if let reporter = providersByID[providerID] as? any AccountIdentityReporting,
                        !reporter.isAccountHistorySafeToExport
                     {
-                        AppLog.warn(.config, "sync: omitting account history with unverified log ownership")
-                        continue
+                        let cachedIdentity = cache.producedByIdentityKey(providerID: providerID)
+                        let retainsVerifiedCache = reporter.verifiedAccountIdentityKey == nil
+                            && providerIdentityKeys[providerID].map {
+                                cachedIdentity?.caseInsensitiveCompare($0) == .orderedSame
+                            } == true
+                        if !retainsVerifiedCache {
+                            AppLog.warn(.config, "sync: omitting account history with unverified log ownership")
+                            continue
+                        }
                     }
                     guard let identity = providerIdentityKeys[providerID] else {
                         AppLog.warn(.config, "sync: omitting unresolved account history for \(providerID)")

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -517,7 +517,8 @@ final class WidgetDataStore {
         isProviderEnabled: @MainActor (String) -> Bool,
         now: Date
     ) -> [(provider: Provider, snapshot: ProviderSnapshot)] {
-        remoteOnly.compactMap { entry in
+        let nameCounts = Dictionary(remoteOnly.map { ($0.displayName, 1) }, uniquingKeysWith: +)
+        return remoteOnly.compactMap { entry in
             guard let familyProvider = registry.providers.first(where: {
                       ProviderAccountID.family(of: $0.id) == entry.family
                           && isProviderEnabled($0.id)
@@ -528,9 +529,12 @@ final class WidgetDataStore {
             let history = UsageHistoryAggregator.mergeHistories(entry.histories, now: now)
             guard !history.series.daily.isEmpty else { return nil }
 
+            let displayName = nameCounts[entry.displayName] == 1
+                ? entry.displayName
+                : "\(entry.displayName) · \(ProviderAccountID.hash8(entry.identityKey).prefix(4))"
             let provider = Provider(
                 id: "\(entry.family)@peer-\(ProviderAccountID.hash8(entry.identityKey))",
-                displayName: "\(entry.family.capitalized) · \(entry.deviceName)",
+                displayName: displayName,
                 icon: familyProvider.icon
             )
             let empty = ProviderSnapshot(

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -433,10 +433,14 @@ final class WidgetDataStore {
         for (providerID, descriptor) in registry.historyDescriptorsByProvider
         where descriptor.scope == .machineLocal && isProviderEnabled(providerID) {
             if let history = localSnapshots[providerID]?.usageHistory {
-                providers[providerID] = history
-                if let identity = providerIdentityKeys[providerID] {
+                if ProviderAccountID.families.contains(ProviderAccountID.family(of: providerID)) {
+                    guard let identity = providerIdentityKeys[providerID] else {
+                        AppLog.warn(.config, "sync: omitting unresolved account history for \(providerID)")
+                        continue
+                    }
                     identities[providerID] = identity
                 }
+                providers[providerID] = history
             }
         }
         return UsageHistoryDocument(
@@ -465,8 +469,12 @@ final class WidgetDataStore {
         // becomes a Total Spend-only remote entry below.
         let remapped = PeerHistoryRemapper.remap(
             documents: peerHistoryDocuments,
-            localIdentityByCardID: providerIdentityKeys
+            localIdentityByCardID: providerIdentityKeys,
+            localAccountCardIDs: Set(registry.providers.map(\.id))
         )
+        if !remapped.quarantined.isEmpty {
+            AppLog.warn(.config, "sync: quarantined \(remapped.quarantined.count) unverified peer account histories")
+        }
         let merged = UsageHistoryAggregator.merged(
             localSnapshots: localSnapshots,
             peerHistories: remapped.histories,
@@ -476,6 +484,7 @@ final class WidgetDataStore {
         remoteOnlySpend = Self.renderRemoteOnlySpend(
             remapped.remoteOnly,
             registry: registry,
+            isProviderEnabled: isProviderEnabled,
             now: renderDate
         )
         var rendered = localSnapshots
@@ -505,23 +514,23 @@ final class WidgetDataStore {
     private static func renderRemoteOnlySpend(
         _ remoteOnly: [PeerHistoryRemapper.RemoteOnlyHistory],
         registry: WidgetRegistry,
+        isProviderEnabled: @MainActor (String) -> Bool,
         now: Date
     ) -> [(provider: Provider, snapshot: ProviderSnapshot)] {
         remoteOnly.compactMap { entry in
-            guard let familyProvider = registry.provider(id: entry.family),
-                  let descriptor = registry.historyDescriptorsByProvider[entry.family]
+            guard let familyProvider = registry.providers.first(where: {
+                      ProviderAccountID.family(of: $0.id) == entry.family
+                          && isProviderEnabled($0.id)
+                          && registry.historyDescriptorsByProvider[$0.id]?.scope == .machineLocal
+                  }),
+                  let descriptor = registry.historyDescriptorsByProvider[familyProvider.id]
             else { return nil }
             let history = UsageHistoryAggregator.mergeHistories(entry.histories, now: now)
             guard !history.series.daily.isEmpty else { return nil }
 
-            let device = entry.deviceNames.count == 1
-                ? entry.deviceNames[0]
-                : "\(entry.deviceNames.count) other Macs"
-            // The stock family name, not the local family card's display name — that card is a
-            // DIFFERENT account (possibly renamed), and this slice shouldn't inherit its rename.
             let provider = Provider(
                 id: "\(entry.family)@peer-\(ProviderAccountID.hash8(entry.identityKey))",
-                displayName: "\(entry.family.capitalized) · \(device)",
+                displayName: entry.cardID,
                 icon: familyProvider.icon
             )
             let empty = ProviderSnapshot(

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -105,6 +105,9 @@ final class WidgetDataStore {
     /// Wired by `ICloudUsageSyncStore`; debounced there so a concurrent provider batch produces one file.
     @ObservationIgnored var onLocalHistoryChanged: (@MainActor () -> Void)?
     @ObservationIgnored private var peerHistoryDocuments: [UsageHistoryDocument] = []
+    /// Accounts synced from other Macs that have NO card here: surfaced in Total Spend only (their
+    /// synthesized snapshots carry the usual Today/Yesterday/Last 30 Days lines), never as cards.
+    private(set) var remoteOnlySpend: [(provider: Provider, snapshot: ProviderSnapshot)] = []
 
     /// Global meter style: whether every bounded tile (and the menu-bar value) renders as "used" or
     /// "left/remaining". Persisted so the choice survives relaunch; defaults to `.remaining`.
@@ -422,23 +425,33 @@ final class WidgetDataStore {
 
     func localHistoryDocument(deviceID: String, deviceName: String, updatedAt: Date = Date()) -> UsageHistoryDocument {
         var providers: [String: ProviderUsageHistory] = [:]
+        var identities: [String: String] = [:]
+        // Every machine-local card syncs — account cards included. Their ids are identity-derived,
+        // so they mean the same account on every Mac; the identities map additionally lets peers
+        // match a default card's history to whatever card that account is over there (see
+        // `PeerHistoryRemapper`).
         for (providerID, descriptor) in registry.historyDescriptorsByProvider
         where descriptor.scope == .machineLocal && isProviderEnabled(providerID) {
             if let history = localSnapshots[providerID]?.usageHistory {
                 providers[providerID] = history
+                if let identity = providerIdentityKeys[providerID] {
+                    identities[providerID] = identity
+                }
             }
         }
         return UsageHistoryDocument(
             deviceID: deviceID,
             deviceName: deviceName,
             updatedAt: updatedAt,
-            providers: providers
+            providers: providers,
+            identities: identities.isEmpty ? nil : identities
         )
     }
 
     private func rebuildRenderedSnapshots() {
         guard !peerHistoryDocuments.isEmpty else {
             snapshots = localSnapshots
+            remoteOnlySpend = []
             return
         }
         let renderDate = now()
@@ -447,10 +460,22 @@ final class WidgetDataStore {
         ) { result, entry in
             if isProviderEnabled(entry.key) { result[entry.key] = entry.value }
         }
+        // Match peers by account identity, not card id — the same account can be the default card
+        // on one Mac and an extra account card on another. Whatever matches no local card at all
+        // becomes a Total Spend-only remote entry below.
+        let remapped = PeerHistoryRemapper.remap(
+            documents: peerHistoryDocuments,
+            localIdentityByCardID: providerIdentityKeys
+        )
         let merged = UsageHistoryAggregator.merged(
             localSnapshots: localSnapshots,
-            peerDocuments: peerHistoryDocuments,
+            peerHistories: remapped.histories,
             descriptors: enabledDescriptors,
+            now: renderDate
+        )
+        remoteOnlySpend = Self.renderRemoteOnlySpend(
+            remapped.remoteOnly,
+            registry: registry,
             now: renderDate
         )
         var rendered = localSnapshots
@@ -472,6 +497,47 @@ final class WidgetDataStore {
             )
         }
         snapshots = rendered
+    }
+
+    /// Synthesize Total Spend entries for accounts that exist only on other Macs: a pseudo provider
+    /// (family icon, "Claude · Mac mini" name) plus a snapshot carrying the standard spend-tile
+    /// lines, rendered from the merged remote history by the same renderer real cards use.
+    private static func renderRemoteOnlySpend(
+        _ remoteOnly: [PeerHistoryRemapper.RemoteOnlyHistory],
+        registry: WidgetRegistry,
+        now: Date
+    ) -> [(provider: Provider, snapshot: ProviderSnapshot)] {
+        remoteOnly.compactMap { entry in
+            guard let familyProvider = registry.provider(id: entry.family),
+                  let descriptor = registry.historyDescriptorsByProvider[entry.family]
+            else { return nil }
+            let history = UsageHistoryAggregator.mergeHistories(entry.histories, now: now)
+            guard !history.series.daily.isEmpty else { return nil }
+
+            let device = entry.deviceNames.count == 1
+                ? entry.deviceNames[0]
+                : "\(entry.deviceNames.count) other Macs"
+            // The stock family name, not the local family card's display name — that card is a
+            // DIFFERENT account (possibly renamed), and this slice shouldn't inherit its rename.
+            let provider = Provider(
+                id: "\(entry.family)@peer-\(ProviderAccountID.hash8(entry.identityKey))",
+                displayName: "\(entry.family.capitalized) · \(device)",
+                icon: familyProvider.icon
+            )
+            let empty = ProviderSnapshot(
+                providerID: provider.id,
+                displayName: provider.displayName,
+                lines: [],
+                refreshedAt: now
+            )
+            let snapshot = UsageHistorySnapshotRenderer.render(
+                local: empty,
+                history: history,
+                descriptor: descriptor,
+                now: now
+            )
+            return (provider, snapshot)
+        }
     }
 
     /// The provider's latest refresh error, or `nil` when its last refresh succeeded.

--- a/Sources/OpenUsage/Support/TotalSpendAggregator.swift
+++ b/Sources/OpenUsage/Support/TotalSpendAggregator.swift
@@ -102,6 +102,11 @@ struct TotalSpendProjection: Equatable {
     let isEstimated: Bool
 
     var isEmpty: Bool { slices.isEmpty }
+
+    var infoTooltip: String {
+        guard !slices.isEmpty else { return metric.emptyMessage }
+        return "Only includes \(slices.map(\.title).formatted(.list(type: .and)))."
+    }
 }
 
 /// A period's cross-provider raw totals: every spend-capable provider that contributed dollars and/or

--- a/Sources/OpenUsage/Support/TotalSpendPalette.swift
+++ b/Sources/OpenUsage/Support/TotalSpendPalette.swift
@@ -46,7 +46,8 @@ enum TotalSpendPalette {
               let brandHex = accountBrandHex[String(providerID[..<separator])]
         else { return nil }
 
-        let accountKey = String(providerID[providerID.index(after: separator)...]).lowercased()
+        var accountKey = String(providerID[providerID.index(after: separator)...]).lowercased()
+        if accountKey.hasPrefix("peer-") { accountKey.removeFirst("peer-".count) }
         guard !accountKey.isEmpty else { return nil }
 
         var hash: UInt64 = 0xcbf29ce484222325

--- a/Sources/OpenUsage/Views/TotalSpendCard.swift
+++ b/Sources/OpenUsage/Views/TotalSpendCard.swift
@@ -37,10 +37,18 @@ struct TotalSpendCard: View {
     }
 
     private var total: TotalSpend {
-        TotalSpendAggregator.total(
+        // Accounts that live only on other Macs (synced, no card here) count toward the total and
+        // get their own legend slice even when their login isn't set up on this machine.
+        var aggregatedProviders = providers
+        var aggregatedSnapshots = dataStore.snapshots
+        for entry in dataStore.remoteOnlySpend {
+            aggregatedProviders.append(entry.provider)
+            aggregatedSnapshots[entry.provider.id] = entry.snapshot
+        }
+        return TotalSpendAggregator.total(
             for: period,
-            providers: providers,
-            snapshots: dataStore.snapshots,
+            providers: aggregatedProviders,
+            snapshots: aggregatedSnapshots,
             title: { container.displayName(for: $0) }
         )
     }

--- a/Sources/OpenUsage/Views/TotalSpendCard.swift
+++ b/Sources/OpenUsage/Views/TotalSpendCard.swift
@@ -114,11 +114,8 @@ struct TotalSpendCard: View {
         .accessibilityValue(metric.title)
     }
 
-    /// Names the providers actually feeding the ring — the enabled spend-capable set — instead of a
-    /// hardcoded list, so disabling a provider (or a new spend provider shipping) can't make the
-    /// tooltip lie about what the total reflects.
     private var infoTooltip: String {
-        let names = providers.map { container.displayName(for: $0) }
+        let names = projection.slices.map(\.title)
         return "Only includes \(names.formatted(.list(type: .and)))."
     }
 

--- a/Sources/OpenUsage/Views/TotalSpendCard.swift
+++ b/Sources/OpenUsage/Views/TotalSpendCard.swift
@@ -74,7 +74,7 @@ struct TotalSpendCard: View {
             Image(systemName: "info.circle")
                 .imageScale(.small)
                 .foregroundStyle(.secondary)
-                .hoverTooltip(infoTooltip)
+                .hoverTooltip(projection.infoTooltip)
             Spacer(minLength: 8)
             shareButton
         }
@@ -112,11 +112,6 @@ struct TotalSpendCard: View {
         .buttonStyle(.plain)
         .accessibilityLabel("Total Spend Metric")
         .accessibilityValue(metric.title)
-    }
-
-    private var infoTooltip: String {
-        let names = projection.slices.map(\.title)
-        return "Only includes \(names.formatted(.list(type: .and)))."
     }
 
     private var shareButton: some View {

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -519,6 +519,31 @@ final class CodexProviderTests: XCTestCase {
         XCTAssertNil(provider.verifiedAccountIdentityKey)
     }
 
+    func testForeignCodexLogHomeCannotBePublishedUnderAuthenticatedAccount() async throws {
+        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let logHome = try CodexLogFixture.makeHome(files: ["sessions/foreign.jsonl": [
+            CodexLogFixture.turnContext(timestamp: "2026-02-20T14:00:00.000Z", model: "gpt-5.2"),
+            CodexLogFixture.tokenCount(timestamp: "2026-02-20T14:01:00.000Z",
+                                      last: CodexLogFixture.usage(input: 10, output: 5)),
+        ].joined(separator: "\n")])
+        let files = FakeFiles([
+            "~/.config/codex/auth.json": #"{"tokens":{"access_token":"a","account_id":"account-a"}}"#,
+            logHome.appendingPathComponent("auth.json").path:
+                #"{"tokens":{"access_token":"b","account_id":"account-b"}}"#,
+        ])
+        let http = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+        let provider = CodexProvider(
+            authStore: CodexAuthStore(files: files, keychain: FakeKeychain()),
+            usageClient: CodexUsageClient(http: http), logUsageScanner: CodexLogFixture.scanner(home: logHome),
+            now: { now }, pricing: { TestPricing.bundled }
+        )
+
+        let snapshot = await provider.refresh()
+        XCTAssertEqual(provider.verifiedAccountIdentityKey, "account-a")
+        XCTAssertFalse(provider.isAccountHistorySafeToExport)
+        XCTAssertNil(snapshot.usageHistory)
+    }
+
     func testNoUsageDataBadgeIsDroppedWhenLocalLogsHaveSpend() async throws {
         let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
         // The live usage API returns nothing mappable (empty body -> no metric lines)...

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -472,6 +472,53 @@ final class CodexUsageMapperTests: XCTestCase {
 
 @MainActor
 final class CodexProviderTests: XCTestCase {
+    func testKeychainAccountIdentityIsProvenOnlyByASuccessfulRefresh() async {
+        let credential = #"{"tokens":{"access_token":"keychain-token","account_id":"ACCOUNT-A"}}"#
+        let http = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+        let provider = CodexProvider(
+            authStore: CodexAuthStore(files: FakeFiles(), keychain: FakeKeychain(credential)),
+            usageClient: CodexUsageClient(http: http), logUsageScanner: CodexLogFixture.scanner(home: nil),
+            pricing: { TestPricing.bundled }
+        )
+
+        XCTAssertNil(provider.verifiedAccountIdentityKey)
+        _ = await provider.refresh()
+        XCTAssertEqual(provider.verifiedAccountIdentityKey, "account-a")
+    }
+
+    func testAccountBoundProviderRejectsForeignCredentialBeforeAnyAPIRequest() async {
+        let credential = #"{"tokens":{"access_token":"foreign-token","account_id":"account-b"}}"#
+        let http = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+        let provider = CodexProvider(
+            authStore: CodexAuthStore(files: FakeFiles(), keychain: FakeKeychain(credential)),
+            usageClient: CodexUsageClient(http: http), logUsageScanner: CodexLogFixture.scanner(home: nil),
+            expectedIdentityKey: "account-a", pricing: { TestPricing.bundled }
+        )
+
+        _ = await provider.refresh()
+        XCTAssertNil(provider.verifiedAccountIdentityKey)
+        XCTAssertTrue(http.requests.isEmpty)
+    }
+
+    func testAccountBoundProviderRejectsLoginChangesDuringUsageRequest() async {
+        let path = "/tmp/codex/auth.json"
+        let files = FakeFiles([path: #"{"tokens":{"access_token":"a","account_id":"account-a"}}"#])
+        let http = RoutingHTTPClient { _ in
+            files.files[path] = #"{"tokens":{"access_token":"b","account_id":"account-b"}}"#
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8))
+        }
+        let provider = CodexProvider(
+            authStore: CodexAuthStore(environment: FakeEnvironment(["CODEX_HOME": "/tmp/codex"]),
+                                      files: files, keychain: FakeKeychain()),
+            usageClient: CodexUsageClient(http: http), logUsageScanner: CodexLogFixture.scanner(home: nil),
+            expectedIdentityKey: "account-a", pricing: { TestPricing.bundled }
+        )
+
+        let snapshot = await provider.refresh()
+        XCTAssertNotNil(snapshot.errorCategory)
+        XCTAssertNil(provider.verifiedAccountIdentityKey)
+    }
+
     func testNoUsageDataBadgeIsDroppedWhenLocalLogsHaveSpend() async throws {
         let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
         // The live usage API returns nothing mappable (empty body -> no metric lines)...

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -526,22 +526,26 @@ final class CodexProviderTests: XCTestCase {
             CodexLogFixture.tokenCount(timestamp: "2026-02-20T14:01:00.000Z",
                                       last: CodexLogFixture.usage(input: 10, output: 5)),
         ].joined(separator: "\n")])
-        let files = FakeFiles([
-            "~/.config/codex/auth.json": #"{"tokens":{"access_token":"a","account_id":"account-a"}}"#,
-            logHome.appendingPathComponent("auth.json").path:
-                #"{"tokens":{"access_token":"b","account_id":"account-b"}}"#,
-        ])
-        let http = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
-        let provider = CodexProvider(
-            authStore: CodexAuthStore(files: files, keychain: FakeKeychain()),
-            usageClient: CodexUsageClient(http: http), logUsageScanner: CodexLogFixture.scanner(home: logHome),
-            now: { now }, pricing: { TestPricing.bundled }
-        )
+        for hasForeignCredential in [true, false] {
+            let files = FakeFiles([
+                "~/.config/codex/auth.json": #"{"tokens":{"access_token":"a","account_id":"account-a"}}"#,
+            ])
+            if hasForeignCredential {
+                files.files[logHome.appendingPathComponent("auth.json").path] =
+                    #"{"tokens":{"access_token":"b","account_id":"account-b"}}"#
+            }
+            let http = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+            let provider = CodexProvider(
+                authStore: CodexAuthStore(files: files, keychain: FakeKeychain()),
+                usageClient: CodexUsageClient(http: http), logUsageScanner: CodexLogFixture.scanner(home: logHome),
+                now: { now }, pricing: { TestPricing.bundled }
+            )
 
-        let snapshot = await provider.refresh()
-        XCTAssertEqual(provider.verifiedAccountIdentityKey, "account-a")
-        XCTAssertFalse(provider.isAccountHistorySafeToExport)
-        XCTAssertNil(snapshot.usageHistory)
+            let snapshot = await provider.refresh()
+            XCTAssertEqual(provider.verifiedAccountIdentityKey, "account-a")
+            XCTAssertFalse(provider.isAccountHistorySafeToExport)
+            XCTAssertNil(snapshot.usageHistory)
+        }
     }
 
     func testNoUsageDataBadgeIsDroppedWhenLocalLogsHaveSpend() async throws {

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+@testable import OpenUsage
+
+/// Identity-keyed iCloud matching: the same account merges into the same card across Macs regardless
+/// of which machine calls it the default and which shows it as an extra account card, and accounts
+/// with no local card surface as remote-only Total Spend entries.
+@MainActor
+final class PeerHistoryIdentityTests: XCTestCase {
+    private let teamKey = "uuid-me|org-team"
+    private let maxKey = "uuid-me|org-max"
+
+    func testDocumentV2AllowsAccountCardsAndV1StaysStrict() throws {
+        var v2 = makeDocument(providers: [
+            "claude": history(day: "2026-07-16", tokens: 10, cost: 1),
+            "claude@ab12cd34": history(day: "2026-07-16", tokens: 20, cost: 2),
+        ], identities: ["claude": maxKey, "claude@ab12cd34": teamKey])
+        XCTAssertNoThrow(try v2.validate())
+
+        v2.schema = UsageHistoryDocument.legacySchemaV1
+        XCTAssertThrowsError(try v2.validate()) // account-card ids are a v2 concept
+
+        let v1 = UsageHistoryDocument(
+            schema: UsageHistoryDocument.legacySchemaV1,
+            deviceID: "d", deviceName: "n", updatedAt: Date(),
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: nil
+        )
+        XCTAssertNoThrow(try v1.validate())
+    }
+
+    func testRemapMatchesAccountsAcrossDefaultAndExtraCardRoles() {
+        // The mini↔MacBook case: mini's DEFAULT card is the Team account (claude), its extra card is
+        // Max. This Mac is the mirror image (default = Max, extra = Team). Every peer history must
+        // land on the LOCAL card with the same account.
+        let miniDoc = makeDocument(
+            deviceName: "Mac mini",
+            providers: [
+                "claude": history(day: "2026-07-16", tokens: 100, cost: 502.34),
+                "claude@b2d3867d": history(day: "2026-07-16", tokens: 90, cost: 494.27),
+            ],
+            identities: ["claude": teamKey, "claude@b2d3867d": maxKey]
+        )
+        let localMap = ["claude": maxKey, "claude@f15456b0": teamKey]
+
+        let remapped = PeerHistoryRemapper.remap(documents: [miniDoc], localIdentityByCardID: localMap)
+
+        XCTAssertTrue(remapped.remoteOnly.isEmpty)
+        let byCard = Dictionary(grouping: remapped.histories, by: { $0.cardID })
+        XCTAssertEqual(byCard["claude"]?.first?.history.series.daily.first?.costUSD, 494.27, "mini's Max spend belongs to this Mac's default (Max) card")
+        XCTAssertEqual(byCard["claude@f15456b0"]?.first?.history.series.daily.first?.costUSD, 502.34, "mini's Team spend belongs to this Mac's Team card")
+    }
+
+    func testRemapCollectsRemoteOnlyAccounts() {
+        let doc = makeDocument(
+            deviceName: "Mac mini",
+            providers: ["claude@ab12cd34": history(day: "2026-07-16", tokens: 50, cost: 42)],
+            identities: ["claude@ab12cd34": "uuid-other|org-x"]
+        )
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [doc],
+            localIdentityByCardID: ["claude": maxKey]
+        )
+        XCTAssertTrue(remapped.histories.isEmpty)
+        XCTAssertEqual(remapped.remoteOnly.count, 1)
+        XCTAssertEqual(remapped.remoteOnly.first?.family, "claude")
+        XCTAssertEqual(remapped.remoteOnly.first?.deviceNames, ["Mac mini"])
+    }
+
+    func testRemapLegacyV1DocumentKeepsSameCardMerge() {
+        let v1 = UsageHistoryDocument(
+            schema: UsageHistoryDocument.legacySchemaV1,
+            deviceID: "d", deviceName: "old Mac", updatedAt: Date(),
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: nil
+        )
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [v1],
+            localIdentityByCardID: ["claude": maxKey]
+        )
+        XCTAssertEqual(remapped.histories.first?.cardID, "claude")
+        XCTAssertTrue(remapped.remoteOnly.isEmpty)
+    }
+
+    func testLocalDocumentPublishesAccountCardsWithIdentities() {
+        let registry = makeRegistry()
+        // Preload the cache; the store's init adopts cached snapshots as its local set. The entries
+        // carry the same account stamp the store is launched with, or the swap guard discards them.
+        let cache = scratchCache()
+        cache.store(
+            snapshot(providerID: "claude", history: history(day: "2026-07-16", tokens: 10, cost: 1)),
+            producedByIdentityKey: maxKey
+        )
+        cache.store(
+            snapshot(providerID: "claude@f15456b0", history: history(day: "2026-07-16", tokens: 20, cost: 2)),
+            producedByIdentityKey: teamKey
+        )
+        let dataStore = WidgetDataStore(
+            registry: registry,
+            providers: [],
+            cache: cache,
+            defaults: makeScratchDefaults("PublishDoc"),
+            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
+        )
+
+        let document = dataStore.localHistoryDocument(deviceID: "dev", deviceName: "This Mac")
+        XCTAssertEqual(document.schema, UsageHistoryDocument.currentSchema)
+        XCTAssertNotNil(document.providers["claude@f15456b0"], "account cards sync now")
+        XCTAssertEqual(document.identities?["claude"], maxKey)
+        XCTAssertEqual(document.identities?["claude@f15456b0"], teamKey)
+        XCTAssertNoThrow(try document.validate())
+    }
+
+    func testRemoteOnlyAccountFeedsTotalSpend() {
+        let registry = makeRegistry()
+        let dataStore = WidgetDataStore(
+            registry: registry,
+            providers: [],
+            cache: scratchCache(),
+            defaults: makeScratchDefaults("RemoteTotal"),
+            providerIdentityKeys: ["claude": maxKey]
+        )
+        let today = dayKey(Date())
+        let doc = makeDocument(
+            deviceName: "Mac mini",
+            providers: ["claude@ab12cd34": history(day: today, tokens: 1_000_000, cost: 42)],
+            identities: ["claude@ab12cd34": "uuid-other|org-x"]
+        )
+        dataStore.setPeerHistoryDocuments([doc], ownDeviceID: "this-mac")
+
+        XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
+        let entry = dataStore.remoteOnlySpend[0]
+        XCTAssertEqual(entry.provider.displayName, "Claude · Mac mini")
+
+        let total = TotalSpendAggregator.total(
+            for: .today,
+            providers: [entry.provider],
+            snapshots: [entry.provider.id: entry.snapshot]
+        )
+        XCTAssertEqual(total.slices.count, 1)
+        XCTAssertEqual(total.slices[0].amountUSD, 42, accuracy: 0.001)
+    }
+
+    func testClearingPeersDropsRemoteOnlyEntries() {
+        let dataStore = WidgetDataStore(
+            registry: makeRegistry(),
+            providers: [],
+            cache: scratchCache(),
+            defaults: makeScratchDefaults("ClearPeers"),
+            providerIdentityKeys: ["claude": maxKey]
+        )
+        let doc = makeDocument(
+            deviceName: "Mac mini",
+            providers: ["claude@ab12cd34": history(day: dayKey(Date()), tokens: 10, cost: 1)],
+            identities: ["claude@ab12cd34": "uuid-other|org-x"]
+        )
+        dataStore.setPeerHistoryDocuments([doc], ownDeviceID: "this-mac")
+        XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
+
+        dataStore.clearPeerHistoryDocuments()
+        XCTAssertTrue(dataStore.remoteOnlySpend.isEmpty, "sync off returns Total Spend to local-only")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeRegistry() -> WidgetRegistry {
+        let claude = ClaudeProvider.makeProvider()
+        let extraCard = ClaudeProvider.makeProvider(id: "claude@f15456b0", displayName: "Claude — Team")
+        let descriptors = [
+            WidgetDescriptor.usageTrend(provider: claude)
+                .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test"),
+            WidgetDescriptor.usageTrend(provider: extraCard)
+                .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test"),
+        ]
+        return WidgetRegistry(providers: [claude, extraCard], descriptors: descriptors)
+    }
+
+    private func scratchCache() -> ProviderSnapshotCache {
+        ProviderSnapshotCache(userDefaults: makeScratchDefaults("Cache"), storageKey: "snapshots", ttl: 600)
+    }
+
+    private func makeScratchDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.PeerIdentity.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return defaults
+    }
+
+    private func makeDocument(
+        deviceName: String = "Peer",
+        providers: [String: ProviderUsageHistory],
+        identities: [String: String]?
+    ) -> UsageHistoryDocument {
+        UsageHistoryDocument(
+            deviceID: UUID().uuidString,
+            deviceName: deviceName,
+            updatedAt: Date(),
+            providers: providers,
+            identities: identities
+        )
+    }
+
+    private func history(day: String, tokens: Int, cost: Double) -> ProviderUsageHistory {
+        ProviderUsageHistory(
+            series: DailyUsageSeries(daily: [DailyUsageEntry(date: day, totalTokens: tokens, costUSD: cost)]),
+            modelUsage: nil,
+            unknownModelsByDay: [:]
+        )
+    }
+
+    private func snapshot(providerID: String, history: ProviderUsageHistory) -> ProviderSnapshot {
+        var snapshot = ProviderSnapshot(
+            providerID: providerID,
+            displayName: providerID,
+            lines: [],
+            refreshedAt: Date()
+        )
+        snapshot.usageHistory = history
+        return snapshot
+    }
+
+    private func dayKey(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -42,7 +42,9 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
         let localMap = ["claude": maxKey, "claude@f15456b0": teamKey]
 
-        let remapped = PeerHistoryRemapper.remap(documents: [miniDoc], localIdentityByCardID: localMap)
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [miniDoc], localIdentityByCardID: localMap, localAccountCardIDs: Set(localMap.keys)
+        )
 
         XCTAssertTrue(remapped.remoteOnly.isEmpty)
         let byCard = Dictionary(grouping: remapped.histories, by: { $0.cardID })
@@ -58,7 +60,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
         let remapped = PeerHistoryRemapper.remap(
             documents: [doc],
-            localIdentityByCardID: ["claude": maxKey]
+            localIdentityByCardID: ["claude": maxKey], localAccountCardIDs: ["claude"]
         )
         XCTAssertTrue(remapped.histories.isEmpty)
         XCTAssertEqual(remapped.remoteOnly.count, 1)
@@ -81,7 +83,8 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
 
         let remapped = PeerHistoryRemapper.remap(
-            documents: [previous, current], localIdentityByCardID: ["claude": maxKey]
+            documents: [previous, current], localIdentityByCardID: ["claude": maxKey],
+            localAccountCardIDs: ["claude"]
         )
 
         XCTAssertEqual(remapped.histories.count, 1)
@@ -97,7 +100,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
         let remapped = PeerHistoryRemapper.remap(
             documents: [v1],
-            localIdentityByCardID: ["claude": maxKey]
+            localIdentityByCardID: ["claude": maxKey], localAccountCardIDs: ["claude"]
         )
         XCTAssertTrue(remapped.histories.isEmpty)
         XCTAssertEqual(remapped.quarantined.first?.reason, .missingPeerIdentity)
@@ -125,7 +128,8 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
         let local = PeerHistoryRemapper.remap(
             documents: [document],
-            localIdentityByCardID: ["claude": maxKey, "claude@12345678": maxKey]
+            localIdentityByCardID: ["claude": maxKey, "claude@12345678": maxKey],
+            localAccountCardIDs: ["claude", "claude@12345678"]
         )
         XCTAssertEqual(local.quarantined.first?.reason, .ambiguousLocalIdentity)
 
@@ -137,9 +141,25 @@ final class PeerHistoryIdentityTests: XCTestCase {
             identities: ["claude": maxKey, "claude@12345678": maxKey]
         )
         let peer = PeerHistoryRemapper.remap(
-            documents: [duplicate], localIdentityByCardID: ["claude": maxKey]
+            documents: [duplicate], localIdentityByCardID: ["claude": maxKey],
+            localAccountCardIDs: ["claude"]
         )
         XCTAssertEqual(peer.quarantined.map(\.reason), [.ambiguousPeerIdentity, .ambiguousPeerIdentity])
+    }
+
+    func testMixedCaseIdentitiesResolveToTheSameAccountAcrossMacs() {
+        let document = makeDocument(
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: ["claude": maxKey.uppercased()]
+        )
+
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [document], localIdentityByCardID: ["claude": maxKey],
+            localAccountCardIDs: ["claude"]
+        )
+
+        XCTAssertEqual(remapped.histories.map(\.cardID), ["claude"])
+        XCTAssertTrue(remapped.remoteOnly.isEmpty)
     }
 
     func testLocalDocumentPublishesAccountCardsWithIdentities() {
@@ -199,6 +219,27 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
         XCTAssertEqual(total.slices.count, 1)
         XCTAssertEqual(total.slices[0].amountUSD, 42, accuracy: 0.001)
+    }
+
+    func testRemoteOnlyAccountAppearsWhenThisMacHasNoLocalLogin() {
+        let provider = ClaudeProvider.makeProvider()
+        let descriptor = WidgetDescriptor.usageTrend(provider: provider)
+            .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test")
+        let dataStore = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: [descriptor]),
+            providers: [], cache: scratchCache(), defaults: makeScratchDefaults("NoLocalAccount"),
+            providerIdentityKeys: [:]
+        )
+        let document = makeDocument(
+            deviceName: "Mac mini",
+            providers: ["claude": history(day: dayKey(Date()), tokens: 100, cost: 4)],
+            identities: ["claude": "remote-account"]
+        )
+
+        dataStore.setPeerHistoryDocuments([document], ownDeviceID: "this-mac")
+
+        XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
+        XCTAssertEqual(dataStore.remoteOnlySpend.first?.provider.displayName, "Claude · Mac mini")
     }
 
     func testClearingPeersDropsRemoteOnlyEntries() {

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -226,6 +226,29 @@ final class PeerHistoryIdentityTests: XCTestCase {
         }
     }
 
+    func testKeychainCodexAccountSwitchStaysQuarantinedAcrossColdRelaunches() async {
+        let defaults = makeScratchDefaults("CodexColdAccountSwitch")
+        let codex = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+        let descriptor = WidgetDescriptor.usageTrend(provider: codex)
+            .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test")
+        let rollout = history(day: "2026-07-16", tokens: 10, cost: 1)
+
+        for (identity, shouldExport) in [("account-a", true), ("account-b", false), ("account-b", false)] {
+            let runtime = AccountReportingRuntime(
+                provider: codex, snapshot: snapshot(providerID: "codex", history: rollout), identity: identity
+            )
+            let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "cold-codex", ttl: 600)
+            let store = WidgetDataStore(
+                registry: WidgetRegistry(providers: [codex], descriptors: [descriptor]),
+                providers: [runtime], cache: cache, defaults: defaults
+            )
+
+            _ = await store.refresh(providerID: "codex", force: true)
+            let document = store.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+            XCTAssertEqual(document.providers["codex"] != nil, shouldExport)
+        }
+    }
+
     func testLocalDocumentPublishesAccountCardsWithIdentities() {
         let registry = makeRegistry()
         // Preload the cache; the store's init adopts cached snapshots as its local set. The entries

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -63,9 +63,29 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertTrue(remapped.histories.isEmpty)
         XCTAssertEqual(remapped.remoteOnly.count, 1)
         XCTAssertEqual(remapped.remoteOnly.first?.family, "claude")
-        XCTAssertEqual(remapped.remoteOnly.first?.deviceName, "Mac mini")
+        XCTAssertEqual(remapped.remoteOnly.first?.deviceNamesByID.values.first, "Mac mini")
         XCTAssertEqual(remapped.remoteOnly.first?.cardID,
                        ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"))
+    }
+
+    func testRemapKeepsOnlyTheNewestVerifiedHistoryFromEachDevice() {
+        let previous = makeDocument(
+            deviceID: "same-mac", updatedAt: Date(timeIntervalSince1970: 100),
+            providers: ["claude": history(day: "2026-07-16", tokens: 900, cost: 90)],
+            identities: ["claude": maxKey]
+        )
+        let current = makeDocument(
+            deviceID: "same-mac", updatedAt: Date(timeIntervalSince1970: 200),
+            providers: ["claude": history(day: "2026-07-16", tokens: 20, cost: 2)],
+            identities: ["claude": maxKey]
+        )
+
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [previous, current], localIdentityByCardID: ["claude": maxKey]
+        )
+
+        XCTAssertEqual(remapped.histories.count, 1)
+        XCTAssertEqual(remapped.histories.first?.history.series.daily.first?.totalTokens, 20)
     }
 
     func testRemapLegacyAccountHistoryWithoutIdentityIsQuarantined() {
@@ -201,6 +221,55 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertTrue(dataStore.remoteOnlySpend.isEmpty, "sync off returns Total Spend to local-only")
     }
 
+    func testOneRemoteAccountAcrossMultipleMacsHasOneStableLabel() {
+        let dataStore = WidgetDataStore(
+            registry: makeRegistry(), providers: [], cache: scratchCache(),
+            defaults: makeScratchDefaults("MultipleMacs"),
+            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
+        )
+        let today = dayKey(Date())
+        let mini = makeDocument(
+            deviceName: "Mac mini", providers: ["claude": history(day: today, tokens: 10, cost: 1)],
+            identities: ["claude": "remote-account"]
+        )
+        let laptop = makeDocument(
+            deviceName: "Mac mini", providers: ["claude": history(day: today, tokens: 20, cost: 2)],
+            identities: ["claude": "remote-account"]
+        )
+
+        dataStore.setPeerHistoryDocuments([mini, laptop], ownDeviceID: "this-mac")
+        XCTAssertEqual(dataStore.remoteOnlySpend.map(\.provider.displayName), ["Claude · 2 Macs"])
+
+        dataStore.setPeerHistoryDocuments([laptop, mini], ownDeviceID: "this-mac")
+        XCTAssertEqual(dataStore.remoteOnlySpend.map(\.provider.displayName), ["Claude · 2 Macs"])
+    }
+
+    func testMultipleRemoteAccountsOnTheSameMacHaveDistinctLabels() {
+        let dataStore = WidgetDataStore(
+            registry: makeRegistry(), providers: [], cache: scratchCache(),
+            defaults: makeScratchDefaults("SameMac"),
+            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
+        )
+        let today = dayKey(Date())
+        let document = makeDocument(
+            deviceName: "Mac mini", providers: [
+                "claude": history(day: today, tokens: 10, cost: 1),
+                "claude@12345678": history(day: today, tokens: 20, cost: 2),
+            ],
+            identities: ["claude": "remote-a", "claude@12345678": "remote-b"]
+        )
+
+        dataStore.setPeerHistoryDocuments([document], ownDeviceID: "this-mac")
+
+        XCTAssertEqual(
+            Set(dataStore.remoteOnlySpend.map(\.provider.displayName)),
+            [
+                "Claude · Mac mini · \(ProviderAccountID.hash8("remote-a").prefix(4))",
+                "Claude · Mac mini · \(ProviderAccountID.hash8("remote-b").prefix(4))",
+            ]
+        )
+    }
+
     // MARK: - Fixtures
 
     private func makeRegistry() -> WidgetRegistry {
@@ -228,14 +297,16 @@ final class PeerHistoryIdentityTests: XCTestCase {
     }
 
     private func makeDocument(
+        deviceID: String = UUID().uuidString,
         deviceName: String = "Peer",
+        updatedAt: Date = Date(),
         providers: [String: ProviderUsageHistory],
         identities: [String: String]?
     ) -> UsageHistoryDocument {
         UsageHistoryDocument(
-            deviceID: UUID().uuidString,
+            deviceID: deviceID,
             deviceName: deviceName,
-            updatedAt: Date(),
+            updatedAt: updatedAt,
             providers: providers,
             identities: identities
         )

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -271,6 +271,48 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertEqual(document.identities?["codex"], "account-a")
     }
 
+    func testUnsafeCodexRefreshKeepsLocalHistoryButNeverReplacesTheVerifiedCache() async {
+        let defaults = makeScratchDefaults("CodexUnsafeLocalHistory")
+        let codex = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+        let descriptor = WidgetDescriptor.usageTrend(provider: codex)
+            .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test")
+        let verifiedHistory = history(day: "2026-07-16", tokens: 10, cost: 1)
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "codex-unsafe", ttl: 600)
+        cache.store(snapshot(providerID: "codex", history: verifiedHistory), producedByIdentityKey: "account-a")
+
+        let unsafe = AccountReportingRuntime(
+            provider: codex,
+            snapshot: ProviderSnapshot(providerID: "codex", displayName: "Updated Codex", lines: []),
+            identity: "account-a",
+            historySafeToExport: false
+        )
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [codex], descriptors: [descriptor]),
+            providers: [unsafe], cache: cache, defaults: defaults,
+            providerIdentityKeys: ["codex": "account-a"]
+        )
+
+        _ = await store.refresh(providerID: "codex", force: true)
+
+        XCTAssertEqual(store.snapshots["codex"]?.usageHistory, verifiedHistory)
+        XCTAssertNil(store.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac").providers["codex"])
+
+        let coldCache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "codex-unsafe", ttl: 600)
+        XCTAssertEqual(coldCache.loadSnapshots(providerIDs: ["codex"])["codex"]?.displayName, "codex")
+        let coldProvider = CodexProvider(expectedIdentityKey: "account-a")
+        let coldStore = WidgetDataStore(
+            registry: WidgetRegistry(providers: [coldProvider.provider], descriptors: [descriptor]),
+            providers: [coldProvider], cache: coldCache, defaults: defaults,
+            providerIdentityKeys: ["codex": "account-a"]
+        )
+
+        XCTAssertEqual(coldStore.snapshots["codex"]?.usageHistory, verifiedHistory)
+        XCTAssertEqual(
+            coldStore.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac").providers["codex"],
+            verifiedHistory
+        )
+    }
+
     func testLocalDocumentPublishesAccountCardsWithIdentities() {
         let registry = makeRegistry()
         // Preload the cache; the store's init adopts cached snapshots as its local set. The entries
@@ -427,12 +469,14 @@ final class PeerHistoryIdentityTests: XCTestCase {
         let widgetDescriptors: [WidgetDescriptor] = []
         let snapshot: ProviderSnapshot
         let identity: String?
+        let isAccountHistorySafeToExport: Bool
         private(set) var verifiedAccountIdentityKey: String?
 
-        init(provider: Provider, snapshot: ProviderSnapshot, identity: String?) {
+        init(provider: Provider, snapshot: ProviderSnapshot, identity: String?, historySafeToExport: Bool = true) {
             self.provider = provider
             self.snapshot = snapshot
             self.identity = identity
+            self.isAccountHistorySafeToExport = historySafeToExport
         }
 
         func refresh() async -> ProviderSnapshot {

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -249,6 +249,28 @@ final class PeerHistoryIdentityTests: XCTestCase {
         }
     }
 
+    func testVerifiedCodexCacheSurvivesInitialCloudWriteBeforeRefresh() {
+        let defaults = makeScratchDefaults("CodexColdCloudWrite")
+        let provider = CodexProvider(expectedIdentityKey: "account-a")
+        let descriptor = WidgetDescriptor.usageTrend(provider: provider.provider)
+            .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test")
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "cold-codex", ttl: 600)
+        cache.store(
+            snapshot(providerID: "codex", history: history(day: "2026-07-16", tokens: 10, cost: 1)),
+            producedByIdentityKey: "account-a"
+        )
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider.provider], descriptors: [descriptor]),
+            providers: [provider], cache: cache, defaults: defaults,
+            providerIdentityKeys: ["codex": "account-a"]
+        )
+
+        let document = store.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+
+        XCTAssertNotNil(document.providers["codex"])
+        XCTAssertEqual(document.identities?["codex"], "account-a")
+    }
+
     func testLocalDocumentPublishesAccountCardsWithIdentities() {
         let registry = makeRegistry()
         // Preload the cache; the store's init adopts cached snapshots as its local set. The entries

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -63,10 +63,11 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertTrue(remapped.histories.isEmpty)
         XCTAssertEqual(remapped.remoteOnly.count, 1)
         XCTAssertEqual(remapped.remoteOnly.first?.family, "claude")
-        XCTAssertEqual(remapped.remoteOnly.first?.deviceNames, ["Mac mini"])
+        XCTAssertEqual(remapped.remoteOnly.first?.cardID,
+                       ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"))
     }
 
-    func testRemapLegacyV1DocumentKeepsSameCardMerge() {
+    func testRemapLegacyAccountHistoryWithoutIdentityIsQuarantined() {
         let v1 = UsageHistoryDocument(
             schema: UsageHistoryDocument.legacySchemaV1,
             deviceID: "d", deviceName: "old Mac", updatedAt: Date(),
@@ -77,8 +78,47 @@ final class PeerHistoryIdentityTests: XCTestCase {
             documents: [v1],
             localIdentityByCardID: ["claude": maxKey]
         )
-        XCTAssertEqual(remapped.histories.first?.cardID, "claude")
+        XCTAssertTrue(remapped.histories.isEmpty)
+        XCTAssertEqual(remapped.quarantined.first?.reason, .missingPeerIdentity)
         XCTAssertTrue(remapped.remoteOnly.isEmpty)
+    }
+
+    func testDifferentProviderFamiliesCannotShareAnIdentity() {
+        let document = makeDocument(
+            providers: ["codex": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: ["codex": maxKey]
+        )
+        let result = PeerHistoryRemapper.remap(
+            documents: [document],
+            localIdentityByCardID: ["claude": maxKey],
+            localAccountCardIDs: ["claude", "codex"]
+        )
+        XCTAssertTrue(result.histories.isEmpty)
+        XCTAssertEqual(result.quarantined.first?.reason, .unresolvedLocalIdentity)
+    }
+
+    func testAmbiguousLocalAndPeerOwnershipAreQuarantined() {
+        let document = makeDocument(
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: ["claude": maxKey]
+        )
+        let local = PeerHistoryRemapper.remap(
+            documents: [document],
+            localIdentityByCardID: ["claude": maxKey, "claude@12345678": maxKey]
+        )
+        XCTAssertEqual(local.quarantined.first?.reason, .ambiguousLocalIdentity)
+
+        let duplicate = makeDocument(
+            providers: [
+                "claude": history(day: "2026-07-16", tokens: 10, cost: 1),
+                "claude@12345678": history(day: "2026-07-16", tokens: 20, cost: 2),
+            ],
+            identities: ["claude": maxKey, "claude@12345678": maxKey]
+        )
+        let peer = PeerHistoryRemapper.remap(
+            documents: [duplicate], localIdentityByCardID: ["claude": maxKey]
+        )
+        XCTAssertEqual(peer.quarantined.map(\.reason), [.ambiguousPeerIdentity, .ambiguousPeerIdentity])
     }
 
     func testLocalDocumentPublishesAccountCardsWithIdentities() {
@@ -117,7 +157,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
             providers: [],
             cache: scratchCache(),
             defaults: makeScratchDefaults("RemoteTotal"),
-            providerIdentityKeys: ["claude": maxKey]
+            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
         )
         let today = dayKey(Date())
         let doc = makeDocument(
@@ -129,7 +169,8 @@ final class PeerHistoryIdentityTests: XCTestCase {
 
         XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
         let entry = dataStore.remoteOnlySpend[0]
-        XCTAssertEqual(entry.provider.displayName, "Claude · Mac mini")
+        XCTAssertEqual(entry.provider.displayName,
+                       ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"))
 
         let total = TotalSpendAggregator.total(
             for: .today,
@@ -146,7 +187,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
             providers: [],
             cache: scratchCache(),
             defaults: makeScratchDefaults("ClearPeers"),
-            providerIdentityKeys: ["claude": maxKey]
+            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
         )
         let doc = makeDocument(
             deviceName: "Mac mini",

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -162,6 +162,70 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertTrue(remapped.remoteOnly.isEmpty)
     }
 
+    func testOrganizationlessIdentityFollowsItsOnlyVerifiedOrganization() {
+        let document = makeDocument(
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: ["claude": "uuid-me"]
+        )
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [document], localIdentityByCardID: ["claude": teamKey],
+            localAccountCardIDs: ["claude"],
+            knownAccountIdentitiesByFamily: ["claude": ["uuid-me", teamKey]]
+        )
+
+        XCTAssertEqual(remapped.histories.map(\.cardID), ["claude"])
+        XCTAssertTrue(remapped.remoteOnly.isEmpty)
+    }
+
+    func testOrganizationlessIdentityIsQuarantinedWhenMultipleOrganizationsExist() {
+        let document = makeDocument(
+            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
+            identities: ["claude": "uuid-me"]
+        )
+        let remapped = PeerHistoryRemapper.remap(
+            documents: [document], localIdentityByCardID: ["claude": teamKey],
+            localAccountCardIDs: ["claude"],
+            knownAccountIdentitiesByFamily: ["claude": [teamKey, maxKey]]
+        )
+
+        XCTAssertEqual(remapped.quarantined.map(\.reason), [.ambiguousPeerIdentity])
+        XCTAssertTrue(remapped.histories.isEmpty)
+    }
+
+    func testCodexExportsOnlyVerifiedHistoryWithoutCrossAccountCarryForward() async {
+        let codex = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+        let descriptor = WidgetDescriptor.usageTrend(provider: codex)
+            .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test")
+        let knownHistory = history(day: "2026-07-16", tokens: 10, cost: 1)
+        let cases: [(previous: String?, current: String?, fresh: Bool, exports: Bool)] = [
+            (nil, "account-b", true, true),
+            ("account-a", "account-b", false, false),
+            ("account-a", nil, false, false),
+            ("account-a", "account-b", true, false),
+        ]
+        for scenario in cases {
+            let cache = scratchCache()
+            if let previous = scenario.previous {
+                cache.store(snapshot(providerID: "codex", history: knownHistory), producedByIdentityKey: previous)
+            }
+            let next = scenario.fresh
+                ? snapshot(providerID: "codex", history: knownHistory)
+                : ProviderSnapshot(providerID: "codex", displayName: "Codex", lines: [])
+            let runtime = AccountReportingRuntime(provider: codex, snapshot: next, identity: scenario.current)
+            let store = WidgetDataStore(
+                registry: WidgetRegistry(providers: [codex], descriptors: [descriptor]),
+                providers: [runtime], cache: cache, defaults: makeScratchDefaults("CodexOwnership"),
+                providerIdentityKeys: scenario.previous.map { ["codex": $0] } ?? [:],
+                knownAccountIdentitiesByFamily: scenario.previous.map { ["codex": Set([$0])] } ?? [:]
+            )
+            _ = await store.refresh(providerID: "codex", force: true)
+            let document = store.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+            XCTAssertEqual(document.providers["codex"] != nil, scenario.exports)
+            XCTAssertEqual(document.identities?["codex"], scenario.exports ? scenario.current : nil)
+            if !scenario.fresh { XCTAssertNil(store.snapshots["codex"]?.usageHistory) }
+        }
+    }
+
     func testLocalDocumentPublishesAccountCardsWithIdentities() {
         let registry = makeRegistry()
         // Preload the cache; the store's init adopts cached snapshots as its local set. The entries
@@ -312,6 +376,25 @@ final class PeerHistoryIdentityTests: XCTestCase {
     }
 
     // MARK: - Fixtures
+
+    private final class AccountReportingRuntime: ProviderRuntime, AccountIdentityReporting {
+        let provider: Provider
+        let widgetDescriptors: [WidgetDescriptor] = []
+        let snapshot: ProviderSnapshot
+        let identity: String?
+        private(set) var verifiedAccountIdentityKey: String?
+
+        init(provider: Provider, snapshot: ProviderSnapshot, identity: String?) {
+            self.provider = provider
+            self.snapshot = snapshot
+            self.identity = identity
+        }
+
+        func refresh() async -> ProviderSnapshot {
+            verifiedAccountIdentityKey = identity
+            return snapshot
+        }
+    }
 
     private func makeRegistry() -> WidgetRegistry {
         let claude = ClaudeProvider.makeProvider()

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -63,6 +63,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertTrue(remapped.histories.isEmpty)
         XCTAssertEqual(remapped.remoteOnly.count, 1)
         XCTAssertEqual(remapped.remoteOnly.first?.family, "claude")
+        XCTAssertEqual(remapped.remoteOnly.first?.deviceName, "Mac mini")
         XCTAssertEqual(remapped.remoteOnly.first?.cardID,
                        ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"))
     }
@@ -169,8 +170,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
 
         XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
         let entry = dataStore.remoteOnlySpend[0]
-        XCTAssertEqual(entry.provider.displayName,
-                       ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"))
+        XCTAssertEqual(entry.provider.displayName, "Claude · Mac mini")
 
         let total = TotalSpendAggregator.total(
             for: .today,

--- a/Tests/OpenUsageTests/ProviderEnablementEnforcementTests.swift
+++ b/Tests/OpenUsageTests/ProviderEnablementEnforcementTests.swift
@@ -79,7 +79,8 @@ final class ProviderEnablementEnforcementTests: XCTestCase {
             cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots"),
             defaults: defaults,
             isProviderEnabled: { enablement.isEnabled($0) },
-            now: { now }
+            now: { now },
+            providerIdentityKeys: [provider.id: "account-a"]
         )
         enablement.onChange = { store.providerEnablementDidChange() }
 
@@ -89,7 +90,8 @@ final class ProviderEnablementEnforcementTests: XCTestCase {
                 deviceID: "peer",
                 deviceName: "Peer Mac",
                 updatedAt: now,
-                providers: [provider.id: history(tokens: 200, cost: 2, now: now)]
+                providers: [provider.id: history(tokens: 200, cost: 2, now: now)],
+                identities: [provider.id: "account-a"]
             )
         ], ownDeviceID: "this-mac")
         XCTAssertEqual(try spendTokens(store.snapshots[provider.id], label: "Today"), 300)

--- a/Tests/OpenUsageTests/TotalSpendAggregatorTests.swift
+++ b/Tests/OpenUsageTests/TotalSpendAggregatorTests.swift
@@ -193,6 +193,7 @@ final class TotalSpendPaletteTests: XCTestCase {
         let second = try XCTUnwrap(TotalSpendPalette.accountComponents(for: "claude@22222222"))
         XCTAssertNotEqual(first, second)
         XCTAssertEqual(first, TotalSpendPalette.accountComponents(for: "claude@11111111"))
+        XCTAssertEqual(first, TotalSpendPalette.accountComponents(for: "claude@peer-11111111"))
         XCTAssertTrue(first.hue <= 0.15 || first.hue >= 0.90)
         XCTAssertTrue((0.62...0.94).contains(first.brightness))
     }

--- a/Tests/OpenUsageTests/TotalSpendAggregatorTests.swift
+++ b/Tests/OpenUsageTests/TotalSpendAggregatorTests.swift
@@ -67,7 +67,9 @@ final class TotalSpendAggregatorTests: XCTestCase {
             title: { $0.id == "claude" ? "Claude Team" : $0.displayName }
         )
 
-        XCTAssertEqual(total.projection(for: .cost).slices.map(\.title), ["Cursor", "Claude Team"])
+        let projection = total.projection(for: .cost)
+        XCTAssertEqual(projection.slices.map(\.title), ["Cursor", "Claude Team"])
+        XCTAssertEqual(projection.infoTooltip, "Only includes Cursor and Claude Team.")
     }
 
     func testProviderWithoutPeriodLineIsExcludedNotZero() {
@@ -93,6 +95,7 @@ final class TotalSpendAggregatorTests: XCTestCase {
         XCTAssertEqual(total.slices.first?.amountUSD, 0)
 
         XCTAssertTrue(total.projection(for: .cost).isEmpty)
+        XCTAssertEqual(total.projection(for: .cost).infoTooltip, TotalSpendMetric.cost.emptyMessage)
         XCTAssertTrue(total.projection(for: .costPerMtok).isEmpty)
 
         let tokens = total.projection(for: .tokens)

--- a/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
@@ -15,28 +15,13 @@ final class UsageHistoryAggregatorTests: XCTestCase {
             lines: [],
             usageHistory: history(tokens: 9_000, cost: 90, model: "Cursor Model")
         )
-        let oldDuplicate = document(
-            deviceID: "peer-a",
-            updatedAt: 100,
-            providers: ["claude": history(tokens: 9_999, cost: 99, model: "Opus")]
-        )
-        let newestDuplicate = document(
-            deviceID: "peer-a",
-            updatedAt: 200,
-            providers: [
-                "claude": history(tokens: 200, cost: 2, model: "opus", unknown: ["unknown-b"]),
-                "cursor": history(tokens: 9_000, cost: 90, model: "Cursor Model")
-            ]
-        )
-        let secondPeer = document(
-            deviceID: "peer-b",
-            updatedAt: 150,
-            providers: ["claude": history(tokens: 50, cost: nil, model: "Sonnet")]
-        )
-
         let merged = UsageHistoryAggregator.merged(
             localSnapshots: ["claude": local, "cursor": cursor],
-            peerDocuments: [oldDuplicate, newestDuplicate, secondPeer],
+            peerHistories: [
+                ("claude", history(tokens: 200, cost: 2, model: "opus", unknown: ["unknown-b"])),
+                ("cursor", history(tokens: 9_000, cost: 90, model: "Cursor Model")),
+                ("claude", history(tokens: 50, cost: nil, model: "Sonnet")),
+            ],
             descriptors: [
                 "claude": UsageHistoryDescriptor(scope: .machineLocal, estimatedCost: true, sourceNote: "logs"),
                 "cursor": UsageHistoryDescriptor(scope: .accountWide, estimatedCost: true, sourceNote: "export")
@@ -77,7 +62,7 @@ final class UsageHistoryAggregatorTests: XCTestCase {
 
         let merged = UsageHistoryAggregator.merged(
             localSnapshots: [:],
-            peerDocuments: [document(deviceID: "peer", updatedAt: 100, providers: ["claude": peerHistory])],
+            peerHistories: [("claude", peerHistory)],
             descriptors: [
                 "claude": UsageHistoryDescriptor(scope: .machineLocal, estimatedCost: true, sourceNote: "logs")
             ],
@@ -143,19 +128,6 @@ final class UsageHistoryAggregatorTests: XCTestCase {
                 ])
             ]),
             unknownModelsByDay: unknown.isEmpty ? [:] : ["2026-07-13": unknown]
-        )
-    }
-
-    private func document(
-        deviceID: String,
-        updatedAt: TimeInterval,
-        providers: [String: ProviderUsageHistory]
-    ) -> UsageHistoryDocument {
-        UsageHistoryDocument(
-            deviceID: deviceID,
-            deviceName: deviceID,
-            updatedAt: Date(timeIntervalSince1970: updatedAt),
-            providers: providers
         )
     }
 

--- a/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
@@ -17,7 +17,7 @@ final class UsageHistoryDocumentTests: XCTestCase {
 
     func testRejectsUnsupportedSchemaInvalidValuesAndImpossibleDates() {
         var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
-        document.schema = "openusage.history.v2"
+        document.schema = "openusage.history.v3"
         XCTAssertThrowsError(try document.validate()) { error in
             XCTAssertEqual(error as? UsageHistoryDocumentError, .unsupportedSchema)
         }

--- a/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
@@ -54,7 +54,7 @@ final class UsageHistoryDocumentTests: XCTestCase {
         XCTAssertThrowsError(try document.validate())
 
         document.providers["claude@ab12cd34"] = document.providers["claude"]
-        document.identities = ["claude": "shared-account", "claude@ab12cd34": "shared-account"]
+        document.identities = ["claude": "shared-account", "claude@ab12cd34": "SHARED-ACCOUNT"]
         XCTAssertThrowsError(try document.validate()) { error in
             guard case .duplicateIdentity = error as? UsageHistoryDocumentError else {
                 return XCTFail("expected duplicate account identity, got \(error)")

--- a/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
@@ -43,6 +43,36 @@ final class UsageHistoryDocumentTests: XCTestCase {
         XCTAssertThrowsError(try document.validate())
     }
 
+    func testRejectsInvalidDuplicateAndUnboundAccountIdentities() {
+        var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
+        for invalid in ["", "/Users/alice/.claude", "account with spaces"] {
+            document.identities = ["claude": invalid]
+            XCTAssertThrowsError(try document.validate())
+        }
+
+        document.identities = ["codex": "missing-provider"]
+        XCTAssertThrowsError(try document.validate())
+
+        document.providers["claude@ab12cd34"] = document.providers["claude"]
+        document.identities = ["claude": "shared-account", "claude@ab12cd34": "shared-account"]
+        XCTAssertThrowsError(try document.validate()) { error in
+            guard case .duplicateIdentity = error as? UsageHistoryDocumentError else {
+                return XCTFail("expected duplicate account identity, got \(error)")
+            }
+        }
+    }
+
+    func testAccountCardsRequireIdentitiesAndLegacyDocumentsRejectThem() {
+        var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
+        document.providers["claude@ab12cd34"] = document.providers["claude"]
+        XCTAssertThrowsError(try document.validate())
+
+        document.providers["claude@ab12cd34"] = nil
+        document.schema = UsageHistoryDocument.legacySchemaV1
+        document.identities = ["claude": "account-a"]
+        XCTAssertThrowsError(try document.validate())
+    }
+
     func testNewestDocumentWinsForDuplicateMachine() {
         let old = makeDocument(deviceID: "same-mac", updatedAt: Date(timeIntervalSince1970: 100))
         let newest = makeDocument(deviceID: "same-mac", updatedAt: Date(timeIntervalSince1970: 200))

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -24,6 +24,21 @@ This Mac updates its file after a five-minute refresh batch, a manual refresh, o
 change. iCloud delivery is eventually consistent, so another Mac can take longer than five minutes to
 receive it, especially while offline. Downloaded changes reload immediately when macOS reports them.
 
+## Multiple accounts across Macs
+
+Histories match by **account**, not by card name. Each Mac's file records which account every card
+belongs to (an opaque account/organization identifier — never an email), so the same account merges into
+the same card everywhere, even when one Mac shows it as the main card and another as an extra account
+card.
+
+An account you use on another Mac but have no login for here doesn't become a card: it appears as its
+own slice in **Total Spend** ("Claude · Mac mini"), so the number at the top is the whole truth across
+your Macs. The moment you log that account in locally, its card appears with the full cross-machine
+history already attached.
+
+Macs running an older OpenUsage read their own format but report this Mac's newer file as "update
+OpenUsage" — update both sides to sync multi-account machines.
+
 Settings lists each valid device file with the time that Mac generated it. To remove a Mac from the
 combined summary, turn sync off on that Mac; this deletes its file from iCloud. Turning sync off also
 stops that Mac from reading peers and immediately returns every surface there to local-only spend.

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -32,9 +32,9 @@ the same card everywhere, even when one Mac shows it as the main card and anothe
 card.
 
 An account you use on another Mac but have no login for here doesn't become a card: it appears as its
-own slice in **Total Spend** ("Claude · Mac mini"), so the number at the top is the whole truth across
-your Macs. The moment you log that account in locally, its card appears with the full cross-machine
-history already attached.
+own slice in **Total Spend** ("Claude · Mac mini", or "Claude · 2 Macs" when that account spans two
+other Macs), so the number at the top is the whole truth across your Macs. The moment you log that
+account in locally, its card appears with the full cross-machine history already attached.
 
 Macs running an older OpenUsage read their own format but report this Mac's newer file as "update
 OpenUsage" — update both sides to sync multi-account machines.


### PR DESCRIPTION
## TL;DR

Sync account-specific usage history across Macs without merging data from different Claude accounts.

## What was happening

- Cloud history identified providers by local card IDs, which can mean different accounts on different Macs.
- Legacy or ambiguous histories could accidentally cross account-ownership boundaries.

## What this changes

- Match synced histories using provider family and verified account identity.
- Reject malformed, ambiguous, duplicate, or unowned account histories.
- Keep remote-only account cards scoped to enabled provider families.

## Heads-up

- This is the third stacked PR and targets the account-presentation branch.

## Tests

- Focused iCloud ownership and history-validation suites: 70 passing tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iCloud merge semantics and export gates for account-tied usage data; mistakes could leak or drop history across Macs or after account switches, though quarantine and verification paths are heavily tested.
> 
> **Overview**
> **iCloud usage history moves to schema v2** with a per-card `identities` map and support for account-scoped card ids (`claude@hash`). Peers are no longer merged by local card id: **`PeerHistoryRemapper`** matches histories on provider family plus verified account identity, **quarantines** missing/ambiguous/unowned account payloads, and feeds **`UsageHistoryAggregator`** pre-mapped `(localCardID, history)` pairs. Legacy v1 documents still validate; account histories without peer identity are not merged.
> 
> **`WidgetDataStore`** exports identities only when account history is verified, tracks **known identities per family** (including persisted verified sets), discards local history on account swap, and skips iCloud export when Codex logs cannot be tied to the signed-in account or when multiple Codex accounts would share one export. **Remote-only accounts** (synced elsewhere, no login here) become synthetic **Total Spend** slices with updated tooltip copy and peer-aware palette ids.
> 
> **Codex** implements **`AccountIdentityReporting`**: optional `expectedIdentityKey`, ownership checks through refresh (including live credential re-reads), and **quarantine** of log-derived history when `auth.json` under each Codex home does not prove the same account. **`AppContainer`** passes `knownAccountIdentitiesByFamily` into the data store.
> 
> Docs cover multi-account sync behavior; tests cover remapping, document validation, Codex ownership, and remote Total Spend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4643ffc7c6f14fa61de4f59748134105559f438b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->