### PR TITLE
Claude accounts 7: explicit account runtime planning

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -77,14 +77,7 @@ final class AppContainer {
         let accountAssembly = ProviderAccountAssembly.make(accountsStore: accounts, waitsForLoginShell: true)
         self.accounts = accounts
 
-        let providers = ProviderCatalog.make(
-            claudeCards: accountAssembly.claudeCards,
-            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName,
-            defaultClaudeCardID: accountAssembly.defaultClaudeCardID,
-            defaultClaudeCoworkRoots: accountAssembly.defaultClaudeCoworkRoots,
-            defaultClaudeOrganization: accountAssembly.defaultClaudeOrganization
-        )
+        let providers = ProviderCatalog.make(claude: accountAssembly.claudeRuntimePlan)
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
         let enablement = ProviderEnablementStore()

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -4,50 +4,30 @@ import Foundation
 /// their runtimes here so credentials, refresh behavior, pricing, and normalization can never drift.
 @MainActor
 enum ProviderCatalog {
-    /// `claudeCards` carries the extra Claude account cards found by the launch account pass
-    /// (`ProviderAccountAssembly`). Each becomes an ordinary runtime inserted right after the default
-    /// Claude card, with credentials and usage logs pinned to exactly its own config dir. The empty
-    /// default keeps the historical single-card set for focused tests and callers that intentionally
-    /// skip the account pass.
     static func make(
         defaults: UserDefaults = .standard,
-        claudeCards: [ClaudeAccountCard] = [],
-        defaultClaudeExtraLogRoots: [URL] = [],
-        defaultClaudeDisplayName: String? = nil,
-        defaultClaudeCardID: String = "claude",
-        defaultClaudeCoworkRoots: [URL]? = nil,
-        defaultClaudeOrganization: String? = nil
+        claude: ClaudeRuntimePlan = ClaudeRuntimePlan()
     ) -> [ProviderRuntime] {
-        // Default provider order (see AGENTS.md "## Providers"): the three established providers first,
-        // then every other provider alphabetically by display name. Account cards slot in right after
-        // their family's default card.
-        //
-        // Every baked `Provider.displayName` here is the DERIVED default — renames live only in the
-        // account registry and are resolved at render time (`ProviderAccountRecord.resolvedDisplayName`),
-        // so a baked name can never be a stale copy of one.
         var runtimes: [ProviderRuntime] = []
-        runtimes.append(ClaudeProvider(
-            provider: ClaudeProvider.makeProvider(
-                id: defaultClaudeCardID,
-                displayName: defaultClaudeDisplayName ?? "Claude"
-            ),
-            // Once extra Claude cards exist, an unpinned Desktop fallback could borrow a login that
-            // belongs to one of them — fetching that account's usage onto the default card. With the
-            // default account's own org known, the fallback stays available pinned to that org;
-            // otherwise it is disabled rather than blind.
-            authStore: ClaudeAuthStore(
-                standardDesktopOrganization: defaultClaudeOrganization,
-                allowsUnpinnedStandardDesktopFallback: claudeCards.isEmpty
-            ),
-            logUsageScanner: ClaudeLogUsageScanner(
-                additionalRoots: defaultClaudeExtraLogRoots,
-                coworkRootsOverride: defaultClaudeCoworkRoots
-            )
-        ))
-        for card in claudeCards {
-            runtimes.append(claudeAccountRuntime(card: card))
+
+        if claude.cards.isEmpty, claude.allowsUnboundFallback {
+            // Preserve the existing spend-only / unresolved-identity behavior when discovery
+            // cannot prove any Claude account. Once an account is verified, every Claude runtime
+            // comes from its record instead; there is never a second hardcoded default card.
+            runtimes.append(ClaudeProvider(
+                authStore: ClaudeAuthStore(
+                    allowsUnpinnedStandardDesktopFallback: claude.defaultCoworkRoots == nil
+                ),
+                logUsageScanner: ClaudeLogUsageScanner(
+                    coworkRootsOverride: claude.defaultCoworkRoots
+                )
+            ))
+        } else {
+            runtimes += claude.cards.map(claudeAccountRuntime)
         }
-        runtimes.sort { $0.provider.id == "claude" && $1.provider.id != "claude" }
+
+        // The three established families remain first, followed by the alphabetical provider tail.
+        // Account instances sit together before Codex regardless of which one holds the default.
         runtimes += [
             CodexProvider(),
             CursorProvider(),
@@ -62,23 +42,43 @@ enum ProviderCatalog {
         return runtimes
     }
 
-    /// An extra Claude account card: same provider machinery, credentials and logs pinned to one
-    /// login (a config-dir home, or Claude Desktop's org-pinned cache for a Cowork account). The
-    /// scanner's parse cache is partitioned per card so distinct homes never share records.
-    private static func claudeAccountRuntime(card: ClaudeAccountCard) -> ClaudeProvider {
-        let scope: ClaudeCredentialScope = switch card.credential {
+    private static func claudeAccountRuntime(_ card: ClaudeAccountCard) -> ClaudeProvider {
+        let authStore: ClaudeAuthStore
+        let scanner: ClaudeLogUsageScanner
+
+        switch card.credential {
+        case .defaultHome:
+            authStore = ClaudeAuthStore(
+                scope: .standard,
+                desktopAccessPolicy: card.desktopAccess,
+                allowsUnscopedStandardKeychainFallback: card.allowsUnscopedKeychainFallback
+            )
+            scanner = ClaudeLogUsageScanner(
+                cacheIdentityOverride: card.id == "claude" ? nil : "claude-account:\(card.id)",
+                additionalRoots: card.additionalLogRoots,
+                coworkRootsOverride: card.coworkRootsOverride
+            )
         case .configDir(let path, let keychainLiteral):
-            .configDir(path: path, keychainLiteral: keychainLiteral)
-        case .desktop(let organization):
-            .desktopOnly(organization: organization)
-        }
-        return ClaudeProvider(
-            provider: ClaudeProvider.makeProvider(id: card.id, displayName: card.displayName),
-            authStore: ClaudeAuthStore(scope: scope),
-            logUsageScanner: ClaudeLogUsageScanner(
+            authStore = ClaudeAuthStore(
+                scope: .configDir(path: path, keychainLiteral: keychainLiteral)
+            )
+            scanner = ClaudeLogUsageScanner(
                 cacheIdentityOverride: "claude-account:\(card.id)",
                 rootsOverride: card.logRoots
             )
+        case .desktop(let organization):
+            authStore = ClaudeAuthStore(scope: .desktopOnly(organization: organization))
+            scanner = ClaudeLogUsageScanner(
+                cacheIdentityOverride: "claude-account:\(card.id)",
+                rootsOverride: card.logRoots
+            )
+        }
+
+        return ClaudeProvider(
+            provider: ClaudeProvider.makeProvider(id: card.id, displayName: card.displayName),
+            authStore: authStore,
+            logUsageScanner: scanner,
+            expectedIdentityKey: card.identityKey
         )
     }
 }

--- a/Sources/OpenUsage/Services/ClaudeAccountPlanning.swift
+++ b/Sources/OpenUsage/Services/ClaudeAccountPlanning.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+/// A complete identity universe is assembled before any source is folded or accepted. Partial
+/// Cowork identities still inform Desktop safety, but cannot create cards or route spend logs.
+@MainActor
+struct ClaudeSourceObservations {
+    struct FamilyOutcome {
+        let family: String
+        let outcome: DefaultAccountObserver.Outcome
+    }
+
+    let outcomes: [FamilyOutcome]
+    let defaultOutcome: DefaultAccountObserver.Outcome?
+    let config: ClaudeConfigDirDiscovery.Result?
+    let cowork: ClaudeCoworkDiscovery.Result?
+    let knownIdentities: Set<String>
+    let preferredIdentities: [String: String]
+    let desktopPolicy: ClaudeDesktopAccountPolicy
+
+    static func observe(
+        observer: DefaultAccountObserver,
+        accountsStore: ProviderAccountsStore,
+        families: Set<String>,
+        claudeDiscovery: ClaudeConfigDirDiscovery?,
+        coworkDiscovery: ClaudeCoworkDiscovery?,
+        preparedDiscovery: PreparedProviderAccountDiscovery?
+    ) -> Self {
+        let outcomes: [FamilyOutcome] = [
+            ("claude", { observer.observeClaude() }),
+            ("codex", { observer.observeCodex() }),
+        ].compactMap { family, observe in
+            families.contains(family) ? FamilyOutcome(family: family, outcome: observe()) : nil
+        }
+        let defaultOutcome = outcomes.first { $0.family == "claude" }?.outcome
+        if case .unresolved? = defaultOutcome {
+            AppLog.info(.config, "discovery: claude default identity is unreadable; checking independently verified config-dir and Desktop accounts")
+        }
+
+        let config = defaultOutcome != nil
+            ? preparedDiscovery?.config ?? claudeDiscovery?.run()
+            : nil
+        let cowork = defaultOutcome != nil
+            ? preparedDiscovery?.cowork ?? coworkDiscovery?.run()
+            : nil
+        for note in (config?.notes ?? []) + (cowork?.notes ?? []) {
+            AppLog.info(.config, "discovery: \(note)")
+        }
+
+        var knownIdentities = Set(
+            accountsStore.records
+                .filter { $0.family == "claude" }
+                .flatMap { [$0.identityKey] + ($0.identityAliases ?? []) }
+        )
+        if case .resolved(let identity, _, _)? = defaultOutcome {
+            knownIdentities.insert(identity)
+        }
+        for finding in config?.findings ?? [] {
+            knownIdentities.insert(finding.identityKey)
+        }
+        if cowork?.truncated != true {
+            for sandbox in cowork?.sandboxes ?? [] {
+                if let identity = sandbox.identityKey { knownIdentities.insert(identity) }
+            }
+        }
+
+        var preferredIdentities: [String: String] = [:]
+        if case .resolved(let raw, _, _)? = defaultOutcome,
+           let identity = ClaudeIdentity(raw)
+        {
+            preferredIdentities[identity.user] = identity.key
+        }
+        for finding in config?.findings ?? [] {
+            guard let identity = ClaudeIdentity(finding.identityKey),
+                  preferredIdentities[identity.user] == nil
+            else { continue }
+            preferredIdentities[identity.user] = identity.key
+        }
+
+        return Self(
+            outcomes: outcomes,
+            defaultOutcome: defaultOutcome,
+            config: config,
+            cowork: cowork,
+            knownIdentities: knownIdentities,
+            preferredIdentities: preferredIdentities,
+            desktopPolicy: ClaudeDesktopAccountPolicy(
+                records: accountsStore.records,
+                defaultOutcome: defaultOutcome,
+                configFindings: config?.findings ?? [],
+                coworkScan: cowork
+            )
+        )
+    }
+
+    func canonicalIdentity(_ raw: String) -> String? {
+        ClaudeIdentity.canonical(raw, among: knownIdentities, preferred: preferredIdentities)
+    }
+}
+
+/// Credential-bearing default/config sources choose the identity spelling a bound runtime can
+/// verify; Cowork partitions may attach roots later, but never change that source ownership.
+@MainActor
+struct ClaudeAccountPlan {
+    struct Account {
+        var identityKey: String
+        var label: String?
+        var sources: [ProviderAccountSource]
+        var credential: ClaudeAccountCard.Credential
+        var logRoots: [URL]
+        var additionalLogRoots: [URL] = []
+    }
+
+    var identityKeysByCard: [String: String] = [:]
+    var otherObservations: [ProviderAccountsStore.AccountObservation] = []
+    var accounts: [String: Account] = [:]
+    var orderedIdentities: [String] = []
+    var defaultIdentity: String?
+
+    static func make(from observed: ClaudeSourceObservations) -> Self {
+        var plan = Self()
+        plan.observeDefaults(observed)
+        plan.attachConfigDirectories(observed)
+        return plan
+    }
+
+    private mutating func observeDefaults(_ observed: ClaudeSourceObservations) {
+        for familyOutcome in observed.outcomes {
+            let family = familyOutcome.family
+            switch familyOutcome.outcome {
+            case .resolved(let rawIdentity, let label, let anchor):
+                let identity: String
+                if family == "claude" {
+                    guard let canonical = observed.canonicalIdentity(rawIdentity) else {
+                        AppLog.warn(.config, "accounts: claude default identity omits its organization while multiple organizations share that login; source quarantined")
+                        continue
+                    }
+                    identity = canonical
+                    defaultIdentity = canonical
+                    orderedIdentities.append(canonical)
+                    accounts[canonical] = Account(
+                        identityKey: canonical,
+                        label: label,
+                        sources: [ProviderAccountSource(
+                            kind: .defaultHome, anchor: anchor, holdsDefaultSource: true
+                        )],
+                        credential: .defaultHome,
+                        logRoots: [URL(fileURLWithPath: anchor)]
+                    )
+                } else {
+                    identity = rawIdentity
+                    otherObservations.append(ProviderAccountsStore.AccountObservation(
+                        family: family,
+                        identityKey: identity,
+                        label: label,
+                        sources: [ProviderAccountSource(
+                            kind: .defaultHome, anchor: anchor, holdsDefaultSource: true
+                        )]
+                    ))
+                    identityKeysByCard[family] = identity
+                }
+                AppLog.info(.config, "accounts: \(family) default identity resolved (\(ProviderAccountID.make(family: family, identityKey: identity)))")
+            case .unresolved(let reason):
+                AppLog.info(.config, "accounts: \(family) default identity unresolved — \(reason)")
+            case .absent:
+                AppLog.debug(.config, "accounts: \(family) has no default login")
+            }
+        }
+    }
+
+    private mutating func attachConfigDirectories(_ observed: ClaudeSourceObservations) {
+        for finding in observed.config?.findings ?? [] {
+            guard let identity = observed.canonicalIdentity(finding.identityKey) else {
+                AppLog.warn(.config, "discovery: claude config-dir identity omits its organization while multiple organizations share that login; source quarantined")
+                continue
+            }
+            let source = ProviderAccountSource(
+                kind: .configDir,
+                anchor: finding.anchorPath,
+                holdsDefaultSource: false,
+                keychainLiteral: finding.keychainLiteral
+            )
+            let root = URL(fileURLWithPath: finding.anchorPath)
+            if var account = accounts[identity] {
+                appendUnique(source, to: &account.sources)
+                appendUnique(root, to: &account.logRoots)
+                if account.credential == .defaultHome {
+                    appendUnique(root, to: &account.additionalLogRoots)
+                }
+                if account.label == nil { account.label = finding.label }
+                accounts[identity] = account
+            } else {
+                orderedIdentities.append(identity)
+                accounts[identity] = Account(
+                    identityKey: identity,
+                    label: finding.label,
+                    sources: [source],
+                    credential: .configDir(
+                        path: finding.anchorPath,
+                        keychainLiteral: finding.keychainLiteral
+                    ),
+                    logRoots: [root]
+                )
+            }
+        }
+    }
+}
+
+/// Cowork discovery changes spend routing and Desktop candidates only after their ownership has
+/// been proven. A partial scan remains account-safety evidence but contributes no spend roots.
+@MainActor
+struct ClaudeCoworkPartition {
+    var defaultRoots: [URL] = []
+    var requiresPartition = false
+
+    static func make(
+        from observed: ClaudeSourceObservations,
+        plan: inout ClaudeAccountPlan,
+        hasDesktopCredentialMaterial: @Sendable () -> Bool
+    ) -> Self {
+        var partition = Self()
+        var unidentifiedRoots: [URL] = []
+        var desktopCredentialMaterial: Bool?
+
+        if let scan = observed.cowork, !scan.truncated {
+            for sandbox in scan.sandboxes {
+                guard let rawIdentity = sandbox.identityKey else {
+                    unidentifiedRoots.append(sandbox.root)
+                    continue
+                }
+                guard let identity = observed.canonicalIdentity(rawIdentity) else {
+                    partition.requiresPartition = true
+                    AppLog.warn(.config, "discovery: cowork sandbox identity omits its organization while multiple organizations share that login; sandbox quarantined")
+                    continue
+                }
+                if identity == plan.defaultIdentity {
+                    appendUnique(sandbox.root, to: &partition.defaultRoots)
+                    continue
+                }
+
+                partition.requiresPartition = true
+                let hasAmbiguousOwner = observed.desktopPolicy.hasAmbiguousOrganization(
+                    sandbox.organization
+                )
+                let desktopSource = ProviderAccountSource(
+                    kind: .desktop, anchor: nil, holdsDefaultSource: false
+                )
+                if var account = plan.accounts[identity] {
+                    appendUnique(sandbox.root, to: &account.logRoots)
+                    if sandbox.organization != nil && !hasAmbiguousOwner {
+                        appendUnique(desktopSource, to: &account.sources)
+                    } else if hasAmbiguousOwner {
+                        AppLog.warn(.config, "discovery: cowork organization names multiple account owners; Desktop credential source quarantined")
+                    }
+                    if account.label == nil { account.label = sandbox.label }
+                    plan.accounts[identity] = account
+                    continue
+                }
+
+                guard let organization = sandbox.organization?.nilIfEmpty else {
+                    AppLog.warn(.config, "discovery: cowork account \(ProviderAccountID.make(family: "claude", identityKey: identity)) has no organization pin; sandbox quarantined")
+                    continue
+                }
+                guard !hasAmbiguousOwner else {
+                    AppLog.warn(.config, "discovery: cowork organization names multiple account owners; Desktop-only account quarantined")
+                    continue
+                }
+                if desktopCredentialMaterial == nil {
+                    desktopCredentialMaterial = hasDesktopCredentialMaterial()
+                }
+                guard desktopCredentialMaterial == true else {
+                    AppLog.info(.config, "discovery: cowork account \(ProviderAccountID.make(family: "claude", identityKey: identity)) has no current Desktop credential material; historical sandbox skipped")
+                    continue
+                }
+                plan.orderedIdentities.append(identity)
+                plan.accounts[identity] = ClaudeAccountPlan.Account(
+                    identityKey: identity,
+                    label: sandbox.label,
+                    sources: [desktopSource],
+                    credential: .desktop(organization: organization),
+                    logRoots: [sandbox.root]
+                )
+            }
+        }
+
+        if plan.accounts.count > 1 { partition.requiresPartition = true }
+        if !unidentifiedRoots.isEmpty, partition.requiresPartition {
+            AppLog.warn(.config, "discovery: \(unidentifiedRoots.count) unidentified cowork sandbox(es) quarantined because account ownership cannot be proven")
+        }
+        if observed.cowork?.truncated == true {
+            partition.requiresPartition = true
+            partition.defaultRoots = []
+            AppLog.warn(.config, "discovery: cowork scan truncated; cowork spend withheld until a complete scan proves account ownership")
+        }
+        return partition
+    }
+}
+
+private func appendUnique<Value: Equatable>(_ value: Value, to values: inout [Value]) {
+    if !values.contains(value) { values.append(value) }
+}

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -1,330 +1,227 @@
 import Foundation
 
-/// One extra Claude account card to build this launch: a login found on this computer whose account
-/// is distinct from the default card's — a custom-config-dir login, or a Claude Desktop (Cowork)
-/// login. Cards render only while their source is found (owner decision 4) — a record with no
-/// finding this launch simply builds no card.
+/// Account-routing inputs cross the assembly/runtime boundary together.
+struct ClaudeRuntimePlan: Sendable {
+    let cards: [ClaudeAccountCard]
+    let allowsUnboundFallback: Bool
+    let defaultCoworkRoots: [URL]?
+
+    init(
+        cards: [ClaudeAccountCard] = [],
+        allowsUnboundFallback: Bool = true,
+        defaultCoworkRoots: [URL]? = nil
+    ) {
+        self.cards = cards
+        self.allowsUnboundFallback = allowsUnboundFallback
+        self.defaultCoworkRoots = defaultCoworkRoots
+    }
+}
+
+/// One verified account-to-runtime binding. The credential source belongs to its permanent account
+/// record, so the original bare card can move while another account takes over the default home.
 struct ClaudeAccountCard: Equatable, Sendable {
-    /// Where the card's credentials come from (its spend logs are `logRoots`, kept separate —
-    /// a Desktop-backed card's logs are Cowork sandboxes, not a credential home).
     enum Credential: Equatable, Sendable {
-        /// One custom `CLAUDE_CONFIG_DIR` home; `keychainLiteral` names the dir's keychain item
-        /// (see `ClaudeCredentialScope.configDir`).
+        case defaultHome
         case configDir(path: String, keychainLiteral: String)
-        /// Claude Desktop's Safe Storage cache, pinned to this org's token
-        /// (see `ClaudeCredentialScope.desktopOnly`).
         case desktop(organization: String)
     }
 
-    /// The account's stable record id (`claude@ab12cd34`) — the card id everywhere: layout, cache,
-    /// CLI/API matching.
     var id: String
-    /// The DERIVED card name (`ProviderAccountRecord.derivedDisplayName`) baked into the launch
-    /// `Provider`. Never a rename: renames live only in the account registry and are resolved at
-    /// render time, so a baked name can never be a stale copy of one.
     var displayName: String
+    var identityKey: String
     var credential: Credential
-    /// Every spend-log root the card scans: its config dir(s), plus any Cowork sandboxes this
-    /// account produced.
     var logRoots: [URL]
+    var additionalLogRoots: [URL] = []
+    var coworkRootsOverride: [URL]?
+    /// Credential ownership is decided once by assembly, never reconstructed from spend roots.
+    var desktopAccess: ClaudeDesktopAccessPolicy = .denied
+    /// The bare CLI keychain item is safe only when one verified account owns the default home.
+    var allowsUnscopedKeychainFallback = false
 }
 
-/// The launch-time account pass: read which account is signed in at each family's default home,
-/// scan for extra Claude logins in custom config dirs, reconcile the account registry, and expose
-/// what the rest of launch consumes — the per-card identity map (snapshot-cache account stamp) and
-/// the extra-card build plan (`ProviderCatalog`). Runs once per launch (app) or per invocation
-/// (one-shot CLI); a mid-run swap is caught on the next launch.
+/// Filesystem discovery happens off the main actor; account reconciliation remains main-actor-owned.
+struct PreparedProviderAccountDiscovery: Sendable {
+    var config: ClaudeConfigDirDiscovery.Result
+    var cowork: ClaudeCoworkDiscovery.Result
+}
+
+/// Account assembly has five explicit phases: observe identity sources, plan verified accounts,
+/// partition Cowork sessions, reconcile stable records, and bind one runtime per observed account.
 @MainActor
 struct ProviderAccountAssembly {
-    /// Card id → the account identity signed in there this launch. A card whose identity didn't
-    /// resolve is absent.
     let identityKeysByCard: [String: String]
-    /// Extra Claude account cards found on this computer this launch, in stable id order.
     var claudeCards: [ClaudeAccountCard] = []
-    /// Same-account custom config dirs discovered for the DEFAULT card's login: extra spend-log
-    /// roots for the default scanner, never extra credentials.
-    var defaultClaudeExtraLogRoots: [URL] = []
-    /// The default account's derived title; custom names are resolved at presentation boundaries.
-    var defaultClaudeDisplayName: String?
-    /// The default runtime follows its account record, even when another account keeps `claude`.
-    var defaultClaudeCardID = "claude"
-    /// Set only when another account's Cowork sandboxes exist: the default card's partition of the
-    /// Cowork walk (that account's sessions must not bleed into the default card's spend). `nil`
-    /// keeps the scanner's built-in walk byte-identical.
-    var defaultClaudeCoworkRoots: [URL]?
+    var allowsUnboundClaudeFallback = true
 
-    /// The default Claude account's org UUID, parsed from its identity key (`uuid|org`) — the pin
-    /// the default card's Desktop fallback reads under once other Claude cards exist. `nil` when
-    /// the default identity is unresolved or the account has no org.
-    var defaultClaudeOrganization: String? {
-        guard let key = identityKeysByCard[defaultClaudeCardID],
-              let separator = key.firstIndex(of: "|")
-        else { return nil }
-        return String(key[key.index(after: separator)...]).nilIfEmpty
+    var claudeRuntimePlan: ClaudeRuntimePlan {
+        ClaudeRuntimePlan(
+            cards: claudeCards,
+            allowsUnboundFallback: allowsUnboundClaudeFallback
+        )
     }
 
-    /// `waitsForLoginShell`: true for the menu-bar app (a Finder/Dock launch inherits no shell
-    /// exports, so the pass leans on the login-shell layers), false for the one-shot CLI (a terminal
-    /// launch's process environment already carries the user's exports). The app passes its own
-    /// `accountsStore` so the registry the pass reconciles is the same instance the UI observes for
-    /// renames; the CLI omits it and gets a throwaway.
     static func make(
         defaults: UserDefaults = .standard,
         accountsStore: ProviderAccountsStore? = nil,
-        waitsForLoginShell: Bool
-    ) -> ProviderAccountAssembly {
-        // The identity read needs the login shell's exports (CLAUDE_CONFIG_DIR/CODEX_HOME name the
-        // default homes), and it reads them through the very same reader the provider auth stores
-        // use — `ProcessEnvironmentReader`, which pins identity-relevant keys to the persisted
-        // shell-environment snapshot for the whole session, so identity and usage resolve the same
-        // homes no matter when the async capture lands. The one unreadable state is a genuinely
-        // FIRST Finder/Dock launch: capture still cold and no snapshot persisted yet — a
-        // shell-exported home override would be invisible, so that family's read must be skipped
-        // rather than misread as "no override". The skip is per family: a family whose home override
-        // is already visible in the process environment (a terminal launch, `launchctl setenv`)
-        // doesn't need the shell layers at all and still resolves.
+        waitsForLoginShell: Bool,
+        preparedDiscovery: PreparedProviderAccountDiscovery? = nil
+    ) -> Self {
+        let store = accountsStore ?? ProviderAccountsStore(defaults: defaults)
         let shellFactsReadable = !waitsForLoginShell
             || LoginShellEnvironment.shared.capturedSuccessfully
             || ShellEnvironmentSnapshotStore.launchSnapshot != nil
         let families = shellFactsReadable
             ? ProviderAccountID.families
             : ProviderAccountID.families.filter { family in
-                guard let key = Self.homeOverrideKeys[family] else { return false }
+                guard let key = homeOverrideKeys[family] else { return false }
                 return ProcessInfo.processInfo.environment[key]?.nilIfEmpty != nil
             }
         if families.count < ProviderAccountID.families.count {
             AppLog.info(.config, "account identity read skipped for \(ProviderAccountID.families.subtracting(families).sorted().joined(separator: ", ")): login shell cold and no shell-environment snapshot exists yet")
         }
         guard !families.isEmpty else {
-            return ProviderAccountAssembly(identityKeysByCard: [:])
+            return Self(
+                identityKeysByCard: [:],
+                allowsUnboundClaudeFallback: !store.records.contains { $0.family == "claude" }
+            )
         }
         return make(
             observer: DefaultAccountObserver(),
-            accountsStore: accountsStore ?? ProviderAccountsStore(defaults: defaults),
+            accountsStore: store,
             families: families,
             claudeDiscovery: ClaudeConfigDirDiscovery(),
-            coworkDiscovery: ClaudeCoworkDiscovery()
+            coworkDiscovery: ClaudeCoworkDiscovery(),
+            preparedDiscovery: preparedDiscovery
         )
     }
 
-    /// The environment variable that relocates each family's default home — the fact whose
-    /// invisibility (shell layers unreadable AND not in the process environment) makes that family's
-    /// identity read unsafe on a first launch.
-    private static let homeOverrideKeys: [String: String] = [
-        "claude": "CLAUDE_CONFIG_DIR",
-        "codex": "CODEX_HOME",
-    ]
-
-    /// The environment-independent core, separated so tests inject a fixed observer, discovery, and
-    /// scratch store. `families` limits the pass to the families whose home facts are readable this
-    /// launch (see `make(defaults:waitsForLoginShell:)`); a family left out is simply not observed —
-    /// no identity key, no reconciliation, exactly as if the pass never ran for it. `claudeDiscovery`
-    /// is skipped alongside the claude family (its exclusion set needs the same home facts).
     static func make(
         observer: DefaultAccountObserver,
         accountsStore: ProviderAccountsStore,
         families: Set<String> = ProviderAccountID.families,
         claudeDiscovery: ClaudeConfigDirDiscovery? = nil,
-        coworkDiscovery: ClaudeCoworkDiscovery? = nil
-    ) -> ProviderAccountAssembly {
-        var identityKeys: [String: String] = [:]
-        var observations: [ProviderAccountsStore.AccountObservation] = []
-
-        let outcomes: [(family: String, outcome: DefaultAccountObserver.Outcome)] = [
-            ("claude", { observer.observeClaude() }),
-            ("codex", { observer.observeCodex() }),
-        ].compactMap { family, observe in
-            families.contains(family) ? (family, observe()) : nil
+        coworkDiscovery: ClaudeCoworkDiscovery? = nil,
+        preparedDiscovery: PreparedProviderAccountDiscovery? = nil,
+        hasDesktopCredentialMaterial: @Sendable () -> Bool = {
+            ClaudeDesktopAuthStore().hasCredentialMaterial()
         }
-        for (family, outcome) in outcomes {
-            switch outcome {
-            case .resolved(let identityKey, let label, let anchor):
-                identityKeys[family] = identityKey
-                observations.append(ProviderAccountsStore.AccountObservation(
-                    family: family,
-                    identityKey: identityKey,
-                    label: label,
-                    sources: [ProviderAccountSource(kind: .defaultHome, anchor: anchor, holdsDefaultSource: true)]
-                ))
-                AppLog.info(.config, "accounts: \(family) default identity resolved (\(ProviderAccountID.make(family: family, identityKey: identityKey)))")
-            case .unresolved(let reason):
-                // The soak signal for later phases: how often a real login can't name its account.
-                AppLog.info(.config, "accounts: \(family) default identity unresolved — \(reason)")
-            case .absent:
-                AppLog.debug(.config, "accounts: \(family) has no default login")
-            }
-        }
-
-        // Extra Claude logins in custom config dirs and Cowork sandboxes. Guarded on the default
-        // read: when a default login clearly EXISTS but can't be named (`unresolved`), accepting
-        // candidates could render the very account the default card shows as a second card — skip
-        // them this launch instead. A machine with no default login at all keeps accepting: there
-        // is nothing to duplicate, and a custom-dir-only login should still get its card.
-        var plannedCards: [PlannedClaudeCard] = []
-        var defaultClaudeExtraLogRoots: [URL] = []
-        var defaultClaudeCoworkRoots: [URL]?
-        let claudeOutcome = outcomes.first { $0.family == "claude" }?.outcome
-        var claudeCandidatesAllowed = false
-        if let claudeOutcome {
-            if case .unresolved = claudeOutcome {
-                AppLog.info(.config, "discovery: claude default login present but its identity is unreadable → skipping extra-account candidates this launch")
-            } else {
-                claudeCandidatesAllowed = true
-            }
-        }
-        if let claudeDiscovery, claudeCandidatesAllowed {
-            let defaultKey = identityKeys["claude"]
-            let scan = claudeDiscovery.run()
-            for note in scan.notes {
-                AppLog.info(.config, "discovery: \(note)")
-            }
-            var order: [String] = []
-            var grouped: [String: [ClaudeConfigDirDiscovery.Finding]] = [:]
-            for finding in scan.findings {
-                if grouped[finding.identityKey] == nil { order.append(finding.identityKey) }
-                grouped[finding.identityKey, default: []].append(finding)
-            }
-            for identityKey in order {
-                let findings = grouped[identityKey] ?? []
-                let sources = findings.map {
-                    ProviderAccountSource(
-                        kind: .configDir,
-                        anchor: $0.anchorPath,
-                        holdsDefaultSource: false,
-                        keychainLiteral: $0.keychainLiteral
-                    )
-                }
-                if identityKey == defaultKey {
-                    // Same account as the default card: its dirs are extra spend-log roots on
-                    // that card, never a second card — duplicate cards are structurally
-                    // impossible because identity routes the source to the existing record.
-                    defaultClaudeExtraLogRoots += findings.map { URL(fileURLWithPath: $0.anchorPath) }
-                    if let index = observations.firstIndex(where: { $0.family == "claude" && $0.identityKey == identityKey }) {
-                        observations[index].sources += sources
-                    }
-                    AppLog.info(.config, "discovery: \(findings.count) config dir(s) fold onto the default claude card (same account)")
-                } else {
-                    guard let primary = findings.first else { continue }
-                    observations.append(ProviderAccountsStore.AccountObservation(
-                        family: "claude",
-                        identityKey: identityKey,
-                        label: primary.label,
-                        sources: sources
-                    ))
-                    plannedCards.append(PlannedClaudeCard(
-                        identityKey: identityKey,
-                        credential: .configDir(path: primary.anchorPath, keychainLiteral: primary.keychainLiteral),
-                        logRoots: findings.map { URL(fileURLWithPath: $0.anchorPath) }
-                    ))
-                }
-            }
-        }
-
-        // Cowork sandboxes: identity comes from each session sandbox's own `.claude.json`.
-        // Sandboxes naming the default login (the overwhelmingly common case) stay exactly where
-        // they are today — on the default card. Sandboxes naming an account already found in a
-        // config dir become that card's extra log roots. A distinct account becomes ONE
-        // Desktop-backed card (org-pinned Safe Storage credentials) with its sandboxes as the
-        // card's spend logs. The moment any non-default sandbox exists, the default card's walk is
-        // partitioned so another account's sessions can't bleed into its spend.
-        if let coworkDiscovery, claudeCandidatesAllowed {
-            let defaultKey = identityKeys["claude"]
-            let scan = coworkDiscovery.run()
-            for note in scan.notes {
-                AppLog.info(.config, "discovery: \(note)")
-            }
-            var defaultBucket: [URL] = []
-            var order: [String] = []
-            var grouped: [String: [ClaudeCoworkDiscovery.Sandbox]] = [:]
-            for sandbox in scan.sandboxes {
-                guard let key = sandbox.identityKey, key != defaultKey else {
-                    // An unidentified sandbox counts on the default card, exactly where the
-                    // built-in walk has always put it.
-                    defaultBucket.append(sandbox.root)
-                    continue
-                }
-                if grouped[key] == nil { order.append(key) }
-                grouped[key, default: []].append(sandbox)
-            }
-            for identityKey in order {
-                let sandboxes = grouped[identityKey] ?? []
-                let roots = sandboxes.map(\.root)
-                if let index = plannedCards.firstIndex(where: { $0.identityKey == identityKey }) {
-                    // The account already has a card from its config dir; its sandboxes are just
-                    // more of its spend logs.
-                    plannedCards[index].logRoots += roots
-                    AppLog.info(.config, "discovery: \(roots.count) cowork sandbox(es) attach to an existing claude account card as log roots")
-                    continue
-                }
-                guard let organization = sandboxes.compactMap(\.organization).first else {
-                    // Desktop caches tokens per org; without the pin the card could only read
-                    // Desktop's ACTIVE org, which may be a different account's usage pool.
-                    AppLog.info(.config, "discovery: cowork account \(ProviderAccountID.make(family: "claude", identityKey: identityKey)) has no organization pin → skipped Desktop-backed card")
-                    continue
-                }
-                let label = sandboxes.compactMap(\.label).first
-                observations.append(ProviderAccountsStore.AccountObservation(
-                    family: "claude",
-                    identityKey: identityKey,
-                    label: label,
-                    sources: [ProviderAccountSource(kind: .desktop, anchor: nil, holdsDefaultSource: false)]
-                ))
-                plannedCards.append(PlannedClaudeCard(
-                    identityKey: identityKey,
-                    credential: .desktop(organization: organization),
-                    logRoots: roots
-                ))
-            }
-            if !order.isEmpty {
-                defaultClaudeCoworkRoots = defaultBucket
-                AppLog.info(.config, "discovery: cowork partition — default keeps \(defaultBucket.count) sandbox dir(s), \(order.count) other account(s) found")
-            }
-        }
-
-        let records = accountsStore.reconcile(with: observations)
-        let defaultClaudeRecord = accountsStore.defaultBadgeHolder(family: "claude")
-        if let defaultClaudeRecord, defaultClaudeRecord.id != "claude" {
-            identityKeys.removeValue(forKey: "claude")
-            identityKeys[defaultClaudeRecord.id] = defaultClaudeRecord.identityKey
-        }
-
-        // The extra-card build plan: one card per distinct account found this launch, under its
-        // reconciled record id.
-        var claudeCards: [ClaudeAccountCard] = []
-        for planned in plannedCards {
-            guard let record = records.first(where: { $0.family == "claude" && $0.identityKey == planned.identityKey }) else {
-                continue
-            }
-            claudeCards.append(ClaudeAccountCard(
-                id: record.id,
-                displayName: record.derivedDisplayName,
-                credential: planned.credential,
-                logRoots: planned.logRoots
-            ))
-            identityKeys[record.id] = planned.identityKey
-            let kind = if case .desktop = planned.credential { "desktop (cowork)" } else { "config dir" }
-            AppLog.info(.config, "accounts: extra claude card \(record.id) — \(kind), \(planned.logRoots.count) log root(s)")
-        }
-        claudeCards.sort { $0.id < $1.id }
-
-        let defaultClaudeName = defaultClaudeRecord.flatMap { record -> String? in
-            guard record.id != "claude" else { return nil }
-            return record.derivedDisplayName
-        }
-        return ProviderAccountAssembly(
-            identityKeysByCard: identityKeys,
-            claudeCards: claudeCards,
-            defaultClaudeExtraLogRoots: defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: defaultClaudeName,
-            defaultClaudeCardID: defaultClaudeRecord?.id ?? "claude",
-            defaultClaudeCoworkRoots: defaultClaudeCoworkRoots
+    ) -> Self {
+        let observed = ClaudeSourceObservations.observe(
+            observer: observer,
+            accountsStore: accountsStore,
+            families: families,
+            claudeDiscovery: claudeDiscovery,
+            coworkDiscovery: coworkDiscovery,
+            preparedDiscovery: preparedDiscovery
+        )
+        var plan = ClaudeAccountPlan.make(from: observed)
+        let partition = ClaudeCoworkPartition.make(
+            from: observed,
+            plan: &plan,
+            hasDesktopCredentialMaterial: hasDesktopCredentialMaterial
+        )
+        let records = reconcile(plan, observed: observed, accountsStore: accountsStore)
+        return bind(
+            plan: plan,
+            observed: observed,
+            partition: partition,
+            records: records,
+            accountsStore: accountsStore
         )
     }
 
-    /// One distinct account's card plan before reconciliation assigns its record id.
-    private struct PlannedClaudeCard {
-        var identityKey: String
-        var credential: ClaudeAccountCard.Credential
-        var logRoots: [URL]
+    private static let homeOverrideKeys: [String: String] = [
+        "claude": "CLAUDE_CONFIG_DIR",
+        "codex": "CODEX_HOME",
+    ]
+
+    private static func reconcile(
+        _ plan: ClaudeAccountPlan,
+        observed: ClaudeSourceObservations,
+        accountsStore: ProviderAccountsStore
+    ) -> [ProviderAccountRecord] {
+        if observed.defaultOutcome != nil, plan.defaultIdentity == nil {
+            accountsStore.clearDefaultSource(family: "claude")
+        }
+        let claudeObservations: [ProviderAccountsStore.AccountObservation] = plan.orderedIdentities.compactMap { identity in
+            guard let account = plan.accounts[identity] else { return nil }
+            return ProviderAccountsStore.AccountObservation(
+                family: "claude",
+                identityKey: account.identityKey,
+                label: account.label,
+                sources: account.sources
+            )
+        }
+        return accountsStore.reconcile(with: claudeObservations + plan.otherObservations)
+    }
+
+    private static func bind(
+        plan: ClaudeAccountPlan,
+        observed: ClaudeSourceObservations,
+        partition: ClaudeCoworkPartition,
+        records: [ProviderAccountRecord],
+        accountsStore: ProviderAccountsStore
+    ) -> Self {
+        let hasExactlyOneDefaultAccount = plan.accounts.count == 1
+            && plan.defaultIdentity.flatMap { plan.accounts[$0]?.credential } == .defaultHome
+        let permitsUnscopedFallback = observed.desktopPolicy.allowsUnpinnedFallback(
+            defaultIdentity: plan.defaultIdentity,
+            hasExactlyOneDefaultAccount: hasExactlyOneDefaultAccount,
+            coworkScan: observed.cowork
+        )
+
+        var identityKeys = plan.identityKeysByCard
+        var cards: [ClaudeAccountCard] = []
+        for identity in plan.orderedIdentities {
+            guard let planned = plan.accounts[identity],
+                  let record = records.first(where: {
+                      $0.family == "claude"
+                          && $0.identityKey == identity
+                          && !$0.removedTombstone
+                  })
+            else { continue }
+            let isDefaultHome = planned.credential == .defaultHome
+            let desktopAccess: ClaudeDesktopAccessPolicy = isDefaultHome
+                ? observed.desktopPolicy.access(
+                    for: record.identityKey,
+                    allowsActiveOrganization: permitsUnscopedFallback
+                )
+                : .denied
+            cards.append(ClaudeAccountCard(
+                id: record.id,
+                displayName: accountsStore.derivedDisplayName(cardID: record.id)
+                    ?? record.derivedDisplayName,
+                identityKey: record.identityKey,
+                credential: planned.credential,
+                logRoots: planned.logRoots,
+                additionalLogRoots: planned.additionalLogRoots,
+                coworkRootsOverride: isDefaultHome && partition.requiresPartition
+                    ? partition.defaultRoots
+                    : nil,
+                desktopAccess: desktopAccess,
+                allowsUnscopedKeychainFallback: isDefaultHome && permitsUnscopedFallback
+            ))
+            identityKeys[record.id] = record.identityKey
+            AppLog.info(.config, "accounts: claude card \(record.id) bound to \(sourceDescription(planned.credential)); \(planned.logRoots.count) verified log root(s)")
+        }
+        cards.sort {
+            if $0.id == "claude" { return true }
+            if $1.id == "claude" { return false }
+            return $0.id < $1.id
+        }
+
+        return Self(
+            identityKeysByCard: identityKeys,
+            claudeCards: cards,
+            allowsUnboundClaudeFallback: !records.contains { $0.family == "claude" }
+        )
+    }
+
+    private static func sourceDescription(_ credential: ClaudeAccountCard.Credential) -> String {
+        switch credential {
+        case .defaultHome: "default home"
+        case .configDir: "config dir"
+        case .desktop: "desktop"
+        }
     }
 }

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -38,9 +38,8 @@ public struct UsageReader {
 
     public func read(providerID requestedProviderID: String? = nil, force: Bool = false) async throws -> UsageReadResult {
         // The launch account pass (see `ProviderAccountAssembly`): resolves each family's default
-        // account so cached snapshots are guarded — and refreshed ones stamped — with the correct
-        // account, and finds the extra Claude cards the catalog must build (the CLI must know the
-        // same card set as the app, or family matching would answer differently between the two).
+        // account and discovers every verified Claude runtime before the catalog is constructed.
+        // The CLI and menu-bar app therefore expose the same stable account graph and cache stamps.
         // Skipped when a test injects its own providers — they have no real homes to read.
         //
         // Warm the login-shell capture FIRST (off-main, one bounded subprocess). Identity-relevant
@@ -54,17 +53,17 @@ public struct UsageReader {
                 _ = LoginShellEnvironment.shared.ensureCaptured()
             }.value
         }
+        let accounts = providersOverride == nil ? ProviderAccountsStore(defaults: defaults) : nil
         let accountAssembly = providersOverride == nil
-            ? ProviderAccountAssembly.make(defaults: defaults, waitsForLoginShell: false)
+            ? ProviderAccountAssembly.make(
+                defaults: defaults,
+                accountsStore: accounts,
+                waitsForLoginShell: false
+            )
             : ProviderAccountAssembly(identityKeysByCard: [:])
         let providers = providersOverride ?? ProviderCatalog.make(
             defaults: defaults,
-            claudeCards: accountAssembly.claudeCards,
-            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName,
-            defaultClaudeCardID: accountAssembly.defaultClaudeCardID,
-            defaultClaudeCoworkRoots: accountAssembly.defaultClaudeCoworkRoots,
-            defaultClaudeOrganization: accountAssembly.defaultClaudeOrganization
+            claude: accountAssembly.claudeRuntimePlan
         )
         let registry = WidgetRegistry.from(providers)
         let knownIDs = Set(registry.providers.map(\.id))
@@ -135,10 +134,6 @@ public struct UsageReader {
                 .compactMap { id in errors[id].map { "\(id): \($0)" } }
         }
 
-        // CLI output is human-read: resolve card titles against the persisted account registry so
-        // renames show, matching the app's UI and HTTP API. Injected-provider tests use their own
-        // defaults suite, so this is a no-op there.
-        let accountTitles = ProviderAccountsStore(defaults: defaults).resolvedDisplayNamesByCardID
         let state = LocalUsageAPI.State(
             enabledOrderedIDs: enabledOrderedIDs,
             knownIDs: knownIDs,
@@ -146,7 +141,7 @@ public struct UsageReader {
             limitDescriptors: registry.limitDescriptorsByProvider,
             errors: errors
         )
-        .resolvingDisplayNames(accountTitles)
+        .resolvingDisplayNames(accounts?.resolvedDisplayNamesByCardID ?? [:])
         let path = requestedToken.map { "/v1/limits/\($0)" } ?? "/v1/limits"
         let response = LocalUsageAPI.respond(method: "GET", path: path, state: state)
         guard let data = response.body else {

--- a/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
@@ -4,15 +4,7 @@ import XCTest
 /// The launch account pass end to end: observer outcomes → account registry records → the per-card
 /// identity map consumed by the snapshot cache stamp and the bare-id resolver.
 @MainActor
-final class ProviderAccountAssemblyTests: XCTestCase {
-    private func makeScratchDefaults() -> UserDefaults {
-        let suiteName = "OpenUsageTests.ProviderAccountAssembly.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
-        return defaults
-    }
-
+final class ProviderAccountAssemblyTests: ClaudeAssemblyTestCase {
     func testResolvedFamiliesFeedIdentityKeysAndTheRegistry() throws {
         let defaults = makeScratchDefaults()
         let store = ProviderAccountsStore(defaults: defaults)
@@ -35,6 +27,9 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         XCTAssertEqual(record.id, "claude")
         XCTAssertEqual(record.label, "dev@example.com")
         XCTAssertEqual(record.sources.map(\.kind), [.defaultHome])
+        XCTAssertEqual(assembly.claudeCards.map(\.id), ["claude"])
+        XCTAssertEqual(assembly.claudeCards.first?.credential, .defaultHome)
+        XCTAssertEqual(assembly.claudeCards.first?.identityKey, "acct-1")
         // An unresolved family claims no account: no record, no identity key.
         XCTAssertNil(store.defaultBadgeHolder(family: "codex"))
     }
@@ -61,7 +56,267 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         XCTAssertNil(store.defaultBadgeHolder(family: "claude"), "an out-of-pass family must not be reconciled")
     }
 
-    private func makeDiscovery(
+    func testNothingObservedLeavesRegistryAndKeysEmpty() {
+        let defaults = makeScratchDefaults()
+        let store = ProviderAccountsStore(defaults: defaults)
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles([:]),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+
+        let assembly = ProviderAccountAssembly.make(observer: observer, accountsStore: store)
+
+        XCTAssertTrue(assembly.identityKeysByCard.isEmpty)
+        XCTAssertTrue(store.records.isEmpty)
+        XCTAssertNil(defaults.data(forKey: ProviderAccountsStore.storageKey), "no observations, no write")
+    }
+
+    func testDefaultSwapKeepsBareAccountBoundToItsMovedConfigDirectory() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let firstObserver = makeClaudeObserver(
+            #"{"oauthAccount":{"accountUuid":"ACCOUNT-A","organizationUuid":"ORG-A"}}"#
+        )
+        let first = ProviderAccountAssembly.make(observer: firstObserver, accountsStore: store)
+        XCTAssertEqual(first.claudeCards.map(\.id), ["claude"])
+        store.rename(cardID: "claude", to: "Personal")
+
+        let secondObserver = makeClaudeObserver(
+            #"{"oauthAccount":{"accountUuid":"ACCOUNT-B","organizationUuid":"ORG-B"}}"#
+        )
+        let oldHome = "/Users/dev/.claude-personal"
+        let discovery = makeDiscovery(
+            files: [
+                oldHome + "/.claude.json":
+                    #"{"oauthAccount":{"accountUuid":"ACCOUNT-A","organizationUuid":"ORG-A"}}"#,
+                oldHome + "/.credentials.json":
+                    #"{"claudeAiOauth":{"accessToken":"personal-token"}}"#,
+            ],
+            subdirectories: [oldHome]
+        )
+
+        let swapped = ProviderAccountAssembly.make(
+            observer: secondObserver,
+            accountsStore: store,
+            claudeDiscovery: discovery
+        )
+
+        XCTAssertEqual(swapped.claudeCards.count, 2)
+        let oldAccount = try XCTUnwrap(swapped.claudeCards.first { $0.id == "claude" })
+        let newAccount = try XCTUnwrap(swapped.claudeCards.first { $0.id != "claude" })
+        XCTAssertEqual(oldAccount.identityKey, "account-a|org-a")
+        XCTAssertEqual(
+            oldAccount.credential,
+            .configDir(path: oldHome, keychainLiteral: oldHome)
+        )
+        XCTAssertEqual(newAccount.identityKey, "account-b|org-b")
+        XCTAssertEqual(newAccount.credential, .defaultHome)
+        XCTAssertEqual(store.defaultBadgeHolder(family: "claude")?.id, newAccount.id)
+        XCTAssertEqual(store.resolvedDisplayName(cardID: "claude"), "Personal")
+        XCTAssertEqual(swapped.identityKeysByCard["claude"], "account-a|org-a")
+        XCTAssertEqual(swapped.identityKeysByCard[newAccount.id], "account-b|org-b")
+
+        let runtimes = ProviderCatalog.make(claude: swapped.claudeRuntimePlan)
+            .compactMap { $0 as? ClaudeProvider }
+        let oldRuntime = try XCTUnwrap(runtimes.first { $0.provider.id == "claude" })
+        let newRuntime = try XCTUnwrap(runtimes.first { $0.provider.id == newAccount.id })
+        XCTAssertEqual(oldRuntime.authStore.scope, .configDir(path: oldHome, keychainLiteral: oldHome))
+        XCTAssertEqual(oldRuntime.expectedIdentityKey, "account-a|org-a")
+        XCTAssertEqual(newRuntime.authStore.scope, .standard)
+        XCTAssertEqual(newRuntime.expectedIdentityKey, "account-b|org-b")
+    }
+
+    func testDefaultSwapKeepsBareAccountBoundToItsDesktopOrganization() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let original = makeClaudeObserver(
+            #"{"oauthAccount":{"accountUuid":"ACCOUNT-A","organizationUuid":"ORG-A"}}"#
+        )
+        _ = ProviderAccountAssembly.make(observer: original, accountsStore: store)
+
+        let replacement = makeClaudeObserver(
+            #"{"oauthAccount":{"accountUuid":"ACCOUNT-B","organizationUuid":"ORG-B"}}"#
+        )
+        let oldSandbox = "/Users/dev/cowork/personal/.claude"
+        let cowork = makeCoworkDiscovery(
+            files: [
+                oldSandbox + "/.claude.json":
+                    #"{"oauthAccount":{"accountUuid":"ACCOUNT-A","organizationUuid":"ORG-A"}}"#,
+            ],
+            sandboxes: [oldSandbox]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: replacement,
+            accountsStore: store,
+            coworkDiscovery: cowork,
+            hasDesktopCredentialMaterial: { true }
+        )
+
+        let originalCard = try XCTUnwrap(assembly.claudeCards.first { $0.id == "claude" })
+        let replacementCard = try XCTUnwrap(assembly.claudeCards.first { $0.id != "claude" })
+        XCTAssertEqual(originalCard.credential, .desktop(organization: "org-a"))
+        XCTAssertEqual(originalCard.logRoots.map(\.path), [oldSandbox])
+        XCTAssertEqual(replacementCard.credential, .defaultHome)
+        XCTAssertEqual(replacementCard.coworkRootsOverride, [])
+        XCTAssertEqual(store.defaultBadgeHolder(family: "claude")?.id, replacementCard.id)
+    }
+
+    func testSameAccountConfigDirectoryAttachesWithoutDuplicatingItsRuntime() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let observer = makeClaudeObserver(
+            #"{"oauthAccount":{"accountUuid":"ACCOUNT-A","organizationUuid":"ORG-A"}}"#
+        )
+        let sideHome = "/Users/dev/.claude-side"
+        let discovery = makeDiscovery(
+            files: [
+                sideHome + "/.claude.json":
+                    #"{"oauthAccount":{"accountUuid":"ACCOUNT-A","organizationUuid":"ORG-A"}}"#,
+                sideHome + "/.credentials.json":
+                    #"{"claudeAiOauth":{"accessToken":"side-token"}}"#,
+            ],
+            subdirectories: [sideHome]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer,
+            accountsStore: store,
+            claudeDiscovery: discovery
+        )
+
+        let card = try XCTUnwrap(assembly.claudeCards.first)
+        XCTAssertEqual(assembly.claudeCards.count, 1)
+        XCTAssertEqual(card.credential, .defaultHome)
+        XCTAssertEqual(card.additionalLogRoots.map(\.path), [sideHome])
+        XCTAssertEqual(Set(store.records[0].sources.map(\.kind)), [.defaultHome, .configDir])
+    }
+
+    func testSameUserOrganizationsStaySeparateAndUnidentifiedSandboxIsQuarantined() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let observer = makeClaudeObserver(
+            #"{"oauthAccount":{"accountUuid":"SAME-USER","organizationUuid":"ORG-PERSONAL"}}"#
+        )
+        let personalRoot = "/Users/dev/cowork/personal/.claude"
+        let workRoot = "/Users/dev/cowork/work/.claude"
+        let unidentifiedRoot = "/Users/dev/cowork/unknown/.claude"
+        let cowork = makeCoworkDiscovery(
+            files: [
+                personalRoot + "/.claude.json":
+                    #"{"oauthAccount":{"accountUuid":"SAME-USER","organizationUuid":"ORG-PERSONAL"}}"#,
+                workRoot + "/.claude.json":
+                    #"{"oauthAccount":{"accountUuid":"SAME-USER","organizationUuid":"ORG-WORK","organizationName":"Work"}}"#,
+                unidentifiedRoot + "/.claude.json":
+                    #"{"oauthAccount":{"accountUuid":"SAME-USER"}}"#,
+            ],
+            sandboxes: [personalRoot, workRoot, unidentifiedRoot]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer,
+            accountsStore: store,
+            coworkDiscovery: cowork,
+            hasDesktopCredentialMaterial: { true }
+        )
+
+        XCTAssertEqual(assembly.claudeCards.count, 2)
+        let personal = try XCTUnwrap(assembly.claudeCards.first { $0.id == "claude" })
+        let work = try XCTUnwrap(assembly.claudeCards.first { $0.id != "claude" })
+        XCTAssertEqual(personal.identityKey, "same-user|org-personal")
+        XCTAssertEqual(personal.coworkRootsOverride?.map(\.path), [personalRoot])
+        XCTAssertEqual(work.identityKey, "same-user|org-work")
+        XCTAssertEqual(work.credential, .desktop(organization: "org-work"))
+        XCTAssertEqual(work.logRoots.map(\.path), [workRoot])
+        XCTAssertFalse(personal.logRoots.map(\.path).contains(unidentifiedRoot))
+        XCTAssertFalse(work.logRoots.map(\.path).contains(unidentifiedRoot))
+    }
+
+    func testOrglessDefaultIsQuarantinedWhenMultipleOrganizationsExist() throws {
+        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
+        let observer = makeClaudeObserver(
+            #"{"oauthAccount":{"accountUuid":"SAME-USER"}}"#
+        )
+        let personal = "/Users/dev/cowork/personal/.claude"
+        let work = "/Users/dev/cowork/work/.claude"
+        let cowork = makeCoworkDiscovery(
+            files: [
+                personal + "/.claude.json":
+                    #"{"oauthAccount":{"accountUuid":"SAME-USER","organizationUuid":"ORG-PERSONAL"}}"#,
+                work + "/.claude.json":
+                    #"{"oauthAccount":{"accountUuid":"SAME-USER","organizationUuid":"ORG-WORK"}}"#,
+            ],
+            sandboxes: [personal, work]
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer,
+            accountsStore: store,
+            coworkDiscovery: cowork,
+            hasDesktopCredentialMaterial: { true }
+        )
+
+        XCTAssertEqual(assembly.claudeCards.count, 2)
+        XCTAssertFalse(assembly.claudeCards.contains { $0.credential == .defaultHome })
+        XCTAssertEqual(
+            Set(assembly.claudeCards.map(\.identityKey)),
+            ["same-user|org-personal", "same-user|org-work"]
+        )
+        XCTAssertNil(store.defaultBadgeHolder(family: "claude"))
+    }
+
+}
+
+/// One small filesystem/registry fixture shared by account planning, partitioning, and auth tests.
+@MainActor
+class ClaudeAssemblyTestCase: XCTestCase {
+    func makeScratchDefaults() -> UserDefaults {
+        let suiteName = "OpenUsageTests.ClaudeAssembly.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return defaults
+    }
+
+    func makeClaudeObserver(_ state: String?) -> DefaultAccountObserver {
+        var files: [String: String] = [:]
+        if let state { files["/Users/dev/.claude.json"] = state }
+        return DefaultAccountObserver(
+            environment: FakeEnvironment([:]),
+            files: FakeFiles(files),
+            keychain: FakeKeychain(nil),
+            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+    }
+
+    func claudeState(_ account: String, organization: String? = nil) -> String {
+        let organizationField = organization.map { ",\"organizationUuid\":\"\($0)\"" } ?? ""
+        return "{\"oauthAccount\":{\"accountUuid\":\"\(account)\"\(organizationField)}}"
+    }
+
+    func makeClaudeStore(
+        identity: String,
+        aliases: [String] = [],
+        otherIdentity: String? = nil,
+        removed: Bool = false
+    ) throws -> ProviderAccountsStore {
+        let defaults = makeScratchDefaults()
+        var records = [ProviderAccountRecord(
+            id: "claude", family: "claude", identityKey: identity, identityAliases: aliases,
+            label: nil,
+            sources: [ProviderAccountSource(
+                kind: .defaultHome, anchor: "/Users/dev/.claude", holdsDefaultSource: true
+            )]
+        )]
+        if let otherIdentity {
+            records.append(ProviderAccountRecord(
+                id: "claude@deadbeef", family: "claude", identityKey: otherIdentity,
+                label: nil, sources: [], removedTombstone: removed
+            ))
+        }
+        defaults.set(try JSONEncoder().encode(records), forKey: ProviderAccountsStore.storageKey)
+        return ProviderAccountsStore(defaults: defaults)
+    }
+
+    func makeDiscovery(
         files: [String: String],
         subdirectories: [String]
     ) -> ClaudeConfigDirDiscovery {
@@ -78,381 +333,29 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         )
     }
 
-    func testADistinctConfigDirAccountMintsAHashedRecordAndAnExtraCard() throws {
-        let defaults = makeScratchDefaults()
-        let store = ProviderAccountsStore(defaults: defaults)
-        let observer = DefaultAccountObserver(
-            environment: FakeEnvironment([:]),
-            files: FakeFiles([
-                "/Users/dev/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1", "emailAddress": "dev@example.com"}}"#,
-            ]),
-            keychain: FakeKeychain(nil),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-        let discovery = makeDiscovery(
-            files: [
-                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "emailAddress": "work@example.com", "organizationName": "Sunstory"}}"#,
-                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
-            ],
-            subdirectories: ["/Users/dev/.claude-work"]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: observer, accountsStore: store, claudeDiscovery: discovery
-        )
-
-        let card = try XCTUnwrap(assembly.claudeCards.first)
-        XCTAssertEqual(assembly.claudeCards.count, 1)
-        XCTAssertTrue(card.id.hasPrefix("claude@"), "a config-dir account never claims the bare id")
-        XCTAssertEqual(card.displayName, "Claude — Sunstory")
-        XCTAssertEqual(card.credential, .configDir(path: "/Users/dev/.claude-work", keychainLiteral: "/Users/dev/.claude-work"))
-        XCTAssertEqual(card.logRoots.map(\.path), ["/Users/dev/.claude-work"])
-        XCTAssertEqual(assembly.identityKeysByCard["claude"], "acct-1")
-        XCTAssertEqual(assembly.identityKeysByCard[card.id], "acct-2")
-        // The registry recorded both: the default holder under the bare id, the extra account with
-        // its config-dir source.
-        let record = try XCTUnwrap(store.records.first { $0.id == card.id })
-        XCTAssertEqual(record.sources.map(\.kind), [.configDir])
-        XCTAssertEqual(record.label, "work@example.com (Sunstory)")
-        XCTAssertTrue(assembly.defaultClaudeExtraLogRoots.isEmpty)
-    }
-
-    func testASameAccountConfigDirFoldsOntoTheDefaultCardAsALogRoot() throws {
-        let defaults = makeScratchDefaults()
-        let store = ProviderAccountsStore(defaults: defaults)
-        let observer = DefaultAccountObserver(
-            environment: FakeEnvironment([:]),
-            files: FakeFiles([
-                "/Users/dev/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
-            ]),
-            keychain: FakeKeychain(nil),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-        let discovery = makeDiscovery(
-            files: [
-                "/Users/dev/.claude-side/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
-                "/Users/dev/.claude-side/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-1"}}"#,
-            ],
-            subdirectories: ["/Users/dev/.claude-side"]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: observer, accountsStore: store, claudeDiscovery: discovery
-        )
-
-        XCTAssertTrue(assembly.claudeCards.isEmpty, "one account never renders as two cards")
-        XCTAssertEqual(assembly.defaultClaudeExtraLogRoots.map(\.path), ["/Users/dev/.claude-side"])
-        let record = try XCTUnwrap(store.defaultBadgeHolder(family: "claude"))
-        XCTAssertEqual(record.id, "claude")
-        XCTAssertEqual(Set(record.sources.map(\.kind)), [.defaultHome, .configDir])
-    }
-
-    func testAnUnresolvedDefaultLoginSkipsCandidatesThisLaunch() {
-        let defaults = makeScratchDefaults()
-        let store = ProviderAccountsStore(defaults: defaults)
-        let observer = DefaultAccountObserver(
-            environment: FakeEnvironment([:]),
-            files: FakeFiles([
-                // Credentials exist but the state file names no account → unresolved, footprint present.
-                "/Users/dev/.claude/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-1"}}"#,
-            ]),
-            keychain: FakeKeychain(nil),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-        let discovery = makeDiscovery(
-            files: [
-                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2"}}"#,
-                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
-            ],
-            subdirectories: ["/Users/dev/.claude-work"]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: observer, accountsStore: store, claudeDiscovery: discovery
-        )
-
-        XCTAssertTrue(
-            assembly.claudeCards.isEmpty,
-            "with a nameless default login, an accepted candidate could be that very account — skip"
-        )
-        XCTAssertTrue(store.records.isEmpty)
-    }
-
-    func testNoDefaultLoginStillAcceptsAConfigDirOnlyAccount() throws {
-        let defaults = makeScratchDefaults()
-        let store = ProviderAccountsStore(defaults: defaults)
-        let observer = DefaultAccountObserver(
-            environment: FakeEnvironment([:]),
-            files: FakeFiles([:]),
-            keychain: FakeKeychain(nil),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-        let discovery = makeDiscovery(
-            files: [
-                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2"}}"#,
-                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
-            ],
-            subdirectories: ["/Users/dev/.claude-work"]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: observer, accountsStore: store, claudeDiscovery: discovery
-        )
-
-        let card = try XCTUnwrap(assembly.claudeCards.first)
-        XCTAssertTrue(
-            card.id.hasPrefix("claude@"),
-            "the bare id stays reserved for a future default-home login even when it is free"
-        )
-    }
-
-    // MARK: - Cowork sandboxes
-
-    private let coworkBase = "/Users/dev/Library/Application Support/Claude/local-agent-mode-sessions/g/s"
-
-    private func makeCoworkDiscovery(
+    func makeCoworkDiscovery(
         files: [String: String],
-        sandboxes: [String]
+        sandboxes: [String],
+        timeBudget: TimeInterval = 3
     ) -> ClaudeCoworkDiscovery {
         ClaudeCoworkDiscovery(
             files: FakeFiles(files),
             homeDirectory: { URL(fileURLWithPath: "/Users/dev") },
-            listSandboxes: { _ in sandboxes.map { URL(fileURLWithPath: $0) } }
+            listSandboxes: { _ in sandboxes.map { URL(fileURLWithPath: $0) } },
+            timeBudget: timeBudget
         )
     }
 
-    private func makeDefaultResolvedObserver() -> DefaultAccountObserver {
-        DefaultAccountObserver(
-            environment: FakeEnvironment([:]),
-            files: FakeFiles([
-                "/Users/dev/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
-            ]),
-            keychain: FakeKeychain(nil),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-    }
-
-    func testDefaultAccountSandboxesLeaveTheBuiltInCoworkWalkUntouched() {
-        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
-        let sandbox = "\(coworkBase)/local_1/.claude"
-        let cowork = makeCoworkDiscovery(
-            files: [sandbox + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#],
-            sandboxes: [sandbox]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
-        )
-
-        XCTAssertTrue(assembly.claudeCards.isEmpty)
-        XCTAssertNil(assembly.defaultClaudeCoworkRoots, "no partition — the scanner's built-in walk stays byte-identical")
-    }
-
-    func testADistinctCoworkAccountBecomesOneDesktopBackedCardAndPartitionsTheWalk() throws {
-        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
-        let mine = "\(coworkBase)/local_1/.claude"
-        let theirsA = "\(coworkBase)/local_2/.claude"
-        let theirsB = "\(coworkBase)/local_3/.claude"
-        let identity = #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2", "organizationName": "Sunstory"}}"#
-        let cowork = makeCoworkDiscovery(
-            files: [
-                mine + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-1"}}"#,
-                theirsA + "/.claude.json": identity,
-                theirsB + "/.claude.json": identity,
-            ],
-            sandboxes: [mine, theirsA, theirsB]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
-        )
-
-        let card = try XCTUnwrap(assembly.claudeCards.first)
-        XCTAssertEqual(assembly.claudeCards.count, 1, "several sandboxes of one account are ONE card")
-        XCTAssertEqual(card.credential, .desktop(organization: "org-2"))
-        XCTAssertEqual(card.displayName, "Claude — Sunstory")
-        XCTAssertEqual(card.logRoots.map(\.path), [theirsA, theirsB])
-        XCTAssertEqual(assembly.identityKeysByCard[card.id], "acct-2|org-2")
-        XCTAssertEqual(assembly.defaultClaudeCoworkRoots?.map(\.path), [mine], "the default card keeps exactly its own sandboxes")
-        let record = try XCTUnwrap(store.records.first { $0.id == card.id })
-        XCTAssertEqual(record.sources.map(\.kind), [.desktop])
-    }
-
-    func testCoworkSandboxesOfAConfigDirAccountAttachAsItsLogRoots() throws {
-        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
-        let sandbox = "\(coworkBase)/local_1/.claude"
-        let discovery = makeDiscovery(
-            files: [
-                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2"}}"#,
-                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
-            ],
-            subdirectories: ["/Users/dev/.claude-work"]
-        )
-        let cowork = makeCoworkDiscovery(
-            files: [sandbox + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2"}}"#],
-            sandboxes: [sandbox]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: makeDefaultResolvedObserver(),
-            accountsStore: store,
-            claudeDiscovery: discovery,
-            coworkDiscovery: cowork
-        )
-
-        let card = try XCTUnwrap(assembly.claudeCards.first)
-        XCTAssertEqual(assembly.claudeCards.count, 1, "the sandbox joins the config-dir card instead of minting a second one")
-        XCTAssertEqual(card.credential, .configDir(path: "/Users/dev/.claude-work", keychainLiteral: "/Users/dev/.claude-work"))
-        XCTAssertEqual(card.logRoots.map(\.path), ["/Users/dev/.claude-work", sandbox])
-        XCTAssertEqual(assembly.defaultClaudeCoworkRoots?.map(\.path), [], "the other account's sandbox leaves the default walk")
-    }
-
-    func testADistinctCoworkAccountWithoutAnOrgPinGetsNoCardButStaysOutOfTheDefaultWalk() {
-        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
-        let sandbox = "\(coworkBase)/local_1/.claude"
-        let cowork = makeCoworkDiscovery(
-            // An account UUID but no org: Desktop caches tokens per org, so there is no safe
-            // credential pin for a card.
-            files: [sandbox + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-3"}}"#],
-            sandboxes: [sandbox]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
-        )
-
-        XCTAssertTrue(assembly.claudeCards.isEmpty)
-        XCTAssertEqual(
-            assembly.defaultClaudeCoworkRoots?.map(\.path), [],
-            "another account's sessions must still not bleed into the default card's spend"
-        )
-        XCTAssertEqual(store.records.count, 1, "only the default account has a record")
-    }
-
-    func testAnUnidentifiedSandboxStaysOnTheDefaultCardEvenWhenAPartitionExists() throws {
-        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
-        let nameless = "\(coworkBase)/local_1/.claude"
-        let theirs = "\(coworkBase)/local_2/.claude"
-        let cowork = makeCoworkDiscovery(
-            files: [theirs + "/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2", "organizationUuid": "ORG-2"}}"#],
-            sandboxes: [nameless, theirs]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: makeDefaultResolvedObserver(), accountsStore: store, coworkDiscovery: cowork
-        )
-
-        XCTAssertEqual(assembly.claudeCards.count, 1)
-        XCTAssertEqual(
-            assembly.defaultClaudeCoworkRoots?.map(\.path), [nameless],
-            "a sandbox naming no account keeps counting on the default card, as the built-in walk always has"
-        )
-    }
-
-    func testARenameNeverBakesIntoTheCardOnlyTheResolverCarriesIt() throws {
-        let defaults = makeScratchDefaults()
-        let store = ProviderAccountsStore(defaults: defaults)
-        let observer = DefaultAccountObserver(
-            environment: FakeEnvironment([:]),
-            files: FakeFiles([:]),
-            keychain: FakeKeychain(nil),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-        let discovery = makeDiscovery(
-            files: [
-                "/Users/dev/.claude-work/.claude.json": #"{"oauthAccount": {"accountUuid": "ACCT-2"}}"#,
-                "/Users/dev/.claude-work/.credentials.json": #"{"claudeAiOauth": {"accessToken": "at-2"}}"#,
-            ],
-            subdirectories: ["/Users/dev/.claude-work"]
-        )
-
-        // First pass creates the record; the user then renames it.
-        let first = ProviderAccountAssembly.make(
-            observer: observer, accountsStore: store, claudeDiscovery: discovery
-        )
-        let cardID = try XCTUnwrap(first.claudeCards.first?.id)
-        XCTAssertEqual(first.claudeCards.first?.displayName, cardID, "no label → the short-hash id fallback")
-        store.rename(cardID: cardID, to: "Work Max")
-
-        let reloadedStore = ProviderAccountsStore(defaults: defaults)
-        let second = ProviderAccountAssembly.make(
-            observer: observer,
-            accountsStore: reloadedStore,
-            claudeDiscovery: discovery
-        )
-        // The baked card name stays the DERIVED default — a rename lives only in the registry and
-        // is resolved at render time, so a baked name can never be a stale copy of it.
-        XCTAssertEqual(second.claudeCards.first?.displayName, cardID)
-        XCTAssertEqual(reloadedStore.resolvedDisplayName(cardID: cardID), "Work Max")
-    }
-
-    func testAccountSwapKeepsTheOriginalCardBoundToItsOwnConfigDirectory() throws {
-        let store = ProviderAccountsStore(defaults: makeScratchDefaults())
-        let original = DefaultAccountObserver(
-            environment: FakeEnvironment(),
-            files: FakeFiles(["/Users/dev/.claude.json":
-                #"{"oauthAccount":{"accountUuid":"ACCOUNT-A"}}"#]),
-            keychain: FakeKeychain(),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-        _ = ProviderAccountAssembly.make(observer: original, accountsStore: store)
-        store.rename(cardID: "claude", to: "Personal")
-
-        let replacement = DefaultAccountObserver(
-            environment: FakeEnvironment(),
-            files: FakeFiles(["/Users/dev/.claude.json":
-                #"{"oauthAccount":{"accountUuid":"ACCOUNT-B"}}"#]),
-            keychain: FakeKeychain(),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-        let path = "/Users/dev/.claude-personal"
-        let discovery = makeDiscovery(
-            files: [
-                path + "/.claude.json": #"{"oauthAccount":{"accountUuid":"ACCOUNT-A"}}"#,
-                path + "/.credentials.json": #"{"claudeAiOauth":{"accessToken":"personal"}}"#,
-            ],
-            subdirectories: [path]
-        )
-
-        let assembly = ProviderAccountAssembly.make(
-            observer: replacement, accountsStore: store, claudeDiscovery: discovery
-        )
-        let originalCard = try XCTUnwrap(assembly.claudeCards.first)
-        XCTAssertEqual(originalCard.id, "claude")
-        XCTAssertEqual(originalCard.credential, .configDir(path: path, keychainLiteral: path))
-        XCTAssertEqual(originalCard.displayName, "Claude")
-        XCTAssertEqual(store.resolvedDisplayName(cardID: "claude"), "Personal")
-        XCTAssertNotEqual(assembly.defaultClaudeCardID, "claude")
-        XCTAssertEqual(assembly.identityKeysByCard["claude"], "account-a")
-        XCTAssertEqual(assembly.identityKeysByCard[assembly.defaultClaudeCardID], "account-b")
-
-        let runtimes = ProviderCatalog.make(
-            claudeCards: assembly.claudeCards,
-            defaultClaudeExtraLogRoots: assembly.defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: assembly.defaultClaudeDisplayName,
-            defaultClaudeCardID: assembly.defaultClaudeCardID
-        ).compactMap { $0 as? ClaudeProvider }
-        XCTAssertEqual(runtimes.first?.provider.id, "claude")
-        XCTAssertEqual(runtimes.first?.authStore.scope,
-                       .configDir(path: path, keychainLiteral: path))
-        XCTAssertEqual(runtimes.last?.provider.id, assembly.defaultClaudeCardID)
-        XCTAssertEqual(runtimes.last?.authStore.scope, .standard)
-    }
-
-    func testNothingObservedLeavesRegistryAndKeysEmpty() {
-        let defaults = makeScratchDefaults()
-        let store = ProviderAccountsStore(defaults: defaults)
-        let observer = DefaultAccountObserver(
-            environment: FakeEnvironment([:]),
-            files: FakeFiles([:]),
-            keychain: FakeKeychain(nil),
-            homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
-        )
-
-        let assembly = ProviderAccountAssembly.make(observer: observer, accountsStore: store)
-
-        XCTAssertTrue(assembly.identityKeysByCard.isEmpty)
-        XCTAssertTrue(store.records.isEmpty)
-        XCTAssertNil(defaults.data(forKey: ProviderAccountsStore.storageKey), "no observations, no write")
+    func claudeRuntime(
+        for assembly: ProviderAccountAssembly,
+        id: String? = nil
+    ) throws -> ClaudeProvider {
+        let runtimes = ProviderCatalog.make(claude: assembly.claudeRuntimePlan)
+            .compactMap { $0 as? ClaudeProvider }
+        let selected = runtimes.first { runtime in
+            if let id { return runtime.provider.id == id }
+            return runtime.authStore.scope == .standard
+        }
+        return try XCTUnwrap(selected)
     }
 }


### PR DESCRIPTION
## TL;DR

Replace special-case Claude account assembly with a single explicit runtime plan for every verified account.

## What was happening

- The default Claude card and additional account cards followed different assembly paths.
- Login swaps, account renames, source changes, and organization overlap made those paths difficult to keep consistent.

## What this changes

- Separate account observation, source planning, Cowork partitioning, persistent reconciliation, and runtime binding.
- Give every discovered Claude account exactly one verified runtime and stable card identity.
- Share the same runtime plan between the menu-bar app and the command-line usage reader.
- Replace overlapping historical assembly cases with focused account ownership and login-switch regressions.

## Heads-up

- Six changed files; the large deletion is the removal of the old special-case assembly and redundant tests.

## Tests

- 53 focused account assembly, discovery, scoped credential, login isolation, and migration tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This rewires how Claude credentials, Desktop fallback, and spend logs are bound to cards. A planning bug could mix accounts or drop usage, but the change is assembly-only and covered by focused ownership/login-switch tests.
> 
> **Overview**
> Replaces the special-case default-vs-extra Claude card path with one explicit runtime plan. Every verified account now gets a single bound card; the hardcoded default runtime exists only when discovery cannot prove any Claude account.
> 
> Assembly is split into observe → plan → Cowork partition → reconcile → bind. Credential ownership is decided at bind time (Desktop access, unscoped keychain fallback, expected identity), and spend roots attach only after identity is canonicalized. Ambiguous org-less identities, unidentified Cowork sandboxes, and truncated scans are quarantined instead of folding onto the default card.
> 
> `ProviderCatalog` and the CLI `UsageReader` consume the same `ClaudeRuntimePlan`, so login swaps keep the original `claude` card on its moved config dir or Desktop org while the new default-home login gets its own runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336cfab6a09f21c1ba46e89bb90618e928c76812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->