### PR TITLE
Claude accounts 14: keep account identifiers out of analytics

### DIFF
--- a/Sources/OpenUsage/Stores/TelemetryRecorder.swift
+++ b/Sources/OpenUsage/Stores/TelemetryRecorder.swift
@@ -69,6 +69,9 @@ final class TelemetryRecorder {
         guard store.enabled else { return }
         guard outcome == .refreshed || outcome == .failed else { return }
 
+        // Account-card identifiers contain a stable account-derived hash. Analytics only describe
+        // provider families, so normalize before either persistence or transmission.
+        let providerID = ProviderAccountID.family(of: providerID)
         let today = Self.dayString(now())
         var counters = store.providerCounters()
         // Roll a stale prior-day counter over to its own event before accumulating today's.
@@ -115,10 +118,10 @@ final class TelemetryRecorder {
             "install_id": store.installID,
             "app_version": AppInfo.version,
             "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
-            "enabled_providers": config.enabledProviders,
-            "enabled_metric_ids": config.enabledMetricIDs,
-            "pinned_metric_ids": config.pinnedMetricIDs,
-            "expanded_metric_ids": config.expandedMetricIDs,
+            "enabled_providers": Self.unique(config.enabledProviders.map(ProviderAccountID.family(of:))),
+            "enabled_metric_ids": Self.familyMetricIDs(config.enabledMetricIDs),
+            "pinned_metric_ids": Self.familyMetricIDs(config.pinnedMetricIDs),
+            "expanded_metric_ids": Self.familyMetricIDs(config.expandedMetricIDs),
             "menu_bar_style": config.menuBarStyle
         ])
         sink.flush()
@@ -131,7 +134,7 @@ final class TelemetryRecorder {
 
     private static func providerRollupProperties(providerID: String, counter: ProviderDailyCounter) -> [String: Any] {
         var properties: [String: Any] = [
-            "provider_id": providerID,
+            "provider_id": ProviderAccountID.family(of: providerID),
             "success_count": counter.success,
             "failure_count": counter.failure,
             "error_categories": counter.errors,
@@ -148,6 +151,21 @@ final class TelemetryRecorder {
         properties["expected_failure_count"] = expectedFailureCount
         properties["unexpected_failure_count"] = max(0, counter.failure - expectedFailureCount)
         return properties
+    }
+
+    private static func familyMetricIDs(_ metricIDs: [String]) -> [String] {
+        unique(metricIDs.map { metricID in
+            guard let separator = metricID.firstIndex(of: ".") else {
+                return ProviderAccountID.family(of: metricID)
+            }
+            let providerID = String(metricID[..<separator])
+            return ProviderAccountID.family(of: providerID) + metricID[separator...]
+        })
+    }
+
+    private static func unique(_ values: [String]) -> [String] {
+        var seen: Set<String> = []
+        return values.filter { seen.insert($0).inserted }
     }
 
     /// Local-calendar `yyyy-MM-dd`. Local (not UTC) so "every day" matches the user's perception; the

--- a/Tests/OpenUsageTests/TelemetryRecorderTests.swift
+++ b/Tests/OpenUsageTests/TelemetryRecorderTests.swift
@@ -99,6 +99,53 @@ final class TelemetryRecorderTests: XCTestCase {
         }
     }
 
+    func testDailyActiveNeverIncludesAccountDerivedIdentifiers() {
+        let sink = FakeSink()
+        let store = makeStore("account-safe-daily-active")
+        let accountSnapshot = TelemetryConfigSnapshot(
+            enabledProviders: ["claude", "claude@ab12cd34", "codex@deadbeef"],
+            enabledMetricIDs: ["claude.session", "claude@ab12cd34.session", "codex@deadbeef.weekly"],
+            pinnedMetricIDs: ["claude@ab12cd34.session"],
+            expandedMetricIDs: ["codex@deadbeef.weekly", "codex.weekly"],
+            menuBarStyle: "text"
+        )
+        let recorder = TelemetryRecorder(
+            sink: sink,
+            store: store,
+            snapshot: { accountSnapshot },
+            now: { self.day(25) }
+        )
+
+        recorder.tick()
+
+        let event = try! XCTUnwrap(sink.events(named: "app_daily_active").first)
+        XCTAssertEqual(event["enabled_providers"] as? [String], ["claude", "codex"])
+        XCTAssertEqual(event["enabled_metric_ids"] as? [String], ["claude.session", "codex.weekly"])
+        XCTAssertEqual(event["pinned_metric_ids"] as? [String], ["claude.session"])
+        XCTAssertEqual(event["expanded_metric_ids"] as? [String], ["codex.weekly"])
+    }
+
+    func testAccountRefreshesShareOneFamilyRollupWithoutPersistingAccountIDs() {
+        let sink = FakeSink()
+        let store = makeStore("account-safe-provider-rollup")
+        var clock = day(25)
+        let recorder = TelemetryRecorder(sink: sink, store: store, snapshot: { self.snapshot }, now: { clock })
+
+        recorder.record(providerID: "claude", outcome: .refreshed, category: nil, manual: false)
+        recorder.record(providerID: "claude@ab12cd34", outcome: .failed, category: .network, manual: true)
+
+        XCTAssertEqual(Set(store.providerCounters().keys), ["claude"])
+
+        clock = day(26)
+        recorder.tick()
+
+        let event = try! XCTUnwrap(sink.events(named: "provider_refresh_daily").first)
+        XCTAssertEqual(event["provider_id"] as? String, "claude")
+        XCTAssertEqual(event["success_count"] as? Int, 1)
+        XCTAssertEqual(event["failure_count"] as? Int, 1)
+        XCTAssertEqual(event["manual_refresh_count"] as? Int, 1)
+    }
+
     func testTickFlushesStalePriorDayCounterEvenWithoutNewOutcomes() {
         let sink = FakeSink()
         let store = makeStore("sweep")


### PR DESCRIPTION
## TL;DR

Prevent account-specific card identifiers from being saved or transmitted in OpenUsage analytics.

## What was happening

- Multi-account card and metric identifiers include a stable account-derived suffix.
- Existing telemetry treated those identifiers as ordinary provider IDs, potentially exposing account-specific values.

## What this changes

- Normalize provider IDs and metric IDs to their provider family before analytics persistence or transmission.
- Deduplicate account-derived provider and metric entries in configuration snapshots.
- Add focused regressions proving account hashes never appear in telemetry events or counters.

## Tests

- Full telemetry recorder privacy regression suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics persistence and event payloads (privacy-sensitive data handling). The change is a narrowing of identifiers, not new collection, but mistakes here could leak account hashes or merge counters incorrectly.
> 
> **Overview**
> Stops multi-account card hashes from being stored or sent in OpenUsage analytics. Provider and metric IDs are now reduced to their provider family (`ProviderAccountID.family`) before counters persist and before `app_daily_active` / `provider_refresh_daily` events fire.
> 
> Account-specific entries in the daily config snapshot are also deduped onto family IDs, so multiple Claude/Codex cards collapse to one family. Tests cover that hashes never appear in events or persisted counter keys, and that account refreshes share a single family rollup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556e4c52a9cad73a46c0d023337b8fc5ae114076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->