### PR TITLE
Claude accounts 12: sync verified Codex account history across Macs

### DIFF
--- a/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
+++ b/Sources/OpenUsage/Providers/Codex/CodexProvider.swift
@@ -1,7 +1,8 @@
+import CryptoKit
 import Foundation
 
 @MainActor
-final class CodexProvider: ProviderRuntime {
+final class CodexProvider: ProviderRuntime, AccountIdentityReporting {
     let provider = Provider(
         id: "codex",
         displayName: "Codex",
@@ -17,6 +18,19 @@ final class CodexProvider: ProviderRuntime {
     let logUsageScanner: CodexLogUsageScanner
     let now: @Sendable () -> Date
     let pricing: @Sendable () async -> ModelPricing
+    /// Identity proven by the credential that produced the most recent successful snapshot.
+    /// Keychain-backed accounts cannot be identified during prompt-free launch discovery, but a
+    /// normal refresh already reads that credential and can safely expose its account id afterward.
+    private(set) var lastSuccessfulIdentityKey: String?
+    /// In-memory lineage anchor for the winning credential or its independently identified auth-file
+    /// precursor. Access tokens routinely rotate, so the anchor survives an overlapping access/refresh
+    /// token or an OAuth exchange we perform ourselves; file seeding never exposes a successful identity.
+    private(set) var lastSuccessfulCredentialFingerprint: Data?
+    private var trackedAccessTokenFingerprint: Data?
+    private var trackedRefreshTokenFingerprint: Data?
+
+    var verifiedAccountIdentityKey: String? { lastSuccessfulIdentityKey }
+    var accountOwnershipContinuityToken: Data? { lastSuccessfulCredentialFingerprint }
 
     init(
         authStore: CodexAuthStore = CodexAuthStore(),
@@ -30,6 +44,7 @@ final class CodexProvider: ProviderRuntime {
         self.logUsageScanner = logUsageScanner
         self.now = now
         self.pricing = pricing
+        seedIdentifiedFileCredential()
     }
 
     var widgetDescriptors: [WidgetDescriptor] {
@@ -102,6 +117,7 @@ final class CodexProvider: ProviderRuntime {
 
     private func probe(authState initialState: CodexAuthState) async throws -> ProviderSnapshot {
         var authState = initialState
+        var continuesSuccessfulCredential = matchesLastSuccessfulCredential(authState.auth)
         guard var accessToken = authState.auth.tokens?.accessToken, !accessToken.isEmpty else {
             if authState.auth.apiKey?.isEmpty == false {
                 throw CodexAuthError.usageAPIKey
@@ -117,6 +133,9 @@ final class CodexProvider: ProviderRuntime {
                let liveToken = live.auth.tokens?.accessToken, !liveToken.isEmpty {
                 authState = live
                 accessToken = liveToken
+                // The same file or Keychain entry can have been replaced by another login. Its
+                // location alone proves nothing, so re-establish continuity from its actual tokens.
+                continuesSuccessfulCredential = matchesLastSuccessfulCredential(live.auth)
             }
         }
 
@@ -164,6 +183,16 @@ final class CodexProvider: ProviderRuntime {
         }
 
         MetricLine.appendNoDataIfNeeded(&mapped.lines)
+        lastSuccessfulIdentityKey = Self.accountIdentityKey(from: authState.auth)
+        let accessFingerprint = Self.credentialFingerprint(currentToken)
+        let refreshFingerprint = authState.auth.tokens?.refreshToken.flatMap { token in
+            token.isEmpty ? nil : Self.credentialFingerprint(token)
+        }
+        if !continuesSuccessfulCredential || lastSuccessfulCredentialFingerprint == nil {
+            lastSuccessfulCredentialFingerprint = refreshFingerprint ?? accessFingerprint
+        }
+        trackedAccessTokenFingerprint = accessFingerprint
+        trackedRefreshTokenFingerprint = refreshFingerprint
         return ProviderSnapshot.make(
             provider: provider,
             plan: mapped.plan,
@@ -171,6 +200,61 @@ final class CodexProvider: ProviderRuntime {
             refreshedAt: now(),
             usageHistory: usageHistory
         )
+    }
+
+    private static func accountIdentityKey(from auth: CodexAuth) -> String? {
+        if let accountID = auth.tokens?.accountID?
+            .trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        {
+            return accountID.lowercased()
+        }
+        for token in [auth.tokens?.idToken, auth.tokens?.accessToken].compactMap({ $0 }) {
+            if let accountID = DefaultAccountObserver.chatGPTAccountID(
+                inIDTokenPayload: ProviderParse.jwtPayload(token)
+            ) {
+                return accountID.lowercased()
+            }
+        }
+        return nil
+    }
+
+    private func seedIdentifiedFileCredential() {
+        // Launch discovery already reads this local file and can name its account without touching
+        // the Keychain. Preserve only token digests, so a newly appearing fallback login cannot
+        // inherit that launch account before its own identity has been verified by a successful API.
+        guard let candidate = authStore.loadAuthCandidates().first(where: {
+            $0.hasUsableAccessToken && Self.accountIdentityKey(from: $0.auth) != nil
+        }),
+              let accessToken = candidate.auth.tokens?.accessToken, !accessToken.isEmpty
+        else { return }
+
+        let accessFingerprint = Self.credentialFingerprint(accessToken)
+        let refreshFingerprint = candidate.auth.tokens?.refreshToken.flatMap { token in
+            token.isEmpty ? nil : Self.credentialFingerprint(token)
+        }
+        lastSuccessfulCredentialFingerprint = refreshFingerprint ?? accessFingerprint
+        trackedAccessTokenFingerprint = accessFingerprint
+        trackedRefreshTokenFingerprint = refreshFingerprint
+    }
+
+    private func matchesLastSuccessfulCredential(_ auth: CodexAuth) -> Bool {
+        guard lastSuccessfulCredentialFingerprint != nil else { return false }
+
+        if let accessToken = auth.tokens?.accessToken, !accessToken.isEmpty,
+           Self.credentialFingerprint(accessToken) == trackedAccessTokenFingerprint
+        {
+            return true
+        }
+        if let refreshToken = auth.tokens?.refreshToken, !refreshToken.isEmpty,
+           Self.credentialFingerprint(refreshToken) == trackedRefreshTokenFingerprint
+        {
+            return true
+        }
+        return false
+    }
+
+    private static func credentialFingerprint(_ token: String) -> Data {
+        Data(SHA256.hash(data: Data(token.utf8)))
     }
 
     /// Fetches the on-demand reset-credit balance (and per-credit expiry) without ever failing the

--- a/Sources/OpenUsage/Providers/ProviderRuntime.swift
+++ b/Sources/OpenUsage/Providers/ProviderRuntime.swift
@@ -38,6 +38,14 @@ protocol ProviderRuntime: AnyObject {
     func hasLocalCredentials() async -> Bool
 }
 
+/// Optional account-ownership evidence produced by a successful provider refresh. The continuity
+/// value is opaque to consumers; each provider owns whatever credential-lineage proof it requires.
+@MainActor
+protocol AccountIdentityReporting: AnyObject {
+    var verifiedAccountIdentityKey: String? { get }
+    var accountOwnershipContinuityToken: Data? { get }
+}
+
 /// Run a blocking, `Sendable` credential load off the MainActor.
 ///
 /// Auth stores read credentials via the `security` (keychain) and `sqlite3` CLIs, whose `ProcessRunner`

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -33,14 +33,12 @@ final class WidgetDataStore {
     /// Quota-notification preferences (three independent triggers). Injected; `nil` disables
     /// notifications entirely (tests and previews that don't wire it).
     private let notificationSettings: (@MainActor () -> NotificationSettingsStore)?
-    /// Card id → the account identity currently signed in there, resolved once at launch by
-    /// `ProviderAccountAssembly`. Drives the snapshot cache's account stamp: writes record the
-    /// producer, and launch loads only paint an entry whose stamp matches. A card absent here has an
-    /// unresolved identity this launch (or isn't account-aware) — its cache behaves as it always did.
-    private let providerIdentityKeys: [String: String]
-    /// The live card title for a card id, `nil` for non-account providers — the account-registry
-    /// name resolver, injected by `AppContainer` so notification titles carry renames. `nil`
-    /// (tests, the one-shot CLI) falls back to the baked derived name.
+    /// Card id → the account identity currently signed in there. Launch discovery seeds verified
+    /// identities; a successful Codex refresh can later prove a keychain-backed account without
+    /// adding a launch-time keychain read. Cache stamps and cloud routing use the current value.
+    @ObservationIgnored private var providerIdentityKeys: [String: String]
+    /// Resolves account-card names from the live account registry, so a rename reaches notifications
+    /// without being copied into cached snapshots or immutable provider values.
     private let resolveDisplayName: (@MainActor (String) -> String?)?
     /// Where a fired milestone is delivered: `(idPrefix, title, subtitle, body) -> Bool`. The Bool is
     /// whether it was actually delivered (authorized + scheduled); on false the caller leaves the
@@ -105,8 +103,8 @@ final class WidgetDataStore {
     /// Wired by `ICloudUsageSyncStore`; debounced there so a concurrent provider batch produces one file.
     @ObservationIgnored var onLocalHistoryChanged: (@MainActor () -> Void)?
     @ObservationIgnored private var peerHistoryDocuments: [UsageHistoryDocument] = []
-    /// Accounts synced from other Macs that have NO card here: surfaced in Total Spend only (their
-    /// synthesized snapshots carry the usual Today/Yesterday/Last 30 Days lines), never as cards.
+    /// Verified accounts found only on another Mac. They contribute to Total Spend but never create
+    /// local provider cards or borrow a local account's identity.
     private(set) var remoteOnlySpend: [(provider: Provider, snapshot: ProviderSnapshot)] = []
 
     /// Global meter style: whether every bounded tile (and the menu-bar value) renders as "used" or
@@ -321,6 +319,8 @@ final class WidgetDataStore {
         refreshingProviderIDs.insert(providerID)
         defer { refreshingProviderIDs.remove(providerID) }
         let start = monotonicNow()
+        let accountIdentityReporter = provider as? any AccountIdentityReporting
+        let previousAccountOwnershipToken = accountIdentityReporter?.accountOwnershipContinuityToken
         // A provider that never returns would otherwise hold the in-flight entry — and the spinner —
         // forever. Past the deadline, stop waiting and treat it as any other failed refresh.
         guard var snapshot = await ProviderRefreshDeadline.snapshot(
@@ -362,6 +362,27 @@ final class WidgetDataStore {
         }
         // Recovered: drop any backoff so the provider resumes the normal cadence immediately.
         failureRetryAfter[providerID] = nil
+
+        if let accountIdentityReporter {
+            if let verifiedIdentity = accountIdentityReporter.verifiedAccountIdentityKey {
+                if providerIdentityKeys[providerID] != verifiedIdentity {
+                    // A snapshot loaded while this identity was unknown, or produced by a different
+                    // account, must never supply carry-forward history to the newly verified account.
+                    localSnapshots.removeValue(forKey: providerID)
+                    providerIdentityKeys[providerID] = verifiedIdentity
+                    AppLog.info(.config, "accounts: \(providerID) identity updated from its successful credential")
+                }
+            } else if let previousOwnershipToken = previousAccountOwnershipToken,
+                      previousOwnershipToken != accountIdentityReporter.accountOwnershipContinuityToken
+            {
+                // Missing account metadata is harmless while the same credential still succeeds,
+                // but a different identityless credential may belong to another account entirely.
+                localSnapshots.removeValue(forKey: providerID)
+                providerIdentityKeys.removeValue(forKey: providerID)
+                AppLog.warn(.config, "accounts: \(providerID) credential changed without a verified identity; history quarantined")
+            }
+        }
+
         // A provider can refresh its live limits successfully while its optional local log/CSV scan
         // produces no result. Keep only the last-good normalized history in that case; the new plan,
         // limits, warnings, and timestamp still win. A non-nil empty history remains authoritative and
@@ -426,14 +447,11 @@ final class WidgetDataStore {
     func localHistoryDocument(deviceID: String, deviceName: String, updatedAt: Date = Date()) -> UsageHistoryDocument {
         var providers: [String: ProviderUsageHistory] = [:]
         var identities: [String: String] = [:]
-        // Every machine-local card syncs — account cards included. Their ids are identity-derived,
-        // so they mean the same account on every Mac; the identities map additionally lets peers
-        // match a default card's history to whatever card that account is over there (see
-        // `PeerHistoryRemapper`).
         for (providerID, descriptor) in registry.historyDescriptorsByProvider
         where descriptor.scope == .machineLocal && isProviderEnabled(providerID) {
             if let history = localSnapshots[providerID]?.usageHistory {
-                if ProviderAccountID.families.contains(ProviderAccountID.family(of: providerID)) {
+                let family = ProviderAccountID.family(of: providerID)
+                if ProviderAccountID.families.contains(family) {
                     guard let identity = providerIdentityKeys[providerID] else {
                         AppLog.warn(.config, "sync: omitting unresolved account history for \(providerID)")
                         continue
@@ -464,16 +482,13 @@ final class WidgetDataStore {
         ) { result, entry in
             if isProviderEnabled(entry.key) { result[entry.key] = entry.value }
         }
-        // Match peers by account identity, not card id — the same account can be the default card
-        // on one Mac and an extra account card on another. Whatever matches no local card at all
-        // becomes a Total Spend-only remote entry below.
         let remapped = PeerHistoryRemapper.remap(
             documents: peerHistoryDocuments,
             localIdentityByCardID: providerIdentityKeys,
             localAccountCardIDs: Set(registry.providers.map(\.id))
         )
         if !remapped.quarantined.isEmpty {
-            AppLog.warn(.config, "sync: quarantined \(remapped.quarantined.count) unverified peer account histories")
+            AppLog.warn(.config, "sync: quarantined \(remapped.quarantined.count) peer account histories with unresolved or ambiguous ownership")
         }
         let merged = UsageHistoryAggregator.merged(
             localSnapshots: localSnapshots,
@@ -508,9 +523,6 @@ final class WidgetDataStore {
         snapshots = rendered
     }
 
-    /// Synthesize Total Spend entries for accounts that exist only on other Macs: a pseudo provider
-    /// (family icon, "Claude · Mac mini" name) plus a snapshot carrying the standard spend-tile
-    /// lines, rendered from the merged remote history by the same renderer real cards use.
     private static func renderRemoteOnlySpend(
         _ remoteOnly: [PeerHistoryRemapper.RemoteOnlyHistory],
         registry: WidgetRegistry,
@@ -518,13 +530,14 @@ final class WidgetDataStore {
         now: Date
     ) -> [(provider: Provider, snapshot: ProviderSnapshot)] {
         remoteOnly.compactMap { entry in
-            guard let familyProvider = registry.providers.first(where: {
-                      ProviderAccountID.family(of: $0.id) == entry.family
-                          && isProviderEnabled($0.id)
-                          && registry.historyDescriptorsByProvider[$0.id]?.scope == .machineLocal
-                  }),
+            guard let familyProvider = registry.providers.first(where: { provider in
+                ProviderAccountID.family(of: provider.id) == entry.family
+                    && isProviderEnabled(provider.id)
+                    && registry.historyDescriptorsByProvider[provider.id]?.scope == .machineLocal
+            }),
                   let descriptor = registry.historyDescriptorsByProvider[familyProvider.id]
             else { return nil }
+
             let history = UsageHistoryAggregator.mergeHistories(entry.histories, now: now)
             guard !history.series.daily.isEmpty else { return nil }
 

--- a/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
+++ b/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
@@ -159,3 +159,44 @@ final class StatusItemShortcutLifecycleTests: XCTestCase {
         XCTAssertEqual(KeyboardShortcuts.getShortcut(for: name), shortcut)
     }
 }
+
+@MainActor
+final class WidgetAccountIdentityCapabilityTests: XCTestCase {
+    func testAccountIdentityCapabilityStampsAndQuarantinesAnyReportingProvider() async {
+        let runtime = IdentityReportingProvider()
+        let suiteName = "OpenUsageTests.PortableAccountIdentity.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots", ttl: 600)
+        let store = WidgetDataStore(
+            registry: WidgetRegistry(providers: [runtime.provider], descriptors: []),
+            providers: [runtime], cache: cache, defaults: defaults
+        )
+
+        await store.refresh(providerID: runtime.provider.id, force: true)
+        XCTAssertEqual(cache.producedByIdentityKey(providerID: runtime.provider.id), "account-a")
+
+        runtime.nextIdentity = (nil, Data("credential-b".utf8))
+        await store.refresh(providerID: runtime.provider.id, force: true)
+        XCTAssertNil(cache.producedByIdentityKey(providerID: runtime.provider.id))
+    }
+}
+
+@MainActor
+private final class IdentityReportingProvider: ProviderRuntime, AccountIdentityReporting {
+    let provider = Provider(id: "portable-account", displayName: "Portable", icon: .providerMark("codex"))
+    let widgetDescriptors: [WidgetDescriptor] = []
+    var verifiedAccountIdentityKey: String? = "account-a"
+    var accountOwnershipContinuityToken: Data? = Data("credential-a".utf8)
+    var nextIdentity: (key: String?, token: Data)?
+
+    func refresh() async -> ProviderSnapshot {
+        if let nextIdentity {
+            verifiedAccountIdentityKey = nextIdentity.key
+            accountOwnershipContinuityToken = nextIdentity.token
+        }
+        return ProviderSnapshot(providerID: provider.id, displayName: provider.displayName, lines: [])
+    }
+
+    func hasLocalCredentials() async -> Bool { true }
+}

--- a/Tests/OpenUsageTests/CodexAccountCloudSyncTests.swift
+++ b/Tests/OpenUsageTests/CodexAccountCloudSyncTests.swift
@@ -1,0 +1,402 @@
+import XCTest
+@testable import OpenUsage
+
+/// Keychain-mode Codex cannot expose an account during prompt-free launch discovery. Its first
+/// successful refresh already owns the selected credential, so cloud history learns the verified
+/// account without another keychain read or any cross-account history carry-forward.
+@MainActor
+final class CodexAccountCloudSyncTests: XCTestCase {
+    let instant = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testKeychainAccountsRequireVerifiedMetadataOrJWTClaimsWithoutExtraReads() async throws {
+        let cases: [(name: String, credential: String, expected: String?)] = [
+            ("explicit account metadata", try authJSON(accountID: "  KEYCHAIN-ACCOUNT  "), "keychain-account"),
+            ("ID-token account claim", try authJSON(
+                accountID: nil, idToken: makeIDToken(accountID: "JWT-ACCOUNT")
+            ), "jwt-account"),
+            ("access-token account claim", try authJSON(
+                accessToken: makeIDToken(accountID: "ACCESS-TOKEN-ACCOUNT"), accountID: nil
+            ), "access-token-account"),
+            ("identityless credential is quarantined", try authJSON(accountID: nil), nil)
+        ]
+        for entry in cases {
+            let fixture = try makeFixture(keychainAuth: entry.credential, includeHistory: true)
+            XCTAssertEqual(fixture.keychain.readCount, 0, "\(entry.name): launch remains prompt-free")
+
+            let outcome = await fixture.store.refresh(providerID: "codex", force: true)
+
+            XCTAssertEqual(outcome, .refreshed, entry.name)
+            XCTAssertEqual(fixture.keychain.readCount, 1, "\(entry.name): no extra keychain read")
+            XCTAssertEqual(fixture.provider.lastSuccessfulIdentityKey, entry.expected, entry.name)
+            XCTAssertEqual(fixture.cache.producedByIdentityKey(providerID: "codex"), entry.expected, entry.name)
+            let document = fixture.store.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+            XCTAssertEqual(document.providers["codex"] != nil, entry.expected != nil, entry.name)
+            XCTAssertEqual(document.identities?["codex"], entry.expected, entry.name)
+        }
+    }
+
+    func testRejectedFileFallbackPublishesOnlyAnIndependentlyVerifiedKeychainOwner() async throws {
+        for accountID in ["ACCOUNT-B", nil] as [String?] {
+            let scenario = accountID == nil ? "identityless fallback is quarantined" : "verified keychain wins"
+            let http = RoutingHTTPClient { request in
+                if request.headers["Authorization"] == "Bearer rejected-file-token" {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8))
+            }
+            let fixture = try makeFixture(
+                keychainAuth: authJSON(accessToken: "winning-keychain-token", accountID: accountID),
+                fileAuth: authJSON(accessToken: "rejected-file-token", accountID: "ACCOUNT-A"),
+                includeHistory: true, initialIdentity: "account-a", cachedHistory: historicalUsage(), http: http
+            )
+            XCTAssertNotNil(fixture.provider.lastSuccessfulCredentialFingerprint, scenario)
+            XCTAssertEqual(fixture.keychain.readCount, 0, scenario)
+
+            let outcome = await fixture.store.refresh(providerID: "codex", force: true)
+
+            let expected = accountID?.lowercased()
+            XCTAssertEqual(outcome, .refreshed, scenario)
+            XCTAssertEqual(fixture.provider.lastSuccessfulIdentityKey, expected, scenario)
+            XCTAssertEqual(fixture.cache.producedByIdentityKey(providerID: "codex"), expected, scenario)
+            let document = fixture.store.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+            XCTAssertEqual(document.identities?["codex"], expected, scenario)
+            XCTAssertEqual(document.providers["codex"] != nil, expected != nil, scenario)
+            XCTAssertEqual(fixture.keychain.readCount, 1, scenario)
+        }
+    }
+
+    func testFirstRefreshPreservesLaunchOwnershipOnlyWhenFileCredentialLineageMatches() async throws {
+        let history = historicalUsage()
+        let cases: [(name: String, file: String?, files: [String: String]?, owner: String,
+                     expected: String?, keychainReads: Int, mutateFile: Bool)] = [
+            ("same identified file loses metadata", try authJSON(accessToken: "file-token", accountID: "ACCOUNT-A"),
+             nil, "account-a", "account-a", 0, true),
+            ("earlier identityless file cannot claim later identified account", nil, [
+                "~/.config/codex/auth.json": try authJSON(accessToken: "identityless-first", accountID: nil),
+                "~/.codex/auth.json": try authJSON(accessToken: "identified-second", accountID: "ACCOUNT-A")
+            ], "account-a", nil, 0, false),
+            ("launch-known account survives first keychain metadata miss", nil, nil,
+             "launch-account", "launch-account", 1, false)
+        ]
+        for entry in cases {
+            let fixture = try makeFixture(
+                keychainAuth: authJSON(accountID: nil), fileAuth: entry.file, fileAuthCandidates: entry.files,
+                includeHistory: false, initialIdentity: entry.owner, cachedHistory: history
+            )
+            let initialFingerprint = fixture.provider.lastSuccessfulCredentialFingerprint
+            XCTAssertEqual(initialFingerprint != nil, entry.file != nil || entry.files != nil, entry.name)
+            if entry.mutateFile {
+                fixture.files.files["/fixture-codex/auth.json"] = try authJSON(accessToken: "file-token", accountID: nil)
+            }
+
+            let outcome = await fixture.store.refresh(providerID: "codex", force: true)
+
+            XCTAssertEqual(outcome, .refreshed, entry.name)
+            XCTAssertNil(fixture.provider.lastSuccessfulIdentityKey, entry.name)
+            XCTAssertEqual(fixture.cache.producedByIdentityKey(providerID: "codex"), entry.expected, entry.name)
+            XCTAssertEqual(fixture.store.localSnapshots["codex"]?.usageHistory,
+                           entry.expected == nil ? nil : history, entry.name)
+            XCTAssertEqual(fixture.keychain.readCount, entry.keychainReads, entry.name)
+            XCTAssertNotNil(fixture.provider.lastSuccessfulCredentialFingerprint, entry.name)
+        }
+    }
+
+    func testAccountSwitchByMetadataOrAccessTokenClaimNeverInheritsCachedHistory() async throws {
+        let cases = [
+            ("account metadata", try authJSON(accountID: "ACCOUNT-B")),
+            ("access-token claim", try authJSON(accessToken: makeIDToken(accountID: "ACCOUNT-B"), accountID: nil))
+        ]
+        for (name, credential) in cases {
+            let fixture = try makeFixture(
+                keychainAuth: credential, includeHistory: false, initialIdentity: "account-a",
+                cachedHistory: historicalUsage()
+            )
+
+            let outcome = await fixture.store.refresh(providerID: "codex", force: true)
+
+            XCTAssertEqual(outcome, .refreshed, name)
+            XCTAssertEqual(fixture.provider.lastSuccessfulIdentityKey, "account-b", name)
+            XCTAssertEqual(fixture.cache.producedByIdentityKey(providerID: "codex"), "account-b", name)
+            XCTAssertNil(fixture.store.localSnapshots["codex"]?.usageHistory, name)
+        }
+    }
+
+    func testIdentitylessCredentialsPreserveHistoryOnlyWithVerifiedTokenLineage() async throws {
+        let history = historicalUsage()
+        let cases: [(name: String, initialAccess: String, initialRefresh: String?, nextAccess: String,
+                     nextRefresh: String?, preserves: Bool)] = [
+            ("same access token", "same-token", nil, "same-token", nil, true),
+            ("rotated access with shared refresh token", "old-access", "stable-refresh", "new-access", "stable-refresh", true),
+            ("unrelated access and refresh tokens", "account-a", "refresh-a", "account-b", "refresh-b", false)
+        ]
+
+        for entry in cases {
+            let fixture = try makeFixture(
+                keychainAuth: authJSON(
+                    accessToken: entry.initialAccess, refreshToken: entry.initialRefresh, accountID: "ACCOUNT-A"
+                ),
+                includeHistory: false, initialIdentity: "account-a", cachedHistory: history
+            )
+            _ = await fixture.store.refresh(providerID: "codex", force: true)
+            let initialFingerprint = fixture.provider.lastSuccessfulCredentialFingerprint
+            fixture.keychain.value = try authJSON(
+                accessToken: entry.nextAccess, refreshToken: entry.nextRefresh, accountID: nil
+            )
+
+            let outcome = await fixture.store.refresh(providerID: "codex", force: true)
+
+            XCTAssertEqual(outcome, .refreshed, entry.name)
+            XCTAssertNil(fixture.provider.lastSuccessfulIdentityKey, entry.name)
+            XCTAssertEqual(
+                fixture.cache.producedByIdentityKey(providerID: "codex"),
+                entry.preserves ? "account-a" : nil, entry.name
+            )
+            XCTAssertEqual(fixture.store.localSnapshots["codex"]?.usageHistory,
+                           entry.preserves ? history : nil, entry.name)
+            XCTAssertEqual(
+                fixture.provider.lastSuccessfulCredentialFingerprint == initialFingerprint,
+                entry.preserves, entry.name
+            )
+            let document = fixture.store.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+            XCTAssertEqual(document.providers["codex"], entry.preserves ? history : nil, entry.name)
+            XCTAssertEqual(document.identities?["codex"], entry.preserves ? "account-a" : nil, entry.name)
+            XCTAssertEqual(fixture.keychain.readCount, 2, entry.name)
+        }
+    }
+
+    func testOwnedOAuthRotationPreservesHistoryForProactiveAndUnauthorizedRefresh() async throws {
+        let history = historicalUsage()
+        for unauthorized in [false, true] {
+            let scenario = unauthorized ? "401 retry" : "proactive stale-token refresh"
+            let http = RoutingHTTPClient { request in
+                if request.url == CodexUsageClient.refreshURL {
+                    return HTTPResponse(statusCode: 200, headers: [:], body: Data(
+                        #"{"access_token":"rotated-access","refresh_token":"rotated-refresh"}"#.utf8
+                    ))
+                }
+                if unauthorized, request.headers["Authorization"] == "Bearer rejected-access" {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8))
+            }
+            let fixture = try makeFixture(
+                keychainAuth: authJSON(
+                    accessToken: "original-access", refreshToken: "original-refresh", accountID: "ACCOUNT-A"
+                ),
+                includeHistory: false, initialIdentity: "account-a", cachedHistory: history, http: http
+            )
+            _ = await fixture.store.refresh(providerID: "codex", force: true)
+            let initialFingerprint = fixture.provider.lastSuccessfulCredentialFingerprint
+            fixture.keychain.value = try authJSON(
+                accessToken: unauthorized ? "rejected-access" : "original-access",
+                refreshToken: "original-refresh", accountID: nil,
+                lastRefresh: unauthorized ? nil : OpenUsageISO8601.string(
+                    from: instant.addingTimeInterval(-9 * 24 * 60 * 60)
+                )
+            )
+
+            let outcome = await fixture.store.refresh(providerID: "codex", force: true)
+
+            XCTAssertEqual(outcome, .refreshed, scenario)
+            XCTAssertTrue(http.requests.contains { $0.url == CodexUsageClient.refreshURL }, scenario)
+            XCTAssertNil(fixture.provider.lastSuccessfulIdentityKey, scenario)
+            XCTAssertEqual(fixture.provider.lastSuccessfulCredentialFingerprint, initialFingerprint, scenario)
+            XCTAssertEqual(fixture.cache.producedByIdentityKey(providerID: "codex"), "account-a", scenario)
+            XCTAssertEqual(fixture.store.localSnapshots["codex"]?.usageHistory, history, scenario)
+        }
+    }
+
+    func testReloadedUnrelatedIdentitylessCredentialBreaksTrustedLineage() async throws {
+        let history = historicalUsage()
+        let fixture = try makeFixture(
+            keychainAuth: authJSON(
+                accessToken: "account-a-access",
+                refreshToken: "account-a-refresh",
+                accountID: "ACCOUNT-A"
+            ),
+            includeHistory: false,
+            initialIdentity: "account-a",
+            cachedHistory: history
+        )
+        _ = await fixture.store.refresh(providerID: "codex", force: true)
+
+        let replacedCredential = try authJSON(
+            accessToken: "different-account-access",
+            refreshToken: "different-account-refresh",
+            accountID: nil
+        )
+        fixture.keychain.value = replacedCredential
+        fixture.keychain.queuedReadValues = [
+            try authJSON(
+                accessToken: "account-a-access",
+                refreshToken: "account-a-refresh",
+                accountID: nil,
+                lastRefresh: OpenUsageISO8601.string(from: instant.addingTimeInterval(-9 * 24 * 60 * 60))
+            ),
+            replacedCredential
+        ]
+
+        let outcome = await fixture.store.refresh(providerID: "codex", force: true)
+
+        XCTAssertEqual(outcome, .refreshed)
+        XCTAssertNil(fixture.provider.lastSuccessfulIdentityKey)
+        XCTAssertNil(fixture.cache.producedByIdentityKey(providerID: "codex"))
+        XCTAssertNil(fixture.store.localSnapshots["codex"]?.usageHistory)
+        XCTAssertNil(
+            fixture.store.localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+                .providers["codex"]
+        )
+    }
+
+}
+
+extension CodexAccountCloudSyncTests {
+    struct Fixture {
+        var provider: CodexProvider
+        var store: WidgetDataStore
+        var cache: ProviderSnapshotCache
+        var keychain: CountingCodexCloudKeychain
+        var files: FakeFiles
+    }
+
+    func historicalUsage() -> ProviderUsageHistory {
+        ProviderUsageHistory(
+            series: DailyUsageSeries(daily: [
+                DailyUsageEntry(date: "2000-01-01", totalTokens: 987_654_321, costUSD: 1234)
+            ]),
+            modelUsage: nil,
+            unknownModelsByDay: [:]
+        )
+    }
+
+    func makeFixture(
+        keychainAuth: String,
+        fileAuth: String? = nil,
+        fileAuthCandidates: [String: String]? = nil,
+        includeHistory: Bool,
+        initialIdentity: String? = nil,
+        cachedHistory: ProviderUsageHistory? = nil,
+        http: (any HTTPClient)? = nil
+    ) throws -> Fixture {
+        let now = instant
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let home = includeHistory
+            ? try CodexLogFixture.makeHome(files: [
+                "sessions/rollout.jsonl": [
+                    CodexLogFixture.turnContext(timestamp: timestamp, model: "gpt-5.2"),
+                    CodexLogFixture.tokenCount(
+                        timestamp: timestamp,
+                        last: CodexLogFixture.usage(input: 100, output: 50)
+                    )
+                ].joined(separator: "\n")
+            ])
+            : nil
+        if let home {
+            addTeardownBlock { try? FileManager.default.removeItem(at: home) }
+        }
+        let keychain = CountingCodexCloudKeychain(value: keychainAuth)
+        let files = FakeFiles(fileAuthCandidates ?? fileAuth.map { ["/fixture-codex/auth.json": $0] } ?? [:])
+        let client = http ?? FakeHTTPClient(response: HTTPResponse(
+            statusCode: 200,
+            headers: [:],
+            body: Data("{}".utf8)
+        ))
+        let provider = CodexProvider(
+            authStore: CodexAuthStore(
+                environment: FakeEnvironment(fileAuthCandidates == nil ? ["CODEX_HOME": "/fixture-codex"] : [:]),
+                files: files,
+                keychain: keychain,
+                now: { now }
+            ),
+            usageClient: CodexUsageClient(http: client),
+            logUsageScanner: CodexLogFixture.scanner(home: home),
+            now: { now },
+            pricing: { TestPricing.bundled }
+        )
+        let defaults = try makeDefaults()
+        let cache = ProviderSnapshotCache(
+            userDefaults: defaults,
+            storageKey: "codex-cloud-snapshots",
+            ttl: 600,
+            now: { now }
+        )
+        if let cachedHistory {
+            cache.store(
+                ProviderSnapshot(
+                    providerID: "codex",
+                    displayName: "Codex",
+                    lines: [.progress(label: "Session", used: 10, limit: 100, format: .percent)],
+                    refreshedAt: now,
+                    usageHistory: cachedHistory
+                ),
+                producedByIdentityKey: initialIdentity
+            )
+        }
+        let store = WidgetDataStore(
+            registry: WidgetRegistry.from([provider]),
+            providers: [provider],
+            cache: cache,
+            defaults: defaults,
+            providerIdentityKeys: initialIdentity.map { ["codex": $0] } ?? [:]
+        )
+        return Fixture(provider: provider, store: store, cache: cache, keychain: keychain, files: files)
+    }
+
+    func authJSON(
+        accessToken: String = "keychain-token",
+        refreshToken: String? = nil,
+        accountID: String?,
+        idToken: String? = nil,
+        lastRefresh: String? = nil
+    ) throws -> String {
+        var tokens: [String: Any] = ["access_token": accessToken]
+        if let refreshToken { tokens["refresh_token"] = refreshToken }
+        if let accountID { tokens["account_id"] = accountID }
+        if let idToken { tokens["id_token"] = idToken }
+        var auth: [String: Any] = ["tokens": tokens]
+        if let lastRefresh { auth["last_refresh"] = lastRefresh }
+        let data = try JSONSerialization.data(withJSONObject: auth)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func makeIDToken(accountID: String) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "https://api.openai.com/auth": ["chatgpt_account_id": accountID]
+        ])
+        let payload = data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "header.\(payload).signature"
+    }
+
+    private func makeDefaults() throws -> UserDefaults {
+        let suiteName = "OpenUsageTests.CodexAccountCloudSync.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return defaults
+    }
+}
+
+final class CountingCodexCloudKeychain: KeychainAccessing, @unchecked Sendable {
+    var value: String?
+    var queuedReadValues: [String] = []
+    private(set) var readCount = 0
+
+    init(value: String?) {
+        self.value = value
+    }
+
+    func readGenericPassword(service: String) throws -> String? {
+        readCount += 1
+        if !queuedReadValues.isEmpty {
+            return queuedReadValues.removeFirst()
+        }
+        return value
+    }
+
+    func writeGenericPassword(service: String, value: String) throws {
+        self.value = value
+    }
+}

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -7,10 +7,11 @@ existing file after app preferences are reset or the app is reinstalled. There i
 pairing code, or separate account.
 
 The file contains normalized daily tokens and spend, model totals, and unknown-model names for sources
-that are local to one Mac: Claude, Codex, Grok, and OpenCode. It does not contain credentials, account
-limits, raw logs, or provider responses. Cursor's history is already account-wide, so it stays local and
-is never added across Macs. Disabling a provider immediately removes its peer contributions from the
-combined view and omits it from this Mac's next iCloud write, while its local cached snapshot remains.
+that are local to one Mac: Antigravity, Claude, Codex, Grok, and OpenCode. It does not contain
+credentials, account limits, raw logs, or provider responses. Cursor's history is already account-wide,
+so it stays local and is never added across Macs. Disabling a provider immediately removes its peer
+contributions from the combined view and omits it from this Mac's next iCloud write, while its local
+cached snapshot remains.
 
 OpenUsage combines the valid files in memory and rebuilds Today, Yesterday, Last 30 Days, Usage Trend,
 unknown-model warnings, and model breakdowns. The same combined spend rows feed the dashboard, Total
@@ -26,22 +27,42 @@ receive it, especially while offline. Downloaded changes reload immediately when
 
 ## Multiple accounts across Macs
 
-Histories match by **account**, not by card name. Each Mac's file records which account every card
-belongs to (an opaque account/organization identifier — never an email), so the same account merges into
-the same card everywhere, even when one Mac shows it as the main card and another as an extra account
-card.
+Histories match by **account**, not by card name. Each Mac's private iCloud file records the stable
+account and organization identifiers supplied by the provider, so the same account merges into the same
+card everywhere, even when one Mac shows it as the main card and another as an extra account card.
+Claude account histories still match when one Mac omits an organization ID and the other includes it,
+but only when all known identities establish exactly one possible organization. If multiple
+organizations could match, that history is left out until its owner can be verified.
+These identifiers are stored as supplied, not hashed, but never include an email address, account name,
+login credential, plan, or quota.
 
-An account you use on another Mac but have no login for here doesn't become a card: it appears as its
-own slice in **Total Spend** ("Claude · Mac mini"), so the number at the top is the whole truth across
-your Macs. The moment you log that account in locally, its card appears with the full cross-machine
-history already attached.
+OpenUsage only combines account history when both Macs identify its owner. If either Mac cannot
+identify an account, two cards claim the same account, or an older Mac sends account history without
+identity information, that history is temporarily left out instead of being assigned to the wrong
+card. Once the account can be identified, its history joins the matching card again. A Codex login kept
+in the system keychain proves its identity during its normal successful refresh, so its history starts
+syncing afterward without an extra Keychain read or a new permission prompt. If that same verified
+login refreshes its access token or temporarily stops reporting its account identifier, syncing
+continues; a different login without an identifiable owner stays excluded until its account can be
+verified.
 
-Macs running an older OpenUsage read their own format but report this Mac's newer file as "update
-OpenUsage" — update both sides to sync multi-account machines.
+An account you use on another Mac but have no login for here doesn't become a card. If this Mac already
+has another enabled, verified account from the same provider, the remote account appears as its own
+slice in **Total Spend**, named by its account code ("claude@ab12cd34"). The code is derived from the
+account identity; an account that was a Mac's original Claude login can still keep the plain `claude`
+card ID there. When you log that account in locally, its verified identity attaches the full
+cross-machine history to the correct card regardless of which ID that card has.
+
+Update every syncing Mac together. Older OpenUsage builds reject the entire newer account-aware history
+file, including other providers, and report that OpenUsage needs updating. Newer builds can still read
+older files, but leave their Claude and Codex histories out because those accounts cannot be identified;
+eligible non-account providers from older files still merge on the newer Mac.
 
 Settings lists each valid device file with the time that Mac generated it. To remove a Mac from the
 combined summary, turn sync off on that Mac; this deletes its file from iCloud. Turning sync off also
-stops that Mac from reading peers and immediately returns every surface there to local-only spend.
+stops that Mac from reading peers and immediately returns every surface there to local-only spend,
+even when a signed-in account changes at the same time. Pending updates from a previous account cannot
+replace the current account's synced history.
 Malformed files are ignored and reported in Settings and the app log.
 
 ## Development and release setup

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -15,6 +15,9 @@ app and macOS version, which providers and metrics you have enabled, and which m
 to the menu bar or tucked behind the "show more" caret. A random ID (not tied to you or any account)
 lets us count daily active users without identifying anyone.
 
+When a provider has multiple accounts, analytics report only the provider and metric names. Account
+identifiers, account-specific card identifiers, and the number of accounts are never included.
+
 - **Crash reports** — if OpenUsage crashes, it saves a report and sends it the next time you open the
   app: the technical stack trace (which parts of *OpenUsage's own code* were running when it crashed)
   plus the app and macOS version. This contains no account details, credentials, or usage values —
@@ -62,10 +65,12 @@ identity caches that have not been used for 35 days are removed. OpenUsage's pri
 the cache is read, so its computed aggregates and totals are not persisted in this cache.
 
 If you explicitly turn on [iCloud Sync](icloud-sync.md), OpenUsage writes normalized daily tokens,
-spend, and model totals to its private iCloud container so your own Macs can show one combined summary.
-Credentials, account limits, provider responses, and raw logs are never written there. This is separate
-from anonymous usage analytics: iCloud Sync defaults off and uses your iCloud account, while the
-analytics toggle controls extra PostHog events, not daily activity or crash reports.
+spend, model totals, and provider-issued account and organization identifiers to its private iCloud
+container so your own Macs can match the right accounts. Those identifiers are stored as supplied by
+the provider; email addresses, account names, credentials, account limits, provider responses, and raw
+logs are never written there. This is separate from anonymous usage analytics: iCloud Sync defaults off
+and uses your iCloud account, while the analytics toggle controls extra PostHog events, not daily
+activity or crash reports.
 
 ## How it works
 


### PR DESCRIPTION
## TL;DR

Identify the active Codex account after a verified refresh so different Codex accounts on different Macs never merge in iCloud.

## What was happening

- Prompt-free Codex launch discovery cannot safely read a protected keychain account identity.
- Two Macs using different Codex accounts could otherwise publish history under the same generic Codex card.
- Losing account metadata during token rotation could accidentally preserve another account's cached usage.

## What this changes

- Derive Codex account ownership from verified credentials and token claims during the normal usage refresh.
- Sync account-owned history only after identity or credential continuity has been proven.
- Quarantine identityless account switches and preserve legitimate token rotations without extra keychain reads.
- Add a reusable provider capability for reporting verified account ownership.
- Explain which account identifiers are synced and how cross-Mac history is separated.

## Tests

- Focused Codex keychain, JWT account claims, logout, token rotation, account switching, iCloud ownership, and generic provider identity-capability suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches account-identity stamping, snapshot history carry-forward, and iCloud ownership matching. A bug here can merge or drop usage across Codex accounts.
> 
> **Overview**
> Stops different Codex logins from sharing one generic iCloud history card. After a successful usage refresh, Codex reports a verified account id (token metadata or JWT claims) plus a SHA-256 credential lineage token so Keychain accounts can sync without a launch-time Keychain prompt.
> 
> `WidgetDataStore` now mutates live identity keys: a newly verified account drops prior cached history, and an identityless credential switch that breaks token lineage quarantines history. Same-credential token rotation still keeps the previous owner.
> 
> Docs spell out that only provider-issued account/org ids are synced, and that unverified Codex/Claude peer history stays out until ownership is proven.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072be01147fc6ac0a488e37bb75c295951d1797b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->