### PR TITLE
fix(codex): restore Session by default

### DIFF
--- a/Sources/OpenUsage/Stores/DefaultLayout.swift
+++ b/Sources/OpenUsage/Stores/DefaultLayout.swift
@@ -13,7 +13,7 @@ enum DefaultLayout {
         "claude.session", "claude.weekly", "claude.fable", "claude.trend",
         "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
 
-        "codex.weekly", "codex.spark", "codex.sparkWeekly", "codex.trend",
+        "codex.session", "codex.weekly", "codex.spark", "codex.sparkWeekly", "codex.trend",
         "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
 
         "cursor.usage", "cursor.auto", "cursor.api", "cursor.grokBot", "cursor.trend",
@@ -56,13 +56,13 @@ enum DefaultLayout {
     ]
 
     /// Metrics pinned to the menu bar on first launch, so the app shows real numbers out of the box
-    /// instead of a lone icon. Antigravity, Claude, and Cursor start at the two-pin per-provider cap
-    /// (`LayoutStore.maxPinsPerProvider`); Codex starts with its Weekly meter. Filtered to the active
-    /// registry by `LayoutStore`, like `metricIDs`.
+    /// instead of a lone icon. Two per provider for Antigravity, Claude, Codex, and Cursor — the
+    /// per-provider cap (`LayoutStore.maxPinsPerProvider`). Filtered to the active registry by
+    /// `LayoutStore`, like `metricIDs`.
     static let pinnedMetricIDs: [String] = [
         "antigravity.geminiPro", "antigravity.geminiWeekly",
         "claude.session", "claude.weekly",
-        "codex.weekly",
+        "codex.session", "codex.weekly",
         "cursor.auto", "cursor.api",
         "copilot.premium",
         "openrouter.credits",

--- a/Tests/OpenUsageTests/LayoutStoreTests.swift
+++ b/Tests/OpenUsageTests/LayoutStoreTests.swift
@@ -662,7 +662,7 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertEqual(Set(store.placed.map(\.descriptorID)), Set([
             "claude.session", "claude.weekly", "claude.fable", "claude.trend",
             "claude.extra", "claude.today", "claude.yesterday", "claude.last30",
-            "codex.weekly", "codex.spark", "codex.sparkWeekly", "codex.trend",
+            "codex.session", "codex.weekly", "codex.spark", "codex.sparkWeekly", "codex.trend",
             "codex.credits", "codex.rateLimitResets", "codex.today", "codex.yesterday", "codex.last30",
             "devin.daily", "devin.weekly", "devin.extra",
             "grok.weekly", "grok.trend",
@@ -674,8 +674,8 @@ final class LayoutStoreTests: XCTestCase {
         XCTAssertTrue(store.isMetricEnabled("claude.fable"))
         XCTAssertFalse(store.isPinned("claude.fable"))
         XCTAssertFalse(store.isMetricEnabled("claude.sonnet"))
-        XCTAssertFalse(store.isMetricEnabled("codex.session"))
-        XCTAssertFalse(store.isPinned("codex.session"))
+        XCTAssertTrue(store.isMetricEnabled("codex.session"))
+        XCTAssertTrue(store.isPinned("codex.session"))
         XCTAssertTrue(store.isPinned("codex.weekly"))
         XCTAssertTrue(store.isMetricEnabled("cursor.grokBot"))
         XCTAssertFalse(store.isMetricEnabled("cursor.requests"))

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -10,7 +10,7 @@ Right-click (or control-click) the menu bar icon for a quick menu with **Setting
 
 Star a metric from any row's right-click menu, or from the always-visible star beside a metric in Customize.
 
-- On first launch the app ships with a default set of stars (Antigravity Session/Weekly, Claude Session/Weekly, Codex Weekly, Cursor Models/Other Models, Copilot Credits, OpenRouter Credits, Z.ai Session/Weekly) so the strip shows numbers right away. Change them anytime; a provider's Reset restores its defaults, and Reset All restores the full set. Only providers that are turned on render in the strip — and a fresh install starts with just the providers detected on your Mac (see [Dashboard § First launch](dashboard.md#first-launch)) — so the default stars don't crowd the menu bar with tools you don't use.
+- On first launch the app ships with a default set of stars (Antigravity Session/Weekly, Claude Session/Weekly, Codex Session/Weekly, Cursor Models/Other Models, Copilot Credits, OpenRouter Credits, Z.ai Session/Weekly) so the strip shows numbers right away. Change them anytime; a provider's Reset restores its defaults, and Reset All restores the full set. Only providers that are turned on render in the strip — and a fresh install starts with just the providers detected on your Mac (see [Dashboard § First launch](dashboard.md#first-launch)) — so the default stars don't crowd the menu bar with tools you don't use.
 - At most **2 stars per provider**.
 - When a star isn't allowed, the star button stays clickable — clicking it shakes and shows the reason in a temporary pill over the bottom of Customize (for example, "Up to 2 stars per provider").
 

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -6,7 +6,7 @@ Tracks your ChatGPT/Codex subscription limits using the login from the Codex CLI
 
 | Metric | Meaning |
 |---|---|
-| Session | 5-hour rolling window usage; hidden by default and available in Customize |
+| Session | 5-hour rolling window usage |
 | Weekly | 7-day window usage |
 | Spark / Spark Weekly | GPT-5.3-Codex-Spark model limits — a 5-hour and a weekly window. Shown only when your account has the limit (otherwise "No data"), and tucked below the "show more" caret by default |
 | Rate Limit Resets | On-demand rate-limit reset credits, shown as a count (e.g. `2 available`) with a colored dot for the soonest expiry; hover the value for a timeline of each credit's expiry |


### PR DESCRIPTION
## TL;DR

Restore Codex Session to the default dashboard and menu bar alongside Weekly.

## What was happening

- PR #1137 hid the Codex Session metric and removed its default menu-bar pin.
- OpenAI is bringing back the five-hour session limit, so that metric needs to be visible again.

## What this changes

- Enable Codex Session by default and keep it above Weekly.
- Restore Session as a default menu-bar pin alongside Weekly.
- Update layout regression coverage and the Codex and menu-bar documentation.

## Tests

- `swift test --filter LayoutStoreTests` with the existing Sparkle framework runtime search path: 64 tests passed.