### PR TITLE
fix(sync): accept legacy Codex account identity metadata

### DIFF
--- a/Sources/OpenUsage/Models/UsageHistoryDocument.swift
+++ b/Sources/OpenUsage/Models/UsageHistoryDocument.swift
@@ -36,13 +36,17 @@ struct UsageHistoryDocument: Hashable, Sendable, Codable, Identifiable {
 
         var seenIdentities = Set<String>()
         for (providerID, identity) in identities ?? [:] {
+            let family = ProviderAccountID.family(of: providerID)
+            // Earlier v2 writers also included the bare Codex account identity. It is valid
+            // metadata, though only Claude identities participate in account-aware merging.
+            let isLegacyCodexIdentity = schema == Self.accountSchema && providerID == "codex"
             guard providers[providerID] != nil,
-                  ProviderAccountID.family(of: providerID) == "claude",
+                  family == "claude" || isLegacyCodexIdentity,
                   !identity.isEmpty,
                   identity.rangeOfCharacter(from: .whitespacesAndNewlines.union(.controlCharacters)) == nil,
                   !identity.contains("/"), !identity.contains("\\")
             else { throw UsageHistoryDocumentError.invalidIdentity(providerID) }
-            guard seenIdentities.insert(identity.lowercased()).inserted else {
+            guard seenIdentities.insert("\(family):\(identity.lowercased())").inserted else {
                 throw UsageHistoryDocumentError.duplicateIdentity(providerID)
             }
         }

--- a/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryAggregatorTests.swift
@@ -169,7 +169,10 @@ final class UsageHistoryAggregatorTests: XCTestCase {
             ]
         )
         peer.schema = UsageHistoryDocument.accountSchema
-        peer.identities = ["claude": "USER|WORK", "claude@abcdef12": "user|personal"]
+        peer.identities = [
+            "claude": "USER|WORK", "claude@abcdef12": "user|personal",
+            "codex": "legacy-codex-account",
+        ]
         XCTAssertNoThrow(try peer.validate())
 
         let descriptor = UsageHistoryDescriptor(scope: .machineLocal, estimatedCost: true, sourceNote: "logs")

--- a/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
+++ b/Tests/OpenUsageTests/UsageHistoryDocumentTests.swift
@@ -38,6 +38,31 @@ final class UsageHistoryDocumentTests: XCTestCase {
         }
     }
 
+    func testAccountSchemaAcceptsLegacyCodexIdentityWithoutRelaxingValidation() throws {
+        var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
+        document.schema = UsageHistoryDocument.accountSchema
+        document.providers["codex"] = document.providers["claude"]
+        // Earlier v2 writers included Codex ownership too. Identity namespaces are per provider.
+        document.identities = ["claude": "shared-account-id", "codex": "shared-account-id"]
+        let decoded = try JSONDecoder().decode(
+            UsageHistoryDocument.self, from: JSONEncoder().encode(document)
+        )
+        XCTAssertNoThrow(try decoded.validate())
+
+        for invalidIdentity in ["", "has space", "has\nnewline", "has/slash", "has\\backslash"] {
+            document.identities?["codex"] = invalidIdentity
+            XCTAssertThrowsError(try document.validate()) { error in
+                XCTAssertEqual(error as? UsageHistoryDocumentError, .invalidIdentity("codex"))
+            }
+        }
+
+        document.identities?["codex"] = "codex-account"
+        document.providers.removeValue(forKey: "codex")
+        XCTAssertThrowsError(try document.validate()) { error in
+            XCTAssertEqual(error as? UsageHistoryDocumentError, .invalidIdentity("codex"))
+        }
+    }
+
     func testAccountSchemaRejectsMissingMismatchedAndDuplicateClaudeIdentities() {
         var document = makeDocument(deviceID: "mac-a", updatedAt: .now)
         document.schema = UsageHistoryDocument.accountSchema

--- a/docs/icloud-sync.md
+++ b/docs/icloud-sync.md
@@ -15,8 +15,9 @@ this Mac's next iCloud write, while its local cached snapshot remains.
 
 Claude history that identifies its account and organization is combined only with matching accounts on
 other Macs. Older single-account history without account information remains compatible when only one
-Claude card is visible, and is ignored when multiple cards are visible. Codex syncing works the same way
-it did before.
+Claude card is visible, and is ignored when multiple cards are visible. Files from earlier builds that
+also include a Codex account ID remain readable; that extra ID does not change how Codex usage is
+combined. Codex syncing works the same way it did before.
 
 OpenUsage combines the valid files in memory and rebuilds Today, Yesterday, Last 30 Days, Usage Trend,
 unknown-model warnings, and model breakdowns. The same combined spend rows feed the dashboard, Total


### PR DESCRIPTION
## TL;DR

Restore compatibility with older iCloud history files that include a Codex account ID. Valid history from another Mac no longer gets rejected merely because it contains this extra metadata.

## What was happening

- Earlier v2 sync writers included both Claude and Codex account identities.
- The current reader only accepted Claude identities, so a valid Codex identity caused the entire device file to be skipped.
- Settings showed a generic unreadable-data warning, while the log misleadingly reported an invalid Claude account identity.

## What this changes

- Accept the legacy bare `codex` identity in v2 documents, while still requiring its provider history and a valid identity value.
- Scope duplicate identity checks by provider family, so identical opaque IDs in Claude and Codex do not collide.
- Cover legacy document decoding, malformed and orphaned Codex identities, and aggregation with legacy Codex metadata.
- Document compatibility with these older files.

## Heads-up

- Codex usage remains synced as before; this does not introduce Codex account-based matching or change the writer format.
- No synced files are deleted or rewritten by the compatibility fix. Claude account matching and its duplicate checks remain intact.
- This is a reader-only logic fix, with no UI layout or copy changes.

## Tests

- Confirmed the new regression test failed before the fix with `invalidIdentity("codex")`.
- `swift test --filter 'UsageHistoryDocumentTests|UsageHistoryAggregatorTests|ICloudUsageSyncStoreTests'`: 23 tests passed. The local Xcode beta test runner needed a symlink to the existing Sparkle framework under its ignored build-output directory.
- `CONFIG=debug ./script/build_and_run.sh verify`: rebuilt, signed, and relaunched successfully.
- With sync enabled, confirmed this Mac wrote fresh history and no new iCloud read errors appeared after restart. Visual inspection was unavailable because the UI tool timed out.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reader-only validation tweak for synced history documents; Claude account matching and duplicate rules within Claude are unchanged.
> 
> **Overview**
> **Restores iCloud compatibility** for v2 history files that still carry a bare `codex` entry in `identities` from older writers. Those peers were failing `UsageHistoryDocument.validate()` and being dropped entirely in `ICloudUsageSyncStore`, even when Claude/Codex usage was otherwise valid.
> 
> `validate()` now treats `codex` identities as allowed metadata on `openusage.history.v2` (still requiring matching `providers["codex"]` and the same identity format rules as Claude). **Duplicate identity detection** keys on `providerFamily:identity` instead of identity alone, so the same opaque string on Claude and Codex no longer counts as a duplicate.
> 
> Tests cover decode/validate edge cases (malformed or orphaned Codex identities) and aggregation with legacy Codex metadata; **docs** note that the extra Codex ID is readable but does not change Codex merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e2745a9d1f6609937623659608ce9d3ca8cd4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->