### PR TITLE
Multi-account 4/4: safe account lifecycle and live runtime updates

### DIFF
--- a/Sources/OpenUsage/App/AccountRuntimeGraph.swift
+++ b/Sources/OpenUsage/App/AccountRuntimeGraph.swift
@@ -26,6 +26,7 @@ final class AccountRuntimeGraph {
     }
 
     func retireCurrentState() {
+        state.codexResetClaim?.retireForAccountGraphReload()
         state.dataStore.retireForAccountGraphReload()
         runtimeTasks = nil
         resetDetection = nil

--- a/Sources/OpenUsage/App/AccountRuntimeGraph.swift
+++ b/Sources/OpenUsage/App/AccountRuntimeGraph.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Observation
+
+/// Account-bound services can change without replacing the status item, HTTP listener, or telemetry.
+@MainActor
+@Observable
+final class AccountRuntimeGraph {
+    struct State {
+        let registry: WidgetRegistry
+        let layout: LayoutStore
+        let dataStore: WidgetDataStore
+        let iCloudSync: ICloudUsageSyncStore
+        let providers: [ProviderRuntime]
+        let apiKeyProviders: [any APIKeyManaging]
+        let codexResetClaim: CodexResetClaimService?
+    }
+
+    var state: State
+    @ObservationIgnored var runtimeTasks: AccountRuntimeTaskLifetime?
+    @ObservationIgnored var accountWatcher: AccountRuntimeTaskLifetime?
+    @ObservationIgnored var resetDetection: AccountRuntimeTaskLifetime?
+
+    init(state: State) {
+        self.state = state
+    }
+
+    func retireCurrentState() {
+        runtimeTasks = nil
+        resetDetection = nil
+        state.iCloudSync.shutdownForAccountGraphReload()
+    }
+}
+
+/// Task handles are Sendable, so destruction cancels them safely even outside the main actor.
+final class AccountRuntimeTaskLifetime: Sendable {
+    private let tasks: [Task<Void, Never>]
+
+    init(_ tasks: [Task<Void, Never>?]) {
+        self.tasks = tasks.compactMap { $0 }
+    }
+
+    deinit {
+        tasks.forEach { $0.cancel() }
+    }
+}

--- a/Sources/OpenUsage/App/AccountRuntimeGraph.swift
+++ b/Sources/OpenUsage/App/AccountRuntimeGraph.swift
@@ -9,6 +9,7 @@ final class AccountRuntimeGraph {
         let registry: WidgetRegistry
         let layout: LayoutStore
         let dataStore: WidgetDataStore
+        let snapshotCache: ProviderSnapshotCache
         let iCloudSync: ICloudUsageSyncStore
         let providers: [ProviderRuntime]
         let apiKeyProviders: [any APIKeyManaging]
@@ -25,6 +26,7 @@ final class AccountRuntimeGraph {
     }
 
     func retireCurrentState() {
+        state.dataStore.retireForAccountGraphReload()
         runtimeTasks = nil
         resetDetection = nil
         state.iCloudSync.shutdownForAccountGraphReload()

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -71,6 +71,7 @@ final class AppContainer {
             identityKeysByCard: [:],
             allowsUnboundClaudeFallback: !accounts.records.contains { $0.family == "claude" },
             isClaudeDiscoveryComplete: false,
+            defaultClaudeCoworkRoots: [],
             defaultClaudeDesktopAccess: .denied
         )
         self.accounts = accounts
@@ -161,6 +162,7 @@ final class AppContainer {
                     identityKeysByCard: [:],
                     allowsUnboundClaudeFallback: !self.accounts.records.contains { $0.family == "claude" },
                     isClaudeDiscoveryComplete: false,
+                    defaultClaudeCoworkRoots: [],
                     defaultClaudeDesktopAccess: .denied
                 )
                 self.replaceAccountRuntime(with: quarantined, quarantinesUnverifiedAccountData: true)

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -172,7 +172,8 @@ final class AppContainer {
         assembly: ProviderAccountAssembly,
         accounts: ProviderAccountsStore,
         enablement: ProviderEnablementStore,
-        notificationSettings: NotificationSettingsStore
+        notificationSettings: NotificationSettingsStore,
+        snapshotCache: ProviderSnapshotCache = ProviderSnapshotCache()
     ) -> AccountRuntimeGraph.State {
         let providers = ProviderCatalog.make(
             claudeCards: assembly.claudeCards,
@@ -194,6 +195,7 @@ final class AppContainer {
         let dataStore = WidgetDataStore(
             registry: registry,
             providers: providers,
+            cache: snapshotCache,
             isProviderEnabled: { [enablement] in enablement.isEnabled($0) },
             orderedDescriptors: { [layout] in layout.visiblePlaced.compactMap { layout.descriptor(for: $0) } },
             notificationSettings: { notificationSettings },
@@ -242,6 +244,7 @@ final class AppContainer {
             registry: registry,
             layout: layout,
             dataStore: dataStore,
+            snapshotCache: snapshotCache,
             iCloudSync: iCloudSync,
             providers: providers,
             apiKeyProviders: providers.compactMap { $0 as? any APIKeyManaging },
@@ -276,10 +279,12 @@ final class AppContainer {
 
     private func replaceAccountRuntime(with assembly: ProviderAccountAssembly) {
         let previousScreen = layout.screen
+        let snapshotCache = accountGraph.state.snapshotCache
         accountGraph.retireCurrentState()
         let replacement = Self.makeAccountRuntime(
             assembly: assembly, accounts: accounts,
-            enablement: enablement, notificationSettings: notificationSettings
+            enablement: enablement, notificationSettings: notificationSettings,
+            snapshotCache: snapshotCache
         )
         replacement.layout.screen = previousScreen
         replacement.dataStore.onRefreshOutcome = { [weak telemetry] providerID, outcome, category, manual in
@@ -299,10 +304,13 @@ final class AppContainer {
             var identityKey: String
             var verifiedIdentityAliases: Set<ClaudeIdentity>
             var credential: ClaudeAccountCard.Credential
+            var logRoots: Set<URL>
         }
 
         var identities: [String: String]
         var cards: [Card]
+        var defaultClaudeExtraLogRoots: Set<URL>
+        var defaultClaudeCoworkRoots: Set<URL>?
         var allowsUnboundClaudeFallback: Bool
         var defaultClaudeVerifiedIdentityAliases: Set<ClaudeIdentity>
         var desktopAccess: ClaudeDesktopAccessPolicy
@@ -312,9 +320,12 @@ final class AppContainer {
             cards = assembly.claudeCards.map {
                 Card(
                     id: $0.id, identityKey: $0.identityKey,
-                    verifiedIdentityAliases: $0.verifiedIdentityAliases, credential: $0.credential
+                    verifiedIdentityAliases: $0.verifiedIdentityAliases, credential: $0.credential,
+                    logRoots: Set($0.logRoots)
                 )
             }
+            defaultClaudeExtraLogRoots = Set(assembly.defaultClaudeExtraLogRoots)
+            defaultClaudeCoworkRoots = assembly.defaultClaudeCoworkRoots.map { Set($0) }
             allowsUnboundClaudeFallback = assembly.allowsUnboundClaudeFallback
             defaultClaudeVerifiedIdentityAliases = assembly.defaultClaudeVerifiedIdentityAliases
             desktopAccess = assembly.defaultClaudeDesktopAccess

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -388,16 +388,24 @@ final class AppContainer {
         func observeDefaults() async -> [String: DefaultAccountObserver.Outcome] {
             await loadOffMainActor {
                 let observer = DefaultAccountObserver()
-                return ["claude": observer.observeClaude(), "codex": observer.observeCodex()]
+                let desktop = ClaudeDesktopAuthStore().lastKnownAccountUUID().map {
+                    DefaultAccountObserver.Outcome.resolved(identityKey: $0, label: nil, anchor: "desktop")
+                } ?? .absent
+                return ["claude": observer.observeClaude(), "codex": observer.observeCodex(), "claude-desktop": desktop]
             }
         }
 
         return Task { @MainActor in
-            let shellReady = await loadOffMainActor { LoginShellEnvironment.shared.ensureCaptured() }
-            guard !Task.isCancelled else { return }
-            guard shellReady || ShellEnvironmentSnapshotStore.launchSnapshot != nil else {
-                AppLog.error(.config, "accounts: login shell unavailable; retaining quarantined startup graph")
-                return
+            while !Task.isCancelled {
+                let shellReady = await loadOffMainActor { LoginShellEnvironment.shared.ensureCaptured() }
+                guard !Task.isCancelled else { return }
+                if shellReady || ShellEnvironmentSnapshotStore.launchSnapshot != nil { break }
+                AppLog.error(.config, "accounts: login shell unavailable; retrying quarantined account discovery")
+                do {
+                    try await Task.sleep(for: .seconds(5))
+                } catch {
+                    return
+                }
             }
             var previousDefaults: [String: DefaultAccountObserver.Outcome] = [:]
             var previousOwnership = AccountOwnershipFingerprint(initialAssembly)

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -175,19 +175,7 @@ final class AppContainer {
         notificationSettings: NotificationSettingsStore,
         snapshotCache: ProviderSnapshotCache = ProviderSnapshotCache()
     ) -> AccountRuntimeGraph.State {
-        let providers = ProviderCatalog.make(
-            claudeCards: assembly.claudeCards,
-            defaultClaudeExtraLogRoots: assembly.defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: assembly.defaultClaudeDisplayName,
-            defaultClaudeCardID: assembly.defaultClaudeCardID,
-            defaultClaudeVerifiedIdentityAliases: assembly.defaultClaudeVerifiedIdentityAliases,
-            claudeIdentityKeys: assembly.identityKeysByCard,
-            allowsUnboundClaudeFallback: assembly.allowsUnboundClaudeFallback,
-            isClaudeDiscoveryComplete: assembly.isClaudeDiscoveryComplete,
-            allowsUnownedClaudeDesktopFallback: assembly.allowsUnownedClaudeDesktopFallback,
-            defaultClaudeCoworkRoots: assembly.defaultClaudeCoworkRoots,
-            defaultClaudeDesktopAccess: assembly.defaultClaudeDesktopAccess
-        )
+        let providers = ProviderCatalog.make(accountAssembly: assembly)
         let registry = WidgetRegistry.from(providers)
         let layout = LayoutStore(
             registry: registry, isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
@@ -217,6 +205,7 @@ final class AppContainer {
             CodexResetClaimService(
                 authStore: codex.authStore,
                 usageClient: codex.usageClient,
+                expectedIdentityKey: codex.expectedIdentityKey,
                 refreshAfterClaim: { [weak dataStore] in
                     var failures = 0
                     for attempt in 0..<45 {

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -449,7 +449,9 @@ final class AppContainer {
                 let observedDefaults = await observeDefaults()
                 guard !Task.isCancelled else { return }
                 checksSinceFullDiscovery += 1
-                guard !bootstrapped || observedDefaults != previousDefaults || checksSinceFullDiscovery >= 12 else {
+                guard !bootstrapped || ownershipIsQuarantined
+                    || observedDefaults != previousDefaults || checksSinceFullDiscovery >= 12
+                else {
                     continue
                 }
                 if bootstrapped && observedDefaults != previousDefaults && !ownershipIsQuarantined {
@@ -465,6 +467,10 @@ final class AppContainer {
                 })
                 guard !Task.isCancelled else { return }
                 guard prepared.isComplete else {
+                    if bootstrapped && !ownershipIsQuarantined {
+                        onOwnershipUnverified()
+                        ownershipIsQuarantined = true
+                    }
                     AppLog.warn(.config, "accounts: incomplete background discovery quarantined before reconciliation")
                     if !bootstrapped {
                         try? await Task.sleep(for: .seconds(5))

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -7,18 +7,19 @@ import Observation
 @MainActor
 @Observable
 final class AppContainer {
-    let registry: WidgetRegistry
-    let layout: LayoutStore
-    let dataStore: WidgetDataStore
+    private let accountGraph: AccountRuntimeGraph
+    var registry: WidgetRegistry { accountGraph.state.registry }
+    var layout: LayoutStore { accountGraph.state.layout }
+    var dataStore: WidgetDataStore { accountGraph.state.dataStore }
     /// Opt-in private iCloud document sync for additive machine-local daily history.
-    let iCloudSync: ICloudUsageSyncStore
+    var iCloudSync: ICloudUsageSyncStore { accountGraph.state.iCloudSync }
     /// Single source of truth for which providers the user has turned off. Both stores consult it (via
     /// injected closures) and the Customize provider list drives it.
     let enablement: ProviderEnablementStore
     /// Providers that need a user-supplied API key (currently OpenRouter and Z.ai), conforming to
     /// `APIKeyManaging`. Each matching Customize provider detail shows an API Key section and writes
     /// changes through the capability. Empty when no installed provider needs a user key.
-    let apiKeyProviders: [any APIKeyManaging]
+    var apiKeyProviders: [any APIKeyManaging] { accountGraph.state.apiKeyProviders }
     /// Quota pace notification preferences (three independent triggers). Drives the Settings section
     /// and is read by `WidgetDataStore.evaluateNotifications`.
     let notificationSettings: NotificationSettingsStore
@@ -40,22 +41,15 @@ final class AppContainer {
     /// write). Shares the Codex provider's auth store and usage client; `nil` only if the Codex
     /// provider were ever removed from the registry. Injected into the view tree via
     /// `\.codexResetClaim`.
-    let codexResetClaim: CodexResetClaimService?
+    var codexResetClaim: CodexResetClaimService? { accountGraph.state.codexResetClaim }
     /// The account registry the launch pass reconciled. The UI observes it live: a rename
     /// (`customLabel`) re-titles the card everywhere without a relaunch.
     let accounts: ProviderAccountsStore
     /// The provider runtimes, kept so on-demand credential detection (the Customize "Reset All" reseed)
     /// can re-probe `hasLocalCredentials()` the same way first-run seeding does.
-    private let providers: [ProviderRuntime]
+    private var providers: [ProviderRuntime] { accountGraph.state.providers }
     /// Read-only usage API on 127.0.0.1:6736 for other local apps (silently off when the port is taken).
     private let localAPI: LocalUsageServer
-    // A `let` of a `Sendable` `Task` is implicitly nonisolated, so the nonisolated `deinit` can cancel it.
-    private let refreshTask: Task<Void, Never>
-    /// The fresh-install credential-detection pass (see `FirstRunSeeder`); `nil` on every later launch.
-    private let seedTask: Task<Void, Never>?
-    /// The new-provider credential-detection pass (see `NewProviderSeeder`); `nil` unless this launch is
-    /// the first with a provider the install has never seen.
-    private let newProviderTask: Task<Void, Never>?
     /// Persists a fresh `ShellEnvironmentSnapshot` once the login-shell capture completes, so the next
     /// launch can read shell-exported facts (provider home overrides) even when its own capture is slow.
     private let shellEnvironmentSnapshotTask: Task<Void, Never>
@@ -77,53 +71,20 @@ final class AppContainer {
         let accountAssembly = ProviderAccountAssembly.make(accountsStore: accounts, waitsForLoginShell: true)
         self.accounts = accounts
 
-        let providers = ProviderCatalog.make(
-            claudeCards: accountAssembly.claudeCards,
-            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName,
-            defaultClaudeCardID: accountAssembly.defaultClaudeCardID,
-            defaultClaudeVerifiedIdentityAliases: accountAssembly.defaultClaudeVerifiedIdentityAliases,
-            claudeIdentityKeys: accountAssembly.identityKeysByCard,
-            allowsUnboundClaudeFallback: accountAssembly.allowsUnboundClaudeFallback,
-            isClaudeDiscoveryComplete: accountAssembly.isClaudeDiscoveryComplete,
-            allowsUnownedClaudeDesktopFallback: accountAssembly.allowsUnownedClaudeDesktopFallback,
-            defaultClaudeCoworkRoots: accountAssembly.defaultClaudeCoworkRoots,
-            defaultClaudeDesktopAccess: accountAssembly.defaultClaudeDesktopAccess
-        )
-        let registry = WidgetRegistry.from(providers)
-        let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
         let enablement = ProviderEnablementStore()
         let notificationSettings = NotificationSettingsStore()
-        let layout = LayoutStore(
-            registry: registry,
-            isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
+        let runtime = Self.makeAccountRuntime(
+            assembly: accountAssembly, accounts: accounts,
+            enablement: enablement, notificationSettings: notificationSettings
         )
-        let dataStore = WidgetDataStore(
-            registry: registry,
-            providers: providers,
-            isProviderEnabled: { [enablement] in enablement.isEnabled($0) },
-            orderedDescriptors: { [layout] in layout.visiblePlaced.compactMap { layout.descriptor(for: $0) } },
-            notificationSettings: { notificationSettings },
-            providerIdentityKeys: accountAssembly.identityKeysByCard,
-            knownAccountIdentitiesByFamily: accounts.records.reduce(into: [:]) { identities, record in
-                identities[record.family, default: []].formUnion(
-                    [record.identityKey] + (record.identityAliases ?? [])
-                )
-            },
-            resolveDisplayName: { [accounts] in accounts.resolvedDisplayName(cardID: $0) }
-        )
-        let iCloudSync = ICloudUsageSyncStore(dataStore: dataStore)
-        // Re-enabling a provider should fetch it promptly, so clear any leftover failure backoff before
-        // the enablement wake refreshes. `weak` breaks the cycle (dataStore already captures enablement).
-        enablement.onProviderEnabled = { [weak dataStore] id in dataStore?.clearFailureBackoff(for: id) }
-        enablement.onChange = { [weak dataStore, weak iCloudSync] in
-            dataStore?.providerEnablementDidChange()
-            iCloudSync?.scheduleWrite()
-        }
+        let providers = runtime.providers
+        let dataStore = runtime.dataStore
+        let accountGraph = AccountRuntimeGraph(state: runtime)
+        self.accountGraph = accountGraph
         // Fresh installs start minimal: seed the enabled-provider list (Claude/Codex/Cursor right away,
         // then the detected set once the local credential probe finishes). No-op on every later launch.
         let onboarding = OnboardingStore()
-        self.seedTask = FirstRunSeeder.seedIfNeeded(
+        let seedTask = FirstRunSeeder.seedIfNeeded(
             isFreshInstall: isFreshInstall,
             providers: providers,
             enablement: enablement,
@@ -132,61 +93,12 @@ final class AppContainer {
         // Providers added by an update get the same credential detection on their first launch — enabled
         // only when the user actually has the tool. Runs every launch; a no-op unless the registry has a
         // provider this install has never seen (fresh installs were just baselined by FirstRunSeeder).
-        self.newProviderTask = NewProviderSeeder.reconcileIfNeeded(
-            providers: providers,
-            enablement: enablement
-        )
-        self.providers = providers
+        let newProviderTask = seedTask == nil
+            ? NewProviderSeeder.reconcileIfNeeded(providers: providers, enablement: enablement)
+            : nil
         self.onboarding = onboarding
-        self.registry = registry
         self.enablement = enablement
-        self.apiKeyProviders = apiKeyProviders
         self.notificationSettings = notificationSettings
-        self.layout = layout
-        self.dataStore = dataStore
-        self.iCloudSync = iCloudSync
-
-        // The resets popover's claim service, sharing the Codex provider's credential loading and HTTP
-        // client so the claim's auth can't drift from the provider's. A successful claim forces a Codex
-        // refresh so the meters and credit count reconcile before the popover shows its result. The
-        // forced refresh returns `.skipped` when another refresh already owns the provider — and that
-        // in-flight probe may carry *pre-claim* usage — so retry until this refresh actually runs
-        // (bounded; the racing probe finishes in seconds).
-        self.codexResetClaim = providers.compactMap { $0 as? CodexProvider }.first.map { codex in
-            CodexResetClaimService(
-                authStore: codex.authStore,
-                usageClient: codex.usageClient,
-                refreshAfterClaim: { [weak dataStore] in
-                    // The bound must outlast the provider's slowest refresh: usage fetch (10s timeout)
-                    // + token refresh (15s) + usage retry (10s) + reset-credit fetch (10s) ≈ 45s. The
-                    // common race (the periodic timer's probe) clears in a couple of seconds; the
-                    // pathological one keeps the popover's honest "Resetting…" up rather than showing
-                    // a success banner over pre-claim meters. A `.failed` probe is retried a few times
-                    // too — a transient flake right after the claim must not strand pre-claim meters
-                    // behind a success banner — before giving up loudly (the provider error already
-                    // shows on the card, so the staleness isn't silent).
-                    var failures = 0
-                    for attempt in 0..<45 {
-                        guard let dataStore else { return }
-                        switch await dataStore.refresh(providerID: codex.provider.id, force: true) {
-                        case .refreshed, .cacheHit, .backedOff:
-                            return
-                        case .failed:
-                            failures += 1
-                            guard failures < 3 else {
-                                AppLog.error(LogTag.plugin("codex"), "post-claim refresh failed \(failures) times; meters may lag until the next cycle")
-                                return
-                            }
-                            try? await Task.sleep(for: .seconds(2))
-                        case .skipped:
-                            AppLog.info(LogTag.plugin("codex"), "post-claim refresh waiting out an in-flight refresh (attempt \(attempt + 1))")
-                            try? await Task.sleep(for: .seconds(1))
-                        }
-                    }
-                    AppLog.error(LogTag.plugin("codex"), "post-claim refresh kept being skipped; meters may lag until the next cycle")
-                }
-            )
-        }
 
         // Anonymous usage telemetry (mandatory daily activity and crashes, optional provider rollups).
         // Its state lives in a dedicated UserDefaults suite, kept separate from app settings so the user's
@@ -197,7 +109,9 @@ final class AppContainer {
         let telemetry = TelemetryRecorder(
             sink: PostHogTelemetrySink(enabled: telemetryStore.enabled),
             store: telemetryStore,
-            snapshot: { [registry, enablement, layout] in
+            snapshot: { [accountGraph, enablement] in
+                let registry = accountGraph.state.registry
+                let layout = accountGraph.state.layout
                 // Report the *active* configuration: a metric whose provider is turned off is hidden
                 // from the dashboard and menu bar, so exclude it here too — keeping the metric arrays
                 // consistent with `enabledProviders` (which is also enablement-filtered).
@@ -220,20 +134,30 @@ final class AppContainer {
         self.telemetry = telemetry
         self.transparency = PopoverTransparencyStore()
         self.privacy = MenuBarPrivacyStore()
-        self.localAPI = LocalUsageServer(state: { [layout, enablement, dataStore, accounts] in
-            LocalUsageAPI.State(
-                enabledOrderedIDs: layout.orderedProviderIDs().filter { enablement.isEnabled($0) },
-                knownIDs: Set(registry.providers.map(\.id)),
-                snapshots: dataStore.snapshots,
-                limitDescriptors: registry.limitDescriptorsByProvider,
-                errors: dataStore.providerErrors
+        self.localAPI = LocalUsageServer(state: { [accountGraph, enablement, accounts] in
+            let current = accountGraph.state
+            return LocalUsageAPI.State(
+                enabledOrderedIDs: current.layout.orderedProviderIDs().filter { enablement.isEnabled($0) },
+                knownIDs: Set(current.registry.providers.map(\.id)),
+                snapshots: current.dataStore.snapshots,
+                limitDescriptors: current.registry.limitDescriptorsByProvider,
+                errors: current.dataStore.providerErrors
             )
             // API output is human-read too: resolve card titles at respond time so renames show,
             // exactly like every UI surface.
             .resolvingDisplayNames(accounts.resolvedDisplayNamesByCardID)
         })
-        self.refreshTask = Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry)
+        accountGraph.runtimeTasks = AccountRuntimeTaskLifetime([
+            Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry),
+            seedTask,
+            newProviderTask,
+        ])
         localAPI.start()
+        accountGraph.accountWatcher = AccountRuntimeTaskLifetime([
+            Self.startAccountGraphWatch(accounts: accounts, initialAssembly: accountAssembly) { [weak self] assembly in
+                self?.replaceAccountRuntime(with: assembly)
+            },
+        ])
         // Become the notification-center delegate so banners show while frontmost — a menu-bar accessory
         // effectively always is. Notification authorization is requested the first time a trigger is
         // turned on in Settings, not at launch — triggers default off. No-op under tests.
@@ -241,10 +165,88 @@ final class AppContainer {
     }
 
     deinit {
-        refreshTask.cancel()
-        seedTask?.cancel()
-        newProviderTask?.cancel()
         shellEnvironmentSnapshotTask.cancel()
+    }
+
+    private static func makeAccountRuntime(
+        assembly: ProviderAccountAssembly,
+        accounts: ProviderAccountsStore,
+        enablement: ProviderEnablementStore,
+        notificationSettings: NotificationSettingsStore
+    ) -> AccountRuntimeGraph.State {
+        let providers = ProviderCatalog.make(
+            claudeCards: assembly.claudeCards,
+            defaultClaudeExtraLogRoots: assembly.defaultClaudeExtraLogRoots,
+            defaultClaudeDisplayName: assembly.defaultClaudeDisplayName,
+            defaultClaudeCardID: assembly.defaultClaudeCardID,
+            defaultClaudeVerifiedIdentityAliases: assembly.defaultClaudeVerifiedIdentityAliases,
+            claudeIdentityKeys: assembly.identityKeysByCard,
+            allowsUnboundClaudeFallback: assembly.allowsUnboundClaudeFallback,
+            isClaudeDiscoveryComplete: assembly.isClaudeDiscoveryComplete,
+            allowsUnownedClaudeDesktopFallback: assembly.allowsUnownedClaudeDesktopFallback,
+            defaultClaudeCoworkRoots: assembly.defaultClaudeCoworkRoots,
+            defaultClaudeDesktopAccess: assembly.defaultClaudeDesktopAccess
+        )
+        let registry = WidgetRegistry.from(providers)
+        let layout = LayoutStore(
+            registry: registry, isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
+        )
+        let dataStore = WidgetDataStore(
+            registry: registry,
+            providers: providers,
+            isProviderEnabled: { [enablement] in enablement.isEnabled($0) },
+            orderedDescriptors: { [layout] in layout.visiblePlaced.compactMap { layout.descriptor(for: $0) } },
+            notificationSettings: { notificationSettings },
+            providerIdentityKeys: assembly.identityKeysByCard,
+            knownAccountIdentitiesByFamily: accounts.records.reduce(into: [:]) { identities, record in
+                identities[record.family, default: []].formUnion(
+                    [record.identityKey] + (record.identityAliases ?? [])
+                )
+            },
+            resolveDisplayName: { [accounts] in accounts.resolvedDisplayName(cardID: $0) }
+        )
+        let iCloudSync = ICloudUsageSyncStore(dataStore: dataStore)
+        enablement.onProviderEnabled = { [weak dataStore] id in dataStore?.clearFailureBackoff(for: id) }
+        enablement.onChange = { [weak dataStore, weak iCloudSync] in
+            dataStore?.providerEnablementDidChange()
+            iCloudSync?.scheduleWrite()
+        }
+        let codexResetClaim = providers.compactMap { $0 as? CodexProvider }.first.map { codex in
+            CodexResetClaimService(
+                authStore: codex.authStore,
+                usageClient: codex.usageClient,
+                refreshAfterClaim: { [weak dataStore] in
+                    var failures = 0
+                    for attempt in 0..<45 {
+                        guard let dataStore else { return }
+                        switch await dataStore.refresh(providerID: codex.provider.id, force: true) {
+                        case .refreshed, .cacheHit, .backedOff:
+                            return
+                        case .failed:
+                            failures += 1
+                            guard failures < 3 else {
+                                AppLog.error(LogTag.plugin("codex"), "post-claim refresh failed \(failures) times; meters may lag until the next cycle")
+                                return
+                            }
+                            try? await Task.sleep(for: .seconds(2))
+                        case .skipped:
+                            AppLog.info(LogTag.plugin("codex"), "post-claim refresh waiting out an in-flight refresh (attempt \(attempt + 1))")
+                            try? await Task.sleep(for: .seconds(1))
+                        }
+                    }
+                    AppLog.error(LogTag.plugin("codex"), "post-claim refresh kept being skipped; meters may lag until the next cycle")
+                }
+            )
+        }
+        return .init(
+            registry: registry,
+            layout: layout,
+            dataStore: dataStore,
+            iCloudSync: iCloudSync,
+            providers: providers,
+            apiKeyProviders: providers.compactMap { $0 as? any APIKeyManaging },
+            codexResetClaim: codexResetClaim
+        )
     }
 
     /// The name a card renders under right now — the app-side face of the one resolver
@@ -267,7 +269,136 @@ final class AppContainer {
     /// Delegates to `FirstRunSeeder.reseed`; returns its detection task so callers can await it.
     @discardableResult
     func reseedEnabledProviders() -> Task<Void, Never> {
-        FirstRunSeeder.reseed(providers: providers, enablement: enablement)
+        let task = FirstRunSeeder.reseed(providers: providers, enablement: enablement)
+        accountGraph.resetDetection = AccountRuntimeTaskLifetime([task])
+        return task
+    }
+
+    private func replaceAccountRuntime(with assembly: ProviderAccountAssembly) {
+        let previousScreen = layout.screen
+        accountGraph.retireCurrentState()
+        let replacement = Self.makeAccountRuntime(
+            assembly: assembly, accounts: accounts,
+            enablement: enablement, notificationSettings: notificationSettings
+        )
+        replacement.layout.screen = previousScreen
+        replacement.dataStore.onRefreshOutcome = { [weak telemetry] providerID, outcome, category, manual in
+            telemetry?.record(providerID: providerID, outcome: outcome, category: category, manual: manual)
+        }
+        accountGraph.state = replacement
+        accountGraph.runtimeTasks = AccountRuntimeTaskLifetime([
+            Self.startPeriodicRefresh(dataStore: replacement.dataStore, telemetry: telemetry),
+            NewProviderSeeder.reconcileIfNeeded(providers: replacement.providers, enablement: enablement),
+        ])
+        AppLog.info(.config, "accounts: account runtimes updated without replacing app services")
+    }
+
+    struct AccountOwnershipFingerprint: Equatable {
+        struct Card: Equatable {
+            var id: String
+            var identityKey: String
+            var verifiedIdentityAliases: Set<ClaudeIdentity>
+            var credential: ClaudeAccountCard.Credential
+        }
+
+        var identities: [String: String]
+        var cards: [Card]
+        var allowsUnboundClaudeFallback: Bool
+        var defaultClaudeVerifiedIdentityAliases: Set<ClaudeIdentity>
+        var desktopAccess: ClaudeDesktopAccessPolicy
+
+        init(_ assembly: ProviderAccountAssembly) {
+            identities = assembly.identityKeysByCard
+            cards = assembly.claudeCards.map {
+                Card(
+                    id: $0.id, identityKey: $0.identityKey,
+                    verifiedIdentityAliases: $0.verifiedIdentityAliases, credential: $0.credential
+                )
+            }
+            allowsUnboundClaudeFallback = assembly.allowsUnboundClaudeFallback
+            defaultClaudeVerifiedIdentityAliases = assembly.defaultClaudeVerifiedIdentityAliases
+            desktopAccess = assembly.defaultClaudeDesktopAccess
+        }
+    }
+
+    private static func startAccountGraphWatch(
+        accounts: ProviderAccountsStore,
+        initialAssembly: ProviderAccountAssembly,
+        onChange: @escaping @MainActor (ProviderAccountAssembly) -> Void
+    ) -> Task<Void, Never> {
+        func observeDefaults() -> [String: DefaultAccountObserver.Outcome] {
+            let observer = DefaultAccountObserver()
+            return ["claude": observer.observeClaude(), "codex": observer.observeCodex()]
+        }
+
+        let initialDefaults = observeDefaults()
+        return Task { @MainActor in
+            var previousDefaults = initialDefaults
+            var previousOwnership = AccountOwnershipFingerprint(initialAssembly)
+            var checksSinceFullDiscovery = 0
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(5))
+                } catch {
+                    return
+                }
+                let observedDefaults = observeDefaults()
+                checksSinceFullDiscovery += 1
+                guard observedDefaults != previousDefaults || checksSinceFullDiscovery >= 12 else { continue }
+                previousDefaults = observedDefaults
+                checksSinceFullDiscovery = 0
+                let preferredAnchors = Set(accounts.records.flatMap { record in
+                    record.sources.filter { $0.kind == .configDir }.compactMap(\.anchor)
+                })
+                let prepared = await prepareAccountDiscovery(configScan: {
+                    ClaudeConfigDirDiscovery().run(prioritizing: preferredAnchors)
+                })
+                guard !Task.isCancelled else { return }
+                guard prepared.isComplete else {
+                    AppLog.warn(.config, "accounts: incomplete background discovery quarantined before reconciliation")
+                    continue
+                }
+                guard observeDefaults() == observedDefaults else {
+                    AppLog.info(.config, "accounts: default login changed during discovery; retrying")
+                    continue
+                }
+                let assembly = ProviderAccountAssembly.make(
+                    accountsStore: accounts, waitsForLoginShell: true, preparedDiscovery: prepared
+                )
+                guard !Task.isCancelled else { return }
+                let ownership = AccountOwnershipFingerprint(assembly)
+                guard ownership != previousOwnership else { continue }
+                previousOwnership = ownership
+                onChange(assembly)
+            }
+        }
+    }
+
+    static func prepareAccountDiscovery(
+        configScan: @escaping @Sendable () -> ClaudeConfigDirDiscovery.Result = {
+            ClaudeConfigDirDiscovery().run()
+        },
+        coworkScan: @escaping @Sendable () -> ClaudeCoworkDiscovery.Result = {
+            ClaudeCoworkDiscovery().run()
+        }
+    ) async -> PreparedProviderAccountDiscovery {
+        let task = Task.detached(priority: .utility) {
+            guard !Task.isCancelled else {
+                return PreparedProviderAccountDiscovery(
+                    config: .init(truncated: true), cowork: .init(truncated: true)
+                )
+            }
+            let config = configScan()
+            guard !Task.isCancelled, !config.truncated else {
+                return PreparedProviderAccountDiscovery(config: config, cowork: .init(truncated: true))
+            }
+            return PreparedProviderAccountDiscovery(config: config, cowork: coworkScan())
+        }
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 
     /// The Settings "Reset All Settings" action: restores every user preference the container owns to

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -64,11 +64,15 @@ final class AppContainer {
         // Once the capture lands, persist its identity-relevant facts so the NEXT launch has them
         // even if that launch's own capture is slow (see `ShellEnvironmentSnapshot`).
         self.shellEnvironmentSnapshotTask = ShellEnvironmentSnapshotStore(defaults: .standard).startRefreshTask()
-        // The launch account pass: which account is signed in at each family's default home, plus
-        // the config-dir scan for extra Claude logins. Feeds the snapshot cache's account stamp,
-        // reconciles the account registry, and hands the catalog its extra-card build plan.
+        // The status item appears from a quarantined local-only graph immediately; the expensive
+        // filesystem walks and first credential detection wait for the verified background bootstrap.
         let accounts = ProviderAccountsStore()
-        let accountAssembly = ProviderAccountAssembly.make(accountsStore: accounts, waitsForLoginShell: true)
+        let accountAssembly = ProviderAccountAssembly(
+            identityKeysByCard: [:],
+            allowsUnboundClaudeFallback: !accounts.records.contains { $0.family == "claude" },
+            isClaudeDiscoveryComplete: false,
+            defaultClaudeDesktopAccess: .denied
+        )
         self.accounts = accounts
 
         let enablement = ProviderEnablementStore()
@@ -77,6 +81,7 @@ final class AppContainer {
             assembly: accountAssembly, accounts: accounts,
             enablement: enablement, notificationSettings: notificationSettings
         )
+        runtime.iCloudSync.shutdownForAccountGraphReload()
         let providers = runtime.providers
         let dataStore = runtime.dataStore
         let accountGraph = AccountRuntimeGraph(state: runtime)
@@ -84,18 +89,13 @@ final class AppContainer {
         // Fresh installs start minimal: seed the enabled-provider list (Claude/Codex/Cursor right away,
         // then the detected set once the local credential probe finishes). No-op on every later launch.
         let onboarding = OnboardingStore()
-        let seedTask = FirstRunSeeder.seedIfNeeded(
+        FirstRunSeeder.seedIfNeeded(
             isFreshInstall: isFreshInstall,
             providers: providers,
             enablement: enablement,
-            onboarding: onboarding
+            onboarding: onboarding,
+            deferDetectionUntilDiscovery: true
         )
-        // Providers added by an update get the same credential detection on their first launch — enabled
-        // only when the user actually has the tool. Runs every launch; a no-op unless the registry has a
-        // provider this install has never seen (fresh installs were just baselined by FirstRunSeeder).
-        let newProviderTask = seedTask == nil
-            ? NewProviderSeeder.reconcileIfNeeded(providers: providers, enablement: enablement)
-            : nil
         self.onboarding = onboarding
         self.enablement = enablement
         self.notificationSettings = notificationSettings
@@ -147,15 +147,12 @@ final class AppContainer {
             // exactly like every UI surface.
             .resolvingDisplayNames(accounts.resolvedDisplayNamesByCardID)
         })
-        accountGraph.runtimeTasks = AccountRuntimeTaskLifetime([
-            Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry),
-            seedTask,
-            newProviderTask,
-        ])
         localAPI.start()
         accountGraph.accountWatcher = AccountRuntimeTaskLifetime([
             Self.startAccountGraphWatch(accounts: accounts, initialAssembly: accountAssembly) { [weak self] assembly in
                 self?.replaceAccountRuntime(with: assembly)
+            } onLogRootsChanged: { [weak self] assembly in
+                await self?.updateAccountLogRouting(with: assembly)
             },
         ])
         // Become the notification-center delegate so banners show while frontmost — a menu-bar accessory
@@ -287,20 +284,48 @@ final class AppContainer {
         AppLog.info(.config, "accounts: account runtimes updated without replacing app services")
     }
 
+    private func updateAccountLogRouting(with assembly: ProviderAccountAssembly) async {
+        var updatedProviderIDs: [String] = []
+        for provider in providers.compactMap({ $0 as? ClaudeProvider }) {
+            guard !Task.isCancelled else { return }
+            let updated: Bool
+            if let card = assembly.claudeCards.first(where: { $0.id == provider.provider.id }) {
+                updated = await provider.logUsageScanner.updateLogRoots(
+                    rootsOverride: card.logRoots, additionalRoots: [], coworkRootsOverride: nil
+                )
+            } else if provider.provider.id == assembly.defaultClaudeCardID {
+                updated = await provider.logUsageScanner.updateLogRoots(
+                    rootsOverride: nil,
+                    additionalRoots: assembly.defaultClaudeExtraLogRoots,
+                    coworkRootsOverride: assembly.defaultClaudeCoworkRoots
+                )
+            } else {
+                continue
+            }
+            if updated { updatedProviderIDs.append(provider.provider.id) }
+        }
+        for providerID in updatedProviderIDs {
+            guard !Task.isCancelled else { return }
+            await dataStore.refresh(providerID: providerID, force: true)
+        }
+        if !updatedProviderIDs.isEmpty {
+            AppLog.info(.config, "accounts: refreshed log routes for \(updatedProviderIDs.count) existing account(s)")
+        }
+    }
+
     struct AccountOwnershipFingerprint: Equatable {
         struct Card: Equatable {
             var id: String
             var identityKey: String
             var verifiedIdentityAliases: Set<ClaudeIdentity>
             var credential: ClaudeAccountCard.Credential
-            var logRoots: Set<URL>
         }
 
         var identities: [String: String]
         var cards: [Card]
-        var defaultClaudeExtraLogRoots: Set<URL>
-        var defaultClaudeCoworkRoots: Set<URL>?
+        var defaultClaudeCardID: String
         var allowsUnboundClaudeFallback: Bool
+        var isClaudeDiscoveryComplete: Bool
         var defaultClaudeVerifiedIdentityAliases: Set<ClaudeIdentity>
         var desktopAccess: ClaudeDesktopAccessPolicy
 
@@ -309,42 +334,90 @@ final class AppContainer {
             cards = assembly.claudeCards.map {
                 Card(
                     id: $0.id, identityKey: $0.identityKey,
-                    verifiedIdentityAliases: $0.verifiedIdentityAliases, credential: $0.credential,
-                    logRoots: Set($0.logRoots)
+                    verifiedIdentityAliases: $0.verifiedIdentityAliases, credential: $0.credential
                 )
             }
-            defaultClaudeExtraLogRoots = Set(assembly.defaultClaudeExtraLogRoots)
-            defaultClaudeCoworkRoots = assembly.defaultClaudeCoworkRoots.map { Set($0) }
+            defaultClaudeCardID = assembly.defaultClaudeCardID
             allowsUnboundClaudeFallback = assembly.allowsUnboundClaudeFallback
+            isClaudeDiscoveryComplete = assembly.isClaudeDiscoveryComplete
             defaultClaudeVerifiedIdentityAliases = assembly.defaultClaudeVerifiedIdentityAliases
             desktopAccess = assembly.defaultClaudeDesktopAccess
+        }
+    }
+
+    struct AccountLogRoutingFingerprint: Equatable {
+        var rootsByCard: [String: Set<URL>]
+        var defaultCardID: String
+        var defaultExtraRoots: Set<URL>
+        var defaultCoworkRoots: Set<URL>?
+
+        init(_ assembly: ProviderAccountAssembly) {
+            rootsByCard = Dictionary(uniqueKeysWithValues: assembly.claudeCards.map {
+                ($0.id, Set($0.logRoots))
+            })
+            defaultCardID = assembly.defaultClaudeCardID
+            defaultExtraRoots = Set(assembly.defaultClaudeExtraLogRoots)
+            defaultCoworkRoots = assembly.defaultClaudeCoworkRoots.map { Set($0) }
+        }
+
+        func reassignsExistingRoots(from previous: Self) -> Bool {
+            var ownersByRoot: [URL: String] = [:]
+            for (cardID, roots) in rootsByCard {
+                for root in roots { ownersByRoot[root] = cardID }
+            }
+            for root in defaultExtraRoots.union(defaultCoworkRoots ?? []) {
+                ownersByRoot[root] = defaultCardID
+            }
+            for (cardID, roots) in previous.rootsByCard {
+                if roots.contains(where: { ownersByRoot[$0].map { $0 != cardID } ?? false }) {
+                    return true
+                }
+            }
+            return previous.defaultExtraRoots.union(previous.defaultCoworkRoots ?? []).contains {
+                ownersByRoot[$0].map { $0 != previous.defaultCardID } ?? false
+            }
         }
     }
 
     private static func startAccountGraphWatch(
         accounts: ProviderAccountsStore,
         initialAssembly: ProviderAccountAssembly,
-        onChange: @escaping @MainActor (ProviderAccountAssembly) -> Void
+        onChange: @escaping @MainActor (ProviderAccountAssembly) -> Void,
+        onLogRootsChanged: @escaping @MainActor (ProviderAccountAssembly) async -> Void
     ) -> Task<Void, Never> {
-        func observeDefaults() -> [String: DefaultAccountObserver.Outcome] {
-            let observer = DefaultAccountObserver()
-            return ["claude": observer.observeClaude(), "codex": observer.observeCodex()]
+        func observeDefaults() async -> [String: DefaultAccountObserver.Outcome] {
+            await loadOffMainActor {
+                let observer = DefaultAccountObserver()
+                return ["claude": observer.observeClaude(), "codex": observer.observeCodex()]
+            }
         }
 
-        let initialDefaults = observeDefaults()
         return Task { @MainActor in
-            var previousDefaults = initialDefaults
+            let shellReady = await loadOffMainActor { LoginShellEnvironment.shared.ensureCaptured() }
+            guard !Task.isCancelled else { return }
+            guard shellReady || ShellEnvironmentSnapshotStore.launchSnapshot != nil else {
+                AppLog.error(.config, "accounts: login shell unavailable; retaining quarantined startup graph")
+                return
+            }
+            var previousDefaults: [String: DefaultAccountObserver.Outcome] = [:]
             var previousOwnership = AccountOwnershipFingerprint(initialAssembly)
+            var previousRouting = AccountLogRoutingFingerprint(initialAssembly)
             var checksSinceFullDiscovery = 0
+            var bootstrapped = false
             while !Task.isCancelled {
-                do {
-                    try await Task.sleep(for: .seconds(5))
-                } catch {
-                    return
+                if bootstrapped {
+                    do {
+                        try await Task.sleep(for: .seconds(5))
+                    } catch {
+                        return
+                    }
                 }
-                let observedDefaults = observeDefaults()
+                let observedDefaults = await observeDefaults()
+                guard !Task.isCancelled else { return }
                 checksSinceFullDiscovery += 1
-                guard observedDefaults != previousDefaults || checksSinceFullDiscovery >= 12 else { continue }
+                guard !bootstrapped || observedDefaults != previousDefaults || checksSinceFullDiscovery >= 12 else {
+                    continue
+                }
                 previousDefaults = observedDefaults
                 checksSinceFullDiscovery = 0
                 let preferredAnchors = Set(accounts.records.flatMap { record in
@@ -356,9 +429,12 @@ final class AppContainer {
                 guard !Task.isCancelled else { return }
                 guard prepared.isComplete else {
                     AppLog.warn(.config, "accounts: incomplete background discovery quarantined before reconciliation")
+                    if !bootstrapped {
+                        try? await Task.sleep(for: .seconds(5))
+                    }
                     continue
                 }
-                guard observeDefaults() == observedDefaults else {
+                guard await observeDefaults() == observedDefaults else {
                     AppLog.info(.config, "accounts: default login changed during discovery; retrying")
                     continue
                 }
@@ -367,9 +443,19 @@ final class AppContainer {
                 )
                 guard !Task.isCancelled else { return }
                 let ownership = AccountOwnershipFingerprint(assembly)
-                guard ownership != previousOwnership else { continue }
+                let routing = AccountLogRoutingFingerprint(assembly)
+                let replacesGraph = !bootstrapped
+                    || ownership != previousOwnership
+                    || routing.reassignsExistingRoots(from: previousRouting)
+                guard replacesGraph || routing != previousRouting else { continue }
+                bootstrapped = true
                 previousOwnership = ownership
-                onChange(assembly)
+                previousRouting = routing
+                if replacesGraph {
+                    onChange(assembly)
+                } else {
+                    await onLogRootsChanged(assembly)
+                }
             }
         }
     }

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -513,6 +513,10 @@ final class AppContainer {
         },
         coworkScan: @escaping @Sendable () -> ClaudeCoworkDiscovery.Result = {
             ClaudeCoworkDiscovery().run()
+        },
+        desktopAccount: @escaping @Sendable () -> String? = {
+            let desktop = ClaudeDesktopAuthStore()
+            return desktop.hasCredentialMaterial() ? desktop.lastKnownAccountUUID() : nil
         }
     ) async -> PreparedProviderAccountDiscovery {
         let task = Task.detached(priority: .utility) {
@@ -525,7 +529,13 @@ final class AppContainer {
             guard !Task.isCancelled, !config.truncated else {
                 return PreparedProviderAccountDiscovery(config: config, cowork: .init(truncated: true))
             }
-            return PreparedProviderAccountDiscovery(config: config, cowork: coworkScan())
+            let cowork = coworkScan()
+            guard !Task.isCancelled, !cowork.truncated else {
+                return PreparedProviderAccountDiscovery(config: config, cowork: cowork)
+            }
+            return PreparedProviderAccountDiscovery(
+                config: config, cowork: cowork, desktopAccountUUID: desktopAccount()
+            )
         }
         return await withTaskCancellationHandler {
             await task.value

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -79,7 +79,8 @@ final class AppContainer {
         let notificationSettings = NotificationSettingsStore()
         let runtime = Self.makeAccountRuntime(
             assembly: accountAssembly, accounts: accounts,
-            enablement: enablement, notificationSettings: notificationSettings
+            enablement: enablement, notificationSettings: notificationSettings,
+            quarantinesUnverifiedAccountData: true
         )
         runtime.iCloudSync.shutdownForAccountGraphReload()
         let providers = runtime.providers
@@ -147,6 +148,9 @@ final class AppContainer {
             // exactly like every UI surface.
             .resolvingDisplayNames(accounts.resolvedDisplayNamesByCardID)
         })
+        accountGraph.runtimeTasks = AccountRuntimeTaskLifetime([
+            Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry)
+        ])
         localAPI.start()
         accountGraph.accountWatcher = AccountRuntimeTaskLifetime([
             Self.startAccountGraphWatch(accounts: accounts, initialAssembly: accountAssembly) { [weak self] assembly in
@@ -170,7 +174,8 @@ final class AppContainer {
         accounts: ProviderAccountsStore,
         enablement: ProviderEnablementStore,
         notificationSettings: NotificationSettingsStore,
-        snapshotCache: ProviderSnapshotCache = ProviderSnapshotCache()
+        snapshotCache: ProviderSnapshotCache = ProviderSnapshotCache(),
+        quarantinesUnverifiedAccountData: Bool = false
     ) -> AccountRuntimeGraph.State {
         let providers = ProviderCatalog.make(accountAssembly: assembly)
         let registry = WidgetRegistry.from(providers)
@@ -190,6 +195,7 @@ final class AppContainer {
                     [record.identityKey] + (record.identityAliases ?? [])
                 )
             },
+            quarantinesUnverifiedAccountData: quarantinesUnverifiedAccountData,
             resolveDisplayName: { [accounts] in accounts.resolvedDisplayName(cardID: $0) }
         )
         let iCloudSync = ICloudUsageSyncStore(dataStore: dataStore)

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -220,6 +220,7 @@ final class AppContainer {
                 authStore: codex.authStore,
                 usageClient: codex.usageClient,
                 expectedIdentityKey: codex.expectedIdentityKey,
+                verifiedIdentityKey: { [weak codex] in codex?.verifiedAccountIdentityKey },
                 refreshAfterClaim: { [weak dataStore] in
                     var failures = 0
                     for attempt in 0..<45 {

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -155,6 +155,15 @@ final class AppContainer {
         accountGraph.accountWatcher = AccountRuntimeTaskLifetime([
             Self.startAccountGraphWatch(accounts: accounts, initialAssembly: accountAssembly) { [weak self] assembly in
                 self?.replaceAccountRuntime(with: assembly)
+            } onOwnershipUnverified: { [weak self] in
+                guard let self else { return }
+                let quarantined = ProviderAccountAssembly(
+                    identityKeysByCard: [:],
+                    allowsUnboundClaudeFallback: !self.accounts.records.contains { $0.family == "claude" },
+                    isClaudeDiscoveryComplete: false,
+                    defaultClaudeDesktopAccess: .denied
+                )
+                self.replaceAccountRuntime(with: quarantined, quarantinesUnverifiedAccountData: true)
             } onLogRootsChanged: { [weak self] assembly in
                 await self?.updateAccountLogRouting(with: assembly)
             },
@@ -180,7 +189,9 @@ final class AppContainer {
         let providers = ProviderCatalog.make(accountAssembly: assembly)
         let registry = WidgetRegistry.from(providers)
         let layout = LayoutStore(
-            registry: registry, isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
+            registry: registry,
+            persistInitialState: !quarantinesUnverifiedAccountData,
+            isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
         )
         let dataStore = WidgetDataStore(
             registry: registry,
@@ -269,15 +280,21 @@ final class AppContainer {
         return task
     }
 
-    private func replaceAccountRuntime(with assembly: ProviderAccountAssembly) {
+    private func replaceAccountRuntime(
+        with assembly: ProviderAccountAssembly, quarantinesUnverifiedAccountData: Bool = false
+    ) {
         let previousScreen = layout.screen
         let snapshotCache = accountGraph.state.snapshotCache
         accountGraph.retireCurrentState()
         let replacement = Self.makeAccountRuntime(
             assembly: assembly, accounts: accounts,
             enablement: enablement, notificationSettings: notificationSettings,
-            snapshotCache: snapshotCache
+            snapshotCache: snapshotCache,
+            quarantinesUnverifiedAccountData: quarantinesUnverifiedAccountData
         )
+        if quarantinesUnverifiedAccountData {
+            replacement.iCloudSync.shutdownForAccountGraphReload()
+        }
         replacement.layout.screen = previousScreen
         replacement.dataStore.onRefreshOutcome = { [weak telemetry] providerID, outcome, category, manual in
             telemetry?.record(providerID: providerID, outcome: outcome, category: category, manual: manual)
@@ -285,7 +302,8 @@ final class AppContainer {
         accountGraph.state = replacement
         accountGraph.runtimeTasks = AccountRuntimeTaskLifetime([
             Self.startPeriodicRefresh(dataStore: replacement.dataStore, telemetry: telemetry),
-            NewProviderSeeder.reconcileIfNeeded(providers: replacement.providers, enablement: enablement),
+            quarantinesUnverifiedAccountData ? nil
+                : NewProviderSeeder.reconcileIfNeeded(providers: replacement.providers, enablement: enablement),
         ])
         AppLog.info(.config, "accounts: account runtimes updated without replacing app services")
     }
@@ -389,6 +407,7 @@ final class AppContainer {
         accounts: ProviderAccountsStore,
         initialAssembly: ProviderAccountAssembly,
         onChange: @escaping @MainActor (ProviderAccountAssembly) -> Void,
+        onOwnershipUnverified: @escaping @MainActor () -> Void,
         onLogRootsChanged: @escaping @MainActor (ProviderAccountAssembly) async -> Void
     ) -> Task<Void, Never> {
         func observeDefaults() async -> [String: DefaultAccountObserver.Outcome] {
@@ -418,6 +437,7 @@ final class AppContainer {
             var previousRouting = AccountLogRoutingFingerprint(initialAssembly)
             var checksSinceFullDiscovery = 0
             var bootstrapped = false
+            var ownershipIsQuarantined = false
             while !Task.isCancelled {
                 if bootstrapped {
                     do {
@@ -432,7 +452,10 @@ final class AppContainer {
                 guard !bootstrapped || observedDefaults != previousDefaults || checksSinceFullDiscovery >= 12 else {
                     continue
                 }
-                previousDefaults = observedDefaults
+                if bootstrapped && observedDefaults != previousDefaults && !ownershipIsQuarantined {
+                    onOwnershipUnverified()
+                    ownershipIsQuarantined = true
+                }
                 checksSinceFullDiscovery = 0
                 let preferredAnchors = Set(accounts.records.flatMap { record in
                     record.sources.filter { $0.kind == .configDir }.compactMap(\.anchor)
@@ -452,6 +475,7 @@ final class AppContainer {
                     AppLog.info(.config, "accounts: default login changed during discovery; retrying")
                     continue
                 }
+                previousDefaults = observedDefaults
                 let assembly = ProviderAccountAssembly.make(
                     accountsStore: accounts, waitsForLoginShell: true, preparedDiscovery: prepared
                 )
@@ -459,10 +483,12 @@ final class AppContainer {
                 let ownership = AccountOwnershipFingerprint(assembly)
                 let routing = AccountLogRoutingFingerprint(assembly)
                 let replacesGraph = !bootstrapped
+                    || ownershipIsQuarantined
                     || ownership != previousOwnership
                     || routing.reassignsExistingRoots(from: previousRouting)
                 guard replacesGraph || routing != previousRouting else { continue }
                 bootstrapped = true
+                ownershipIsQuarantined = false
                 previousOwnership = ownership
                 previousRouting = routing
                 if replacesGraph {

--- a/Sources/OpenUsage/App/FirstRunSeeder.swift
+++ b/Sources/OpenUsage/App/FirstRunSeeder.swift
@@ -23,13 +23,24 @@ enum FirstRunSeeder {
         isFreshInstall: Bool,
         providers: [ProviderRuntime],
         enablement: ProviderEnablementStore,
-        onboarding: OnboardingStore
+        onboarding: OnboardingStore,
+        deferDetectionUntilDiscovery: Bool = false
     ) -> Task<Void, Never>? {
         guard isFreshInstall, enablement.enabledIDs == nil else { return nil }
 
         // Persist the unfinished job before marking providers known, so an interrupted launch can
         // still distinguish an outstanding first-run check from a completed one.
-        let task = seedFallbackThenDetect(providers: providers, enablement: enablement, logPrefix: "first run")
+        let task: Task<Void, Never>?
+        if deferDetectionUntilDiscovery {
+            let providerIDs = Set(providers.map(\.provider.id))
+            let fallback = fallbackProviderIDs.intersection(providerIDs)
+            enablement.seedEnabledProviders(fallback)
+            enablement.beginProviderDetection(providerIDs, mode: .replacement, baseline: fallback)
+            AppLog.info(.config, "first run: seeded providers \(fallback.sorted()); awaiting verified account discovery")
+            task = nil
+        } else {
+            task = seedFallbackThenDetect(providers: providers, enablement: enablement, logPrefix: "first run")
+        }
         enablement.registerKnownProviders(Set(providers.map(\.provider.id)))
         onboarding.markCustomizeHintPending()
         return task

--- a/Sources/OpenUsage/App/FirstRunSeeder.swift
+++ b/Sources/OpenUsage/App/FirstRunSeeder.swift
@@ -62,14 +62,21 @@ enum FirstRunSeeder {
         logPrefix: String,
         probeVerb: String = "probing"
     ) -> Task<Void, Never> {
-        let fallback = fallbackProviderIDs.intersection(Set(providers.map(\.provider.id)))
+        let providerIDs = Set(providers.map(\.provider.id))
+        let fallback = fallbackProviderIDs.intersection(providerIDs)
         enablement.seedEnabledProviders(fallback)
+        enablement.markProviderDetectionPending(providerIDs)
         AppLog.info(.config, "\(logPrefix): seeded providers \(fallback.sorted()); \(probeVerb) local credentials")
         return Task {
             let detected = await detectLocalProviders(providers)
+            guard !Task.isCancelled else { return }
+            defer { enablement.finishProviderDetection(providerIDs) }
             AppLog.info(.config, "\(logPrefix): detected credentials for \(detected.sorted())")
             guard enablement.enabledIDs == fallback, !detected.isEmpty else { return }
-            enablement.seedEnabledProviders(detected)
+            let honoringUserChoices = detected.intersection(enablement.pendingDetectionIDs)
+                .union(fallback.subtracting(enablement.pendingDetectionIDs))
+            guard !honoringUserChoices.isEmpty else { return }
+            enablement.seedEnabledProviders(honoringUserChoices)
         }
     }
 

--- a/Sources/OpenUsage/App/FirstRunSeeder.swift
+++ b/Sources/OpenUsage/App/FirstRunSeeder.swift
@@ -87,12 +87,14 @@ enum FirstRunSeeder {
         enablement: ProviderEnablementStore,
         logPrefix: String
     ) -> Task<Void, Never> {
-        let providerIDs = Set(providers.map(\.provider.id)).intersection(enablement.pendingDetectionIDs)
+        let pendingIDs = enablement.pendingDetectionIDs
+        let providerIDs = Set(providers.map(\.provider.id)).intersection(pendingIDs)
+        let completedIDs = enablement.detectionJob?.mode == .replacement ? pendingIDs : providerIDs
         let pendingProviders = providers.filter { providerIDs.contains($0.provider.id) }
         return Task {
             let detected = await detectLocalProviders(pendingProviders)
             guard !Task.isCancelled else { return }
-            defer { enablement.finishProviderDetection(providerIDs) }
+            defer { enablement.finishProviderDetection(completedIDs) }
             AppLog.info(.config, "\(logPrefix): detected credentials for \(detected.sorted())")
             guard let job = enablement.detectionJob else { return }
             let pendingDetected = detected.intersection(job.ids)

--- a/Sources/OpenUsage/App/FirstRunSeeder.swift
+++ b/Sources/OpenUsage/App/FirstRunSeeder.swift
@@ -27,11 +27,12 @@ enum FirstRunSeeder {
     ) -> Task<Void, Never>? {
         guard isFreshInstall, enablement.enabledIDs == nil else { return nil }
 
-        // Baseline the known-provider set: everything shipping today has been "seen" by this install,
-        // so `NewProviderSeeder` only ever probes providers added in a later release.
+        // Persist the unfinished job before marking providers known, so an interrupted launch can
+        // still distinguish an outstanding first-run check from a completed one.
+        let task = seedFallbackThenDetect(providers: providers, enablement: enablement, logPrefix: "first run")
         enablement.registerKnownProviders(Set(providers.map(\.provider.id)))
         onboarding.markCustomizeHintPending()
-        return seedFallbackThenDetect(providers: providers, enablement: enablement, logPrefix: "first run")
+        return task
     }
 
     /// Re-runs first-launch detection on demand for the Customize "Reset All" action. Unlike first-run
@@ -65,18 +66,39 @@ enum FirstRunSeeder {
         let providerIDs = Set(providers.map(\.provider.id))
         let fallback = fallbackProviderIDs.intersection(providerIDs)
         enablement.seedEnabledProviders(fallback)
-        enablement.markProviderDetectionPending(providerIDs)
+        enablement.beginProviderDetection(providerIDs, mode: .replacement, baseline: fallback)
         AppLog.info(.config, "\(logPrefix): seeded providers \(fallback.sorted()); \(probeVerb) local credentials")
+        return resumeDetection(providers: providers, enablement: enablement, logPrefix: logPrefix)
+    }
+
+    static func resumeDetection(
+        providers: [ProviderRuntime],
+        enablement: ProviderEnablementStore,
+        logPrefix: String
+    ) -> Task<Void, Never> {
+        let providerIDs = Set(providers.map(\.provider.id)).intersection(enablement.pendingDetectionIDs)
+        let pendingProviders = providers.filter { providerIDs.contains($0.provider.id) }
         return Task {
-            let detected = await detectLocalProviders(providers)
+            let detected = await detectLocalProviders(pendingProviders)
             guard !Task.isCancelled else { return }
             defer { enablement.finishProviderDetection(providerIDs) }
             AppLog.info(.config, "\(logPrefix): detected credentials for \(detected.sorted())")
-            guard enablement.enabledIDs == fallback, !detected.isEmpty else { return }
-            let honoringUserChoices = detected.intersection(enablement.pendingDetectionIDs)
-                .union(fallback.subtracting(enablement.pendingDetectionIDs))
-            guard !honoringUserChoices.isEmpty else { return }
-            enablement.seedEnabledProviders(honoringUserChoices)
+            guard let job = enablement.detectionJob else { return }
+            let pendingDetected = detected.intersection(job.ids)
+
+            switch job.mode {
+            case .replacement:
+                guard enablement.enabledIDs == job.baseline, !pendingDetected.isEmpty else { return }
+                let honoringUserChoices = pendingDetected.union(job.baseline.subtracting(job.ids))
+                enablement.seedEnabledProviders(honoringUserChoices)
+            case .additive:
+                for id in pendingDetected.sorted() {
+                    guard !Task.isCancelled else { return }
+                    guard enablement.pendingDetectionIDs.contains(id), !enablement.isEnabled(id) else { continue }
+                    AppLog.info(.config, "new provider \(id): credentials detected, enabling")
+                    enablement.setEnabled(true, for: id)
+                }
+            }
         }
     }
 
@@ -93,10 +115,15 @@ enum FirstRunSeeder {
         let probes = providers.map { provider in
             (provider.provider.id, Task { await provider.hasLocalCredentials() })
         }
-        var detected = Set<String>()
-        for (id, probe) in probes where await probe.value {
-            detected.insert(id)
+        return await withTaskCancellationHandler {
+            var detected = Set<String>()
+            for (id, probe) in probes {
+                guard !Task.isCancelled else { return detected }
+                if await probe.value { detected.insert(id) }
+            }
+            return detected
+        } onCancel: {
+            for (_, probe) in probes { probe.cancel() }
         }
-        return detected
     }
 }

--- a/Sources/OpenUsage/App/NewProviderSeeder.swift
+++ b/Sources/OpenUsage/App/NewProviderSeeder.swift
@@ -34,7 +34,12 @@ enum NewProviderSeeder {
         let newIDs = currentIDs.subtracting(enablement.knownIDs)
         let pendingIDs = enablement.pendingDetectionIDs.intersection(currentIDs)
         let detectionIDs = newIDs.union(pendingIDs)
-        guard !detectionIDs.isEmpty else { return nil }
+        guard !detectionIDs.isEmpty else {
+            if enablement.detectionJob?.mode == .replacement {
+                enablement.finishProviderDetection(enablement.pendingDetectionIDs.subtracting(currentIDs))
+            }
+            return nil
+        }
         if let job = enablement.detectionJob,
            job.mode == .replacement,
            enablement.enabledIDs == job.baseline

--- a/Sources/OpenUsage/App/NewProviderSeeder.swift
+++ b/Sources/OpenUsage/App/NewProviderSeeder.swift
@@ -26,37 +26,36 @@ enum NewProviderSeeder {
         // seeded before this shipped — bundled installs get it from the v2 settings migration or
         // `FirstRunSeeder`). Baseline it to the current registry without probing: we can't tell "new"
         // from "user turned it off", so auto-enabling anything here could override a real choice.
-        guard !enablement.knownIDs.isEmpty else {
+        guard !enablement.knownIDs.isEmpty || enablement.detectionJob != nil else {
             enablement.registerKnownProviders(currentIDs)
             return nil
         }
 
-        let newIDs = enablement.registerKnownProviders(currentIDs)
+        let newIDs = currentIDs.subtracting(enablement.knownIDs)
         let pendingIDs = enablement.pendingDetectionIDs.intersection(currentIDs)
         let detectionIDs = newIDs.union(pendingIDs)
         guard !detectionIDs.isEmpty else { return nil }
-        enablement.markProviderDetectionPending(detectionIDs)
+        if let job = enablement.detectionJob,
+           job.mode == .replacement,
+           enablement.enabledIDs == job.baseline
+        {
+            enablement.beginProviderDetection(detectionIDs, mode: .replacement, baseline: job.baseline)
+        } else {
+            enablement.beginProviderDetection(
+                detectionIDs,
+                mode: .additive,
+                baseline: enablement.enabledIDs ?? []
+            )
+        }
+        enablement.registerKnownProviders(currentIDs)
         AppLog.info(
             .config,
             "new or interrupted provider checks: \(detectionIDs.sorted()); probing local credentials"
         )
-
-        return Task {
-            // Same concurrent local-only probe as first-run detection and the Reset All reseed.
-            let newProviders = providers.filter { detectionIDs.contains($0.provider.id) }
-            let detected = await FirstRunSeeder.detectLocalProviders(newProviders)
-            guard !Task.isCancelled else { return }
-            defer { enablement.finishProviderDetection(detectionIDs) }
-            for id in detected.sorted() {
-                guard !Task.isCancelled else { return }
-                // The probe takes a moment; if the user already turned the provider on themselves,
-                // or explicitly toggled it back off, their choice cancels its pending detection.
-                guard enablement.pendingDetectionIDs.contains(id),
-                      !enablement.isEnabled(id)
-                else { continue }
-                AppLog.info(.config, "new provider \(id): credentials detected, enabling")
-                enablement.setEnabled(true, for: id)
-            }
-        }
+        return FirstRunSeeder.resumeDetection(
+            providers: providers,
+            enablement: enablement,
+            logPrefix: "new or interrupted provider checks"
+        )
     }
 }

--- a/Sources/OpenUsage/App/NewProviderSeeder.swift
+++ b/Sources/OpenUsage/App/NewProviderSeeder.swift
@@ -32,17 +32,28 @@ enum NewProviderSeeder {
         }
 
         let newIDs = enablement.registerKnownProviders(currentIDs)
-        guard !newIDs.isEmpty else { return nil }
-        AppLog.info(.config, "new providers since last run: \(newIDs.sorted()); probing local credentials")
+        let pendingIDs = enablement.pendingDetectionIDs.intersection(currentIDs)
+        let detectionIDs = newIDs.union(pendingIDs)
+        guard !detectionIDs.isEmpty else { return nil }
+        enablement.markProviderDetectionPending(detectionIDs)
+        AppLog.info(
+            .config,
+            "new or interrupted provider checks: \(detectionIDs.sorted()); probing local credentials"
+        )
 
         return Task {
             // Same concurrent local-only probe as first-run detection and the Reset All reseed.
-            let newProviders = providers.filter { newIDs.contains($0.provider.id) }
+            let newProviders = providers.filter { detectionIDs.contains($0.provider.id) }
             let detected = await FirstRunSeeder.detectLocalProviders(newProviders)
+            guard !Task.isCancelled else { return }
+            defer { enablement.finishProviderDetection(detectionIDs) }
             for id in detected.sorted() {
+                guard !Task.isCancelled else { return }
                 // The probe takes a moment; if the user already turned the provider on themselves,
-                // leave their toggle alone (setEnabled would be a no-op anyway).
-                guard !enablement.isEnabled(id) else { continue }
+                // or explicitly toggled it back off, their choice cancels its pending detection.
+                guard enablement.pendingDetectionIDs.contains(id),
+                      !enablement.isEnabled(id)
+                else { continue }
                 AppLog.info(.config, "new provider \(id): credentials detected, enabling")
                 enablement.setEnabled(true, for: id)
             }

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -17,6 +17,19 @@ final class MenuBarPanel: NSPanel {
     override var canBecomeMain: Bool { false }
 }
 
+/// Reinjection happens inside an observed view so account changes keep the existing AppKit shell.
+private struct AccountRuntimeHost: View {
+    @Environment(AppContainer.self) private var container
+
+    var body: some View {
+        DashboardView()
+            .reduceAnimationsWhenRequested()
+            .environment(container.layout)
+            .environment(container.dataStore)
+            .environment(\.codexResetClaim, container.codexResetClaim)
+    }
+}
+
 /// Owns the menu-bar status item and the panel that shows the dashboard.
 ///
 /// Deliberately not SwiftUI's `MenuBarExtra`: its `.window` panel never became a proper key window for
@@ -61,16 +74,10 @@ final class StatusItemController: NSObject {
 
         let hosting = NSHostingController(
             rootView: AnyView(
-                DashboardView()
-                    // Own the preference outside `DashboardView` so the view can read the resolved
-                    // value while deciding whether to mount its two-page transition structure.
-                    .reduceAnimationsWhenRequested()
+                AccountRuntimeHost()
                     .environment(container)
-                    .environment(container.layout)
-                    .environment(container.dataStore)
                     .environment(container.transparency)
                     .environment(updater)
-                    .environment(\.codexResetClaim, container.codexResetClaim)
             )
         )
         // The host view fills the panel. SwiftUI measures each screen and drives the panel height;

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -29,15 +29,16 @@ actor ClaudeLogUsageScanner {
     /// Extra account cards pin the scan to exactly their config dir(s), replacing the standard
     /// resolution (env override, XDG, `~/.claude`, Cowork sandboxes) entirely — another account's
     /// logs must never bleed into a scoped card. `nil` keeps the standard walk byte-identical.
-    private let rootsOverride: [URL]?
+    private var rootsOverride: [URL]?
     /// Same-account custom config dirs appended to the DEFAULT card's standard roots, so spend the
     /// user's own login produced in a side home still counts on its card.
-    private let additionalRoots: [URL]
+    private var additionalRoots: [URL]
     /// When set, replaces the built-in Cowork sandbox walk: `[]` for scoped account cards (Cowork
     /// logs belong to the account that produced them, not this card), the account's partition of the
     /// walk otherwise. `nil` keeps the built-in walk byte-identical (a machine where every sandbox
     /// belongs to the default login).
-    private let coworkRootsOverride: [URL]?
+    private var coworkRootsOverride: [URL]?
+    private var rootRoutingGeneration = 0
 
     /// One parsed usage line. Token buckets are pre-normalized into `TokenBreakdown`; dedup fields
     /// ride along so the global dedup pass can run over cached entries.
@@ -87,10 +88,29 @@ actor ClaudeLogUsageScanner {
         self.coworkRootsOverride = coworkRootsOverride
     }
 
+    @discardableResult
+    func updateLogRoots(
+        rootsOverride: [URL]?,
+        additionalRoots: [URL],
+        coworkRootsOverride: [URL]?
+    ) -> Bool {
+        guard self.rootsOverride != rootsOverride
+            || self.additionalRoots != additionalRoots
+            || self.coworkRootsOverride != coworkRootsOverride
+        else { return false }
+        precondition(rootsOverride == nil || cacheIdentityOverride != nil)
+        self.rootsOverride = rootsOverride
+        self.additionalRoots = additionalRoots
+        self.coworkRootsOverride = coworkRootsOverride
+        rootRoutingGeneration += 1
+        return true
+    }
+
     /// Scan the last `daysBack` days of Claude logs. Returns `nil` when no Claude data directory or
     /// no log files exist (the spend tiles then render "No data"); returns an empty series when logs
     /// exist but have no usage in the window.
     func scan(daysBack: Int = 30, now: Date = Date(), pricing: ModelPricing) async -> LogUsageScan? {
+        let generation = rootRoutingGeneration
         let since = JSONLScanning.sinceDate(daysBack: daysBack, now: now)
         let cacheIdentity = parseCacheIdentity()
         let roots = claudeRoots()
@@ -115,7 +135,7 @@ actor ClaudeLogUsageScanner {
             since: since,
             cacheIdentity: cacheIdentity,
             parse: Self.parseFile
-        ), !Task.isCancelled else { return nil }
+        ), !Task.isCancelled, generation == rootRoutingGeneration else { return nil }
         return Self.aggregate(entries: Self.dedup(entries), since: since, pricing: pricing)
     }
 

--- a/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
@@ -162,11 +162,20 @@ final class CodexResetClaimService {
         var lastRejection: Int?
         for credentials in candidates {
             guard !isRetiredForAccountGraphReload else { return .failed }
+            let currentCandidates = await credentialCandidates()
+            let currentCredentials = currentCandidates.first {
+                Self.belongsToSameAccount($0, as: credentials)
+                    && $0.accessToken == credentials.accessToken
+            } ?? currentCandidates.first { Self.belongsToSameAccount($0, as: credentials) }
+            guard !isRetiredForAccountGraphReload, let currentCredentials else {
+                AppLog.error(LogTag.plugin("codex"), "reset claim: the original account is no longer signed in")
+                return .failed
+            }
             let response: HTTPResponse
             do {
                 response = try await usageClient.consumeResetCredit(
-                    accessToken: credentials.accessToken,
-                    accountID: credentials.accountID,
+                    accessToken: currentCredentials.accessToken,
+                    accountID: currentCredentials.accountID,
                     creditID: creditID,
                     redeemRequestID: redeemRequestID
                 )

--- a/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
@@ -29,22 +29,25 @@ final class CodexResetClaimService {
 
     private let usageClient: CodexUsageClient
     private let credentialCandidates: () async -> [Credentials]
+    private let expectedIdentityKey: String?
     private let refreshAfterClaim: () async -> Void
     /// The credit id each idempotency key was matched to, kept for the key's retries: if a consume
     /// succeeded but its response was lost, the credit is gone from a re-fetched list — a fresh match
     /// would misread the retry as "no longer available" instead of replaying the POST and letting the
     /// server answer `already_redeemed`. Session-lived, keyed by the popover's per-credit UUIDs.
-    private var matchedCreditIDs: [String: String] = [:]
+    private var matchedCredits: [String: (id: String, credentials: Credentials)] = [:]
 
     /// Test seam: injected credential candidates and refresh hook, the same `usageClient` the requests
     /// go through. Candidates are tried in order until one authenticates (see `claim`).
     init(
         usageClient: CodexUsageClient,
         credentialCandidates: @escaping () async -> [Credentials],
+        expectedIdentityKey: String? = nil,
         refreshAfterClaim: @escaping () async -> Void = {}
     ) {
         self.usageClient = usageClient
         self.credentialCandidates = credentialCandidates
+        self.expectedIdentityKey = expectedIdentityKey
         self.refreshAfterClaim = refreshAfterClaim
     }
 
@@ -57,6 +60,7 @@ final class CodexResetClaimService {
     convenience init(
         authStore: CodexAuthStore,
         usageClient: CodexUsageClient,
+        expectedIdentityKey: String?,
         refreshAfterClaim: @escaping () async -> Void
     ) {
         self.init(
@@ -70,9 +74,10 @@ final class CodexResetClaimService {
                     guard candidate.hasUsableAccessToken, let token = candidate.auth.tokens?.accessToken else {
                         return nil
                     }
-                    return (token, candidate.auth.tokens?.accountID)
+                    return (token, candidate.accountIdentityKey)
                 }
             },
+            expectedIdentityKey: expectedIdentityKey,
             refreshAfterClaim: refreshAfterClaim
         )
     }
@@ -80,7 +85,10 @@ final class CodexResetClaimService {
     /// Claims the credit expiring at `expiry`. Never throws — every failure mode is logged loudly and
     /// collapsed to an outcome the popover can render.
     func claim(creditExpiringAt expiry: Date, redeemRequestID: String) async -> ResetClaimOutcome {
-        let candidates = await credentialCandidates()
+        let candidates = await credentialCandidates().filter { candidate in
+            guard let expectedIdentityKey else { return true }
+            return candidate.accountID?.caseInsensitiveCompare(expectedIdentityKey) == .orderedSame
+        }
         guard !candidates.isEmpty else {
             AppLog.error(LogTag.plugin("codex"), "reset claim: no usable Codex credentials")
             return .failed
@@ -91,18 +99,18 @@ final class CodexResetClaimService {
         // the list, and only the replay lets the server's `already_redeemed` prove the claim landed.
         let creditID: String
         var preferredCandidates = candidates
-        if let replayID = matchedCreditIDs[redeemRequestID] {
-            creditID = replayID
+        if let matched = matchedCredits[redeemRequestID] {
+            creditID = matched.id
+            preferredCandidates = candidates.filter { Self.belongsToSameAccount($0, as: matched.credentials) }
         } else {
             switch await matchCredit(expiringAt: expiry, candidates: candidates) {
             case .matched(let id, let authenticated):
                 creditID = id
-                matchedCreditIDs[redeemRequestID] = id
-                // Lead with the credential that just authenticated the list fetch. Deduplicate by the
-                // full (token, account) pair — ChatGPT-Account-Id changes what a token is authorized
-                // for, so a same-token candidate with a different account is a distinct fallback.
+                matchedCredits[redeemRequestID] = (id, authenticated)
+                // A rejected write can retry another token for this account, never another account.
                 preferredCandidates = [authenticated] + candidates.filter {
-                    $0.accessToken != authenticated.accessToken || $0.accountID != authenticated.accountID
+                    Self.belongsToSameAccount($0, as: authenticated)
+                        && $0.accessToken != authenticated.accessToken
                 }
             case .noCredit:
                 // Not an error: the credit was claimed elsewhere (CLI/web) or expired since the popover
@@ -115,6 +123,11 @@ final class CodexResetClaimService {
             }
         }
 
+        guard !preferredCandidates.isEmpty else {
+            AppLog.error(LogTag.plugin("codex"), "reset claim: the original account is no longer signed in")
+            return .failed
+        }
+
         let outcome = await consume(
             creditID: creditID, redeemRequestID: redeemRequestID, candidates: preferredCandidates
         )
@@ -124,6 +137,14 @@ final class CodexResetClaimService {
             await refreshAfterClaim()
         }
         return outcome
+    }
+
+    private static func belongsToSameAccount(_ candidate: Credentials, as original: Credentials) -> Bool {
+        guard let candidateAccount = candidate.accountID, let originalAccount = original.accountID else {
+            return candidate.accountID == nil && original.accountID == nil
+                && candidate.accessToken == original.accessToken
+        }
+        return candidateAccount.caseInsensitiveCompare(originalAccount) == .orderedSame
     }
 
     /// POSTs the consume, falling back across credential candidates on an auth rejection (401/403).

--- a/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
@@ -30,6 +30,7 @@ final class CodexResetClaimService {
     private let usageClient: CodexUsageClient
     private let credentialCandidates: () async -> [Credentials]
     private let expectedIdentityKey: String?
+    private let verifiedIdentityKey: (@MainActor () -> String?)?
     private let refreshAfterClaim: () async -> Void
     private var isRetiredForAccountGraphReload = false
     /// The credit id each idempotency key was matched to, kept for the key's retries: if a consume
@@ -44,11 +45,13 @@ final class CodexResetClaimService {
         usageClient: CodexUsageClient,
         credentialCandidates: @escaping () async -> [Credentials],
         expectedIdentityKey: String? = nil,
+        verifiedIdentityKey: (@MainActor () -> String?)? = nil,
         refreshAfterClaim: @escaping () async -> Void = {}
     ) {
         self.usageClient = usageClient
         self.credentialCandidates = credentialCandidates
         self.expectedIdentityKey = expectedIdentityKey
+        self.verifiedIdentityKey = verifiedIdentityKey
         self.refreshAfterClaim = refreshAfterClaim
     }
 
@@ -62,6 +65,7 @@ final class CodexResetClaimService {
         authStore: CodexAuthStore,
         usageClient: CodexUsageClient,
         expectedIdentityKey: String?,
+        verifiedIdentityKey: @escaping @MainActor () -> String?,
         refreshAfterClaim: @escaping () async -> Void
     ) {
         self.init(
@@ -79,6 +83,7 @@ final class CodexResetClaimService {
                 }
             },
             expectedIdentityKey: expectedIdentityKey,
+            verifiedIdentityKey: verifiedIdentityKey,
             refreshAfterClaim: refreshAfterClaim
         )
     }
@@ -87,6 +92,11 @@ final class CodexResetClaimService {
     /// collapsed to an outcome the popover can render.
     func claim(creditExpiringAt expiry: Date, redeemRequestID: String) async -> ResetClaimOutcome {
         guard !isRetiredForAccountGraphReload else { return .failed }
+        let expectedIdentityKey = expectedIdentityKey ?? verifiedIdentityKey?()
+        guard expectedIdentityKey != nil || verifiedIdentityKey == nil else {
+            AppLog.error(LogTag.plugin("codex"), "reset claim: the displayed account has not been verified")
+            return .failed
+        }
         let candidates = await credentialCandidates().filter { candidate in
             guard let expectedIdentityKey else { return true }
             return candidate.accountID?.caseInsensitiveCompare(expectedIdentityKey) == .orderedSame
@@ -167,7 +177,12 @@ final class CodexResetClaimService {
                 Self.belongsToSameAccount($0, as: credentials)
                     && $0.accessToken == credentials.accessToken
             } ?? currentCandidates.first { Self.belongsToSameAccount($0, as: credentials) }
-            guard !isRetiredForAccountGraphReload, let currentCredentials else {
+            let expectedOwner = expectedIdentityKey ?? verifiedIdentityKey?()
+            guard !isRetiredForAccountGraphReload, let currentCredentials,
+                  (expectedOwner.map {
+                      currentCredentials.accountID?.caseInsensitiveCompare($0) == .orderedSame
+                  } ?? (verifiedIdentityKey == nil))
+            else {
                 AppLog.error(LogTag.plugin("codex"), "reset claim: the original account is no longer signed in")
                 return .failed
             }

--- a/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexResetClaimService.swift
@@ -31,6 +31,7 @@ final class CodexResetClaimService {
     private let credentialCandidates: () async -> [Credentials]
     private let expectedIdentityKey: String?
     private let refreshAfterClaim: () async -> Void
+    private var isRetiredForAccountGraphReload = false
     /// The credit id each idempotency key was matched to, kept for the key's retries: if a consume
     /// succeeded but its response was lost, the credit is gone from a re-fetched list — a fresh match
     /// would misread the retry as "no longer available" instead of replaying the POST and letting the
@@ -85,6 +86,7 @@ final class CodexResetClaimService {
     /// Claims the credit expiring at `expiry`. Never throws — every failure mode is logged loudly and
     /// collapsed to an outcome the popover can render.
     func claim(creditExpiringAt expiry: Date, redeemRequestID: String) async -> ResetClaimOutcome {
+        guard !isRetiredForAccountGraphReload else { return .failed }
         let candidates = await credentialCandidates().filter { candidate in
             guard let expectedIdentityKey else { return true }
             return candidate.accountID?.caseInsensitiveCompare(expectedIdentityKey) == .orderedSame
@@ -123,7 +125,7 @@ final class CodexResetClaimService {
             }
         }
 
-        guard !preferredCandidates.isEmpty else {
+        guard !isRetiredForAccountGraphReload, !preferredCandidates.isEmpty else {
             AppLog.error(LogTag.plugin("codex"), "reset claim: the original account is no longer signed in")
             return .failed
         }
@@ -137,6 +139,10 @@ final class CodexResetClaimService {
             await refreshAfterClaim()
         }
         return outcome
+    }
+
+    func retireForAccountGraphReload() {
+        isRetiredForAccountGraphReload = true
     }
 
     private static func belongsToSameAccount(_ candidate: Credentials, as original: Credentials) -> Bool {
@@ -155,6 +161,7 @@ final class CodexResetClaimService {
     ) async -> ResetClaimOutcome {
         var lastRejection: Int?
         for credentials in candidates {
+            guard !isRetiredForAccountGraphReload else { return .failed }
             let response: HTTPResponse
             do {
                 response = try await usageClient.consumeResetCredit(

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -4,6 +4,26 @@ import Foundation
 /// their runtimes here so credentials, refresh behavior, pricing, and normalization can never drift.
 @MainActor
 enum ProviderCatalog {
+    static func make(
+        defaults: UserDefaults = .standard,
+        accountAssembly: ProviderAccountAssembly
+    ) -> [ProviderRuntime] {
+        make(
+            defaults: defaults,
+            claudeCards: accountAssembly.claudeCards,
+            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
+            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName,
+            defaultClaudeCardID: accountAssembly.defaultClaudeCardID,
+            defaultClaudeVerifiedIdentityAliases: accountAssembly.defaultClaudeVerifiedIdentityAliases,
+            claudeIdentityKeys: accountAssembly.identityKeysByCard,
+            allowsUnboundClaudeFallback: accountAssembly.allowsUnboundClaudeFallback,
+            isClaudeDiscoveryComplete: accountAssembly.isClaudeDiscoveryComplete,
+            allowsUnownedClaudeDesktopFallback: accountAssembly.allowsUnownedClaudeDesktopFallback,
+            defaultClaudeCoworkRoots: accountAssembly.defaultClaudeCoworkRoots,
+            defaultClaudeDesktopAccess: accountAssembly.defaultClaudeDesktopAccess
+        )
+    }
+
     /// `claudeCards` carries the extra Claude account cards found by the launch account pass
     /// (`ProviderAccountAssembly`). Each becomes an ordinary runtime inserted right after the default
     /// Claude card, with credentials and usage logs pinned to exactly its own config dir. The empty

--- a/Sources/OpenUsage/Services/LoginShellEnvironment.swift
+++ b/Sources/OpenUsage/Services/LoginShellEnvironment.swift
@@ -91,7 +91,7 @@ final class LoginShellEnvironment: @unchecked Sendable {
         if let env = cachedSnapshot() { return env }
         let captured = capture()
         stateLock.lock()
-        cached = captured
+        cached = captured.isEmpty ? nil : captured
         stateLock.unlock()
         return captured
     }

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -36,6 +36,7 @@ struct ClaudeAccountCard: Equatable, Sendable {
 struct PreparedProviderAccountDiscovery: Sendable {
     var config: ClaudeConfigDirDiscovery.Result
     var cowork: ClaudeCoworkDiscovery.Result
+    var desktopAccountUUID: String? = nil
 
     var isComplete: Bool { !config.truncated && !cowork.truncated }
 }
@@ -385,7 +386,9 @@ struct ProviderAccountAssembly {
                     continue
                 }
                 guard let user = ClaudeIdentity(identityKey)?.user,
-                      hasDesktopCredentialMaterial(user),
+                      preparedDiscovery.map({
+                          $0.desktopAccountUUID?.caseInsensitiveCompare(user) == .orderedSame
+                      }) ?? hasDesktopCredentialMaterial(user),
                       desktopPolicy.access(for: identityKey, allowsActiveOrganization: false)
                           == .pinned(organization)
                 else {

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -32,6 +32,14 @@ struct ClaudeAccountCard: Equatable, Sendable {
     var logRoots: [URL]
 }
 
+/// A background scan is reusable only when both account-source walks completed.
+struct PreparedProviderAccountDiscovery: Sendable {
+    var config: ClaudeConfigDirDiscovery.Result
+    var cowork: ClaudeCoworkDiscovery.Result
+
+    var isComplete: Bool { !config.truncated && !cowork.truncated }
+}
+
 /// The launch-time account pass: read which account is signed in at each family's default home,
 /// scan for extra Claude logins in custom config dirs, reconcile the account registry, and expose
 /// what the rest of launch consumes — the per-card identity map (snapshot-cache account stamp) and
@@ -70,7 +78,8 @@ struct ProviderAccountAssembly {
     static func make(
         defaults: UserDefaults = .standard,
         accountsStore: ProviderAccountsStore? = nil,
-        waitsForLoginShell: Bool
+        waitsForLoginShell: Bool,
+        preparedDiscovery: PreparedProviderAccountDiscovery? = nil
     ) -> ProviderAccountAssembly {
         // The identity read needs the login shell's exports (CLAUDE_CONFIG_DIR/CODEX_HOME name the
         // default homes), and it reads them through the very same reader the provider auth stores
@@ -105,7 +114,8 @@ struct ProviderAccountAssembly {
             accountsStore: resolvedAccountsStore,
             families: families,
             claudeDiscovery: ClaudeConfigDirDiscovery(),
-            coworkDiscovery: ClaudeCoworkDiscovery()
+            coworkDiscovery: ClaudeCoworkDiscovery(),
+            preparedDiscovery: preparedDiscovery
         )
     }
 
@@ -128,12 +138,22 @@ struct ProviderAccountAssembly {
         families: Set<String> = ProviderAccountID.families,
         claudeDiscovery: ClaudeConfigDirDiscovery? = nil,
         coworkDiscovery: ClaudeCoworkDiscovery? = nil,
+        preparedDiscovery: PreparedProviderAccountDiscovery? = nil,
         hasDesktopCredentialMaterial: @Sendable (String) -> Bool = { expectedUser in
             let desktop = ClaudeDesktopAuthStore()
             return desktop.hasCredentialMaterial()
                 && desktop.lastKnownAccountUUID()?.caseInsensitiveCompare(expectedUser) == .orderedSame
         }
     ) -> ProviderAccountAssembly {
+        guard preparedDiscovery?.isComplete != false else {
+            AppLog.warn(.config, "accounts: refusing to reconcile incomplete prepared account discovery")
+            return ProviderAccountAssembly(
+                identityKeysByCard: [:],
+                allowsUnboundClaudeFallback: !accountsStore.records.contains { $0.family == "claude" },
+                isClaudeDiscoveryComplete: false,
+                defaultClaudeDesktopAccess: .denied
+            )
+        }
         var identityKeys: [String: String] = [:]
         var observations: [ProviderAccountsStore.AccountObservation] = []
 
@@ -188,9 +208,12 @@ struct ProviderAccountAssembly {
             }
         }
         let configScan = claudeCandidatesAllowed
-            ? claudeDiscovery?.run(prioritizing: Set(preferredConfigAnchors.values))
+            ? preparedDiscovery?.config
+                ?? claudeDiscovery?.run(prioritizing: Set(preferredConfigAnchors.values))
             : nil
-        let coworkScan = claudeCandidatesAllowed ? coworkDiscovery?.run() : nil
+        let coworkScan = claudeCandidatesAllowed
+            ? preparedDiscovery?.cowork ?? coworkDiscovery?.run()
+            : nil
         isClaudeDiscoveryComplete = claudeCandidatesAllowed
             && configScan?.truncated != true
             && coworkScan?.truncated != true

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -152,6 +152,7 @@ struct ProviderAccountAssembly {
                 identityKeysByCard: [:],
                 allowsUnboundClaudeFallback: !accountsStore.records.contains { $0.family == "claude" },
                 isClaudeDiscoveryComplete: false,
+                defaultClaudeCoworkRoots: [],
                 defaultClaudeDesktopAccess: .denied
             )
         }

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -58,18 +58,7 @@ public struct UsageReader {
             ? ProviderAccountAssembly.make(defaults: defaults, waitsForLoginShell: false)
             : ProviderAccountAssembly(identityKeysByCard: [:])
         let providers = providersOverride ?? ProviderCatalog.make(
-            defaults: defaults,
-            claudeCards: accountAssembly.claudeCards,
-            defaultClaudeExtraLogRoots: accountAssembly.defaultClaudeExtraLogRoots,
-            defaultClaudeDisplayName: accountAssembly.defaultClaudeDisplayName,
-            defaultClaudeCardID: accountAssembly.defaultClaudeCardID,
-            defaultClaudeVerifiedIdentityAliases: accountAssembly.defaultClaudeVerifiedIdentityAliases,
-            claudeIdentityKeys: accountAssembly.identityKeysByCard,
-            allowsUnboundClaudeFallback: accountAssembly.allowsUnboundClaudeFallback,
-            isClaudeDiscoveryComplete: accountAssembly.isClaudeDiscoveryComplete,
-            allowsUnownedClaudeDesktopFallback: accountAssembly.allowsUnownedClaudeDesktopFallback,
-            defaultClaudeCoworkRoots: accountAssembly.defaultClaudeCoworkRoots,
-            defaultClaudeDesktopAccess: accountAssembly.defaultClaudeDesktopAccess
+            defaults: defaults, accountAssembly: accountAssembly
         )
         let registry = WidgetRegistry.from(providers)
         let knownIDs = Set(registry.providers.map(\.id))

--- a/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
+++ b/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
@@ -137,15 +137,10 @@ actor ICloudUsageHistoryFileStore: UsageHistoryFileStoring {
         return try result?.get() ?? { throw CocoaError(.fileReadUnknown) }()
     }
 
-    func coordinatedWrite(
-        _ data: Data,
-        to url: URL,
-        beforeWriting: @Sendable () -> Void = {}
-    ) throws {
+    func coordinatedWrite(_ data: Data, to url: URL) throws {
         var coordinationError: NSError?
         var operationError: Error?
         NSFileCoordinator().coordinate(writingItemAt: url, options: .forReplacing, error: &coordinationError) { coordinatedURL in
-            beforeWriting()
             do {
                 // File coordination can block until after this account graph has been retired.
                 // Recheck inside its accessor so an older graph cannot overwrite its replacement.
@@ -259,7 +254,8 @@ final class ICloudUsageSyncStore {
         isShutDownForAccountGraphReload = true
         writeTask?.cancel()
         writeTask = nil
-        activationTask?.cancel()
+        let retiredActivation = activationTask
+        retiredActivation?.cancel()
         activationTask = nil
         dataStore.onLocalHistoryChanged = nil
         stopObserving()
@@ -277,6 +273,7 @@ final class ICloudUsageSyncStore {
                 }
             }
             await previousCleanup?.value
+            await retiredActivation?.value
             guard !defaults.bool(forKey: Self.enabledKey) else { return }
             do {
                 try await fileStore.delete(deviceID: deviceID)

--- a/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
+++ b/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
@@ -90,10 +90,12 @@ actor ICloudUsageHistoryFileStore: UsageHistoryFileStoring {
     }
 
     func write(_ document: UsageHistoryDocument) async throws {
+        try Task.checkCancellation()
         try document.validate()
         let directory = try historyDirectory(create: true)
         let url = directory.appendingPathComponent(document.deviceID).appendingPathExtension("json")
         let data = try encoder.encode(document)
+        try Task.checkCancellation()
         try coordinatedWrite(data, to: url)
     }
 
@@ -135,11 +137,21 @@ actor ICloudUsageHistoryFileStore: UsageHistoryFileStoring {
         return try result?.get() ?? { throw CocoaError(.fileReadUnknown) }()
     }
 
-    private func coordinatedWrite(_ data: Data, to url: URL) throws {
+    func coordinatedWrite(
+        _ data: Data,
+        to url: URL,
+        beforeWriting: @Sendable () -> Void = {}
+    ) throws {
         var coordinationError: NSError?
         var operationError: Error?
         NSFileCoordinator().coordinate(writingItemAt: url, options: .forReplacing, error: &coordinationError) { coordinatedURL in
-            do { try data.write(to: coordinatedURL, options: .atomic) }
+            beforeWriting()
+            do {
+                // File coordination can block until after this account graph has been retired.
+                // Recheck inside its accessor so an older graph cannot overwrite its replacement.
+                try Task.checkCancellation()
+                try data.write(to: coordinatedURL, options: .atomic)
+            }
             catch { operationError = error }
         }
         if let coordinationError { throw coordinationError }
@@ -152,6 +164,12 @@ actor ICloudUsageHistoryFileStore: UsageHistoryFileStoring {
 final class ICloudUsageSyncStore {
     private static let enabledKey = "openusage.icloudSync.enabled.v1"
     private static let deviceIDKey = "openusage.icloudSync.deviceID.v1"
+    private static var pendingDisableCleanups: [String: PendingDisableCleanup] = [:]
+
+    private struct PendingDisableCleanup {
+        var id: UUID
+        var task: Task<Void, Never>
+    }
 
     private let defaults: UserDefaults
     private let fileStore: any UsageHistoryFileStoring
@@ -160,9 +178,11 @@ final class ICloudUsageSyncStore {
     private let writeDebounce: Duration
     private let observesMetadataChanges: Bool
     private var writeTask: Task<Void, Never>?
+    private var activationTask: Task<Void, Never>?
     private var metadataQuery: NSMetadataQuery?
     private var notificationTokens: [NSObjectProtocol] = []
     private var syncActivityCount = 0
+    private var isShutDownForAccountGraphReload = false
 
     let deviceID: String
     let deviceName: String
@@ -170,7 +190,7 @@ final class ICloudUsageSyncStore {
         didSet {
             guard enabled != oldValue else { return }
             defaults.set(enabled, forKey: Self.enabledKey)
-            Task { await applyEnabledChange() }
+            activationTask = Task { [weak self] in await self?.applyEnabledChange() }
         }
     }
     private(set) var isSyncing = false
@@ -199,7 +219,7 @@ final class ICloudUsageSyncStore {
         self.enabled = defaults.bool(forKey: Self.enabledKey)
         dataStore.onLocalHistoryChanged = { [weak self] in self?.scheduleWrite() }
         if enabled {
-            Task { await applyEnabledChange() }
+            activationTask = Task { [weak self] in await self?.applyEnabledChange() }
         }
     }
 
@@ -212,20 +232,62 @@ final class ICloudUsageSyncStore {
     }
 
     func scheduleWrite() {
-        guard enabled else { return }
+        guard enabled, !isShutDownForAccountGraphReload else { return }
         writeTask?.cancel()
         writeTask = Task { [weak self] in
             guard let self else { return }
             try? await Task.sleep(for: writeDebounce)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, !isShutDownForAccountGraphReload else { return }
             await writeNow()
         }
     }
 
+    /// Retire this graph's sync worker before its replacement starts writing the same device file.
+    /// Unlike turning sync off, a graph reload keeps both the user's preference and the existing
+    /// iCloud document intact; the replacement worker immediately rewrites that document itself.
+    func shutdownForAccountGraphReload() {
+        guard !isShutDownForAccountGraphReload else { return }
+        isShutDownForAccountGraphReload = true
+        writeTask?.cancel()
+        writeTask = nil
+        activationTask?.cancel()
+        activationTask = nil
+        dataStore.onLocalHistoryChanged = nil
+        stopObserving()
+
+        guard !enabled else { return }
+        // Opt-out may have queued its deletion without getting a chance to run before the graph was
+        // retired. Finish independently of that worker, and serialize every later graph's activation
+        // behind this device's cleanup so a delayed delete cannot remove its replacement's new file.
+        let cleanupID = UUID()
+        let previousCleanup = Self.pendingDisableCleanups[deviceID]?.task
+        let cleanup = Task { @MainActor [defaults, fileStore, deviceID] in
+            defer {
+                if Self.pendingDisableCleanups[deviceID]?.id == cleanupID {
+                    Self.pendingDisableCleanups.removeValue(forKey: deviceID)
+                }
+            }
+            await previousCleanup?.value
+            guard !defaults.bool(forKey: Self.enabledKey) else { return }
+            do {
+                try await fileStore.delete(deviceID: deviceID)
+            } catch {
+                AppLog.error(.config, "iCloud history disable cleanup failed after account reload: \(error.localizedDescription)")
+            }
+        }
+        Self.pendingDisableCleanups[deviceID] = PendingDisableCleanup(id: cleanupID, task: cleanup)
+    }
+
     private func applyEnabledChange() async {
+        guard !isShutDownForAccountGraphReload else { return }
         if enabled {
+            if let cleanup = Self.pendingDisableCleanups[deviceID] {
+                await cleanup.task.value
+            }
+            guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
             startObserving()
             await reload()
+            guard !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
             await writeNow()
         } else {
             writeTask?.cancel()
@@ -243,8 +305,9 @@ final class ICloudUsageSyncStore {
     }
 
     private func writeNow() async {
-        guard enabled else { return }
+        guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
         await withSyncActivity {
+            guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
             let document = dataStore.localHistoryDocument(
                 deviceID: deviceID,
                 deviceName: deviceName
@@ -257,21 +320,23 @@ final class ICloudUsageSyncStore {
                     try await fileStore.delete(deviceID: deviceID)
                     return
                 }
+                guard !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
                 operationError = nil
                 await reload()
             } catch {
+                guard !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
                 report(error, context: "write")
             }
         }
     }
 
     private func reload() async {
-        guard enabled else { return }
+        guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
         await withSyncActivity {
             do {
                 let result = try await fileStore.loadDocuments()
                 // A read that began while enabled must not restore peer state after sync was disabled.
-                guard enabled else { return }
+                guard enabled, !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
                 documents = UsageHistoryDocument.newestByDevice(result.documents)
                 invalidFileMessages = result.invalidFileMessages
                 dataStore.setPeerHistoryDocuments(result.documents, ownDeviceID: deviceID)
@@ -279,6 +344,7 @@ final class ICloudUsageSyncStore {
                     ? nil
                     : "Some synced usage data couldn’t be read. Check the log for details."
             } catch {
+                guard !isShutDownForAccountGraphReload, !Task.isCancelled else { return }
                 report(error, context: "read")
             }
         }

--- a/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
+++ b/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
@@ -190,6 +190,7 @@ final class ICloudUsageSyncStore {
         didSet {
             guard enabled != oldValue else { return }
             defaults.set(enabled, forKey: Self.enabledKey)
+            activationTask?.cancel()
             activationTask = Task { [weak self] in await self?.applyEnabledChange() }
         }
     }

--- a/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
+++ b/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
@@ -260,7 +260,7 @@ final class ICloudUsageSyncStore {
         dataStore.onLocalHistoryChanged = nil
         stopObserving()
 
-        guard !enabled, disableCleanupPending else { return }
+        guard disableCleanupPending else { return }
         // Opt-out may have queued its deletion without getting a chance to run before the graph was
         // retired. Finish independently of that worker, and serialize every later graph's activation
         // behind this device's cleanup so a delayed delete cannot remove its replacement's new file.

--- a/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
+++ b/Sources/OpenUsage/Stores/ICloudUsageSyncStore.swift
@@ -183,6 +183,7 @@ final class ICloudUsageSyncStore {
     private var notificationTokens: [NSObjectProtocol] = []
     private var syncActivityCount = 0
     private var isShutDownForAccountGraphReload = false
+    private var disableCleanupPending = false
 
     let deviceID: String
     let deviceName: String
@@ -190,8 +191,15 @@ final class ICloudUsageSyncStore {
         didSet {
             guard enabled != oldValue else { return }
             defaults.set(enabled, forKey: Self.enabledKey)
-            activationTask?.cancel()
-            activationTask = Task { [weak self] in await self?.applyEnabledChange() }
+            if !enabled { disableCleanupPending = true }
+            let previousActivation = activationTask
+            previousActivation?.cancel()
+            let isEnabling = enabled
+            activationTask = Task { [weak self] in
+                if isEnabling { await previousActivation?.value }
+                guard !Task.isCancelled else { return }
+                await self?.applyEnabledChange()
+            }
         }
     }
     private(set) var isSyncing = false
@@ -256,7 +264,7 @@ final class ICloudUsageSyncStore {
         dataStore.onLocalHistoryChanged = nil
         stopObserving()
 
-        guard !enabled else { return }
+        guard !enabled, disableCleanupPending else { return }
         // Opt-out may have queued its deletion without getting a chance to run before the graph was
         // retired. Finish independently of that worker, and serialize every later graph's activation
         // behind this device's cleanup so a delayed delete cannot remove its replacement's new file.
@@ -298,8 +306,11 @@ final class ICloudUsageSyncStore {
             invalidFileMessages = []
             do {
                 try await fileStore.delete(deviceID: deviceID)
+                disableCleanupPending = false
+                guard !Task.isCancelled, !isShutDownForAccountGraphReload, !enabled else { return }
                 operationError = nil
             } catch {
+                guard !Task.isCancelled, !isShutDownForAccountGraphReload, !enabled else { return }
                 report(error, context: "disable")
             }
         }

--- a/Sources/OpenUsage/Stores/LayoutStore.swift
+++ b/Sources/OpenUsage/Stores/LayoutStore.swift
@@ -118,6 +118,7 @@ final class LayoutStore {
         migrationBaselineMetricIDs: [String] = DefaultLayout.migrationBaselineMetricIDs,
         defaultPinnedMetricIDs: [String] = DefaultLayout.pinnedMetricIDs,
         defaultExpandedMetricIDs: [String] = DefaultLayout.expandedMetricIDs,
+        persistInitialState: Bool = true,
         isProviderEnabled: @escaping @MainActor (String) -> Bool = { _ in true }
     ) {
         self.registry = registry
@@ -152,10 +153,12 @@ final class LayoutStore {
         defaultExpandedOnEnableIDs = initial.defaultExpandedOnEnableIDs
         menuBarStyle = initial.menuBarStyle
 
-        if initial.shouldPersistExpandOnEnable { persistExpandOnEnable() }
-        if initial.shouldPersistExpanded { persistExpanded() }
-        if let seededDefaults = initial.seededDefaultsToPersist { persistSeededDefaults(seededDefaults) }
-        syncPlacedOrder(persistChanges: initial.shouldPersistPlaced)
+        if persistInitialState {
+            if initial.shouldPersistExpandOnEnable { persistExpandOnEnable() }
+            if initial.shouldPersistExpanded { persistExpanded() }
+            if let seededDefaults = initial.seededDefaultsToPersist { persistSeededDefaults(seededDefaults) }
+        }
+        syncPlacedOrder(persistChanges: persistInitialState && initial.shouldPersistPlaced)
     }
 
     func isProviderExpanded(_ providerID: String) -> Bool {

--- a/Sources/OpenUsage/Stores/ProviderEnablementStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderEnablementStore.swift
@@ -26,6 +26,18 @@ final class ProviderEnablementStore {
     private static let enabledStorageKey = "openusage.enabledProviders.v1"
     private static let knownStorageKey = "openusage.knownProviders.v1"
     private static let pendingDetectionStorageKey = "openusage.pendingProviderDetection.v1"
+    private static let detectionJobStorageKey = "openusage.providerDetectionJob.v1"
+
+    struct DetectionJob: Codable, Equatable, Sendable {
+        enum Mode: String, Codable, Sendable {
+            case replacement
+            case additive
+        }
+
+        var mode: Mode
+        var ids: Set<String>
+        var baseline: Set<String>
+    }
 
     /// Posted when the enabled-provider set actually changes. The refresh loop listens for this to wake
     /// early and fetch a newly-enabled provider promptly, instead of waiting out the full interval —
@@ -54,14 +66,16 @@ final class ProviderEnablementStore {
     /// Every provider ID this install has ever seen (see the type comment). Seeded by the v2 settings
     /// migration or `FirstRunSeeder`, then grown by `registerKnownProviders`.
     private(set) var knownIDs: Set<String>
-    /// Credential checks that were registered but have not finished. Account graph replacement can
-    /// cancel their owning task, so the next graph resumes them without mistaking "known" for done.
-    private(set) var pendingDetectionIDs: Set<String>
+    /// One persisted detection job preserves both the unfinished checks and whether they replace the
+    /// first-launch fallback or only add newly detected providers.
+    private(set) var detectionJob: DetectionJob?
+    var pendingDetectionIDs: Set<String> { detectionJob?.ids ?? [] }
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        if let enabled = defaults.stringArray(forKey: Self.enabledStorageKey) {
+        let persistedEnabledIDs = defaults.stringArray(forKey: Self.enabledStorageKey)
+        if let enabled = persistedEnabledIDs {
             self.enabledIDs = Set(enabled)
             self.disabledIDs = []
         } else {
@@ -69,7 +83,25 @@ final class ProviderEnablementStore {
             self.disabledIDs = Set(defaults.stringArray(forKey: Self.disabledStorageKey) ?? [])
         }
         self.knownIDs = Set(defaults.stringArray(forKey: Self.knownStorageKey) ?? [])
-        self.pendingDetectionIDs = Set(defaults.stringArray(forKey: Self.pendingDetectionStorageKey) ?? [])
+        if let data = defaults.data(forKey: Self.detectionJobStorageKey) {
+            do {
+                self.detectionJob = try JSONDecoder().decode(DetectionJob.self, from: data)
+            } catch {
+                self.detectionJob = nil
+                AppLog.error(.config, "provider detection job was undecodable: \(error.localizedDescription)")
+            }
+        } else {
+            let legacyPending = Set(defaults.stringArray(forKey: Self.pendingDetectionStorageKey) ?? [])
+            self.detectionJob = legacyPending.isEmpty ? nil : DetectionJob(
+                mode: .additive,
+                ids: legacyPending,
+                baseline: Set(persistedEnabledIDs ?? [])
+            )
+            if !legacyPending.isEmpty {
+                persistDetectionJob()
+                defaults.removeObject(forKey: Self.pendingDetectionStorageKey)
+            }
+        }
     }
 
     func isEnabled(_ id: String) -> Bool {
@@ -120,20 +152,42 @@ final class ProviderEnablementStore {
     }
 
     func markProviderDetectionPending(_ ids: Set<String>) {
-        updatePendingDetection(pendingDetectionIDs.union(ids))
+        beginProviderDetection(
+            ids,
+            mode: detectionJob?.mode ?? .additive,
+            baseline: detectionJob?.baseline ?? enabledIDs ?? []
+        )
+    }
+
+    func beginProviderDetection(_ ids: Set<String>, mode: DetectionJob.Mode, baseline: Set<String>) {
+        let updated = DetectionJob(
+            mode: mode,
+            ids: pendingDetectionIDs.union(ids),
+            baseline: baseline
+        )
+        guard !updated.ids.isEmpty, updated != detectionJob else { return }
+        detectionJob = updated
+        persistDetectionJob()
     }
 
     func finishProviderDetection(_ ids: Set<String>) {
-        updatePendingDetection(pendingDetectionIDs.subtracting(ids))
+        guard var job = detectionJob else { return }
+        job.ids.subtract(ids)
+        let updated = job.ids.isEmpty ? nil : job
+        guard updated != detectionJob else { return }
+        detectionJob = updated
+        persistDetectionJob()
     }
 
-    private func updatePendingDetection(_ pending: Set<String>) {
-        guard pending != pendingDetectionIDs else { return }
-        pendingDetectionIDs = pending
-        if pending.isEmpty {
-            defaults.removeObject(forKey: Self.pendingDetectionStorageKey)
-        } else {
-            defaults.set(Array(pending), forKey: Self.pendingDetectionStorageKey)
+    private func persistDetectionJob() {
+        guard let detectionJob else {
+            defaults.removeObject(forKey: Self.detectionJobStorageKey)
+            return
+        }
+        do {
+            defaults.set(try JSONEncoder().encode(detectionJob), forKey: Self.detectionJobStorageKey)
+        } catch {
+            AppLog.error(.config, "failed to persist provider detection job: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/OpenUsage/Stores/ProviderEnablementStore.swift
+++ b/Sources/OpenUsage/Stores/ProviderEnablementStore.swift
@@ -25,6 +25,7 @@ final class ProviderEnablementStore {
     private static let disabledStorageKey = "openusage.disabledProviders.v1"
     private static let enabledStorageKey = "openusage.enabledProviders.v1"
     private static let knownStorageKey = "openusage.knownProviders.v1"
+    private static let pendingDetectionStorageKey = "openusage.pendingProviderDetection.v1"
 
     /// Posted when the enabled-provider set actually changes. The refresh loop listens for this to wake
     /// early and fetch a newly-enabled provider promptly, instead of waiting out the full interval —
@@ -53,6 +54,9 @@ final class ProviderEnablementStore {
     /// Every provider ID this install has ever seen (see the type comment). Seeded by the v2 settings
     /// migration or `FirstRunSeeder`, then grown by `registerKnownProviders`.
     private(set) var knownIDs: Set<String>
+    /// Credential checks that were registered but have not finished. Account graph replacement can
+    /// cancel their owning task, so the next graph resumes them without mistaking "known" for done.
+    private(set) var pendingDetectionIDs: Set<String>
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -65,6 +69,7 @@ final class ProviderEnablementStore {
             self.disabledIDs = Set(defaults.stringArray(forKey: Self.disabledStorageKey) ?? [])
         }
         self.knownIDs = Set(defaults.stringArray(forKey: Self.knownStorageKey) ?? [])
+        self.pendingDetectionIDs = Set(defaults.stringArray(forKey: Self.pendingDetectionStorageKey) ?? [])
     }
 
     func isEnabled(_ id: String) -> Bool {
@@ -89,6 +94,9 @@ final class ProviderEnablementStore {
             guard disabledIDs != before else { return }
             defaults.set(Array(disabledIDs), forKey: Self.disabledStorageKey)
         }
+        // A real user choice owns this provider from now on, even if a credential check started
+        // before the toggle and reports a login after an account graph replacement.
+        finishProviderDetection([id])
         // Clear the backoff BEFORE the wake notification, so the refresh it triggers actually probes the
         // just-enabled provider instead of skipping it as recently-failed.
         if enabled { onProviderEnabled?(id) }
@@ -109,6 +117,24 @@ final class ProviderEnablementStore {
         knownIDs.formUnion(new)
         defaults.set(Array(knownIDs), forKey: Self.knownStorageKey)
         return new
+    }
+
+    func markProviderDetectionPending(_ ids: Set<String>) {
+        updatePendingDetection(pendingDetectionIDs.union(ids))
+    }
+
+    func finishProviderDetection(_ ids: Set<String>) {
+        updatePendingDetection(pendingDetectionIDs.subtracting(ids))
+    }
+
+    private func updatePendingDetection(_ pending: Set<String>) {
+        guard pending != pendingDetectionIDs else { return }
+        pendingDetectionIDs = pending
+        if pending.isEmpty {
+            defaults.removeObject(forKey: Self.pendingDetectionStorageKey)
+        } else {
+            defaults.set(Array(pending), forKey: Self.pendingDetectionStorageKey)
+        }
     }
 
     func seedEnabledProviders(_ ids: Set<String>) {

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -39,6 +39,7 @@ final class WidgetDataStore {
     /// unresolved identity this launch (or isn't account-aware) — its cache behaves as it always did.
     @ObservationIgnored private var providerIdentityKeys: [String: String]
     @ObservationIgnored private var knownAccountIdentitiesByFamily: [String: Set<String>]
+    private let quarantinesUnverifiedAccountData: Bool
     /// The live card title for a card id, `nil` for non-account providers — the account-registry
     /// name resolver, injected by `AppContainer` so notification titles carry renames. `nil`
     /// (tests, the one-shot CLI) falls back to the baked derived name.
@@ -155,6 +156,7 @@ final class WidgetDataStore {
         postNotification: (@MainActor (String, String, String, String) async -> Bool)? = nil,
         providerIdentityKeys: [String: String] = [:],
         knownAccountIdentitiesByFamily: [String: Set<String>] = [:],
+        quarantinesUnverifiedAccountData: Bool = false,
         resolveDisplayName: (@MainActor (String) -> String?)? = nil
     ) {
         precondition(slowProviderRefreshThreshold >= 0)
@@ -193,6 +195,7 @@ final class WidgetDataStore {
             }
         }
         self.knownAccountIdentitiesByFamily = knownIdentities
+        self.quarantinesUnverifiedAccountData = quarantinesUnverifiedAccountData
         self.resolveDisplayName = resolveDisplayName
         self.meterStyle = defaults.enumValue(forKey: Self.meterStyleKey, default: .remaining)
         self.resetDisplayMode = defaults.enumValue(forKey: Self.resetDisplayModeKey, default: .relative)
@@ -209,6 +212,12 @@ final class WidgetDataStore {
         // keeps its cache, exactly as before the guard existed. Non-account providers are unaffected.
         let loaded = cache.loadSnapshots(providerIDs: registry.providers.map(\.id))
             .filter { cardID, _ in
+                if quarantinesUnverifiedAccountData,
+                   ProviderAccountID.families.contains(ProviderAccountID.family(of: cardID)),
+                   providerIdentityKeys[cardID] == nil
+                {
+                    return false
+                }
                 guard cache.hasStaleAccountStamp(providerID: cardID, currentIdentityKey: providerIdentityKeys[cardID]) else {
                     return true
                 }
@@ -318,6 +327,12 @@ final class WidgetDataStore {
         notifyHistoryChange: Bool = true
     ) async -> RefreshOutcome {
         guard !isRetiredForAccountGraphReload, !Task.isCancelled, isProviderEnabled(providerID) else {
+            return .skipped
+        }
+        if quarantinesUnverifiedAccountData,
+           ProviderAccountID.families.contains(ProviderAccountID.family(of: providerID)),
+           providerIdentityKeys[providerID] == nil
+        {
             return .skipped
         }
         // A TTL-fresh entry that provably belongs to another account (swap since it was written) must

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -476,16 +476,6 @@ final class WidgetDataStore {
     func setPeerHistoryDocuments(_ documents: [UsageHistoryDocument], ownDeviceID: String) {
         peerHistoryDocuments = UsageHistoryDocument.newestByDevice(documents)
             .filter { $0.deviceID != ownDeviceID }
-            .map { document in
-                var document = document
-                document.providers = document.providers.filter {
-                    ProviderAccountID.family(of: $0.key) != "codex"
-                }
-                document.identities = document.identities?.filter {
-                    ProviderAccountID.family(of: $0.key) != "codex"
-                }
-                return document
-            }
         rebuildRenderedSnapshots()
     }
 
@@ -504,7 +494,6 @@ final class WidgetDataStore {
         // `PeerHistoryRemapper`).
         for (providerID, descriptor) in registry.historyDescriptorsByProvider
         where descriptor.scope == .machineLocal
-            && ProviderAccountID.family(of: providerID) != "codex"
             && isProviderEnabled(providerID)
         {
             if let history = localSnapshots[providerID]?.usageHistory {
@@ -556,7 +545,7 @@ final class WidgetDataStore {
         let enabledDescriptors = registry.historyDescriptorsByProvider.reduce(
             into: [String: UsageHistoryDescriptor]()
         ) { result, entry in
-            if ProviderAccountID.family(of: entry.key) != "codex", isProviderEnabled(entry.key) {
+            if isProviderEnabled(entry.key) {
                 result[entry.key] = entry.value
             }
         }

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -94,6 +94,7 @@ final class WidgetDataStore {
     /// Per-provider earliest next-probe time after a failure (see `failureRetryBackoff`). Not part of
     /// observable UI state, so it's excluded from `@Observable` tracking.
     @ObservationIgnored private var failureRetryAfter: [String: Date] = [:]
+    @ObservationIgnored private var isRetiredForAccountGraphReload = false
 
     /// Owns the quota pace-notification subsystem (dedup state, fire/deliver decision, trace). This store
     /// just gathers each pass's enabled bounded metrics and delegates.
@@ -224,6 +225,7 @@ final class WidgetDataStore {
     /// `force` bypasses the snapshot cache (the manual "refresh now" path); the periodic loop keeps
     /// honoring it.
     func refreshAll(force: Bool = false) async {
+        guard !isRetiredForAccountGraphReload, !Task.isCancelled else { return }
         // `Task {}` from MainActor context inherits the isolation (a task-group child can't capture
         // the non-Sendable store), so: fire one task per provider, then await them all.
         let providerIDs = registry.providers.map(\.id).filter { isProviderEnabled($0) }
@@ -232,11 +234,17 @@ final class WidgetDataStore {
         let tasks = providerIDs.map { providerID in
             Task { await self.refresh(providerID: providerID, force: force, notifyHistoryChange: false) }
         }
-        var outcomes: [RefreshOutcome] = []
-        outcomes.reserveCapacity(tasks.count)
-        for task in tasks {
-            outcomes.append(await task.value)
+        let outcomes = await withTaskCancellationHandler {
+            var outcomes: [RefreshOutcome] = []
+            outcomes.reserveCapacity(tasks.count)
+            for task in tasks {
+                outcomes.append(await task.value)
+            }
+            return outcomes
+        } onCancel: {
+            tasks.forEach { $0.cancel() }
         }
+        guard !Task.isCancelled, !isRetiredForAccountGraphReload else { return }
         // Stamp the end of the pass so the footer countdown targets the next scheduled refresh
         // (this time + one refresh interval), mirroring the periodic loop that sleeps one interval
         // after each pass.
@@ -250,6 +258,10 @@ final class WidgetDataStore {
         let backedOff = outcomes.count { $0 == .backedOff }
         if refreshed > 0 { onLocalHistoryChanged?() }
         AppLog.info(.refresh, "batch end (\(durationMs)ms, \(refreshed) ok / \(failed) failed / \(cached) cached / \(backedOff) backed off)")
+    }
+
+    func retireForAccountGraphReload() {
+        isRetiredForAccountGraphReload = true
     }
 
     /// Evaluate every visible, enabled metric for a quota pace milestone and post a notification for any
@@ -305,7 +317,9 @@ final class WidgetDataStore {
         force: Bool = false,
         notifyHistoryChange: Bool = true
     ) async -> RefreshOutcome {
-        guard isProviderEnabled(providerID) else { return .skipped }
+        guard !isRetiredForAccountGraphReload, !Task.isCancelled, isProviderEnabled(providerID) else {
+            return .skipped
+        }
         // A TTL-fresh entry that provably belongs to another account (swap since it was written) must
         // not short-circuit the refresh — under persisted freshness (the one-shot CLI) it would copy
         // the previous account's snapshot back in. Treat it as a miss so the fetch overwrites it.
@@ -349,6 +363,7 @@ final class WidgetDataStore {
             force: force,
             timeout: providerRefreshTimeout
         ) else {
+            guard !Task.isCancelled, !isRetiredForAccountGraphReload else { return .skipped }
             providerErrors[providerID] = "Refresh timed out after \(Int(providerRefreshTimeout))s"
             failureRetryAfter[providerID] = now().addingTimeInterval(Self.failureRetryBackoff)
             AppLog.warn(.refresh, "\(providerID) timed out after \(Int(providerRefreshTimeout))s")
@@ -357,7 +372,7 @@ final class WidgetDataStore {
         }
         // A canceled refresh may still return if a provider's underlying work is non-throwing. Never
         // publish that potentially partial snapshot; keep the last-good state exactly as it was.
-        guard !Task.isCancelled else {
+        guard !Task.isCancelled, !isRetiredForAccountGraphReload else {
             AppLog.debug(.refresh, "cancelled \(providerID) refresh; keeping last-good snapshot")
             return .skipped
         }

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -461,6 +461,16 @@ final class WidgetDataStore {
     func setPeerHistoryDocuments(_ documents: [UsageHistoryDocument], ownDeviceID: String) {
         peerHistoryDocuments = UsageHistoryDocument.newestByDevice(documents)
             .filter { $0.deviceID != ownDeviceID }
+            .map { document in
+                var document = document
+                document.providers = document.providers.filter {
+                    ProviderAccountID.family(of: $0.key) != "codex"
+                }
+                document.identities = document.identities?.filter {
+                    ProviderAccountID.family(of: $0.key) != "codex"
+                }
+                return document
+            }
         rebuildRenderedSnapshots()
     }
 
@@ -478,7 +488,10 @@ final class WidgetDataStore {
         // match a default card's history to whatever card that account is over there (see
         // `PeerHistoryRemapper`).
         for (providerID, descriptor) in registry.historyDescriptorsByProvider
-        where descriptor.scope == .machineLocal && isProviderEnabled(providerID) {
+        where descriptor.scope == .machineLocal
+            && ProviderAccountID.family(of: providerID) != "codex"
+            && isProviderEnabled(providerID)
+        {
             if let history = localSnapshots[providerID]?.usageHistory {
                 if ProviderAccountID.families.contains(ProviderAccountID.family(of: providerID)) {
                     if let reporter = providersByID[providerID] as? any AccountIdentityReporting,
@@ -528,7 +541,9 @@ final class WidgetDataStore {
         let enabledDescriptors = registry.historyDescriptorsByProvider.reduce(
             into: [String: UsageHistoryDescriptor]()
         ) { result, entry in
-            if isProviderEnabled(entry.key) { result[entry.key] = entry.value }
+            if ProviderAccountID.family(of: entry.key) != "codex", isProviderEnabled(entry.key) {
+                result[entry.key] = entry.value
+            }
         }
         // Match peers by account identity, not card id — the same account can be the default card
         // on one Mac and an extra account card on another. Whatever matches no local card at all

--- a/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
+++ b/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
@@ -6,11 +6,13 @@ final class AccountRuntimeLifecycleTests: XCTestCase {
     func testAccountFilesystemScansRunOffTheMainThread() async {
         let prepared = await AppContainer.prepareAccountDiscovery(
             configScan: { .init(notes: [Thread.isMainThread ? "main" : "background"]) },
-            coworkScan: { .init(notes: [Thread.isMainThread ? "main" : "background"]) }
+            coworkScan: { .init(notes: [Thread.isMainThread ? "main" : "background"]) },
+            desktopAccount: { Thread.isMainThread ? "main" : "background" }
         )
 
         XCTAssertEqual(prepared.config.notes, ["background"])
         XCTAssertEqual(prepared.cowork.notes, ["background"])
+        XCTAssertEqual(prepared.desktopAccountUUID, "background")
         XCTAssertTrue(prepared.isComplete)
     }
 

--- a/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
+++ b/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
@@ -39,6 +39,7 @@ final class AccountRuntimeLifecycleTests: XCTestCase {
 
         XCTAssertEqual(accounts.defaultBadgeHolder(family: "claude")?.identityKey, "original")
         XCTAssertFalse(assembly.isClaudeDiscoveryComplete)
+        XCTAssertEqual(assembly.defaultClaudeCoworkRoots, [])
         XCTAssertEqual(assembly.defaultClaudeDesktopAccess, .denied)
     }
 

--- a/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
+++ b/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
@@ -40,18 +40,28 @@ final class AccountRuntimeLifecycleTests: XCTestCase {
         XCTAssertEqual(assembly.defaultClaudeDesktopAccess, .denied)
     }
 
-    func testSessionRootChangesNeverChangeAccountOwnershipFingerprint() {
+    func testAnySessionRootChangeInvalidatesAccountRuntimeFingerprint() {
         let account = ClaudeAccountCard(
             id: "claude@team", displayName: "Team", identityKey: "person|team",
             credential: .desktop(organization: "team"),
             logRoots: [URL(fileURLWithPath: "/tmp/session-one")]
         )
-        var updated = account
-        updated.logRoots.append(URL(fileURLWithPath: "/tmp/session-two"))
-        let first = ProviderAccountAssembly(identityKeysByCard: [account.id: account.identityKey], claudeCards: [account])
-        let second = ProviderAccountAssembly(identityKeysByCard: [updated.id: updated.identityKey], claudeCards: [updated])
+        let first = ProviderAccountAssembly(
+            identityKeysByCard: [account.id: account.identityKey], claudeCards: [account],
+            defaultClaudeExtraLogRoots: [URL(fileURLWithPath: "/tmp/default-config")],
+            defaultClaudeCoworkRoots: [URL(fileURLWithPath: "/tmp/default-cowork")]
+        )
+        var updatedCard = first
+        updatedCard.claudeCards[0].logRoots.append(URL(fileURLWithPath: "/tmp/session-two"))
+        var updatedConfig = first
+        updatedConfig.defaultClaudeExtraLogRoots.append(URL(fileURLWithPath: "/tmp/another-config"))
+        var updatedCowork = first
+        updatedCowork.defaultClaudeCoworkRoots?.append(URL(fileURLWithPath: "/tmp/another-cowork"))
+        let original = AppContainer.AccountOwnershipFingerprint(first)
 
-        XCTAssertEqual(AppContainer.AccountOwnershipFingerprint(first), .init(second))
+        XCTAssertNotEqual(original, .init(updatedCard))
+        XCTAssertNotEqual(original, .init(updatedConfig))
+        XCTAssertNotEqual(original, .init(updatedCowork))
     }
 
     func testCancellationAfterConfigScanNeverRunsCoworkDiscovery() async {
@@ -65,5 +75,81 @@ final class AccountRuntimeLifecycleTests: XCTestCase {
 
         XCTAssertEqual(prepared.config.notes, ["config scanned"])
         XCTAssertTrue(prepared.cowork.truncated)
+    }
+
+    func testRetiredRefreshNeverOverwritesReplacementSnapshot() async {
+        let suiteName = "OpenUsageTests.RetiredAccountRuntime.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let oldSnapshot = ProviderSnapshot(providerID: provider.id, displayName: "Old Account", lines: [])
+        let newSnapshot = ProviderSnapshot(providerID: provider.id, displayName: "New Account", lines: [])
+        let oldRuntime = DeferredSnapshotRuntime(provider: provider, snapshot: oldSnapshot)
+        let registry = WidgetRegistry(providers: [provider], descriptors: [])
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "handoff")
+        let oldStore = WidgetDataStore(registry: registry, providers: [oldRuntime], cache: cache, defaults: defaults)
+        let oldRefresh = Task { await oldStore.refresh(providerID: provider.id, force: true) }
+        while !oldRuntime.isWaiting { await Task.yield() }
+
+        oldStore.retireForAccountGraphReload()
+        let replacementRuntime = TestProviderRuntime(provider: provider, descriptors: [], snapshot: newSnapshot)
+        let replacementStore = WidgetDataStore(
+            registry: registry, providers: [replacementRuntime], cache: cache, defaults: defaults
+        )
+        let replacementOutcome = await replacementStore.refresh(providerID: provider.id, force: true)
+        oldRuntime.complete()
+        let retiredOutcome = await oldRefresh.value
+
+        XCTAssertEqual(replacementOutcome, .refreshed)
+        XCTAssertEqual(retiredOutcome, .skipped)
+        let persisted = ProviderSnapshotCache(userDefaults: defaults, storageKey: "handoff")
+        XCTAssertEqual(persisted.loadSnapshots(providerIDs: [provider.id])[provider.id]?.displayName, "New Account")
+    }
+
+    func testCancellingRefreshBatchCancelsOutstandingProviderWork() async {
+        let suiteName = "OpenUsageTests.CancelledAccountRuntime.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let provider = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let runtime = HangingProviderRuntime(provider: provider, descriptors: [])
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [provider], descriptors: []),
+            providers: [runtime], cache: ProviderSnapshotCache(userDefaults: defaults), defaults: defaults
+        )
+        let refresh = Task { await store.refreshAll(force: true) }
+        while store.refreshingProviderIDs.isEmpty { await Task.yield() }
+
+        store.retireForAccountGraphReload()
+        refresh.cancel()
+        await refresh.value
+
+        XCTAssertTrue(runtime.wasCancelled)
+        XCTAssertNil(store.lastRefreshAt)
+        let retiredOutcome = await store.refresh(providerID: provider.id, force: true)
+        XCTAssertEqual(retiredOutcome, .skipped)
+    }
+}
+
+@MainActor
+private final class DeferredSnapshotRuntime: ProviderRuntime {
+    let provider: Provider
+    let widgetDescriptors: [WidgetDescriptor] = []
+    private let snapshot: ProviderSnapshot
+    private var continuation: CheckedContinuation<ProviderSnapshot, Never>?
+
+    var isWaiting: Bool { continuation != nil }
+
+    init(provider: Provider, snapshot: ProviderSnapshot) {
+        self.provider = provider
+        self.snapshot = snapshot
+    }
+
+    func refresh() async -> ProviderSnapshot {
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func complete() {
+        continuation?.resume(returning: snapshot)
+        continuation = nil
     }
 }

--- a/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
+++ b/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class AccountRuntimeLifecycleTests: XCTestCase {
+    func testAccountFilesystemScansRunOffTheMainThread() async {
+        let prepared = await AppContainer.prepareAccountDiscovery(
+            configScan: { .init(notes: [Thread.isMainThread ? "main" : "background"]) },
+            coworkScan: { .init(notes: [Thread.isMainThread ? "main" : "background"]) }
+        )
+
+        XCTAssertEqual(prepared.config.notes, ["background"])
+        XCTAssertEqual(prepared.cowork.notes, ["background"])
+        XCTAssertTrue(prepared.isComplete)
+    }
+
+    func testIncompletePreparedDiscoveryNeverMutatesPersistedAccountOwnership() {
+        let suiteName = "OpenUsageTests.IncompleteAccountGraph.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let accounts = ProviderAccountsStore(defaults: defaults)
+        accounts.reconcile(with: [.init(
+            family: "claude", identityKey: "original", label: "Original",
+            sources: [.init(kind: .defaultHome, anchor: "/Users/dev/.claude", holdsDefaultSource: true)]
+        )])
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment(), files: FakeFiles([
+                "/Users/dev/.claude.json": #"{"oauthAccount":{"accountUuid":"replacement"}}"#,
+            ]), keychain: FakeKeychain(), homeDirectory: { URL(fileURLWithPath: "/Users/dev") }
+        )
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: accounts,
+            preparedDiscovery: .init(config: .init(truncated: true), cowork: .init())
+        )
+
+        XCTAssertEqual(accounts.defaultBadgeHolder(family: "claude")?.identityKey, "original")
+        XCTAssertFalse(assembly.isClaudeDiscoveryComplete)
+        XCTAssertEqual(assembly.defaultClaudeDesktopAccess, .denied)
+    }
+
+    func testSessionRootChangesNeverChangeAccountOwnershipFingerprint() {
+        let account = ClaudeAccountCard(
+            id: "claude@team", displayName: "Team", identityKey: "person|team",
+            credential: .desktop(organization: "team"),
+            logRoots: [URL(fileURLWithPath: "/tmp/session-one")]
+        )
+        var updated = account
+        updated.logRoots.append(URL(fileURLWithPath: "/tmp/session-two"))
+        let first = ProviderAccountAssembly(identityKeysByCard: [account.id: account.identityKey], claudeCards: [account])
+        let second = ProviderAccountAssembly(identityKeysByCard: [updated.id: updated.identityKey], claudeCards: [updated])
+
+        XCTAssertEqual(AppContainer.AccountOwnershipFingerprint(first), .init(second))
+    }
+
+    func testCancellationAfterConfigScanNeverRunsCoworkDiscovery() async {
+        let prepared = await AppContainer.prepareAccountDiscovery(
+            configScan: {
+                withUnsafeCurrentTask { $0?.cancel() }
+                return .init(notes: ["config scanned"])
+            },
+            coworkScan: { .init(notes: ["must not run"]) }
+        )
+
+        XCTAssertEqual(prepared.config.notes, ["config scanned"])
+        XCTAssertTrue(prepared.cowork.truncated)
+    }
+}

--- a/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
+++ b/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
@@ -40,7 +40,7 @@ final class AccountRuntimeLifecycleTests: XCTestCase {
         XCTAssertEqual(assembly.defaultClaudeDesktopAccess, .denied)
     }
 
-    func testAnySessionRootChangeInvalidatesAccountRuntimeFingerprint() {
+    func testSessionRootChangesUpdateRoutingWithoutReplacingAccountOwnership() {
         let account = ClaudeAccountCard(
             id: "claude@team", displayName: "Team", identityKey: "person|team",
             credential: .desktop(organization: "team"),
@@ -57,11 +57,19 @@ final class AccountRuntimeLifecycleTests: XCTestCase {
         updatedConfig.defaultClaudeExtraLogRoots.append(URL(fileURLWithPath: "/tmp/another-config"))
         var updatedCowork = first
         updatedCowork.defaultClaudeCoworkRoots?.append(URL(fileURLWithPath: "/tmp/another-cowork"))
-        let original = AppContainer.AccountOwnershipFingerprint(first)
+        let ownership = AppContainer.AccountOwnershipFingerprint(first)
+        let routing = AppContainer.AccountLogRoutingFingerprint(first)
 
-        XCTAssertNotEqual(original, .init(updatedCard))
-        XCTAssertNotEqual(original, .init(updatedConfig))
-        XCTAssertNotEqual(original, .init(updatedCowork))
+        for update in [updatedCard, updatedConfig, updatedCowork] {
+            XCTAssertEqual(ownership, .init(update))
+            XCTAssertNotEqual(routing, .init(update))
+            XCTAssertFalse(AppContainer.AccountLogRoutingFingerprint(update).reassignsExistingRoots(from: routing))
+        }
+
+        var changedOwner = first
+        changedOwner.claudeCards[0].logRoots.append(URL(fileURLWithPath: "/tmp/default-cowork"))
+        changedOwner.defaultClaudeCoworkRoots = []
+        XCTAssertTrue(AppContainer.AccountLogRoutingFingerprint(changedOwner).reassignsExistingRoots(from: routing))
     }
 
     func testCancellationAfterConfigScanNeverRunsCoworkDiscovery() async {

--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
@@ -564,8 +564,16 @@ final class ClaudeLogUsageScannerTests: XCTestCase {
             environment: FakeEnvironment([:]),
             homeDirectory: { home },
             incrementalScanner: IncrementalJSONLScanner<Entry>(),
-            coworkRootsOverride: [mine]
+            coworkRootsOverride: []
         )
+
+        let initialResult = await scanner.scan(now: now, pricing: pricing)
+        let beforeRoutingUpdate = try XCTUnwrap(initialResult)
+        XCTAssertEqual(beforeRoutingUpdate.series.daily[0].totalTokens, 150)
+        let updated = await scanner.updateLogRoots(
+            rootsOverride: nil, additionalRoots: [], coworkRootsOverride: [mine]
+        )
+        XCTAssertTrue(updated)
 
         let result = await scanner.scan(now: now, pricing: pricing)
         let scan = try XCTUnwrap(result)

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -548,6 +548,56 @@ final class CodexProviderTests: XCTestCase {
         }
     }
 
+    func testBoundAccountRejectsAnotherLoginWithoutPublishingOrCachingIt() async {
+        let suite = "OpenUsageTests.CodexOwnership.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let http = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
+        let provider = CodexProvider(
+            authStore: CodexAuthStore(
+                environment: FakeEnvironment(["CODEX_HOME": "/tmp/codex-owned"]),
+                files: FakeFiles([
+                    "/tmp/codex-owned/auth.json": #"{"tokens":{"access_token":"token-b","account_id":"account-b"}}"#,
+                ]),
+                keychain: FakeKeychain()
+            ),
+            usageClient: CodexUsageClient(http: http),
+            expectedIdentityKey: "account-a"
+        )
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "ownership")
+        let store = WidgetDataStore(
+            registry: WidgetRegistry.from([provider]), providers: [provider], cache: cache,
+            defaults: defaults, providerIdentityKeys: ["codex": "account-a"]
+        )
+
+        let outcome = await store.refresh(providerID: "codex", force: true)
+
+        XCTAssertEqual(outcome, .failed)
+        XCTAssertNil(cache.snapshot(providerID: "codex"))
+        XCTAssertTrue(http.requests.isEmpty)
+    }
+
+    func testBoundAccountAcceptsVerifiedIdentityTokenOwnership() async throws {
+        let path = "/tmp/codex-owned/auth.json"
+        let payload = Data(#"{"https://api.openai.com/auth":{"chatgpt_account_id":"account-a"}}"#.utf8)
+            .base64EncodedString()
+        let owned = #"{"tokens":{"access_token":"token-a","id_token":"header.\#(payload).signature"}}"#
+        let response = HTTPResponse(statusCode: 200, headers: [:], body: Data(#"{"plan_type":"plus"}"#.utf8))
+        let home = try CodexLogFixture.makeHome(files: [:])
+        let matching = CodexProvider(
+            authStore: CodexAuthStore(
+                environment: FakeEnvironment(["CODEX_HOME": "/tmp/codex-owned"]),
+                files: FakeFiles([path: owned]), keychain: FakeKeychain()
+            ),
+            usageClient: CodexUsageClient(http: FakeHTTPClient(response: response)),
+            logUsageScanner: CodexLogFixture.scanner(home: home),
+            expectedIdentityKey: "ACCOUNT-A"
+        )
+
+        let validSnapshot = await matching.refresh()
+        XCTAssertEqual(validSnapshot.plan, "Plus")
+    }
+
     func testNoUsageDataBadgeIsDroppedWhenLocalLogsHaveSpend() async throws {
         let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
         // The live usage API returns nothing mappable (empty body -> no metric lines)...

--- a/Tests/OpenUsageTests/CodexResetClaimTests.swift
+++ b/Tests/OpenUsageTests/CodexResetClaimTests.swift
@@ -328,6 +328,31 @@ final class CodexResetClaimTests: XCTestCase {
         XCTAssertTrue(http.requests.isEmpty)
     }
 
+    func testRetiredAccountNeverConsumesAfterSuspendedCreditLookup() async {
+        let gate = ResetClaimRequestGate()
+        let http = RoutingHTTPClient { request in
+            if request.url == CodexUsageClient.resetCreditsURL {
+                await gate.wait()
+                return HTTPResponse(statusCode: 200, headers: [:], body: Self.listBody())
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Self.consumeBody(code: "reset"))
+        }
+        let service = CodexResetClaimService(
+            usageClient: CodexUsageClient(http: http),
+            credentialCandidates: { [("old-account-token", "acct-A")] },
+            expectedIdentityKey: "acct-A"
+        )
+        let claim = Task { await service.claim(creditExpiringAt: Self.expiry, redeemRequestID: "redeem-1") }
+        while await !gate.isWaiting { await Task.yield() }
+
+        service.retireForAccountGraphReload()
+        await gate.release()
+
+        let result = await claim.value
+        XCTAssertEqual(result, .failed)
+        XCTAssertFalse(http.requests.contains { $0.url == CodexUsageClient.consumeResetCreditURL })
+    }
+
     func testClaimFailsWhenEveryCandidateIsRejected() async {
         let http = RoutingHTTPClient { _ in HTTPResponse(statusCode: 401, headers: [:], body: Data()) }
         let service = CodexResetClaimService(
@@ -339,5 +364,19 @@ final class CodexResetClaimTests: XCTestCase {
 
         XCTAssertEqual(outcome, .failed)
         XCTAssertEqual(http.requests.count, 2, "every candidate is tried once, then the claim fails loudly")
+    }
+}
+
+private actor ResetClaimRequestGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    var isWaiting: Bool { continuation != nil }
+
+    func wait() async {
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/Tests/OpenUsageTests/CodexResetClaimTests.swift
+++ b/Tests/OpenUsageTests/CodexResetClaimTests.swift
@@ -328,6 +328,25 @@ final class CodexResetClaimTests: XCTestCase {
         XCTAssertTrue(http.requests.isEmpty)
     }
 
+    func testKeychainClaimRejectsForeignOrUnverifiedDisplayedAccount() async {
+        for displayedAccount in ["acct-A", nil] as [String?] {
+            let http = RoutingHTTPClient { _ in
+                XCTFail("an unverified or foreign keychain account must never receive a claim request")
+                return HTTPResponse(statusCode: 200, headers: [:], body: Self.listBody())
+            }
+            let service = CodexResetClaimService(
+                usageClient: CodexUsageClient(http: http),
+                credentialCandidates: { [("new-account-token", "acct-B")] },
+                verifiedIdentityKey: { displayedAccount }
+            )
+
+            let outcome = await service.claim(creditExpiringAt: Self.expiry, redeemRequestID: "redeem-1")
+
+            XCTAssertEqual(outcome, .failed)
+            XCTAssertTrue(http.requests.isEmpty)
+        }
+    }
+
     func testRetiredAccountNeverConsumesAfterSuspendedCreditLookup() async {
         let gate = ResetClaimRequestGate()
         let http = RoutingHTTPClient { request in
@@ -370,7 +389,7 @@ final class CodexResetClaimTests: XCTestCase {
                     ? [("old-account-token", "acct-A")]
                     : [("new-account-token", "acct-B")]
             },
-            expectedIdentityKey: "acct-A"
+            verifiedIdentityKey: { activeAccount.count == 0 ? "acct-A" : "acct-B" }
         )
         let claim = Task { await service.claim(creditExpiringAt: Self.expiry, redeemRequestID: "redeem-1") }
         while await !gate.isWaiting { await Task.yield() }

--- a/Tests/OpenUsageTests/CodexResetClaimTests.swift
+++ b/Tests/OpenUsageTests/CodexResetClaimTests.swift
@@ -353,6 +353,36 @@ final class CodexResetClaimTests: XCTestCase {
         XCTAssertFalse(http.requests.contains { $0.url == CodexUsageClient.consumeResetCreditURL })
     }
 
+    func testAccountSwitchDuringCreditLookupNeverConsumesBeforeRuntimeRetires() async {
+        let gate = ResetClaimRequestGate()
+        let activeAccount = RefreshCounter()
+        let http = RoutingHTTPClient { request in
+            if request.url == CodexUsageClient.resetCreditsURL {
+                await gate.wait()
+                return HTTPResponse(statusCode: 200, headers: [:], body: Self.listBody())
+            }
+            return HTTPResponse(statusCode: 200, headers: [:], body: Self.consumeBody(code: "reset"))
+        }
+        let service = CodexResetClaimService(
+            usageClient: CodexUsageClient(http: http),
+            credentialCandidates: {
+                activeAccount.count == 0
+                    ? [("old-account-token", "acct-A")]
+                    : [("new-account-token", "acct-B")]
+            },
+            expectedIdentityKey: "acct-A"
+        )
+        let claim = Task { await service.claim(creditExpiringAt: Self.expiry, redeemRequestID: "redeem-1") }
+        while await !gate.isWaiting { await Task.yield() }
+
+        activeAccount.count = 1
+        await gate.release()
+
+        let result = await claim.value
+        XCTAssertEqual(result, .failed)
+        XCTAssertEqual(http.requests.map(\.url), [CodexUsageClient.resetCreditsURL])
+    }
+
     func testClaimFailsWhenEveryCandidateIsRejected() async {
         let http = RoutingHTTPClient { _ in HTTPResponse(statusCode: 401, headers: [:], body: Data()) }
         let service = CodexResetClaimService(

--- a/Tests/OpenUsageTests/CodexResetClaimTests.swift
+++ b/Tests/OpenUsageTests/CodexResetClaimTests.swift
@@ -272,7 +272,8 @@ final class CodexResetClaimTests: XCTestCase {
         }
         let service = CodexResetClaimService(
             usageClient: CodexUsageClient(http: http),
-            credentialCandidates: { [("stale-token", "acct-old"), ("live-token", "acct-456")] }
+            credentialCandidates: { [("stale-token", "acct-456"), ("live-token", "acct-456")] },
+            expectedIdentityKey: "acct-456"
         )
 
         let outcome = await service.claim(creditExpiringAt: Self.expiry, redeemRequestID: "redeem-1")
@@ -282,11 +283,7 @@ final class CodexResetClaimTests: XCTestCase {
         XCTAssertEqual(consume.headers["Authorization"], "Bearer live-token")
     }
 
-    func testConsumeFallsBackToSameTokenDifferentAccountCandidate() async throws {
-        // ChatGPT-Account-Id changes what a token is authorized for: a same-token candidate with a
-        // different account is a distinct fallback and must not be deduplicated away. The list fetch
-        // authenticates with account A, the consume is rejected for A and must retry with account B —
-        // safe, because both attempts carry the same idempotency key.
+    func testConsumeNeverFallsBackToAnotherAccount() async throws {
         let http = RoutingHTTPClient { request in
             switch request.url {
             case CodexUsageClient.resetCreditsURL:
@@ -302,14 +299,33 @@ final class CodexResetClaimTests: XCTestCase {
         }
         let service = CodexResetClaimService(
             usageClient: CodexUsageClient(http: http),
-            credentialCandidates: { [("shared-token", "acct-A"), ("shared-token", "acct-B")] }
+            credentialCandidates: { [("shared-token", "acct-A"), ("shared-token", "acct-B")] },
+            expectedIdentityKey: "acct-A"
         )
 
         let outcome = await service.claim(creditExpiringAt: Self.expiry, redeemRequestID: "redeem-1")
 
-        XCTAssertEqual(outcome, .success)
+        XCTAssertEqual(outcome, .failed)
         let consume = try XCTUnwrap(http.requests.last)
-        XCTAssertEqual(consume.headers["ChatGPT-Account-Id"], "acct-B")
+        XCTAssertEqual(consume.headers["ChatGPT-Account-Id"], "acct-A")
+        XCTAssertEqual(http.requests.count, 2, "the other account must receive neither a GET nor a POST")
+    }
+
+    func testClaimFailsWithoutRequestsAfterAccountSwitch() async {
+        let http = RoutingHTTPClient { _ in
+            XCTFail("a switched account must never receive the previous account's request")
+            return HTTPResponse(statusCode: 200, headers: [:], body: Data())
+        }
+        let service = CodexResetClaimService(
+            usageClient: CodexUsageClient(http: http),
+            credentialCandidates: { [("new-account-token", "acct-B")] },
+            expectedIdentityKey: "acct-A"
+        )
+
+        let outcome = await service.claim(creditExpiringAt: Self.expiry, redeemRequestID: "redeem-1")
+
+        XCTAssertEqual(outcome, .failed)
+        XCTAssertTrue(http.requests.isEmpty)
     }
 
     func testClaimFailsWhenEveryCandidateIsRejected() async {

--- a/Tests/OpenUsageTests/FirstRunSeederTests.swift
+++ b/Tests/OpenUsageTests/FirstRunSeederTests.swift
@@ -46,6 +46,37 @@ final class FirstRunSeederTests: XCTestCase {
         XCTAssertEqual(enablement.enabledIDs, ["claude", "codex", "cursor"])
     }
 
+    func testDeferredFirstRunDetectionWaitsForVerifiedDesktopAccount() async throws {
+        let enablement = ProviderEnablementStore(defaults: makeDefaults("deferred-desktop"))
+        let onboarding = OnboardingStore(defaults: makeDefaults("deferred-desktop-onboarding"))
+        let provisional: [ProviderRuntime] = [
+            stub("claude", hasCredentials: false),
+            stub("codex", hasCredentials: true),
+            stub("cursor", hasCredentials: false),
+        ]
+
+        let deferred = FirstRunSeeder.seedIfNeeded(
+            isFreshInstall: true, providers: provisional, enablement: enablement,
+            onboarding: onboarding, deferDetectionUntilDiscovery: true
+        )
+
+        XCTAssertNil(deferred)
+        XCTAssertEqual(enablement.enabledIDs, ["claude", "codex", "cursor"])
+        XCTAssertEqual(enablement.detectionJob?.mode, .replacement)
+
+        let verified: [ProviderRuntime] = [
+            stub("claude@desktop", hasCredentials: true),
+            stub("codex", hasCredentials: true),
+            stub("cursor", hasCredentials: false),
+        ]
+        let resumed = try XCTUnwrap(NewProviderSeeder.reconcileIfNeeded(
+            providers: verified, enablement: enablement
+        ))
+        await resumed.value
+
+        XCTAssertEqual(enablement.enabledIDs, ["claude@desktop", "codex"])
+    }
+
     func testExistingInstallIsNeverSeeded() async {
         let enablement = ProviderEnablementStore(defaults: makeDefaults("existing"))
         let onboarding = OnboardingStore(defaults: makeDefaults("existing-onboarding"))

--- a/Tests/OpenUsageTests/FirstRunSeederTests.swift
+++ b/Tests/OpenUsageTests/FirstRunSeederTests.swift
@@ -95,6 +95,42 @@ final class FirstRunSeederTests: XCTestCase {
         XCTAssertEqual(enablement.enabledIDs, ["claude", "cursor"])
     }
 
+    func testCancelledFirstRunResumesAdditivelyWithoutUndoingUserChoices() async throws {
+        let defaults = makeDefaults("cancelled-first-run-resume")
+        let staleEnablement = ProviderEnablementStore(defaults: defaults)
+        let onboarding = OnboardingStore(defaults: makeDefaults("cancelled-first-run-onboarding"))
+        let providers: [ProviderRuntime] = [
+            stub("claude", hasCredentials: true),
+            stub("codex", hasCredentials: true),
+            stub("cursor", hasCredentials: false),
+            stub("grok", hasCredentials: true),
+            stub("devin", hasCredentials: true),
+            stub("windsurf", hasCredentials: false),
+        ]
+        let oldTask = try XCTUnwrap(FirstRunSeeder.seedIfNeeded(
+            isFreshInstall: true, providers: providers, enablement: staleEnablement, onboarding: onboarding
+        ))
+
+        let replacementEnablement = ProviderEnablementStore(defaults: defaults)
+        replacementEnablement.setEnabled(false, for: "codex")
+        replacementEnablement.setEnabled(true, for: "windsurf")
+        replacementEnablement.setEnabled(true, for: "grok")
+        replacementEnablement.setEnabled(false, for: "grok")
+        oldTask.cancel()
+        await oldTask.value
+        XCTAssertEqual(replacementEnablement.enabledIDs, ["claude", "cursor", "windsurf"])
+
+        let resumedTask = try XCTUnwrap(NewProviderSeeder.reconcileIfNeeded(
+            providers: providers, enablement: replacementEnablement
+        ))
+        await resumedTask.value
+
+        XCTAssertEqual(replacementEnablement.enabledIDs, ["claude", "cursor", "devin", "windsurf"])
+        XCTAssertFalse(replacementEnablement.isEnabled("codex"))
+        XCTAssertFalse(replacementEnablement.isEnabled("grok"))
+        XCTAssertTrue(replacementEnablement.pendingDetectionIDs.isEmpty)
+    }
+
     // MARK: - Reset All reseed
 
     func testReseedOverwritesCurrentChoicesWithDetectedSet() async {

--- a/Tests/OpenUsageTests/FirstRunSeederTests.swift
+++ b/Tests/OpenUsageTests/FirstRunSeederTests.swift
@@ -95,6 +95,33 @@ final class FirstRunSeederTests: XCTestCase {
         XCTAssertEqual(enablement.enabledIDs, ["claude", "cursor"])
     }
 
+    func testCancelledFirstRunStillReplacesCredentiallessFallbackAfterReload() async throws {
+        let defaults = makeDefaults("cancelled-first-run-replacement")
+        let original = ProviderEnablementStore(defaults: defaults)
+        let onboarding = OnboardingStore(defaults: makeDefaults("cancelled-replacement-onboarding"))
+        let providers: [ProviderRuntime] = [
+            stub("claude", hasCredentials: true),
+            stub("codex", hasCredentials: false),
+            stub("cursor", hasCredentials: false),
+            stub("grok", hasCredentials: true),
+        ]
+        let cancelled = try XCTUnwrap(FirstRunSeeder.seedIfNeeded(
+            isFreshInstall: true, providers: providers, enablement: original, onboarding: onboarding
+        ))
+        cancelled.cancel()
+        await cancelled.value
+
+        let replacement = ProviderEnablementStore(defaults: defaults)
+        XCTAssertEqual(replacement.detectionJob?.mode, .replacement)
+        let resumed = try XCTUnwrap(NewProviderSeeder.reconcileIfNeeded(
+            providers: providers, enablement: replacement
+        ))
+        await resumed.value
+
+        XCTAssertEqual(replacement.enabledIDs, ["claude", "grok"])
+        XCTAssertNil(replacement.detectionJob)
+    }
+
     func testCancelledFirstRunResumesAdditivelyWithoutUndoingUserChoices() async throws {
         let defaults = makeDefaults("cancelled-first-run-resume")
         let staleEnablement = ProviderEnablementStore(defaults: defaults)
@@ -195,6 +222,28 @@ final class FirstRunSeederTests: XCTestCase {
         XCTAssertEqual(detected, Set(ids), "all probes must be in flight at once, not one after another")
     }
 
+    func testCancellingDetectionAlsoCancelsItsCredentialProbes() async {
+        var probeStarted = false
+        var probeCancelled = false
+        let provider = CredentialStubProvider(id: "claude", probe: {
+            probeStarted = true
+            do {
+                try await Task.sleep(for: .seconds(10))
+                return true
+            } catch {
+                probeCancelled = true
+                return false
+            }
+        })
+        let detection = Task { await FirstRunSeeder.detectLocalProviders([provider]) }
+        while !probeStarted { await Task.yield() }
+
+        detection.cancel()
+        _ = await detection.value
+
+        XCTAssertTrue(probeCancelled)
+    }
+
     // MARK: - OnboardingStore persistence
 
     func testCustomizeHintFlagPersistsAcrossInstances() {
@@ -238,6 +287,11 @@ private final class CredentialStubProvider: ProviderRuntime {
     init(id: String, gate: ProbeGate) {
         self.provider = Provider(id: id, displayName: id.capitalized, icon: .providerMark(id))
         self.hasCredentials = { await gate.arrive() }
+    }
+
+    init(id: String, probe: @escaping @MainActor () async -> Bool) {
+        self.provider = Provider(id: id, displayName: id.capitalized, icon: .providerMark(id))
+        self.hasCredentials = probe
     }
 
     func refresh() async -> ProviderSnapshot {

--- a/Tests/OpenUsageTests/FirstRunSeederTests.swift
+++ b/Tests/OpenUsageTests/FirstRunSeederTests.swift
@@ -47,7 +47,8 @@ final class FirstRunSeederTests: XCTestCase {
     }
 
     func testDeferredFirstRunDetectionWaitsForVerifiedDesktopAccount() async throws {
-        let enablement = ProviderEnablementStore(defaults: makeDefaults("deferred-desktop"))
+        let defaults = makeDefaults("deferred-desktop")
+        let enablement = ProviderEnablementStore(defaults: defaults)
         let onboarding = OnboardingStore(defaults: makeDefaults("deferred-desktop-onboarding"))
         let provisional: [ProviderRuntime] = [
             stub("claude", hasCredentials: false),
@@ -75,6 +76,8 @@ final class FirstRunSeederTests: XCTestCase {
         await resumed.value
 
         XCTAssertEqual(enablement.enabledIDs, ["claude@desktop", "codex"])
+        XCTAssertNil(enablement.detectionJob)
+        XCTAssertNil(ProviderEnablementStore(defaults: defaults).detectionJob)
     }
 
     func testExistingInstallIsNeverSeeded() async {

--- a/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
+++ b/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
@@ -220,6 +220,32 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         XCTAssertTrue(replacement.enabled)
     }
 
+    func testEnabledReplacementWaitsForRetiredGraphsInFlightDisableDeletion() async throws {
+        let defaults = makeDefaults("reenable-before-account-graph-reload")
+        let fileStore = RecordingHistoryFileStore()
+        let deviceIDStore = MemoryDeviceIDStore()
+        let retired = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+        retired.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !retired.isSyncing }
+
+        await fileStore.holdNextDelete()
+        retired.enabled = false
+        try await waitUntil { await fileStore.deleteIsHeld }
+        retired.enabled = true
+        retired.shutdownForAccountGraphReload()
+        let replacement = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+
+        for _ in 0..<10 { await Task.yield() }
+        let writesBeforeDeleteCompletes = await fileStore.writeCount
+        XCTAssertEqual(writesBeforeDeleteCompletes, 1, "replacement waits for the retired graph's deletion")
+        await fileStore.releaseDelete()
+        try await waitUntil { await fileStore.writeCount == 2 && !replacement.isSyncing }
+        let documents = await fileStore.documents
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        XCTAssertEqual(documents.map(\.deviceID), [replacement.deviceID])
+        XCTAssertEqual(deletedDeviceIDs, [replacement.deviceID])
+    }
+
     func testDisableDeletesWriteThatWasAlreadyInFlight() async throws {
         let defaults = makeDefaults("disable-in-flight-write")
         let fileStore = RecordingHistoryFileStore()

--- a/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
+++ b/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
@@ -162,13 +162,8 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
 
         let fileStore = ICloudUsageHistoryFileStore()
         let retiredWriter = Task.detached {
-            try await fileStore.coordinatedWrite(
-                Data("retired-account".utf8),
-                to: documentURL,
-                beforeWriting: {
-                    withUnsafeCurrentTask { task in task?.cancel() }
-                }
-            )
+            withUnsafeCurrentTask { $0?.cancel() }
+            try await fileStore.coordinatedWrite(Data("retired-account".utf8), to: documentURL)
         }
 
         do {
@@ -208,8 +203,8 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
 
         await fileStore.holdNextDelete()
         retired.enabled = false
-        retired.shutdownForAccountGraphReload()
         try await waitUntil { await fileStore.deleteIsHeld }
+        retired.shutdownForAccountGraphReload()
         let replacement = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
         replacement.enabled = true
 
@@ -220,6 +215,8 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         try await waitUntil { await fileStore.writeCount == 2 && !replacement.isSyncing }
         let documents = await fileStore.documents
         XCTAssertEqual(documents.map(\.deviceID), [replacement.deviceID])
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        XCTAssertEqual(deletedDeviceIDs, [replacement.deviceID])
         XCTAssertTrue(replacement.enabled)
     }
 

--- a/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
+++ b/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
@@ -58,6 +58,21 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "openusage.icloudSync.enabled.v1"))
     }
 
+    func testShutdownNeverTouchesCloudWhenSyncWasNeverEnabled() async throws {
+        let defaults = makeDefaults("never-enabled")
+        let fileStore = RecordingHistoryFileStore()
+        let sync = makeSync(defaults, fileStore: fileStore)
+
+        sync.shutdownForAccountGraphReload()
+        for _ in 0..<10 { await Task.yield() }
+
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        let writeCount = await fileStore.writeCount
+        XCTAssertTrue(deletedDeviceIDs.isEmpty)
+        XCTAssertEqual(writeCount, 0)
+        XCTAssertNil(sync.serviceError)
+    }
+
     func testAccountGraphShutdownCancelsInFlightWriteWithoutReplacingExistingFile() async throws {
         let defaults = makeDefaults("account-graph-shutdown-in-flight")
         let deviceIDStore = MemoryDeviceIDStore()
@@ -112,6 +127,28 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         let deletedDeviceIDs = await fileStore.deletedDeviceIDs
         XCTAssertEqual(documents, [currentDocument])
         XCTAssertTrue(deletedDeviceIDs.isEmpty)
+    }
+
+    func testReenableWaitsForAnInFlightDisableDeletion() async throws {
+        let defaults = makeDefaults("reenable-during-delete")
+        let fileStore = RecordingHistoryFileStore()
+        let sync = makeSync(defaults, fileStore: fileStore)
+        sync.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !sync.isSyncing }
+
+        await fileStore.holdNextDelete()
+        sync.enabled = false
+        try await waitUntil { await fileStore.deleteIsHeld }
+        sync.enabled = true
+
+        for _ in 0..<10 { await Task.yield() }
+        let writesBeforeDeletion = await fileStore.writeCount
+        XCTAssertEqual(writesBeforeDeletion, 1)
+
+        await fileStore.releaseDelete()
+        try await waitUntil { await fileStore.writeCount == 2 && !sync.isSyncing }
+        let documents = await fileStore.documents
+        XCTAssertEqual(documents.map(\.deviceID), [sync.deviceID])
     }
 
     func testCanceledCoordinatedAccessorCannotOverwriteReplacementAccountDocument() async throws {

--- a/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
+++ b/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
@@ -6,7 +6,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     func testEnableWritesLoadsAndDisableDeletesThisMac() async throws {
         let defaults = makeDefaults("enable-disable")
         let fileStore = RecordingHistoryFileStore()
-        let sync = makeSync(defaults: defaults, fileStore: fileStore, writeDebounce: .milliseconds(10))
+        let sync = makeSync(defaults, fileStore: fileStore, writeDebounce: .milliseconds(10))
 
         sync.enabled = true
         try await waitUntil { await fileStore.writeCount == 1 && sync.displayedDocuments.count == 1 }
@@ -22,7 +22,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     func testAdjacentHistoryChangesDebounceToOneWrite() async throws {
         let defaults = makeDefaults("debounce")
         let fileStore = RecordingHistoryFileStore()
-        let sync = makeSync(defaults: defaults, fileStore: fileStore, writeDebounce: .milliseconds(20))
+        let sync = makeSync(defaults, fileStore: fileStore, writeDebounce: .milliseconds(20))
         sync.enabled = true
         try await waitUntil { await fileStore.writeCount == 1 }
 
@@ -36,10 +36,134 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         XCTAssertEqual(writeCount, 2)
     }
 
+    func testAccountGraphShutdownCancelsDebouncedWriteWithoutDisablingOrDeleting() async throws {
+        let defaults = makeDefaults("account-graph-shutdown-debounce")
+        let fileStore = RecordingHistoryFileStore()
+        let sync = makeSync(defaults, fileStore: fileStore, writeDebounce: .milliseconds(30))
+        sync.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !sync.isSyncing }
+
+        sync.scheduleWrite()
+        sync.shutdownForAccountGraphReload()
+        sync.scheduleWrite()
+        try await Task.sleep(for: .milliseconds(80))
+
+        let writeCount = await fileStore.writeCount
+        let documents = await fileStore.documents
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        XCTAssertEqual(writeCount, 1, "the retired graph cannot publish a queued or newly scheduled write")
+        XCTAssertEqual(documents.map(\.deviceID), [sync.deviceID], "graph reload keeps this Mac's existing file")
+        XCTAssertTrue(deletedDeviceIDs.isEmpty, "graph reload is not the same as opting out of iCloud")
+        XCTAssertTrue(sync.enabled)
+        XCTAssertTrue(defaults.bool(forKey: "openusage.icloudSync.enabled.v1"))
+    }
+
+    func testAccountGraphShutdownCancelsInFlightWriteWithoutReplacingExistingFile() async throws {
+        let defaults = makeDefaults("account-graph-shutdown-in-flight")
+        let deviceIDStore = MemoryDeviceIDStore()
+        let expectedDeviceID = UUID().uuidString.lowercased()
+        try deviceIDStore.writeDeviceID(expectedDeviceID)
+        let existingDocument = UsageHistoryDocument(
+            deviceID: expectedDeviceID,
+            deviceName: "Previous Account Graph",
+            updatedAt: Date(timeIntervalSince1970: 123),
+            providers: [:]
+        )
+        let fileStore = RecordingHistoryFileStore(seedDocuments: [existingDocument])
+        let sync = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+
+        await fileStore.holdNextWrite()
+        sync.enabled = true
+        try await waitUntil { await fileStore.writeInFlight }
+
+        sync.shutdownForAccountGraphReload()
+        await fileStore.releaseWrite()
+        try await waitUntil { !(await fileStore.writeInFlight) && !sync.isSyncing }
+
+        let documents = await fileStore.documents
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        XCTAssertEqual(documents, [existingDocument], "a canceled stale graph must not replace the current device file")
+        XCTAssertTrue(deletedDeviceIDs.isEmpty, "only the replacement graph owns subsequent writes")
+        XCTAssertTrue(sync.enabled)
+        XCTAssertNil(sync.serviceError, "cancellation is an intentional shutdown, not an iCloud failure")
+    }
+
+    func testCanceledCoordinatedAccessorCannotOverwriteReplacementAccountDocument() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openusage-sync-coordination-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let documentURL = directory.appendingPathComponent("device.json")
+        let currentAccount = Data("replacement-account".utf8)
+        try currentAccount.write(to: documentURL)
+
+        let fileStore = ICloudUsageHistoryFileStore()
+        let retiredWriter = Task.detached {
+            try await fileStore.coordinatedWrite(
+                Data("retired-account".utf8),
+                to: documentURL,
+                beforeWriting: {
+                    withUnsafeCurrentTask { task in task?.cancel() }
+                }
+            )
+        }
+
+        do {
+            try await retiredWriter.value
+            XCTFail("a graph retired while waiting for file coordination must not commit")
+        } catch is CancellationError {
+            // Expected: cancellation is checked after the coordinated accessor begins.
+        }
+        XCTAssertEqual(try Data(contentsOf: documentURL), currentAccount)
+    }
+
+    func testDisableImmediatelyBeforeGraphReloadStillDeletesThisMac() async throws {
+        let defaults = makeDefaults("disable-immediate-account-graph-reload")
+        let fileStore = RecordingHistoryFileStore()
+        let deviceIDStore = MemoryDeviceIDStore()
+        let retired = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+        retired.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !retired.isSyncing }
+
+        retired.enabled = false
+        retired.shutdownForAccountGraphReload()
+        let replacement = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+
+        XCTAssertFalse(replacement.enabled)
+        try await waitUntil { await fileStore.deletedDeviceIDs.contains(retired.deviceID) }
+        let documents = await fileStore.documents
+        XCTAssertFalse(documents.contains { $0.deviceID == retired.deviceID })
+    }
+
+    func testReenabledReplacementKeepsThisMacAfterInterruptedDisable() async throws {
+        let defaults = makeDefaults("disable-reload-reenable")
+        let fileStore = RecordingHistoryFileStore()
+        let deviceIDStore = MemoryDeviceIDStore()
+        let retired = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+        retired.enabled = true
+        try await waitUntil { await fileStore.writeCount == 1 && !retired.isSyncing }
+
+        await fileStore.holdNextDelete()
+        retired.enabled = false
+        retired.shutdownForAccountGraphReload()
+        try await waitUntil { await fileStore.deleteIsHeld }
+        let replacement = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+        replacement.enabled = true
+
+        for _ in 0..<10 { await Task.yield() }
+        let writesBeforeDeleteCompletes = await fileStore.writeCount
+        XCTAssertEqual(writesBeforeDeleteCompletes, 1, "replacement waits for the retired graph's deletion")
+        await fileStore.releaseDelete()
+        try await waitUntil { await fileStore.writeCount == 2 && !replacement.isSyncing }
+        let documents = await fileStore.documents
+        XCTAssertEqual(documents.map(\.deviceID), [replacement.deviceID])
+        XCTAssertTrue(replacement.enabled)
+    }
+
     func testDisableDeletesWriteThatWasAlreadyInFlight() async throws {
         let defaults = makeDefaults("disable-in-flight-write")
         let fileStore = RecordingHistoryFileStore()
-        let sync = makeSync(defaults: defaults, fileStore: fileStore)
+        let sync = makeSync(defaults, fileStore: fileStore)
 
         // Hold the enable write open so disable can race it deliberately, instead of hoping an
         // 80ms sleep is still in flight when the test flips the toggle on a loaded CI runner.
@@ -66,7 +190,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     func testUnavailableStoreSurfacesFriendlyError() async throws {
         let defaults = makeDefaults("unavailable")
         let fileStore = RecordingHistoryFileStore(unavailable: true)
-        let sync = makeSync(defaults: defaults, fileStore: fileStore)
+        let sync = makeSync(defaults, fileStore: fileStore)
 
         sync.enabled = true
         try await waitUntil { sync.serviceError != nil && !sync.isSyncing }
@@ -87,7 +211,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
             seedDocuments: [peer],
             invalidFileMessages: ["broken.json: invalid value"]
         )
-        let sync = makeSync(defaults: defaults, fileStore: fileStore)
+        let sync = makeSync(defaults, fileStore: fileStore)
 
         sync.enabled = true
         try await waitUntil { sync.invalidFileMessages.count == 1 }
@@ -99,7 +223,7 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     func testBackgroundReloadShowsSyncActivity() async throws {
         let defaults = makeDefaults("background-sync-activity")
         let fileStore = RecordingHistoryFileStore()
-        let sync = makeSync(defaults: defaults, fileStore: fileStore, writeDebounce: .milliseconds(10))
+        let sync = makeSync(defaults, fileStore: fileStore, writeDebounce: .milliseconds(10))
 
         sync.enabled = true
         try await waitUntil {
@@ -125,9 +249,9 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         firstDefaults.set(expectedID, forKey: "openusage.icloudSync.deviceID.v1")
         let deviceIDStore = MemoryDeviceIDStore()
 
-        let first = makeSync(defaults: firstDefaults, fileStore: RecordingHistoryFileStore(), deviceIDStore: deviceIDStore)
+        let first = makeSync(firstDefaults, deviceIDStore: deviceIDStore)
         let resetDefaults = makeDefaults("identity-after-reset")
-        let afterReset = makeSync(defaults: resetDefaults, fileStore: RecordingHistoryFileStore(), deviceIDStore: deviceIDStore)
+        let afterReset = makeSync(resetDefaults, deviceIDStore: deviceIDStore)
 
         XCTAssertEqual(first.deviceID, expectedID)
         XCTAssertEqual(afterReset.deviceID, expectedID)
@@ -153,19 +277,18 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
     }
 
     private func makeSync(
-        defaults: UserDefaults,
-        fileStore: RecordingHistoryFileStore,
+        _ defaults: UserDefaults,
+        fileStore: RecordingHistoryFileStore = RecordingHistoryFileStore(),
         deviceIDStore: MemoryDeviceIDStore = MemoryDeviceIDStore(),
         writeDebounce: Duration = .seconds(3)
     ) -> ICloudUsageSyncStore {
-        let dataStore = WidgetDataStore(
-            registry: WidgetRegistry(providers: [], descriptors: []),
-            providers: [],
-            cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots"),
-            defaults: defaults
-        )
-        return ICloudUsageSyncStore(
-            dataStore: dataStore,
+        ICloudUsageSyncStore(
+            dataStore: WidgetDataStore(
+                registry: WidgetRegistry(providers: [], descriptors: []),
+                providers: [],
+                cache: ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots"),
+                defaults: defaults
+            ),
             defaults: defaults,
             fileStore: fileStore,
             deviceIDStore: deviceIDStore,
@@ -217,8 +340,11 @@ private actor RecordingHistoryFileStore: UsageHistoryFileStoring {
     private(set) var writeInFlight = false
     private var shouldHoldNextLoad = false
     private var shouldHoldNextWrite = false
+    private var shouldHoldNextDelete = false
     private var loadGate: CheckedContinuation<Void, Never>?
     private var writeGate: CheckedContinuation<Void, Never>?
+    private var deleteGate: CheckedContinuation<Void, Never>?
+    var deleteIsHeld: Bool { deleteGate != nil }
 
     init(
         unavailable: Bool = false,
@@ -245,6 +371,7 @@ private actor RecordingHistoryFileStore: UsageHistoryFileStoring {
 
     func write(_ document: UsageHistoryDocument) async throws {
         if unavailable { throw ICloudUsageSyncError.unavailable }
+        try Task.checkCancellation()
         writeCount += 1
         writeInFlight = true
         defer { writeInFlight = false }
@@ -254,12 +381,17 @@ private actor RecordingHistoryFileStore: UsageHistoryFileStoring {
                 writeGate = continuation
             }
         }
+        try Task.checkCancellation()
         documents.removeAll { $0.deviceID == document.deviceID }
         documents.append(document)
     }
 
     func delete(deviceID: String) async throws {
         if unavailable { throw ICloudUsageSyncError.unavailable }
+        if shouldHoldNextDelete {
+            shouldHoldNextDelete = false
+            await withCheckedContinuation { deleteGate = $0 }
+        }
         deletedDeviceIDs.append(deviceID)
         documents.removeAll { $0.deviceID == deviceID }
     }
@@ -271,6 +403,9 @@ private actor RecordingHistoryFileStore: UsageHistoryFileStoring {
     func holdNextWrite() {
         shouldHoldNextWrite = true
     }
+
+    func holdNextDelete() { shouldHoldNextDelete = true }
+    func releaseDelete() { deleteGate?.resume(); deleteGate = nil }
 
     func releaseLoad() {
         loadGate?.resume()

--- a/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
+++ b/Tests/OpenUsageTests/ICloudUsageSyncStoreTests.swift
@@ -88,6 +88,32 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
         XCTAssertNil(sync.serviceError, "cancellation is an intentional shutdown, not an iCloud failure")
     }
 
+    func testRapidEnableChangesCannotLeaveAnOrphanedWriterAfterShutdown() async throws {
+        let defaults = makeDefaults("orphaned-activation")
+        let deviceIDStore = MemoryDeviceIDStore()
+        let deviceID = UUID().uuidString.lowercased()
+        try deviceIDStore.writeDeviceID(deviceID)
+        let currentDocument = UsageHistoryDocument(
+            deviceID: deviceID, deviceName: "Current Account", updatedAt: Date(), providers: [:]
+        )
+        let fileStore = RecordingHistoryFileStore(seedDocuments: [currentDocument])
+        let sync = makeSync(defaults, fileStore: fileStore, deviceIDStore: deviceIDStore)
+
+        await fileStore.holdNextWrite()
+        sync.enabled = true
+        try await waitUntil { await fileStore.writeInFlight }
+        sync.enabled = false
+        sync.enabled = true
+        sync.shutdownForAccountGraphReload()
+        await fileStore.releaseWrite()
+        try await waitUntil { !(await fileStore.writeInFlight) && !sync.isSyncing }
+
+        let documents = await fileStore.documents
+        let deletedDeviceIDs = await fileStore.deletedDeviceIDs
+        XCTAssertEqual(documents, [currentDocument])
+        XCTAssertTrue(deletedDeviceIDs.isEmpty)
+    }
+
     func testCanceledCoordinatedAccessorCannotOverwriteReplacementAccountDocument() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("openusage-sync-coordination-\(UUID().uuidString)", isDirectory: true)
@@ -178,9 +204,8 @@ final class ICloudUsageSyncStoreTests: XCTestCase {
 
         await fileStore.releaseWrite()
         try await waitUntil {
-            let deletedCount = await fileStore.deletedDeviceIDs.filter { $0 == sync.deviceID }.count
             let writeInFlight = await fileStore.writeInFlight
-            return deletedCount >= 2 && !writeInFlight && !sync.isSyncing
+            return !writeInFlight && !sync.isSyncing
         }
 
         let documents = await fileStore.documents

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -843,6 +843,25 @@ final class LayoutStoreTests: XCTestCase {
             store.defaultExpandedOnEnableIDs.contains("claude@work.sonnet"),
             "the caret split translates with the metric set"
         )
+
+        let freshDefaults = makeDefaults("AccountCardFreshDiscovery")
+        let provisionalRegistry = WidgetRegistry(
+            providers: [claude],
+            descriptors: registry.descriptors.filter { $0.providerID == "claude" }
+        )
+        _ = LayoutStore(
+            registry: provisionalRegistry, defaults: freshDefaults, storageKey: "layout",
+            defaultMetricIDs: ["claude.session"],
+            defaultExpandedMetricIDs: ["claude.session", "claude.sonnet"],
+            persistInitialState: false
+        )
+        let discovered = LayoutStore(
+            registry: registry, defaults: freshDefaults, storageKey: "layout",
+            defaultMetricIDs: ["claude.session"],
+            defaultExpandedMetricIDs: ["claude.session", "claude.sonnet"]
+        )
+        XCTAssertTrue(discovered.expandedMetricIDs.contains("claude@work.session"))
+        XCTAssertTrue(discovered.expandedMetricIDs.contains("claude@work.sonnet"))
     }
 
     func testResetToDefaultRestoresProviderOrderAndMarksDefaultsSeeded() {

--- a/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
+++ b/Tests/OpenUsageTests/LoginShellEnvironmentTests.swift
@@ -53,21 +53,42 @@ final class LoginShellEnvironmentTests: XCTestCase {
         XCTAssertNil(env.value(for: "K"))
         XCTAssertEqual(runner.callCount, 0)
     }
+
+    func testFailedCaptureCanRecoverOnTheNextAttempt() {
+        let runner = RecordingRunner(outputs: [
+            "malformed shell output",
+            [begin, "PATH=/usr/bin", end].joined(separator: "\0")
+        ])
+        let env = LoginShellEnvironment(runner: runner)
+        let recovered = expectation(description: "failed shell capture recovered")
+        DispatchQueue.global().async {
+            XCTAssertFalse(env.ensureCaptured())
+            XCTAssertTrue(env.ensureCaptured())
+            recovered.fulfill()
+        }
+        wait(for: [recovered], timeout: 5)
+        XCTAssertEqual(runner.callCount, 2)
+        XCTAssertEqual(env.value(for: "PATH"), "/usr/bin")
+    }
 }
 
 /// Returns a fixed stdout and counts how many times it was invoked, so tests can assert the capture
 /// ran exactly once (or not at all on the main thread).
 private final class RecordingRunner: ProcessRunning, @unchecked Sendable {
-    let stdout: String
+    let outputs: [String]
     private let lock = NSLock()
     private var count = 0
 
     var callCount: Int { lock.lock(); defer { lock.unlock() }; return count }
 
-    init(stdout: String) { self.stdout = stdout }
+    init(stdout: String) { self.outputs = [stdout] }
+    init(outputs: [String]) { self.outputs = outputs }
 
     func run(executable: String, arguments: [String], environment: [String: String], timeout: TimeInterval) throws -> ProcessResult {
-        lock.lock(); count += 1; lock.unlock()
-        return ProcessResult(exitCode: 0, stdout: stdout, stderr: "")
+        lock.lock()
+        let index = count
+        count += 1
+        lock.unlock()
+        return ProcessResult(exitCode: 0, stdout: outputs[min(index, outputs.count - 1)], stderr: "")
     }
 }

--- a/Tests/OpenUsageTests/NewProviderSeederTests.swift
+++ b/Tests/OpenUsageTests/NewProviderSeederTests.swift
@@ -102,6 +102,46 @@ final class NewProviderSeederTests: XCTestCase {
         XCTAssertEqual(enableCallbacks, ["windsurf"], "the seeder must not fire a second enable")
     }
 
+    func testCancelledDetectionWaitsForAccountReturnAndPreservesUserChoices() async throws {
+        let defaults = makeDefaults("cancelled-graph-resume")
+        let staleEnablement = ProviderEnablementStore(defaults: defaults)
+        staleEnablement.seedEnabledProviders(["claude"])
+        staleEnablement.registerKnownProviders(["claude", "codex"])
+        let returningAccount = probe("claude@deadbeef", hasCredentials: true)
+        let userOwned = probe("windsurf", hasCredentials: true)
+        let providers: [ProviderRuntime] = [
+            probe("claude", hasCredentials: true), probe("codex", hasCredentials: false), returningAccount, userOwned,
+        ]
+        let oldTask = try XCTUnwrap(NewProviderSeeder.reconcileIfNeeded(
+            providers: providers, enablement: staleEnablement
+        ))
+
+        let replacementEnablement = ProviderEnablementStore(defaults: defaults)
+        replacementEnablement.setEnabled(true, for: "codex")
+        replacementEnablement.setEnabled(true, for: "windsurf")
+        replacementEnablement.setEnabled(false, for: "windsurf")
+        oldTask.cancel()
+        await oldTask.value
+
+        XCTAssertEqual(replacementEnablement.enabledIDs, ["claude", "codex"])
+        XCTAssertEqual(replacementEnablement.pendingDetectionIDs, ["claude@deadbeef"])
+        XCTAssertNil(NewProviderSeeder.reconcileIfNeeded(
+            providers: providers.filter { $0.provider.id != "claude@deadbeef" }, enablement: replacementEnablement
+        ))
+        XCTAssertEqual(replacementEnablement.pendingDetectionIDs, ["claude@deadbeef"])
+
+        let resumedTask = try XCTUnwrap(NewProviderSeeder.reconcileIfNeeded(
+            providers: providers, enablement: replacementEnablement
+        ))
+        await resumedTask.value
+
+        XCTAssertEqual(replacementEnablement.enabledIDs, ["claude", "codex", "claude@deadbeef"])
+        XCTAssertFalse(replacementEnablement.isEnabled("windsurf"))
+        XCTAssertTrue(replacementEnablement.pendingDetectionIDs.isEmpty)
+        XCTAssertEqual(returningAccount.probeCount, 2)
+        XCTAssertEqual(userOwned.probeCount, 1)
+    }
+
     // MARK: - Helpers
 
     private func seededStore(_ name: String, enabled: Set<String>, known: Set<String>) -> ProviderEnablementStore {

--- a/Tests/OpenUsageTests/NewProviderSeederTests.swift
+++ b/Tests/OpenUsageTests/NewProviderSeederTests.swift
@@ -86,6 +86,27 @@ final class NewProviderSeederTests: XCTestCase {
         XCTAssertEqual(grok.probeCount, 0)
     }
 
+    func testPersistedFirstRunJobResumesBeforeItsProvidersWereMarkedKnown() async throws {
+        let enablement = seededStore("job-before-known", enabled: ["claude", "codex"], known: [])
+        let providers = [
+            probe("claude", hasCredentials: true),
+            probe("codex", hasCredentials: false),
+            probe("grok", hasCredentials: true),
+        ]
+        enablement.beginProviderDetection(
+            ["claude", "codex", "grok"], mode: .replacement, baseline: ["claude", "codex"]
+        )
+
+        let task = try XCTUnwrap(NewProviderSeeder.reconcileIfNeeded(
+            providers: providers, enablement: enablement
+        ))
+        await task.value
+
+        XCTAssertEqual(enablement.enabledIDs, ["claude", "grok"])
+        XCTAssertEqual(enablement.knownIDs, ["claude", "codex", "grok"])
+        XCTAssertNil(enablement.detectionJob)
+    }
+
     func testUserToggleDuringDetectionWins() async {
         let enablement = seededStore("toggle-wins", enabled: ["claude"], known: ["claude"])
         var enableCallbacks: [String] = []

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -342,6 +342,56 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertNoThrow(try document.validate())
     }
 
+    func testCodexHistoryStaysLocalWhileClaudeStillSyncsBothWays() throws {
+        let existing = makeRegistry()
+        let codex = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+        let codexDescriptor = WidgetDescriptor.usageTrend(provider: codex)
+            .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "test")
+        let registry = WidgetRegistry(
+            providers: existing.providers + [codex],
+            descriptors: existing.descriptors + [codexDescriptor]
+        )
+        let cache = scratchCache()
+        let today = dayKey(Date())
+        let localCodex = history(day: today, tokens: 20, cost: 2)
+        let codexSnapshot = UsageHistorySnapshotRenderer.render(
+            local: snapshot(providerID: "codex", history: localCodex),
+            history: localCodex,
+            descriptor: try XCTUnwrap(registry.historyDescriptorsByProvider["codex"]),
+            combined: false
+        )
+        cache.store(
+            snapshot(providerID: "claude", history: history(day: today, tokens: 10, cost: 1)),
+            producedByIdentityKey: maxKey
+        )
+        cache.store(codexSnapshot, producedByIdentityKey: "codex-local")
+        let dataStore = WidgetDataStore(
+            registry: registry,
+            providers: [],
+            cache: cache,
+            defaults: makeScratchDefaults("CodexDeviceLocal"),
+            providerIdentityKeys: ["claude": maxKey, "codex": "codex-local"]
+        )
+
+        let outgoing = dataStore.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+        XCTAssertEqual(Set(outgoing.providers.keys), ["claude"])
+        XCTAssertEqual(outgoing.identities, ["claude": maxKey])
+        XCTAssertNoThrow(try outgoing.validate())
+
+        let incoming = makeDocument(
+            providers: [
+                "claude": history(day: today, tokens: 100, cost: 10),
+                "codex": history(day: today, tokens: 900, cost: 90),
+            ],
+            identities: ["claude": maxKey, "codex": "codex-local"]
+        )
+        dataStore.setPeerHistoryDocuments([incoming], ownDeviceID: "this-mac")
+
+        XCTAssertEqual(dataStore.snapshots["codex"], codexSnapshot)
+        XCTAssertNotNil(dataStore.snapshots["claude"]?.line(label: "Today"))
+        XCTAssertTrue(dataStore.remoteOnlySpend.isEmpty)
+    }
+
     func testRemoteOnlyAccountFeedsTotalSpend() {
         let registry = makeRegistry()
         let dataStore = WidgetDataStore(

--- a/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
+++ b/Tests/OpenUsageTests/PeerHistoryIdentityTests.swift
@@ -342,7 +342,7 @@ final class PeerHistoryIdentityTests: XCTestCase {
         XCTAssertNoThrow(try document.validate())
     }
 
-    func testCodexHistoryStaysLocalWhileClaudeStillSyncsBothWays() throws {
+    func testCodexAndClaudeHistoriesSyncForTheirVerifiedAccounts() throws {
         let existing = makeRegistry()
         let codex = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
         let codexDescriptor = WidgetDescriptor.usageTrend(provider: codex)
@@ -374,8 +374,8 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
 
         let outgoing = dataStore.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
-        XCTAssertEqual(Set(outgoing.providers.keys), ["claude"])
-        XCTAssertEqual(outgoing.identities, ["claude": maxKey])
+        XCTAssertEqual(Set(outgoing.providers.keys), ["claude", "codex"])
+        XCTAssertEqual(outgoing.identities, ["claude": maxKey, "codex": "codex-local"])
         XCTAssertNoThrow(try outgoing.validate())
 
         let incoming = makeDocument(
@@ -387,7 +387,8 @@ final class PeerHistoryIdentityTests: XCTestCase {
         )
         dataStore.setPeerHistoryDocuments([incoming], ownDeviceID: "this-mac")
 
-        XCTAssertEqual(dataStore.snapshots["codex"], codexSnapshot)
+        XCTAssertNotEqual(dataStore.snapshots["codex"], codexSnapshot)
+        XCTAssertNotNil(dataStore.snapshots["codex"]?.line(label: "Today"))
         XCTAssertNotNil(dataStore.snapshots["claude"]?.line(label: "Today"))
         XCTAssertTrue(dataStore.remoteOnlySpend.isEmpty)
     }

--- a/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
+++ b/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
@@ -171,6 +171,24 @@ final class ProviderEnablementStoreTests: XCTestCase {
         wait(for: [notPosted], timeout: 0.2)
     }
 
+    func testPendingChecksPersistAcrossReplacementAndYieldToUserChoices() {
+        let defaults = makeDefaults("pending-persistence")
+        let original = ProviderEnablementStore(defaults: defaults)
+        original.seedEnabledProviders(["claude"])
+        original.markProviderDetectionPending(["claude@deadbeef", "grok"])
+
+        let replacement = ProviderEnablementStore(defaults: defaults)
+        XCTAssertEqual(replacement.pendingDetectionIDs, ["claude@deadbeef", "grok"])
+
+        replacement.setEnabled(true, for: "grok")
+        XCTAssertEqual(replacement.pendingDetectionIDs, ["claude@deadbeef"])
+        XCTAssertEqual(ProviderEnablementStore(defaults: defaults).pendingDetectionIDs, ["claude@deadbeef"])
+
+        replacement.finishProviderDetection(["claude@deadbeef"])
+        XCTAssertTrue(ProviderEnablementStore(defaults: defaults).pendingDetectionIDs.isEmpty)
+        XCTAssertNil(defaults.object(forKey: "openusage.pendingProviderDetection.v1"))
+    }
+
     private func makeDefaults(_ name: String) -> UserDefaults {
         let suiteName = "OpenUsageTests.Enablement.\(name).\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
+++ b/Tests/OpenUsageTests/ProviderEnablementStoreTests.swift
@@ -189,6 +189,20 @@ final class ProviderEnablementStoreTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: "openusage.pendingProviderDetection.v1"))
     }
 
+    func testLegacyPendingChecksMigrateIntoOneAdditiveDetectionJob() {
+        let defaults = makeDefaults("pending-job-migration")
+        defaults.set(["claude"], forKey: "openusage.enabledProviders.v1")
+        defaults.set(["grok", "claude@deadbeef"], forKey: "openusage.pendingProviderDetection.v1")
+
+        let migrated = ProviderEnablementStore(defaults: defaults)
+
+        XCTAssertEqual(migrated.detectionJob?.mode, .additive)
+        XCTAssertEqual(migrated.detectionJob?.baseline, ["claude"])
+        XCTAssertEqual(migrated.pendingDetectionIDs, ["grok", "claude@deadbeef"])
+        XCTAssertNil(defaults.object(forKey: "openusage.pendingProviderDetection.v1"))
+        XCTAssertEqual(ProviderEnablementStore(defaults: defaults).detectionJob, migrated.detectionJob)
+    }
+
     private func makeDefaults(_ name: String) -> UserDefaults {
         let suiteName = "OpenUsageTests.Enablement.\(name).\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/OpenUsageTests/WidgetDataStoreAccountCacheTests.swift
+++ b/Tests/OpenUsageTests/WidgetDataStoreAccountCacheTests.swift
@@ -34,14 +34,16 @@ final class WidgetDataStoreAccountCacheTests: XCTestCase {
         providers: [Provider],
         cache: ProviderSnapshotCache,
         defaults: UserDefaults,
-        identityKeys: [String: String]
+        identityKeys: [String: String],
+        quarantinesUnverifiedAccountData: Bool = false
     ) -> WidgetDataStore {
         WidgetDataStore(
             registry: WidgetRegistry(providers: providers, descriptors: []),
             providers: [],
             cache: cache,
             defaults: defaults,
-            providerIdentityKeys: identityKeys
+            providerIdentityKeys: identityKeys,
+            quarantinesUnverifiedAccountData: quarantinesUnverifiedAccountData
         )
     }
 
@@ -96,6 +98,24 @@ final class WidgetDataStoreAccountCacheTests: XCTestCase {
         )
         XCTAssertNotNil(store.snapshots["claude"])
         XCTAssertNotNil(store.snapshots["codex"])
+    }
+
+    func testProvisionalQuarantineSuppressesAccountCachesButKeepsOtherProviders() {
+        let defaults = makeUserDefaults("provisional")
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600, now: Date.init)
+        cache.store(snapshot("claude", used: 40), producedByIdentityKey: "previous-account")
+        cache.store(snapshot("codex", used: 50), producedByIdentityKey: "another-previous-account")
+        cache.store(snapshot("cursor", used: 60))
+
+        let store = makeStore(
+            providers: [provider("claude"), provider("codex"), provider("cursor")],
+            cache: cache, defaults: defaults, identityKeys: [:],
+            quarantinesUnverifiedAccountData: true
+        )
+
+        XCTAssertNil(store.snapshots["claude"])
+        XCTAssertNil(store.snapshots["codex"])
+        XCTAssertNotNil(store.snapshots["cursor"])
     }
 
     /// Non-account providers are untouched by the guard: their entries load with or without a stamp

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -7,10 +7,12 @@ existing file after app preferences are reset or the app is reinstalled. There i
 pairing code, or separate account.
 
 The file contains normalized daily tokens and spend, model totals, and unknown-model names for sources
-that are local to one Mac: Claude, Codex, Grok, and OpenCode. It does not contain credentials, account
-limits, raw logs, or provider responses. Cursor's history is already account-wide, so it stays local and
-is never added across Macs. Disabling a provider immediately removes its peer contributions from the
-combined view and omits it from this Mac's next iCloud write, while its local cached snapshot remains.
+that are local to one Mac: Claude, Grok, and OpenCode. Codex history remains device-local because its
+logs cannot yet prove which account produced them; it will not sync across Macs until account ownership
+can be verified. The file does not contain credentials, account limits, raw logs, or provider responses.
+Cursor's history is already account-wide, so it stays local and is never added across Macs. Disabling a
+provider immediately removes its peer contributions from the combined view and omits it from this
+Mac's next iCloud write, while its local cached snapshot remains.
 
 OpenUsage combines the valid files in memory and rebuilds Today, Yesterday, Last 30 Days, Usage Trend,
 unknown-model warnings, and model breakdowns. The same combined spend rows feed the dashboard, Total


### PR DESCRIPTION
## TL;DR

Keep provider enablement stable when account discovery is cancelled, restarted, or changes while the app is running.

## What was happening

- First-run and newly added-provider discovery could finish after their owning app runtime had already been replaced.
- A late result could overwrite the current account's provider-enablement choices.

## What this changes

- Respect cancellation in first-run and new-provider credential discovery.
- Keep provider-family enablement consistent while account cards appear or disappear.
- Add focused regressions for cancellation, replacement, and account-scoped provider enablement.

## Tests

- First-run seeding, new-provider seeding, and provider-enablement store suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large lifecycle refactor touches account discovery, cache quarantine, iCloud coordination, and Codex reset writes; races or incomplete discovery could briefly hide data or block claims until verification completes.
> 
> **Overview**
> Introduces **`AccountRuntimeGraph`** so registry, layout, data store, iCloud sync, providers, and Codex reset claim can be **rebuilt when accounts change** without tearing down the menu bar shell, local HTTP API, or telemetry. Launch starts from a **quarantined** graph (no full filesystem walk on the main thread); a background watcher runs **`prepareAccountDiscovery`** off-main, then either **`replaceAccountRuntime`** or updates Claude log routing only when ownership vs. log roots diverge.
> 
> **Safety while swapping:** retired graphs call **`retireForAccountGraphReload`** / **`shutdownForAccountGraphReload`** so in-flight refreshes, iCloud writes, and reset claims cannot overwrite the replacement. **`WidgetDataStore`** can **quarantine** account-family caches when identities are unverified; **`LayoutStore`** can skip persisting provisional layout. **`CodexResetClaimService`** binds claims to the displayed account and stops cross-account credential fallback.
> 
> **Provider enablement:** first-run and new-provider detection use a **persisted detection job** (replacement vs. additive), can **defer** until verified discovery, **resume** after cancel/relaunch, and **cancel** concurrent credential probes. **`ClaudeLogUsageScanner.updateLogRoots`** supports routing-only updates. Docs note Codex history stays device-local until ownership is provable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b26d8de17dc1953a729d191d0376f1f9b35362. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->