### PR TITLE
Claude accounts 6: credential ownership, subscription tiers, and logout

### DIFF
--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -186,15 +186,14 @@ struct ClaudeAuthStore: Sendable {
     var desktop: ClaudeDesktopAuthStore
     var now: @Sendable () -> Date
     let scope: ClaudeCredentialScope
-    /// The `.standard` card's Desktop fallback pins to this org once extra Claude cards exist (the
-    /// default account's own org, parsed from its identity key) — an unpinned fallback could borrow
-    /// a Desktop login that belongs to one of the other cards, fetching that account's usage onto
-    /// the default card.
-    let standardDesktopOrganization: String?
-    /// Whether the `.standard` store may fall back to Desktop's *active* org when no org pin is
-    /// known. On by default (the historical single-account behavior); the catalog turns it OFF once
-    /// extra Claude account cards exist, so without a pin the fallback is disabled rather than blind.
-    let allowsUnpinnedStandardDesktopFallback: Bool
+    /// Account assembly owns this closed authorization; spend-root routing cannot widen it.
+    let desktopAccessPolicy: ClaudeDesktopAccessPolicy
+    /// The standard CLI store's unsuffixed keychain fallback is independent of Desktop routing.
+    let allowsUnscopedStandardKeychainFallback: Bool
+
+    var standardDesktopOrganization: String? { desktopAccessPolicy.organization }
+    /// Compatibility for direct auth-store callers; account-bound runtimes use the semantic name.
+    var allowsUnpinnedStandardDesktopFallback: Bool { allowsUnscopedStandardKeychainFallback }
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
@@ -202,8 +201,10 @@ struct ClaudeAuthStore: Sendable {
         keychain: KeychainAccessing = SecurityKeychainAccessor(),
         desktop: ClaudeDesktopAuthStore? = nil,
         scope: ClaudeCredentialScope = .standard,
+        desktopAccessPolicy: ClaudeDesktopAccessPolicy? = nil,
         standardDesktopOrganization: String? = nil,
         allowsUnpinnedStandardDesktopFallback: Bool = true,
+        allowsUnscopedStandardKeychainFallback: Bool? = nil,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.environment = environment
@@ -211,8 +212,17 @@ struct ClaudeAuthStore: Sendable {
         self.keychain = keychain
         self.desktop = desktop ?? ClaudeDesktopAuthStore(files: files, now: now)
         self.scope = scope
-        self.standardDesktopOrganization = standardDesktopOrganization?.nilIfEmpty?.lowercased()
-        self.allowsUnpinnedStandardDesktopFallback = allowsUnpinnedStandardDesktopFallback
+        if let desktopAccessPolicy {
+            self.desktopAccessPolicy = desktopAccessPolicy
+        } else if let organization = standardDesktopOrganization?.nilIfEmpty?.lowercased() {
+            self.desktopAccessPolicy = .pinned(organization)
+        } else {
+            self.desktopAccessPolicy = allowsUnpinnedStandardDesktopFallback
+                ? .activeOrganization
+                : .denied
+        }
+        self.allowsUnscopedStandardKeychainFallback = allowsUnscopedStandardKeychainFallback
+            ?? allowsUnpinnedStandardDesktopFallback
         self.now = now
     }
 
@@ -232,18 +242,16 @@ struct ClaudeAuthStore: Sendable {
         // scope), never a competing account source. Scoped cards are stricter: a `.configDir` card
         // never consults Desktop at all (that login belongs to another card), and a `.desktopOnly`
         // card consults nothing else — always pinned to its own org.
-        let desktopAllowed: Bool
-        var desktopOrganization: String?
+        let desktopAccess: ClaudeDesktopAccessPolicy
         switch scope {
         case .standard:
-            desktopAllowed = standardDesktopOrganization != nil || allowsUnpinnedStandardDesktopFallback
-            desktopOrganization = standardDesktopOrganization
+            desktopAccess = desktopAccessPolicy
         case .desktopOnly(let organization):
-            desktopAllowed = true
-            desktopOrganization = organization
+            desktopAccess = .pinned(organization)
         case .configDir:
-            desktopAllowed = false
+            desktopAccess = .denied
         }
+        let desktopAllowed = desktopAccess != .denied
         if forceDesktopFallback, !desktopAllowed {
             // Tell the provider there is no safe Desktop candidate so it preserves the original CLI
             // auth error instead of converting it to a generic "not logged in" result.
@@ -253,7 +261,10 @@ struct ClaudeAuthStore: Sendable {
             $0.hasUsableAccessToken && liveUsageAvailability($0) == .available
         }
         if desktopAllowed, forceDesktopFallback || !hasUsableCLILogin {
-            let result = desktop.load(allowInteraction: allowDesktopInteraction, organization: desktopOrganization)
+            let result = desktop.load(
+                allowInteraction: allowDesktopInteraction,
+                organization: desktopAccess.organization
+            )
             desktopStatus = result.status
             if let oauth = result.oauth {
                 stored.insert(ClaudeCredentialState(
@@ -286,12 +297,62 @@ struct ClaudeAuthStore: Sendable {
             return keychainServiceCandidates().contains {
                 keychain.genericPasswordExists(service: $0) == true
             }
-        case .desktopOnly(let organization):
-            // `allowInteraction: false` can never raise a dialog: a not-yet-granted Safe Storage key
-            // read comes back as `.permissionRequired`, which still proves a Desktop login exists.
-            let status = desktop.load(allowInteraction: false, organization: organization).status
-            return status == .available || status == .permissionRequired || status == .stale
+        case .desktopOnly:
+            // Assembly already established this account's organization from its Cowork state.
+            // Encrypted Desktop material is sufficient for seeding; decrypting it here would
+            // touch another app's Safe Storage item before the user explicitly refreshes.
+            return desktop.hasCredentialMaterial()
         }
+    }
+
+    /// Verify the identity attached to this exact credential source before a bound account card
+    /// reads or publishes anything. Credential files do not identify their owner, so the source's
+    /// own Claude state file is the authority; a missing or ambiguous state never gets guessed.
+    func matchesIdentity(_ expectedIdentityKey: String) -> Bool {
+        guard let expected = ClaudeIdentity(expectedIdentityKey) else { return false }
+        let identityPath: String
+
+        switch scope {
+        case .desktopOnly(let organization):
+            return expected.organization == organization.lowercased()
+
+        case .configDir(let path, _):
+            identityPath = "\(path)/.claude.json"
+
+        case .standard:
+            let configuredHome = claudeHomeOverride() ?? Self.defaultClaudeHome
+            guard !configuredHome.contains(",") else { return false }
+            let expandedHome = (configuredHome as NSString).expandingTildeInPath
+            let expandedDefault = (Self.defaultClaudeHome as NSString).expandingTildeInPath
+            identityPath = URL(fileURLWithPath: expandedHome).standardizedFileURL.path
+                == URL(fileURLWithPath: expandedDefault).standardizedFileURL.path
+                ? "\(configuredHome).json"
+                : "\(configuredHome)/.claude.json"
+        }
+
+        let text: String
+        do {
+            guard let stored = try files.readTextIfPresent(identityPath) else { return false }
+            text = stored
+        } catch {
+            AppLog.error(
+                LogTag.auth("claude"),
+                "couldn't verify the bound Claude account identity: \(error.localizedDescription)"
+            )
+            return false
+        }
+
+        guard let state = try? JSONDecoder().decode(
+                  DefaultAccountObserver.ClaudeStateFile.self,
+                  from: Data(text.utf8)
+              ),
+              let account = state.oauthAccount,
+              let observed = DefaultAccountObserver.claudeIdentityKey(account)
+        else {
+            return false
+        }
+        guard let identity = ClaudeIdentity(observed) else { return false }
+        return identity.matchesExactly(expected)
     }
 
     private func applyingEnvironmentToken(to stored: [ClaudeCredentialState]) -> [ClaudeCredentialState] {
@@ -486,7 +547,10 @@ struct ClaudeAuthStore: Sendable {
             return []
         case .standard:
             if let configDir = claudeHomeOverride() {
-                return ["\(base)-\(hashSuffix(configDir))", base]
+                let scoped = "\(base)-\(hashSuffix(configDir))"
+                // With multiple known logins, the unsuffixed item can belong to another
+                // account's default home. A config-dir login must never borrow it.
+                return allowsUnscopedStandardKeychainFallback ? [scoped, base] : [scoped]
             }
             return [base]
         }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
@@ -267,18 +267,21 @@ struct ClaudeDesktopAuthStore: Sendable {
         now: Date
     ) -> Selection {
         let normalizedOrg = activeOrganization.lowercased()
-        let v2Candidates = candidates(in: v2, organization: normalizedOrg, now: now)
-        if let best = v2Candidates.available.max(by: { $0.rank < $1.rank }) {
-            return .available(best.oauth)
-        }
+        let v2Candidates = candidates(in: v2, organization: normalizedOrg, now: now, isCurrentGeneration: true)
 
+        // A v2 key (live or tombstoned) always speaks for its v1 twin, but the two generations
+        // compete in ONE ranked pool. Short-circuiting on "any live v2 entry" once let a
+        // profile-only v2 leftover (carrying stale tier metadata) beat the current full-scope
+        // login whose live token existed only in v1 — token quality must outrank cache
+        // generation, with generation only breaking quality ties.
         let v2Keys = Set(v2?.keys ?? Dictionary<String, Any>().keys)
         let v1Candidates = candidates(
             in: v1?.filter { !v2Keys.contains($0.key) },
             organization: normalizedOrg,
-            now: now
+            now: now,
+            isCurrentGeneration: false
         )
-        if let best = v1Candidates.available.max(by: { $0.rank < $1.rank }) {
+        if let best = (v2Candidates.available + v1Candidates.available).max(by: { $0.rank < $1.rank }) {
             return .available(best.oauth)
         }
         if v2Candidates.sawStale || v1Candidates.sawStale { return .stale }
@@ -297,12 +300,15 @@ struct ClaudeDesktopAuthStore: Sendable {
         var clientID: String
         var scopes: [String]
         var expiresAt: Double
+        /// `true` for the v2 cache, Desktop's current generation.
+        var isCurrentGeneration: Bool
 
         /// Selection order mirrors Desktop's own resolution instead of raw expiry: production client
         /// with full scopes first, then any full-scope entry over bare `user:profile` leftovers, then
-        /// scope richness, with expiry only as the final tiebreak. A stale wrong-tier token with a
-        /// longer TTL must not outrank the current login.
-        var rank: (Int, Int, Int, Double) {
+        /// scope richness, then the newer cache generation, with expiry only as the final tiebreak.
+        /// A stale wrong-tier token with a longer TTL must not outrank the current login, and a
+        /// newer-generation entry must not outrank a better-quality older one.
+        var rank: (Int, Int, Int, Int, Double) {
             let hasFullScope = scopes.contains(ClaudeDesktopAuthStore.usageScope)
                 && scopes.contains(ClaudeDesktopAuthStore.inferenceScope)
             let isProductionClient = clientID == ClaudeDesktopAuthStore.productionClientID
@@ -310,6 +316,7 @@ struct ClaudeDesktopAuthStore: Sendable {
                 isProductionClient && hasFullScope ? 1 : 0,
                 hasFullScope ? 1 : 0,
                 scopes.count,
+                isCurrentGeneration ? 1 : 0,
                 expiresAt
             )
         }
@@ -318,7 +325,8 @@ struct ClaudeDesktopAuthStore: Sendable {
     private static func candidates(
         in cache: [String: Any]?,
         organization: String,
-        now: Date
+        now: Date,
+        isCurrentGeneration: Bool
     ) -> (available: [Candidate], sawStale: Bool, sawInvalid: Bool) {
         guard let cache else { return ([], false, false) }
         var available: [Candidate] = []
@@ -358,7 +366,8 @@ struct ClaudeDesktopAuthStore: Sendable {
                 oauth: oauth,
                 clientID: parsedKey.clientID,
                 scopes: parsedKey.scopes,
-                expiresAt: expiresAt
+                expiresAt: expiresAt,
+                isCurrentGeneration: isCurrentGeneration
             ))
         }
         return (available, sawStale, sawInvalid)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -3,9 +3,6 @@ import Foundation
 
 @MainActor
 final class ClaudeProvider: ProviderRuntime {
-    /// The default card's identity. Extra account cards inject their own `Provider` with an
-    /// `@`-suffixed id and an account-derived display name; everything else about the runtime is
-    /// identical.
     static func makeProvider(id: String = "claude", displayName: String = "Claude") -> Provider {
         Provider(
             id: id,
@@ -25,6 +22,7 @@ final class ClaudeProvider: ProviderRuntime {
     let logUsageScanner: ClaudeLogUsageScanner
     let now: @Sendable () -> Date
     let pricing: @Sendable () async -> ModelPricing
+    let expectedIdentityKey: String?
 
     /// Last successful live-usage result and a rate-limit cooldown, carried across refreshes (the provider
     /// is a long-lived singleton). `/api/oauth/usage` rate-limits aggressively, so on a 429 we serve the
@@ -42,7 +40,8 @@ final class ClaudeProvider: ProviderRuntime {
         usageClient: ClaudeUsageClient = ClaudeUsageClient(),
         logUsageScanner: ClaudeLogUsageScanner = ClaudeLogUsageScanner(),
         now: @escaping @Sendable () -> Date = Date.init,
-        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
+        pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() },
+        expectedIdentityKey: String? = nil
     ) {
         self.provider = provider
         self.authStore = authStore
@@ -50,6 +49,7 @@ final class ClaudeProvider: ProviderRuntime {
         self.logUsageScanner = logUsageScanner
         self.now = now
         self.pricing = pricing
+        self.expectedIdentityKey = expectedIdentityKey
     }
 
     var widgetDescriptors: [WidgetDescriptor] {
@@ -74,9 +74,6 @@ final class ClaudeProvider: ProviderRuntime {
     }
 
     func hasLocalCredentials() async -> Bool {
-        // Scoped cards answer from footprints only (file existence / keychain attributes) so the
-        // every-launch seeding probe can never raise a keychain dialog for an account the user
-        // hasn't granted yet. The secret read happens on the first refresh.
         if authStore.scope != .standard {
             return await loadOffMainActor { [authStore] in authStore.hasCredentialFootprint() }
         }
@@ -102,12 +99,22 @@ final class ClaudeProvider: ProviderRuntime {
         forceDesktopFallback: Bool,
         previousFallbackError: ClaudeAuthError?
     ) async -> ProviderSnapshot {
+        guard await sourceStillBelongsToAccount() else {
+            clearLiveUsageCache()
+            AppLog.warn(LogTag.auth("claude"), "account-bound credential source no longer matches its card")
+            return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.credentialsChanged)
+        }
+
         let allowDesktopInteraction = ProviderRefreshContext.isManual
         let credentialLoad = await loadOffMainActor { [authStore] in
             authStore.loadCredentialSet(
                 allowDesktopInteraction: allowDesktopInteraction,
                 forceDesktopFallback: forceDesktopFallback
             )
+        }
+        guard await sourceStillBelongsToAccount() else {
+            clearLiveUsageCache()
+            return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.credentialsChanged)
         }
         let storedCandidates = credentialLoad.candidates
         let candidates = storedCandidates.filter {
@@ -159,6 +166,10 @@ final class ClaudeProvider: ProviderRuntime {
                 mapped: ClaudeMappedUsage(plan: nil, lines: []),
                 warning: error.localizedDescription
             )
+            guard await sourceStillBelongsToAccount() else {
+                clearLiveUsageCache()
+                return ProviderSnapshot.error(provider: provider, error: ClaudeAuthError.credentialsChanged)
+            }
             guard let history = snapshot.usageHistory,
                   history.series.daily.contains(where: {
                       $0.totalTokens > 0 || ($0.costUSD ?? 0) > 0
@@ -276,7 +287,9 @@ final class ClaudeProvider: ProviderRuntime {
             warning = fallbackWarning
         }
 
-        return await snapshotWithLocalUsage(mapped: mapped, warning: warning)
+        let snapshot = await snapshotWithLocalUsage(mapped: mapped, warning: warning)
+        guard await sourceStillBelongsToAccount() else { throw ClaudeAuthError.credentialsChanged }
+        return snapshot
     }
 
     private func snapshotWithLocalUsage(
@@ -289,6 +302,9 @@ final class ClaudeProvider: ProviderRuntime {
         // Both scans run on their scanner actors, off the main actor, and do not require an OAuth login.
         let pricing = await pricing()
         let nativeScan = await logUsageScanner.scan(now: now(), pricing: pricing)
+        // pi's logs name the Claude family, never an account id. Attribute them only to the
+        // runtime that currently owns the default credential source, even when that account's
+        // stable card id is hashed and the original bare-id account has moved elsewhere.
         let piScan: LogUsageScan?
         if authStore.scope == .standard {
             piScan = await PiUsageScanner.shared.scan(cardID: "claude", now: now(), pricing: pricing)
@@ -385,6 +401,7 @@ final class ClaudeProvider: ProviderRuntime {
             authStore.credentialGeneration(forceDesktopFallback: forceDesktopGeneration)
         }
         guard currentGeneration == expectedGeneration else { throw ClaudeAuthError.credentialsChanged }
+        guard await sourceStillBelongsToAccount() else { throw ClaudeAuthError.credentialsChanged }
 
         // 429 can come back from either attempt; the helper hands both through unchanged. Start a cooldown
         // (respecting Retry-After) and serve the last-good usage rather than a bare badge.
@@ -420,8 +437,19 @@ final class ClaudeProvider: ProviderRuntime {
         let fingerprint = Self.credentialFingerprint(credentials)
         guard cachedCredentialFingerprint != fingerprint else { return }
         cachedCredentialFingerprint = fingerprint
+        clearLiveUsageCache()
+    }
+
+    private func clearLiveUsageCache() {
         lastGoodUsage = nil
         rateLimitedUntil = nil
+    }
+
+    private func sourceStillBelongsToAccount() async -> Bool {
+        guard let expectedIdentityKey else { return true }
+        return await loadOffMainActor { [authStore] in
+            authStore.matchesIdentity(expectedIdentityKey)
+        }
     }
 
     private static func credentialFingerprint(_ credentials: ClaudeOAuth) -> Data {
@@ -475,8 +503,12 @@ final class ClaudeProvider: ProviderRuntime {
         // rather than fail the live fetch.
         let persisted: Bool
         do {
+            let expectedIdentityKey = expectedIdentityKey
             guard try await Task.detached(priority: .utility, operation: { [authStore, state] in
-                try authStore.save(state, ifUnchanged: expectedGeneration)
+                if let expectedIdentityKey, !authStore.matchesIdentity(expectedIdentityKey) {
+                    throw ClaudeAuthError.credentialsChanged
+                }
+                return try authStore.save(state, ifUnchanged: expectedGeneration)
             }).value else {
                 throw ClaudeAuthError.credentialsChanged
             }

--- a/Tests/OpenUsageTests/ClaudeAccountIsolationTests.swift
+++ b/Tests/OpenUsageTests/ClaudeAccountIsolationTests.swift
@@ -134,6 +134,82 @@ final class ClaudeAccountIsolationTests: XCTestCase {
         XCTAssertEqual(usageRequests(fixture.http).count, 2)
     }
 
+    func testAccountBoundRuntimeNeverPublishesADifferentLoginAfterMidRequestSwap() async {
+        let accountA = credentials(access: "account-a", refresh: "refresh-a", plan: "pro")
+        let accountB = credentials(access: "account-b", refresh: "refresh-b", plan: "max")
+        let identityPath = "/tmp/claude/.claude.json"
+        let files = FakeFiles([
+            path: accountA,
+            identityPath: Self.identity(uuid: "account-a", organization: "personal"),
+        ])
+        let fixture = makeFixture(
+            files: files,
+            expectedIdentityKey: "account-a|personal"
+        ) { [path] request in
+            if request.headers["Authorization"] == "Bearer account-a" {
+                files.files[path] = accountB
+                files.files[identityPath] = Self.identity(uuid: "account-b", organization: "work")
+                return Self.usageResponse(percent: 25)
+            }
+            return Self.usageResponse(percent: 75)
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertNil(sessionUsage(snapshot), "another account's limits must never be published on the bound card")
+        XCTAssertNotNil(snapshot.errorCategory)
+        XCTAssertFalse(usageRequests(fixture.http).contains {
+            $0.headers["Authorization"] == "Bearer account-b"
+        })
+    }
+
+    func testAccountBoundRuntimeRejectsAnotherOrganizationForTheSameClaudeUser() async {
+        let files = FakeFiles([
+            path: credentials(access: "team-token", refresh: "team-refresh", plan: "team"),
+            "/tmp/claude/.claude.json": Self.identity(uuid: "shared-user", organization: "team"),
+        ])
+        let fixture = makeFixture(
+            files: files,
+            expectedIdentityKey: "shared-user|personal"
+        ) { _ in
+            XCTFail("a credential owned by another organization must never reach the usage endpoint")
+            return Self.usageResponse(percent: 80)
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertNil(sessionUsage(snapshot))
+        XCTAssertNotNil(snapshot.errorCategory)
+        XCTAssertTrue(fixture.http.requests.isEmpty)
+    }
+
+    func testAccountBoundRuntimeStillAcceptsTokenRotationForTheSameAccount() async {
+        let files = FakeFiles([
+            path: credentials(
+                access: "old-access", refresh: "old-refresh", plan: "pro", expiresAt: 1
+            ),
+            "/tmp/claude/.claude.json": Self.identity(uuid: "account-a", organization: "personal"),
+        ])
+        let fixture = makeFixture(
+            files: files,
+            expectedIdentityKey: "account-a|personal"
+        ) { request in
+            if request.url.absoluteString.hasSuffix("/v1/oauth/token") {
+                return HTTPResponse(
+                    statusCode: 200,
+                    headers: [:],
+                    body: Data(#"{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}"#.utf8)
+                )
+            }
+            return Self.usageResponse(percent: 25)
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertEqual(sessionUsage(snapshot), 25)
+        XCTAssertTrue(files.files[path]?.contains("new-refresh") == true)
+    }
+
     func testHigherPriorityLoginAddedDuringUsageRequestWins() async {
         let accountA = credentials(access: "account-a", refresh: "refresh-a", plan: "pro")
         let accountB = credentials(access: "account-b", refresh: "refresh-b", plan: "max")
@@ -232,6 +308,34 @@ final class ClaudeAccountIsolationTests: XCTestCase {
         )
     }
 
+
+    func testSubscriptionDowngradeUpdatesPlanWithoutChangingAccountOrBillingLookup() async {
+        let identityPath = "/tmp/claude/.claude.json"
+        let files = FakeFiles([
+            identityPath:
+                #"{"oauthAccount":{"accountUuid":"ACCOUNT-A","organizationUuid":"PERSONAL"}}"#,
+            path:
+                #"{"claudeAiOauth":{"accessToken":"same-account-token","subscriptionType":"max","rateLimitTier":"default_claude_max_20x","scopes":["user:profile"]}}"#,
+        ])
+        let fixture = makeFixture(files: files, expectedIdentityKey: "account-a|personal") {
+            _ in Self.usageResponse(percent: 25)
+        }
+
+        let maxSnapshot = await fixture.provider.refresh()
+        XCTAssertEqual(maxSnapshot.plan, "Max 20x")
+
+        files.files[path] =
+            #"{"claudeAiOauth":{"accessToken":"same-account-token","subscriptionType":"pro","rateLimitTier":"default_claude_pro","scopes":["user:profile"]}}"#
+        let downgradedSnapshot = await fixture.provider.refresh()
+
+        XCTAssertEqual(downgradedSnapshot.plan, "Pro")
+        XCTAssertEqual(downgradedSnapshot.providerID, maxSnapshot.providerID)
+        XCTAssertEqual(fixture.http.requests.count, 2)
+        XCTAssertTrue(fixture.http.requests.allSatisfy {
+            $0.url.absoluteString == "https://api.anthropic.com/api/oauth/usage"
+        })
+    }
+
     private struct Fixture {
         var provider: ClaudeProvider
         var files: FakeFiles
@@ -248,6 +352,7 @@ final class ClaudeAccountIsolationTests: XCTestCase {
     private func makeFixture(
         files: FakeFiles,
         keychain: any KeychainAccessing = FakeKeychain(),
+        expectedIdentityKey: String? = nil,
         handler: @escaping @Sendable (HTTPRequest) async throws -> HTTPResponse
     ) -> Fixture {
         let http = RoutingHTTPClient(handler: handler)
@@ -263,7 +368,8 @@ final class ClaudeAccountIsolationTests: XCTestCase {
                 usageClient: ClaudeUsageClient(httpClient: http),
                 logUsageScanner: ClaudeLogFixture.scanner(home: nil),
                 now: { now },
-                pricing: { TestPricing.bundled }
+                pricing: { TestPricing.bundled },
+                expectedIdentityKey: expectedIdentityKey
             ),
             files: files,
             http: http
@@ -277,6 +383,10 @@ final class ClaudeAccountIsolationTests: XCTestCase {
         expiresAt: Double = 4_102_444_800_000
     ) -> String {
         #"{"claudeAiOauth":{"accessToken":"\#(access)","refreshToken":"\#(refresh)","expiresAt":\#(expiresAt),"subscriptionType":"\#(plan)","scopes":["user:profile"]}}"#
+    }
+
+    private nonisolated static func identity(uuid: String, organization: String) -> String {
+        #"{"oauthAccount":{"accountUuid":"\#(uuid)","organizationUuid":"\#(organization)"}}"#
     }
 
     private nonisolated static func usageResponse(percent: Double) -> HTTPResponse {

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -454,6 +454,33 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         XCTAssertEqual(httpClient.requests.count, 1)
     }
 
+    @MainActor
+    func testDesktopOnlyFootprintTracksLogoutWithoutReadingSafeStorage() async throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)],
+            requiresInteraction: true
+        )
+        let now = now
+        let provider = ClaudeProvider(authStore: ClaudeAuthStore(
+            environment: FakeEnvironment(), files: fixture.files, keychain: FakeKeychain(),
+            desktop: fixture.store, scope: .desktopOnly(organization: organization), now: { now }
+        ))
+        let configPath = home
+            .appendingPathComponent("Library/Application Support/Claude/config.json").path
+        let encryptedConfig = try XCTUnwrap(fixture.files.files[configPath])
+
+        let signedIn = await provider.hasLocalCredentials()
+        XCTAssertTrue(signedIn)
+        fixture.files.files.removeValue(forKey: configPath)
+        let signedOut = await provider.hasLocalCredentials()
+        XCTAssertFalse(signedOut)
+        fixture.files.files[configPath] = encryptedConfig
+        let restored = await provider.hasLocalCredentials()
+        XCTAssertTrue(restored)
+        XCTAssertTrue(fixture.keyReader.calls.isEmpty)
+    }
+
     private func makeFixture(
         activeOrganization: String,
         v2: [String: Any],


### PR DESCRIPTION
## TL;DR

Keep Claude credentials attached to the correct account during login changes, Desktop fallback, subscription downgrades, and logout.

## What was happening

- A login could change while a usage request was in flight, allowing the wrong account to reach an existing card.
- Desktop's mixed token-cache generations could choose stale subscription metadata, hiding plan multipliers such as Max 20x.
- Desktop credential detection could unnecessarily touch protected Safe Storage during a simple signed-in check.

## What this changes

- Verify account ownership before and after credential reads, refreshes, usage requests, and token persistence.
- Rank Desktop tokens by scope and quality across cache generations before considering cache age.
- Detect Desktop logout and restored logins without reading protected credential material.
- Preserve subscription-tier labels when an account upgrades or downgrades.

## Heads-up

- Five changed files; stacked on account identity migrations.

## Tests

- 66 focused credential isolation, Desktop authentication, identity migration, and iCloud ownership tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Claude credential ownership, identity matching, Desktop token selection, and keychain fallback — a mistake can leak one account’s usage onto another card or skip a needed login.
> 
> **Overview**
> Keeps Claude usage attached to the card that owns the login when credentials change mid-refresh, Desktop caches mix generations, or a Desktop-only account logs out.
> 
> Bound runtimes now take an `expectedIdentityKey` and re-check `matchesIdentity` around credential load, usage fetch, snapshot publish, and token persist. A mid-request swap or org mismatch fails as `credentialsChanged` instead of publishing another account’s limits. Desktop access is a closed `ClaudeDesktopAccessPolicy`; unsuffixed keychain fallback is a separate flag so multi-account CLI homes cannot borrow the default item.
> 
> Desktop token selection ranks v1 and v2 together by scope/quality, using cache generation only as a tiebreak, so a leftover profile-only v2 entry cannot hide a full-scope plan (e.g. Max 20x). Desktop-only seeding uses encrypted material only and no longer decrypts Safe Storage just to detect logout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419dd4eb59dd9b74a577e8c9883cf192f76c6926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->