### PR TITLE
Claude accounts 11: rediscover account changes without restarting

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -7,6 +7,12 @@ import Observation
 @MainActor
 @Observable
 final class AppContainer {
+    /// The AppDelegate replaces its immutable registry, layout, runtime, and status-item graph when
+    /// a login changes; posting only after a verified graph diff keeps account cards stable otherwise.
+    static let accountGraphDidChangeNotification = Notification.Name(
+        "OpenUsage.accountGraphDidChange"
+    )
+
     let registry: WidgetRegistry
     let layout: LayoutStore
     let dataStore: WidgetDataStore
@@ -41,9 +47,9 @@ final class AppContainer {
     /// provider were ever removed from the registry. Injected into the view tree via
     /// `\.codexResetClaim`.
     let codexResetClaim: CodexResetClaimService?
-    /// The account registry the launch pass reconciled. The UI observes it live: a rename
-    /// (`customLabel`) re-titles the card everywhere without a relaunch.
+    /// The authoritative account registry shared by discovery, runtime assembly, and live renames.
     let accounts: ProviderAccountsStore
+
     /// The provider runtimes, kept so on-demand credential detection (the Customize "Reset All" reseed)
     /// can re-probe `hasLocalCredentials()` the same way first-run seeding does.
     private let providers: [ProviderRuntime]
@@ -59,6 +65,8 @@ final class AppContainer {
     /// Persists a fresh `ShellEnvironmentSnapshot` once the login-shell capture completes, so the next
     /// launch can read shell-exported facts (provider home overrides) even when its own capture is slow.
     private let shellEnvironmentSnapshotTask: Task<Void, Never>
+    /// Cheap default-home identity checks catch live swaps promptly; full discovery is throttled.
+    private let accountGraphWatchTask: Task<Void, Never>
 
     /// `isFreshInstall` must be captured by the caller BEFORE `SettingsMigrator.migrate()` runs (the
     /// migrator's schema stamp makes the defaults domain non-empty). See `AppDelegate`.
@@ -70,14 +78,18 @@ final class AppContainer {
         // Once the capture lands, persist its identity-relevant facts so the NEXT launch has them
         // even if that launch's own capture is slow (see `ShellEnvironmentSnapshot`).
         self.shellEnvironmentSnapshotTask = ShellEnvironmentSnapshotStore(defaults: .standard).startRefreshTask()
-        // The launch account pass: which account is signed in at each family's default home, plus
-        // the config-dir scan for extra Claude logins. Feeds the snapshot cache's account stamp,
-        // reconciles the account registry, and hands the catalog its extra-card build plan.
+        // Reconcile one shared registry before constructing any account-aware runtime. Every Claude
+        // runtime then follows its record's current verified source, regardless of its card id.
         let accounts = ProviderAccountsStore()
-        let accountAssembly = ProviderAccountAssembly.make(accountsStore: accounts, waitsForLoginShell: true)
+        let accountAssembly = ProviderAccountAssembly.make(
+            accountsStore: accounts,
+            waitsForLoginShell: true
+        )
         self.accounts = accounts
 
-        let providers = ProviderCatalog.make(claude: accountAssembly.claudeRuntimePlan)
+        let providers = ProviderCatalog.make(
+            claude: accountAssembly.claudeRuntimePlan
+        )
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
         let enablement = ProviderEnablementStore()
@@ -106,19 +118,19 @@ final class AppContainer {
         // Fresh installs start minimal: seed the enabled-provider list (Claude/Codex/Cursor right away,
         // then the detected set once the local credential probe finishes). No-op on every later launch.
         let onboarding = OnboardingStore()
-        self.seedTask = FirstRunSeeder.seedIfNeeded(
+        let firstRunSeedTask = FirstRunSeeder.seedIfNeeded(
             isFreshInstall: isFreshInstall,
             providers: providers,
             enablement: enablement,
             onboarding: onboarding
         )
+        self.seedTask = firstRunSeedTask
         // Providers added by an update get the same credential detection on their first launch — enabled
         // only when the user actually has the tool. Runs every launch; a no-op unless the registry has a
         // provider this install has never seen (fresh installs were just baselined by FirstRunSeeder).
-        self.newProviderTask = NewProviderSeeder.reconcileIfNeeded(
-            providers: providers,
-            enablement: enablement
-        )
+        self.newProviderTask = firstRunSeedTask == nil
+            ? NewProviderSeeder.reconcileIfNeeded(providers: providers, enablement: enablement)
+            : nil
         self.providers = providers
         self.onboarding = onboarding
         self.registry = registry
@@ -211,11 +223,13 @@ final class AppContainer {
                 limitDescriptors: registry.limitDescriptorsByProvider,
                 errors: dataStore.providerErrors
             )
-            // API output is human-read too: resolve card titles at respond time so renames show,
-            // exactly like every UI surface.
             .resolvingDisplayNames(accounts.resolvedDisplayNamesByCardID)
         })
         self.refreshTask = Self.startPeriodicRefresh(dataStore: dataStore, telemetry: telemetry)
+        self.accountGraphWatchTask = Self.startAccountGraphWatch(
+            accounts: accounts,
+            initialAssembly: accountAssembly
+        )
         localAPI.start()
         // Become the notification-center delegate so banners show while frontmost — a menu-bar accessory
         // effectively always is. Notification authorization is requested the first time a trigger is
@@ -228,21 +242,32 @@ final class AppContainer {
         seedTask?.cancel()
         newProviderTask?.cancel()
         shellEnvironmentSnapshotTask.cancel()
+        accountGraphWatchTask.cancel()
     }
 
-    /// The name a card renders under right now — the app-side face of the one resolver
-    /// (`ProviderAccountRecord.resolvedDisplayName`). Live: a rename in the account registry
-    /// re-titles the card everywhere without a relaunch. Non-account providers (no record) keep
-    /// their static display name; `Provider.displayName` itself only ever carries the derived
-    /// default, so the fallback can never be a stale rename.
+    /// Stop every long-lived service before the AppDelegate installs the replacement graph.
+    func shutdownForAccountGraphReload() async {
+        accountGraphWatchTask.cancel()
+        refreshTask.cancel()
+        seedTask?.cancel()
+        newProviderTask?.cancel()
+        shellEnvironmentSnapshotTask.cancel()
+        iCloudSync.shutdownForAccountGraphReload()
+        await localAPI.stop()
+    }
+
     func displayName(for provider: Provider) -> String {
         accounts.resolvedDisplayName(cardID: provider.id) ?? provider.displayName
     }
 
-    /// Whether the card has an account record a rename can attach to (accounts-model families only,
-    /// and only once the account's identity has been observed at least once).
+    func displayName(for providerID: String) -> String {
+        accounts.resolvedDisplayName(cardID: providerID)
+            ?? registry.provider(id: providerID)?.displayName
+            ?? providerID
+    }
+
     func canRename(_ providerID: String) -> Bool {
-        accounts.records.contains { $0.id == providerID }
+        accounts.runtimeRecord(for: providerID) != nil
     }
 
     /// Re-runs first-launch credential detection on demand — the enablement half of the Customize
@@ -286,6 +311,91 @@ final class AppContainer {
         AppearanceSetting.applyCurrent()
         AppLog.reloadLevel()
         AppLog.info(.config, "All settings reset to defaults")
+    }
+
+    /// Watch one tiny default-home identity file every five seconds, and only walk config dirs and
+    /// Cowork sandboxes after a detected swap or once a minute. The potentially hundreds of identity
+    /// files are collected off the main actor; account-store reconciliation alone returns to it.
+    private static func startAccountGraphWatch(
+        accounts: ProviderAccountsStore,
+        initialAssembly: ProviderAccountAssembly
+    ) -> Task<Void, Never> {
+        let initialDefaultIdentity = DefaultAccountObserver().observeClaude()
+        return Task { @MainActor in
+            var previousDefaultIdentity = initialDefaultIdentity
+            var checksSinceFullDiscovery = 0
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(5))
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                let currentDefaultIdentity = DefaultAccountObserver().observeClaude()
+                checksSinceFullDiscovery += 1
+                let defaultChanged = currentDefaultIdentity != previousDefaultIdentity
+                guard defaultChanged || checksSinceFullDiscovery >= 12 else { continue }
+
+                previousDefaultIdentity = currentDefaultIdentity
+                checksSinceFullDiscovery = 0
+                let preparedDiscovery = await prepareAccountDiscovery()
+                guard !Task.isCancelled else { return }
+                guard DefaultAccountObserver().observeClaude() == currentDefaultIdentity else {
+                    AppLog.info(.config, "accounts: default login changed during discovery; retrying with a fresh graph scan")
+                    continue
+                }
+                let currentAssembly = ProviderAccountAssembly.make(
+                    accountsStore: accounts,
+                    waitsForLoginShell: true,
+                    preparedDiscovery: preparedDiscovery
+                )
+                guard !Task.isCancelled else { return }
+                guard currentAssembly.claudeCards != initialAssembly.claudeCards
+                    || currentAssembly.identityKeysByCard != initialAssembly.identityKeysByCard
+                    || currentAssembly.allowsUnboundClaudeFallback != initialAssembly.allowsUnboundClaudeFallback
+                else { continue }
+
+                AppLog.info(.config, "accounts: verified account sources changed; rebuilding the runtime graph")
+                NotificationCenter.default.post(
+                    name: Self.accountGraphDidChangeNotification,
+                    object: nil
+                )
+                return
+            }
+        }
+    }
+
+    /// Collect blocking filesystem/keychain-attribute discovery on a detached utility executor.
+    /// Cancelling the graph watcher also cancels its detached scan; no stale result may reconcile.
+    static func prepareAccountDiscovery(
+        configScan: @escaping @Sendable () -> ClaudeConfigDirDiscovery.Result = {
+            ClaudeConfigDirDiscovery().run()
+        },
+        coworkScan: @escaping @Sendable () -> ClaudeCoworkDiscovery.Result = {
+            ClaudeCoworkDiscovery().run()
+        }
+    ) async -> PreparedProviderAccountDiscovery {
+        let task = Task.detached(priority: .utility) {
+            guard !Task.isCancelled else {
+                return PreparedProviderAccountDiscovery(
+                    config: ClaudeConfigDirDiscovery.Result(),
+                    cowork: ClaudeCoworkDiscovery.Result(truncated: true)
+                )
+            }
+            let config = configScan()
+            guard !Task.isCancelled else {
+                return PreparedProviderAccountDiscovery(
+                    config: config,
+                    cowork: ClaudeCoworkDiscovery.Result(truncated: true)
+                )
+            }
+            return PreparedProviderAccountDiscovery(config: config, cowork: coworkScan())
+        }
+        return await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 
     /// Drives live updates: refresh on launch, then again every refresh interval. Each pass honors the

--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -5,6 +5,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     private var container: AppContainer?
     private var statusItemController: StatusItemController?
     private var singleInstanceLock: SingleInstanceLock.Token?
+    private var accountGraphObserver: NSObjectProtocol?
+    private var isReloadingAccountGraph = false
     private let updater = UpdaterController()
 
     public override init() {
@@ -71,8 +73,46 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         let container = AppContainer(isFreshInstall: isFreshInstall)
         self.container = container
         statusItemController = StatusItemController(container: container, updater: updater)
+        observeAccountGraphChanges()
         // Starts background update checks (release build only; dormant under preview/`swift run`).
         updater.start()
+    }
+
+    private func observeAccountGraphChanges() {
+        guard accountGraphObserver == nil else { return }
+        accountGraphObserver = NotificationCenter.default.addObserver(
+            forName: AppContainer.accountGraphDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                _ = Task<Void, Never> { [weak self] in
+                    await self?.reloadAccountGraph()
+                }
+            }
+        }
+    }
+
+    private func reloadAccountGraph() async {
+        guard !isReloadingAccountGraph, let previous = container else { return }
+        isReloadingAccountGraph = true
+        defer { isReloadingAccountGraph = false }
+
+        let wasVisible = statusItemController?.isPopoverVisible == true
+        let previousScreen = previous.layout.screen
+        statusItemController?.shutdown()
+        statusItemController = nil
+        await previous.shutdownForAccountGraphReload()
+
+        let replacement = AppContainer()
+        replacement.layout.screen = previousScreen
+        container = replacement
+        let replacementController = StatusItemController(container: replacement, updater: updater)
+        statusItemController = replacementController
+        if wasVisible {
+            replacementController.showPopover()
+        }
+        AppLog.info(.config, "account graph rebuilt after a Claude login changed")
     }
 
     /// Flush queued telemetry on quit. The SDK's lifecycle autocapture is off (we emit our own daily

--- a/Sources/OpenUsage/App/StatusItemController.swift
+++ b/Sources/OpenUsage/App/StatusItemController.swift
@@ -107,7 +107,8 @@ final class StatusItemController: NSObject {
                 self?.panel.appearance = AppearanceSetting.current.nsAppearance
             }
         }
-        // Registered once here; the controller lives for the app's whole life.
+        // Each account graph owns one controller; shutdown removes this handler before its
+        // replacement registers another, without clearing the user's configured shortcut.
         KeyboardShortcuts.onKeyUp(for: .togglePopover) { [weak self] in
             AppLog.info(.statusItem, "Global shortcut fired; toggling popover")
             self?.togglePopover()
@@ -299,6 +300,28 @@ final class StatusItemController: NSObject {
             return
         }
         showPanel()
+    }
+
+    var isPopoverVisible: Bool { panel.isVisible }
+
+    /// Account ownership can change while the app remains open. Remove the old status item and
+    /// observers before installing the graph's replacement, otherwise both controllers stay visible.
+    func shutdown() {
+        // onKeyUp appends listeners globally, so leaving this installed would make every account
+        // graph reload add another popover toggle. Removing a handler preserves the saved shortcut.
+        KeyboardShortcuts.removeHandler(for: .togglePopover)
+        if panel.isVisible {
+            hidePanel()
+        } else {
+            outsideClickMonitor.stop()
+            panel.orderOut(nil)
+        }
+        if let appearanceObserver {
+            NotificationCenter.default.removeObserver(appearanceObserver)
+            self.appearanceObserver = nil
+        }
+        statusItem.button?.target = nil
+        NSStatusBar.system.removeStatusItem(statusItem)
     }
 
     private func showPanel() {

--- a/Sources/OpenUsage/Services/LocalUsageServer.swift
+++ b/Sources/OpenUsage/Services/LocalUsageServer.swift
@@ -1,10 +1,30 @@
 import Foundation
 import Network
 
+/// The listener boundary keeps asynchronous port-release races testable without binding a real port.
+@MainActor
+protocol LocalUsageListening: AnyObject {
+    func setStateHandler(_ handler: (@Sendable (NWListener.State) -> Void)?)
+    func setConnectionHandler(_ handler: (@Sendable (NWConnection) -> Void)?)
+    func start(queue: DispatchQueue)
+    func cancel()
+}
+
+@MainActor
+private final class NetworkLocalUsageListener: LocalUsageListening {
+    private let listener: NWListener
+
+    init(parameters: NWParameters) throws { listener = try NWListener(using: parameters) }
+    func setStateHandler(_ handler: (@Sendable (NWListener.State) -> Void)?) { listener.stateUpdateHandler = handler }
+    func setConnectionHandler(_ handler: (@Sendable (NWConnection) -> Void)?) { listener.newConnectionHandler = handler }
+    func start(queue: DispatchQueue) { listener.start(queue: queue) }
+    func cancel() { listener.cancel() }
+}
+
 /// Loopback-only HTTP/1.1 listener for the read-only usage API on `127.0.0.1:6736`. Starts with
-/// the app; when the port is already taken the feature is silently disabled for the session
-/// (matching the original app). At most 16 requests are served concurrently — beyond that a
-/// connection gets `503 {"error":"server_busy"}` immediately.
+/// the app; account graph replacement waits for the old listener's completed cancellation before
+/// binding its successor. At most 16 requests are served concurrently — beyond that a connection gets
+/// `503 {"error":"server_busy"}` immediately.
 @MainActor
 final class LocalUsageServer {
     static let port: UInt16 = 6736
@@ -12,61 +32,131 @@ final class LocalUsageServer {
     private static let headLimit = 8192
 
     private let state: @MainActor () -> LocalUsageAPI.State
+    private let makeListener: @MainActor (NWParameters) throws -> any LocalUsageListening
     private let queue = DispatchQueue(label: "openusage.local-api")
-    private var listener: NWListener?
+    private var listener: (any LocalUsageListening)?
+    private var listenerGeneration: UUID?
+    private var cancellationContinuation: CheckedContinuation<Void, Never>?
+    private var shouldRun = false
     private var activeConnections = 0
 
-    init(state: @escaping @MainActor () -> LocalUsageAPI.State) {
+    init(
+        state: @escaping @MainActor () -> LocalUsageAPI.State,
+        makeListener: (@MainActor (NWParameters) throws -> any LocalUsageListening)? = nil
+    ) {
         self.state = state
+        self.makeListener = makeListener ?? { try NetworkLocalUsageListener(parameters: $0) }
     }
 
     func start() {
+        guard !shouldRun else { return }
+        shouldRun = true
         let parameters = NWParameters.tcp
         parameters.requiredLocalEndpoint = NWEndpoint.hostPort(
             host: "127.0.0.1",
             port: NWEndpoint.Port(rawValue: Self.port)!
         )
 
-        let listener: NWListener
+        let listener: any LocalUsageListening
         do {
-            listener = try NWListener(using: parameters)
+            listener = try makeListener(parameters)
         } catch {
+            shouldRun = false
             AppLog.info(.localAPI, "disabled: \(error.localizedDescription)")
             return
         }
 
-        listener.stateUpdateHandler = { state in
-            if case .failed(let error) = state {
-                // Most commonly the port is already in use — silently disable for this session.
-                AppLog.info(.localAPI, "disabled: \(error.localizedDescription)")
-            }
-        }
-        listener.newConnectionHandler = { connection in
+        let generation = UUID()
+        listenerGeneration = generation
+        listener.setStateHandler { [weak self] state in
             Task { @MainActor [weak self] in
-                self?.accept(connection)
+                guard let self,
+                      self.shouldRun,
+                      self.listenerGeneration == generation
+                else { return }
+                if case .failed(let error) = state {
+                    self.disableListener(error)
+                }
             }
         }
-        listener.start(queue: queue)
+        listener.setConnectionHandler { [weak self] connection in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      self.shouldRun,
+                      self.listenerGeneration == generation
+                else {
+                    connection.cancel()
+                    return
+                }
+                self.accept(connection, generation: generation)
+            }
+        }
         self.listener = listener
+        listener.start(queue: queue)
     }
 
-    private func accept(_ connection: NWConnection) {
+    private func disableListener(_ error: Error) {
+        shouldRun = false
+        listenerGeneration = nil
+        listener?.setConnectionHandler(nil)
+        listener?.setStateHandler(nil)
+        listener?.cancel()
+        listener = nil
+        AppLog.info(.localAPI, "disabled: \(error.localizedDescription)")
+    }
+
+    /// Network cancellation is asynchronous. Keep its state handler installed until `.cancelled`
+    /// confirms the socket was released, then let the replacement account graph bind the same port.
+    func stop() async {
+        shouldRun = false
+        listenerGeneration = nil
+        guard let listener else { return }
+        listener.setConnectionHandler(nil)
+        await withCheckedContinuation { continuation in
+            cancellationContinuation = continuation
+            listener.setStateHandler { [weak self] state in
+                guard case .cancelled = state else { return }
+                Task { @MainActor [weak self] in
+                    self?.finishListenerCancellation()
+                }
+            }
+            listener.cancel()
+        }
+    }
+
+    private func finishListenerCancellation() {
+        listener?.setStateHandler(nil)
+        listener = nil
+        let continuation = cancellationContinuation
+        cancellationContinuation = nil
+        continuation?.resume()
+    }
+
+    private func accept(_ connection: NWConnection, generation: UUID) {
         connection.start(queue: queue)
         guard activeConnections < Self.maxConcurrentConnections else {
             Self.send(LocalUsageAPI.busy, over: connection)
             return
         }
         activeConnections += 1
-        receiveHead(connection, buffered: Data())
+        receiveHead(connection, buffered: Data(), generation: generation)
     }
 
     /// Reads until the end of the request head (`\r\n\r\n`). GET/OPTIONS bodies are irrelevant,
     /// so the head is all the router needs.
-    private func receiveHead(_ connection: NWConnection, buffered: Data) {
-        connection.receive(minimumIncompleteLength: 1, maximumLength: Self.headLimit) { data, _, isComplete, error in
+    private func receiveHead(_ connection: NWConnection, buffered: Data, generation: UUID) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: Self.headLimit) { [weak self] data, _, isComplete, error in
             Task { @MainActor [weak self] in
                 guard let self else {
                     connection.cancel()
+                    return
+                }
+                guard Self.canServeConnection(
+                    isRunning: self.shouldRun,
+                    listenerGeneration: self.listenerGeneration,
+                    connectionGeneration: generation
+                ) else {
+                    self.finish(connection, with: nil)
                     return
                 }
                 var buffered = buffered
@@ -79,10 +169,20 @@ final class LocalUsageServer {
                 } else if error != nil || isComplete || buffered.count >= Self.headLimit {
                     self.finish(connection, with: nil)
                 } else {
-                    self.receiveHead(connection, buffered: buffered)
+                    self.receiveHead(connection, buffered: buffered, generation: generation)
                 }
             }
         }
+    }
+
+    /// Accepted sockets can outlive their listener during account-graph replacement. Their original
+    /// generation must still own the live listener before any old account state can be routed.
+    nonisolated static func canServeConnection(
+        isRunning: Bool,
+        listenerGeneration: UUID?,
+        connectionGeneration: UUID
+    ) -> Bool {
+        isRunning && listenerGeneration == connectionGeneration
     }
 
     private func route(head: String) -> LocalUsageAPI.Response {

--- a/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
+++ b/Tests/OpenUsageTests/AccountRuntimeLifecycleTests.swift
@@ -1,0 +1,161 @@
+import KeyboardShortcuts
+import Network
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class LocalUsageServerTests: XCTestCase {
+    func testReplacementWaitsForOldListenerCancellationBeforeStarting() async throws {
+        let first = FakeLocalUsageListener()
+        first.automaticallyFinishesCancellation = false
+        let replacement = FakeLocalUsageListener()
+        let retired = LocalUsageServer(state: Self.emptyState, makeListener: { _ in first })
+        let successor = LocalUsageServer(state: Self.emptyState, makeListener: { _ in replacement })
+        retired.start()
+        XCTAssertEqual(first.startCount, 1)
+
+        let handoff = Task { @MainActor in
+            await retired.stop()
+            successor.start()
+        }
+        try await waitUntil { first.cancelCount == 1 }
+        XCTAssertEqual(replacement.startCount, 0, "the old socket must be released before rebinding")
+
+        first.send(.cancelled)
+        await handoff.value
+
+        XCTAssertEqual(replacement.startCount, 1)
+        XCTAssertEqual(replacement.cancelCount, 0)
+        await successor.stop()
+        XCTAssertEqual(replacement.cancelCount, 1)
+    }
+
+    func testOccupiedPortDisablesListenerWithoutRetrying() async throws {
+        let listener = FakeLocalUsageListener()
+        var attempts = 0
+        let server = LocalUsageServer(state: Self.emptyState, makeListener: { _ in
+            attempts += 1
+            return listener
+        })
+        server.start()
+        listener.send(.failed(.posix(.EADDRINUSE)))
+        try await waitUntil { listener.cancelCount == 1 }
+
+        XCTAssertEqual(attempts, 1, "an externally occupied port disables the optional API")
+        await server.stop()
+    }
+
+    func testAcceptedConnectionCannotServeAfterStopOrListenerReplacement() {
+        let originalGeneration = UUID()
+        let replacementGeneration = UUID()
+        let cases: [(Bool, UUID?, Bool)] = [
+            (true, originalGeneration, true), (false, originalGeneration, false),
+            (true, nil, false), (true, replacementGeneration, false),
+        ]
+        for (running, listenerGeneration, expected) in cases {
+            XCTAssertEqual(LocalUsageServer.canServeConnection(
+                isRunning: running, listenerGeneration: listenerGeneration,
+                connectionGeneration: originalGeneration
+            ), expected)
+        }
+    }
+
+    private nonisolated static func emptyState() -> LocalUsageAPI.State {
+        LocalUsageAPI.State(enabledOrderedIDs: [], knownIDs: [], snapshots: [:])
+    }
+
+    private func waitUntil(timeout: Duration = .seconds(2), condition: @escaping @MainActor () -> Bool) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if condition() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTFail("Condition was not met before timeout")
+    }
+}
+
+@MainActor
+private final class FakeLocalUsageListener: LocalUsageListening {
+    private var stateHandler: (@Sendable (NWListener.State) -> Void)?
+    private(set) var startCount = 0
+    private(set) var cancelCount = 0
+    var automaticallyFinishesCancellation = true
+
+    func setStateHandler(_ handler: (@Sendable (NWListener.State) -> Void)?) { stateHandler = handler }
+    func setConnectionHandler(_ handler: (@Sendable (NWConnection) -> Void)?) {}
+    func start(queue: DispatchQueue) { startCount += 1 }
+
+    func cancel() {
+        cancelCount += 1
+        if automaticallyFinishesCancellation { send(.cancelled) }
+    }
+
+    func send(_ state: NWListener.State) { stateHandler?(state) }
+}
+
+@MainActor
+final class AccountDiscoveryThreadingTests: XCTestCase {
+    func testAccountFilesystemScansRunOffTheMainThread() async {
+        let prepared = await AppContainer.prepareAccountDiscovery(
+            configScan: { ClaudeConfigDirDiscovery.Result(notes: [Thread.isMainThread ? "main" : "background"]) },
+            coworkScan: { ClaudeCoworkDiscovery.Result(notes: [Thread.isMainThread ? "main" : "background"]) }
+        )
+
+        XCTAssertEqual(prepared.config.notes, ["background"])
+        XCTAssertEqual(prepared.cowork.notes, ["background"])
+    }
+
+    func testCancelledCoworkScanQuarantinesItsPartialResult() async {
+        let sandbox = URL(fileURLWithPath: "/Users/dev/cowork/.claude")
+        let result = await Task.detached {
+            ClaudeCoworkDiscovery(
+                files: FakeFiles([:]),
+                homeDirectory: { URL(fileURLWithPath: "/Users/dev") },
+                listSandboxes: { _ in
+                    withUnsafeCurrentTask { task in task?.cancel() }
+                    return [sandbox]
+                }
+            ).run()
+        }.value
+
+        XCTAssertTrue(result.truncated)
+        XCTAssertTrue(result.sandboxes.isEmpty)
+    }
+
+    func testCancellationAfterConfigScanSkipsCoworkDiscovery() async {
+        let prepared = await AppContainer.prepareAccountDiscovery(
+            configScan: {
+                withUnsafeCurrentTask { task in task?.cancel() }
+                return ClaudeConfigDirDiscovery.Result(notes: ["config scanned"])
+            },
+            coworkScan: { ClaudeCoworkDiscovery.Result(notes: ["cowork should not run"]) }
+        )
+
+        XCTAssertEqual(prepared.config.notes, ["config scanned"])
+        XCTAssertTrue(prepared.cowork.truncated)
+    }
+}
+
+@MainActor
+final class StatusItemShortcutLifecycleTests: XCTestCase {
+    func testRemovingControllerHandlerPreservesShortcutAndAllowsReplacement() {
+        let name = KeyboardShortcuts.Name("OpenUsageTests.StatusItemShortcut.\(UUID().uuidString)")
+        let shortcut = KeyboardShortcuts.Shortcut(.f19, modifiers: [.command, .control, .option, .shift])
+        defer {
+            KeyboardShortcuts.removeHandler(for: name)
+            KeyboardShortcuts.reset(name)
+        }
+
+        KeyboardShortcuts.setShortcut(shortcut, for: name)
+        KeyboardShortcuts.onKeyUp(for: name) {}
+
+        KeyboardShortcuts.removeHandler(for: name)
+        XCTAssertFalse(KeyboardShortcuts.isEnabled(for: name))
+        XCTAssertEqual(KeyboardShortcuts.getShortcut(for: name), shortcut)
+
+        KeyboardShortcuts.onKeyUp(for: name) {}
+        XCTAssertTrue(KeyboardShortcuts.isEnabled(for: name))
+        XCTAssertEqual(KeyboardShortcuts.getShortcut(for: name), shortcut)
+    }
+}


### PR DESCRIPTION
## TL;DR

Update Claude account cards automatically when local accounts are added, removed, or changed without restarting OpenUsage.

## What was happening

- Account discovery only ran at launch, so changed Claude CLI or Desktop logins left stale cards on screen.
- Replacing the app runtime could otherwise leave behind keyboard shortcuts, local API listeners, or cloud tasks.

## What this changes

- Rediscover account sources in the background and replace the app runtime when verified account ownership changes.
- Shut down old iCloud work, keyboard handlers, and local API listeners before activating their replacements.
- Keep filesystem scans off the main thread and quarantine cancelled or partial discovery results.

## Tests

- Focused local API listener handoff, background account discovery, cancellation, keyboard shortcut lifecycle, cloud sync, and provider enablement suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Replaces the live composition root, menu-bar status item, loopback API listener, and iCloud sync worker without quitting. A failed handoff can duplicate status items, leak shortcut handlers, or race the local port.
> 
> **Overview**
> Claude account cards now update in-session when local logins are added, removed, or swapped. A background watcher cheaply polls the default-home identity every 5s, runs full config/Cowork discovery off the main thread (throttled to about once a minute unless that identity changes), and only posts a rebuild after a verified graph diff.
> 
> `AppDelegate` then tears down the old `AppContainer` and status item and installs a replacement, restoring popover visibility and layout screen. Shutdown cancels refresh/seed/watch tasks, stops iCloud writes without disabling sync or deleting the document, removes the keyboard-shortcut handler without clearing the saved shortcut, and waits for the loopback listener’s `.cancelled` state before rebinding `127.0.0.1:6736`. Stale connections cannot serve after a generation change.
> 
> First-run seeding and new-provider seeding no longer run on the same launch. Tests cover listener handoff, discovery cancellation, and shortcut handler replacement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2133e9ed8a63f4ed36eaefa2e99a61ed1bdff6fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->