### PR TITLE
fix(claude): show reset countdown for sub-1% sessions instead of "Not started"

### DIFF
--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -84,14 +84,11 @@ struct WidgetData: Hashable {
     /// than a hardcoded widget-ID list in the model. `nil` for every other row.
     var sessionStartSignal: SessionStartSignal?
 
-    /// True for rows opted into the session-window "Not started" treatment (any `sessionStartSignal`).
-    var isSessionWindow: Bool { sessionStartSignal != nil }
-
     /// How a session-window meter tells a not-yet-started window from an in-flight one.
     enum SessionStartSignal: Hashable {
-        /// Zero usage is the fresh signal. For providers whose payload carries a reset instant even
-        /// for an untouched window (Antigravity rounds to whole percents on purpose so a fresh pool
-        /// reads 0; OpenCode reports 0 directly), so `used == 0` is what distinguishes fresh.
+        /// Zero usage is the fresh signal. These providers report a reset instant even for an
+        /// untouched window (Antigravity's mapper rounds a fresh pool's fraction-derived percent
+        /// to 0; OpenCode reports 0 directly), so `used == 0` is what marks the window as fresh.
         case zeroUsage
         /// A missing reset date is the fresh signal. Claude's five-hour block only exists once the
         /// first message is sent, so a reported `resets_at` proves the window started. Zero usage is
@@ -580,17 +577,14 @@ extension WidgetData {
     }
 
     /// Session meters only (Claude/Antigravity/OpenCode): a "Not started" state for the current window
-    /// when nothing has been spent in it yet, detected through the descriptor's `sessionStartSignal`.
-    /// Both signals read frozen snapshot fields, not a `resetsAt - now ≈ full period` window-timing
-    /// test — that test is only valid the instant the snapshot is captured, then drifts every second
-    /// until the next refresh, which split the headline from the label (headline "100% left" while the
-    /// label fell back to "Resets in 5h").
-    /// - `.zeroUsage` trusts `used == 0` (the provider reports a reset instant for fresh windows too),
-    ///   gated on `now < resetsAt`: once the reset has passed the snapshot is stale, so we drop the
-    ///   "Not started" claim and let the row fall back to the normal "Resets soon"/countdown formatting.
-    /// - `.missingResetDate` trusts the absence of `resetsAt` (the provider only reports one once the
-    ///   window exists). `used == 0` mustn't decide there: Claude reports whole-percent utilization, so
-    ///   an in-flight window under 1% also reads 0 (#1160) and must keep its reset countdown.
+    /// when nothing has been spent in it yet, detected through the descriptor's `sessionStartSignal`
+    /// (see `SessionStartSignal` for why each provider trusts its signal). Both signals read frozen
+    /// snapshot fields, not a `resetsAt - now ≈ full period` window-timing test — that test is only
+    /// valid the instant the snapshot is captured, then drifts every second until the next refresh,
+    /// which split the headline from the label (headline "100% left" while the label fell back to
+    /// "Resets in 5h"). `.zeroUsage` is additionally gated on `now < resetsAt`: once the reset has
+    /// passed the snapshot is stale, so we drop the "Not started" claim and let the row fall back to
+    /// the normal "Resets soon"/countdown formatting.
     func isFreshSessionWindow(now: Date = Date()) -> Bool {
         guard let signal = sessionStartSignal, hasData, limit != nil, used <= 0 else { return false }
         switch signal {

--- a/Sources/OpenUsage/Models/WidgetData.swift
+++ b/Sources/OpenUsage/Models/WidgetData.swift
@@ -77,10 +77,28 @@ struct WidgetData: Hashable {
     /// Rate Limit Resets → "2 resets"). Set by the descriptor, so renaming the tile can't silently drop
     /// the suffix — replaces matching on the tile's title. `nil` for tiles that show the bare value.
     var traySuffix: String?
-    /// Session-window meters (Claude/Antigravity 5-hour pools) that read "Not started" when unused.
-    /// Set by those descriptors and carried through `WidgetDataStore.resolve`, so the "fresh window"
-    /// treatment is a descriptor opt-in rather than a hardcoded widget-ID list in the model.
-    var isSessionWindow: Bool = false
+    /// Session-window meters (Claude/Antigravity/OpenCode rolling 5-hour pools) that read "Not started"
+    /// while the window hasn't begun — the value names the signal that detects that state, because the
+    /// providers report fresh windows differently (see `SessionStartSignal`). Set by those descriptors
+    /// and carried through `WidgetDataStore.resolve`, so the treatment is a descriptor opt-in rather
+    /// than a hardcoded widget-ID list in the model. `nil` for every other row.
+    var sessionStartSignal: SessionStartSignal?
+
+    /// True for rows opted into the session-window "Not started" treatment (any `sessionStartSignal`).
+    var isSessionWindow: Bool { sessionStartSignal != nil }
+
+    /// How a session-window meter tells a not-yet-started window from an in-flight one.
+    enum SessionStartSignal: Hashable {
+        /// Zero usage is the fresh signal. For providers whose payload carries a reset instant even
+        /// for an untouched window (Antigravity rounds to whole percents on purpose so a fresh pool
+        /// reads 0; OpenCode reports 0 directly), so `used == 0` is what distinguishes fresh.
+        case zeroUsage
+        /// A missing reset date is the fresh signal. Claude's five-hour block only exists once the
+        /// first message is sent, so a reported `resets_at` proves the window started. Zero usage is
+        /// NOT trusted here: Claude reports utilization in whole percents, so an in-flight window
+        /// under 1% also reads 0 (#1160) — the reset date is what tells the two apart.
+        case missingResetDate
+    }
     /// Per-day points for a Usage Trend row (empty for every other tile). Set true `isChart` flags the
     /// row so the view draws the sparkline instead of the value layout; `chartNote` is the source line
     /// shown on hover (e.g. "From your Claude usage history (estimated)").
@@ -561,19 +579,27 @@ extension WidgetData {
         return boundedSubtitle // period cadence / dollar limit / count suffix — nothing to flip
     }
 
-    /// Claude and Antigravity session meters only: a "Not started" state for the current window
-    /// when nothing has been spent in it yet. Driven by frozen usage (`used == 0`), not a window-timing
-    /// read — the `resetsAt - now ≈ full period` test is only valid the instant the snapshot is captured,
-    /// then drifts every second until the next refresh, which split the headline from the label (headline
-    /// "100% left" while the label fell back to "Resets in 5h"). Usage is the stable, snapshot-consistent
-    /// signal: providers that report 0 utilization directly remain at 0, and Antigravity's mapper rounds
-    /// its fraction-derived percent (so a pool under ~0.5% used also reads 0). Codex percentages are
-    /// preserved verbatim, so a reported 1% is not treated as "Not started."
-    /// Still gated on `now < resetsAt`: once the reset has passed the snapshot is stale, so we drop the
-    /// "Not started" claim and let the row fall back to the normal "Resets soon"/countdown formatting.
+    /// Session meters only (Claude/Antigravity/OpenCode): a "Not started" state for the current window
+    /// when nothing has been spent in it yet, detected through the descriptor's `sessionStartSignal`.
+    /// Both signals read frozen snapshot fields, not a `resetsAt - now ≈ full period` window-timing
+    /// test — that test is only valid the instant the snapshot is captured, then drifts every second
+    /// until the next refresh, which split the headline from the label (headline "100% left" while the
+    /// label fell back to "Resets in 5h").
+    /// - `.zeroUsage` trusts `used == 0` (the provider reports a reset instant for fresh windows too),
+    ///   gated on `now < resetsAt`: once the reset has passed the snapshot is stale, so we drop the
+    ///   "Not started" claim and let the row fall back to the normal "Resets soon"/countdown formatting.
+    /// - `.missingResetDate` trusts the absence of `resetsAt` (the provider only reports one once the
+    ///   window exists). `used == 0` mustn't decide there: Claude reports whole-percent utilization, so
+    ///   an in-flight window under 1% also reads 0 (#1160) and must keep its reset countdown.
     func isFreshSessionWindow(now: Date = Date()) -> Bool {
-        guard isSessionWindow, hasData, limit != nil, let resetsAt, used <= 0 else { return false }
-        return now < resetsAt
+        guard let signal = sessionStartSignal, hasData, limit != nil, used <= 0 else { return false }
+        switch signal {
+        case .zeroUsage:
+            guard let resetsAt else { return false }
+            return now < resetsAt
+        case .missingResetDate:
+            return resetsAt == nil
+        }
     }
 
     /// True when the bounded primary row's trailing text is a concrete reset countdown (so the row makes

--- a/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
+++ b/Sources/OpenUsage/Models/WidgetDescriptor+Factories.swift
@@ -5,18 +5,18 @@ import Foundation
 /// builders. Template numbers are structural only (a row without real data renders the no-data marker,
 /// never the template), so every factory seeds `used: 0`.
 extension WidgetDescriptor {
-    /// Bounded 0–100% meter (session/weekly-style quotas). `isSessionWindow` opts the tile into the
-    /// "Not started" fresh-window treatment (rolling 5-hour session pools), replacing a hardcoded
-    /// widget-ID list in the model.
+    /// Bounded 0–100% meter (session/weekly-style quotas). `sessionStartSignal` opts the tile into the
+    /// "Not started" fresh-window treatment (rolling 5-hour session pools) and names how that state is
+    /// detected for this provider — see `WidgetData.SessionStartSignal`.
     static func percent(
         id: String,
         provider: Provider,
         title: String,
         metricLabel: String? = nil,
-        isSessionWindow: Bool = false
+        sessionStartSignal: WidgetData.SessionStartSignal? = nil
     ) -> WidgetDescriptor {
         var sample = WidgetData(title: title, icon: provider.icon, kind: .percent, used: 0, limit: 100)
-        sample.isSessionWindow = isSessionWindow
+        sample.sessionStartSignal = sessionStartSignal
         return make(id: id, provider: provider, metricLabel: metricLabel ?? title, sample: sample)
     }
 

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityProvider.swift
@@ -43,11 +43,11 @@ final class AntigravityProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: AntigravityMetric.geminiID, provider: provider, title: AntigravityMetric.sessionLabel, isSessionWindow: true)
+            .percent(id: AntigravityMetric.geminiID, provider: provider, title: AntigravityMetric.sessionLabel, sessionStartSignal: .zeroUsage)
                 .exportingLimit("geminiSession", unit: "percent"),
             .percent(id: AntigravityMetric.geminiWeeklyID, provider: provider, title: AntigravityMetric.weeklyLabel)
                 .exportingLimit("geminiWeekly", unit: "percent"),
-            .percent(id: AntigravityMetric.claudeID, provider: provider, title: AntigravityMetric.claudeLabel, isSessionWindow: true)
+            .percent(id: AntigravityMetric.claudeID, provider: provider, title: AntigravityMetric.claudeLabel, sessionStartSignal: .zeroUsage)
                 .exportingLimit("nonGeminiSession", unit: "percent"),
             .percent(id: AntigravityMetric.claudeWeeklyID, provider: provider, title: AntigravityMetric.claudeWeeklyLabel)
                 .exportingLimit("nonGeminiWeekly", unit: "percent"),

--- a/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
+++ b/Sources/OpenUsage/Providers/Claude/ClaudeProvider.swift
@@ -54,7 +54,7 @@ final class ClaudeProvider: ProviderRuntime {
 
     var widgetDescriptors: [WidgetDescriptor] {
         [
-            .percent(id: "\(provider.id).session", provider: provider, title: "Session", isSessionWindow: true)
+            .percent(id: "\(provider.id).session", provider: provider, title: "Session", sessionStartSignal: .missingResetDate)
                 .exportingLimit("session", unit: "percent"),
             .percent(id: "\(provider.id).weekly", provider: provider, title: "Weekly")
                 .exportingLimit("weekly", unit: "percent"),

--- a/Sources/OpenUsage/Providers/OpenCode/OpenCodeProvider.swift
+++ b/Sources/OpenUsage/Providers/OpenCode/OpenCodeProvider.swift
@@ -83,7 +83,7 @@ final class OpenCodeProvider: ProviderRuntime {
         // Go plan windows from `/zen/go/v1/usage` (Session/Weekly/Monthly + trend above the fold);
         // the spend tiles below sum combined OpenCode-hosted (Go + Zen) spend from local logs.
         [
-            .percent(id: "opencode.session", provider: provider, title: "Session", isSessionWindow: true)
+            .percent(id: "opencode.session", provider: provider, title: "Session", sessionStartSignal: .zeroUsage)
                 .exportingLimit("session", unit: "percent"),
             .percent(id: "opencode.weekly", provider: provider, title: "Weekly")
                 .exportingLimit("weekly", unit: "percent"),

--- a/Sources/OpenUsage/Stores/WidgetDataStore.swift
+++ b/Sources/OpenUsage/Stores/WidgetDataStore.swift
@@ -599,8 +599,8 @@ final class WidgetDataStore {
                 infoNote: descriptor.sample.infoNote
             )
             // Descriptor opt-in (session-window meters read "Not started" when unused); the fresh
-            // `.progress` result doesn't start from the sample, so carry the flag explicitly.
-            result.isSessionWindow = descriptor.sample.isSessionWindow
+            // `.progress` result doesn't start from the sample, so carry the signal explicitly.
+            result.sessionStartSignal = descriptor.sample.sessionStartSignal
             return result
         case .text:
             // Text lines carry provider notices for the local API; no dashboard descriptor consumes

--- a/Tests/OpenUsageTests/ResetDisplayTests.swift
+++ b/Tests/OpenUsageTests/ResetDisplayTests.swift
@@ -53,7 +53,7 @@ final class ResetDisplayTests: XCTestCase {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let period: TimeInterval = 5 * 3600
         var data = WidgetData(title: "Session", icon: .providerMark("codex"), kind: .percent, used: 0, limit: 100)
-        data.isSessionWindow = true
+        data.sessionStartSignal = .zeroUsage
         data.periodDurationMs = Int(period * 1000)
         data.resetsAt = now.addingTimeInterval(period / 2)
 
@@ -69,24 +69,50 @@ final class ResetDisplayTests: XCTestCase {
     }
 
     @MainActor
-    func testSessionWindowFlagIsWiredOnExactlyTheShippingSessionDescriptors() {
-        // The test above hand-sets `isSessionWindow`, so it pins the mechanism but not the wiring.
-        // This one pins the wiring: the descriptor opt-in replaced a model-level widget-ID set, so a
-        // provider dropping (or spuriously gaining) the flag must fail here, not ship silently.
+    func testSessionWindowSignalIsWiredOnExactlyTheShippingSessionDescriptors() {
+        // The tests around this hand-set `sessionStartSignal`, so they pin the mechanism but not the
+        // wiring. This one pins the wiring: the descriptor opt-in replaced a model-level widget-ID set,
+        // so a provider dropping (or spuriously gaining) the signal — or flipping which signal it uses —
+        // must fail here, not ship silently. Claude must stay on `.missingResetDate`: its whole-percent
+        // utilization reads 0 for an in-flight window under 1%, so `.zeroUsage` would regress #1160.
         let providers: [ProviderRuntime] = [
             ClaudeProvider(), CodexProvider(), CursorProvider(),
             AntigravityProvider(), CopilotProvider(), DevinProvider(),
-            GrokProvider(), OpenRouterProvider(), ZAIProvider()
+            GrokProvider(), OpenRouterProvider(), ZAIProvider(), OpenCodeProvider()
         ]
         let descriptors = providers.flatMap(\.widgetDescriptors)
-        let sessionIDs = Set(descriptors.filter(\.sample.isSessionWindow).map(\.id))
-        XCTAssertEqual(sessionIDs, ["claude.session",
-                                    "antigravity.geminiPro", "antigravity.claude"])
+        let signals = Dictionary(uniqueKeysWithValues: descriptors
+            .compactMap { d in d.sample.sessionStartSignal.map { (d.id, $0) } })
+        XCTAssertEqual(signals, ["claude.session": .missingResetDate,
+                                 "antigravity.geminiPro": .zeroUsage,
+                                 "antigravity.claude": .zeroUsage,
+                                 "opencode.session": .zeroUsage])
 
         // Same wiring pin for the menu-bar tray suffix (it replaced a title-string match).
         let suffixed = descriptors.filter { $0.sample.traySuffix != nil }
         XCTAssertEqual(suffixed.map(\.id), ["codex.rateLimitResets"])
         XCTAssertEqual(suffixed.first?.sample.traySuffix, "resets")
+    }
+
+    func testMissingResetDateSignalKeepsCountdownForSubOnePercentSession() {
+        // #1160: Claude reports utilization in whole percents, so an in-flight session under 1% reads
+        // used == 0 — but its reset date exists precisely because the window started. The row must show
+        // the normal countdown, never "Not started".
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        var data = WidgetData(title: "Session", icon: .providerMark("claude"), kind: .percent, used: 0, limit: 100)
+        data.sessionStartSignal = .missingResetDate
+        data.periodDurationMs = 5 * 3600 * 1000
+        data.resetsAt = now.addingTimeInterval(2 * 3600)
+
+        XCTAssertFalse(data.isFreshSessionWindow(now: now))
+        XCTAssertTrue(data.hasResetLabel(now: now))
+        XCTAssertEqual(data.boundedTrailingText(now: now)?.hasPrefix("Resets in"), true)
+
+        // A genuinely fresh session carries no reset date — that is this signal's "Not started" state.
+        data.resetsAt = nil
+        XCTAssertTrue(data.isFreshSessionWindow(now: now))
+        XCTAssertEqual(data.boundedTrailingText(now: now), "Not started")
+        XCTAssertEqual(data.resetTooltip(now: now), WidgetData.freshSessionTooltip)
     }
 
     func testNonSessionWindowNeverReadsNotStarted() {

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -68,4 +68,4 @@ Local spend does not require a Claude OAuth login. If Claude Code uses an API-ke
 
 `GET https://api.anthropic.com/api/oauth/usage` with the selected OAuth token. Claude Code tokens refresh via `platform.claude.com/v1/oauth/token`; Claude Desktop tokens are read-only and must be renewed by Desktop itself. If a token is expired or revoked, OpenUsage retries with the next credential source before reporting an error.
 
-When the five-hour session window has no usage yet, the Session row shows **Not started** on the trailing label; hover explains that the session begins after your first message.
+When the five-hour session window hasn't begun (the usage API reports no reset time), the Session row shows **Not started** on the trailing label; hover explains that the session begins after your first message. A reported reset time means the window is running, so the row always shows the countdown then — even when Anthropic's whole-percent numbers still read 0% because less than 1% has been used, which matches what Claude Code itself shows.


### PR DESCRIPTION
## TL;DR

Claude sessions with under 1% usage showed as "Not started" with no reset countdown, as if nothing had been used. The Session row now shows its countdown whenever the window is actually running. Fixes #1160.

## What was happening

- Anthropic's usage API reports session utilization in whole percents, so anything under 1% comes back as a literal `0`.
- OpenUsage treated `used == 0` on a session meter as "the window hasn't started yet", so it showed **Not started** and hid the reset countdown — even while the five-hour window was mid-flight.
- Claude Code itself shows "0%" for this state, but with a live countdown; OpenUsage looked like it had detected no usage at all.

## What this changes

- Session meters now declare *how* a fresh window is detected, via a new `WidgetData.SessionStartSignal` on the descriptor, instead of one shared zero-usage rule.
- **Claude** uses `.missingResetDate`: a reported `resets_at` proves the window started (a five-hour block only exists after the first message), so a 0%-reading in-flight session keeps its countdown. A genuinely fresh session (no reset time) now correctly reads "Not started".
- **Antigravity** and **OpenCode** keep the previous zero-usage behavior via `.zeroUsage` — their APIs report reset times for untouched windows, so zero usage is the right signal there.
- Updated `docs/providers/claude.md` to describe the new behavior.

## Heads-up

- Sub-1% usage still displays as "0% used" — that's the API's whole-percent granularity and matches Claude Code's own UI; the countdown is what signals activity. Showing "<1% used" instead would be a small follow-up if wanted.
- The wiring test now also covers OpenCode's session descriptor, which the previous pin missed.

## Tests

- New regression test: a `.missingResetDate` session at `used == 0` with a reset date shows the countdown, and without one shows "Not started".
- The session-descriptor wiring test now pins each provider's exact signal, so a provider flipping signals fails loudly.
- Full suite passes: 1174 tests, 0 failures.
- Reproduced live before the fix via `openusage-cli`: `session { used: 0, resetsAt: ~4h out }` while the account was actively in use.

## Screenshots

The fix session had no screen-capture permission, so no after-screenshot yet — the row reads "0% used · Resets in Xh Ym" instead of "0% used · Not started". Happy to have one attached from a local run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized presentation logic for session meter labels, covered by wiring and regression tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **#1160**: Claude Session rows with an active five-hour window but **0%** usage (whole-percent API granularity) no longer show **Not started** and hide the countdown.
> 
> Session **"fresh window"** detection moves from a single `isSessionWindow` + `used == 0` rule to descriptor opt-in **`sessionStartSignal`**: **`.missingResetDate`** for Claude (no `resets_at` ⇒ not started; a reset time ⇒ show countdown even at 0% used) and **`.zeroUsage`** for Antigravity/OpenCode session meters (unchanged behavior). The percent factory, `WidgetDataStore.resolve`, and provider descriptors are updated accordingly; **`docs/providers/claude.md`** documents the Claude-specific rule.
> 
> Tests now pin each shipping session widget’s signal (including OpenCode) and add a regression for sub-1% Claude sessions with a reset date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed429a6f809ef68e74e8985bc8dd6031ebb00e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->