### PR TITLE
fix(grok): include subagent session usage

### DIFF
--- a/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Grok/GrokLogUsageScanner.swift
@@ -45,8 +45,10 @@ actor GrokLogUsageScanner {
         let directory = grokHome().appendingPathComponent("sessions", isDirectory: true)
         let identity = directory.resolvingSymlinksInPath().standardizedFileURL.path
         let since = JSONLScanning.sinceDate(daysBack: daysBack, now: now)
+        // Child sessions can contain usage absent from their coordinator. Include every ledger;
+        // dedup below removes replayed events by event ID and model, not by session kind or totals.
         let files = JSONLScanning.jsonlFiles(under: directory)
-            .filter(Self.isCoordinatorSession)
+            .filter { URL(fileURLWithPath: $0.path).lastPathComponent == "updates.jsonl" }
 
         guard !files.isEmpty else {
             _ = await scanner.items(from: [], since: since, cacheIdentity: identity, parse: Self.parseFile)
@@ -68,29 +70,6 @@ actor GrokLogUsageScanner {
             return URL(fileURLWithPath: expandHome(raw))
         }
         return homeDirectory().appendingPathComponent(".grok", isDirectory: true)
-    }
-
-    /// Coordinator turns already include their subagents, so reading both ledgers would charge every
-    /// child task twice. Older sessions without a summary remain eligible because their kind is unknown.
-    private static func isCoordinatorSession(_ file: JSONLScanning.DiscoveredFile) -> Bool {
-        let fileURL = URL(fileURLWithPath: file.path)
-        guard fileURL.lastPathComponent == "updates.jsonl" else { return false }
-
-        let summaryURL = fileURL.deletingLastPathComponent().appendingPathComponent("summary.json")
-        guard FileManager.default.fileExists(atPath: summaryURL.path) else { return true }
-
-        do {
-            let data = try Data(contentsOf: summaryURL)
-            guard let summary = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                AppLog.warn(LogTag.plugin("grok"), "Session summary is not a JSON object; skipped session")
-                return false
-            }
-            guard let kind = summary["session_kind"] as? String else { return true }
-            return !kind.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("subagent")
-        } catch {
-            AppLog.warn(LogTag.plugin("grok"), "Could not read session summary; skipped session: \(error.localizedDescription)")
-            return false
-        }
     }
 
     // MARK: - Session parsing

--- a/Tests/OpenUsageTests/GrokLogUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/GrokLogUsageScannerTests.swift
@@ -256,27 +256,34 @@ final class GrokLogUsageScannerTests: XCTestCase {
         XCTAssertEqual(usage?.series.daily.map(\.totalTokens), [200, 100])
     }
 
-    func testSkipsSubagentSessionsAlreadyIncludedInCoordinatorTotals() async throws {
+    func testIncludesSubagentResumeAndForkUsageNotReplayedByCoordinator() async throws {
         let coordinator = GrokLogFixture.completedTurn(
             timestamp: "2026-06-10T10:00:00.000Z",
             model: "grok-4.6-build",
-            input: 300,
-            costUsdTicks: 30_000_000_000,
+            input: 100,
+            costUsdTicks: 10_000_000_000,
             eventID: "coordinator-turn"
         )
         let subagent = GrokLogFixture.completedTurn(
-            timestamp: "2026-06-10T10:01:00.000Z",
+            timestamp: "2026-06-11T10:01:00.000Z",
             model: "grok-4.6-build",
             input: 100,
             costUsdTicks: 10_000_000_000,
             eventID: "subagent-turn"
         )
         let fork = GrokLogFixture.completedTurn(
-            timestamp: "2026-06-10T10:02:00.000Z",
+            timestamp: "2026-06-11T10:02:00.000Z",
             model: "grok-4.6-build",
             input: 200,
             costUsdTicks: 20_000_000_000,
             eventID: "fork-turn"
+        )
+        let resume = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-12T10:00:00.000Z",
+            model: "grok-4.6-build",
+            input: 400,
+            costUsdTicks: 40_000_000_000,
+            eventID: "resume-turn"
         )
         let legacy = GrokLogFixture.completedTurn(
             timestamp: "2026-06-10T11:00:00.000Z",
@@ -292,7 +299,38 @@ final class GrokLogUsageScannerTests: XCTestCase {
             "project/coordinator/subagents/worker/summary.json": #"{"session_kind":"subagent"}"#,
             "project/fork/updates.jsonl": fork,
             "project/fork/summary.json": #"{"session_kind":"subagent_fork"}"#,
+            "project/resume/updates.jsonl": resume,
+            "project/resume/summary.json": #"{"session_kind":"subagent_resume"}"#,
             "project/legacy/updates.jsonl": legacy
+        ])
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let usage = await GrokLogFixture.scanner(home: home).scan(
+            daysBack: 30,
+            now: OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!,
+            pricing: TestPricing.bundled
+        )
+        let days = try XCTUnwrap(usage?.series.daily)
+
+        XCTAssertEqual(days.map(\.date), ["2026-06-12", "2026-06-11", "2026-06-10"])
+        XCTAssertEqual(days.map(\.totalTokens), [400, 300, 150])
+        XCTAssertEqual(days.map(\.costUSD), [4, 3, 1.5])
+    }
+
+    func testCountsReplayedParentAndChildEventsOncePerModel() async throws {
+        let parent = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T10:00:00.000Z", model: "grok-build", input: 100,
+            costUsdTicks: 10_000_000_000, eventID: "parent-turn"
+        )
+        let child = GrokLogFixture.completedTurn(
+            timestamp: "2026-06-10T11:00:00.000Z", model: "grok-build", input: 200,
+            costUsdTicks: 20_000_000_000, eventID: "child-turn",
+            additionalModels: ["grok-4.6-build": ["inputTokens": 300, "costUsdTicks": 30_000_000_000]]
+        )
+        let home = try GrokLogFixture.makeHome(files: [
+            "project/parent/updates.jsonl": [parent, child].joined(separator: "\n"),
+            "project/parent/subagents/worker/updates.jsonl": [parent, child, child].joined(separator: "\n"),
+            "project/parent/subagents/worker/summary.json": #"{"session_kind":"subagent"}"#
         ])
         defer { try? FileManager.default.removeItem(at: home) }
 
@@ -303,11 +341,11 @@ final class GrokLogUsageScannerTests: XCTestCase {
         )
         let day = try XCTUnwrap(usage?.series.daily.first)
 
-        XCTAssertEqual(day.totalTokens, 350, "subagent and fork tokens are already included in their coordinator")
-        XCTAssertEqual(try XCTUnwrap(day.costUSD), 3.5, accuracy: 0.0001)
+        XCTAssertEqual(day.totalTokens, 600)
+        XCTAssertEqual(try XCTUnwrap(day.costUSD), 6, accuracy: 0.0001)
     }
 
-    func testSkipsSessionWithMalformedSummaryInsteadOfGuessingItsKind() async throws {
+    func testReadsSessionWithoutDependingOnSummary() async throws {
         let line = GrokLogFixture.completedTurn(
             timestamp: "2026-06-10T10:00:00.000Z", model: "grok-build", input: 1_000
         )
@@ -317,9 +355,13 @@ final class GrokLogUsageScannerTests: XCTestCase {
         ])
         defer { try? FileManager.default.removeItem(at: home) }
 
-        let usage = await GrokLogFixture.scanner(home: home).scan(pricing: TestPricing.bundled)
+        let usage = await GrokLogFixture.scanner(home: home).scan(
+            daysBack: 30,
+            now: OpenUsageISO8601.date(from: "2026-06-18T12:00:00.000Z")!,
+            pricing: TestPricing.bundled
+        )
 
-        XCTAssertNil(usage)
+        XCTAssertEqual(usage?.series.daily.first?.totalTokens, 1_000)
     }
 
     func testReadsWhitespaceTrimmedGrokHomeOverride() async throws {

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -20,7 +20,7 @@ Sign in once with the Grok CLI (`grok login`); OpenUsage reads the same `~/.grok
 
 ## The spend tiles
 
-Today / Yesterday / Last 30 Days are computed **locally** from completed Grok CLI sessions under `~/.grok/sessions/` (or `$GROK_HOME/sessions/`). Subagent usage is counted through its parent session, so parallel tasks do not inflate the totals. OpenUsage uses the cost Grok recorded for each completed turn when available; older turns without a recorded cost are estimated using the shared [model pricing](../pricing.md). Days follow your Mac's local time zone, and each period shows cost and tokens together (`$4.08 · 1.2M tokens`). These amounts are separate from the credits reported by Grok's billing API, and no session data leaves your Mac. A period with no completed usage reads "No data" rather than `$0.00 · 0 tokens`.
+Today / Yesterday / Last 30 Days are computed **locally** from completed Grok CLI sessions under `~/.grok/sessions/` (or `$GROK_HOME/sessions/`). This includes subagent, resumed, and forked sessions: their work is not necessarily included in the parent session's usage. Copies of the same completed event are counted once per model across session logs. OpenUsage uses the cost Grok recorded for each completed turn when available; older turns without a recorded cost are estimated using the shared [model pricing](../pricing.md). Days follow your Mac's local time zone, and each period shows cost and tokens together (`$4.08 · 1.2M tokens`). These amounts are separate from the credits reported by Grok's billing API, and no session data leaves your Mac. A period with no completed usage reads "No data" rather than `$0.00 · 0 tokens`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## TL;DR
Include Grok subagent, resumed, and forked session usage in local spend tiles and Usage Trend, while retaining event-ID/model deduplication. Fixes #1191.

## What was happening
- The scanner skipped every session marked `subagent*`, assuming the coordinator already included its usage.
- Child work missing from coordinator turns disappeared from spend totals and could leave entire days without usage.
- An unreadable session summary also excluded an otherwise valid usage ledger.

## What this changes
- Scan every durable `updates.jsonl` ledger regardless of session kind, without requiring `summary.json`.
- Preserve existing event-ID/model deduplication across parent and child logs.
- Add regression coverage for child-only days, subagent/resume/fork sessions, replayed multi-model events, and malformed summaries.
- Update the Grok provider documentation to describe child-session accounting.

## Heads-up
- Deduplication uses event IDs and models, not matching token totals: separate turns can have identical totals.
- Weekly billing metrics and metric layout defaults are unchanged.

## Tests
- `swift test --filter Grok` compiled successfully; the local Xcode beta test runner initially could not locate Sparkle.
- After linking the existing Sparkle artifact into the local build's `PackageFrameworks` directory, `swift test --skip-build --filter Grok` passed all 50 tests.
- `CONFIG=debug ./script/build_and_run.sh verify` rebuilt, signed, and launched the dev app successfully.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grok spend aggregation logic users rely on for cost visibility; dedup by event ID may miss edge cases where IDs differ for the same work.
> 
> **Overview**
> **Grok local spend tiles** no longer exclude subagent, fork, and resume sessions based on `summary.json` `session_kind`. The scanner now ingests every `updates.jsonl` under `$GROK_HOME/sessions`, so usage that only appears in child ledgers shows up in Today / Yesterday / Last 30 Days.
> 
> **Double-counting** is still avoided by the existing **event ID + model** dedup when the same `turn_completed` is copied across parent and child logs. Sessions with missing or malformed `summary.json` are counted again instead of being dropped entirely.
> 
> Tests and **Grok provider docs** were updated for child-only days, replayed events, and summary-independent reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca9625a025955c5648b179090e5f016c0acb2cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->