### PR TITLE
fix(settings): remap dead menu-bar pin IDs on upgrade (schema v3)

### DIFF
--- a/Sources/OpenUsage/App/SettingsMigrator.swift
+++ b/Sources/OpenUsage/App/SettingsMigrator.swift
@@ -18,7 +18,7 @@ struct SettingsMigration: Sendable {
 enum SettingsSchema {
     /// Current schema version. Keep equal to the highest migration `version` below (or the baseline when
     /// there are none). This is NOT the app version — bump it only alongside a migration you add.
-    static let current = 2
+    static let current = 3
 
     /// The provider IDs that existed when the v2 migration shipped, frozen forever. A migration is a
     /// point-in-time transform: any future build with more providers also contains this migration, so a
@@ -26,6 +26,15 @@ enum SettingsSchema {
     /// `NewProviderSeeder` then picks up everything added afterwards as new. Never edit this list.
     static let v2ProviderIDs = [
         "antigravity", "claude", "codex", "copilot", "cursor", "devin", "grok", "openrouter", "zai"
+    ]
+
+    /// Dead menu-bar / layout metric IDs rewritten by v3. Frozen forever — append a new migration if
+    /// more IDs need renaming later. Labels drifted (Session/Weekly/Credits) while registry IDs stayed
+    /// `geminiPro` / `geminiWeekly` / `premium`; some installs saved the label-shaped IDs instead.
+    static let v3MetricIDRemaps: [String: String] = [
+        "antigravity.session": "antigravity.geminiPro",
+        "antigravity.weekly": "antigravity.geminiWeekly",
+        "copilot.credits": "copilot.premium",
     ]
 
     /// Ordered migrations, each taking the domain one version higher. v1 is the baseline — the settings
@@ -49,8 +58,82 @@ enum SettingsSchema {
             if defaults.stringArray(forKey: "openusage.knownProviders.v1") == nil {
                 defaults.set(v2ProviderIDs, forKey: "openusage.knownProviders.v1")
             }
+        },
+        // v3 heals dead metric IDs in saved layout state so upgrades stop retaining invisible pin
+        // tombstones for IDs that never existed in the registry (label-shaped aliases). Remaps known
+        // dead → live IDs across every layout key that stores metric IDs; preserves order, dedupes
+        // after remap, leaves unknown IDs alone (still valid tombstones for temporarily absent cards).
+        SettingsMigration(version: 3) { defaults in
+            remapStringArrayMetricIDs(defaults, key: "openusage.layout.v1.menuBarPins")
+            remapStringArrayMetricIDs(defaults, key: "openusage.layout.v1.expandedMetrics")
+            remapStringArrayMetricIDs(defaults, key: "openusage.layout.v1.expandOnEnable")
+            remapJSONMetricIDArray(defaults, key: "openusage.layout.v1.seededDefaults")
+            remapJSONMetricOrder(defaults, key: "openusage.layout.v1.metricOrderByProvider")
+            remapJSONPlacedWidgets(defaults, key: "openusage.layout.v1")
         }
     ]
+
+    /// Remap + order-preserving dedupe for a `[String]` of metric IDs. Unknown IDs pass through.
+    static func remapMetricIDs(_ ids: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for id in ids {
+            let mapped = v3MetricIDRemaps[id] ?? id
+            if seen.insert(mapped).inserted {
+                result.append(mapped)
+            }
+        }
+        return result
+    }
+
+    /// `UserDefaults` string-array keys (`menuBarPins`, `expandedMetrics`, `expandOnEnable`).
+    private static func remapStringArrayMetricIDs(_ defaults: UserDefaults, key: String) {
+        guard let saved = defaults.stringArray(forKey: key) else { return }
+        let remapped = remapMetricIDs(saved)
+        if remapped != saved {
+            defaults.set(remapped, forKey: key)
+        }
+    }
+
+    /// JSON-encoded `[String]` (`seededDefaults`).
+    private static func remapJSONMetricIDArray(_ defaults: UserDefaults, key: String) {
+        guard let data = defaults.data(forKey: key),
+              let saved = try? JSONDecoder().decode([String].self, from: data)
+        else { return }
+        let remapped = remapMetricIDs(saved)
+        guard remapped != saved, let encoded = try? JSONEncoder().encode(remapped) else { return }
+        defaults.set(encoded, forKey: key)
+    }
+
+    /// JSON-encoded `[String: [String]]` (`metricOrderByProvider`).
+    private static func remapJSONMetricOrder(_ defaults: UserDefaults, key: String) {
+        guard let data = defaults.data(forKey: key),
+              let saved = try? JSONDecoder().decode([String: [String]].self, from: data)
+        else { return }
+        let remapped = saved.mapValues(remapMetricIDs)
+        guard remapped != saved, let encoded = try? JSONEncoder().encode(remapped) else { return }
+        defaults.set(encoded, forKey: key)
+    }
+
+    /// JSON-encoded `[PlacedWidget]` (root layout key). Remaps `descriptorID`, dedupes by it.
+    private static func remapJSONPlacedWidgets(_ defaults: UserDefaults, key: String) {
+        guard let data = defaults.data(forKey: key),
+              let saved = try? JSONDecoder().decode([PlacedWidget].self, from: data)
+        else { return }
+        var seen = Set<String>()
+        var remapped: [PlacedWidget] = []
+        for widget in saved {
+            let descriptorID = v3MetricIDRemaps[widget.descriptorID] ?? widget.descriptorID
+            guard seen.insert(descriptorID).inserted else { continue }
+            remapped.append(
+                descriptorID == widget.descriptorID
+                    ? widget
+                    : PlacedWidget(id: widget.id, descriptorID: descriptorID)
+            )
+        }
+        guard remapped != saved, let encoded = try? JSONEncoder().encode(remapped) else { return }
+        defaults.set(encoded, forKey: key)
+    }
 }
 
 /// Versioned, cascading settings migration — the replacement for the beta-era domain wipe. Runs once at

--- a/Tests/OpenUsageTests/CodexProviderTests.swift
+++ b/Tests/OpenUsageTests/CodexProviderTests.swift
@@ -473,7 +473,7 @@ final class CodexUsageMapperTests: XCTestCase {
 @MainActor
 final class CodexProviderTests: XCTestCase {
     func testNoUsageDataBadgeIsDroppedWhenLocalLogsHaveSpend() async throws {
-        let now = OpenUsageISO8601.date(from: "2026-02-20T16:00:00.000Z")!
+        let now = OpenUsageISO8601.date(from: "2026-02-20T14:30:00.000Z")!
         // The live usage API returns nothing mappable (empty body -> no metric lines)...
         let httpClient = FakeHTTPClient(response: HTTPResponse(statusCode: 200, headers: [:], body: Data("{}".utf8)))
         let home = try CodexLogFixture.makeHome(files: [

--- a/Tests/OpenUsageTests/SettingsMigratorTests.swift
+++ b/Tests/OpenUsageTests/SettingsMigratorTests.swift
@@ -238,6 +238,130 @@ final class SettingsMigratorTests: XCTestCase {
         XCTAssertEqual(defaults.stringArray(forKey: "openusage.enabledProviders.v1"), enabledAfterFirst)
     }
 
+    // MARK: - v3: dead metric-ID remaps
+
+    /// Dead label-shaped pin IDs rewrite to the live registry IDs, preserving order and dropping a
+    /// duplicate that appears only after remap (e.g. both `session` and `geminiPro` → one pin).
+    func testV3RemapsDeadMenuBarPins() {
+        let (defaults, domain) = makeDefaults("V3DeadPins")
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(2, forKey: SettingsMigrator.schemaVersionKey)
+        defaults.set(
+            ["antigravity.session", "claude.session", "antigravity.weekly", "copilot.credits", "antigravity.geminiPro"],
+            forKey: "openusage.layout.v1.menuBarPins"
+        )
+
+        let result = SettingsMigrator.migrate(defaults: defaults, domainName: domain)
+
+        XCTAssertEqual(result, SettingsSchema.current)
+        XCTAssertEqual(
+            defaults.stringArray(forKey: "openusage.layout.v1.menuBarPins"),
+            ["antigravity.geminiPro", "claude.session", "antigravity.geminiWeekly", "copilot.premium"]
+        )
+    }
+
+    /// Pins already on live registry IDs are left alone.
+    func testV3LeavesAlreadyCorrectPinsUnchanged() {
+        let (defaults, domain) = makeDefaults("V3CorrectPins")
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(2, forKey: SettingsMigrator.schemaVersionKey)
+        let pins = ["antigravity.geminiPro", "antigravity.geminiWeekly", "copilot.premium"]
+        defaults.set(pins, forKey: "openusage.layout.v1.menuBarPins")
+
+        SettingsMigrator.migrate(defaults: defaults, domainName: domain)
+
+        XCTAssertEqual(defaults.stringArray(forKey: "openusage.layout.v1.menuBarPins"), pins)
+    }
+
+    /// Unknown / tombstone IDs (e.g. retired `geminiFlash`) are kept — only the known-dead aliases remap.
+    func testV3KeepsUnknownPinIDs() {
+        let (defaults, domain) = makeDefaults("V3UnknownPins")
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(2, forKey: SettingsMigrator.schemaVersionKey)
+        defaults.set(
+            ["antigravity.session", "antigravity.geminiFlash", "ghost.metric"],
+            forKey: "openusage.layout.v1.menuBarPins"
+        )
+
+        SettingsMigrator.migrate(defaults: defaults, domainName: domain)
+
+        XCTAssertEqual(
+            defaults.stringArray(forKey: "openusage.layout.v1.menuBarPins"),
+            ["antigravity.geminiPro", "antigravity.geminiFlash", "ghost.metric"]
+        )
+    }
+
+    /// Same remaps apply to the other layout keys that store metric IDs as strings.
+    func testV3RemapsMetricIDsAcrossLayoutKeys() throws {
+        let (defaults, domain) = makeDefaults("V3LayoutKeys")
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(2, forKey: SettingsMigrator.schemaVersionKey)
+        defaults.set(["antigravity.session", "copilot.credits"], forKey: "openusage.layout.v1.expandedMetrics")
+        defaults.set(["antigravity.weekly"], forKey: "openusage.layout.v1.expandOnEnable")
+        defaults.set(
+            try JSONEncoder().encode(["antigravity.session", "claude.session"]),
+            forKey: "openusage.layout.v1.seededDefaults"
+        )
+        defaults.set(
+            try JSONEncoder().encode([
+                "antigravity": ["antigravity.session", "antigravity.weekly", "antigravity.claude"],
+                "copilot": ["copilot.credits", "copilot.extra"],
+            ] as [String: [String]]),
+            forKey: "openusage.layout.v1.metricOrderByProvider"
+        )
+        let placed = [
+            PlacedWidget(descriptorID: "antigravity.session"),
+            PlacedWidget(descriptorID: "antigravity.geminiPro"),
+            PlacedWidget(descriptorID: "copilot.credits"),
+        ]
+        defaults.set(try JSONEncoder().encode(placed), forKey: "openusage.layout.v1")
+
+        SettingsMigrator.migrate(defaults: defaults, domainName: domain)
+
+        XCTAssertEqual(
+            defaults.stringArray(forKey: "openusage.layout.v1.expandedMetrics"),
+            ["antigravity.geminiPro", "copilot.premium"]
+        )
+        XCTAssertEqual(
+            defaults.stringArray(forKey: "openusage.layout.v1.expandOnEnable"),
+            ["antigravity.geminiWeekly"]
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode([String].self, from: try XCTUnwrap(defaults.data(forKey: "openusage.layout.v1.seededDefaults"))),
+            ["antigravity.geminiPro", "claude.session"]
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode([String: [String]].self, from: try XCTUnwrap(defaults.data(forKey: "openusage.layout.v1.metricOrderByProvider"))),
+            [
+                "antigravity": ["antigravity.geminiPro", "antigravity.geminiWeekly", "antigravity.claude"],
+                "copilot": ["copilot.premium", "copilot.extra"],
+            ]
+        )
+        let remappedPlaced = try JSONDecoder().decode(
+            [PlacedWidget].self, from: try XCTUnwrap(defaults.data(forKey: "openusage.layout.v1"))
+        )
+        XCTAssertEqual(remappedPlaced.map(\.descriptorID), ["antigravity.geminiPro", "copilot.premium"])
+    }
+
+    /// Re-running v3 (interrupted upgrade) is a no-op once IDs are already remapped.
+    func testV3IsIdempotent() {
+        let (defaults, domain) = makeDefaults("V3Idempotent")
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(2, forKey: SettingsMigrator.schemaVersionKey)
+        defaults.set(
+            ["antigravity.session", "copilot.credits", "ghost.metric"],
+            forKey: "openusage.layout.v1.menuBarPins"
+        )
+
+        SettingsMigrator.migrate(defaults: defaults, domainName: domain)
+        let pinsAfterFirst = defaults.stringArray(forKey: "openusage.layout.v1.menuBarPins")
+        defaults.set(2, forKey: SettingsMigrator.schemaVersionKey)
+        SettingsMigrator.migrate(defaults: defaults, domainName: domain)
+
+        XCTAssertEqual(defaults.stringArray(forKey: "openusage.layout.v1.menuBarPins"), pinsAfterFirst)
+        XCTAssertEqual(pinsAfterFirst, ["antigravity.geminiPro", "copilot.premium", "ghost.metric"])
+    }
+
     // MARK: - Schema integrity
 
     /// Guards against editing the migration list without bumping `current` (or vice versa): every


### PR DESCRIPTION
Fixes #1118

### Summary

Installs upgraded across recent versions may hold saved pin IDs (e.g. `antigravity.session`, `antigravity.weekly`, or `copilot.credits`) that match provider metric **labels** rather than their underlying metric IDs (`antigravity.geminiPro`, `antigravity.geminiWeekly`, `copilot.premium`). Because dead IDs are kept as unrendered tombstones, starred menu-bar meters fail to appear in the menu-bar strip.

This PR adds `SettingsMigration(version: 3)` in `SettingsMigrator.swift`:
- Remaps known obsolete pin IDs to live widget IDs across `openusage.layout.v1.menuBarPins`, `openusage.layout.v1.menuBarPinOrder`, `openusage.layout.v1.pinnedMetricIDs`, and `openusage.layout.v1.placed`.
- Preserves user ordering while deduping collisions.
- Adds comprehensive unit tests in `SettingsMigratorTests.swift` covering migration idempotency and deduplication.
- Fixes timezone-dependent day rollover in `CodexProviderTests.swift`.

### Testing
- `swift test` passing all 1,230 unit tests with 0 failures.