### PR TITLE
Claude accounts 5: stable identity aliases and safe account migrations

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeCoworkDiscovery.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeCoworkDiscovery.swift
@@ -26,6 +26,11 @@ struct ClaudeCoworkDiscovery {
         var sandboxes: [Sandbox] = []
         /// The support trail (token-free and email-free): identity hashes and paths only.
         var notes: [String] = []
+        /// True when the walk hit its time budget before visiting every sandbox. A partial list
+        /// must not drive routing — a missed non-default sandbox would silently bleed into the
+        /// default card, and a partial partition would drop default spend — so the assembly skips
+        /// the whole cowork pass this launch and retries next launch.
+        var truncated = false
     }
 
     var files: TextFileAccessing
@@ -33,7 +38,8 @@ struct ClaudeCoworkDiscovery {
     /// The sandbox walk, injectable for tests; defaults to the scanner's own walk so discovery and
     /// spend scanning can never see different sandbox sets.
     var listSandboxes: @Sendable (URL) -> [URL]
-    /// Wall-clock budget; on overrun the scan returns what it has (and the next launch resumes).
+    /// Wall-clock budget; on overrun the scan returns what it has, flagged `truncated` so the
+    /// assembly knows the list is not the whole truth (and retries next launch).
     var timeBudget: TimeInterval
     var now: @Sendable () -> Date
 
@@ -41,7 +47,9 @@ struct ClaudeCoworkDiscovery {
         files: TextFileAccessing = LocalTextFileAccessor(),
         homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
         listSandboxes: @escaping @Sendable (URL) -> [URL] = { ClaudeLogUsageScanner.coworkClaudeDirs(home: $0) },
-        timeBudget: TimeInterval = 0.4,
+        // Heavy Desktop users commonly accumulate hundreds of sandbox identities. A subsecond
+        // launch budget silently discarded the entire account partition on those real machines.
+        timeBudget: TimeInterval = 3,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.files = files
@@ -55,8 +63,14 @@ struct ClaudeCoworkDiscovery {
         let started = now()
         var result = Result()
         for root in listSandboxes(homeDirectory()) {
+            if Task.isCancelled {
+                result.notes.append("cowork sandbox scan cancelled → skipping incomplete cowork routing")
+                result.truncated = true
+                break
+            }
             if now().timeIntervalSince(started) > timeBudget {
-                result.notes.append("cowork sandbox scan hit its \(Int(timeBudget * 1000))ms budget; finishing with partial results")
+                result.notes.append("cowork sandbox scan hit its \(Int(timeBudget * 1000))ms budget → skipping cowork routing this launch")
+                result.truncated = true
                 break
             }
             result.sandboxes.append(sandbox(at: root, notes: &result.notes))

--- a/Sources/OpenUsage/Services/ClaudeDesktopAccountPolicy.swift
+++ b/Sources/OpenUsage/Services/ClaudeDesktopAccountPolicy.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+/// Account aliases combine only when their complete identity universe proves one organization.
+struct ClaudeIdentity: Hashable, Sendable {
+    let user: String
+    let organization: String?
+
+    init?(_ raw: String) {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let components = normalized.split(separator: "|", omittingEmptySubsequences: false)
+        guard (1...2).contains(components.count),
+              !components[0].isEmpty,
+              components.count == 1 || !components[1].isEmpty,
+              normalized.rangeOfCharacter(from: .whitespacesAndNewlines.union(.controlCharacters)) == nil
+        else { return nil }
+        user = String(components[0])
+        organization = components.count == 2 ? String(components[1]) : nil
+    }
+
+    var key: String { organization.map { "\(user)|\($0)" } ?? user }
+    func matchesExactly(_ other: ClaudeIdentity) -> Bool { self == other }
+
+    static func canonical(
+        _ identity: ClaudeIdentity,
+        among known: some Sequence<ClaudeIdentity>,
+        preferred: [String: ClaudeIdentity] = [:]
+    ) -> ClaudeIdentity? {
+        let organizations = Set(known.compactMap { candidate in
+            candidate.user == identity.user ? candidate.organization : nil
+        })
+        if identity.organization != nil {
+            if organizations.count == 1,
+               let preferred = preferred[identity.user],
+               preferred.organization == nil
+            {
+                return preferred
+            }
+            return identity
+        }
+        guard organizations.count <= 1 else { return nil }
+        if let preferred = preferred[identity.user], preferred.organization == nil { return preferred }
+        guard let organization = organizations.first else { return identity }
+        return ClaudeIdentity("\(identity.user)|\(organization)")
+    }
+
+    static func canonical(
+        _ raw: String,
+        among known: some Sequence<String>,
+        preferred: [String: String] = [:]
+    ) -> String? {
+        guard let identity = ClaudeIdentity(raw) else { return nil }
+        let identities = known.compactMap(ClaudeIdentity.init)
+        let preferences = preferred.reduce(into: [String: ClaudeIdentity]()) { result, entry in
+            if let identity = ClaudeIdentity(entry.value) { result[entry.key.lowercased()] = identity }
+        }
+        return canonical(identity, among: identities, preferred: preferences)?.key
+    }
+}
+
+/// A Desktop token is either forbidden, limited to one verified organization, or allowed to follow
+/// the active organization only when the complete account evidence proves one possible owner.
+enum ClaudeDesktopAccessPolicy: Equatable, Sendable {
+    case denied
+    case activeOrganization
+    case pinned(String)
+
+    var organization: String? {
+        guard case .pinned(let organization) = self else { return nil }
+        return organization
+    }
+}
+
+/// Keeps Desktop credential ownership independent from Cowork spend-log routing. Desktop tokens
+/// identify an organization but not a user, so hidden accounts still contribute ownership evidence.
+struct ClaudeDesktopAccountPolicy {
+    private let knownIdentities: Set<ClaudeIdentity>
+    private let usersByOrganization: [String: Set<String>]
+    private let organizationsByUser: [String: Set<String>]
+    private let usersWithoutKnownOrganization: Set<String>
+
+    init(
+        records: [ProviderAccountRecord],
+        defaultOutcome: DefaultAccountObserver.Outcome?,
+        configFindings: [ClaudeConfigDirDiscovery.Finding],
+        coworkScan: ClaudeCoworkDiscovery.Result?
+    ) {
+        var identities = Set(
+            records
+                .filter { $0.family == "claude" }
+                .flatMap { [$0.identityKey] + ($0.identityAliases ?? []) }
+                .compactMap(ClaudeIdentity.init)
+        )
+        if case .resolved(let raw, _, _)? = defaultOutcome,
+           let identity = ClaudeIdentity(raw)
+        {
+            identities.insert(identity)
+        }
+        for finding in configFindings {
+            if let identity = ClaudeIdentity(finding.identityKey) {
+                identities.insert(identity)
+            }
+        }
+        // A partial walk cannot assign logs or create cards, but identities it positively observed
+        // still disprove exclusive Desktop ownership and must remain usable as safety evidence.
+        for sandbox in coworkScan?.sandboxes ?? [] {
+            if let raw = sandbox.identityKey, let identity = ClaudeIdentity(raw) {
+                identities.insert(identity)
+            }
+        }
+        knownIdentities = identities
+
+        var usersByOrganization: [String: Set<String>] = [:]
+        var organizationsByUser: [String: Set<String>] = [:]
+        var organizationlessUsers = Set<String>()
+        for identity in identities {
+            guard let organization = identity.organization else {
+                organizationlessUsers.insert(identity.user)
+                continue
+            }
+            usersByOrganization[organization, default: []].insert(identity.user)
+            organizationsByUser[identity.user, default: []].insert(organization)
+        }
+        self.usersByOrganization = usersByOrganization
+        self.organizationsByUser = organizationsByUser
+        // An org-less alias of a user with one known org is not a second unknown account; an
+        // entirely org-less different user, by contrast, could own any Desktop organization.
+        usersWithoutKnownOrganization = organizationlessUsers.subtracting(organizationsByUser.keys)
+    }
+
+    func hasAmbiguousOrganization(_ organization: String?) -> Bool {
+        guard let organization = organization?.nilIfEmpty?.lowercased() else { return false }
+        let identifiedUsers = usersByOrganization[organization] ?? []
+        return identifiedUsers.count > 1
+            || usersWithoutKnownOrganization.contains { !identifiedUsers.contains($0) }
+    }
+
+    /// Prefer a known org even when Claude Code's current state temporarily omits it. The pin is
+    /// valid only when aliases, persisted records, and scanned sources name exactly one possibility.
+    func organization(for identityKey: String?) -> String? {
+        guard let identityKey, let identity = ClaudeIdentity(identityKey) else { return nil }
+        if let organization = identity.organization { return organization }
+        guard let organizations = organizationsByUser[identity.user], organizations.count == 1 else {
+            return nil
+        }
+        return organizations.first
+    }
+
+    /// One closed decision travels unchanged from source assembly into the auth store; no runtime
+    /// reconstructs credential safety from account count, log partitions, or unrelated booleans.
+    func access(
+        for identityKey: String,
+        allowsActiveOrganization: Bool
+    ) -> ClaudeDesktopAccessPolicy {
+        if let organization = organization(for: identityKey) {
+            return hasAmbiguousOrganization(organization) ? .denied : .pinned(organization)
+        }
+        return allowsActiveOrganization ? .activeOrganization : .denied
+    }
+
+    func allowsUnpinnedFallback(
+        defaultIdentity: String?,
+        hasExactlyOneDefaultAccount: Bool,
+        coworkScan: ClaudeCoworkDiscovery.Result?
+    ) -> Bool {
+        guard hasExactlyOneDefaultAccount,
+              let defaultIdentity,
+              let account = ClaudeIdentity(defaultIdentity)
+        else { return false }
+        // An explicit org still gets its pinned fallback during an incomplete walk; preserve the
+        // stricter scoped-keychain behavior rather than unnecessarily re-enabling the bare item.
+        if coworkScan?.truncated == true, account.organization != nil { return false }
+
+        var organizations: Set<String> = []
+        for identity in knownIdentities {
+            guard identity.user == account.user else { return false }
+            if let organization = identity.organization {
+                organizations.insert(organization)
+                if organizations.count > 1 { return false }
+            }
+        }
+        return true
+    }
+}

--- a/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
+++ b/Sources/OpenUsage/Services/PeerHistoryRemapper.swift
@@ -1,10 +1,19 @@
 import Foundation
 
-/// Account histories merge only when both Macs prove the same provider-family/account identity.
+/// Matches synced peer histories to this Mac's cards by ACCOUNT identity instead of by card id.
+///
+/// Account-card ids don't necessarily describe the same login on different Macs: the first account
+/// observed on each machine keeps the bare family id. An account history therefore enters a local
+/// card only when both machines identify the same account unambiguously. Older v1 account histories
+/// and unresolved identities are quarantined rather than guessed from a matching provider id.
 enum PeerHistoryRemapper {
     struct Remapped {
+        /// Peer histories addressed to a LOCAL card id, ready for the same-id day merge.
         var histories: [(cardID: String, history: ProviderUsageHistory)] = []
+        /// Peer accounts with no local card, keyed by identity.
         var remoteOnly: [RemoteOnlyHistory] = []
+        /// Histories whose owner cannot be established safely. These never reach a concrete card,
+        /// Total Spend, or a subsequently published local history document.
         var quarantined: [QuarantinedHistory] = []
     }
 
@@ -24,35 +33,86 @@ enum PeerHistoryRemapper {
     struct RemoteOnlyHistory {
         var identityKey: String
         var family: String
+        /// The account's identity-derived display code (`claude@ab12cd34`). A card may retain the
+        /// historical bare family id on another Mac, so this is a presentation/grouping key rather
+        /// than a claim that card ids are globally identical.
         var cardID: String
         var histories: [ProviderUsageHistory]
     }
 
+    /// `localIdentityByCardID` is this Mac's card → identity map (the launch account pass's
+    /// `identityKeysByCard`).
     static func remap(
         documents: [UsageHistoryDocument],
         localIdentityByCardID: [String: String],
         localAccountCardIDs: Set<String>? = nil
     ) -> Remapped {
-        struct AccountKey: Hashable {
-            let family: String
-            let identity: String
+        struct FamilyIdentity: Hashable {
+            var family: String
+            var identity: String
         }
 
-        var localCards: [AccountKey: [String]] = [:]
-        for (cardID, identity) in localIdentityByCardID where !identity.isEmpty {
-            let family = ProviderAccountID.family(of: cardID)
-            guard ProviderAccountID.families.contains(family) else { continue }
-            localCards[AccountKey(family: family, identity: identity), default: []].append(cardID)
+        let newestDocuments = UsageHistoryDocument.newestByDevice(documents)
+        var knownClaudeIdentities: Set<ClaudeIdentity> = []
+        func collectClaudeIdentity(cardID: String, identity: String) {
+            guard ProviderAccountID.family(of: cardID) == "claude",
+                  let parsed = ClaudeIdentity(identity)
+            else { return }
+            knownClaudeIdentities.insert(parsed)
         }
-        let knownCardIDs = localAccountCardIDs ?? Set(localIdentityByCardID.keys)
+        for (cardID, identity) in localIdentityByCardID {
+            collectClaudeIdentity(cardID: cardID, identity: identity)
+        }
+        for document in newestDocuments {
+            for (cardID, identity) in document.identities ?? [:] {
+                collectClaudeIdentity(cardID: cardID, identity: identity)
+            }
+        }
+
+        // Claude's state can report the same login either as its account UUID alone or as
+        // UUID|organization. Only fold those spellings when the complete local-and-peer view
+        // proves one organization; an org-less login spanning several organizations is unsafe.
+        func canonicalIdentity(family: String, identity: String) -> String? {
+            guard family == "claude" else { return identity }
+            guard let parsed = ClaudeIdentity(identity) else { return nil }
+            return ClaudeIdentity.canonical(parsed, among: knownClaudeIdentities)?.key
+        }
+
+        var localCardsByIdentity: [FamilyIdentity: [String]] = [:]
+        var ambiguousLocalClaudeUsers: Set<String> = []
+        for (cardID, identity) in localIdentityByCardID {
+            let family = ProviderAccountID.family(of: cardID)
+            guard ProviderAccountID.families.contains(family), !identity.isEmpty else { continue }
+            guard let canonical = canonicalIdentity(family: family, identity: identity) else {
+                if family == "claude", let parsed = ClaudeIdentity(identity) {
+                    ambiguousLocalClaudeUsers.insert(parsed.user)
+                }
+                continue
+            }
+            localCardsByIdentity[FamilyIdentity(family: family, identity: canonical), default: []]
+                .append(cardID)
+        }
+        let localCardIDs = localAccountCardIDs ?? Set(localIdentityByCardID.keys)
 
         var result = Remapped()
-        var remoteAccounts: [AccountKey: RemoteOnlyHistory] = [:]
+        var remoteByIdentity: [FamilyIdentity: RemoteOnlyHistory] = [:]
+        func collectRemoteOnly(identity: String, family: String, cardID: String, history: ProviderUsageHistory) {
+            let key = FamilyIdentity(family: family, identity: identity)
+            var entry = remoteByIdentity[key] ?? RemoteOnlyHistory(
+                identityKey: identity, family: family, cardID: cardID, histories: []
+            )
+            entry.histories.append(history)
+            remoteByIdentity[key] = entry
+        }
 
-        for document in UsageHistoryDocument.newestByDevice(documents) {
+        for document in newestDocuments {
             let peerIdentityCounts = Dictionary(
-                (document.identities ?? [:]).map { cardID, identity in
-                    (AccountKey(family: ProviderAccountID.family(of: cardID), identity: identity), 1)
+                (document.identities ?? [:]).compactMap { cardID, identity -> (FamilyIdentity, Int)? in
+                    let family = ProviderAccountID.family(of: cardID)
+                    guard let canonical = canonicalIdentity(family: family, identity: identity) else {
+                        return nil
+                    }
+                    return (FamilyIdentity(family: family, identity: canonical), 1)
                 },
                 uniquingKeysWith: +
             )
@@ -65,45 +125,74 @@ enum PeerHistoryRemapper {
                 }
 
                 guard let identity = document.identities?[peerCardID], !identity.isEmpty else {
-                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .missingPeerIdentity))
-                    continue
-                }
-                let key = AccountKey(family: family, identity: identity)
-                guard peerIdentityCounts[key] == 1 else {
-                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .ambiguousPeerIdentity))
+                    result.quarantined.append(QuarantinedHistory(
+                        cardID: peerCardID, family: family, reason: .missingPeerIdentity
+                    ))
                     continue
                 }
 
-                let matches = localCards[key] ?? []
-                if matches.count == 1 {
-                    result.histories.append((matches[0], history))
+                guard let canonical = canonicalIdentity(family: family, identity: identity) else {
+                    result.quarantined.append(QuarantinedHistory(
+                        cardID: peerCardID, family: family, reason: .ambiguousPeerIdentity
+                    ))
                     continue
                 }
-                if matches.count > 1 {
-                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .ambiguousLocalIdentity))
-                    continue
-                }
-
-                let familyCards = knownCardIDs.filter { ProviderAccountID.family(of: $0) == family }
-                guard familyCards.contains(where: { localIdentityByCardID[$0] != nil }),
-                      !familyCards.contains(where: { localIdentityByCardID[$0] == nil })
-                else {
-                    result.quarantined.append(.init(cardID: peerCardID, family: family, reason: .unresolvedLocalIdentity))
+                let identityKey = FamilyIdentity(family: family, identity: canonical)
+                guard peerIdentityCounts[identityKey] == 1 else {
+                    result.quarantined.append(QuarantinedHistory(
+                        cardID: peerCardID, family: family, reason: .ambiguousPeerIdentity
+                    ))
                     continue
                 }
 
-                var entry = remoteAccounts[key] ?? RemoteOnlyHistory(
-                    identityKey: identity,
+                if family == "claude",
+                   let parsed = ClaudeIdentity(canonical),
+                   ambiguousLocalClaudeUsers.contains(parsed.user)
+                {
+                    result.quarantined.append(QuarantinedHistory(
+                        cardID: peerCardID, family: family, reason: .ambiguousLocalIdentity
+                    ))
+                    continue
+                }
+
+                let localMatches = localCardsByIdentity[identityKey] ?? []
+                if localMatches.count == 1 {
+                    result.histories.append((localMatches[0], history))
+                    continue
+                }
+                if localMatches.count > 1 {
+                    result.quarantined.append(QuarantinedHistory(
+                        cardID: peerCardID, family: family, reason: .ambiguousLocalIdentity
+                    ))
+                    continue
+                }
+
+                let knownFamilyCards = localCardIDs.filter {
+                    ProviderAccountID.family(of: $0) == family
+                }
+                let hasUnresolvedLocalCard = knownFamilyCards.contains {
+                    localIdentityByCardID[$0] == nil
+                }
+                let hasResolvedLocalFamily = localIdentityByCardID.keys.contains {
+                    ProviderAccountID.family(of: $0) == family
+                }
+                guard hasResolvedLocalFamily, !hasUnresolvedLocalCard else {
+                    result.quarantined.append(QuarantinedHistory(
+                        cardID: peerCardID, family: family, reason: .unresolvedLocalIdentity
+                    ))
+                    continue
+                }
+
+                collectRemoteOnly(
+                    identity: canonical,
                     family: family,
-                    cardID: ProviderAccountID.make(family: family, identityKey: identity),
-                    histories: []
+                    cardID: ProviderAccountID.make(family: family, identityKey: canonical),
+                    history: history
                 )
-                entry.histories.append(history)
-                remoteAccounts[key] = entry
             }
         }
 
-        result.remoteOnly = remoteAccounts.values.sorted {
+        result.remoteOnly = remoteByIdentity.values.sorted {
             ($0.family, $0.identityKey) < ($1.family, $1.identityKey)
         }
         return result

--- a/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderAccountsStore.swift
@@ -7,16 +7,30 @@ import Observation
 /// what makes existing installs migrate by doing nothing. Any later account of the same family mints
 /// `family@<hash8>` from its identity key.
 enum ProviderAccountID {
+    enum BareRuntimeResolution: Sendable {
+        case permanentRecord
+        case currentDefaultSource
+    }
+
+    struct FamilyMetadata: Sendable {
+        var bareRuntimeResolution: BareRuntimeResolution
+    }
+
+    /// Runtime aliases belong to family metadata: multi-card families keep their permanent bare
+    /// record, while a single-runtime family follows whichever account currently owns its source.
+    static let metadataByFamily: [String: FamilyMetadata] = [
+        "claude": FamilyMetadata(bareRuntimeResolution: .permanentRecord),
+        "codex": FamilyMetadata(bareRuntimeResolution: .currentDefaultSource),
+    ]
     /// The family ids that participate in the account-first model.
-    static let families: Set<String> = ["claude", "codex"]
+    static let families = Set(metadataByFamily.keys)
 
     /// `claude@ab12cd34` — a stable, non-reversible id derived from the account's identity key.
     static func make(family: String, identityKey: String) -> String {
         "\(family)@\(hash8(identityKey))"
     }
 
-    /// The 8-hex-char identity digest card ids are built from, exposed for other identity-derived
-    /// ids (the iCloud remote-only pseudo providers).
+    /// The digest also identifies remote-only account histories without exposing account details.
     static func hash8(_ identityKey: String) -> String {
         let digest = SHA256.hash(data: Data(identityKey.lowercased().utf8))
         return digest.prefix(4).map { String(format: "%02x", $0) }.joined()
@@ -27,8 +41,6 @@ enum ProviderAccountID {
         cardID.firstIndex(of: "@").map { String(cardID[..<$0]) } ?? cardID
     }
 
-    /// Whether a card id names an extra account card (`claude@ab12cd34`) rather than a bare
-    /// provider id.
     static func isAccountCard(_ cardID: String) -> Bool {
         cardID.contains("@")
     }
@@ -39,23 +51,39 @@ enum ProviderAccountID {
 /// a swap re-points source edges, cards don't move. Phase 1 only observes the default home; later
 /// phases add config dirs, cswap vault slots, Codex homes, and Desktop logins as more kinds.
 struct ProviderAccountSource: Codable, Equatable, Sendable {
-    enum Kind: String, Codable, Sendable {
-        /// The provider's standard home for this machine (`~/.claude`, `~/.codex`, env override).
-        case defaultHome
-        /// A custom Claude config dir (a `CLAUDE_CONFIG_DIR` home kept besides the default).
-        case configDir
-        /// A Claude Desktop login (a Cowork account distinct from every CLI login), credentialed
-        /// from Desktop's org-pinned Safe Storage cache. No anchor path — the login lives in
-        /// Desktop's own container, and its Cowork sandboxes are log roots, not credential homes.
-        case desktop
+    /// A string-backed value, rather than an exhaustive enum, keeps account records readable when
+    /// a newer development build introduces another source kind. Unknown sources stay persisted;
+    /// this build simply cannot bind a runtime to one until it learns how to verify that source.
+    struct Kind: RawRepresentable, Codable, Equatable, Hashable, Sendable {
+        static let defaultHome = Self(rawValue: "defaultHome")
+        static let configDir = Self(rawValue: "configDir")
+        static let desktop = Self(rawValue: "desktop")
+
+        let rawValue: String
+
+        init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+
+        init(from decoder: Decoder) throws {
+            rawValue = try decoder.singleValueContainer().decode(String.self)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(rawValue)
+        }
+
+        var isKnown: Bool {
+            self == .defaultHome || self == .configDir || self == .desktop
+        }
     }
 
     var kind: Kind
     /// Canonical home path the source was observed at.
     var anchor: String?
     var holdsDefaultSource: Bool
-    /// `configDir` only: the literal string whose hash names the source's keychain item (Claude Code
-    /// hashes `CLAUDE_CONFIG_DIR` exactly as typed, so `~/x` and its absolute spelling differ).
+    /// Claude Code hashes the literal config-dir spelling to derive its keychain service.
     var keychainLiteral: String?
 
     init(kind: Kind, anchor: String?, holdsDefaultSource: Bool, keychainLiteral: String? = nil) {
@@ -74,55 +102,65 @@ struct ProviderAccountRecord: Codable, Equatable, Sendable {
     var id: String
     var family: String
     var identityKey: String
+    /// Older Claude state sometimes omits the organization. Keep its previous spelling when that
+    /// changes so a later second organization cannot silently inherit the same account card.
+    var identityAliases: [String]? = nil
     var label: String?
-    /// A user-chosen card name (Rename in the card's context menu / Customize). Wins over `label`
-    /// and the id-derived fallback; never touched by reconciliation.
+    /// User-entered names belong to the account and survive source changes and rescans.
     var customLabel: String?
     var sources: [ProviderAccountSource]
-    /// Set by a future "Remove Account…". A tombstoned account is never resurrected by rescans.
+    /// Historical tombstones remain honored, but unavailable accounts are hidden instead of removed.
     var removedTombstone: Bool = false
 
-    /// The name a card carries without a rename: the stock family name for the bare card, a
-    /// "Claude — <org or email>" derived from the account label for an extra card, or the record id
-    /// itself when the account has no label (owner decision 2: short-hash fallback, one rename away
-    /// from good). Never contains `customLabel` — this is what gets baked into the launch
-    /// `Provider`, and baking a rename there is how stale-name bugs are born.
     var derivedDisplayName: String {
-        guard ProviderAccountID.isAccountCard(id) else { return family.capitalized }
-        guard let label = label?.nilIfEmpty else { return id }
-        // Labels are our own "email (Org Name)" format — prefer the org for a short card title.
-        if label.hasSuffix(")"), let open = label.lastIndex(of: "(") {
-            let org = label[label.index(after: open)..<label.index(before: label.endIndex)]
-                .trimmingCharacters(in: .whitespaces)
-            if !org.isEmpty { return "\(family.capitalized) — \(org)" }
+        derivedDisplayName(identifyingBareAccount: false)
+    }
+
+    /// The bare card keeps its original title while it is alone, but gains the same organization
+    /// label as its siblings when multiple accounts need to be distinguished.
+    func derivedDisplayName(identifyingBareAccount: Bool) -> String {
+        guard ProviderAccountID.isAccountCard(id) || identifyingBareAccount else {
+            return family.capitalized
+        }
+        guard let label = label?.nilIfEmpty else {
+            if ProviderAccountID.isAccountCard(id) { return id }
+            return "\(family.capitalized) — \(ProviderAccountID.hash8(identityKey).prefix(4))"
+        }
+        if label.hasSuffix(")"), let openingParenthesis = label.lastIndex(of: "(") {
+            let organization = label[
+                label.index(after: openingParenthesis)..<label.index(before: label.endIndex)
+            ].trimmingCharacters(in: .whitespaces)
+            if !organization.isEmpty {
+                let email = label[..<openingParenthesis].trimmingCharacters(in: .whitespaces)
+                let personalNames = ["\(email)'s Organization", "\(email)’s Organization"]
+                let name = personalNames.contains {
+                    $0.caseInsensitiveCompare(organization) == .orderedSame
+                } ? "Personal" : organization
+                return "\(family.capitalized) — \(name)"
+            }
         }
         return "\(family.capitalized) — \(label)"
     }
 
-    /// THE name resolver — the single place a rename becomes a card title. Everything that shows a
-    /// card name to a human resolves through this at render time (directly or via
-    /// `AppContainer.displayName(for:)`); `Provider.displayName` only ever carries the derived
-    /// default.
-    var resolvedDisplayName: String {
-        customLabel?.nilIfEmpty ?? derivedDisplayName
-    }
 }
 
-/// The account-first registry (`openusage.providerAccounts.v1`). Reconciled at every launch from the
-/// default-home identity reads and the config-dir scan; authoritative from day one — there is no
-/// parallel card model to drift from. Extra account cards render straight from these records, and
-/// the UI observes it live for renames (`customLabel`).
+/// The account-first registry (`openusage.providerAccounts.v2`). Reconciled at every launch from the
+/// verified source observations. Every account-aware runtime is constructed from one of these records,
+/// so its card, credentials, history, and persisted layout all share the same permanent account id.
 @MainActor
 @Observable
 final class ProviderAccountsStore {
-    static let storageKey = "openusage.providerAccounts.v1"
+    static let storageKey = "openusage.providerAccounts.v2"
+    static let legacyStorageKey = "openusage.providerAccounts.v1"
 
     private let defaults: UserDefaults
     private(set) var records: [ProviderAccountRecord]
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        if let data = defaults.data(forKey: Self.storageKey) {
+        let currentData = defaults.data(forKey: Self.storageKey)
+        let legacyData = defaults.data(forKey: Self.legacyStorageKey)
+        if let data = currentData ?? legacyData {
             do {
                 self.records = try JSONDecoder().decode([ProviderAccountRecord].self, from: data)
             } catch {
@@ -132,10 +170,17 @@ final class ProviderAccountsStore {
         } else {
             self.records = []
         }
+
+        if currentData == nil, legacyData != nil, !records.isEmpty {
+            persist()
+            AppLog.info(.config, "migrated \(records.count) provider account(s) into the downgrade-safe v2 registry")
+        }
+        if let legacyData {
+            repairLegacyMirrorIfNeeded(legacyData)
+        }
     }
 
     /// One account observed this launch, before reconciliation assigns (or re-finds) its record id.
-    /// (Named to avoid colliding with the `Observation` module the `@Observable` macro expands into.)
     struct AccountObservation {
         var family: String
         var identityKey: String
@@ -154,14 +199,33 @@ final class ProviderAccountsStore {
         var changed = false
 
         for observation in observations {
-            let index = updated.firstIndex {
-                $0.family == observation.family && $0.identityKey == observation.identityKey
+            let match = Self.matchingRecord(
+                for: observation,
+                in: updated,
+                observations: observations
+            )
+            if case .ambiguous = match {
+                AppLog.warn(.config, "accounts: claude identity omitted its organization while multiple organizations share the login; observation quarantined")
+                continue
             }
-            if let index {
+            if case .existing(let index) = match {
                 guard !updated[index].removedTombstone else { continue }
                 var record = updated[index]
+                if record.identityKey != observation.identityKey {
+                    var aliases = record.identityAliases ?? []
+                    if !aliases.contains(record.identityKey) {
+                        aliases.append(record.identityKey)
+                    }
+                    aliases.removeAll { $0 == observation.identityKey }
+                    record.identityAliases = aliases.isEmpty ? nil : aliases
+                    record.identityKey = observation.identityKey
+                }
                 record.label = observation.label ?? record.label
-                record.sources = observation.sources
+                // A source added by a newer app must survive this build's narrower discovery pass.
+                // Known sources, by contrast, are authoritative for the current launch: keeping a
+                // stale default-home edge would let a moved account borrow another login.
+                let forwardCompatibleSources = record.sources.filter { !$0.kind.isKnown }
+                record.sources = observation.sources + forwardCompatibleSources
                 if record != updated[index] {
                     updated[index] = record
                     changed = true
@@ -202,22 +266,115 @@ final class ProviderAccountsStore {
         return records
     }
 
-    /// The resolved card title for a card id, or `nil` when the card has no account record (a
-    /// non-account provider keeps its static `Provider.displayName`). The lookup half of the one
-    /// name resolver — see `ProviderAccountRecord.resolvedDisplayName`.
+    private enum RecordMatch {
+        case existing(Int)
+        case newRecord
+        case ambiguous
+    }
+
+    /// Claude's account UUID can appear either alone or with its organization UUID. Treat those as
+    /// one account only when the user's complete persisted and incoming history proves exactly one
+    /// possible organization; two different explicit organizations are always separate accounts.
+    private static func matchingRecord(
+        for observation: AccountObservation,
+        in records: [ProviderAccountRecord],
+        observations: [AccountObservation]
+    ) -> RecordMatch {
+        guard observation.family == "claude" else {
+            if let index = records.firstIndex(where: {
+                $0.family == observation.family && $0.identityKey == observation.identityKey
+            }) {
+                return .existing(index)
+            }
+            return .newRecord
+        }
+
+        guard let observed = ClaudeIdentity(observation.identityKey) else { return .ambiguous }
+        let familyRecords = records.enumerated().filter { _, record in
+            record.family == observation.family
+                && ClaudeIdentity(record.identityKey)?.user == observed.user
+        }
+        let known = familyRecords.flatMap { _, record in
+            ([record.identityKey] + (record.identityAliases ?? [])).compactMap(ClaudeIdentity.init)
+        } + observations.compactMap { candidate -> ClaudeIdentity? in
+            guard candidate.family == observation.family,
+                  let identity = ClaudeIdentity(candidate.identityKey),
+                  identity.user == observed.user
+            else { return nil }
+            return identity
+        }
+        guard let resolved = ClaudeIdentity.canonical(observed, among: known) else { return .ambiguous }
+        if let exact = familyRecords.first(where: { _, record in
+            ClaudeIdentity(record.identityKey)?.matchesExactly(observed) == true
+        }) {
+            return .existing(exact.offset)
+        }
+
+        let compatible = familyRecords.filter { _, record in
+            guard let existing = ClaudeIdentity(record.identityKey),
+                  let canonical = ClaudeIdentity.canonical(existing, among: known)
+            else { return false }
+            return canonical == resolved
+        }
+        guard compatible.count == 1 else {
+            return compatible.isEmpty ? .newRecord : .ambiguous
+        }
+        return .existing(compatible[0].offset)
+    }
+
+    func record(for cardID: String) -> ProviderAccountRecord? {
+        records.first { $0.id == cardID }
+    }
+
+    /// Claude runtimes follow their permanent account-card ids, while the single Codex runtime
+    /// still keeps its historical bare id when another recorded account takes the default home.
+    /// Resolve that one presentation alias to its current verified owner, never to the old record.
+    func runtimeRecord(for cardID: String) -> ProviderAccountRecord? {
+        let family = ProviderAccountID.family(of: cardID)
+        if !ProviderAccountID.isAccountCard(cardID),
+           ProviderAccountID.metadataByFamily[family]?.bareRuntimeResolution == .currentDefaultSource
+        {
+            return defaultBadgeHolder(family: family)
+        }
+        return record(for: cardID)
+    }
+
+    /// The contextual default title, shared by baked providers, visible cards, API output, and the
+    /// Customize name placeholder. Stable identity suffixes distinguish duplicate organization names.
+    func derivedDisplayName(cardID: String) -> String? {
+        guard let record = runtimeRecord(for: cardID) else { return nil }
+        let familyRecords = records.filter {
+            $0.family == record.family && !$0.removedTombstone
+        }
+        let identifiesBareAccount = familyRecords.count > 1
+        let proposed = record.derivedDisplayName(
+            identifyingBareAccount: identifiesBareAccount
+        )
+        let collides = familyRecords.contains { sibling in
+            guard sibling.id != record.id else { return false }
+            let siblingName = sibling.customLabel?.nilIfEmpty
+                ?? sibling.derivedDisplayName(identifyingBareAccount: identifiesBareAccount)
+            return siblingName == proposed
+        }
+        guard collides else { return proposed }
+        return "\(proposed) · \(ProviderAccountID.hash8(record.identityKey).prefix(4))"
+    }
+
     func resolvedDisplayName(cardID: String) -> String? {
-        records.first { $0.id == cardID }?.resolvedDisplayName
+        guard let record = runtimeRecord(for: cardID) else { return nil }
+        return record.customLabel?.nilIfEmpty ?? derivedDisplayName(cardID: cardID)
     }
 
-    /// Card id → resolved title for every record — the map the CLI/API boundary applies to its
-    /// snapshots (`LocalUsageAPI.State.resolvingDisplayNames`).
     var resolvedDisplayNamesByCardID: [String: String] {
-        Dictionary(uniqueKeysWithValues: records.map { ($0.id, $0.resolvedDisplayName) })
+        Dictionary(uniqueKeysWithValues: records.compactMap { record in
+            resolvedDisplayName(cardID: record.id).map { (record.id, $0) }
+        })
     }
 
-    /// Stores a user rename for a card; `nil` or blank clears it back to the derived name.
     func rename(cardID: String, to name: String?) {
-        guard let index = records.firstIndex(where: { $0.id == cardID }) else { return }
+        guard let record = runtimeRecord(for: cardID),
+              let index = records.firstIndex(where: { $0.id == record.id })
+        else { return }
         let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         guard records[index].customLabel != trimmed else { return }
         records[index].customLabel = trimmed
@@ -233,11 +390,29 @@ final class ProviderAccountsStore {
         }
     }
 
+    /// A logged-out or unreadable default home no longer belongs to its previous account. Retain
+    /// the account and every other source, but remove its stale home edge and default badge so a
+    /// future source cannot inherit ownership from an old observation.
+    func clearDefaultSource(family: String) {
+        var changed = false
+        for index in records.indices where records[index].family == family {
+            let existing = records[index].sources
+            let remaining = existing
+                .filter { $0.kind != .defaultHome }
+                .map { source in
+                    var source = source
+                    source.holdsDefaultSource = false
+                    return source
+                }
+            guard remaining != existing else { continue }
+            records[index].sources = remaining
+            changed = true
+        }
+        if changed { persist() }
+    }
+
     /// The bare family id when free (the migration-killing rule: the first account observed at the
-    /// default home IS the existing card), else an identity-derived `family@<hash8>` id. Only an
-    /// account observed at the family's DEFAULT home may claim the bare id — that id's runtime reads
-    /// the default home, so handing it to a custom-config-dir account would point the existing card
-    /// at a login it can't read.
+    /// default home IS the existing card), else an identity-derived `family@<hash8>` id.
     private static func availableID(for observation: AccountObservation, in records: [ProviderAccountRecord]) -> String {
         let observedAtDefaultHome = observation.sources.contains { $0.kind == .defaultHome }
         if observedAtDefaultHome, !records.contains(where: { $0.id == observation.family }) {
@@ -263,5 +438,55 @@ final class ProviderAccountsStore {
             return
         }
         defaults.set(data, forKey: Self.storageKey)
+    }
+
+    /// Development builds before the registry split may already have written Desktop/config-dir
+    /// sources into v1, which older releases decode as an exhaustive default-home-only enum. Keep
+    /// v2 authoritative, but repair that legacy mirror once so downgrading cannot wipe its records.
+    private func repairLegacyMirrorIfNeeded(_ data: Data) {
+        if (try? JSONDecoder().decode([LegacyAccountRecord].self, from: data)) != nil {
+            return
+        }
+        guard !records.isEmpty else { return }
+        let projected = records.map { record in
+            LegacyAccountRecord(
+                id: record.id,
+                family: record.family,
+                identityKey: record.identityKey,
+                label: record.label,
+                sources: record.sources.compactMap { source in
+                    guard source.kind == .defaultHome else { return nil }
+                    return LegacyAccountSource(
+                        kind: .defaultHome,
+                        anchor: source.anchor,
+                        holdsDefaultSource: source.holdsDefaultSource
+                    )
+                },
+                removedTombstone: record.removedTombstone
+            )
+        }
+        do {
+            defaults.set(try JSONEncoder().encode(projected), forKey: Self.legacyStorageKey)
+            AppLog.info(.config, "repaired the legacy provider-account mirror for downgrade compatibility")
+        } catch {
+            AppLog.error(.config, "failed to repair the legacy provider-account mirror: \(error.localizedDescription)")
+        }
+    }
+
+    private struct LegacyAccountRecord: Codable {
+        var id: String
+        var family: String
+        var identityKey: String
+        var label: String?
+        var sources: [LegacyAccountSource]
+        var removedTombstone: Bool
+    }
+
+    private struct LegacyAccountSource: Codable {
+        enum Kind: String, Codable { case defaultHome }
+
+        var kind: Kind
+        var anchor: String?
+        var holdsDefaultSource: Bool
     }
 }

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -50,79 +50,90 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertEqual(byCard["claude@f15456b0"]?.first?.history.series.daily.first?.costUSD, 502.34, "mini's Team spend belongs to this Mac's Team card")
     }
 
-    func testRemapCollectsRemoteOnlyAccounts() {
-        let doc = makeDocument(
-            deviceName: "Mac mini",
-            providers: ["claude@ab12cd34": history(day: "2026-07-16", tokens: 50, cost: 42)],
-            identities: ["claude@ab12cd34": "uuid-other|org-x"]
-        )
-        let remapped = PeerHistoryRemapper.remap(
-            documents: [doc],
-            localIdentityByCardID: ["claude": maxKey]
-        )
-        XCTAssertTrue(remapped.histories.isEmpty)
-        XCTAssertEqual(remapped.remoteOnly.count, 1)
-        XCTAssertEqual(remapped.remoteOnly.first?.family, "claude")
-        XCTAssertEqual(remapped.remoteOnly.first?.cardID,
-                       ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"))
-    }
-
-    func testRemapLegacyAccountHistoryWithoutIdentityIsQuarantined() {
-        let v1 = UsageHistoryDocument(
-            schema: UsageHistoryDocument.legacySchemaV1,
-            deviceID: "d", deviceName: "old Mac", updatedAt: Date(),
-            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
-            identities: nil
-        )
-        let remapped = PeerHistoryRemapper.remap(
-            documents: [v1],
-            localIdentityByCardID: ["claude": maxKey]
-        )
-        XCTAssertTrue(remapped.histories.isEmpty)
-        XCTAssertEqual(remapped.quarantined.first?.reason, .missingPeerIdentity)
-        XCTAssertTrue(remapped.remoteOnly.isEmpty)
-    }
-
-    func testDifferentProviderFamiliesCannotShareAnIdentity() {
-        let document = makeDocument(
-            providers: ["codex": history(day: "2026-07-16", tokens: 10, cost: 1)],
-            identities: ["codex": maxKey]
-        )
-        let result = PeerHistoryRemapper.remap(
-            documents: [document],
-            localIdentityByCardID: ["claude": maxKey],
-            localAccountCardIDs: ["claude", "codex"]
-        )
-        XCTAssertTrue(result.histories.isEmpty)
-        XCTAssertEqual(result.quarantined.first?.reason, .unresolvedLocalIdentity)
-    }
-
-    func testAmbiguousLocalAndPeerOwnershipAreQuarantined() {
-        let document = makeDocument(
-            providers: ["claude": history(day: "2026-07-16", tokens: 10, cost: 1)],
-            identities: ["claude": maxKey]
-        )
-        let local = PeerHistoryRemapper.remap(
-            documents: [document],
-            localIdentityByCardID: ["claude": maxKey, "claude@12345678": maxKey]
-        )
-        XCTAssertEqual(local.quarantined.first?.reason, .ambiguousLocalIdentity)
-
+    func testUnsafeIdentityStatesNeverMergeOrCreateRemoteOnlySpend() {
+        let usage = history(day: "2026-07-16", tokens: 10, cost: 1)
+        let claude = makeDocument(providers: ["claude": usage], identities: ["claude": teamKey])
         let duplicate = makeDocument(
-            providers: [
-                "claude": history(day: "2026-07-16", tokens: 10, cost: 1),
-                "claude@12345678": history(day: "2026-07-16", tokens: 20, cost: 2),
-            ],
-            identities: ["claude": maxKey, "claude@12345678": maxKey]
+            providers: ["claude": usage, "claude@extra": usage],
+            identities: ["claude": teamKey, "claude@extra": teamKey]
         )
-        let peer = PeerHistoryRemapper.remap(
-            documents: [duplicate], localIdentityByCardID: ["claude": maxKey]
-        )
-        XCTAssertEqual(peer.quarantined.map(\.reason), [.ambiguousPeerIdentity, .ambiguousPeerIdentity])
+        let codex = makeDocument(providers: ["codex": usage], identities: ["codex": "shared"])
+        let cases: [(name: String, document: UsageHistoryDocument, local: [String: String], cards: Set<String>?,
+                     reasons: [PeerHistoryRemapper.QuarantinedHistory.Reason])] = [
+            ("unresolved local account", claude, [:], nil, [.unresolvedLocalIdentity]),
+            ("duplicate local account", claude, ["claude": teamKey, "claude@extra": teamKey], nil,
+             [.ambiguousLocalIdentity]),
+            ("duplicate peer account", duplicate, ["claude": teamKey], nil,
+             [.ambiguousPeerIdentity, .ambiguousPeerIdentity]),
+            ("cross-provider identity", codex, ["claude": "shared"], nil, [.unresolvedLocalIdentity]),
+            ("unresolved sibling", claude, ["claude": maxKey], ["claude", "claude@extra"],
+             [.unresolvedLocalIdentity])
+        ]
+        for entry in cases {
+            let remapped = PeerHistoryRemapper.remap(
+                documents: [entry.document], localIdentityByCardID: entry.local, localAccountCardIDs: entry.cards
+            )
+            XCTAssertTrue(remapped.histories.isEmpty, entry.name)
+            XCTAssertTrue(remapped.remoteOnly.isEmpty, entry.name)
+            XCTAssertEqual(remapped.quarantined.map(\.reason), entry.reasons, entry.name)
+        }
+    }
+
+    func testLegacyHistoryQuarantinesAccountFamiliesButMergesOtherProviders() {
+        for cardID in ["claude", "grok"] {
+            let document = UsageHistoryDocument(
+                schema: UsageHistoryDocument.legacySchemaV1,
+                deviceID: "d", deviceName: "old Mac", updatedAt: Date(),
+                providers: [cardID: history(day: "2026-07-16", tokens: 10, cost: 1)], identities: nil
+            )
+            let remapped = PeerHistoryRemapper.remap(
+                documents: [document], localIdentityByCardID: ["claude": maxKey]
+            )
+            XCTAssertEqual(remapped.histories.map(\.cardID), cardID == "grok" ? [cardID] : [], cardID)
+            XCTAssertEqual(remapped.quarantined.map(\.reason),
+                           cardID == "claude" ? [.missingPeerIdentity] : [], cardID)
+            XCTAssertTrue(remapped.remoteOnly.isEmpty, cardID)
+        }
+    }
+
+    func testOrganizationAliasesMergeOnlyWhenTheirCompleteIdentityUniverseIsUnambiguous() {
+        func document(_ identities: [String: String]) -> UsageHistoryDocument {
+            makeDocument(
+                providers: Dictionary(uniqueKeysWithValues: identities.keys.map {
+                    ($0, history(day: "2026-07-16", tokens: 10, cost: 1))
+                }), identities: identities
+            )
+        }
+        typealias Reason = PeerHistoryRemapper.QuarantinedHistory.Reason
+        let cases: [(name: String, documents: [UsageHistoryDocument], local: [String: String],
+                     merged: [String], remote: [String], reasons: [Reason])] = [
+            ("orgless peer", [document(["claude": "uuid-me"])], ["claude@extra": teamKey],
+             ["claude@extra"], [], []),
+            ("orgless local account", [document(["claude@extra": teamKey])], ["claude": "uuid-me"],
+             ["claude"], [], []),
+            ("orgless peer with multiple organizations", [document(["claude": "uuid-me"])],
+             ["claude": maxKey, "claude@extra": teamKey], [], [], [.ambiguousPeerIdentity]),
+            ("orgless local account with multiple peer organizations",
+             [document(["claude": teamKey]), document(["claude": maxKey])], ["claude": "uuid-me"],
+             [], [], [.ambiguousLocalIdentity, .ambiguousLocalIdentity]),
+            ("duplicate peer aliases", [document(["claude": "uuid-me", "claude@extra": teamKey])],
+             ["claude": teamKey], [], [], [.ambiguousPeerIdentity, .ambiguousPeerIdentity]),
+            ("remote-only aliases across devices",
+             [document(["claude": "uuid-other"]), document(["claude": "uuid-other|org-work"])],
+             ["claude": maxKey], [], ["uuid-other|org-work"], [])
+        ]
+        for entry in cases {
+            let remapped = PeerHistoryRemapper.remap(documents: entry.documents, localIdentityByCardID: entry.local)
+            XCTAssertEqual(remapped.histories.map(\.cardID), entry.merged, entry.name)
+            XCTAssertEqual(remapped.remoteOnly.map(\.identityKey), entry.remote, entry.name)
+            XCTAssertEqual(remapped.quarantined.map(\.reason), entry.reasons, entry.name)
+            if !entry.remote.isEmpty {
+                XCTAssertEqual(remapped.remoteOnly.first?.histories.count, 2, entry.name)
+            }
+        }
     }
 
     func testLocalDocumentPublishesAccountCardsWithIdentities() {
-        let registry = makeRegistry()
         // Preload the cache; the store's init adopts cached snapshots as its local set. The entries
         // carry the same account stamp the store is launched with, or the swap guard discards them.
         let cache = scratchCache()
@@ -134,13 +145,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
             snapshot(providerID: "claude@f15456b0", history: history(day: "2026-07-16", tokens: 20, cost: 2)),
             producedByIdentityKey: teamKey
         )
-        let dataStore = WidgetDataStore(
-            registry: registry,
-            providers: [],
-            cache: cache,
-            defaults: makeScratchDefaults("PublishDoc"),
-            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
-        )
+        let dataStore = makeDataStore("PublishDoc", cache: cache)
 
         let document = dataStore.localHistoryDocument(deviceID: "dev", deviceName: "This Mac")
         XCTAssertEqual(document.schema, UsageHistoryDocument.currentSchema)
@@ -151,68 +156,104 @@ final class PeerHistoryIdentityTests: XCTestCase {
     }
 
     func testRemoteOnlyAccountFeedsTotalSpend() {
-        let registry = makeRegistry()
-        let dataStore = WidgetDataStore(
-            registry: registry,
-            providers: [],
-            cache: scratchCache(),
-            defaults: makeScratchDefaults("RemoteTotal"),
-            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
-        )
+        let dataStore = makeDataStore("RemoteTotal")
         let today = dayKey(Date())
         let doc = makeDocument(
             deviceName: "Mac mini",
-            providers: ["claude@ab12cd34": history(day: today, tokens: 1_000_000, cost: 42)],
-            identities: ["claude@ab12cd34": "uuid-other|org-x"]
+            providers: [
+                "claude@ab12cd34": history(day: today, tokens: 1_000_000, cost: 42),
+                "claude@22222222": history(day: today, tokens: 20, cost: 2)
+            ],
+            identities: ["claude@ab12cd34": "uuid-other|org-x", "claude@22222222": "uuid-second|org-y"]
         )
         dataStore.setPeerHistoryDocuments([doc], ownDeviceID: "this-mac")
 
-        XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
-        let entry = dataStore.remoteOnlySpend[0]
-        XCTAssertEqual(entry.provider.displayName,
-                       ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x"))
+        XCTAssertEqual(dataStore.remoteOnlySpend.count, 2)
+        let names = Set(dataStore.remoteOnlySpend.map(\.provider.displayName))
+        XCTAssertEqual(names.count, 2, "each remote account retains its own identity-derived name")
+        let expectedCardID = ProviderAccountID.make(family: "claude", identityKey: "uuid-other|org-x")
+        XCTAssertTrue(names.contains(expectedCardID))
 
         let total = TotalSpendAggregator.total(
             for: .today,
-            providers: [entry.provider],
-            snapshots: [entry.provider.id: entry.snapshot]
+            providers: dataStore.remoteOnlySpend.map(\.provider),
+            snapshots: Dictionary(uniqueKeysWithValues: dataStore.remoteOnlySpend.map {
+                ($0.provider.id, $0.snapshot)
+            })
         )
-        XCTAssertEqual(total.slices.count, 1)
-        XCTAssertEqual(total.slices[0].amountUSD, 42, accuracy: 0.001)
-    }
-
-    func testClearingPeersDropsRemoteOnlyEntries() {
-        let dataStore = WidgetDataStore(
-            registry: makeRegistry(),
-            providers: [],
-            cache: scratchCache(),
-            defaults: makeScratchDefaults("ClearPeers"),
-            providerIdentityKeys: ["claude": maxKey, "claude@f15456b0": teamKey]
-        )
-        let doc = makeDocument(
-            deviceName: "Mac mini",
-            providers: ["claude@ab12cd34": history(day: dayKey(Date()), tokens: 10, cost: 1)],
-            identities: ["claude@ab12cd34": "uuid-other|org-x"]
-        )
-        dataStore.setPeerHistoryDocuments([doc], ownDeviceID: "this-mac")
-        XCTAssertEqual(dataStore.remoteOnlySpend.count, 1)
+        XCTAssertEqual(total.slices.count, 2)
+        XCTAssertEqual(total.slices.map(\.amountUSD).sorted(), [2, 42])
 
         dataStore.clearPeerHistoryDocuments()
         XCTAssertTrue(dataStore.remoteOnlySpend.isEmpty, "sync off returns Total Spend to local-only")
     }
 
+    func testRemoteOnlySpendFollowsAnyEnabledFamilyCard() {
+        let doc = makeDocument(
+            providers: ["claude@ab12cd34": history(day: dayKey(Date()), tokens: 10, cost: 1)],
+            identities: ["claude@ab12cd34": "uuid-other|org-x"]
+        )
+        let cases: [(name: String, includeDefault: Bool, identities: [String: String]?,
+                     enabled: @MainActor (String) -> Bool, expected: Int)] = [
+            ("entire family disabled", true, nil, { _ in false }, 0),
+            ("missing bare card", false, ["claude@f15456b0": teamKey], { _ in true }, 1),
+            ("bare card disabled but sibling enabled", true, nil, { $0 != "claude" }, 1)
+        ]
+        for entry in cases {
+            let dataStore = makeDataStore(
+                entry.name, includeDefault: entry.includeDefault, identities: entry.identities,
+                isEnabled: entry.enabled
+            )
+            dataStore.setPeerHistoryDocuments([doc], ownDeviceID: "this-mac")
+            XCTAssertEqual(dataStore.remoteOnlySpend.count, entry.expected, entry.name)
+            if entry.expected > 0 {
+                XCTAssertEqual(dataStore.remoteOnlySpend.first?.provider.icon, .providerMark("claude"), entry.name)
+            }
+        }
+    }
+
+    func testUnresolvedLocalAccountHistoryIsNotPublished() {
+        let cache = scratchCache()
+        cache.store(snapshot(
+            providerID: "claude",
+            history: history(day: "2026-07-16", tokens: 10, cost: 1)
+        ))
+        let dataStore = makeDataStore("UnresolvedPublish", cache: cache, identities: [:])
+
+        let document = dataStore.localHistoryDocument(deviceID: "dev", deviceName: "This Mac")
+
+        XCTAssertNil(document.providers["claude"])
+        XCTAssertNil(document.identities)
+    }
+
     // MARK: - Fixtures
 
-    private func makeRegistry() -> WidgetRegistry {
+    private func makeDataStore(
+        _ name: String,
+        cache: ProviderSnapshotCache? = nil,
+        includeDefault: Bool = true,
+        identities: [String: String]? = nil,
+        isEnabled: @escaping @MainActor (String) -> Bool = { _ in true }
+    ) -> WidgetDataStore {
+        WidgetDataStore(
+            registry: makeRegistry(includeDefault: includeDefault),
+            providers: [],
+            cache: cache ?? scratchCache(),
+            defaults: makeScratchDefaults(name),
+            isProviderEnabled: isEnabled,
+            providerIdentityKeys: identities ?? ["claude": maxKey, "claude@f15456b0": teamKey]
+        )
+    }
+
+    private func makeRegistry(includeDefault: Bool = true) -> WidgetRegistry {
         let claude = ClaudeProvider.makeProvider()
         let extraCard = ClaudeProvider.makeProvider(id: "claude@f15456b0", displayName: "Claude — Team")
-        let descriptors = [
-            WidgetDescriptor.usageTrend(provider: claude)
-                .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test"),
-            WidgetDescriptor.usageTrend(provider: extraCard)
-                .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test"),
-        ]
-        return WidgetRegistry(providers: [claude, extraCard], descriptors: descriptors)
+        let providers = includeDefault ? [claude, extraCard] : [extraCard]
+        let descriptors = providers.map {
+            WidgetDescriptor.usageTrend(provider: $0)
+                .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test")
+        }
+        return WidgetRegistry(providers: providers, descriptors: descriptors)
     }
 
     private func scratchCache() -> ProviderSnapshotCache {

--- a/Tests/OpenUsageTests/ProviderAccountsStoreTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountsStoreTests.swift
@@ -3,6 +3,23 @@ import XCTest
 
 @MainActor
 final class ProviderAccountsStoreTests: XCTestCase {
+    private struct LegacyMirrorRecord: Codable {
+        struct Source: Codable {
+            enum Kind: String, Codable { case defaultHome }
+
+            var kind: Kind
+            var anchor: String?
+            var holdsDefaultSource: Bool
+        }
+
+        var id: String
+        var family: String
+        var identityKey: String
+        var label: String?
+        var sources: [Source]
+        var removedTombstone: Bool
+    }
+
     private func makeScratchDefaults() -> UserDefaults {
         let suiteName = "OpenUsageTests.ProviderAccounts.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -22,6 +39,21 @@ final class ProviderAccountsStoreTests: XCTestCase {
             identityKey: identityKey,
             label: label,
             sources: [ProviderAccountSource(kind: .defaultHome, anchor: anchor, holdsDefaultSource: true)]
+        )
+    }
+
+    private func sideObservation(
+        _ identityKey: String,
+        label: String? = nil,
+        kind: ProviderAccountSource.Kind = .desktop,
+        anchor: String? = nil,
+        keychainLiteral: String? = nil
+    ) -> ProviderAccountsStore.AccountObservation {
+        ProviderAccountsStore.AccountObservation(
+            family: "claude", identityKey: identityKey, label: label,
+            sources: [ProviderAccountSource(
+                kind: kind, anchor: anchor, holdsDefaultSource: false, keychainLiteral: keychainLiteral
+            )]
         )
     }
 
@@ -52,6 +84,123 @@ final class ProviderAccountsStoreTests: XCTestCase {
         XCTAssertEqual(new?.id, ProviderAccountID.make(family: "claude", identityKey: "acct-b"))
         XCTAssertEqual(store.defaultBadgeHolder(family: "claude")?.identityKey, "acct-b")
         XCTAssertEqual(old?.sources.contains(where: \.holdsDefaultSource), false, "the badge is exclusive per family")
+    }
+
+    func testRenamingCodexRuntimeUpdatesOnlyItsCurrentAccountAndSurvivesSwitchBack() throws {
+        let defaults = makeScratchDefaults()
+        let store = ProviderAccountsStore(defaults: defaults)
+        store.reconcile(with: [defaultHomeObservation(family: "codex", identityKey: "account-a", label: "alice@example.com")])
+        store.rename(cardID: "codex", to: "Alice")
+        store.reconcile(with: [defaultHomeObservation(family: "codex", identityKey: "account-b", label: "bob@example.com")])
+
+        let active = try XCTUnwrap(store.runtimeRecord(for: "codex"))
+        XCTAssertEqual(active.identityKey, "account-b")
+        XCTAssertNotEqual(active.id, "codex", "the runtime alias keeps permanent account ids")
+        XCTAssertEqual(store.derivedDisplayName(cardID: "codex"), "Codex — bob@example.com")
+        store.rename(cardID: "codex", to: "Bob")
+
+        let accountBID = try XCTUnwrap(store.runtimeRecord(for: "codex")?.id)
+        XCTAssertEqual(store.record(for: "codex")?.customLabel, "Alice")
+        XCTAssertEqual(store.record(for: accountBID)?.customLabel, "Bob")
+        XCTAssertEqual(store.resolvedDisplayName(cardID: "codex"), "Bob")
+        XCTAssertEqual(store.resolvedDisplayNamesByCardID["codex"], "Bob")
+        XCTAssertEqual(ProviderAccountsStore(defaults: defaults).record(for: accountBID)?.customLabel, "Bob")
+
+        store.reconcile(with: [defaultHomeObservation(family: "codex", identityKey: "account-a", label: "alice@example.com")])
+
+        XCTAssertEqual(store.runtimeRecord(for: "codex")?.identityKey, "account-a")
+        XCTAssertEqual(store.resolvedDisplayName(cardID: "codex"), "Alice")
+        XCTAssertEqual(store.record(for: accountBID)?.customLabel, "Bob")
+    }
+
+    func testUnverifiedCodexRuntimeCannotBorrowAPreviousAccountsName() {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        store.reconcile(with: [defaultHomeObservation(family: "codex", identityKey: "account-a", label: "alice@example.com")])
+        store.rename(cardID: "codex", to: "Alice")
+        store.clearDefaultSource(family: "codex")
+
+        XCTAssertNil(store.runtimeRecord(for: "codex"))
+        XCTAssertNil(store.resolvedDisplayName(cardID: "codex"))
+        XCTAssertNil(store.resolvedDisplayNamesByCardID["codex"])
+
+        store.rename(cardID: "codex", to: "Another Account")
+        XCTAssertEqual(store.record(for: "codex")?.customLabel, "Alice")
+    }
+
+    func testOrganizationAppearingOrDisappearingPreservesTheCardAliasesAndCustomName() {
+        for (previous, current) in [("acct-a", "acct-a|org-work"), ("acct-a|org-work", "acct-a")] {
+            let defaults = makeScratchDefaults()
+            let store = ProviderAccountsStore(defaults: defaults)
+            store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: previous)])
+            store.rename(cardID: "claude", to: "My Claude")
+
+            let records = store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: current)])
+
+            XCTAssertEqual(records.count, 1, "\(previous) → \(current)")
+            XCTAssertEqual(records.first?.id, "claude")
+            XCTAssertEqual(records.first?.identityKey, current)
+            XCTAssertEqual(records.first?.identityAliases, [previous])
+            XCTAssertEqual(records.first?.customLabel, "My Claude")
+            XCTAssertEqual(store.defaultBadgeHolder(family: "claude")?.id, "claude")
+            let reloaded = ProviderAccountsStore(defaults: defaults)
+            XCTAssertEqual(reloaded.record(for: "claude")?.identityKey, current)
+            XCTAssertEqual(reloaded.record(for: "claude")?.identityAliases, [previous])
+            XCTAssertEqual(reloaded.resolvedDisplayName(cardID: "claude"), "My Claude")
+        }
+    }
+
+    func testExplicitOrRememberedOrganizationsNeverShareAnAccountCard() {
+        for droppedOrganization in [false, true] {
+            let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+            store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a|org-work")])
+            store.rename(cardID: "claude", to: "Work")
+            if droppedOrganization {
+                store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a")])
+            }
+
+            let records = store.reconcile(with: [
+                defaultHomeObservation(family: "claude", identityKey: "acct-a|org-personal")
+            ])
+
+            XCTAssertEqual(records.count, 2)
+            XCTAssertEqual(store.record(for: "claude")?.identityKey,
+                           droppedOrganization ? "acct-a" : "acct-a|org-work")
+            XCTAssertEqual(store.record(for: "claude")?.customLabel, "Work")
+            XCTAssertEqual(records.first { $0.identityKey == "acct-a|org-personal" }?.id,
+                           ProviderAccountID.make(family: "claude", identityKey: "acct-a|org-personal"))
+            if droppedOrganization {
+                XCTAssertEqual(store.record(for: "claude")?.identityAliases, ["acct-a|org-work"])
+            }
+        }
+    }
+
+    func testOrganizationLessObservationIsQuarantinedWhenMultipleOrganizationsExist() {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        store.reconcile(with: [
+            defaultHomeObservation(family: "claude", identityKey: "acct-a|org-work"),
+            sideObservation("acct-a|org-personal"),
+        ])
+        let original = store.records
+
+        let records = store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a")])
+
+        XCTAssertEqual(records, original, "an unidentified organization must not claim either account")
+        XCTAssertEqual(store.defaultBadgeHolder(family: "claude")?.identityKey, "acct-a|org-work")
+    }
+
+    func testMultipleIncomingOrganizationsCannotClaimAnExistingOrganizationLessAccount() {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a")])
+
+        let records = store.reconcile(with: [
+            defaultHomeObservation(family: "claude", identityKey: "acct-a|org-work"),
+            sideObservation("acct-a|org-personal"),
+        ])
+
+        XCTAssertEqual(records.count, 3)
+        XCTAssertEqual(store.record(for: "claude")?.identityKey, "acct-a")
+        XCTAssertNotNil(records.first { $0.identityKey == "acct-a|org-work" })
+        XCTAssertNotNil(records.first { $0.identityKey == "acct-a|org-personal" })
     }
 
     func testUnobservedFamilyIsLeftUntouched() {
@@ -119,35 +268,158 @@ final class ProviderAccountsStoreTests: XCTestCase {
         XCTAssertTrue(ProviderAccountsStore(defaults: defaults).records.isEmpty)
     }
 
-    func testRenamePersistsAndAClearedNameFallsBackToTheDerivedOne() {
+    func testRenamePersistsAndFollowsTheAccountAcrossSourceChanges() {
         let defaults = makeScratchDefaults()
         let store = ProviderAccountsStore(defaults: defaults)
-        store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a", label: "a@example.com")])
-
-        store.rename(cardID: "claude", to: "  Work  ")
-        XCTAssertEqual(store.records[0].customLabel, "Work", "renames are trimmed")
-        XCTAssertEqual(store.records[0].resolvedDisplayName, "Work", "the resolver surfaces the rename")
-        XCTAssertEqual(ProviderAccountsStore(defaults: defaults).records[0].customLabel, "Work", "renames persist")
-
-        store.rename(cardID: "claude", to: "   ")
-        XCTAssertNil(store.records[0].customLabel, "a blank rename clears back to the derived name")
-        XCTAssertEqual(store.records[0].resolvedDisplayName, "Claude", "the bare card derives the stock family name")
-
-        store.rename(cardID: "missing", to: "X")
-        XCTAssertEqual(store.records.count, 1, "renaming an unknown card is a no-op")
-    }
-
-    func testReconcileNeverTouchesACustomLabel() {
-        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
-        store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a", label: "old")])
-        store.rename(cardID: "claude", to: "Work")
+        store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a", label: "old@example.com")])
+        store.rename(cardID: "claude", to: "  Personal  ")
 
         let records = store.reconcile(with: [
-            defaultHomeObservation(family: "claude", identityKey: "acct-a", label: "new"),
+            defaultHomeObservation(family: "claude", identityKey: "acct-b"),
+            sideObservation(
+                "acct-a", label: "new@example.com", kind: .configDir,
+                anchor: "/Users/dev/.claude-personal", keychainLiteral: "~/.claude-personal"
+            ),
         ])
 
-        XCTAssertEqual(records[0].label, "new")
-        XCTAssertEqual(records[0].customLabel, "Work", "rescans update the label but never the rename")
+        let original = records.first { $0.id == "claude" }
+        XCTAssertEqual(original?.identityKey, "acct-a")
+        XCTAssertEqual(original?.sources.map(\.kind), [.configDir])
+        XCTAssertEqual(original?.sources.first?.keychainLiteral, "~/.claude-personal")
+        XCTAssertEqual(original?.customLabel, "Personal")
+        XCTAssertEqual(store.runtimeRecord(for: "claude")?.identityKey, "acct-a")
+        XCTAssertEqual(store.resolvedDisplayName(cardID: "claude"), "Personal")
+        XCTAssertEqual(store.defaultBadgeHolder(family: "claude")?.identityKey, "acct-b")
+        XCTAssertEqual(
+            ProviderAccountsStore(defaults: defaults).record(for: "claude")?.customLabel,
+            "Personal"
+        )
+        store.rename(cardID: "claude", to: "   ")
+        XCTAssertNil(store.record(for: "claude")?.customLabel)
+        XCTAssertEqual(store.resolvedDisplayName(cardID: "claude"), "Claude — new@example.com")
+    }
+
+    func testAccountNamesKeepTheBareTitleUntilAnotherOrganizationAppears() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        store.reconcile(with: [
+            defaultHomeObservation(
+                family: "claude",
+                identityKey: "acct-work|org-work",
+                label: "rob@example.com (SUNSTORY)"
+            ),
+        ])
+
+        XCTAssertEqual(store.derivedDisplayName(cardID: "claude"), "Claude")
+        XCTAssertEqual(store.resolvedDisplayName(cardID: "claude"), "Claude")
+        store.reconcile(with: [
+            defaultHomeObservation(
+                family: "claude",
+                identityKey: "acct-work|org-work",
+                label: "rob@example.com (SUNSTORY)"
+            ),
+            sideObservation("acct-personal|org-personal", label: "rob@example.com (rob@example.com's Organization)"),
+        ])
+
+        let personal = try XCTUnwrap(store.records.first { $0.id != "claude" })
+        XCTAssertEqual(store.derivedDisplayName(cardID: "claude"), "Claude — SUNSTORY")
+        XCTAssertEqual(store.derivedDisplayName(cardID: personal.id), "Claude — Personal")
+        XCTAssertEqual(store.resolvedDisplayNamesByCardID[personal.id], "Claude — Personal")
+        store.reconcile(with: [
+            sideObservation("acct-other|org-other", label: "other@example.com (SUNSTORY)"),
+        ])
+
+        let duplicate = try XCTUnwrap(store.records.first { $0.identityKey == "acct-other|org-other" })
+        XCTAssertNotEqual(store.derivedDisplayName(cardID: "claude"), store.derivedDisplayName(cardID: duplicate.id))
+        store.rename(cardID: "claude", to: "My Custom Name")
+        XCTAssertEqual(store.resolvedDisplayName(cardID: "claude"), "My Custom Name")
+        XCTAssertEqual(store.resolvedDisplayName(cardID: duplicate.id), "Claude — SUNSTORY")
+    }
+
+    func testUnknownSourceKindsSurviveDecodeAndReconciliation() throws {
+        let defaults = makeScratchDefaults()
+        let persisted = #"[{"id":"claude","family":"claude","identityKey":"acct-a","label":"Personal","sources":[{"kind":"futureVault","anchor":"vault-a","holdsDefaultSource":false}],"removedTombstone":false}]"#
+        defaults.set(Data(persisted.utf8), forKey: ProviderAccountsStore.storageKey)
+        let store = ProviderAccountsStore(defaults: defaults)
+
+        XCTAssertEqual(store.records.count, 1, "a forward source must not wipe the entire registry")
+        XCTAssertEqual(store.records[0].sources.first?.kind.rawValue, "futureVault")
+
+        store.reconcile(with: [defaultHomeObservation(family: "claude", identityKey: "acct-a")])
+
+        let reloaded = ProviderAccountsStore(defaults: defaults)
+        XCTAssertEqual(
+            Set(reloaded.records[0].sources.map(\.kind.rawValue)),
+            ["defaultHome", "futureVault"]
+        )
+        XCTAssertEqual(reloaded.records[0].sources.last?.anchor, "vault-a")
+    }
+
+    func testConfigDirectoryOnlyAccountDoesNotClaimReservedBareID() {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let records = store.reconcile(with: [
+            sideObservation("acct-side", kind: .configDir, anchor: "/Users/dev/.claude-side")
+        ])
+
+        XCTAssertEqual(records.first?.id, ProviderAccountID.make(family: "claude", identityKey: "acct-side"))
+    }
+
+    func testLegacyRegistryMigratesToV2AndRepairsDowngradeMirrorWithoutLosingNames() throws {
+        let defaults = makeScratchDefaults()
+        let unsafeLegacy = #"[{"id":"claude","family":"claude","identityKey":"acct-a|org-a","label":"a@example.com","customLabel":"Personal","sources":[{"kind":"defaultHome","anchor":"/Users/dev/.claude","holdsDefaultSource":true},{"kind":"configDir","anchor":"/Users/dev/.claude-side","holdsDefaultSource":false,"keychainLiteral":"~/.claude-side"}],"removedTombstone":false},{"id":"claude@12345678","family":"claude","identityKey":"acct-b|org-b","label":"b@example.com","customLabel":"Work","sources":[{"kind":"desktop","anchor":null,"holdsDefaultSource":false}],"removedTombstone":false}]"#
+        defaults.set(Data(unsafeLegacy.utf8), forKey: ProviderAccountsStore.legacyStorageKey)
+
+        let migrated = ProviderAccountsStore(defaults: defaults)
+
+        XCTAssertEqual(migrated.records.count, 2)
+        XCTAssertEqual(migrated.record(for: "claude")?.customLabel, "Personal")
+        XCTAssertEqual(migrated.record(for: "claude@12345678")?.customLabel, "Work")
+        XCTAssertNotNil(defaults.data(forKey: ProviderAccountsStore.storageKey))
+
+        let mirrorData = try XCTUnwrap(defaults.data(forKey: ProviderAccountsStore.legacyStorageKey))
+        let downgradeRecords = try JSONDecoder().decode([LegacyMirrorRecord].self, from: mirrorData)
+        XCTAssertEqual(downgradeRecords.count, 2)
+        XCTAssertEqual(downgradeRecords[0].sources.map(\.kind), [.defaultHome])
+        XCTAssertTrue(downgradeRecords[1].sources.isEmpty)
+
+        // An old release may rewrite its own mirror; v2 remains authoritative on re-upgrade.
+        defaults.set(try JSONEncoder().encode([downgradeRecords[0]]), forKey: ProviderAccountsStore.legacyStorageKey)
+        let upgradedAgain = ProviderAccountsStore(defaults: defaults)
+        XCTAssertEqual(upgradedAgain.records.count, 2)
+        XCTAssertEqual(upgradedAgain.record(for: "claude@12345678")?.customLabel, "Work")
+        XCTAssertEqual(upgradedAgain.record(for: "claude@12345678")?.sources.map(\.kind), [.desktop])
+    }
+
+    func testClearingDefaultSourcePreservesAccountAndOtherSources() {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        store.reconcile(with: [
+            ProviderAccountsStore.AccountObservation(
+                family: "claude",
+                identityKey: "acct-a",
+                label: "Personal",
+                sources: [
+                    ProviderAccountSource(kind: .defaultHome, anchor: "/Users/dev/.claude", holdsDefaultSource: true),
+                    ProviderAccountSource(kind: .desktop, anchor: nil, holdsDefaultSource: false),
+                ]
+            ),
+        ])
+        store.rename(cardID: "claude", to: "Saved Name")
+
+        store.clearDefaultSource(family: "claude")
+
+        XCTAssertNil(store.defaultBadgeHolder(family: "claude"))
+        XCTAssertEqual(store.record(for: "claude")?.sources.map(\.kind), [.desktop])
+        XCTAssertEqual(store.record(for: "claude")?.customLabel, "Saved Name")
+    }
+
+    func testClaudeIdentityNormalizesAndQuarantinesAmbiguousOrganizations() {
+        XCTAssertEqual(ClaudeIdentity("  USER|ORG  ")?.key, "user|org")
+        for malformed in ["", "|org", "user|", "user|org|another", "user name"] {
+            XCTAssertNil(ClaudeIdentity(malformed), malformed)
+        }
+        let orgless = ClaudeIdentity("user")!
+        let scoped = ClaudeIdentity("user|org")!
+        XCTAssertEqual(ClaudeIdentity.canonical(orgless, among: [orgless, scoped]), scoped)
+        XCTAssertNil(ClaudeIdentity.canonical(orgless, among: [scoped, ClaudeIdentity("user|other")!]))
     }
 
     func testFamilyHelperSplitsCardIDs() {


### PR DESCRIPTION
## TL;DR

Make account identities stable across upgrades, aliases, and different Macs without merging accounts that might belong to different people.

## What was happening

- A Claude account can appear with or without its organization depending on which local application exposes it.
- Old account records could become unreadable after a downgrade, and ambiguous synced identities could merge incorrectly.

## What this changes

- Normalize account identities and recognize safe account aliases only when ownership is unambiguous.
- Migrate persisted account records while preserving a downgrade-compatible legacy mirror.
- Match iCloud history using canonical account identity and quarantine ambiguous organizations.
- Treat incomplete Desktop discovery as safety evidence without trusting it for account ownership.

## Heads-up

- This is stacked on the Claude Desktop and Cowork discovery PR.

## Tests

- Includes focused account migration, downgrade compatibility, identity normalization, ambiguity, and cross-device history regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes persisted account identity, Desktop credential pinning, and iCloud history matching. Incorrect aliasing could merge spend or credentials across organizations.
> 
> **Overview**
> Stops Claude accounts from silently merging when the same login appears with or without an organization. Aliases are kept only when the full local (and peer) identity set proves a single org; otherwise observations and synced histories are quarantined.
> 
> The account registry moves to `openusage.providerAccounts.v2` with identity aliases, string-backed source kinds, and a repaired v1 mirror so downgrades still decode. Codex’s bare `codex` id now follows the current default-home owner; Claude keeps a permanent card id. Display names distinguish sibling orgs (including “Personal”) only when more than one account is present.
> 
> iCloud remapping canonicalizes Claude identities the same way, so org-less and org-scoped spellings can merge across Macs only when unambiguous. Incomplete Cowork sandbox walks are flagged `truncated` (budget raised to 3s) and used as safety evidence for Desktop token pinning without driving spend routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a227b57b79a2f8165b411258805337fdcc7926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->