### PR TITLE
Enforce approved and assigned external contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,12 @@
 <!-- OpenUsage has a strict, issue-first PR policy. External pull requests are closed
 automatically unless they link an issue a maintainer has approved with the `approved`
-label, stay under 1,000 changed lines, and include screenshots for visual changes.
+label and assigned to the PR author. PRs adding more than 1,000 lines receive a warning.
+Visual changes require screenshots during maintainer review.
 See CONTRIBUTING.md. Maintainers and collaborators may open PRs directly. -->
 
 ## Approved issue
 
-<!-- External PRs require an open issue approved with the `approved` label. -->
+<!-- External PRs require an open issue labeled `approved` and assigned to their author. -->
 Fixes #
 
 ## TL;DR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,81 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  eligibility:
-    name: Check PR Eligibility
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
-    steps:
-      - name: Require an approved issue assigned to the PR author
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const pullRequest = context.payload.pull_request;
-            const { owner, repo } = context.repo;
-            const author = pullRequest.user.login;
-            const labels = pullRequest.labels ?? [];
-
-            if (
-              ["OWNER", "MEMBER", "COLLABORATOR"].includes(pullRequest.author_association) ||
-              author === "dependabot[bot]" ||
-              labels.some(label => label.name.toLowerCase() === "keep-open")
-            ) {
-              core.info(`Trusted or explicitly exempt pull request from @${author}.`);
-              return;
-            }
-
-            const references = [
-              ...new Set(
-                [...(pullRequest.body ?? "").matchAll(
-                  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
-                )].map(match => Number(match[1]))
-              )
-            ];
-
-            for (const issueNumber of references) {
-              let issue;
-
-              try {
-                ({ data: issue } = await github.rest.issues.get({
-                  owner,
-                  repo,
-                  issue_number: issueNumber
-                }));
-              } catch (error) {
-                if (error.status === 404) {
-                  core.info(`Referenced issue #${issueNumber} does not exist.`);
-                  continue;
-                }
-
-                throw error;
-              }
-
-              const isApproved = (issue.labels ?? []).some(label => {
-                const name = typeof label === "string" ? label : label.name;
-                return name.toLowerCase() === "approved";
-              });
-              const authorIsAssigned = (issue.assignees ?? []).some(
-                assignee => assignee.login.toLowerCase() === author.toLowerCase()
-              );
-
-              if (!issue.pull_request && issue.state === "open" && isApproved && authorIsAssigned) {
-                core.info(`Pull request #${pullRequest.number} is approved by issue #${issue.number}.`);
-                return;
-              }
-            }
-
-            core.setFailed(
-              "External pull requests require an open issue labeled `approved` and assigned " +
-                `to @${author}. Reference it in the pull request description with Fixes #123.`
-            );
-
   check:
     name: Build and Test
-    needs: eligibility
     # Builds against the macOS 26 SDK with the package's macOS 15 deployment target (Package.swift
     # .macOS(.v15)), so this compiles the whole codebase — including the `if #available(macOS 26, *)`
     # Liquid Glass branches — for the macOS 15 floor. That is the floor's compile guarantee: a binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,81 @@ permissions:
   contents: read
 
 jobs:
+  eligibility:
+    name: Check PR Eligibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Require an approved issue assigned to the PR author
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const author = pullRequest.user.login;
+            const labels = pullRequest.labels ?? [];
+
+            if (
+              ["OWNER", "MEMBER", "COLLABORATOR"].includes(pullRequest.author_association) ||
+              author === "dependabot[bot]" ||
+              labels.some(label => label.name.toLowerCase() === "keep-open")
+            ) {
+              core.info(`Trusted or explicitly exempt pull request from @${author}.`);
+              return;
+            }
+
+            const references = [
+              ...new Set(
+                [...(pullRequest.body ?? "").matchAll(
+                  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
+                )].map(match => Number(match[1]))
+              )
+            ];
+
+            for (const issueNumber of references) {
+              let issue;
+
+              try {
+                ({ data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber
+                }));
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Referenced issue #${issueNumber} does not exist.`);
+                  continue;
+                }
+
+                throw error;
+              }
+
+              const isApproved = (issue.labels ?? []).some(label => {
+                const name = typeof label === "string" ? label : label.name;
+                return name.toLowerCase() === "approved";
+              });
+              const authorIsAssigned = (issue.assignees ?? []).some(
+                assignee => assignee.login.toLowerCase() === author.toLowerCase()
+              );
+
+              if (!issue.pull_request && issue.state === "open" && isApproved && authorIsAssigned) {
+                core.info(`Pull request #${pullRequest.number} is approved by issue #${issue.number}.`);
+                return;
+              }
+            }
+
+            core.setFailed(
+              "External pull requests require an open issue labeled `approved` and assigned " +
+                `to @${author}. Reference it in the pull request description with Fixes #123.`
+            );
+
   check:
     name: Build and Test
+    needs: eligibility
     # Builds against the macOS 26 SDK with the package's macOS 15 deployment target (Package.swift
     # .macOS(.v15)), so this compiles the whole codebase — including the `if #available(macOS 26, *)`
     # Liquid Glass branches — for the macOS 15 floor. That is the floor's compile guarantee: a binary

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -39,7 +39,7 @@ jobs:
             const references = [
               ...new Set(
                 [...(pullRequest.body ?? "").matchAll(
-                  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
+                  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+#(\d+)\b/gi
                 )].map(match => Number(match[1]))
               )
             ];

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,177 @@
+name: Pull Request Policy
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, labeled]
+
+permissions:
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: pr-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enforce:
+    name: Enforce Approved Issue
+    runs-on: ubuntu-latest
+    steps:
+      # This privileged workflow only inspects GitHub API data. Never check out
+      # the pull request or run contributor-controlled code here.
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const author = pullRequest.user.login;
+            const labels = pullRequest.labels ?? [];
+
+            if (
+              ["OWNER", "MEMBER", "COLLABORATOR"].includes(pullRequest.author_association) ||
+              author === "dependabot[bot]" ||
+              labels.some(label => label.name.toLowerCase() === "keep-open")
+            ) {
+              core.info(`Trusted or explicitly exempt pull request from @${author}.`);
+              return;
+            }
+
+            const references = [
+              ...new Set(
+                [...(pullRequest.body ?? "").matchAll(
+                  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi
+                )].map(match => Number(match[1]))
+              )
+            ];
+
+            let approvedIssue;
+
+            for (const issueNumber of references) {
+              let issue;
+
+              try {
+                ({ data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber
+                }));
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Referenced issue #${issueNumber} does not exist.`);
+                  continue;
+                }
+
+                throw error;
+              }
+
+              const isApproved = (issue.labels ?? []).some(label => {
+                const name = typeof label === "string" ? label : label.name;
+                return name.toLowerCase() === "approved";
+              });
+              const authorIsAssigned = (issue.assignees ?? []).some(
+                assignee => assignee.login.toLowerCase() === author.toLowerCase()
+              );
+
+              if (!issue.pull_request && issue.state === "open" && isApproved && authorIsAssigned) {
+                approvedIssue = issue;
+                break;
+              }
+
+              core.info(
+                `Issue #${issueNumber} is not an open, approved issue assigned to @${author}.`
+              );
+            }
+
+            const findBotComment = async marker => {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pullRequest.number,
+                per_page: 100
+              });
+
+              return comments.find(
+                comment => comment.user?.login === "github-actions[bot]" &&
+                  comment.body?.includes(marker)
+              );
+            };
+
+            if (!approvedIssue) {
+              const marker = "<!-- openusage:approved-issue-required -->";
+              const body = [
+                marker,
+                "Thanks for your interest in contributing to OpenUsage!",
+                "",
+                "External pull requests must reference an **open issue** that:",
+                "",
+                "1. Has been approved by a maintainer with the `approved` label.",
+                `2. Is assigned to the pull request author (@${author}).`,
+                "",
+                "Please discuss the change on an issue first, wait for a maintainer to approve " +
+                  "and assign it to you, then reopen this pull request with `Fixes #123` in " +
+                  "its description.",
+                "",
+                `[Read the contribution guidelines](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md).`
+              ].join("\n");
+              const existingComment = await findBotComment(marker);
+
+              if (existingComment) {
+                if (existingComment.body !== body) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existingComment.id,
+                    body
+                  });
+                }
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pullRequest.number,
+                  body
+                });
+              }
+
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pullRequest.number,
+                state: "closed"
+              });
+
+              core.info(`Closed pull request #${pullRequest.number}: no eligible approved issue.`);
+              return;
+            }
+
+            core.info(`Pull request #${pullRequest.number} is approved by issue #${approvedIssue.number}.`);
+
+            const { data: currentPullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullRequest.number
+            });
+
+            if (currentPullRequest.additions <= 1000) {
+              return;
+            }
+
+            const marker = "<!-- openusage:large-pr-warning -->";
+
+            if (await findBotComment(marker)) {
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pullRequest.number,
+              body: [
+                marker,
+                `This pull request adds **${currentPullRequest.additions.toLocaleString()} lines**.`,
+                "",
+                "Pull requests with more than 1,000 added lines are rarely merged because " +
+                  "they are difficult to review and often extend beyond the approved issue. " +
+                  "Please consider breaking this into a smaller, more surgical contribution."
+              ].join("\n")
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ OpenUsage accepts contributions through a strict, issue-first workflow, and the 
 
 OpenUsage is highly opinionated. It focuses on clean design, fast performance, and a great user experience. The feature set is intentionally limited to core functionality: tracking AI coding subscription usage, nothing more. Contributions that try to expand that scope, add unnecessary complexity, or compromise the UX will be closed.
 
-If you're unsure whether your idea fits, open an issue first. External pull requests without a linked, maintainer-approved issue are closed automatically — without review.
+If you're unsure whether your idea fits, open an issue first. External pull requests without a linked, maintainer-approved issue assigned to their author are closed automatically — without review.
 
 ## Ground Rules
 
-- **Open an approved issue first.** External PRs must link an open issue a maintainer has approved with the `approved` label. No approved issue, no review.
+- **Get an issue approved and assigned first.** External PRs must link an open issue a maintainer has approved with the `approved` label and assigned to the PR author. No approved assignment, no review.
 - **Most external PRs get closed, by design.** It's not personal — it keeps a small, focused project sane. See the Pull Request Policy below.
 - No feature creep. If it's not about usage tracking, it doesn't belong here.
 - No AI-generated commit messages. Write your own.
@@ -24,10 +24,11 @@ If you're unsure whether your idea fits, open an issue first. External pull requ
 External pull requests are gatekept automatically and **closed** if they:
 
 - **Have no approved issue** — they don't link an open issue labeled `approved`.
-- **Are too large** — they change more than 1,000 lines. Split the work into smaller PRs.
-- **Miss screenshots** — they make a visual change without before/after screenshots.
+- **Aren't assigned to the author** — the PR author isn't one of the approved issue's assignees.
 
-Closures aren't personal and are reversible: get the issue approved (or fix the problem), then reopen or open a focused replacement. Maintainers and collaborators may open PRs directly, and can override the automation with the `keep-open` label.
+Approved external PRs that add more than 1,000 lines receive an automatic warning encouraging a smaller, more focused change; deletions don't count toward that threshold, and the PR stays open. Visual changes still require before/after screenshots, which maintainers check during review.
+
+Closures aren't personal and are reversible: get the issue approved and assigned to you, then reopen or open a focused replacement. Maintainers, collaborators, and Dependabot may open PRs directly, and maintainers can override the automation with the `keep-open` label.
 
 ## License Agreement
 
@@ -37,18 +38,19 @@ By submitting a pull request, you agree that your contribution is licensed under
 
 ### Fork and PR workflow
 
-1. Open an issue describing the change, and wait for a maintainer to approve it with the `approved` label
-2. Fork the repo
-3. Create a branch (`feat/my-change`, `fix/some-bug`, etc.)
-4. Make only the approved change
-5. Run `swift build` and `swift test` to verify nothing is broken
-6. Open a PR against `main` and link the approved issue with `Fixes #<issue>`
+1. Open or comment on an issue describing the change, and tell maintainers you'd like to work on it
+2. Wait for a maintainer to approve the issue with the `approved` label and assign it to you
+3. Fork the repo
+4. Create a branch (`feat/my-change`, `fix/some-bug`, etc.)
+5. Make only the approved change
+6. Run `swift build` and `swift test` to verify nothing is broken
+7. Open a PR against `main` and link your assigned, approved issue with `Fixes #<issue>`
 
 ### Add a provider
 
 Each provider is a small Swift module under `Sources/OpenUsage/Providers/<Name>/` that conforms to `ProviderRuntime`: an auth store reads credentials already on the user's machine, a usage client calls the provider's API, and a mapper normalizes the response into metric lines. See [docs/adding-a-provider.md](docs/adding-a-provider.md) for the full walkthrough (and [docs/architecture.md](docs/architecture.md) for how the pieces fit together).
 
-1. Open an issue and get it approved (`approved` label) — include why the provider fits and how its usage data is accessible
+1. Open or comment on an issue and wait for a maintainer to approve it (`approved` label) and assign it to you — include why the provider fits and how its usage data is accessible
 2. Create `Sources/OpenUsage/Providers/<Name>/` and implement `ProviderRuntime`
 3. Register the provider in `AppContainer`
 4. Add focused tests under `Tests/OpenUsageTests/`
@@ -60,14 +62,14 @@ You can also [open an issue](https://github.com/robinebers/openusage/issues/new?
 
 ### Fix a bug
 
-1. Reference the approved issue number in your PR
+1. Reference the approved issue assigned to you in your PR
 2. Describe the root cause and fix
 3. Include before/after screenshots for UI bugs
 4. Add a regression test if applicable
 
 ### Request a feature
 
-Don't open a PR for a feature without an approved issue first. [Open an issue](https://github.com/robinebers/openusage/issues/new?template=feature_request.yml), make your case, and wait for the `approved` label.
+Don't open a PR for a feature without an approved issue assigned to you first. [Open an issue](https://github.com/robinebers/openusage/issues/new?template=feature_request.yml), make your case, and wait for a maintainer to add the `approved` label and assign it to you.
 
 ## What Gets Accepted
 
@@ -79,8 +81,8 @@ Don't open a PR for a feature without an approved issue first. [Open an issue](h
 
 ## What Gets Rejected
 
-- External PRs without an approved issue (closed automatically)
-- PRs over 1,000 lines, or that bundle unrelated changes
+- External PRs without an approved issue assigned to their author (closed automatically)
+- PRs that bundle unrelated changes; PRs with more than 1,000 added lines receive an automatic warning
 - Features that expand the scope beyond usage tracking
 - Changes that compromise speed, simplicity, or the existing UX
 - PRs without testing evidence

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The repository must be public (Sparkle fetches the DMG and appcast anonymously),
 
 ## Contributing
 
-Issues are welcome. Pull requests are **strict and issue-first**: external PRs must link an issue a maintainer has approved with the `approved` label, and automation closes anything that doesn't follow the rules — so **most external PRs are closed by design**. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening one. Report security issues privately per [SECURITY.md](SECURITY.md). The OpenUsage name and logo are covered by the [trademark policy](TRADEMARK.md).
+Issues are welcome. Pull requests are **strict and issue-first**: comment on an issue, wait for a maintainer to add the `approved` label and assign it to you, then reference it in your PR with `Fixes #123`. Automation closes external PRs without an approved issue assigned to their author, and warns when an accepted PR adds more than 1,000 lines. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening one. Report security issues privately per [SECURITY.md](SECURITY.md). The OpenUsage name and logo are covered by the [trademark policy](TRADEMARK.md).
 
 ## License
 


### PR DESCRIPTION
## TL;DR
Enforce the approved-issue and assigned-contributor policy for external pull requests and warn on PRs with more than 1,000 added lines.

## What was happening
- The contribution guide promised automatic enforcement, but no workflow actually closed unapproved external PRs.
- Approved issues could be referenced by contributors who had not been assigned to the work.
- The documentation described large PRs as automatically rejected even though the desired behavior is an advisory warning based on added lines only.

## What this changes
- Add a metadata-only `pull_request_target` workflow that closes external PRs without an open `approved` issue assigned to their author.
- Preserve exemptions for owners, collaborators, organization members, Dependabot, and the existing `keep-open` override.
- Add a single advisory comment when an eligible external PR adds more than 1,000 lines, ignoring deletions.
- Update the README, contribution guide, and pull request template to document the approval and assignment process.

## Heads-up
- External contributors should comment on an issue before a maintainer assigns it to them.
- Visual-change screenshots remain a maintainer-reviewed requirement; they are not automatically enforced.
- The policy workflow is the single enforcement point. An earlier revision duplicated the same evaluator as a CI eligibility job gating the macOS build; that was dropped — the policy workflow closes ineligible PRs anyway, and macOS runners are free on a public repo.

## Tests
- `actionlint` across all repository workflows.
- `git diff --check`.
- Mocked GitHub-event scenarios covering approved assignments, invalid issues, trusted exemptions, additions-only thresholds, duplicate comments, and API failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses privileged `pull_request_target` with `pull-requests: write` to auto-close PRs; incorrect parsing or assignment checks could close valid contributions, though the workflow avoids running contributor code.
> 
> **Overview**
> **Adds automated pull request policy enforcement** that was previously only described in docs. A new `pull_request_target` workflow inspects GitHub metadata only (no checkout) and **closes external PRs** that do not reference an open issue with the `approved` label **and** the PR author among assignees, after posting or updating a bot comment with contribution steps.
> 
> **Trusted paths are unchanged in spirit:** owners, members, collaborators, Dependabot, and PRs labeled `keep-open` skip enforcement. Eligible external PRs with **more than 1,000 added lines** get a one-time advisory comment instead of being closed; deletions are not counted.
> 
> **CONTRIBUTING.md**, **README.md**, and the PR template are updated so contributors must get an issue approved **and assigned** before opening a PR, large PRs are warned rather than auto-rejected, and screenshot requirements stay a maintainer review check—not workflow-enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12df5dd22d2630f59c937990424f0d69da37c2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->