### PR TITLE
Claude accounts 10: cancel stale iCloud account writes

### DIFF
--- a/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
+++ b/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
@@ -90,10 +90,12 @@ actor ICloudUsageHistoryFileStore: UsageHistoryFileStoring {
     }
 
     func write(_ document: UsageHistoryDocument) async throws {
+        try Task.checkCancellation()
         try document.validate()
         let directory = try historyDirectory(create: true)
         let url = directory.appendingPathComponent(document.deviceID).appendingPathExtension("json")
         let data = try encoder.encode(document)
+        try Task.checkCancellation()
         try coordinatedWrite(data, to: url)
     }
 
@@ -135,11 +137,21 @@ actor ICloudUsageHistoryFileStore: UsageHistoryFileStoring {
         return try result?.get() ?? { throw CocoaError(.fileReadUnknown) }()
     }
 
-    private func coordinatedWrite(_ data: Data, to url: URL) throws {
+    func coordinatedWrite(
+        _ data: Data,
+        to url: URL,
+        beforeWriting: @Sendable () -> Void = {}
+    ) throws {
         var coordinationError: NSError?
         var operationError: Error?
         NSFileCoordinator().coordinate(writingItemAt: url, options: .forReplacing, error: &coordinationError) { coordinatedURL in
-            do { try data.write(to: coordinatedURL, options: .atomic) }
+            beforeWriting()
+            do {
+                // File coordination can block until after this account graph has been retired.
+                // Recheck inside its accessor so an older graph cannot overwrite its replacement.
+                try Task.checkCancellation()
+                try data.write(to: coordinatedURL, options: .atomic)
+            }
             catch { operationError = error }
         }
         if let coordinationError { throw coordinationError }
@@ -152,6 +164,12 @@ actor ICloudUsageHistoryFileStore: UsageHistoryFileStoring {
 final class ICloudUsageSyncStore {
     private static let enabledKey = "openusage.icloudSync.enabled.v1"
     private static let deviceIDKey = "openusage.icloudSync.deviceID.v1"
+    private static var pendingDisableCleanups: [String: PendingDisableCleanup] = [:]
+
+    private struct PendingDisableCleanup {
+        var id: UUID
+        var task: Task<Void, Never>
+    }
 
     private let defaults: UserDefaults
     private let fileStore: any UsageHistoryFileStoring
@@ -160,9 +178,11 @@ final class ICloudUsageSyncStore {
     private let writeDebounce: Duration
     private let observesMetadataChanges: Bool
     private var writeTask: Task<Void, Never>?
+    private var activationTask: Task<Void, Never>?
     private var metadataQuery: NSMetadataQuery?
     private var notificationTokens: [NSObjectProtocol] = []
     private var syncActivityCount = 0
+    private var isShutDownForAccountGraphReload = false
 
     let deviceID: String
     let deviceName: String
@@ -170,7 +190,7 @@ final class ICloudUsageSyncStore {
         didSet {
             guard enabled != oldValue else { return }
             defaults.set(enabled, forKey: Self.enabledKey)
-            Task { await applyEnabledChange() }
+            activationTask = Task { [weak self] in await self?.applyEnabledChange() }
         }
     }
     private(set) var isSyncing = false
@@ -199,7 +219,7 @@ final class ICloudUsageSyncStore {
         self.enabled = defaults.bool(forKey: Self.enabledKey)
         dataStore.onLocalHistoryChanged = { [weak self] in self?.scheduleWrite() }
         if enabled {
-            Task { await applyEnabledChange() }
+            activationTask = Task { [weak self] in await self?.applyEnabledChange() }
         }
     }
 
@@ -212,20 +232,62 @@ final class ICloudUsageSyncStore {
     }
 
     func scheduleWrite() {
-        guard enabled else { return }
+        guard enabled, !isShutDownForAccountGraphReload else { return }
         writeTask?.cancel()
         writeTask = Task { [weak self] in
             guard let self else { return }
             try? await Task.sleep(for: writeDebounce)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, !isShutDownForAccountGraphReload else { return }
             await writeNow()
         }
     }
 
+    /// Retire this graph's sync worker before its replacement starts writing the same device file.
+    /// Unlike turning sync off, a graph reload keeps both the user's preference and the existing
+    /// iCloud document intact; the replacement worker immediately rewrites that document itself.
+    func shutdownForAccountGraphReload() {
+        guard !isShutDownForAccountGraphReload else { return }
+        isShutDownForAccountGraphReload = true
+        writeTask?.cancel()
+        writeTask = nil
+        activationTask?.cancel()
+        activationTask = nil
+        dataStore.onLocalHistoryChanged = nil
+        stopObserving()
+
+        guard !enabled else { return }
+        // Opt-out may have queued its deletion without getting a chance to run before the graph was
+        // retired. Finish independently of that worker, and serialize every later graph's activation
+        // behind this device's cleanup so a delayed delete cannot remove its replacement's new file.
+        let cleanupID = UUID()
+        let previousCleanup = Self.pendingDisableCleanups[deviceID]?.task
+        let cleanup = Task { @MainActor [defaults, fileStore, deviceID] in
+            defer {
+                if Self.pendingDisableCleanups[deviceID]?.id == cleanupID {
+                    Self.pendingDisableCleanups.removeValue(forKey: deviceID)
+                }
+            }
+            await previousCleanup?.value
+            guard !defaults.bool(forKey: Self.enabledKey) else { return }
+            do {
+                try await fileStore.delete(deviceID: deviceID)
+            } catch {
+                AppLog.error(.config, "iCloud history disable cleanup failed after account reload: \(error.localizedDescription)")
+            }
+        }
+        Self.pendingDisableCleanups[deviceID] = PendingDisableCleanup(id: cleanupID, task: cleanup)
+    }
+
     private func applyEnabledChange() async {
+        guard !isShutDownForAccountGraphReload else { return }
         if enabled {
+            if let cleanup = Self.pendingDisableCleanups[deviceID] {
+                await cleanup.task.value
+            }
+            guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
             startObserving()
             await reload()
+            guard !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
             await writeNow()
         } else {
             writeTask?.cancel()
@@ -243,8 +305,9 @@ final class ICloudUsageSyncStore {
     }
 
     private func writeNow() async {
-        guard enabled else { return }
+        guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
         await withSyncActivity {
+            guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
             let document = dataStore.localHistoryDocument(
                 deviceID: deviceID,
                 deviceName: deviceName
@@ -257,21 +320,23 @@ final class ICloudUsageSyncStore {
                     try await fileStore.delete(deviceID: deviceID)
                     return
                 }
+                guard !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
                 operationError = nil
                 await reload()
             } catch {
+                guard !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
                 report(error, context: "write")
             }
         }
     }
 
     private func reload() async {
-        guard enabled else { return }
+        guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
         await withSyncActivity {
             do {
                 let result = try await fileStore.loadDocuments()
                 // A read that began while enabled must not restore peer state after sync was disabled.
-                guard enabled else { return }
+                guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
                 documents = UsageHistoryDocument.newestByDevice(result.documents)
                 invalidFileMessages = result.invalidFileMessages
                 dataStore.setPeerHistoryDocuments(result.documents, ownDeviceID: deviceID)
@@ -279,6 +344,7 @@ final class ICloudUsageSyncStore {
                     ? nil
                     : "Some synced usage data couldn’t be read. Check the log for details."
             } catch {
+                guard !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
                 report(error, context: "read")
             }
         }

--- a/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
+++ b/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
@@ -190,6 +190,7 @@ final class ICloudUsageSyncStore {
         didSet {
             guard enabled != oldValue else { return }
             defaults.set(enabled, forKey: Self.enabledKey)
+            activationTask?.cancel()
             activationTask = Task { [weak self] in await self?.applyEnabledChange() }
         }
     }

--- a/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
+++ b/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
@@ -183,6 +183,7 @@ final class ICloudUsageSyncStore {
     private var notificationTokens: [NSObjectProtocol] = []
     private var syncActivityCount = 0
     private var isShutDownForAccountGraphReload = false
+    private var disableCleanupPending = false
 
     let deviceID: String
     let deviceName: String
@@ -190,8 +191,15 @@ final class ICloudUsageSyncStore {
         didSet {
             guard enabled != oldValue else { return }
             defaults.set(enabled, forKey: Self.enabledKey)
-            activationTask?.cancel()
-            activationTask = Task { [weak self] in await self?.applyEnabledChange() }
+            if !enabled { disableCleanupPending = true }
+            let previousActivation = activationTask
+            previousActivation?.cancel()
+            let isEnabling = enabled
+            activationTask = Task { [weak self] in
+                if isEnabling { await previousActivation?.value }
+                guard !Task.isCancelled else { return }
+                await self?.applyEnabledChange()
+            }
         }
     }
     private(set) var isSyncing = false
@@ -256,7 +264,7 @@ final class ICloudUsageSyncStore {
         dataStore.onLocalHistoryChanged = nil
         stopObserving()
 
-        guard !enabled else { return }
+        guard !enabled, disableCleanupPending else { return }
         // Opt-out may have queued its deletion without getting a chance to run before the graph was
         // retired. Finish independently of that worker, and serialize every later graph's activation
         // behind this device's cleanup so a delayed delete cannot remove its replacement's new file.
@@ -298,8 +306,11 @@ final class ICloudUsageSyncStore {
             invalidFileMessages = []
             do {
                 try await fileStore.delete(deviceID: deviceID)
+                disableCleanupPending = false
+                guard !Task.isCancelled, !isShutDownForAccountGraphReload, !enabled else { return }
                 operationError = nil
             } catch {
+                guard !Task.isCancelled, !isShutDownForAccountGraphReload, !enabled else { return }
                 report(error, context: "disable")
             }
         }

--- a/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
+++ b/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
@@ -58,6 +58,21 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "openusage.icloudSync.enabled.v1"))
     }
 
+    func testShutdownNeverTouchesCloudWhenSyncWasNeverEnabled() async throws {
+        let defaults = makeDefaults("never-enabled")
+        let fileStore = RecordingHistoryFileStore()
+        let sync = makeSync(defaults, fileStore: fileStore)
+
+        sync.shutdownForAccountGraphReload()
+        for _ in 0..<10 { await Task.yield() }
+
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        let writeCount = await fileStore.writeCount
+        XCTAssertTrue(deletedDeviceIDs.isEmpty)
+        XCTAssertEqual(writeCount, 0)
+        XCTAssertNil(sync.serviceError)
+    }
+
     func testAccountGraphShutdownCancelsInFlightWriteWithoutReplacingExistingFile() async throws {
         let defaults = makeDefaults("account-graph-shutdown-in-flight")
         let deviceIDStore = MemoryDeviceIDStore()
@@ -112,6 +127,28 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         let deletedDeviceIDs = await fileStore.deletedDeviceIDs
         XCTAssertEqual(documents, [currentDocument])
         XCTAssertTrue(deletedDeviceIDs.isEmpty)
+    }
+
+    func testReenableWaitsForAnInFlightDisableDeletion() async throws {
+        let defaults = makeDefaults("reenable-during-delete")
+        let fileStore = RecordingHistoryFileStore()
+        let sync = makeSync(defaults, fileStore: fileStore)
+        sync.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !sync.isSyncing }
+
+        await fileStore.holdNextDelete()
+        sync.enabled = false
+        try await waitUntil { await fileStore.deleteIsHeld }
+        sync.enabled = true
+
+        for _ in 0..<10 { await Task.yield() }
+        let writesBeforeDeletion = await fileStore.writeCount
+        XCTAssertEqual(writesBeforeDeletion, 1)
+
+        await fileStore.releaseDelete()
+        try await waitUntil { await fileStore.writeCount == 2 && !sync.isSyncing }
+        let documents = await fileStore.documents
+        XCTAssertEqual(documents.map(\.deviceID), [sync.deviceID])
     }
 
     func testCanceledCoordinatedAccessorCannotOverwriteReplacementAccountDocument() async throws {

--- a/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
+++ b/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
@@ -6,7 +6,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     func testEnableWritesLoadsAndDisableDeletesThisMac() async throws {
         let defaults = makeDefaults("enable-disable")
         let fileStore = RecordingHistoryFileStore()
-        let sync = makeSync(defaults: defaults, fileStore: fileStore, writeDebounce: .milliseconds(10))
+        let sync = makeSync(defaults, fileStore: fileStore, writeDebounce: .milliseconds(10))
 
         sync.enabled = true
         try await waitUntil { await fileStore.writeCount == 1 && sync.displayedDocuments.count == 1 }
@@ -22,7 +22,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     func testAdjacentHistoryChangesDebounceToOneWrite() async throws {
         let defaults = makeDefaults("debounce")
         let fileStore = RecordingHistoryFileStore()
-        let sync = makeSync(defaults: defaults, fileStore: fileStore, writeDebounce: .milliseconds(20))
+        let sync = makeSync(defaults, fileStore: fileStore, writeDebounce: .milliseconds(20))
         sync.enabled = true
         try await waitUntil { await fileStore.writeCount == 1 }
 
@@ -36,10 +36,134 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         XCTAssertEqual(writeCount, 2)
     }
 
+    func testAccountGraphShutdownCancelsDebouncedWriteWithoutDisablingOrDeleting() async throws {
+        let defaults = makeDefaults("account-graph-shutdown-debounce")
+        let fileStore = RecordingHistoryFileStore()
+        let sync = makeSync(defaults, fileStore: fileStore, writeDebounce: .milliseconds(30))
+        sync.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !sync.isSyncing }
+
+        sync.scheduleWrite()
+        sync.shutdownForAccountGraphReload()
+        sync.scheduleWrite()
+        try await Task.sleep(for: .milliseconds(80))
+
+        let writeCount = await fileStore.writeCount
+        let documents = await fileStore.documents
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        XCTAssertEqual(writeCount, 1, "the retired graph cannot publish a queued or newly scheduled write")
+        XCTAssertEqual(documents.map(\.deviceID), [sync.deviceID], "graph reload keeps this Mac's existing file")
+        XCTAssertTrue(deletedDeviceIDs.isEmpty, "graph reload is not the same as opting out of iCloud")
+        XCTAssertTrue(sync.enabled)
+        XCTAssertTrue(defaults.bool(forKey: "openusage.icloudSync.enabled.v1"))
+    }
+
+    func testAccountGraphShutdownCancelsInFlightWriteWithoutReplacingExistingFile() async throws {
+        let defaults = makeDefaults("account-graph-shutdown-in-flight")
+        let deviceIDStore = MemoryDeviceIDStore()
+        let expectedDeviceID = UUID().uuidString.lowercased()
+        try deviceIDStore.writeDeviceID(expectedDeviceID)
+        let existingDocument = UsageHistoryDocument(
+            deviceID: expectedDeviceID,
+            deviceName: "Previous Account Graph",
+            updatedAt: Date(timeIntervalSince1970: 123),
+            providers: [:]
+        )
+        let fileStore = RecordingHistoryFileStore(seedDocuments: [existingDocument])
+        let sync = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+
+        await fileStore.holdNextWrite()
+        sync.enabled = true
+        try await waitUntil { await fileStore.writeInFlight }
+
+        sync.shutdownForAccountGraphReload()
+        await fileStore.releaseWrite()
+        try await waitUntil { !(await fileStore.writeInFlight) && !sync.isSyncing }
+
+        let documents = await fileStore.documents
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        XCTAssertEqual(documents, [existingDocument], "a canceled stale graph must not replace the current device file")
+        XCTAssertTrue(deletedDeviceIDs.isEmpty, "only the replacement graph owns subsequent writes")
+        XCTAssertTrue(sync.enabled)
+        XCTAssertNil(sync.serviceError, "cancellation is an intentional shutdown, not an iCloud failure")
+    }
+
+    func testCanceledCoordinatedAccessorCannotOverwriteReplacementAccountDocument() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openusage-sync-coordination-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let documentURL = directory.appendingPathComponent("device.json")
+        let currentAccount = Data("replacement-account".utf8)
+        try currentAccount.write(to: documentURL)
+
+        let fileStore = ICloudUsageHistoryFileStore()
+        let retiredWriter = Task.detached {
+            try await fileStore.coordinatedWrite(
+                Data("retired-account".utf8),
+                to: documentURL,
+                beforeWriting: {
+                    withUnsafeCurrentTask { task in task?.cancel() }
+                }
+            )
+        }
+
+        do {
+            try await retiredWriter.value
+            XCTFail("a graph retired while waiting for file coordination must not commit")
+        } catch is CancellationError {
+            // Expected: cancellation is checked after the coordinated accessor begins.
+        }
+        XCTAssertEqual(try Data(contentsOf: documentURL), currentAccount)
+    }
+
+    func testDisableImmediatelyBeforeGraphReloadStillDeletesThisMac() async throws {
+        let defaults = makeDefaults("disable-immediate-account-graph-reload")
+        let fileStore = RecordingHistoryFileStore()
+        let deviceIDStore = MemoryDeviceIDStore()
+        let retired = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+        retired.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !retired.isSyncing }
+
+        retired.enabled = false
+        retired.shutdownForAccountGraphReload()
+        let replacement = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+
+        XCTAssertFalse(replacement.enabled)
+        try await waitUntil { await fileStore.deletedDeviceIDs.contains(retired.deviceID) }
+        let documents = await fileStore.documents
+        XCTAssertFalse(documents.contains { $0.deviceID == retired.deviceID })
+    }
+
+    func testReenabledReplacementKeepsThisMacAfterInterruptedDisable() async throws {
+        let defaults = makeDefaults("disable-reload-reenable")
+        let fileStore = RecordingHistoryFileStore()
+        let deviceIDStore = MemoryDeviceIDStore()
+        let retired = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+        retired.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !retired.isSyncing }
+
+        await fileStore.holdNextDelete()
+        retired.enabled = false
+        retired.shutdownForAccountGraphReload()
+        try await waitUntil { await fileStore.deleteIsHeld }
+        let replacement = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+        replacement.enabled = true
+
+        for _ in 0..<10 { await Task.yield() }
+        let writesBeforeDeleteCompletes = await fileStore.writeCount
+        XCTAssertEqual(writesBeforeDeleteCompletes, 1, "replacement waits for the retired graph's deletion")
+        await fileStore.releaseDelete()
+        try await waitUntil { await fileStore.writeCount == 2 && !replacement.isSyncing }
+        let documents = await fileStore.documents
+        XCTAssertEqual(documents.map(\.deviceID), [replacement.deviceID])
+        XCTAssertTrue(replacement.enabled)
+    }
+
     func testDisableDeletesWriteThatWasAlreadyInFlight() async throws {
         let defaults = makeDefaults("disable-in-flight-write")
         let fileStore = RecordingHistoryFileStore()
-        let sync = makeSync(defaults: defaults, fileStore: fileStore)
+        let sync = makeSync(defaults, fileStore: fileStore)
 
         // Hold the enable write open so disable can race it deliberately, instead of hoping an
         // 80ms sleep is still in flight when the test flips the toggle on a loaded CI runner.
@@ -66,7 +190,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     func testUnavailableStoreSurfacesFriendlyError() async throws {
         let defaults = makeDefaults("unavailable")
         let fileStore = RecordingHistoryFileStore(unavailable: true)
-        let sync = makeSync(defaults: defaults, fileStore: fileStore)
+        let sync = makeSync(defaults, fileStore: fileStore)
 
         sync.enabled = true
         try await waitUntil { sync.serviceError != nil && !sync.isSyncing }
@@ -87,7 +211,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
             seedDocuments: [peer],
             invalidFileMessages: ["broken.json: invalid value"]
         )
-        let sync = makeSync(defaults: defaults, fileStore: fileStore)
+        let sync = makeSync(defaults, fileStore: fileStore)
 
         sync.enabled = true
         try await waitUntil { sync.invalidFileMessages.count == 1 }
@@ -99,7 +223,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     func testBackgroundReloadShowsSyncActivity() async throws {
         let defaults = makeDefaults("background-sync-activity")
         let fileStore = RecordingHistoryFileStore()
-        let sync = makeSync(defaults: defaults, fileStore: fileStore, writeDebounce: .milliseconds(10))
+        let sync = makeSync(defaults, fileStore: fileStore, writeDebounce: .milliseconds(10))
 
         sync.enabled = true
         try await waitUntil {
@@ -125,9 +249,9 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         firstDefaults.set(expectedID, forKey: "openusage.icloudSync.deviceID.v1")
         let deviceIDStore = MemoryDeviceIDStore()
 
-        let first = makeSync(defaults: firstDefaults, fileStore: RecordingHistoryFileStore(), deviceIDStore: deviceIDStore)
+        let first = makeSync(firstDefaults, deviceIDStore: deviceIDStore)
         let resetDefaults = makeDefaults("identity-after-reset")
-        let afterReset = makeSync(defaults: resetDefaults, fileStore: RecordingHistoryFileStore(), deviceIDStore: deviceIDStore)
+        let afterReset = makeSync(resetDefaults, deviceIDStore: deviceIDStore)
 
         XCTAssertEqual(first.deviceID, expectedID)
         XCTAssertEqual(afterReset.deviceID, expectedID)
@@ -153,19 +277,18 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     }
 
     private func makeSync(
-        defaults: UserDefaults,
-        fileStore: RecordingHistoryFileStore,
+        _ defaults: UserDefaults,
+        fileStore: RecordingHistoryFileStore = RecordingHistoryFileStore(),
         deviceIDStore: MemoryDeviceIDStore = MemoryDeviceIDStore(),
         writeDebounce: Duration = .seconds(3)
     ) -> ICloudUsageSyncStore {
-        let dataStore = WidgetDataStore(
-            registry: WidgetRegistry(providers: [], descriptors: []),
-            providers: [],
-            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots"),
-            defaults: defaults
-        )
-        return ICloudUsageSyncStore(
-            dataStore: dataStore,
+        ICloudUsageSyncStore(
+            dataStore: WidgetDataStore(
+                registry: WidgetRegistry(providers: [], descriptors: []),
+                providers: [],
+                cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots"),
+                defaults: defaults
+            ),
             defaults: defaults,
             fileStore: fileStore,
             deviceIDStore: deviceIDStore,
@@ -217,8 +340,11 @@ private actor RecordingHistoryFileStore: UsageHistoryFileStoring {
     private(set) var writeInFlight = false
     private var shouldHoldNextLoad = false
     private var shouldHoldNextWrite = false
+    private var shouldHoldNextDelete = false
     private var loadGate: CheckedContinuation<Void, Never>?
     private var writeGate: CheckedContinuation<Void, Never>?
+    private var deleteGate: CheckedContinuation<Void, Never>?
+    var deleteIsHeld: Bool { deleteGate != nil }
 
     init(
         unavailable: Bool = false,
@@ -245,6 +371,7 @@ private actor RecordingHistoryFileStore: UsageHistoryFileStoring {
 
     func write(_ document: UsageHistoryDocument) async throws {
         if unavailable { throw ICloudUsageSyncError.unavailable }
+        try Task.checkCancellation()
         writeCount += 1
         writeInFlight = true
         defer { writeInFlight = false }
@@ -254,12 +381,17 @@ private actor RecordingHistoryFileStore: UsageHistoryFileStoring {
                 writeGate = continuation
             }
         }
+        try Task.checkCancellation()
         documents.removeAll { $0.deviceID == document.deviceID }
         documents.append(document)
     }
 
     func delete(deviceID: String) async throws {
         if unavailable { throw ICloudUsageSyncError.unavailable }
+        if shouldHoldNextDelete {
+            shouldHoldNextDelete = false
+            await withCheckedContinuation { deleteGate = $0 }
+        }
         deletedDeviceIDs.append(deviceID)
         documents.removeAll { $0.deviceID == deviceID }
     }
@@ -271,6 +403,9 @@ private actor RecordingHistoryFileStore: UsageHistoryFileStoring {
     func holdNextWrite() {
         shouldHoldNextWrite = true
     }
+
+    func holdNextDelete() { shouldHoldNextDelete = true }
+    func releaseDelete() { deleteGate?.resume(); deleteGate = nil }
 
     func releaseLoad() {
         loadGate?.resume()

--- a/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
+++ b/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
@@ -88,6 +88,32 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         XCTAssertNil(sync.serviceError, "cancellation is an intentional shutdown, not an iCloud failure")
     }
 
+    func testRapidEnableChangesCannotLeaveAnOrphanedWriterAfterShutdown() async throws {
+        let defaults = makeDefaults("orphaned-activation")
+        let deviceIDStore = MemoryDeviceIDStore()
+        let deviceID = UUID().uuidString.lowercased()
+        try deviceIDStore.writeDeviceID(deviceID)
+        let currentDocument = UsageHistoryDocument(
+            deviceID: deviceID, deviceName: "Current Account", updatedAt: Date(), providers: [:]
+        )
+        let fileStore = RecordingHistoryFileStore(seedDocuments: [currentDocument])
+        let sync = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+
+        await fileStore.holdNextWrite()
+        sync.enabled = true
+        try await waitUntil { await fileStore.writeInFlight }
+        sync.enabled = false
+        sync.enabled = true
+        sync.shutdownForAccountGraphReload()
+        await fileStore.releaseWrite()
+        try await waitUntil { !(await fileStore.writeInFlight) && !sync.isSyncing }
+
+        let documents = await fileStore.documents
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        XCTAssertEqual(documents, [currentDocument])
+        XCTAssertTrue(deletedDeviceIDs.isEmpty)
+    }
+
     func testCanceledCoordinatedAccessorCannotOverwriteReplacementAccountDocument() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("openusage-sync-coordination-\(UUID().uuidString)", isDirectory: true)
@@ -178,9 +204,8 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
 
         await fileStore.releaseWrite()
         try await waitUntil {
-            let deletedCount = await fileStore.deletedDeviceIDs.filter { $0 == sync.deviceID }.count
             let writeInFlight = await fileStore.writeInFlight
-            return deletedCount >= 2 && !writeInFlight && !sync.isSyncing
+            return !writeInFlight && !sync.isSyncing
         }
 
         let documents = await fileStore.documents


### PR DESCRIPTION
## TL;DR

Prevent a replaced account runtime from writing stale or deleted account history back into iCloud.

## What was happening

- Scheduled iCloud writes could outlive the account runtime that scheduled them.
- Account removal or a rapid runtime replacement could race with an already pending cloud write.

## What this changes

- Cancel obsolete iCloud work when its owning account runtime shuts down.
- Preserve pending account deletions and reject writes from replaced runtime generations.
- Add focused regressions for replacement races, account removal, and stale cloud publishes.

## Tests

- iCloud sync store, account-history remapping, and sync-document validation suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches iCloud history write/delete races and cancellation around account replacement. Incorrect sequencing could drop or resurrect a device’s synced file, but the change is well covered by targeted race tests.
> 
> **Overview**
> Stops a retired account runtime from publishing stale usage history to iCloud when the account graph is replaced.
> 
> Adds `shutdownForAccountGraphReload()` so the old worker cancels writes, observation, and activation without turning sync off or deleting the device file. Coordinated writes now re-check cancellation inside the file-coordinator accessor so a blocked write cannot overwrite the replacement graph. Enable/disable is serialized through `activationTask`, and pending opt-out deletions are handed off to a per-device cleanup queue so a delayed delete cannot remove a replacement’s new file.
> 
> Tests cover debounce/in-flight shutdown, enable/disable races across graph reload, and a coordinated-write cancellation that must not clobber the current document.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223185d8f854f80e8054f162a5b78ddcc7cf97dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->