### PR TITLE
fix(pricing): add GLM 5.3 model rates

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries; https://developers.openai.com/api/docs/models/daybreak-blue-latest and https://developers.openai.com/api/docs/pricing for Daybreak aliases and rates.",
-  "updated_at": "2026-08-24T05:18:50Z",
+  "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries; https://developers.openai.com/api/docs/models/daybreak-blue-latest and https://developers.openai.com/api/docs/pricing for Daybreak aliases and rates; https://docs.z.ai/guides/overview/pricing for GLM 5.3.",
+  "updated_at": "2026-08-25T12:25:52Z",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -49,6 +49,13 @@
       "cache_write_per_million": 5.0,
       "cache_read_per_million": 0.5,
       "output_per_million": 30.0
+    },
+    "glm-5.3": {
+      "$comment": "Z.ai's official GLM 5.3 API rates. Cache storage has no separate charge, so cache writes bill at the input rate. Neither bundled public catalog carries the model yet.",
+      "input_per_million": 1.4,
+      "cache_write_per_million": 1.4,
+      "cache_read_per_million": 0.26,
+      "output_per_million": 4.4
     },
     "grok-4.5": {
       "$comment": "Cursor + SpaceXAI first-party model. Cache write not published separately; defaults to input.",
@@ -260,6 +267,7 @@
     { "pattern": "^kimi-k2\\.5$", "canonical": "moonshot/kimi-k2.5" },
     { "pattern": "^kimi-k2p5$", "canonical": "moonshot/kimi-k2.5" },
     { "pattern": "^glm-5\\.2(?:-(?:high|max))?$", "canonical": "glm-5.2" },
+    { "pattern": "(?i)^(?:(?:z-ai|zai|zhipu)/)?glm-5\\.3(?:-(?:low|high|max))?$", "canonical": "glm-5.3" },
     { "pattern": "^[Pp]remium \\((?:[Gg][Pp][Tt]-5\\.3-[Cc]odex|[Cc]odex 5\\.3)\\)$", "canonical": "gpt-5.3-codex" },
     { "pattern": "(?i)^Composer 2\\.5 Fast \\(Auto[^)]*\\)$", "canonical": "composer-2.5-fast" },
     { "pattern": "(?i)^Composer 2\\.5 \\(Auto[^)]*\\)$", "canonical": "composer-2.5" },
@@ -282,6 +290,7 @@
     { "pattern": "(?i)^Gemini 3\\.6 Flash \\(Auto[^)]*\\)$", "canonical": "gemini-3.6-flash" },
     { "pattern": "(?i)^Gemini 3\\.7 Flash \\(Auto[^)]*\\)$", "canonical": "gemini-3.7-flash" },
     { "pattern": "(?i)^GLM 5\\.2 \\(Auto[^)]*\\)$", "canonical": "glm-5.2" },
+    { "pattern": "(?i)^GLM 5\\.3 \\(Auto[^)]*\\)$", "canonical": "glm-5.3" },
     { "pattern": "(?i)^Kimi K3 \\(Auto[^)]*\\)$", "canonical": "kimi-k3" }
   ]
 }

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -51,7 +51,7 @@ final class PricingBundledResourceTests: XCTestCase {
             ("grok-4-6-xhigh-fast", 4), ("kimi-k2p5", 0.6),
             ("kimi-k2.7-code", 0.95), ("kimi-k2p7", 0.95), ("kimi-k3-max", 3),
             ("claude-4.7-opus-high-thinking", 5), ("claude-4.7-opus-max-thinking-fast", 30),
-            ("glm-5.2-max", 1.4)
+            ("glm-5.2-max", 1.4), ("glm-5.3-max", 1.4)
         ]
         for (model, expected) in expectedInputRates {
             XCTAssertEqual(pricing.resolve(model: model)?.inputPerMillion, expected, model)
@@ -211,6 +211,7 @@ final class PricingBundledResourceTests: XCTestCase {
             "Gemini 3.6 Flash (Auto)": "gemini-3.6-flash",
             "Gemini 3.7 Flash (Auto Balanced)": "gemini-3.7-flash",
             "GLM 5.2 (Auto)": "glm-5.2",
+            "GLM 5.3 (Auto Intelligence)": "glm-5.3",
             "Kimi K3 (Auto Intelligence)": "kimi-k3"
         ]
         for (label, canonical) in expected {
@@ -276,6 +277,29 @@ final class PricingBundledResourceTests: XCTestCase {
         let outputOnly = TokenBreakdown(output: 1_000_000)
         XCTAssertEqual(pricing.estimatedCostDollars(model: "glm-5.2-high", tokens: outputOnly)!, 4.4, accuracy: 1e-9)
         XCTAssertNil(pricing.estimatedCostDollars(model: "glm-5.2-bogus", tokens: outputOnly))
+    }
+
+    /// GLM 5.3 has its own identity and Z.ai's published rates; its three supported effort levels
+    /// and provider-prefixed API identifiers all resolve to that same distinct model.
+    func testGLM53PricingAndAliases() throws {
+        let pricing = Self.pricing
+        let glm = try XCTUnwrap(pricing.resolve(model: "glm-5.3"))
+        XCTAssertEqual(glm.inputPerMillion, 1.4)
+        XCTAssertEqual(glm.cacheWritePerMillion, 1.4)
+        XCTAssertEqual(glm.cacheReadPerMillion, 0.26)
+        XCTAssertEqual(glm.outputPerMillion, 4.4)
+
+        for model in [
+            "glm-5.3-low", "glm-5.3-high", "glm-5.3-max",
+            "z-ai/glm-5.3", "zai/glm-5.3-max", "ZHIPU/GLM-5.3"
+        ] {
+            XCTAssertEqual(pricing.supplement.canonicalName(for: model), "glm-5.3", model)
+            XCTAssertEqual(pricing.resolve(model: model), glm, model)
+        }
+
+        let outputOnly = TokenBreakdown(output: 1_000_000)
+        XCTAssertEqual(pricing.estimatedCostDollars(model: "glm-5.3-low", tokens: outputOnly)!, 4.4, accuracy: 1e-9)
+        XCTAssertNil(pricing.estimatedCostDollars(model: "glm-5.3-medium", tokens: outputOnly))
     }
 
     /// Grok CLI model ids route through the alias rules to their catalog entries.


### PR DESCRIPTION
## TL;DR

Add official GLM 5.3 pricing and supported model aliases so usage contributes accurate spend estimates instead of appearing unpriced.

Closes #1133.

## What was happening

- Neither bundled public pricing catalog contains GLM 5.3, so usage reported under the new model could not be priced.
- Supported reasoning-effort suffixes, provider-prefixed API identifiers, and Cursor Router labels had no GLM 5.3 aliases.

## What this changes

- Add a distinct `glm-5.3` pricing entry using the [official Z.ai pricing](https://docs.z.ai/guides/overview/pricing): $1.40 input and cache write, $0.26 cached input, and $4.40 output per million tokens.
- Resolve the supported `low`, `high`, and `max` effort variants plus `z-ai/`, `zai/`, and `ZHIPU/` model prefixes.
- Recognize GLM 5.3 Cursor Router labels without merging GLM 5.3 model identity into GLM 5.2.
- Update the supplement publication timestamp and add bundled-resource regression coverage for rates and aliases.

## Tests

- `swift test --filter "ModelPricing|PricingBundledResource"`: 50 tests passed.
- Validated pricing entries, alias regular expressions, and fast multipliers with `jq`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only pricing supplement and test updates; no runtime logic changes beyond what the bundled JSON already drives.
> 
> **Overview**
> Adds **GLM 5.3** as its own priced model in `pricing_supplement.json` so usage that public LiteLLM/models.dev snapshots still omit can show spend estimates instead of appearing unpriced.
> 
> Rates follow Z.ai’s published API pricing: **$1.40** input and cache write, **$0.26** cache read, and **$4.40** output per million tokens. New alias rules map `glm-5.3-low` / `high` / `max`, optional `z-ai/` / `zai/` / `ZHIPU/` prefixes, and Cursor Router labels like `GLM 5.3 (Auto …)` to canonical `glm-5.3` without folding 5.3 into the existing GLM 5.2 entry.
> 
> The supplement `updated_at` timestamp and source comment are refreshed. **PricingBundledResourceTests** extend spot checks, router label coverage, and a dedicated `testGLM53PricingAndAliases` regression (including that unsupported effort slugs such as `glm-5.3-medium` stay unpriced).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4760e83bb44d2f3bb8bfeee635495d72a35bee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->