### PR TITLE
Support multiple Claude accounts

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -71,13 +71,28 @@ final class AppContainer {
         // the snapshot cache's account stamp and reconciles the account registry.
         let accountAssembly = ProviderAccountAssembly.make(waitsForLoginShell: true)
 
-        let providers = ProviderCatalog.make()
+        let providers = ProviderCatalog.make(
+            claudeCards: accountAssembly.claudeCards,
+            claudeIdentityKeys: accountAssembly.identityKeysByCard
+        )
         let registry = WidgetRegistry.from(providers)
         let apiKeyProviders = providers.compactMap { $0 as? any APIKeyManaging }
         let enablement = ProviderEnablementStore()
         let notificationSettings = NotificationSettingsStore()
+        let additionalClaudeIDs = providers.map(\.provider.id).filter {
+            $0 != "claude" && ProviderAccountID.family(of: $0) == "claude"
+        }
+        let claudeAccountDefaults: ([String]) -> [String] = { metricIDs in
+            metricIDs.flatMap { metricID -> [String] in
+                guard metricID.hasPrefix("claude.") else { return [metricID] }
+                let suffix = metricID.dropFirst("claude".count)
+                return [metricID] + additionalClaudeIDs.map { "\($0)\(suffix)" }
+            }
+        }
         let layout = LayoutStore(
             registry: registry,
+            defaultMetricIDs: claudeAccountDefaults(DefaultLayout.metricIDs),
+            defaultExpandedMetricIDs: claudeAccountDefaults(DefaultLayout.expandedMetricIDs),
             isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
         )
         let dataStore = WidgetDataStore(

--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -92,6 +92,7 @@ final class AppContainer {
         let layout = LayoutStore(
             registry: registry,
             defaultMetricIDs: claudeAccountDefaults(DefaultLayout.metricIDs),
+            defaultPinnedMetricIDs: claudeAccountDefaults(DefaultLayout.pinnedMetricIDs),
             defaultExpandedMetricIDs: claudeAccountDefaults(DefaultLayout.expandedMetricIDs),
             isProviderEnabled: { [enablement] in enablement.isEnabled($0) }
         )

--- a/Sources/OpenUsage/App/OpenUsageApp.swift
+++ b/Sources/OpenUsage/App/OpenUsageApp.swift
@@ -68,6 +68,21 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // preferredColorScheme, so the override is applied at the AppKit level once at launch;
         // the Theme picker on the Settings screen re-applies it on change.
         AppearanceSetting.applyCurrent()
+
+        if ShellEnvironmentSnapshotStore.launchSnapshot == nil,
+           !LoginShellEnvironment.shared.capturedSuccessfully {
+            Task { [weak self] in
+                await Task.detached(priority: .userInitiated) {
+                    _ = LoginShellEnvironment.shared.ensureCaptured()
+                }.value
+                self?.finishLaunching(isFreshInstall: isFreshInstall)
+            }
+            return
+        }
+        finishLaunching(isFreshInstall: isFreshInstall)
+    }
+
+    private func finishLaunching(isFreshInstall: Bool) {
         let container = AppContainer(isFreshInstall: isFreshInstall)
         self.container = container
         statusItemController = StatusItemController(container: container, updater: updater)

--- a/Sources/OpenUsage/Models/UsageHistoryDocument.swift
+++ b/Sources/OpenUsage/Models/UsageHistoryDocument.swift
@@ -3,12 +3,15 @@ import Foundation
 /// One Mac's presentation-free usage history in the private iCloud container.
 struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
     static let currentSchema = "openusage.history.v1"
+    static let accountSchema = "openusage.history.v2"
 
     var schema: String = currentSchema
     var deviceID: String
     var deviceName: String
     var updatedAt: Date
     var providers: [String: ProviderUsageHistory]
+    /// Claude card ownership, when known. Older clients ignore this optional v1 field.
+    var identities: [String: String]? = nil
 
     var id: String { deviceID }
 
@@ -24,14 +27,42 @@ struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
     }
 
     func validate() throws {
-        guard schema == Self.currentSchema else { throw UsageHistoryDocumentError.unsupportedSchema }
+        guard schema == Self.currentSchema || schema == Self.accountSchema else {
+            throw UsageHistoryDocumentError.unsupportedSchema
+        }
         guard !deviceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !deviceName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { throw UsageHistoryDocumentError.invalidDevice }
 
+        var seenIdentities = Set<String>()
+        for (providerID, identity) in identities ?? [:] {
+            guard providers[providerID] != nil,
+                  ProviderAccountID.family(of: providerID) == "claude",
+                  !identity.isEmpty,
+                  identity.rangeOfCharacter(from: .whitespacesAndNewlines.union(.controlCharacters)) == nil,
+                  !identity.contains("/"), !identity.contains("\\")
+            else { throw UsageHistoryDocumentError.invalidIdentity(providerID) }
+            guard seenIdentities.insert(identity.lowercased()).inserted else {
+                throw UsageHistoryDocumentError.duplicateIdentity(providerID)
+            }
+        }
+
+        let providerPattern = schema == Self.currentSchema
+            ? #"^[a-z0-9][a-z0-9-]*$"#
+            : #"^[a-z0-9][a-z0-9-]*(?:@[a-f0-9]{8})?$"#
         for (providerID, history) in providers {
-            guard providerID.range(of: #"^[a-z0-9][a-z0-9-]*$"#, options: .regularExpression) != nil else {
+            guard providerID.range(of: providerPattern, options: .regularExpression) != nil else {
                 throw UsageHistoryDocumentError.invalidProvider(providerID)
+            }
+            if providerID.contains("@") {
+                guard ProviderAccountID.family(of: providerID) == "claude",
+                      identities?[providerID] != nil
+                else { throw UsageHistoryDocumentError.invalidIdentity(providerID) }
+            }
+            if schema == Self.accountSchema, ProviderAccountID.family(of: providerID) == "claude" {
+                guard identities?[providerID] != nil else {
+                    throw UsageHistoryDocumentError.invalidIdentity(providerID)
+                }
             }
             var seriesDays: Set<String> = []
             for day in history.series.daily {
@@ -100,6 +131,8 @@ enum UsageHistoryDocumentError: Error, LocalizedError, Equatable {
     case unsupportedSchema
     case invalidDevice
     case invalidProvider(String)
+    case invalidIdentity(String)
+    case duplicateIdentity(String)
     case invalidDay(String)
     case duplicateDay(String)
     case duplicateModel(String)
@@ -110,6 +143,8 @@ enum UsageHistoryDocumentError: Error, LocalizedError, Equatable {
         case .unsupportedSchema: "This Mac wrote a newer usage-history format. Update OpenUsage."
         case .invalidDevice: "The synced Mac identity is invalid."
         case .invalidProvider: "The synced provider identifier is invalid."
+        case .invalidIdentity: "The synced Claude account identity is invalid."
+        case .duplicateIdentity: "The synced Claude account appears more than once."
         case .invalidDay: "The synced history contains an invalid date."
         case .duplicateDay: "The synced history contains the same date more than once."
         case .duplicateModel: "The synced history contains the same model more than once."

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -172,6 +172,7 @@ struct ClaudeAuthStore: Sendable {
     let desktopOrganization: String?
     let expectedIdentityKey: String?
     let desktopOnly: Bool
+    let preferOrganizationScopedDesktop: Bool
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
@@ -181,6 +182,7 @@ struct ClaudeAuthStore: Sendable {
         desktopOrganization: String? = nil,
         expectedIdentityKey: String? = nil,
         desktopOnly: Bool = false,
+        preferOrganizationScopedDesktop: Bool = false,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.environment = environment
@@ -190,6 +192,7 @@ struct ClaudeAuthStore: Sendable {
         self.desktopOrganization = desktopOrganization?.lowercased()
         self.expectedIdentityKey = expectedIdentityKey?.lowercased()
         self.desktopOnly = desktopOnly
+        self.preferOrganizationScopedDesktop = preferOrganizationScopedDesktop
         self.now = now
     }
 
@@ -204,13 +207,14 @@ struct ClaudeAuthStore: Sendable {
     ) -> ClaudeCredentialLoad {
         var stored = desktopOnly ? [] : orderedStoredCandidates()
         var desktopStatus: ClaudeDesktopCredentialStatus = .notChecked
-        // A working CLI login remains the source of truth and avoids a second Keychain prompt. Desktop
-        // is a fallback for people who only use the native app (or whose stored CLI login lacks profile
-        // scope), never a competing account source.
+        // A working CLI login normally remains the source of truth and avoids a second Keychain prompt.
+        // When several organizations have cards, though, its global Keychain token can belong to a
+        // different organization than the CLI state file, so prefer the Desktop token pinned to this
+        // card's organization while retaining the CLI credential as a fallback.
         let hasUsableCLILogin = stored.contains {
             $0.hasUsableAccessToken && liveUsageAvailability($0) == .available
         }
-        if forceDesktopFallback || !hasUsableCLILogin {
+        if forceDesktopFallback || !hasUsableCLILogin || preferOrganizationScopedDesktop {
             let expectedUser = expectedIdentityKey?.split(separator: "|").first.map(String.init)
             let result = desktop.load(
                 allowInteraction: allowDesktopInteraction,

--- a/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeAuthStore.swift
@@ -169,18 +169,27 @@ struct ClaudeAuthStore: Sendable {
     var keychain: KeychainAccessing
     var desktop: ClaudeDesktopAuthStore
     var now: @Sendable () -> Date
+    let desktopOrganization: String?
+    let expectedIdentityKey: String?
+    let desktopOnly: Bool
 
     init(
         environment: EnvironmentReading = ProcessEnvironmentReader(),
         files: TextFileAccessing = LocalTextFileAccessor(),
         keychain: KeychainAccessing = SecurityKeychainAccessor(),
         desktop: ClaudeDesktopAuthStore? = nil,
+        desktopOrganization: String? = nil,
+        expectedIdentityKey: String? = nil,
+        desktopOnly: Bool = false,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.environment = environment
         self.files = files
         self.keychain = keychain
         self.desktop = desktop ?? ClaudeDesktopAuthStore(files: files, now: now)
+        self.desktopOrganization = desktopOrganization?.lowercased()
+        self.expectedIdentityKey = expectedIdentityKey?.lowercased()
+        self.desktopOnly = desktopOnly
         self.now = now
     }
 
@@ -193,7 +202,7 @@ struct ClaudeAuthStore: Sendable {
         allowDesktopInteraction: Bool = false,
         forceDesktopFallback: Bool = false
     ) -> ClaudeCredentialLoad {
-        var stored = orderedStoredCandidates()
+        var stored = desktopOnly ? [] : orderedStoredCandidates()
         var desktopStatus: ClaudeDesktopCredentialStatus = .notChecked
         // A working CLI login remains the source of truth and avoids a second Keychain prompt. Desktop
         // is a fallback for people who only use the native app (or whose stored CLI login lacks profile
@@ -202,7 +211,12 @@ struct ClaudeAuthStore: Sendable {
             $0.hasUsableAccessToken && liveUsageAvailability($0) == .available
         }
         if forceDesktopFallback || !hasUsableCLILogin {
-            let result = desktop.load(allowInteraction: allowDesktopInteraction)
+            let expectedUser = expectedIdentityKey?.split(separator: "|").first.map(String.init)
+            let result = desktop.load(
+                allowInteraction: allowDesktopInteraction,
+                organization: desktopOrganization,
+                expectedAccountUUID: expectedUser
+            )
             desktopStatus = result.status
             if let oauth = result.oauth {
                 stored.insert(ClaudeCredentialState(
@@ -214,7 +228,7 @@ struct ClaudeAuthStore: Sendable {
             }
         }
 
-        let candidates = applyingEnvironmentToken(to: stored)
+        let candidates = desktopOnly ? stored : applyingEnvironmentToken(to: stored)
         return ClaudeCredentialLoad(candidates: candidates, desktopStatus: desktopStatus)
     }
 

--- a/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeDesktopAuthStore.swift
@@ -16,6 +16,7 @@ enum ClaudeDesktopCredentialStatus: Sendable, Equatable {
 struct ClaudeDesktopCredentialResult: Sendable {
     var oauth: ClaudeOAuth?
     var status: ClaudeDesktopCredentialStatus
+    var organization: String? = nil
 }
 
 protocol ClaudeDesktopSafeStorageKeyReading: Sendable {
@@ -120,10 +121,34 @@ struct ClaudeDesktopAuthStore: Sendable {
         else {
             return false
         }
-        return Self.cookieRelativePaths.contains { files.exists(path($0)) }
+        let sql = "SELECT 1 FROM cookies WHERE name = 'lastActiveOrg' AND host_key IN ('.claude.ai', 'claude.ai') LIMIT 1"
+        return Self.cookieRelativePaths.contains { relativePath in
+            let databasePath = path(relativePath)
+            return files.exists(databasePath)
+                && (try? sqlite.queryValue(path: databasePath, sql: sql)) != nil
+        }
     }
 
-    func load(allowInteraction: Bool) -> ClaudeDesktopCredentialResult {
+    func lastKnownAccountUUID() -> String? {
+        guard let text = try? files.readTextIfPresent(path(Self.configRelativePath)),
+              let data = text.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let user = root["lastKnownAccountUuid"] as? String,
+              UUID(uuidString: user) != nil
+        else { return nil }
+        return user.lowercased()
+    }
+
+    func load(
+        allowInteraction: Bool,
+        organization: String? = nil,
+        expectedAccountUUID: String? = nil
+    ) -> ClaudeDesktopCredentialResult {
+        if let expectedAccountUUID,
+           lastKnownAccountUUID()?.caseInsensitiveCompare(expectedAccountUUID) != .orderedSame
+        {
+            return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
+        }
         guard hasCredentialMaterial() else {
             return ClaudeDesktopCredentialResult(oauth: nil, status: .notFound)
         }
@@ -138,15 +163,18 @@ struct ClaudeDesktopAuthStore: Sendable {
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .invalid)
             }
 
+            let targetOrganization = organization?.lowercased() ?? activeOrg
             let selection = Self.selectCredential(
-                activeOrganization: activeOrg,
+                activeOrganization: targetOrganization,
                 v2: caches.v2,
                 v1: caches.v1,
                 now: now()
             )
             switch selection {
             case .available(let oauth):
-                return ClaudeDesktopCredentialResult(oauth: oauth, status: .available)
+                return ClaudeDesktopCredentialResult(
+                    oauth: oauth, status: .available, organization: targetOrganization
+                )
             case .stale:
                 return ClaudeDesktopCredentialResult(oauth: nil, status: .stale)
             case .notFound:

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -28,6 +28,7 @@ actor ClaudeLogUsageScanner {
     private let cacheIdentityOverride: String?
     private let organizationID: String?
     private let accountID: String?
+    private let allowsUnattributedSessions: Bool
     private var sessionOwnership: [String: (
         size: Int, mtime: Date, organizationID: String?, accountID: String?
     )] = [:]
@@ -64,7 +65,8 @@ actor ClaudeLogUsageScanner {
         incrementalScanner: IncrementalJSONLScanner<Entry>? = nil,
         cacheIdentityOverride: String? = nil,
         accountUUID: String? = nil,
-        organizationUUID: String? = nil
+        organizationUUID: String? = nil,
+        allowsUnattributedSessions: Bool = false
     ) {
         precondition(cacheIdentityOverride?.isEmpty != true)
         self.environment = environment
@@ -73,6 +75,7 @@ actor ClaudeLogUsageScanner {
         self.cacheIdentityOverride = cacheIdentityOverride
         self.organizationID = organizationUUID?.lowercased()
         self.accountID = accountUUID?.lowercased()
+        self.allowsUnattributedSessions = allowsUnattributedSessions
     }
 
     /// Scan the last `daysBack` days of Claude logs. Returns `nil` when no Claude data directory or
@@ -281,6 +284,8 @@ actor ClaudeLogUsageScanner {
                 if owner == organizationID, accountID == nil || ownership.accountID == accountID {
                     ownedFiles.append(file)
                 }
+            } else if allowsUnattributedSessions {
+                ownedFiles.append(file)
             } else if let accountID {
                 if desktopSessionIDs == nil {
                     desktopSessionIDs = indexedDesktopSessionIDs(accountID: accountID, organizationID: organizationID)

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -26,6 +26,11 @@ actor ClaudeLogUsageScanner {
     /// Scoped provider instances pass their stable parse-source identity here. Account or time filters
     /// over the same physical roots deliberately pass the same value and share whole-file records.
     private let cacheIdentityOverride: String?
+    private let organizationID: String?
+    private let accountID: String?
+    private var sessionOwnership: [String: (
+        size: Int, mtime: Date, organizationID: String?, accountID: String?
+    )] = [:]
 
     /// One parsed usage line. Token buckets are pre-normalized into `TokenBreakdown`; dedup fields
     /// ride along so the global dedup pass can run over cached entries.
@@ -57,13 +62,17 @@ actor ClaudeLogUsageScanner {
         environment: EnvironmentReading = ProcessEnvironmentReader(),
         homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
         incrementalScanner: IncrementalJSONLScanner<Entry>? = nil,
-        cacheIdentityOverride: String? = nil
+        cacheIdentityOverride: String? = nil,
+        accountUUID: String? = nil,
+        organizationUUID: String? = nil
     ) {
         precondition(cacheIdentityOverride?.isEmpty != true)
         self.environment = environment
         self.homeDirectory = homeDirectory
         self.scanner = incrementalScanner ?? Self.sharedScanner
         self.cacheIdentityOverride = cacheIdentityOverride
+        self.organizationID = organizationUUID?.lowercased()
+        self.accountID = accountUUID?.lowercased()
     }
 
     /// Scan the last `daysBack` days of Claude logs. Returns `nil` when no Claude data directory or
@@ -80,7 +89,11 @@ actor ClaudeLogUsageScanner {
             return nil
         }
 
-        let files = Self.usageFiles(under: roots)
+        var files = Self.usageFiles(under: roots)
+        if let organizationID {
+            files = ownedUsageFiles(files, organizationID: organizationID)
+        }
+        guard !Task.isCancelled else { return nil }
         guard !files.isEmpty else {
             _ = await scanner.items(
                 from: [], since: since, cacheIdentity: cacheIdentity, parse: Self.parseFile
@@ -171,7 +184,9 @@ actor ClaudeLogUsageScanner {
             addIfValid(home.appendingPathComponent(".claude"))
         }
 
-        for sandbox in Self.coworkClaudeDirs(home: homeDirectory()) {
+        for sandbox in Self.coworkClaudeDirs(
+            home: homeDirectory(), organizationID: organizationID, accountID: accountID
+        ) {
             addIfValid(sandbox)
         }
         return roots
@@ -182,7 +197,7 @@ actor ClaudeLogUsageScanner {
     /// (plus an `agent/local_*` variant one level deeper). Each holds the same `projects/**/*.jsonl`
     /// session logs as `~/.claude`, so they scan as additional roots. The walk is bounded to those
     /// known levels — session dirs contain full sandbox homes we must not recurse into.
-    private static func coworkClaudeDirs(home: URL) -> [URL] {
+    private static func coworkClaudeDirs(home: URL, organizationID: String?, accountID: String?) -> [URL] {
         let base = home
             .appendingPathComponent("Library/Application Support/Claude/local-agent-mode-sessions")
 
@@ -197,7 +212,12 @@ actor ClaudeLogUsageScanner {
 
         var dirs: [URL] = []
         for group in subdirectories(of: base) {
+            guard organizationID == nil || accountID == nil || group.lastPathComponent.lowercased() == accountID
+            else { continue }
             for sub in subdirectories(of: group) {
+                guard organizationID == nil || sub.lastPathComponent.lowercased() == organizationID else {
+                    continue
+                }
                 var sessions = subdirectories(of: sub)
                 for holder in sessions where holder.lastPathComponent == "agent" {
                     sessions.append(contentsOf: subdirectories(of: holder))
@@ -216,6 +236,93 @@ actor ClaudeLogUsageScanner {
         roots
             .flatMap { JSONLScanning.jsonlFiles(under: $0.appendingPathComponent("projects")) }
             .sorted { $0.path < $1.path }
+    }
+
+    /// Desktop roots already carry their organization in the verified directory layout. Terminal
+    /// sessions identify theirs in a separate bridge event; subagent files inherit that event from
+    /// their parent session. Keep this outside the parsed-entry cache so all cards still share it.
+    private func ownedUsageFiles(
+        _ files: [JSONLScanning.DiscoveredFile],
+        organizationID: String
+    ) -> [JSONLScanning.DiscoveredFile] {
+        let coworkPrefix = homeDirectory()
+            .appendingPathComponent("Library/Application Support/Claude/local-agent-mode-sessions")
+            .resolvingSymlinksInPath().path + "/"
+        let filesByPath = Dictionary(files.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
+        var seenPaths: Set<String> = []
+        var ownedFiles: [JSONLScanning.DiscoveredFile] = []
+
+        for file in files {
+            guard !Task.isCancelled else { return [] }
+            guard seenPaths.insert(file.path).inserted else { continue }
+            let canonicalPath = URL(fileURLWithPath: file.path).resolvingSymlinksInPath().path
+            if canonicalPath.hasPrefix(coworkPrefix) {
+                let components = canonicalPath.dropFirst(coworkPrefix.count).split(separator: "/")
+                if components.count > 1,
+                   components[1].lowercased() == organizationID,
+                   accountID == nil || components[0].lowercased() == accountID
+                {
+                    ownedFiles.append(file)
+                }
+                continue
+            }
+
+            let directory = URL(fileURLWithPath: file.path).deletingLastPathComponent()
+            let sessionFile: JSONLScanning.DiscoveredFile?
+            if directory.lastPathComponent == "subagents" {
+                let parentPath = directory.deletingLastPathComponent().appendingPathExtension("jsonl").path
+                sessionFile = filesByPath[parentPath]
+            } else {
+                sessionFile = file
+            }
+            if let sessionFile,
+               let ownership = sessionIdentity(sessionFile),
+               ownership.organizationID == organizationID,
+               accountID == nil || ownership.accountID == accountID
+            {
+                ownedFiles.append(file)
+            }
+        }
+        return ownedFiles
+    }
+
+    private func sessionIdentity(
+        _ file: JSONLScanning.DiscoveredFile
+    ) -> (organizationID: String?, accountID: String?)? {
+        if let cached = sessionOwnership[file.path],
+           cached.size == file.size, cached.mtime == file.mtime
+        {
+            return (cached.organizationID, cached.accountID)
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: URL(fileURLWithPath: file.path), options: .mappedIfSafe)
+        } catch {
+            AppLog.warn(LogTag.plugin("claude"), "Failed to read Claude session ownership from \(file.path): \(error)")
+            return nil
+        }
+
+        let marker = Data(#""ownerOrganizationUuid""#.utf8)
+        var owner: String?
+        var account: String?
+        for line in data.split(separator: UInt8(ascii: "\n")) where line.range(of: marker) != nil {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
+                  let value = object["ownerOrganizationUuid"] as? String,
+                  !value.isEmpty
+            else { continue }
+            let candidate = value.lowercased()
+            if let owner, owner != candidate { return nil }
+            owner = candidate
+            if let candidateAccount = object["ownerAccountUuid"] as? String, !candidateAccount.isEmpty {
+                let normalizedAccount = candidateAccount.lowercased()
+                if let account, account != normalizedAccount { return nil }
+                account = normalizedAccount
+            }
+        }
+
+        sessionOwnership[file.path] = (file.size, file.mtime, owner, account)
+        return (owner, account)
     }
 
     // MARK: - Line parsing

--- a/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeLogUsageScanner.swift
@@ -238,9 +238,9 @@ actor ClaudeLogUsageScanner {
             .sorted { $0.path < $1.path }
     }
 
-    /// Desktop roots already carry their organization in the verified directory layout. Terminal
-    /// sessions identify theirs in a separate bridge event; subagent files inherit that event from
-    /// their parent session. Keep this outside the parsed-entry cache so all cards still share it.
+    /// Cowork roots carry their organization in the directory layout. Other sessions identify theirs
+    /// in a bridge event or Desktop's account-and-organization-scoped session index; subagent files
+    /// inherit their parent session's ownership. Keep this outside the shared parsed-entry cache.
     private func ownedUsageFiles(
         _ files: [JSONLScanning.DiscoveredFile],
         organizationID: String
@@ -251,6 +251,7 @@ actor ClaudeLogUsageScanner {
         let filesByPath = Dictionary(files.map { ($0.path, $0) }, uniquingKeysWith: { first, _ in first })
         var seenPaths: Set<String> = []
         var ownedFiles: [JSONLScanning.DiscoveredFile] = []
+        var desktopSessionIDs: Set<String>?
 
         for file in files {
             guard !Task.isCancelled else { return [] }
@@ -275,15 +276,50 @@ actor ClaudeLogUsageScanner {
             } else {
                 sessionFile = file
             }
-            if let sessionFile,
-               let ownership = sessionIdentity(sessionFile),
-               ownership.organizationID == organizationID,
-               accountID == nil || ownership.accountID == accountID
-            {
-                ownedFiles.append(file)
+            guard let sessionFile, let ownership = sessionIdentity(sessionFile) else { continue }
+            if let owner = ownership.organizationID {
+                if owner == organizationID, accountID == nil || ownership.accountID == accountID {
+                    ownedFiles.append(file)
+                }
+            } else if let accountID {
+                if desktopSessionIDs == nil {
+                    desktopSessionIDs = indexedDesktopSessionIDs(accountID: accountID, organizationID: organizationID)
+                }
+                let sessionID = URL(fileURLWithPath: sessionFile.path)
+                    .deletingPathExtension().lastPathComponent.lowercased()
+                if desktopSessionIDs?.contains(sessionID) == true {
+                    ownedFiles.append(file)
+                }
             }
         }
         return ownedFiles
+    }
+
+    private func indexedDesktopSessionIDs(accountID: String, organizationID: String) -> Set<String> {
+        let directory = homeDirectory()
+            .appendingPathComponent("Library/Application Support/Claude/claude-code-sessions")
+            .appendingPathComponent(accountID)
+            .appendingPathComponent(organizationID)
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        return Set(files.compactMap { file in
+            guard file.lastPathComponent.hasPrefix("local_"), file.pathExtension == "json",
+                  let values = try? file.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+                  values.isRegularFile == true, values.isSymbolicLink != true,
+                  let handle = try? FileHandle(forReadingFrom: file)
+            else { return nil }
+            defer { try? handle.close() }
+            guard let prefix = try? handle.read(upToCount: 512),
+                  let header = String(data: prefix, encoding: .utf8),
+                  let field = header.range(of: #""cliSessionId"\s*:\s*""#, options: .regularExpression),
+                  let end = header[field.upperBound...].firstIndex(of: "\""),
+                  let sessionID = UUID(uuidString: String(header[field.upperBound..<end]))
+            else { return nil }
+            return sessionID.uuidString.lowercased()
+        })
     }
 
     private func sessionIdentity(

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -347,10 +347,20 @@ final class ClaudeProvider: ProviderRuntime {
 
         var working = state
         defer { state = working }
-        try await verifyAccountIfNeeded(accessToken: working.oauth.accessToken ?? "")
+        var verificationResponse = try await verifyAccountIfNeeded(
+            accessToken: working.oauth.accessToken ?? ""
+        )
         let response = try await ProviderAuthRetry.fetch(
             token: working.oauth.accessToken ?? "",
-            attempt: { try await self.usageClient.fetchUsage(accessToken: $0, config: self.authStore.oauthConfig()) },
+            attempt: { accessToken in
+                if let response = verificationResponse {
+                    verificationResponse = nil
+                    return response
+                }
+                return try await self.usageClient.fetchUsage(
+                    accessToken: accessToken, config: self.authStore.oauthConfig()
+                )
+            },
             refreshAccessToken: {
                 if working.source == .desktop {
                     throw ClaudeAuthError.desktopTokenExpired
@@ -366,7 +376,9 @@ final class ClaudeProvider: ProviderRuntime {
                 if refreshed.persisted {
                     expectedGeneration = expectedGeneration.replacing(working)
                 }
-                try await self.verifyAccountIfNeeded(accessToken: refreshed.accessToken)
+                verificationResponse = try await self.verifyAccountIfNeeded(
+                    accessToken: refreshed.accessToken
+                )
                 return refreshed.accessToken
             },
             connectionFailed: ClaudeUsageError.connectionFailed,
@@ -394,16 +406,19 @@ final class ClaudeProvider: ProviderRuntime {
         return mapped
     }
 
-    private func verifyAccountIfNeeded(accessToken: String) async throws {
+    private func verifyAccountIfNeeded(accessToken: String) async throws -> HTTPResponse? {
         guard let identity = authStore.expectedIdentityKey,
               identity.split(separator: "|").count == 2
-        else { return }
+        else { return nil }
         let fingerprint = Data(SHA256.hash(data: Data("\(identity)\u{0}\(accessToken)".utf8)))
-        guard verifiedCredentialFingerprint != fingerprint else { return }
-        try await usageClient.verifyAccount(
+        guard verifiedCredentialFingerprint != fingerprint else { return nil }
+        if let response = try await usageClient.verifyAccount(
             accessToken: accessToken, expectedIdentityKey: identity, config: authStore.oauthConfig()
-        )
+        ) {
+            return response
+        }
         verifiedCredentialFingerprint = fingerprint
+        return nil
     }
 
     /// Last-good usage with an appended staleness note when we have it; otherwise the plain rate-limited

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -29,6 +29,7 @@ final class ClaudeProvider: ProviderRuntime {
     /// entirely until the cooldown expires so we don't keep hammering an endpoint that's already limiting
     /// us. Mirrors the legacy plugin's `cachedUsageData` + `rateLimitedUntilMs`.
     private var cachedCredentialFingerprint: Data?
+    private var verifiedCredentialFingerprint: Data?
     private var lastGoodUsage: ClaudeMappedUsage?
     private var rateLimitedUntil: Date?
     private static let rateLimitCooldown: TimeInterval = 5 * 60
@@ -346,6 +347,7 @@ final class ClaudeProvider: ProviderRuntime {
 
         var working = state
         defer { state = working }
+        try await verifyAccountIfNeeded(accessToken: working.oauth.accessToken ?? "")
         let response = try await ProviderAuthRetry.fetch(
             token: working.oauth.accessToken ?? "",
             attempt: { try await self.usageClient.fetchUsage(accessToken: $0, config: self.authStore.oauthConfig()) },
@@ -364,6 +366,7 @@ final class ClaudeProvider: ProviderRuntime {
                 if refreshed.persisted {
                     expectedGeneration = expectedGeneration.replacing(working)
                 }
+                try await self.verifyAccountIfNeeded(accessToken: refreshed.accessToken)
                 return refreshed.accessToken
             },
             connectionFailed: ClaudeUsageError.connectionFailed,
@@ -389,6 +392,18 @@ final class ClaudeProvider: ProviderRuntime {
         lastGoodUsage = mapped
         rateLimitedUntil = nil
         return mapped
+    }
+
+    private func verifyAccountIfNeeded(accessToken: String) async throws {
+        guard let identity = authStore.expectedIdentityKey,
+              identity.split(separator: "|").count == 2
+        else { return }
+        let fingerprint = Data(SHA256.hash(data: Data("\(identity)\u{0}\(accessToken)".utf8)))
+        guard verifiedCredentialFingerprint != fingerprint else { return }
+        try await usageClient.verifyAccount(
+            accessToken: accessToken, expectedIdentityKey: identity, config: authStore.oauthConfig()
+        )
+        verifiedCredentialFingerprint = fingerprint
     }
 
     /// Last-good usage with an appended staleness note when we have it; otherwise the plain rate-limited

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -3,19 +3,23 @@ import Foundation
 
 @MainActor
 final class ClaudeProvider: ProviderRuntime {
-    let provider = Provider(
-        id: "claude",
-        displayName: "Claude",
-        icon: .providerMark("claude"),
-        links: [
-            .init(label: "Status", url: "https://status.anthropic.com/"),
-            .init(label: "Dashboard", url: "https://claude.ai/settings/usage")
-        ]
-    )
+    static func makeProvider(id: String = "claude", displayName: String = "Claude") -> Provider {
+        Provider(
+            id: id,
+            displayName: displayName,
+            icon: .providerMark("claude"),
+            links: [
+                .init(label: "Status", url: "https://status.anthropic.com/"),
+                .init(label: "Dashboard", url: "https://claude.ai/settings/usage")
+            ]
+        )
+    }
 
+    let provider: Provider
     let authStore: ClaudeAuthStore
     let usageClient: ClaudeUsageClient
     let logUsageScanner: ClaudeLogUsageScanner
+    let allowsUnattributedPiUsage: Bool
     let now: @Sendable () -> Date
     let pricing: @Sendable () async -> ModelPricing
 
@@ -30,30 +34,34 @@ final class ClaudeProvider: ProviderRuntime {
     private static let rateLimitCooldown: TimeInterval = 5 * 60
 
     init(
+        provider: Provider = ClaudeProvider.makeProvider(),
         authStore: ClaudeAuthStore = ClaudeAuthStore(),
         usageClient: ClaudeUsageClient = ClaudeUsageClient(),
         logUsageScanner: ClaudeLogUsageScanner = ClaudeLogUsageScanner(),
+        allowsUnattributedPiUsage: Bool = true,
         now: @escaping @Sendable () -> Date = Date.init,
         pricing: @escaping @Sendable () async -> ModelPricing = { await ModelPricingStore.shared.current() }
     ) {
+        self.provider = provider
         self.authStore = authStore
         self.usageClient = usageClient
         self.logUsageScanner = logUsageScanner
+        self.allowsUnattributedPiUsage = allowsUnattributedPiUsage
         self.now = now
         self.pricing = pricing
     }
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "claude.session", provider: provider, title: "Session", isSessionWindow: true)
+            .percent(id: "\(provider.id).session", provider: provider, title: "Session", isSessionWindow: true)
                 .exportingLimit("session", unit: "percent"),
-            .percent(id: "claude.weekly", provider: provider, title: "Weekly")
+            .percent(id: "\(provider.id).weekly", provider: provider, title: "Weekly")
                 .exportingLimit("weekly", unit: "percent"),
-            .percent(id: "claude.fable", provider: provider, title: "Fable")
+            .percent(id: "\(provider.id).fable", provider: provider, title: "Fable")
                 .exportingLimit("fable", unit: "percent"),
-            .percent(id: "claude.sonnet", provider: provider, title: "Sonnet")
+            .percent(id: "\(provider.id).sonnet", provider: provider, title: "Sonnet")
                 .exportingLimit("sonnet", unit: "percent"),
-            .boundedDollars(id: "claude.extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent")
+            .boundedDollars(id: "\(provider.id).extra", provider: provider, title: "Extra Usage", metricLabel: "Extra usage spent", limit: 100, valueWord: "spent")
                 .exportingLimit("extraUsage", unit: "usd", source: .progressOrValue(kind: .dollars)),
             .usageTrend(provider: provider)
                 .exportingHistory(
@@ -274,7 +282,9 @@ final class ClaudeProvider: ProviderRuntime {
         // Both scans run on their scanner actors, off the main actor, and do not require an OAuth login.
         let pricing = await pricing()
         let nativeScan = await logUsageScanner.scan(now: now(), pricing: pricing)
-        let piScan = await PiUsageScanner.shared.scan(cardID: provider.id, now: now(), pricing: pricing)
+        let piScan = allowsUnattributedPiUsage
+            ? await PiUsageScanner.shared.scan(cardID: provider.id, now: now(), pricing: pricing)
+            : nil
         var usageHistory: ProviderUsageHistory?
         // Cancellation can land between the native and pi scans. Treat the pair as one unit so a
         // partial result cannot replace the last-good combined history in WidgetDataStore.

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageClient.swift
@@ -80,27 +80,39 @@ struct ClaudeUsageClient: Sendable {
         )
     }
 
-    func verifyAccount(accessToken: String, expectedIdentityKey: String, config: ClaudeOAuthConfig) async throws {
+    func verifyAccount(
+        accessToken: String,
+        expectedIdentityKey: String,
+        config: ClaudeOAuthConfig
+    ) async throws -> HTTPResponse? {
         let expected = expectedIdentityKey.split(separator: "|", omittingEmptySubsequences: false)
         guard expected.count == 2 else { throw ClaudeAuthError.sessionExpired }
 
-        let response = try await httpClient.send(HTTPRequest(
-            method: "GET",
-            url: config.usageURL.deletingLastPathComponent().appendingPathComponent("profile"),
-            headers: [
-                "Authorization": "Bearer \(accessToken.trimmingCharacters(in: .whitespacesAndNewlines))",
-                "Accept": "application/json",
-                "anthropic-beta": "oauth-2025-04-20"
-            ],
-            timeout: 10
-        ))
-        guard (200..<300).contains(response.statusCode),
-              let profile = try? JSONDecoder().decode(AccountProfile.self, from: response.body),
-              profile.account.uuid.caseInsensitiveCompare(String(expected[0])) == .orderedSame,
+        let response: HTTPResponse
+        do {
+            response = try await httpClient.send(HTTPRequest(
+                method: "GET",
+                url: config.usageURL.deletingLastPathComponent().appendingPathComponent("profile"),
+                headers: [
+                    "Authorization": "Bearer \(accessToken.trimmingCharacters(in: .whitespacesAndNewlines))",
+                    "Accept": "application/json",
+                    "anthropic-beta": "oauth-2025-04-20"
+                ],
+                timeout: 10
+            ))
+        } catch {
+            throw ClaudeUsageError.connectionFailed
+        }
+        guard (200..<300).contains(response.statusCode) else { return response }
+        guard let profile = try? JSONDecoder().decode(AccountProfile.self, from: response.body) else {
+            throw ClaudeUsageError.invalidResponse
+        }
+        guard profile.account.uuid.caseInsensitiveCompare(String(expected[0])) == .orderedSame,
               profile.organization?.uuid.caseInsensitiveCompare(String(expected[1])) == .orderedSame
         else {
             AppLog.warn(LogTag.auth("claude"), "Claude credential does not match its account or organization")
             throw ClaudeAuthError.sessionExpired
         }
+        return nil
     }
 }

--- a/Sources/OpenUsage/Providers/Claude/ClaudeUsageClient.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeUsageClient.swift
@@ -32,6 +32,12 @@ enum ClaudeUsageError: Error, LocalizedError, Equatable {
 struct ClaudeUsageClient: Sendable {
     private static let scopes = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
 
+    private struct AccountProfile: Decodable {
+        struct Identity: Decodable { var uuid: String }
+        var account: Identity
+        var organization: Identity?
+    }
+
     var httpClient: HTTPClient
 
     init(httpClient: HTTPClient = URLSessionHTTPClient()) {
@@ -73,5 +79,28 @@ struct ClaudeUsageClient: Sendable {
             )
         )
     }
-}
 
+    func verifyAccount(accessToken: String, expectedIdentityKey: String, config: ClaudeOAuthConfig) async throws {
+        let expected = expectedIdentityKey.split(separator: "|", omittingEmptySubsequences: false)
+        guard expected.count == 2 else { throw ClaudeAuthError.sessionExpired }
+
+        let response = try await httpClient.send(HTTPRequest(
+            method: "GET",
+            url: config.usageURL.deletingLastPathComponent().appendingPathComponent("profile"),
+            headers: [
+                "Authorization": "Bearer \(accessToken.trimmingCharacters(in: .whitespacesAndNewlines))",
+                "Accept": "application/json",
+                "anthropic-beta": "oauth-2025-04-20"
+            ],
+            timeout: 10
+        ))
+        guard (200..<300).contains(response.statusCode),
+              let profile = try? JSONDecoder().decode(AccountProfile.self, from: response.body),
+              profile.account.uuid.caseInsensitiveCompare(String(expected[0])) == .orderedSame,
+              profile.organization?.uuid.caseInsensitiveCompare(String(expected[1])) == .orderedSame
+        else {
+            AppLog.warn(LogTag.auth("claude"), "Claude credential does not match its account or organization")
+            throw ClaudeAuthError.sessionExpired
+        }
+    }
+}

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -18,7 +18,10 @@ enum ProviderCatalog {
             providers = claudeCards.map { card in
                 let identity = claudeIdentityKeys[card.id] ?? card.identityKey
                 let user = identity.split(separator: "|").first.map(String.init)
-                let scanner = ClaudeLogUsageScanner(accountUUID: user, organizationUUID: card.organizationID)
+                let scanner = ClaudeLogUsageScanner(
+                    accountUUID: user, organizationUUID: card.organizationID,
+                    allowsUnattributedSessions: card.allowsUnattributedPiUsage
+                )
                 return ClaudeProvider(
                     provider: ClaudeProvider.makeProvider(
                         id: card.id,

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -27,7 +27,8 @@ enum ProviderCatalog {
                     authStore: ClaudeAuthStore(
                         desktopOrganization: card.organizationID,
                         expectedIdentityKey: identity,
-                        desktopOnly: card.usesDesktopCredentials
+                        desktopOnly: card.usesDesktopCredentials,
+                        preferOrganizationScopedDesktop: claudeCards.count > 1 && !card.usesDesktopCredentials
                     ),
                     logUsageScanner: scanner,
                     allowsUnattributedPiUsage: card.allowsUnattributedPiUsage

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -4,11 +4,39 @@ import Foundation
 /// their runtimes here so credentials, refresh behavior, pricing, and normalization can never drift.
 @MainActor
 enum ProviderCatalog {
-    static func make(defaults: UserDefaults = .standard) -> [ProviderRuntime] {
+    static func make(
+        defaults: UserDefaults = .standard,
+        claudeCards: [ClaudeAccountCard] = [],
+        claudeIdentityKeys: [String: String] = [:]
+    ) -> [ProviderRuntime] {
         // Default provider order (see AGENTS.md "## Providers"): the three established providers first,
         // then every other provider alphabetically by display name.
-        [
-            ClaudeProvider(),
+        var providers: [ProviderRuntime]
+        if claudeCards.isEmpty {
+            providers = [ClaudeProvider()]
+        } else {
+            providers = claudeCards.map { card in
+                let identity = claudeIdentityKeys[card.id] ?? card.identityKey
+                let user = identity.split(separator: "|").first.map(String.init)
+                let scanner = claudeCards.count == 1
+                    ? ClaudeLogUsageScanner()
+                    : ClaudeLogUsageScanner(accountUUID: user, organizationUUID: card.organizationID)
+                return ClaudeProvider(
+                    provider: ClaudeProvider.makeProvider(
+                        id: card.id,
+                        displayName: claudeCards.count == 1 ? "Claude" : card.displayName
+                    ),
+                    authStore: ClaudeAuthStore(
+                        desktopOrganization: card.organizationID,
+                        expectedIdentityKey: identity,
+                        desktopOnly: card.usesDesktopCredentials
+                    ),
+                    logUsageScanner: scanner,
+                    allowsUnattributedPiUsage: claudeCards.count == 1
+                )
+            }
+        }
+        providers += [
             CodexProvider(),
             CursorProvider(),
             AntigravityProvider(),
@@ -19,5 +47,6 @@ enum ProviderCatalog {
             OpenRouterProvider(),
             ZAIProvider()
         ]
+        return providers
     }
 }

--- a/Sources/OpenUsage/Providers/ProviderCatalog.swift
+++ b/Sources/OpenUsage/Providers/ProviderCatalog.swift
@@ -18,9 +18,7 @@ enum ProviderCatalog {
             providers = claudeCards.map { card in
                 let identity = claudeIdentityKeys[card.id] ?? card.identityKey
                 let user = identity.split(separator: "|").first.map(String.init)
-                let scanner = claudeCards.count == 1
-                    ? ClaudeLogUsageScanner()
-                    : ClaudeLogUsageScanner(accountUUID: user, organizationUUID: card.organizationID)
+                let scanner = ClaudeLogUsageScanner(accountUUID: user, organizationUUID: card.organizationID)
                 return ClaudeProvider(
                     provider: ClaudeProvider.makeProvider(
                         id: card.id,
@@ -32,7 +30,7 @@ enum ProviderCatalog {
                         desktopOnly: card.usesDesktopCredentials
                     ),
                     logUsageScanner: scanner,
-                    allowsUnattributedPiUsage: claudeCards.count == 1
+                    allowsUnattributedPiUsage: card.allowsUnattributedPiUsage
                 )
             }
         }

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -111,6 +111,11 @@ struct ProviderAccountAssembly {
             }
         }
 
+        guard families.contains("claude") else {
+            accountsStore.reconcile(with: observations)
+            return ProviderAccountAssembly(identityKeysByCard: identityKeys)
+        }
+
         if let claudeIdentity = identityKeys["claude"], !claudeIdentity.contains("|") {
             accountsStore.reconcile(with: observations)
             return ProviderAccountAssembly(identityKeysByCard: identityKeys)

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -6,6 +6,7 @@ struct ClaudeAccountCard: Equatable, Sendable {
     let organizationID: String
     let displayName: String
     let usesDesktopCredentials: Bool
+    let allowsUnattributedPiUsage: Bool
 }
 
 /// The launch-time account pass: read which account is signed in at each family's default home,
@@ -110,6 +111,11 @@ struct ProviderAccountAssembly {
             }
         }
 
+        if let claudeIdentity = identityKeys["claude"], !claudeIdentity.contains("|") {
+            accountsStore.reconcile(with: observations)
+            return ProviderAccountAssembly(identityKeysByCard: identityKeys)
+        }
+
         let desktop = desktop ?? ClaudeDesktopAuthStore(
             files: observer.files, homeDirectory: observer.homeDirectory
         )
@@ -138,6 +144,7 @@ struct ProviderAccountAssembly {
 
         let defaultClaudeIdentity = identityKeys["claude"]
         let records = accountsStore.reconcile(with: observations)
+        let allowsUnattributedPiUsage = records.count { $0.family == "claude" } == 1
         var cards: [ClaudeAccountCard] = []
         if let defaultIdentity = defaultClaudeIdentity,
            let organization = defaultIdentity.split(separator: "|").last,
@@ -152,7 +159,8 @@ struct ProviderAccountAssembly {
             } ?? "Organization"
             cards.append(ClaudeAccountCard(
                 id: record.id, identityKey: defaultIdentity, organizationID: String(organization),
-                displayName: "Claude — \(label)", usesDesktopCredentials: false
+                displayName: "Claude — \(label)", usesDesktopCredentials: false,
+                allowsUnattributedPiUsage: allowsUnattributedPiUsage
             ))
             identityKeys.removeValue(forKey: "claude")
             identityKeys[record.id] = defaultIdentity
@@ -166,7 +174,7 @@ struct ProviderAccountAssembly {
             cards.append(ClaudeAccountCard(
                 id: cardID, identityKey: organization.identityKey, organizationID: organization.id,
                 displayName: "Claude — \(organizationLabel(record.label) ?? organization.label)",
-                usesDesktopCredentials: true
+                usesDesktopCredentials: true, allowsUnattributedPiUsage: allowsUnattributedPiUsage
             ))
             identityKeys[cardID] = organization.identityKey
         }

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+struct ClaudeAccountCard: Equatable, Sendable {
+    let id: String
+    let identityKey: String
+    let organizationID: String
+    let displayName: String
+    let usesDesktopCredentials: Bool
+}
+
 /// The launch-time account pass: read which account is signed in at each family's default home,
 /// reconcile the account registry, and expose the per-card identity map that the snapshot cache's
 /// account stamp consumes. Runs once per launch (app) or per invocation (one-shot CLI); a mid-run
@@ -9,6 +17,7 @@ struct ProviderAccountAssembly {
     /// Card id → the account identity signed in there this launch. Phase 1 observes only default
     /// homes, so the keys are the bare family ids; a family whose identity didn't resolve is absent.
     let identityKeysByCard: [String: String]
+    var claudeCards: [ClaudeAccountCard] = []
 
     /// `waitsForLoginShell`: true for the menu-bar app (a Finder/Dock launch inherits no shell
     /// exports, so the pass leans on the login-shell layers), false for the one-shot CLI (a terminal
@@ -36,9 +45,6 @@ struct ProviderAccountAssembly {
         if families.count < ProviderAccountID.families.count {
             AppLog.info(.config, "account identity read skipped for \(ProviderAccountID.families.subtracting(families).sorted().joined(separator: ", ")): login shell cold and no shell-environment snapshot exists yet")
         }
-        guard !families.isEmpty else {
-            return ProviderAccountAssembly(identityKeysByCard: [:])
-        }
         return make(
             observer: DefaultAccountObserver(),
             accountsStore: ProviderAccountsStore(defaults: defaults),
@@ -61,7 +67,20 @@ struct ProviderAccountAssembly {
     static func make(
         observer: DefaultAccountObserver,
         accountsStore: ProviderAccountsStore,
-        families: Set<String> = ProviderAccountID.families
+        families: Set<String> = ProviderAccountID.families,
+        desktop: ClaudeDesktopAuthStore? = nil,
+        listDesktopOrganizationDirectories: @escaping @Sendable (URL) -> [String] = { root in
+            let urls = (try? FileManager.default.contentsOfDirectory(
+                at: root, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+            return urls.compactMap { url in
+                guard let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+                      values.isDirectory == true, values.isSymbolicLink != true
+                else { return nil }
+                return url.lastPathComponent
+            }
+        }
     ) -> ProviderAccountAssembly {
         var identityKeys: [String: String] = [:]
         var observations: [ProviderAccountsStore.Observation] = []
@@ -91,7 +110,135 @@ struct ProviderAccountAssembly {
             }
         }
 
-        accountsStore.reconcile(with: observations)
-        return ProviderAccountAssembly(identityKeysByCard: identityKeys)
+        let desktop = desktop ?? ClaudeDesktopAuthStore(
+            files: observer.files, homeDirectory: observer.homeDirectory
+        )
+        let desktopOrganizations = discoverDesktopOrganizations(
+            desktop: desktop,
+            cliIdentity: identityKeys["claude"],
+            listDirectories: listDesktopOrganizationDirectories
+        )
+        let desktopAnchor = desktop.homeDirectory()
+            .appendingPathComponent("Library/Application Support/Claude").path
+        for organization in desktopOrganizations {
+            let source = ProviderAccountSource(
+                kind: .defaultHome, anchor: desktopAnchor, holdsDefaultSource: false
+            )
+            if let index = observations.firstIndex(where: {
+                $0.family == "claude" && $0.identityKey == organization.identityKey
+            }) {
+                observations[index].sources.append(source)
+            } else {
+                observations.append(ProviderAccountsStore.Observation(
+                    family: "claude", identityKey: organization.identityKey,
+                    label: organization.label, sources: [source]
+                ))
+            }
+        }
+
+        let defaultClaudeIdentity = identityKeys["claude"]
+        let records = accountsStore.reconcile(with: observations)
+        var cards: [ClaudeAccountCard] = []
+        if let defaultIdentity = defaultClaudeIdentity,
+           let organization = defaultIdentity.split(separator: "|").last,
+           defaultIdentity.contains("|"),
+           let record = records.first(where: {
+               $0.family == "claude" && $0.identityKey == defaultIdentity && !$0.removedTombstone
+           })
+        {
+            let label = outcomes.first(where: { $0.family == "claude" }).flatMap { outcome -> String? in
+                guard case .resolved(_, let value, _) = outcome.outcome else { return nil }
+                return organizationLabel(value)
+            } ?? "Organization"
+            cards.append(ClaudeAccountCard(
+                id: record.id, identityKey: defaultIdentity, organizationID: String(organization),
+                displayName: "Claude — \(label)", usesDesktopCredentials: false
+            ))
+            identityKeys.removeValue(forKey: "claude")
+            identityKeys[record.id] = defaultIdentity
+        }
+        for organization in desktopOrganizations where organization.identityKey != defaultClaudeIdentity {
+            guard let record = records.first(where: {
+                $0.family == "claude" && $0.identityKey == organization.identityKey && !$0.removedTombstone
+            }) else { continue }
+            let cardID = record.id
+            guard !cards.contains(where: { $0.id == cardID }) else { continue }
+            cards.append(ClaudeAccountCard(
+                id: cardID, identityKey: organization.identityKey, organizationID: organization.id,
+                displayName: "Claude — \(organizationLabel(record.label) ?? organization.label)",
+                usesDesktopCredentials: true
+            ))
+            identityKeys[cardID] = organization.identityKey
+        }
+
+        return ProviderAccountAssembly(identityKeysByCard: identityKeys, claudeCards: cards)
+    }
+
+    private struct DesktopOrganization {
+        var id: String
+        var identityKey: String
+        var label: String
+    }
+
+    private static func organizationLabel(_ value: String?) -> String? {
+        guard let value, let opening = value.lastIndex(of: "("), value.last == ")" else { return value }
+        return String(value[value.index(after: opening)..<value.index(before: value.endIndex)])
+    }
+
+    private static func discoverDesktopOrganizations(
+        desktop: ClaudeDesktopAuthStore,
+        cliIdentity: String?,
+        listDirectories: @Sendable (URL) -> [String]
+    ) -> [DesktopOrganization] {
+        guard let user = desktop.lastKnownAccountUUID(), desktop.hasCredentialMaterial() else { return [] }
+        let active = desktop.load(allowInteraction: false, expectedAccountUUID: user)
+        let activeOrganization = active.organization
+
+        let root = desktop.homeDirectory().appendingPathComponent("Library/Application Support/Claude")
+        let memberships = Set(["claude-code-sessions", "local-agent-mode-sessions"].flatMap { directory in
+            listDirectories(root.appendingPathComponent(directory).appendingPathComponent(user))
+                .compactMap { UUID(uuidString: $0)?.uuidString.lowercased() }
+        })
+        var organizations = memberships
+        if let activeOrganization { organizations.insert(activeOrganization) }
+        if let text = try? desktop.files.readTextIfPresent(root.appendingPathComponent("config.json").path),
+           let rootObject = try? JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any]
+        {
+            organizations.formUnion(rootObject.keys.compactMap {
+                $0.split(separator: ":").last.flatMap { UUID(uuidString: String($0))?.uuidString.lowercased() }
+            })
+        }
+        if let text = try? desktop.files.readTextIfPresent(
+            root.appendingPathComponent("plan-usage-history.json").path
+        ), let history = try? JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any],
+           let samples = history["samples"] as? [[String: Any]]
+        {
+            organizations.formUnion(samples.compactMap {
+                ($0["org"] as? String).flatMap { UUID(uuidString: $0)?.uuidString.lowercased() }
+            })
+        }
+        let cliOrganization = cliIdentity.flatMap { identity -> String? in
+            let parts = identity.split(separator: "|")
+            guard parts.count == 2,
+                  String(parts[0]).caseInsensitiveCompare(user) == .orderedSame
+            else { return nil }
+            return String(parts[1]).lowercased()
+        }
+
+        return organizations.sorted { lhs, rhs in
+            lhs == activeOrganization ? true : rhs == activeOrganization ? false : lhs < rhs
+        }.compactMap { organization in
+            guard memberships.contains(organization)
+                || organization == activeOrganization || organization == cliOrganization
+            else { return nil }
+            let result = organization == activeOrganization ? active : desktop.load(
+                allowInteraction: false, organization: organization, expectedAccountUUID: user
+            )
+            guard result.status == .available || result.status == .permissionRequired else { return nil }
+            let plan = result.oauth?.subscriptionType?.lowercased()
+            let label = plan.map { ["max", "pro", "free"].contains($0) } == true ? "Personal"
+                : plan?.capitalized ?? "Organization \(organization.prefix(8))"
+            return DesktopOrganization(id: organization, identityKey: "\(user)|\(organization)", label: label)
+        }
     }
 }

--- a/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
+++ b/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
@@ -63,7 +63,7 @@ enum UsageHistoryAggregator {
         guard document.schema == UsageHistoryDocument.currentSchema,
               allowsUnattributedHistory
         else { return nil }
-        return document.providers[providerID]
+        return document.providers["claude"]
     }
 
     private static func merge(

--- a/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
+++ b/Sources/OpenUsage/Services/UsageHistoryAggregator.swift
@@ -7,22 +7,63 @@ enum UsageHistoryAggregator {
         localSnapshots: [String: ProviderSnapshot],
         peerDocuments: [UsageHistoryDocument],
         descriptors: [String: UsageHistoryDescriptor],
+        providerIdentityKeys: [String: String] = [:],
         now: Date = Date()
     ) -> [String: ProviderUsageHistory] {
         var inputs: [String: [ProviderUsageHistory]] = [:]
         let peerDocuments = UsageHistoryDocument.newestByDevice(peerDocuments)
+        let localClaudeCards = Set(descriptors.keys.filter {
+            ProviderAccountID.family(of: $0) == "claude"
+        }).union(providerIdentityKeys.keys.filter {
+            ProviderAccountID.family(of: $0) == "claude"
+        })
         for (providerID, descriptor) in descriptors where descriptor.scope == .machineLocal {
             if let local = localSnapshots[providerID]?.usageHistory {
                 inputs[providerID, default: []].append(local)
             }
             for document in peerDocuments {
-                if let peer = document.providers[providerID] {
+                let peer: ProviderUsageHistory?
+                if ProviderAccountID.family(of: providerID) == "claude" {
+                    peer = claudeHistory(
+                        in: document,
+                        providerID: providerID,
+                        identity: providerIdentityKeys[providerID],
+                        allowsUnattributedHistory: localClaudeCards.count <= 1
+                    )
+                } else {
+                    peer = document.providers[providerID]
+                }
+                if let peer {
                     inputs[providerID, default: []].append(peer)
                 }
             }
         }
         let includedDays = UsageHistoryWindow.dayKeys(through: now)
         return inputs.mapValues { merge($0, includedDays: includedDays) }
+    }
+
+    private static func claudeHistory(
+        in document: UsageHistoryDocument,
+        providerID: String,
+        identity: String?,
+        allowsUnattributedHistory: Bool
+    ) -> ProviderUsageHistory? {
+        if let identities = document.identities,
+           identities.keys.contains(where: { ProviderAccountID.family(of: $0) == "claude" })
+        {
+            guard let identity,
+                  let matchingID = identities.first(where: {
+                      ProviderAccountID.family(of: $0.key) == "claude"
+                          && $0.value.caseInsensitiveCompare(identity) == .orderedSame
+                  })?.key
+            else { return nil }
+            return document.providers[matchingID]
+        }
+
+        guard document.schema == UsageHistoryDocument.currentSchema,
+              allowsUnattributedHistory
+        else { return nil }
+        return document.providers[providerID]
     }
 
     private static func merge(

--- a/Sources/OpenUsage/Services/UsageReader.swift
+++ b/Sources/OpenUsage/Services/UsageReader.swift
@@ -37,10 +37,6 @@ public struct UsageReader {
     }
 
     public func read(providerID requestedProviderID: String? = nil, force: Bool = false) async throws -> UsageReadResult {
-        let providers = providersOverride ?? ProviderCatalog.make(defaults: defaults)
-        let registry = WidgetRegistry.from(providers)
-        let knownIDs = Set(registry.providers.map(\.id))
-        let enablement = ProviderEnablementStore(defaults: defaults)
         // The launch account pass (see `ProviderAccountAssembly`): resolves each family's default
         // account so cached snapshots are guarded — and refreshed ones stamped — with the correct
         // account. Skipped when a test injects its own providers — they have no real homes to read.
@@ -59,6 +55,14 @@ public struct UsageReader {
         let accountAssembly = providersOverride == nil
             ? ProviderAccountAssembly.make(defaults: defaults, waitsForLoginShell: false)
             : ProviderAccountAssembly(identityKeysByCard: [:])
+        let providers = providersOverride ?? ProviderCatalog.make(
+            defaults: defaults,
+            claudeCards: accountAssembly.claudeCards,
+            claudeIdentityKeys: accountAssembly.identityKeysByCard
+        )
+        let registry = WidgetRegistry.from(providers)
+        let knownIDs = Set(registry.providers.map(\.id))
+        let enablement = ProviderEnablementStore(defaults: defaults)
         // A requested id names cards by plain string matching — an exact card id, or a family id
         // naming all of that family's cards — mirroring the local HTTP API exactly (see
         // `LocalUsageAPI.State.matchingCardIDs`). Never resolved from runtime state: the same

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -432,6 +432,15 @@ final class WidgetDataStore {
                 providers[providerID] = history
             }
         }
+        let exportedClaudeIDs = providers.keys.filter {
+            ProviderAccountID.family(of: $0) == "claude"
+        }
+        if let onlyClaudeID = exportedClaudeIDs.first,
+           exportedClaudeIDs.count == 1, onlyClaudeID != "claude"
+        {
+            providers["claude"] = providers.removeValue(forKey: onlyClaudeID)
+            identities["claude"] = identities.removeValue(forKey: onlyClaudeID)
+        }
         let hasClaudeAccountCards = providers.keys.contains {
             ProviderAccountID.family(of: $0) == "claude" && $0 != "claude"
         }

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -414,17 +414,34 @@ final class WidgetDataStore {
 
     func localHistoryDocument(deviceID: String, deviceName: String, updatedAt: Date = Date()) -> UsageHistoryDocument {
         var providers: [String: ProviderUsageHistory] = [:]
+        var identities: [String: String] = [:]
+        let hasMultipleClaudeCards = registry.providers.count {
+            ProviderAccountID.family(of: $0.id) == "claude"
+        } > 1
         for (providerID, descriptor) in registry.historyDescriptorsByProvider
         where descriptor.scope == .machineLocal && isProviderEnabled(providerID) {
             if let history = localSnapshots[providerID]?.usageHistory {
+                if ProviderAccountID.family(of: providerID) == "claude" {
+                    if let identity = providerIdentityKeys[providerID] {
+                        identities[providerID] = identity.lowercased()
+                    } else if hasMultipleClaudeCards || providerID != "claude" {
+                        AppLog.warn(.config, "sync: omitting Claude history without account ownership")
+                        continue
+                    }
+                }
                 providers[providerID] = history
             }
         }
+        let hasClaudeAccountCards = providers.keys.contains {
+            ProviderAccountID.family(of: $0) == "claude" && $0 != "claude"
+        }
         return UsageHistoryDocument(
+            schema: hasClaudeAccountCards ? UsageHistoryDocument.accountSchema : UsageHistoryDocument.currentSchema,
             deviceID: deviceID,
             deviceName: deviceName,
             updatedAt: updatedAt,
-            providers: providers
+            providers: providers,
+            identities: identities.isEmpty ? nil : identities
         )
     }
 
@@ -443,6 +460,7 @@ final class WidgetDataStore {
             localSnapshots: localSnapshots,
             peerDocuments: peerHistoryDocuments,
             descriptors: enabledDescriptors,
+            providerIdentityKeys: providerIdentityKeys,
             now: renderDate
         )
         var rendered = localSnapshots

--- a/Tests/OpenUsageTests/ClaudeAccountIsolationTests.swift
+++ b/Tests/OpenUsageTests/ClaudeAccountIsolationTests.swift
@@ -232,6 +232,88 @@ final class ClaudeAccountIsolationTests: XCTestCase {
         )
     }
 
+    func testAccountVerificationRefreshesExpiredTokenBeforeFetchingUsage() async {
+        let fixture = makeFixture(
+            credentials: credentials(access: "expired", refresh: "refresh-token", plan: "pro"),
+            expectedIdentityKey: "account|organization"
+        ) { request in
+            switch request.url.path {
+            case "/api/oauth/profile":
+                guard request.headers["Authorization"] == "Bearer fresh" else {
+                    return HTTPResponse(statusCode: 401, headers: [:], body: Data())
+                }
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"account":{"uuid":"account"},"organization":{"uuid":"organization"}}"#.utf8)
+                )
+            case "/v1/oauth/token":
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"access_token":"fresh","refresh_token":"rotated","expires_in":3600}"#.utf8)
+                )
+            case "/api/oauth/usage":
+                XCTAssertEqual(request.headers["Authorization"], "Bearer fresh")
+                return Self.usageResponse(percent: 42)
+            default:
+                XCTFail("Unexpected request: \(request.url.path)")
+                return HTTPResponse(statusCode: 404, headers: [:], body: Data())
+            }
+        }
+
+        let snapshot = await fixture.provider.refresh()
+
+        XCTAssertEqual(sessionUsage(snapshot), 42)
+        XCTAssertEqual(fixture.http.requests.map(\.url.path), [
+            "/api/oauth/profile", "/v1/oauth/token", "/api/oauth/profile", "/api/oauth/usage"
+        ])
+        XCTAssertTrue(fixture.files.files[path]?.contains("rotated") == true)
+    }
+
+    func testAccountVerificationRateLimitUsesExistingCooldown() async {
+        let fixture = makeFixture(
+            credentials: credentials(access: "token", refresh: "refresh", plan: "pro"),
+            expectedIdentityKey: "account|organization"
+        ) { request in
+            XCTAssertEqual(request.url.path, "/api/oauth/profile")
+            return HTTPResponse(statusCode: 429, headers: ["retry-after": "600"], body: Data())
+        }
+
+        let first = await fixture.provider.refresh()
+        let second = await fixture.provider.refresh()
+
+        XCTAssertEqual(status(first)?.hasPrefix("Rate limited"), true)
+        XCTAssertEqual(second.warning?.contains("Retrying in ~10m"), true)
+        XCTAssertEqual(fixture.http.requests.count, 1)
+        XCTAssertTrue(usageRequests(fixture.http).isEmpty)
+    }
+
+    func testAccountVerificationOutagesAndMalformedResponsesDoNotClaimLogout() async {
+        let cases = [
+            (status: 503, body: "", expected: ClaudeUsageError.requestFailed(503).localizedDescription),
+            (status: 200, body: "not-json", expected: ClaudeUsageError.invalidResponse.localizedDescription)
+        ]
+        for scenario in cases {
+            let fixture = makeFixture(
+                credentials: credentials(access: "token", refresh: "refresh", plan: "pro"),
+                expectedIdentityKey: "account|organization"
+            ) { request in
+                XCTAssertEqual(request.url.path, "/api/oauth/profile")
+                return HTTPResponse(
+                    statusCode: scenario.status, headers: [:], body: Data(scenario.body.utf8)
+                )
+            }
+
+            let snapshot = await fixture.provider.refresh()
+
+            if case let .badge(_, message, _, _)? = snapshot.line(label: "Error") {
+                XCTAssertEqual(message, scenario.expected)
+            } else {
+                XCTFail("Missing error for profile status \(scenario.status)")
+            }
+            XCTAssertTrue(usageRequests(fixture.http).isEmpty)
+        }
+    }
+
     private struct Fixture {
         var provider: ClaudeProvider
         var files: FakeFiles
@@ -240,14 +322,20 @@ final class ClaudeAccountIsolationTests: XCTestCase {
 
     private func makeFixture(
         credentials: String,
+        expectedIdentityKey: String? = nil,
         handler: @escaping @Sendable (HTTPRequest) async throws -> HTTPResponse
     ) -> Fixture {
-        makeFixture(files: FakeFiles([path: credentials]), handler: handler)
+        makeFixture(
+            files: FakeFiles([path: credentials]),
+            expectedIdentityKey: expectedIdentityKey,
+            handler: handler
+        )
     }
 
     private func makeFixture(
         files: FakeFiles,
         keychain: any KeychainAccessing = FakeKeychain(),
+        expectedIdentityKey: String? = nil,
         handler: @escaping @Sendable (HTTPRequest) async throws -> HTTPResponse
     ) -> Fixture {
         let http = RoutingHTTPClient(handler: handler)
@@ -258,6 +346,7 @@ final class ClaudeAccountIsolationTests: XCTestCase {
                     environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
                     files: files,
                     keychain: keychain,
+                    expectedIdentityKey: expectedIdentityKey,
                     now: { now }
                 ),
                 usageClient: ClaudeUsageClient(httpClient: http),

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -88,6 +88,37 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testUnreadableClaudeEnvironmentSkipsDesktopDiscoveryWhileReconcilingCodex() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("desktop-token", expiresIn: 3_600)],
+            accountUUID: accountUUID
+        )
+        fixture.files.files["\(home.path)/.codex/auth.json"] =
+            #"{"tokens":{"access_token":"codex-token","account_id":"CODEX-1"}}"#
+        let suite = "OpenUsageTests.UnreadableClaudeEnvironment.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let fixtureHome = home
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment(), files: fixture.files, keychain: FakeKeychain(),
+            homeDirectory: { fixtureHome }
+        )
+        let accountsStore = ProviderAccountsStore(defaults: defaults)
+        let organizations = [organization]
+
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: accountsStore, families: ["codex"],
+            desktop: fixture.store, listDesktopOrganizationDirectories: { _ in organizations }
+        )
+
+        XCTAssertTrue(assembly.claudeCards.isEmpty)
+        XCTAssertEqual(assembly.identityKeysByCard, ["codex": "codex-1"])
+        XCTAssertEqual(accountsStore.records.map(\.family), ["codex"])
+        XCTAssertTrue(fixture.keyReader.calls.isEmpty)
+    }
+
+    @MainActor
     func testOrganizationSwitchKeepsPersistedCardIDsAndDistinctScopedRuntimes() throws {
         let fixture = try makeFixture(
             activeOrganization: organization,

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -131,6 +131,22 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         XCTAssertEqual(providers.map { $0.provider.id }, [workID, "claude"])
         XCTAssertEqual(providers.map { $0.authStore.desktopOnly }, [false, true])
         XCTAssertFalse(providers.contains { $0.allowsUnattributedPiUsage })
+
+        let withoutDesktop = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: ProviderAccountsStore(defaults: defaults), families: ["claude"],
+            desktop: ClaudeDesktopAuthStore(files: FakeFiles(), homeDirectory: { fixtureHome })
+        )
+        XCTAssertEqual(withoutDesktop.claudeCards.count, 1)
+        XCTAssertFalse(try XCTUnwrap(withoutDesktop.claudeCards.first).allowsUnattributedPiUsage)
+
+        fixture.files.files["\(home.path)/.claude.json"] =
+            #"{"oauthAccount":{"accountUuid":"\#(accountUUID)"}}"#
+        let legacy = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: ProviderAccountsStore(defaults: defaults), families: ["claude"],
+            desktop: fixture.store, listDesktopOrganizationDirectories: { _ in organizations }
+        )
+        XCTAssertTrue(legacy.claudeCards.isEmpty)
+        XCTAssertEqual(legacy.identityKeysByCard["claude"], accountUUID)
     }
 
     func testV1FallbackDoesNotOverrideTombstonedV2Key() throws {

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -8,6 +8,7 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
     private let home = URL(fileURLWithPath: "/fixture-home", isDirectory: true)
     private let organization = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
     private let otherOrganization = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    private let accountUUID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
     private let clientID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
     private let otherClientID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
     private let password = "fixture-safe-storage-password"
@@ -40,6 +41,96 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         XCTAssertEqual(result.oauth?.accessToken, "desktop-token")
         XCTAssertNil(result.oauth?.refreshToken)
         XCTAssertEqual(result.oauth?.scopes, ["user:profile", "user:inference"])
+    }
+
+    func testPinnedInactiveOrganizationRequiresTheCurrentDesktopAccount() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization): tokenEntry("active-token", expiresIn: 3_600),
+                cacheKey(organization: otherOrganization): tokenEntry("other-token", expiresIn: 3_600),
+            ],
+            accountUUID: accountUUID
+        )
+
+        let result = fixture.store.load(
+            allowInteraction: false, organization: otherOrganization, expectedAccountUUID: accountUUID
+        )
+
+        XCTAssertEqual(result.status, .available)
+        XCTAssertEqual(result.organization, otherOrganization)
+        XCTAssertEqual(result.oauth?.accessToken, "other-token")
+        XCTAssertEqual(fixture.store.load(
+            allowInteraction: false, organization: otherOrganization,
+            expectedAccountUUID: "ffffffff-ffff-4fff-8fff-ffffffffffff"
+        ).status, .notFound)
+    }
+
+    func testLogoutWithRetainedDatabaseAndCacheDoesNotExposeCredentials() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [cacheKey(organization: organization): tokenEntry("retained-token", expiresIn: 3_600)],
+            accountUUID: accountUUID
+        )
+        let fixtureHome = home
+        let loggedOut = ClaudeDesktopAuthStore(
+            files: fixture.files,
+            sqlite: FakeClaudeDesktopSQLite(value: nil),
+            keyReader: fixture.keyReader,
+            homeDirectory: { fixtureHome }
+        )
+
+        XCTAssertFalse(loggedOut.hasCredentialMaterial())
+        XCTAssertEqual(loggedOut.load(
+            allowInteraction: false, organization: organization, expectedAccountUUID: accountUUID
+        ).status, .notFound)
+        XCTAssertTrue(fixture.keyReader.calls.isEmpty)
+    }
+
+    @MainActor
+    func testOrganizationSwitchKeepsPersistedCardIDsAndDistinctScopedRuntimes() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization): tokenEntry("personal-token", expiresIn: 3_600),
+                cacheKey(organization: otherOrganization): tokenEntry("work-token", expiresIn: 3_600),
+            ],
+            accountUUID: accountUUID
+        )
+        let previousIdentity = "\(accountUUID)|\(organization)"
+        let currentIdentity = "\(accountUUID)|\(otherOrganization)"
+        let suite = "OpenUsageTests.OrganizationSwitch.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let existing = ProviderAccountRecord(
+            id: "claude", family: "claude", identityKey: previousIdentity,
+            label: "Personal",
+            sources: [.init(kind: .defaultHome, anchor: "\(home.path)/.claude", holdsDefaultSource: true)]
+        )
+        defaults.set(try JSONEncoder().encode([existing]), forKey: ProviderAccountsStore.storageKey)
+        fixture.files.files["\(home.path)/.claude.json"] =
+            #"{"oauthAccount":{"accountUuid":"\#(accountUUID)","organizationUuid":"\#(otherOrganization)","emailAddress":"work@example.com","organizationName":"SUNSTORY"}}"#
+        let fixtureHome = home
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment(), files: fixture.files, keychain: FakeKeychain(),
+            homeDirectory: { fixtureHome }
+        )
+        let organizations = [organization, otherOrganization]
+        let assembly = ProviderAccountAssembly.make(
+            observer: observer, accountsStore: ProviderAccountsStore(defaults: defaults), families: ["claude"],
+            desktop: fixture.store, listDesktopOrganizationDirectories: { _ in organizations }
+        )
+        let workID = ProviderAccountID.make(family: "claude", identityKey: currentIdentity)
+
+        XCTAssertEqual(assembly.claudeCards.map(\.id), [workID, "claude"])
+        XCTAssertEqual(assembly.identityKeysByCard, [workID: currentIdentity, "claude": previousIdentity])
+        XCTAssertEqual(assembly.claudeCards.map(\.displayName), ["Claude — SUNSTORY", "Claude — Personal"])
+        let providers = ProviderCatalog.make(
+            claudeCards: assembly.claudeCards, claudeIdentityKeys: assembly.identityKeysByCard
+        ).compactMap { $0 as? ClaudeProvider }
+        XCTAssertEqual(providers.map { $0.provider.id }, [workID, "claude"])
+        XCTAssertEqual(providers.map { $0.authStore.desktopOnly }, [false, true])
+        XCTAssertFalse(providers.contains { $0.allowsUnattributedPiUsage })
     }
 
     func testV1FallbackDoesNotOverrideTombstonedV2Key() throws {
@@ -314,7 +405,8 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         activeOrganization: String,
         v2: [String: Any],
         v1: [String: Any]? = nil,
-        requiresInteraction: Bool = false
+        requiresInteraction: Bool = false,
+        accountUUID: String? = nil
     ) throws -> DesktopFixture {
         let key = try ClaudeDesktopAuthStore.deriveKey(password: password)
         let cookieHost = ".claude.ai"
@@ -323,6 +415,7 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         let v2Data = try JSONSerialization.data(withJSONObject: v2)
         let encryptedV2 = try encrypt(v2Data, key: key)
         var config: [String: Any] = ["oauth:tokenCacheV2": encryptedV2.base64EncodedString()]
+        if let accountUUID { config["lastKnownAccountUuid"] = accountUUID }
         if let v1 {
             let v1Data = try JSONSerialization.data(withJSONObject: v1)
             config["oauth:tokenCache"] = try encrypt(v1Data, key: key).base64EncodedString()

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -130,6 +130,7 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         ).compactMap { $0 as? ClaudeProvider }
         XCTAssertEqual(providers.map { $0.provider.id }, [workID, "claude"])
         XCTAssertEqual(providers.map { $0.authStore.desktopOnly }, [false, true])
+        XCTAssertEqual(providers.map { $0.authStore.preferOrganizationScopedDesktop }, [true, false])
         XCTAssertFalse(providers.contains { $0.allowsUnattributedPiUsage })
 
         let withoutDesktop = ProviderAccountAssembly.make(
@@ -248,6 +249,34 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         XCTAssertEqual(load.candidates.first?.oauth.accessToken, "cli-token")
         XCTAssertEqual(load.desktopStatus, .notChecked)
         XCTAssertTrue(fixture.keyReader.calls.isEmpty)
+    }
+
+    func testMultiOrganizationCLICardPrefersItsOwnScopedDesktopCredential() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization): tokenEntry("personal-token", expiresIn: 3_600),
+                cacheKey(organization: otherOrganization): tokenEntry("work-token", expiresIn: 3_600),
+            ],
+            accountUUID: accountUUID
+        )
+        let fixtureNow = now
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: fixture.files,
+            keychain: FakeKeychain(cliCredentials(token: "personal-token")),
+            desktop: fixture.store,
+            desktopOrganization: otherOrganization,
+            expectedIdentityKey: "\(accountUUID)|\(otherOrganization)",
+            preferOrganizationScopedDesktop: true,
+            now: { fixtureNow }
+        )
+
+        let load = authStore.loadCredentialSet()
+
+        XCTAssertEqual(load.desktopStatus, .available)
+        XCTAssertEqual(load.candidates.map(\.oauth.accessToken), ["work-token", "personal-token"])
+        XCTAssertEqual(load.candidates.first?.source, .desktop)
     }
 
     func testWhitespaceOnlyCLIEntryDoesNotBlockDesktop() throws {

--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
@@ -456,6 +456,10 @@ final class ClaudeLogUsageScannerTests: XCTestCase {
                 timestamp: timestamp, input: 1000, output: 500, costUSD: 9,
                 messageID: "unowned", requestID: "unowned"
             ),
+            "workspace/unowned/subagents/agent-unowned.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: timestamp, input: 10, output: 5, costUSD: 0.05,
+                messageID: "agent-unowned", requestID: "agent-unowned"
+            ),
             "workspace/foreign-user.jsonl": #"{"ownerOrganizationUuid":"org-a","ownerAccountUuid":"user-b"}"# +
                 "\n" + ClaudeLogFixture.usageLine(
                     timestamp: timestamp, input: 3000, output: 500, costUSD: 11,
@@ -479,6 +483,15 @@ final class ClaudeLogUsageScannerTests: XCTestCase {
             XCTAssertEqual(scan.series.daily.first?.totalTokens, expectedTokens, organizationID)
             XCTAssertEqual(scan.series.daily.first?.costUSD ?? 0, expectedCost, accuracy: 1e-9, organizationID)
         }
+
+        let singleAccountScanner = ClaudeLogUsageScanner(
+            environment: FakeEnvironment([:]), homeDirectory: { home }, incrementalScanner: sharedCache,
+            accountUUID: "user-a", organizationUUID: "org-a", allowsUnattributedSessions: true
+        )
+        let singleAccountResult = await singleAccountScanner.scan(now: now, pricing: pricing)
+        let singleAccountScan = try XCTUnwrap(singleAccountResult)
+        XCTAssertEqual(singleAccountScan.series.daily.first?.totalTokens, 1680)
+        XCTAssertEqual(singleAccountScan.series.daily.first?.costUSD ?? 0, 9.35, accuracy: 1e-9)
     }
 
     func testOrganizationScanRefreshesChangedSessionOwnership() async throws {

--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
@@ -434,6 +434,128 @@ final class ClaudeLogUsageScannerTests: XCTestCase {
         XCTAssertNil(scan)
     }
 
+    func testOrganizationScanSeparatesTerminalSessionsAndTheirSubagents() async throws {
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let home = try ClaudeLogFixture.makeUserHome(claudeFiles: [
+            "workspace/session-a.jsonl": #"{"type":"bridge-session","ownerOrganizationUuid":"ORG-A","ownerAccountUuid":"USER-A"}"# + "\n" +
+                ClaudeLogFixture.usageLine(timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
+                                           messageID: "main-a", requestID: "main-a"),
+            "workspace/session-a/subagents/agent-a.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: timestamp, input: 10, output: 5, costUSD: 0.05,
+                messageID: "agent-a", requestID: "agent-a"
+            ),
+            "workspace/session-b.jsonl": #"{"type":"bridge-session","ownerOrganizationUuid":"org-b","ownerAccountUuid":"user-a"}"# + "\n" +
+                ClaudeLogFixture.usageLine(timestamp: timestamp, input: 200, output: 20, costUSD: 0.40,
+                                           messageID: "main-b", requestID: "main-b"),
+            "workspace/session-b/subagents/agent-b.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: timestamp, input: 20, output: 2, costUSD: 0.06,
+                messageID: "agent-b", requestID: "agent-b"
+            ),
+            "workspace/unowned.jsonl": ClaudeLogFixture.usageLine(
+                timestamp: timestamp, input: 1000, output: 500, costUSD: 9,
+                messageID: "unowned", requestID: "unowned"
+            ),
+            "workspace/foreign-user.jsonl": #"{"ownerOrganizationUuid":"org-a","ownerAccountUuid":"user-b"}"# +
+                "\n" + ClaudeLogFixture.usageLine(
+                    timestamp: timestamp, input: 3000, output: 500, costUSD: 11,
+                    messageID: "foreign-user", requestID: "foreign-user"
+                ),
+            "workspace/ambiguous.jsonl": #"{"ownerOrganizationUuid":"org-a"}"# + "\n" +
+                #"{"ownerOrganizationUuid":"org-b"}"# + "\n" + ClaudeLogFixture.usageLine(
+                    timestamp: timestamp, input: 2000, output: 500, costUSD: 10,
+                    messageID: "ambiguous", requestID: "ambiguous"
+            )
+        ])
+        let sharedCache = IncrementalJSONLScanner<Entry>()
+
+        for (organizationID, expectedTokens, expectedCost) in [("org-a", 165, 0.30), ("ORG-B", 242, 0.46)] {
+            let scanner = ClaudeLogUsageScanner(
+                environment: FakeEnvironment([:]), homeDirectory: { home },
+                incrementalScanner: sharedCache, accountUUID: "user-a", organizationUUID: organizationID
+            )
+            let result = await scanner.scan(now: now, pricing: pricing)
+            let scan = try XCTUnwrap(result)
+            XCTAssertEqual(scan.series.daily.first?.totalTokens, expectedTokens, organizationID)
+            XCTAssertEqual(scan.series.daily.first?.costUSD ?? 0, expectedCost, accuracy: 1e-9, organizationID)
+        }
+    }
+
+    func testOrganizationScanRefreshesChangedSessionOwnership() async throws {
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let line = ClaudeLogFixture.usageLine(
+            timestamp: timestamp, input: 100, output: 50, costUSD: 0.25
+        )
+        let home = try ClaudeLogFixture.makeUserHome(claudeFiles: [
+            "workspace/session.jsonl": #"{"ownerOrganizationUuid":"org-a","ownerAccountUuid":"user-a"}"# +
+                "\n" + line
+        ])
+        let scanner = ClaudeLogUsageScanner(
+            environment: FakeEnvironment([:]), homeDirectory: { home },
+            incrementalScanner: IncrementalJSONLScanner<Entry>(), accountUUID: "user-a", organizationUUID: "org-a"
+        )
+
+        let firstResult = await scanner.scan(now: now, pricing: pricing)
+        let first = try XCTUnwrap(firstResult)
+        XCTAssertEqual(first.series.daily.first?.totalTokens, 150)
+
+        let session = home.appendingPathComponent(".claude/projects/workspace/session.jsonl")
+        try (#"{"ownerOrganizationUuid":"organization-b","ownerAccountUuid":"user-a"}"# + "\n" + line)
+            .write(to: session, atomically: true, encoding: .utf8)
+
+        let second = await scanner.scan(now: now, pricing: pricing)
+        XCTAssertNil(second)
+    }
+
+    func testOrganizationScanCombinesOwnedDesktopAndTerminalLogsWithoutForeignSpending() async throws {
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let home = try ClaudeLogFixture.makeUserHome(
+            claudeFiles: [
+                "workspace/session.jsonl": #"{"ownerOrganizationUuid":"org-a","ownerAccountUuid":"user-a"}"# +
+                    "\n" +
+                    ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 100, output: 50, costUSD: 0.25,
+                        messageID: "shared", requestID: "terminal"
+                    )
+            ],
+            coworkSessions: [
+                "user-a/ORG-A/local_owned": [
+                    "workspace/replay.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 90_000, output: 10, costUSD: 9.99,
+                        messageID: "shared", requestID: "desktop", isSidechain: true
+                    ),
+                    "workspace/unique.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 10, output: 5, costUSD: 0.05,
+                        messageID: "desktop-owned", requestID: "desktop-owned"
+                    )
+                ],
+                "user-a/org-b/local_foreign": [
+                    "workspace/session.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 5000, output: 500, costUSD: 20,
+                        messageID: "desktop-foreign", requestID: "desktop-foreign"
+                    )
+                ],
+                "user-b/org-a/local_foreign_user": [
+                    "workspace/session.jsonl": ClaudeLogFixture.usageLine(
+                        timestamp: timestamp, input: 6000, output: 500, costUSD: 30,
+                        messageID: "desktop-foreign-user", requestID: "desktop-foreign-user"
+                    )
+                ]
+            ]
+        )
+        let scanner = ClaudeLogUsageScanner(
+            environment: FakeEnvironment([:]), homeDirectory: { home },
+            incrementalScanner: IncrementalJSONLScanner<Entry>(), accountUUID: "user-a", organizationUUID: "org-a"
+        )
+
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+        XCTAssertEqual(scan.series.daily.first?.totalTokens, 165)
+        XCTAssertEqual(scan.series.daily.first?.costUSD ?? 0, 0.30, accuracy: 1e-9)
+    }
+
     /// Manual parity harness against the real logs on this machine: prints per-day totals to compare
     /// with `ccusage daily --json --offline`. Gated like the other live tests.
     func testParityAgainstRealLocalLogs() async throws {

--- a/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/ClaudeLogUsageScannerTests.swift
@@ -508,6 +508,98 @@ final class ClaudeLogUsageScannerTests: XCTestCase {
         XCTAssertNil(second)
     }
 
+    func testOrganizationScanRecoversOnlyMatchingIndexedDesktopSessionsAndSubagents() async throws {
+        let now = Date()
+        let timestamp = OpenUsageISO8601.string(from: now)
+        let owned = "11111111-1111-4111-8111-111111111111"
+        let foreignOrganization = "22222222-2222-4222-8222-222222222222"
+        let foreignAccount = "33333333-3333-4333-8333-333333333333"
+        let conflictingOrganization = "44444444-4444-4444-8444-444444444444"
+        let conflictingAccount = "55555555-5555-4555-8555-555555555555"
+        let ambiguous = "66666666-6666-4666-8666-666666666666"
+        let unindexed = "77777777-7777-4777-8777-777777777777"
+
+        func line(_ id: String, input: Int, output: Int, cost: Double) -> String {
+            ClaudeLogFixture.usageLine(
+                timestamp: timestamp, input: input, output: output, costUSD: cost,
+                messageID: id, requestID: id
+            )
+        }
+
+        let home = try ClaudeLogFixture.makeUserHome(claudeFiles: [
+            "workspace/\(owned).jsonl": line(owned, input: 100, output: 50, cost: 0.25),
+            "workspace/\(owned)/subagents/agent.jsonl": line("agent", input: 10, output: 5, cost: 0.05),
+            "workspace/\(foreignOrganization).jsonl": line(foreignOrganization, input: 1000, output: 500, cost: 9),
+            "workspace/\(foreignAccount).jsonl": line(foreignAccount, input: 2000, output: 500, cost: 10),
+            "workspace/\(conflictingOrganization).jsonl":
+                #"{"ownerOrganizationUuid":"org-b","ownerAccountUuid":"user-a"}"# + "\n" +
+                line(conflictingOrganization, input: 3000, output: 500, cost: 11),
+            "workspace/\(conflictingAccount).jsonl":
+                #"{"ownerOrganizationUuid":"org-a","ownerAccountUuid":"user-b"}"# + "\n" +
+                line(conflictingAccount, input: 4000, output: 500, cost: 12),
+            "workspace/\(ambiguous).jsonl":
+                #"{"ownerOrganizationUuid":"org-a"}"# + "\n" +
+                #"{"ownerOrganizationUuid":"org-b"}"# + "\n" +
+                line(ambiguous, input: 5000, output: 500, cost: 13),
+            "workspace/\(unindexed).jsonl": line(unindexed, input: 6000, output: 500, cost: 14),
+            "workspace/not-a-uuid.jsonl": line("not-a-uuid", input: 7000, output: 500, cost: 15)
+        ])
+        let desktopRoot = home.appendingPathComponent("Library/Application Support/Claude/claude-code-sessions")
+
+        func index(_ sessionID: String, account: String, organization: String) throws -> URL {
+            let directory = desktopRoot.appendingPathComponent(account).appendingPathComponent(organization)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let file = directory.appendingPathComponent("local_\(sessionID).json")
+            try #"{"sessionId":"local_session", "cliSessionId" : "\#(sessionID)"}"#
+                .write(to: file, atomically: true, encoding: .utf8)
+            return file
+        }
+
+        for sessionID in [owned, conflictingOrganization, conflictingAccount, ambiguous, "not-a-uuid"] {
+            _ = try index(sessionID, account: "user-a", organization: "org-a")
+        }
+        _ = try index(foreignOrganization, account: "user-a", organization: "org-b")
+        let foreignFile = try index(foreignAccount, account: "user-b", organization: "org-a")
+        try FileManager.default.createSymbolicLink(
+            at: desktopRoot.appendingPathComponent("user-a/org-a/local_foreign-link.json"),
+            withDestinationURL: foreignFile
+        )
+
+        let scanner = ClaudeLogUsageScanner(
+            environment: FakeEnvironment([:]), homeDirectory: { home },
+            incrementalScanner: IncrementalJSONLScanner<Entry>(), accountUUID: "user-a", organizationUUID: "org-a"
+        )
+        let result = await scanner.scan(now: now, pricing: pricing)
+        let scan = try XCTUnwrap(result)
+
+        XCTAssertEqual(scan.series.daily.first?.totalTokens, 165)
+        XCTAssertEqual(scan.series.daily.first?.costUSD ?? 0, 0.30, accuracy: 1e-9)
+    }
+
+    func testOrganizationScanDoesNotRecoverIndexedDesktopSessionsWithoutAccount() async throws {
+        let now = Date()
+        let sessionID = "11111111-1111-4111-8111-111111111111"
+        let home = try ClaudeLogFixture.makeUserHome(claudeFiles: [
+            "workspace/\(sessionID).jsonl": ClaudeLogFixture.usageLine(
+                timestamp: OpenUsageISO8601.string(from: now), input: 100, output: 50
+            )
+        ])
+        let directory = home.appendingPathComponent(
+            "Library/Application Support/Claude/claude-code-sessions/user-a/org-a"
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try #"{"cliSessionId":"\#(sessionID)"}"#
+            .write(to: directory.appendingPathComponent("local_session.json"), atomically: true, encoding: .utf8)
+
+        let scanner = ClaudeLogUsageScanner(
+            environment: FakeEnvironment([:]), homeDirectory: { home },
+            incrementalScanner: IncrementalJSONLScanner<Entry>(), organizationUUID: "org-a"
+        )
+        let result = await scanner.scan(now: now, pricing: pricing)
+
+        XCTAssertNil(result)
+    }
+
     func testOrganizationScanCombinesOwnedDesktopAndTerminalLogsWithoutForeignSpending() async throws {
         let now = Date()
         let timestamp = OpenUsageISO8601.string(from: now)

--- a/Tests/OpenUsageTests/ClaudeProviderTests.swift
+++ b/Tests/OpenUsageTests/ClaudeProviderTests.swift
@@ -580,6 +580,53 @@ final class ClaudeProviderTests: XCTestCase {
         XCTAssertNil(badge(snapshot.lines, "Error"))
     }
 
+    func testOrganizationBoundProviderRejectsForeignTokensBeforeFetchingUsage() async {
+        let account = "11111111-1111-4111-8111-111111111111"
+        let organization = "22222222-2222-4222-8222-222222222222"
+        let wrongOrganization = "33333333-3333-4333-8333-333333333333"
+        let files = FakeFiles([
+            "/tmp/claude/.credentials.json":
+                #"{"claudeAiOauth":{"accessToken":"owned-token","expiresAt":4102444800000,"subscriptionType":"team","scopes":["user:profile"]}}"#
+        ])
+        let keychain = ServiceKeychain()
+        let authStore = ClaudeAuthStore(
+            environment: FakeEnvironment(["CLAUDE_CONFIG_DIR": "/tmp/claude"]),
+            files: files, keychain: keychain, expectedIdentityKey: "\(account)|\(organization)"
+        )
+        keychain.currentUserValues[authStore.keychainServiceCandidates().first!] =
+            #"{"claudeAiOauth":{"accessToken":"foreign-token","expiresAt":4102444800000,"subscriptionType":"max","scopes":["user:profile"]}}"#
+        let httpClient = RoutingHTTPClient { request in
+            let authorization = request.headers["Authorization"] ?? ""
+            if request.url.path == "/api/oauth/profile" {
+                let tokenOrganization = authorization == "Bearer foreign-token" ? wrongOrganization : organization
+                return HTTPResponse(
+                    statusCode: 200, headers: [:],
+                    body: Data(#"{"account":{"uuid":"\#(account)"},"organization":{"uuid":"\#(tokenOrganization)"}}"#.utf8)
+                )
+            }
+            XCTAssertEqual(request.url.path, "/api/oauth/usage")
+            XCTAssertEqual(authorization, "Bearer owned-token")
+            return HTTPResponse(
+                statusCode: 200, headers: [:],
+                body: Data(#"{"five_hour":{"utilization":42,"resets_at":"2099-01-01T00:00:00.000Z"}}"#.utf8)
+            )
+        }
+        let provider = ClaudeProvider(
+            authStore: authStore, usageClient: ClaudeUsageClient(httpClient: httpClient),
+            logUsageScanner: ClaudeLogFixture.scanner(home: nil), pricing: { TestPricing.bundled }
+        )
+
+        let first = await provider.refresh()
+        let second = await provider.refresh()
+
+        XCTAssertEqual(Self.progress(first.lines, "Session")?.used, 42)
+        XCTAssertEqual(Self.progress(second.lines, "Session")?.used, 42)
+        XCTAssertEqual(httpClient.requests.filter {
+            $0.url.path == "/api/oauth/profile" && $0.headers["Authorization"] == "Bearer owned-token"
+        }.count, 1)
+        XCTAssertEqual(httpClient.requests.filter { $0.url.path == "/api/oauth/usage" }.count, 2)
+    }
+
     func testSurfacesAuthErrorWhenAllCredentialSourcesAreExpired() async {
         // The fallback must not mask a genuine all-sources-expired state: when both keychain and file
         // tokens are revoked, the refresh fails loudly with the auth error rather than silently

--- a/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
@@ -91,6 +91,165 @@ final class UsageHistoryAggregatorTests: XCTestCase {
         XCTAssertEqual(claude.unknownModelsByDay, ["2026-07-13": ["current-unknown"]])
     }
 
+    func testClaudeOrganizationsMatchByIdentityInsteadOfCardID() throws {
+        let personalID = "claude"
+        let workID = "claude@1234abcd"
+        let personal = ProviderSnapshot(
+            providerID: personalID,
+            displayName: "Claude Personal",
+            lines: [],
+            usageHistory: history(tokens: 100, cost: 1, model: "Opus")
+        )
+        let work = ProviderSnapshot(
+            providerID: workID,
+            displayName: "Claude Work",
+            lines: [],
+            usageHistory: history(tokens: 200, cost: 2, model: "Sonnet")
+        )
+        let codex = ProviderSnapshot(
+            providerID: "codex",
+            displayName: "Codex",
+            lines: [],
+            usageHistory: history(tokens: 300, cost: 3, model: "GPT")
+        )
+        var peer = document(
+            deviceID: "peer",
+            updatedAt: 200,
+            providers: [
+                "claude": history(tokens: 40, cost: 4, model: "Sonnet"),
+                "claude@abcdef12": history(tokens: 30, cost: 3, model: "Opus"),
+                "codex": history(tokens: 50, cost: 5, model: "GPT"),
+            ]
+        )
+        peer.schema = UsageHistoryDocument.accountSchema
+        peer.identities = ["claude": "USER|WORK", "claude@abcdef12": "user|personal"]
+        XCTAssertNoThrow(try peer.validate())
+
+        let descriptor = UsageHistoryDescriptor(scope: .machineLocal, estimatedCost: true, sourceNote: "logs")
+        let merged = UsageHistoryAggregator.merged(
+            localSnapshots: [personalID: personal, workID: work, "codex": codex],
+            peerDocuments: [peer],
+            descriptors: [personalID: descriptor, workID: descriptor, "codex": descriptor],
+            providerIdentityKeys: [personalID: "user|personal", workID: "user|work", "codex": "different-codex"],
+            now: localDay(2026, 7, 13)
+        )
+
+        XCTAssertEqual(try XCTUnwrap(merged[personalID]).series.daily.first?.totalTokens, 130)
+        XCTAssertEqual(try XCTUnwrap(merged[workID]).series.daily.first?.totalTokens, 240)
+        XCTAssertEqual(try XCTUnwrap(merged["codex"]).series.daily.first?.totalTokens, 350)
+    }
+
+    func testMismatchedClaudeIdentityNeverFallsBackToMatchingCardID() throws {
+        let local = ProviderSnapshot(
+            providerID: "claude",
+            displayName: "Claude",
+            lines: [],
+            usageHistory: history(tokens: 100, cost: 1, model: "Opus")
+        )
+        var peer = document(
+            deviceID: "peer",
+            updatedAt: 200,
+            providers: ["claude": history(tokens: 900, cost: 9, model: "Opus")]
+        )
+        peer.identities = ["claude": "user|different"]
+
+        let merged = UsageHistoryAggregator.merged(
+            localSnapshots: ["claude": local],
+            peerDocuments: [peer],
+            descriptors: [
+                "claude": UsageHistoryDescriptor(scope: .machineLocal, estimatedCost: true, sourceNote: "logs")
+            ],
+            providerIdentityKeys: ["claude": "user|personal"],
+            now: localDay(2026, 7, 13)
+        )
+
+        XCTAssertEqual(try XCTUnwrap(merged["claude"]).series.daily.first?.totalTokens, 100)
+    }
+
+    func testLegacyClaudeHistoryMergesOnlyWhenOneOrganizationExists() throws {
+        let peer = document(
+            deviceID: "peer",
+            updatedAt: 200,
+            providers: [
+                "claude": history(tokens: 90, cost: 9, model: "Opus"),
+                "codex": history(tokens: 50, cost: 5, model: "GPT"),
+            ]
+        )
+        let descriptor = UsageHistoryDescriptor(scope: .machineLocal, estimatedCost: true, sourceNote: "logs")
+
+        let single = UsageHistoryAggregator.merged(
+            localSnapshots: [:],
+            peerDocuments: [peer],
+            descriptors: ["claude": descriptor, "codex": descriptor],
+            providerIdentityKeys: ["claude": "user|personal"],
+            now: localDay(2026, 7, 13)
+        )
+        XCTAssertEqual(try XCTUnwrap(single["claude"]).series.daily.first?.totalTokens, 90)
+
+        let multiple = UsageHistoryAggregator.merged(
+            localSnapshots: [:],
+            peerDocuments: [peer],
+            descriptors: ["claude": descriptor, "claude@1234abcd": descriptor, "codex": descriptor],
+            providerIdentityKeys: ["claude": "user|personal", "claude@1234abcd": "user|work"],
+            now: localDay(2026, 7, 13)
+        )
+        XCTAssertNil(multiple["claude"])
+        XCTAssertNil(multiple["claude@1234abcd"])
+        XCTAssertEqual(try XCTUnwrap(multiple["codex"]).series.daily.first?.totalTokens, 50)
+    }
+
+    @MainActor
+    func testCloudExportUsesLegacySchemaUntilAnOwnedClaudeAccountCardExists() throws {
+        let suiteName = "UsageHistoryAggregatorTests.Export.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let personal = Provider(id: "claude", displayName: "Claude", icon: .providerMark("claude"))
+        let work = Provider(id: "claude@1234abcd", displayName: "Claude Work", icon: .providerMark("claude"))
+        let codex = Provider(id: "codex", displayName: "Codex", icon: .providerMark("codex"))
+        let providers = [personal, work, codex]
+        let descriptors = providers.map {
+            WidgetDescriptor.usageTrend(provider: $0)
+                .exportingHistory(scope: .machineLocal, estimatedCost: true, sourceNote: "logs")
+        }
+        let cache = ProviderSnapshotCache(userDefaults: defaults, storageKey: "snapshots")
+        let identities = ["claude": "User|Personal", "claude@1234abcd": "user|work", "codex": "codex-account"]
+        for provider in providers {
+            cache.store(
+                ProviderSnapshot(
+                    providerID: provider.id,
+                    displayName: provider.displayName,
+                    lines: [],
+                    usageHistory: history(tokens: 10, cost: 1, model: "model")
+                ),
+                producedByIdentityKey: identities[provider.id]
+            )
+        }
+
+        let single = WidgetDataStore(
+            registry: WidgetRegistry(providers: [personal, codex], descriptors: descriptors.filter {
+                $0.providerID != work.id
+            }),
+            providers: [], cache: cache, defaults: defaults,
+            providerIdentityKeys: identities
+        ).localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+
+        XCTAssertEqual(single.schema, UsageHistoryDocument.currentSchema)
+        XCTAssertEqual(single.identities, ["claude": "user|personal"])
+        XCTAssertNotNil(single.providers["codex"])
+        XCTAssertNoThrow(try single.validate())
+
+        let multiple = WidgetDataStore(
+            registry: WidgetRegistry(providers: providers, descriptors: descriptors),
+            providers: [], cache: cache, defaults: defaults,
+            providerIdentityKeys: identities
+        ).localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+
+        XCTAssertEqual(multiple.schema, UsageHistoryDocument.accountSchema)
+        XCTAssertEqual(multiple.identities, ["claude": "user|personal", "claude@1234abcd": "user|work"])
+        XCTAssertEqual(Set(multiple.providers.keys), ["claude", "claude@1234abcd", "codex"])
+        XCTAssertNoThrow(try multiple.validate())
+    }
+
     func testRendererReplacesOnlySpendRowsAndKeepsLocalState() throws {
         let local = ProviderSnapshot(
             providerID: "claude",

--- a/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
@@ -186,6 +186,15 @@ final class UsageHistoryAggregatorTests: XCTestCase {
         )
         XCTAssertEqual(try XCTUnwrap(single["claude"]).series.daily.first?.totalTokens, 90)
 
+        let switched = UsageHistoryAggregator.merged(
+            localSnapshots: [:],
+            peerDocuments: [peer],
+            descriptors: ["claude@1234abcd": descriptor],
+            providerIdentityKeys: ["claude@1234abcd": "user|personal"],
+            now: localDay(2026, 7, 13)
+        )
+        XCTAssertEqual(try XCTUnwrap(switched["claude@1234abcd"]).series.daily.first?.totalTokens, 90)
+
         let multiple = UsageHistoryAggregator.merged(
             localSnapshots: [:],
             peerDocuments: [peer],

--- a/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
@@ -247,6 +247,19 @@ final class UsageHistoryAggregatorTests: XCTestCase {
         XCTAssertNotNil(single.providers["codex"])
         XCTAssertNoThrow(try single.validate())
 
+        let switched = WidgetDataStore(
+            registry: WidgetRegistry(providers: [work, codex], descriptors: descriptors.filter {
+                $0.providerID != personal.id
+            }),
+            providers: [], cache: cache, defaults: defaults,
+            providerIdentityKeys: identities
+        ).localHistoryDocument(deviceID: "this-mac", deviceName: "This Mac")
+
+        XCTAssertEqual(switched.schema, UsageHistoryDocument.currentSchema)
+        XCTAssertEqual(switched.identities, ["claude": "user|work"])
+        XCTAssertEqual(Set(switched.providers.keys), ["claude", "codex"])
+        XCTAssertNoThrow(try switched.validate())
+
         let multiple = WidgetDataStore(
             registry: WidgetRegistry(providers: providers, descriptors: descriptors),
             providers: [], cache: cache, defaults: defaults,

--- a/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
@@ -15,9 +15,56 @@ final class UsageHistoryDocumentTests: XCTestCase {
         XCTAssertNoThrow(try decoded.validate())
     }
 
+    func testClaudeIdentitySupportsLegacyAndAccountCardSchemas() throws {
+        var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
+        document.identities = ["claude": "user|personal"]
+
+        XCTAssertEqual(document.schema, "openusage.history.v1")
+        XCTAssertNoThrow(try document.validate())
+        XCTAssertEqual(try JSONDecoder().decode(
+            UsageHistoryDocument.self,
+            from: JSONEncoder().encode(document)
+        ).identities, document.identities)
+
+        document.schema = UsageHistoryDocument.accountSchema
+        document.providers["claude@1234abcd"] = document.providers["claude"]
+        document.identities?["claude@1234abcd"] = "user|work"
+
+        XCTAssertNoThrow(try document.validate())
+
+        document.schema = UsageHistoryDocument.currentSchema
+        XCTAssertThrowsError(try document.validate()) { error in
+            XCTAssertEqual(error as? UsageHistoryDocumentError, .invalidProvider("claude@1234abcd"))
+        }
+    }
+
+    func testAccountSchemaRejectsMissingMismatchedAndDuplicateClaudeIdentities() {
+        var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
+        document.schema = UsageHistoryDocument.accountSchema
+
+        XCTAssertThrowsError(try document.validate()) { error in
+            XCTAssertEqual(error as? UsageHistoryDocumentError, .invalidIdentity("claude"))
+        }
+
+        document.identities = ["claude": "user|personal", "missing": "user|missing"]
+        XCTAssertThrowsError(try document.validate()) { error in
+            XCTAssertEqual(error as? UsageHistoryDocumentError, .invalidIdentity("missing"))
+        }
+
+        document.providers["claude@1234abcd"] = document.providers["claude"]
+        document.identities = ["claude": "User|Personal", "claude@1234abcd": "user|personal"]
+        XCTAssertThrowsError(try document.validate()) { error in
+            let identityError = error as? UsageHistoryDocumentError
+            XCTAssertTrue(
+                identityError == .duplicateIdentity("claude")
+                    || identityError == .duplicateIdentity("claude@1234abcd")
+            )
+        }
+    }
+
     func testRejectsUnsupportedSchemaInvalidValuesAndImpossibleDates() {
         var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
-        document.schema = "openusage.history.v2"
+        document.schema = "openusage.history.v3"
         XCTAssertThrowsError(try document.validate()) { error in
             XCTAssertEqual(error as? UsageHistoryDocumentError, .unsupportedSchema)
         }

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -7,10 +7,16 @@ existing file after app preferences are reset or the app is reinstalled. There i
 pairing code, or separate account.
 
 The file contains normalized daily tokens and spend, model totals, and unknown-model names for sources
-that are local to one Mac: Claude, Codex, Grok, and OpenCode. It does not contain credentials, account
-limits, raw logs, or provider responses. Cursor's history is already account-wide, so it stays local and
-is never added across Macs. Disabling a provider immediately removes its peer contributions from the
-combined view and omits it from this Mac's next iCloud write, while its local cached snapshot remains.
+that are local to one Mac: Claude, Codex, Grok, and OpenCode. It also includes Claude account and
+organization identities when available, but never credentials, account limits, raw logs, or provider
+responses. Cursor's history is already account-wide, so it stays local and is never added across Macs.
+Disabling a provider immediately removes its peer contributions from the combined view and omits it from
+this Mac's next iCloud write, while its local cached snapshot remains.
+
+Claude history that identifies its account and organization is combined only with matching accounts on
+other Macs. Older single-account history without account information remains compatible when only one
+Claude card is visible, and is ignored when multiple cards are visible. Codex syncing works the same way
+it did before.
 
 OpenUsage combines the valid files in memory and rebuilds Today, Yesterday, Last 30 Days, Usage Trend,
 unknown-model warnings, and model breakdowns. The same combined spend rows feed the dashboard, Total

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -2,6 +2,9 @@
 
 Tracks your Claude subscription limits using the login you already have from Claude Code or Claude Desktop.
 
+Each account and organization gets its own Claude card with separate limits and spending. Signing in to
+the same account and organization through both Claude Code and Claude Desktop still creates only one card.
+
 ## What it tracks
 
 | Metric | Meaning |
@@ -22,8 +25,11 @@ Sign in with Claude Code or Claude Desktop; OpenUsage reads the existing login. 
 
 1. The macOS keychain entry Claude Code maintains (its source of truth on macOS)
 2. `~/.claude/.credentials.json` (or `$CLAUDE_CONFIG_DIR/.credentials.json`)
-3. Claude Desktop's encrypted login cache, when no working Claude Code login is available
+3. Claude Desktop's encrypted login cache
 4. `CLAUDE_CODE_OAUTH_TOKEN` environment variable
+
+When multiple accounts are available, a Claude Desktop login for the card's organization takes precedence
+when needed. OpenUsage verifies that a credential belongs to the correct account and organization.
 
 Claude Desktop support is read-only. OpenUsage decrypts its currently valid access token using the
 `Claude Safe Storage` item in your macOS Keychain. It never reads or uses Desktop's refresh token, and
@@ -41,7 +47,11 @@ If one source holds an expired or "locked out" token, OpenUsage falls back to th
 
 ## The spend tiles
 
-Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the Claude Code session logs under `~/.claude/projects/` (or `$CLAUDE_CONFIG_DIR`) itself — no external tools needed. Symlinks are followed, so a projects folder linked into a synced location (say, a Dropbox folder) is read all the same. Claude usage from the [pi](https://github.com/earendil-works/pi) coding agent counts too: OpenUsage reads pi's session logs under `~/.pi/agent/sessions/` (or `$PI_CODING_AGENT_SESSION_DIR`) and folds any Claude usage there into the same tiles and trend, so a Claude sub driven through pi still shows up here. pi records its own per-message cost, so those dollars come straight from pi rather than being re-estimated. Cowork (the Claude desktop app's agent mode) counts too: it writes the same logs into per-session folders under `~/Library/Application Support/Claude/local-agent-mode-sessions/`, and OpenUsage scans those as well, so desktop agent sessions show up in the tiles alongside terminal ones. Persisted `claude -p` runs count as well. Runs made with `--no-session-persistence` cannot appear because Claude deliberately writes no session log for OpenUsage to read. Advisor work recorded inside a message is counted once under the advisor's own model; the parent's main-model totals are kept separate, and ordinary iteration details are not counted again. A log's recorded fast or standard speed controls its price; OpenUsage does not infer speed from the event date. Days are grouped in your Mac's local time zone, so they line up with your own calendar. Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`); a day with no usage reads **No data** rather than a misleading `$0.00 · 0 tokens` — the same as every other spend-tracking provider. The live Session and Weekly meters are unaffected. The dollars are estimated from token counts at API rates (that's the ⓘ) using the shared [model pricing](../pricing.md); the token counts themselves are measured. No log data leaves your Mac.
+Today / Yesterday / Last 30 Days are computed **locally**: OpenUsage reads the Claude Code session logs under `~/.claude/projects/` (or `$CLAUDE_CONFIG_DIR`) itself — no external tools needed. Symlinks are followed, so a projects folder linked into a synced location (say, a Dropbox folder) is read all the same. With one known account, Claude usage from the [pi](https://github.com/earendil-works/pi) coding agent counts too: OpenUsage reads pi's session logs under `~/.pi/agent/sessions/` (or `$PI_CODING_AGENT_SESSION_DIR`) and folds any Claude usage there into the same tiles and trend, so a Claude sub driven through pi still shows up here. pi records its own per-message cost, so those dollars come straight from pi rather than being re-estimated. Cowork (the Claude desktop app's agent mode) counts too: it writes the same logs into per-session folders under `~/Library/Application Support/Claude/local-agent-mode-sessions/`, and OpenUsage scans those as well, so desktop agent sessions show up in the tiles alongside terminal ones. Persisted `claude -p` runs count as well. Runs made with `--no-session-persistence` cannot appear because Claude deliberately writes no session log for OpenUsage to read. Advisor work recorded inside a message is counted once under the advisor's own model; the parent's main-model totals are kept separate, and ordinary iteration details are not counted again. A log's recorded fast or standard speed controls its price; OpenUsage does not infer speed from the event date. Days are grouped in your Mac's local time zone, so they line up with your own calendar. Each period is one tile showing cost and tokens together (`$4.08 · 1.2M tokens`); a day with no usage reads **No data** rather than a misleading `$0.00 · 0 tokens` — the same as every other spend-tracking provider. The live Session and Weekly meters are unaffected. The dollars are estimated from token counts at API rates (that's the ⓘ) using the shared [model pricing](../pricing.md); the token counts themselves are measured. No log data leaves your Mac.
+
+Sessions that do not identify their account, including usage from pi and third-party tools such as
+Conductor, count as long as OpenUsage has never seen more than one Claude account. Once multiple
+accounts are discovered, unattributed usage is left out instead of being assigned to the wrong card.
 
 Local spend does not require a Claude OAuth login. If Claude Code uses an API-key gateway instead, the spend tiles and usage trend still load from its session logs; the Claude header shows **Not logged in** because the live Session and Weekly meters still require a Claude subscription login.
 


### PR DESCRIPTION
## TL;DR

Show one Claude card per real account and organization, combining Claude Code and Claude Desktop when they access the same organization while keeping different organizations isolated.

## What was happening

- Claude Desktop and CLI installation locations could create duplicate cards for the same account.
- Claude Code can leave SUNSTORY in its state file after its global Keychain token has switched to Personal, causing two apparently different cards to show identical usage.
- The previous implementation was split across four oversized PRs and introduced unrelated runtime complexity.

## What this changes

- Discover Claude organizations from current-user Desktop directories and CLI account metadata.
- Keep persistent organization identities when the active Desktop or CLI organization changes.
- Prefer the organization-scoped Desktop credential over a mismatched global CLI credential.
- Verify each credential against the official OAuth account-and-organization profile before displaying usage; cache verified results and reject incorrect-account fallbacks.
- Attribute session logs using explicit account/organization markers or the exact organization-scoped Claude Desktop session index.
- Match iCloud history by real account and organization while preserving legacy documents and Codex synchronization.
- Automatically create clearly named organization cards such as Claude — SUNSTORY and Claude — Personal.

## Heads-up

- First launch captures shell configuration off the main thread before creating account cards; restart after later adding or removing an organization.
- Claude Agent SDK frontends such as Conductor are tracked separately in #1166 because they lack durable session-to-account ownership records.
- Codex remains unchanged and keeps its existing synchronization behavior.

## Tests

- Full rebased Swift suite: 1,200 tests, three expected skips, zero failures.
- Regression tests cover stale CLI identity, wrong-organization credentials, successful fallback, token revalidation, account switches, logout, organization-specific sessions, and old iCloud formats.
- Signed, iCloud-provisioned app verified locally: SUNSTORY Team 5x and Personal Max 20x expose distinct live quotas and separate spending.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes span auth verification, credential selection, log attribution, and iCloud merge rules—mistakes could show wrong-org usage or drop history across Macs.
> 
> **Overview**
> Adds **multi-organization Claude**: launch discovers Desktop and CLI organizations, builds one provider card per real account+org (named e.g. **Claude — Personal** / **Claude — SUNSTORY**), and wires layout defaults for each card’s metrics.
> 
> **Credentials and live usage** prefer organization-scoped Desktop tokens when several orgs exist, can run **desktop-only** cards, and call the OAuth **profile** endpoint to confirm a token matches the card’s `account|organization` before usage—wrong tokens are rejected instead of showing duplicate quotas.
> 
> **Local spend** filters session logs (Cowork paths, bridge ownership, Desktop session index) per card; **pi** and unattributed sessions count only while a single Claude account is known.
> 
> **iCloud** gains history **v2** with optional `identities`, merges peer Claude history by identity (legacy v1 still works for one card), and exports owned cards only when multiple orgs are visible.
> 
> **Launch** may defer `AppContainer` setup until login-shell / snapshot facts are ready so account discovery is consistent on Finder launches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ac878c24a0ec99018f6a3bc13a659b3588e87bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->