### PR TITLE
fix(opencode): support OpenCode 2 session_message schema and credential table

### DIFF
--- a/Sources/OpenUsage/Providers/OpenCode/OpenCodeAuthStore.swift
+++ b/Sources/OpenUsage/Providers/OpenCode/OpenCodeAuthStore.swift
@@ -3,19 +3,44 @@ import Foundation
 /// Reads the OpenCode Go credential already on the machine. Local-only — never the network. The
 /// `opencode-go` key is both the first-run detection signal and the Bearer token for
 /// `GET /zen/go/v1/usage`, so it lives behind one loader.
+///
+/// OpenCode 2 moved auth from `auth.json` (`{"opencode-go":{"key":"sk-..."}}`) to the SQLite
+/// `credential` table (`integration_id='opencode-go'`, `value` JSON `{"type":"key","key":"sk-..."}`).
+/// This store tries the file first for backwards compat, then falls back to the SQLite credential
+/// table across all `opencode*.db` files so fresh installs after 2026 still get Go meters.
 struct OpenCodeAuthStore: Sendable {
     var files: TextFileAccessing
     var environment: EnvironmentReading
     var homeDirectory: @Sendable () -> URL
+    var sqlite: SQLiteAccessing
+    var databasePaths: @Sendable () throws -> [String]
+
+    /// Credential lookup in the SQLite `credential` table — tries the Go integration first, then
+    /// any `sk-` key as a last resort (mirrors the `opencode-go` → `opencode` fallback in the issue workaround).
+    private static let credentialSQLGo = "SELECT json_extract(value,'$.key') FROM credential WHERE integration_id = 'opencode-go' AND json_extract(value,'$.key') LIKE 'sk-%' LIMIT 1;"
+    private static let credentialSQLFallback = "SELECT json_extract(value,'$.key') FROM credential WHERE json_extract(value,'$.key') LIKE 'sk-%' LIMIT 1;"
 
     init(
         files: TextFileAccessing = LocalTextFileAccessor(),
         environment: EnvironmentReading = ProcessEnvironmentReader(),
-        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser }
+        homeDirectory: @escaping @Sendable () -> URL = { FileManager.default.homeDirectoryForCurrentUser },
+        sqlite: SQLiteAccessing = SQLiteCLIAccessor(),
+        databasePaths: (@Sendable () throws -> [String])? = nil
     ) {
         self.files = files
         self.environment = environment
         self.homeDirectory = homeDirectory
+        self.sqlite = sqlite
+        if let databasePaths {
+            self.databasePaths = databasePaths
+        } else {
+            let env = environment
+            let home = homeDirectory
+            self.databasePaths = {
+                let dir = OpenCodePaths.dataDirectory(environment: env, homeDirectory: home())
+                return try OpenCodePaths.databaseFiles(in: dir)
+            }
+        }
     }
 
     var dataDirectory: String {
@@ -26,11 +51,13 @@ struct OpenCodeAuthStore: Sendable {
         OpenCodePaths.authFilePath(dataDirectory: dataDirectory)
     }
 
-    /// The non-empty `opencode-go` API key from `auth.json`, or `nil` when the user has not logged into
-    /// OpenCode Go. Reads only that one entry — tolerant of unrelated sibling entries (other providers, or
-    /// a future non-object field like a schema marker) so one odd value can't hide a valid key. A present
-    /// file that can't be read or parsed throws `credentialsUnreadable` so broken storage is never
-    /// mistaken for logout; an absent file is the normal "not logged in" `nil`.
+    /// The non-empty `opencode-go` API key, or `nil` when the user has not logged into OpenCode Go.
+    /// Reads `auth.json` first (OpenCode 1), then falls back to the SQLite `credential` table
+    /// (OpenCode 2: `integration_id='opencode-go'` with `value` JSON `{"type":"key","key":"sk-..."}`).
+    /// Tolerant of unrelated sibling entries so one odd value can't hide a valid key. A present file
+    /// that can't be read or parsed throws `credentialsUnreadable` so broken storage is never mistaken
+    /// for logout; an absent file or missing entry falls through to the DB fallback, and only if neither
+    /// source has a key does it return `nil`.
     func goAPIKey() throws -> String? {
         let text: String?
         do {
@@ -38,15 +65,53 @@ struct OpenCodeAuthStore: Sendable {
         } catch {
             throw OpenCodeUsageError.credentialsUnreadable(detail: error.localizedDescription)
         }
-        guard let text else { return nil }
-        guard let data = text.data(using: .utf8),
-              let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
-        else {
-            throw OpenCodeUsageError.credentialsUnreadable(detail: "auth.json is not valid JSON")
+        if let text {
+            guard let data = text.data(using: .utf8),
+                  let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+            else {
+                throw OpenCodeUsageError.credentialsUnreadable(detail: "auth.json is not valid JSON")
+            }
+            if let entry = object["opencode-go"] as? [String: Any],
+               let key = entry["key"] as? String,
+               let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
+                return trimmed
+            }
+            // File present but no valid opencode-go key — fall through to DB before returning nil
         }
-        guard let entry = object["opencode-go"] as? [String: Any],
-              let key = entry["key"] as? String
-        else { return nil }
-        return key.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        // File missing or without a valid key — try SQLite credential table (OpenCode 2)
+        if let dbKey = credentialKeyFromDatabase() {
+            return dbKey
+        }
+        return nil
+    }
+
+    /// Best-effort lookup in `credential` table across all `opencode*.db` files. Tries the
+    /// `opencode-go` integration first, then any `sk-` key. Missing tables / databases are ignored;
+    /// only a file-level read error throws, so broken DB access is treated as "not logged in" rather
+    /// than a user-visible error (the scanner already surfaces DB unreadability).
+    private func credentialKeyFromDatabase() -> String? {
+        let paths: [String]
+        do {
+            paths = try databasePaths()
+        } catch {
+            return nil
+        }
+        guard !paths.isEmpty else { return nil }
+        // Priority: opencode-go specific key, then any sk- key (covers `opencode` integration or generic)
+        for sql in [Self.credentialSQLGo, Self.credentialSQLFallback] {
+            for path in paths {
+                do {
+                    if let value = try sqlite.queryValue(path: path, sql: sql) {
+                        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if let valid = trimmed.nilIfEmpty {
+                            return valid
+                        }
+                    }
+                } catch {
+                    continue
+                }
+            }
+        }
+        return nil
     }
 }

--- a/Sources/OpenUsage/Providers/OpenCode/OpenCodeUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/OpenCode/OpenCodeUsageScanner.swift
@@ -173,24 +173,40 @@ struct OpenCodeUsageScanner: Sendable {
         SELECT json_group_array(json_array(
                  time_created,
                  json_extract(data,'$.cost'),
-                 COALESCE(json_extract(data,'$.tokens.total'),0),
-                 json_extract(data,'$.modelID'),
-                 json_extract(data,'$.providerID')))
-        FROM message
-        WHERE time_created >= \(cutoffMs)
-          AND json_valid(data)
-          AND json_extract(data,'$.role') = 'assistant'
-          AND json_extract(data,'$.providerID') IN \(providerFilter)
-          AND json_type(data,'$.cost') IN ('integer','real');
+                 COALESCE(json_extract(data,'$.tokens.total'), COALESCE(json_extract(data,'$.tokens.input'),0)+COALESCE(json_extract(data,'$.tokens.output'),0)+COALESCE(json_extract(data,'$.tokens.reasoning'),0)+COALESCE(json_extract(data,'$.tokens.cache.read'),0)+COALESCE(json_extract(data,'$.tokens.cache.write'),0)),
+                 COALESCE(json_extract(data,'$.model.id'), json_extract(data,'$.modelID')),
+                 COALESCE(json_extract(data,'$.model.providerID'), json_extract(data,'$.providerID'))))
+        FROM (
+          SELECT time_created, data FROM message
+          WHERE time_created >= \(cutoffMs)
+            AND json_valid(data)
+            AND json_extract(data,'$.role') = 'assistant'
+            AND COALESCE(json_extract(data,'$.model.providerID'), json_extract(data,'$.providerID')) IN \(providerFilter)
+            AND json_type(data,'$.cost') IN ('integer','real')
+          UNION ALL
+          SELECT time_created, data FROM session_message
+          WHERE time_created >= \(cutoffMs)
+            AND type = 'assistant'
+            AND json_valid(data)
+            AND COALESCE(json_extract(data,'$.model.providerID'), json_extract(data,'$.providerID')) IN \(providerFilter)
+            AND json_type(data,'$.cost') IN ('integer','real')
+        );
         """
     }
 
     static let probeSQL = """
-        SELECT 1 FROM message
-        WHERE json_valid(data)
-          AND json_extract(data,'$.role') = 'assistant'
-          AND json_extract(data,'$.providerID') IN \(providerFilter)
-          AND json_type(data,'$.cost') IN ('integer','real')
-        LIMIT 1;
+        SELECT 1 FROM (
+          SELECT 1 as x FROM message
+          WHERE json_valid(data)
+            AND json_extract(data,'$.role') = 'assistant'
+            AND COALESCE(json_extract(data,'$.model.providerID'), json_extract(data,'$.providerID')) IN \(providerFilter)
+            AND json_type(data,'$.cost') IN ('integer','real')
+          UNION ALL
+          SELECT 1 FROM session_message
+          WHERE type = 'assistant'
+            AND json_valid(data)
+            AND COALESCE(json_extract(data,'$.model.providerID'), json_extract(data,'$.providerID')) IN \(providerFilter)
+            AND json_type(data,'$.cost') IN ('integer','real')
+        ) LIMIT 1;
         """
 }

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -23,9 +23,14 @@ subscription), the cap meters are hidden and you'll just see the spend tiles.
 ## Where credentials come from
 
 Use OpenCode as usual. OpenUsage reads the `opencode-go` API key from OpenCode's local data directory
-(`~/.local/share/opencode/auth.json`, or `$OPENCODE_DATA_DIR` / `$XDG_DATA_HOME` if you've set them) and
-sends it as a Bearer token to the usage API. There's no login prompt and no token to paste. Spend tiles
-still read the local SQLite logs in that same directory.
+(`~/.local/share/opencode`, or `$OPENCODE_DATA_DIR` / `$XDG_DATA_HOME` if you've set them) and
+sends it as a Bearer token to the usage API. There's no login prompt and no token to paste.
+
+OpenCode 1 stored the key in `auth.json` (`{"opencode-go":{"key":"sk-..."}}`); OpenCode 2 (beta)
+stores it in the SQLite `credential` table (`integration_id='opencode-go'`, `value` JSON
+`{"type":"key","key":"sk-..."}`). OpenUsage tries `auth.json` first, then falls back to the
+`credential` table so fresh installs after 2026 still get Go meters. Spend tiles still read the
+local SQLite logs in that same directory.
 
 ## The meters and spend tiles
 
@@ -38,14 +43,15 @@ usage reads "No data" rather than a misleading `$0.00`. No log data leaves your 
 ## Troubleshooting
 
 - **No Session / Weekly / Monthly meters** — those are Go-plan windows. You'll see them when you're
-  logged into OpenCode Go (`opencode-go` in `auth.json`) and the key has an active subscription.
-  Zen-only users see the spend tiles instead.
+  logged into OpenCode Go (`opencode-go` in `auth.json` or the `credential` table) and the key has an
+  active subscription. Zen-only users see the spend tiles instead.
 - **"OpenCode Go key was rejected"** — the local key was not accepted. Log into OpenCode Go again so
-  `auth.json` is rewritten.
+  the credential is rewritten (either `auth.json` or the `credential` table).
 - **"No OpenCode Go subscription on this key"** — the key is valid but this account isn't on Go. The
   spend tiles still work if you use Zen locally.
 - **"Couldn't read OpenCode's auth.json"** — the file exists but is unreadable or not valid JSON. Check
-  its permissions, or log into OpenCode Go again to rewrite it.
+  its permissions, or log into OpenCode Go again to rewrite it. On OpenCode 2 the key may live in
+  `opencode.db`'s `credential` table instead, so this error only appears when `auth.json` is present but broken.
 - **Spend tiles show "No data"** — OpenUsage needs OpenCode's local database at
   `~/.local/share/opencode/opencode*.db`. Run an OpenCode session, then refresh.
 - **"Couldn't read OpenCode's local database"** — the database (or data directory) exists but couldn't be
@@ -60,5 +66,8 @@ Bearer …`. The response is `{ usage: { rolling, weekly, monthly } }`, each wit
 
 Spend tiles and trend: assistant-message `cost` and token fields from every `opencode*.db` in the data
 directory (OpenCode partitions its database by release channel — stable is `opencode.db`, the preview
-line is `opencode-next.db` — so all channels are unioned). Both `opencode-go` (Go) and `opencode` (Zen)
-count. Read-only.
+line is `opencode-next.db` — so all channels are unioned). OpenCode 1 logged to the `message` table
+(`$.role`, `$.providerID`, `$.modelID`, `$.tokens.total`); OpenCode 2 logs to `session_message`
+(`type='assistant'`, `$.model.providerID`, `$.model.id`, `$.tokens.input/output/reasoning/cache.*`). The
+query unions both tables with coalesced JSON paths so either schema (or both during migration) works.
+Both `opencode-go` (Go) and `opencode` (Zen) count. Read-only.


### PR DESCRIPTION
## Approved issue

Fixes #1124

## TL;DR

OpenUsage failed on OpenCode 2 beta — "Couldn't read OpenCode's local database" and no Go meters — because the scanner still hit the v1 `message` table / `auth.json` only. This unions both `message` + `session_message` tables and falls back from `auth.json` to the SQLite `credential` table.

## What was happening

OpenCode 2 (1.18.x beta, current stable) changed local storage:

* `message` (fields `role`, `providerID`, `modelID`, `tokens.total`) → `session_message` (columns `type`, `seq`, `data` with `type='assistant'`, JSON `model.providerID`, `model.id`, `tokens.input/output/reasoning/cache.*` — no `total`)
* `~/.local/share/opencode/auth.json` → SQLite `credential` table (`integration_id='opencode-go'`, `value` JSON `{"key":"sk-..."}`)

OpenUsage only queried `FROM message` with `$.role` / `$.providerID` / `$.tokens.total` and only read `auth.json`, so on a v2 DB every scan threw `no such table: message` or returned empty, and `goAPIKey()` returned nil.

## What this changes

* **`OpenCodeUsageScanner`**: `dataSQL`/`probeSQL` now `UNION ALL` both tables with coalesced JSON paths
* **`OpenCodeAuthStore`**: try `auth.json` first, then fallback to `credential` table

## Tests

swift build → Build complete
swift test --filter OpenCode → 40 passed
