### PR TITLE
Claude accounts 13: preserve account names, charts, and layouts

### DIFF
--- a/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
+++ b/Sources/OpenUsage/Views/CustomizeProviderDetailView.swift
@@ -215,11 +215,11 @@ private struct CardNameSection: View {
     }
 
     private var record: ProviderAccountRecord? {
-        container.accounts.records.first { $0.id == providerID }
+        container.accounts.runtimeRecord(for: providerID)
     }
 
     private var placeholder: String {
-        record?.derivedDisplayName ?? ""
+        container.accounts.derivedDisplayName(cardID: providerID) ?? ""
     }
 
     private func commit() {

--- a/Sources/OpenUsage/Views/TotalSpendCard.swift
+++ b/Sources/OpenUsage/Views/TotalSpendCard.swift
@@ -38,13 +38,16 @@ struct TotalSpendCard: View {
 
     private var total: TotalSpend {
         // Accounts that live only on other Macs (synced, no card here) count toward the total and
-        // get their own legend slice even when their login isn't set up on this machine.
+        // get their own legend slice ("claude@ab12cd34") — the number should be the whole truth
+        // even when a login isn't set up on this machine.
         var aggregatedProviders = providers
         var aggregatedSnapshots = dataStore.snapshots
         for entry in dataStore.remoteOnlySpend {
             aggregatedProviders.append(entry.provider)
             aggregatedSnapshots[entry.provider.id] = entry.snapshot
         }
+        // Titles resolve here — the one place with registry access — so the legend AND the share
+        // export (rendered outside the environment) carry live renames.
         return TotalSpendAggregator.total(
             for: period,
             providers: aggregatedProviders,
@@ -119,6 +122,7 @@ struct TotalSpendCard: View {
     /// tooltip lie about what the total reflects.
     private var infoTooltip: String {
         let names = providers.map { container.displayName(for: $0) }
+            + dataStore.remoteOnlySpend.map(\.provider.displayName)
         return "Only includes \(names.formatted(.list(type: .and)))."
     }
 

--- a/Sources/OpenUsage/Views/WidgetGroupedListView.swift
+++ b/Sources/OpenUsage/Views/WidgetGroupedListView.swift
@@ -20,7 +20,6 @@ struct WidgetGroupedListView: View {
     @State private var frameStore = ReorderFrameStore()
     @State private var activeProviderID: String?
     @State private var activeMetricID: String?
-    /// The card the "Rename…" alert is currently editing; `nil` when the alert is closed.
     @State private var renameCardID: String?
     @State private var renameDraft = ""
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
@@ -40,7 +39,6 @@ struct WidgetGroupedListView: View {
             TextField("Name", text: $renameDraft)
             Button("Rename") {
                 if let renameCardID {
-                    // A cleared field resets the card back to its derived name.
                     container.accounts.rename(cardID: renameCardID, to: renameDraft)
                 }
             }
@@ -89,11 +87,9 @@ struct WidgetGroupedListView: View {
             Button("Refresh \(name)") {
                 Task { await dataStore.refresh(providerID: group.provider.id, force: true) }
             }
-            // Renaming needs an account record to write to, so it only shows on account-model cards
-            // whose identity has been observed at least once.
             if container.canRename(group.provider.id) {
                 Button("Rename…") {
-                    renameDraft = name
+                    renameDraft = container.accounts.runtimeRecord(for: group.provider.id)?.customLabel ?? ""
                     renameCardID = group.provider.id
                 }
             }

--- a/Tests/OpenUsageTests/LayoutAccountTests.swift
+++ b/Tests/OpenUsageTests/LayoutAccountTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import OpenUsage
+
+@MainActor
+final class LayoutAccountTests: XCTestCase {
+    private func accountLayoutRegistry(_ providers: [Provider], suffixes: [String]) -> WidgetRegistry {
+        WidgetRegistry(providers: providers, descriptors: providers.flatMap { provider in
+            suffixes.map { suffix in
+                let id = "\(provider.id).\(suffix)"
+                return WidgetDescriptor(
+                    id: id, providerID: provider.id, metricLabel: id,
+                    sample: WidgetData(title: id, icon: provider.icon, kind: .percent, used: 0, limit: 100)
+                )
+            }
+        })
+    }
+
+    func testProviderReorderPreservesAnAbsentAccountCardSlot() {
+        let defaults = makeDefaults("ReorderAbsentAccountCard")
+        let storageKey = "layout"
+        let hidden = "claude@hidden"
+        let persistence = LayoutPersistence(defaults: defaults, storageKey: storageKey)
+        persistence.saveProviderOrder(["claude", hidden, "cursor"])
+        let store = LayoutStore(registry: .mock, defaults: defaults, storageKey: storageKey)
+
+        XCTAssertTrue(store.reorderProvider(dragged: "cursor", target: "claude"))
+        XCTAssertEqual(Array(store.providerOrder.prefix(3)), ["cursor", hidden, "claude"])
+        XCTAssertEqual(persistence.loadProviderOrder()?.contains(hidden), true)
+    }
+
+    func testTranslatedDefaultsSeedAnAccountCardTheFirstTimeItAppears() {
+        let claude = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let work = Provider(id: "claude@work", displayName: "Claude — Work", icon: .providerMark("claude"))
+        let suffixes = ["session", "weekly", "fable", "sonnet"]
+        let registry = accountLayoutRegistry([claude, work], suffixes: suffixes)
+        let defaults = makeDefaults("AccountCardSeeding")
+        let familyDefaults = suffixes.dropLast().map { "claude.\($0)" }
+        saveStored(familyDefaults.map { PlacedWidget(descriptorID: $0) }, forKey: "layout", in: defaults)
+        defaults.set(suffixes.map { "claude.\($0)" }, forKey: "layout.seededDefaults")
+
+        let store = LayoutStore(
+            registry: registry, defaults: defaults, storageKey: "layout", defaultMetricIDs: familyDefaults,
+            defaultExpandedMetricIDs: ["claude.sonnet"]
+        )
+
+        for suffix in suffixes.dropLast() {
+            XCTAssertTrue(store.isMetricEnabled("claude@work.\(suffix)"))
+        }
+        XCTAssertFalse(store.isPinned("claude@work.fable"))
+        XCTAssertFalse(store.expandedMetricIDs.contains("claude@work.fable"))
+        XCTAssertEqual(store.orderedSupportedMetrics(for: "claude@work").map(\.id), suffixes.map { "claude@work.\($0)" })
+        XCTAssertFalse(store.isMetricEnabled("claude.sonnet"))
+        XCTAssertTrue(store.defaultExpandedOnEnableIDs.contains("claude@work.sonnet"))
+    }
+
+    func testAccountCustomizationSurvivesAbsenceAnUnrelatedEditAndGraphRebuild() {
+        let claude = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let work = Provider(id: "claude@ab12cd34", displayName: "Claude — Work", icon: .providerMark("claude"))
+        func registry(includingWork: Bool) -> WidgetRegistry {
+            self.accountLayoutRegistry(includingWork ? [claude, work] : [claude], suffixes: ["session", "weekly"])
+        }
+        let defaults = makeDefaults("AccountGraphRebuild")
+        func load(includingWork: Bool) -> LayoutStore {
+            LayoutStore(
+                registry: registry(includingWork: includingWork), defaults: defaults, storageKey: "layout",
+                defaultMetricIDs: ["claude.session", "claude.weekly"], defaultPinnedMetricIDs: [],
+                defaultExpandedMetricIDs: ["claude.weekly"]
+            )
+        }
+
+        let first = load(includingWork: true)
+        first.setMetricEnabled("claude@ab12cd34.weekly", false)
+        first.setPinned(true, for: "claude@ab12cd34.session")
+        XCTAssertTrue(first.setProviderExpanded(true, for: "claude@ab12cd34"))
+        XCTAssertTrue(first.reorderProvider(dragged: "claude@ab12cd34", target: "claude"))
+
+        let temporarilyAbsent = load(includingWork: false)
+        XCTAssertFalse(temporarilyAbsent.isMetricEnabled("claude@ab12cd34.session"))
+        XCTAssertTrue(temporarilyAbsent.pinnedMetricIDs.contains("claude@ab12cd34.session"))
+        XCTAssertTrue(temporarilyAbsent.expandedProviderIDs.contains("claude@ab12cd34"))
+        XCTAssertEqual(temporarilyAbsent.providerOrder.first, "claude@ab12cd34")
+
+        temporarilyAbsent.setMetricEnabled("claude.weekly", false)
+        temporarilyAbsent.setPinned(true, for: "claude.session")
+
+        let restored = load(includingWork: true)
+        XCTAssertTrue(restored.isMetricEnabled("claude@ab12cd34.session"))
+        XCTAssertFalse(restored.isMetricEnabled("claude@ab12cd34.weekly"))
+        XCTAssertTrue(restored.isPinned("claude@ab12cd34.session"))
+        XCTAssertTrue(restored.isProviderExpanded("claude@ab12cd34"))
+        XCTAssertEqual(restored.orderedProviderIDs().first, "claude@ab12cd34")
+        XCTAssertFalse(restored.isMetricEnabled("claude.weekly"))
+        XCTAssertTrue(restored.isPinned("claude.session"))
+    }
+
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let suiteName = "OpenUsageTests.LayoutAccount.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func saveStored<T: Encodable>(_ value: T, forKey key: String, in defaults: UserDefaults) {
+        defaults.set(try! JSONEncoder().encode(value), forKey: key)
+    }
+}

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -780,71 +780,6 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(store.pinnedMetricIDs, expected)
     }
 
-    func testProviderReorderPreservesAnAbsentAccountCardSlot() {
-        let defaults = makeDefaults("ReorderAbsentAccountCard")
-        let storageKey = "layout"
-        let hidden = "claude@hidden"
-        LayoutPersistence(defaults: defaults, storageKey: storageKey).saveProviderOrder([
-            "claude", hidden, "cursor",
-        ])
-        let store = LayoutStore(registry: .mock, defaults: defaults, storageKey: storageKey)
-
-        XCTAssertTrue(store.reorderProvider(dragged: "cursor", target: "claude"))
-
-        XCTAssertEqual(Array(store.providerOrder.prefix(3)), ["cursor", hidden, "claude"])
-        XCTAssertEqual(
-            LayoutPersistence(defaults: defaults, storageKey: storageKey).loadProviderOrder()?.contains(hidden),
-            true,
-            "the absent card keeps its slot for the launch it returns on"
-        )
-    }
-
-    func testTranslatedDefaultsSeedAnAccountCardTheFirstTimeItAppears() {
-        // An existing user's layout predates the account card entirely; when the card first enters
-        // the registry, its family's default metrics seed for it (enabled), because translated ids
-        // are never part of the seeded-defaults baseline.
-        let claude = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
-        let work = Provider(id: "claude@work", displayName: "Claude — Work", icon: .providerMark("claude"))
-        func descriptor(_ id: String, _ provider: Provider) -> WidgetDescriptor {
-            WidgetDescriptor(
-                id: id,
-                providerID: provider.id,
-                metricLabel: id,
-                sample: WidgetData(title: id, icon: provider.icon, kind: .percent, used: 0, limit: 100)
-            )
-        }
-        let registry = WidgetRegistry(
-            providers: [claude, work],
-            descriptors: [
-                descriptor("claude.session", claude),
-                descriptor("claude.sonnet", claude),
-                descriptor("claude@work.session", work),
-                descriptor("claude@work.sonnet", work),
-            ]
-        )
-        let defaults = makeDefaults("AccountCardSeeding")
-        saveStored([PlacedWidget(descriptorID: "claude.session")], forKey: "layout", in: defaults)
-        defaults.set(["claude.session", "claude.sonnet"], forKey: "layout.seededDefaults")
-
-        let store = LayoutStore(
-            registry: registry,
-            defaults: defaults,
-            storageKey: "layout",
-            defaultMetricIDs: ["claude.session"],
-            defaultExpandedMetricIDs: ["claude.sonnet"]
-        )
-
-        XCTAssertTrue(store.isMetricEnabled("claude@work.session"))
-        XCTAssertFalse(
-            store.isMetricEnabled("claude.sonnet"),
-            "the family's own disabled default stays exactly as the user left it"
-        )
-        XCTAssertTrue(
-            store.defaultExpandedOnEnableIDs.contains("claude@work.sonnet"),
-            "the caret split translates with the metric set"
-        )
-    }
-
     func testResetToDefaultRestoresProviderOrderAndMarksDefaultsSeeded() {
         let defaults = makeDefaults("ResetSeeded")
         let store = LayoutStore(
@@ -1082,10 +1017,7 @@ final class LayoutStoreTests: XCTestCase {
 
         let store = LayoutStore(registry: .mock, defaults: defaults, storageKey: "layout")
         XCTAssertTrue(store.expandedMetricIDs.contains("claude.session"))
-        XCTAssertTrue(
-            store.expandedMetricIDs.contains("missing.metric"),
-            "unknown state stays persisted so a temporarily absent account card can recover it"
-        )
+        XCTAssertTrue(store.expandedMetricIDs.contains("missing.metric"))
     }
 
     func testDisplayGroupsPartitionEnabledMetrics() {

--- a/Tests/OpenUsageTests/ShareCardRendererTests.swift
+++ b/Tests/OpenUsageTests/ShareCardRendererTests.swift
@@ -48,6 +48,33 @@ final class ShareCardRendererTests: XCTestCase {
         XCTAssertGreaterThan(rep.pixelsHigh, 0)
     }
 
+    func testMultiAccountShareCardsRenderDistinctAccountLabels() throws {
+        let provider = MockData.claude
+        let personalProvider = Provider(
+            id: "claude@ab12cd34",
+            displayName: "Claude — Personal",
+            icon: provider.icon
+        )
+        let cases = [
+            (provider, "Claude — SUNSTORY", "Team 5x"),
+            (personalProvider, "Claude — Personal", "Max 20x")
+        ]
+
+        for (account, name, plan) in cases {
+            let row = WidgetData(title: "Session", icon: account.icon, kind: .percent, used: 22, limit: 100)
+            let card = ShareCardView(
+                provider: account,
+                plan: plan,
+                rows: [row],
+                appearance: .dark,
+                displayNameOverride: name
+            )
+            XCTAssertEqual(card.displayNameOverride, name)
+            XCTAssertEqual(card.plan, plan)
+            XCTAssertNotNil(ShareCardRenderer.image(for: card))
+        }
+    }
+
     func testCondensedTextRowIndicesFollowsNeighborRule() {
         let rows = MockData.descriptors(for: MockData.claude.id).map { $0.sample }
         XCTAssertGreaterThan(rows.count, 1, "sample fixture should have multiple rows")

--- a/Tests/OpenUsageTests/TotalSpendAggregatorTests.swift
+++ b/Tests/OpenUsageTests/TotalSpendAggregatorTests.swift
@@ -180,27 +180,48 @@ final class TotalSpendAggregatorTests: XCTestCase {
 }
 
 final class TotalSpendPaletteTests: XCTestCase {
-    func testExistingBrandColorsRemainStable() {
+    func testBareProviderBrandColorsRemainUnchanged() {
         XCTAssertEqual(TotalSpendPalette.color(for: "claude"),
                        Color(red: 222.0 / 255, green: 115.0 / 255, blue: 86.0 / 255))
         XCTAssertEqual(TotalSpendPalette.color(for: "codex"),
                        Color(red: 16.0 / 255, green: 163.0 / 255, blue: 127.0 / 255))
         XCTAssertNil(TotalSpendPalette.accountComponents(for: "claude"))
+        XCTAssertNil(TotalSpendPalette.accountComponents(for: "codex"))
     }
 
-    func testAccountAndRemoteAliasShareOneDistinctBrandShade() throws {
-        let first = try XCTUnwrap(TotalSpendPalette.accountComponents(for: "claude@11111111"))
-        let second = try XCTUnwrap(TotalSpendPalette.accountComponents(for: "claude@22222222"))
-        XCTAssertNotEqual(first, second)
-        XCTAssertEqual(first, TotalSpendPalette.accountComponents(for: "claude@peer-11111111"))
-        XCTAssertEqual(first, TotalSpendPalette.accountComponents(for: "claude@11111111"))
-        XCTAssertTrue(first.hue <= 0.15 || first.hue >= 0.90)
-        XCTAssertTrue((0.62...0.94).contains(first.brightness))
+    func testAccountColorIsStableAndMatchesItsRemoteOnlyAlias() throws {
+        let local = try XCTUnwrap(TotalSpendPalette.accountComponents(for: "claude@ab12cd34"))
+        for alias in ["claude@ab12cd34", "claude@AB12CD34", "claude@peer-ab12cd34"] {
+            XCTAssertEqual(local, TotalSpendPalette.accountComponents(for: alias))
+        }
+        XCTAssertEqual(TotalSpendPalette.color(for: "claude@ab12cd34"),
+                       TotalSpendPalette.color(for: "claude@peer-ab12cd34"))
     }
 
-    func testUnknownProvidersKeepTheirFallbackColor() {
+    func testSiblingAccountsThatCollidedInTheLegacyFallbackGetDistinctColors() throws {
+        let siblings = try ["11111111", "22222222", "33333333"].map {
+            try XCTUnwrap(TotalSpendPalette.accountComponents(for: "claude@\($0)"))
+        }
+        XCTAssertNotEqual(siblings[0], siblings[1])
+        XCTAssertNotEqual(siblings[0], siblings[2])
+        XCTAssertNotEqual(siblings[1], siblings[2])
+    }
+
+    func testAccountShadesStayNearTheirFamilyBrandAndRemainLegible() throws {
+        let claude = try XCTUnwrap(TotalSpendPalette.accountComponents(for: "claude@ab12cd34"))
+        let codex = try XCTUnwrap(TotalSpendPalette.accountComponents(for: "codex@ab12cd34"))
+        XCTAssertTrue(claude.hue <= 0.15 || claude.hue >= 0.90)
+        XCTAssertTrue((0.33...0.56).contains(codex.hue))
+        for color in [claude, codex] {
+            XCTAssertGreaterThanOrEqual(color.saturation, 0.50)
+            XCTAssertTrue((0.62...0.94).contains(color.brightness))
+        }
+    }
+
+    func testUnknownProvidersRetainTheExistingFallbackPalette() {
         XCTAssertEqual(TotalSpendPalette.color(for: "mystery-provider"),
                        Color(red: 162.0 / 255, green: 132.0 / 255, blue: 94.0 / 255))
+        XCTAssertNil(TotalSpendPalette.accountComponents(for: "mystery-provider"))
         XCTAssertNil(TotalSpendPalette.accountComponents(for: "cursor@ab12cd34"))
     }
 }

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -8,6 +8,15 @@ A fresh install doesn't turn on every provider OpenUsage knows about. It starts 
 
 This full detection only happens on a brand-new install. Updates never change the providers you already have on or off — but when an update ships a provider you've never seen, the same local check runs once for just that provider and turns it on only if you actually have the tool. See [Which Providers Are On](provider-enablement.md) for the full lifecycle.
 
+When OpenUsage finds multiple verified Claude logins, each account gets its own provider card. Changing
+the active Claude Code login while the app is running updates those cards automatically; an account's
+name, metric choices, menu-bar stars, and position stay with that account instead of following the
+login location. If an account temporarily disappears, its card stays hidden until a verified login
+for that same account returns. Account cards use their organization names when more than one account
+is present, so a work account and its personal counterpart can appear as **Claude — SUNSTORY** and
+**Claude — Personal** even when both use the same email address. Codex still uses a single card;
+if its verified account changes, that card's name and custom label follow the current account.
+
 Each provider card leads with its **Always Visible** metrics. Any metrics you've moved below the **On Demand** line are tucked away behind the in-card caret — click it to reveal them below the caret, click again to collapse. Open cards stay open across popover closes and app restarts. A provider with neither On Demand metrics nor quick links shows no caret.
 
 When you expand a card, the tucked-away metrics open below the caret as a single-column list, so each detail row keeps the full card width.
@@ -16,13 +25,18 @@ A provider card can also show **quick-link buttons** pinned at the bottom of its
 
 ## Total Spend
 
-When any enabled provider tracks daily spend (Claude, Codex, Cursor, Grok, or OpenCode), a card sits above the provider sections. The title is a pull-down menu for **Cost**, **Cost/MTok**, or **Tokens** (Cost is the default; the choice sticks across restarts). A capsule switcher flips the period between **Today**, **Yesterday**, and **30 Days**. The ring, center total, and ranked legend follow the selected metric:
+When any enabled provider tracks daily spend (Antigravity, Claude, Codex, Cursor, Grok, or OpenCode), a card sits above the provider sections. The title is a pull-down menu for **Cost**, **Cost/MTok**, or **Tokens** (Cost is the default; the choice sticks across restarts). A capsule switcher flips the period between **Today**, **Yesterday**, and **30 Days**. The ring, center total, and ranked legend follow the selected metric:
 
 - **Cost** — each segment is that provider's share of combined dollars (biggest spender first).
 - **Cost/MTok** — each segment is sized by that provider's dollars-per-million-tokens rate; the center is the blended rate across providers that have both spend and tokens; the legend lists each provider's own rate.
 - **Tokens** — each segment is that provider's share of combined tokens.
 
-The ring center is always two short lines — a compact number on top and a quiet unit underneath (`$533` / `dollars`, `12.4` / `million`, or `$1.37` / `MTok`) — so Cost/MTok and big totals stay readable in the hole. Cost modes keep the `$` on the number. Hover the center for the exact one-line figure (and a note when any contributor's dollars are a local estimate — Cost and Cost/MTok only). Each provider keeps a fixed color drawn from its brand (Claude's terracotta, OpenAI's green, and so on), and even a tiny share keeps a visible sliver of the ring. Providers with nothing for the selected metric simply don't appear — they're never counted as zero. (An enabled provider counts even if you've hidden its own spend rows in Customize; other dollar rows, like OpenRouter's API spend, never mix in.) The header's share icon (or right-clicking the card) copies a branded PNG of the ring to your clipboard, just like sharing a provider card. The header also carries a small ⓘ naming the providers that feed the total. A period with nothing to show for the active metric shows a quiet empty state instead of hiding the card. Don't want the card at all? Turn it off with **Show Total Spend** at the top of [Settings](settings.md).
+Each Claude account gets its own ring segment and legend entry instead of being folded into a single
+Claude total. The ring and legend are ranked by the selected amount, highest first, even when you've
+dragged the dashboard cards into a different order. A verified account that only exists on another
+synced Mac can also contribute its own separate account-code entry without creating a local card.
+
+The ring center is always two short lines — a compact number on top and a quiet unit underneath (`$533` / `dollars`, `12.4` / `million`, or `$1.37` / `MTok`) — so Cost/MTok and big totals stay readable in the hole. Cost modes keep the `$` on the number. Hover the center for the exact one-line figure (and a note when any contributor's dollars are a local estimate — Cost and Cost/MTok only). Each provider keeps a fixed brand color, such as Claude's terracotta or OpenAI's green; additional accounts use consistent related shades so separate accounts remain distinguishable as the chart re-sorts. Even a tiny share keeps a visible sliver of the ring. Providers with nothing for the selected metric simply don't appear — they're never counted as zero. (An enabled provider counts even if you've hidden its own spend rows in Customize; other dollar rows, like OpenRouter's API spend, never mix in.) The header's share icon (or right-clicking the card) copies a branded PNG of the ring to your clipboard, just like sharing a provider card. The header also carries a small ⓘ naming the providers that feed the total. A period with nothing to show for the active metric shows a quiet empty state instead of hiding the card. Don't want the card at all? Turn it off with **Show Total Spend** at the top of [Settings](settings.md).
 
 ## Rows
 

--- a/docs/provider-enablement.md
+++ b/docs/provider-enablement.md
@@ -15,6 +15,8 @@ The same detection runs for providers that arrive later. On the first launch aft
 
 This check happens **once per provider**. After that, the provider is yours to manage: if you turn it off, no update will ever turn it back on, and installing the tool later won't flip it on behind your back either — head to Customize when you want it.
 
+If your account changes while a check is still running, OpenUsage resumes that unfinished check after rebuilding the account list. It never repeats a completed check or overrides a provider switch you changed yourself.
+
 ## Your choices always stick
 
 Everything you set in Customize — providers on or off, metric layout, menu-bar stars — carries across updates untouched. The only thing an update may ever change is turning **on** a provider you have never seen before, and only when you actually have that tool installed.
@@ -27,6 +29,7 @@ The app persists three small lists in its settings:
 
 - **Enabled providers** — the providers currently on. This is the source of truth the dashboard and menu bar read.
 - **Known providers** — every provider this install has ever seen. This is what makes "new in this update" distinguishable from "you turned it off": a provider missing from the enabled list but present in the known list is a deliberate choice, and is left alone. Only providers missing from *both* get the credential check, and each is marked known immediately so the check never repeats.
+- **Pending checks** — providers whose first credential check has started but hasn't finished yet. This short-lived list lets an interrupted check resume without turning a completed check into a recurring one.
 - Each provider implements a cheap, local-only credential probe (`hasLocalCredentials()`) — the same files, keychain entries, saved keys, and environment variables its normal refresh reads, never the network.
 
 Older installs (from before first-run detection existed) started with every provider on and stored only the ones turned *off*. A one-time settings migration converts them to the lists above with the exact same providers on and off as before — nothing visibly changes on the launch that migrates; those installs simply join the same new-provider detection from then on.

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -47,27 +47,38 @@ Local spend does not require a Claude OAuth login. If Claude Code uses an API-ke
 
 ## Multiple accounts
 
-If you keep more than one Claude login on this Mac using custom config dirs (separate `CLAUDE_CONFIG_DIR`
-homes, each with its own sign-in), OpenUsage finds them at launch and gives each **account** its own
-card, with its own limits, plan, and spend tiles read from that home. A custom dir signed into the same
-account as your main login doesn't become a second card — its session logs simply count into the main
-card's spend tiles.
+OpenUsage discovers separate Claude Code logins in hidden folders directly under your home directory
+and folders directly under `~/.config`. Each account gets its own card, limits, plan, and local spend;
+another folder signed into the same account contributes to the existing card instead of creating a
+duplicate. The account using `$CLAUDE_CONFIG_DIR` is treated as the default login, even when that
+folder lives elsewhere. Cards stay attached to their original account when the default login changes.
 
-Cowork sessions are account-aware too. Each Cowork session folder records which account ran it: sessions
-from your main login keep counting on the main card, and sessions from an account that already has a
-config-dir card count on that card. If Claude Desktop is signed into a *different* account than the CLI,
-its Cowork sessions become their own card, backed read-only by Desktop's login (same Safe Storage read
-as above, pinned to that account's organization so it never borrows another card's token) — with that
-account's limits, plan, and its Cowork sessions as the card's spend. Signing Desktop out again makes
-the card disappear the same way a deleted config dir does.
+Cowork session folders are assigned to the account named by their own Claude state. A separate
+Claude Desktop account needs at least one Cowork session identifying its organization and a matching
+cached Desktop login; signing into Desktop alone does not create a card. Desktop credentials are
+pinned to their verified or uniquely remembered organization, so switching Desktop's active
+organization cannot make a card borrow another account's usage. If users share an organization, or
+another known user's organization is missing, its Desktop login is not used until the owner can be
+verified. Previously seen accounts remain safety checks even while their cards are hidden. Sessions
+without a provable owner are left unassigned when multiple accounts are present. An incomplete session
+scan temporarily withholds Desktop spend history while a verified single-account login can still show
+its live limits. Old Cowork sessions can keep a signed-out organization visible with a login warning.
 
-Extra cards are named from the account ("Claude — Acme Corp"); right-click a card and choose **Rename…**
-(or use the Name field in Customize) to call it whatever you like. A card only shows while its login is
-still found on this Mac — log it out or delete the dir and the card disappears, keeping its
-customization and history for if it returns. Turn a card off like any provider in Customize.
+Changes to the default Claude Code login are detected within about five seconds; custom folders,
+Desktop logins, and new Cowork sessions are checked about once a minute. Existing sessions update on
+normal refreshes. The first Desktop refresh may ask for Keychain permission; choose **Always Allow**.
+Subscription upgrades or downgrades appear after Claude Code or Desktop updates its saved login
+details and OpenUsage refreshes; OpenUsage does not make a separate billing request.
 
-In the [CLI](../cli.md) and [local API](../local-http-api.md), extra cards appear under ids like
-`claude@ab12cd34`; requesting `claude` returns every Claude card.
+Cards keep their account identity, layout, and menu-bar pins when a login moves between sources or
+temporarily disappears. When several accounts share the same email address, their cards use the
+organization name instead; Claude's generic email-based organization becomes **Personal**. For
+example, **Claude — SUNSTORY** and **Claude — Personal** stay easy to tell apart. Right-click a card
+and choose **Rename…**, or change its name in Customize. Extra cards have identifiers such as
+`claude@ab12cd34`; the original account keeps the existing
+`claude` identifier even when it no longer occupies the default login. In the local API and CLI,
+requesting `claude` returns every Claude account. There are no manual Add Account or Remove Account
+controls; sign in or out through Claude Code or Claude Desktop instead.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## TL;DR

Keep account names, chart entries, saved layouts, menu-bar pins, and exported cards consistent as accounts appear, disappear, and return.

## What was happening

- Account customization could target a stale account record after a login change.
- Saved card ordering and menu-bar pins needed to survive a temporarily missing account.
- Shared spend cards and chart descriptions could omit remote-only accounts or stale account labels.

## What this changes

- Resolve rename placeholders and edit targets against the current verified runtime account.
- Preserve account-specific layout, card ordering, and menu-bar pins across account disappearance and return.
- Keep local and remote account names consistent in chart legends, descriptions, and shared cards.
- Move account-layout regressions into their own focused suite and remove duplicate general-layout cases.
- Explain account discovery, naming, logout, synchronization, and subscription changes in existing user-facing docs.

## Tests

- Focused account layout, general layout, account registry, spend aggregation, and shared-card rendering suites.

## Screenshots

![Named account cards and account-aware spend chart](https://github.com/robinebers/openusage/raw/d7df557ed8ac6fdf633eaf5f4172392a43a4c250/docs/assets/claude-multi-account.png)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches account identity, persisted layout, and spend-chart labeling. Wrong runtime resolution could rename or hide the wrong card, but the change is mostly view wiring plus tests rather than a new auth path.
> 
> **Overview**
> Keeps Claude/Codex account identity stable as logins move, vanish, and return: rename targets, default names, layout slots, and Total Spend labels now follow the **current verified runtime account**, not a stale stored record.
> 
> Rename in Customize and the dashboard alert resolve via `runtimeRecord` / `derivedDisplayName`, and the alert seeds from the custom label (empty = default). Total Spend still aggregates remote-only accounts, now listing them in the ⓘ tooltip and resolving live titles once so the ring legend and share export stay in sync.
> 
> Tests for absent-card order, first-appearance seeding, and customization surviving a graph rebuild move into `LayoutAccountTests`. Palette tests require distinct, stable account shades (including remote aliases). Docs cover multi-account discovery, org-based names, pending credential checks, and per-account spend slices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f17a72b9c5861fec0a2d434729eb3238599e2f13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->