### PR TITLE
fix(pricing): add Fable 5.1 rates and Grok bot aliases

### DIFF
--- a/Sources/OpenUsage/Resources/pricing_supplement.json
+++ b/Sources/OpenUsage/Resources/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries; https://developers.openai.com/api/docs/models/daybreak-blue-latest and https://developers.openai.com/api/docs/pricing for Daybreak aliases and rates; https://docs.z.ai/guides/overview/pricing for GLM 5.3.",
-  "updated_at": "2026-08-26T12:39:17Z",
+  "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries; https://platform.claude.com/docs/en/about-claude/pricing for Claude Fable 5.1; https://developers.openai.com/api/docs/models/daybreak-blue-latest and https://developers.openai.com/api/docs/pricing for Daybreak aliases and rates; https://docs.z.ai/guides/overview/pricing for GLM 5.3.",
+  "updated_at": "2026-09-01T20:30:00Z",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -111,6 +111,13 @@
       "cache_read_per_million": 1.0,
       "output_per_million": 50.0
     },
+    "claude-fable-5.1": {
+      "$comment": "Claude Fable 5.1 launch pricing per platform.claude.com and Cursor's Other Models table. Same $10/$50 input/output as Fable 5; cache reads are $0.25/M (0.025x, 75% below Fable 5). Cache write is the standard 1.25x 5m rate. Neither bundled public catalog carries the model yet.",
+      "input_per_million": 10.0,
+      "cache_write_per_million": 12.5,
+      "cache_read_per_million": 0.25,
+      "output_per_million": 50.0
+    },
     "claude-opus-5": {
       "$comment": "Claude Opus 5 launch pricing per anthropic.com/news/claude-opus-5: $5 input / $25 output per million, plus the standard Anthropic cache multipliers (1.25x 5m cache write, 0.1x cache read). LiteLLM, models.dev, and Cursor have not listed the model yet, so it would otherwise show as an unpriced model.",
       "input_per_million": 5.0,
@@ -195,6 +202,7 @@
     { "pattern": "^(?:cursor-)?grok-4[.-]6-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.6-fast" },
     { "pattern": "^(?:cursor-)?grok-4[.-]6(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.6-fast" },
     { "pattern": "^(?:cursor-)?grok-4[.-]6(?:-(?:build|low|medium|high|xhigh))?$", "canonical": "grok-4.6" },
+    { "pattern": "^grok-bot-(?:automation|cua|default)$", "canonical": "grok-4.6" },
     { "pattern": "^(?:cursor-)?grok-4[.-]5-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5-fast" },
     { "pattern": "^(?:cursor-)?grok-4[.-]5(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.5-fast" },
     { "pattern": "^(?:cursor-)?grok-4[.-]5(?:-(?:build|low|medium|high|xhigh))?$", "canonical": "grok-4.5" },
@@ -217,6 +225,7 @@
     { "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-4-8" },
     { "pattern": "^claude-opus-5(?:\\[1m\\])?(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-opus-5-fast" },
     { "pattern": "^claude-opus-5(?:\\[1m\\])?(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-5" },
+    { "pattern": "^claude-fable-5[.-]1(?:\\[1m\\])?(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-fable-5.1" },
     { "pattern": "^claude-fable-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-fable-5" },
     { "pattern": "^claude-sonnet-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-sonnet-5" },
     { "pattern": "^gemini-2\\.5-flash(?:-(?:none|low|medium|high|xhigh))?$", "canonical": "gemini-2.5-flash" },
@@ -281,6 +290,7 @@
     { "pattern": "(?i)^(?:Claude )?Opus 4\\.8 \\(Auto[^)]*\\)$", "canonical": "claude-opus-4-8" },
     { "pattern": "(?i)^(?:Claude )?Opus 5 \\(Auto[^)]*\\)$", "canonical": "claude-opus-5" },
     { "pattern": "(?i)^(?:Claude )?Sonnet 5 \\(Auto[^)]*\\)$", "canonical": "claude-sonnet-5" },
+    { "pattern": "(?i)^(?:Claude )?Fable 5\\.1 \\(Auto[^)]*\\)$", "canonical": "claude-fable-5.1" },
     { "pattern": "(?i)^(?:Claude )?Fable 5 \\(Auto[^)]*\\)$", "canonical": "claude-fable-5" },
     { "pattern": "(?i)^GPT-5\\.5 \\(Auto[^)]*\\)$", "canonical": "gpt-5.5" },
     { "pattern": "(?i)^GPT-5\\.6 Sol \\(Auto[^)]*\\)$", "canonical": "gpt-5.6-sol" },

--- a/Tests/OpenUsageTests/PricingBundledResourceTests.swift
+++ b/Tests/OpenUsageTests/PricingBundledResourceTests.swift
@@ -51,7 +51,9 @@ final class PricingBundledResourceTests: XCTestCase {
             ("grok-4-6-xhigh-fast", 4), ("kimi-k2p5", 0.6),
             ("kimi-k2.7-code", 0.95), ("kimi-k2p7", 0.95), ("kimi-k3-max", 3),
             ("claude-4.7-opus-high-thinking", 5), ("claude-4.7-opus-max-thinking-fast", 30),
-            ("glm-5.2-max", 1.4), ("glm-5.3-max", 1.4)
+            ("glm-5.2-max", 1.4), ("glm-5.3-max", 1.4),
+            ("claude-fable-5-1-thinking-high", 10),
+            ("grok-bot-default", 2), ("grok-bot-automation", 2), ("grok-bot-cua", 2)
         ]
         for (model, expected) in expectedInputRates {
             XCTAssertEqual(pricing.resolve(model: model)?.inputPerMillion, expected, model)
@@ -93,6 +95,33 @@ final class PricingBundledResourceTests: XCTestCase {
             XCTAssertEqual(pricing.resolve(model: variant), pricing.resolve(model: canonical), "wrong rates for '\(variant)'")
         }
         XCTAssertNil(pricing.supplement.canonicalName(for: "gemini-3-pro"))
+    }
+
+    /// Claude Fable 5.1: same $10/$50 input/output as Fable 5, but cache reads are $0.25/M
+    /// (0.025x). Cursor CSV slugs (`claude-fable-5-1-thinking-*`) and the Anthropic API id
+    /// (`claude-fable-5-1`) must not collapse into the Fable 5 catalog entry.
+    func testClaudeFable51PricingAndAliases() throws {
+        let pricing = Self.pricing
+        let fable51 = try XCTUnwrap(pricing.resolve(model: "claude-fable-5-1-thinking-high"))
+        XCTAssertEqual(fable51.inputPerMillion, 10.0)
+        XCTAssertEqual(fable51.cacheWritePerMillion, 12.5)
+        XCTAssertEqual(fable51.cacheReadPerMillion, 0.25)
+        XCTAssertEqual(fable51.outputPerMillion, 50.0)
+
+        for model in [
+            "claude-fable-5-1", "claude-fable-5.1", "claude-fable-5-1-thinking",
+            "claude-fable-5-1-thinking-low", "claude-fable-5-1-thinking-medium",
+            "claude-fable-5.1-thinking-xhigh", "claude-fable-5-1[1m]"
+        ] {
+            XCTAssertEqual(pricing.supplement.canonicalName(for: model), "claude-fable-5.1", model)
+            XCTAssertEqual(pricing.resolve(model: model), fable51, model)
+        }
+
+        let fable5 = try XCTUnwrap(pricing.resolve(model: "claude-fable-5"))
+        XCTAssertEqual(fable5.inputPerMillion, fable51.inputPerMillion)
+        XCTAssertEqual(fable5.outputPerMillion, fable51.outputPerMillion)
+        XCTAssertNotEqual(fable5.cacheReadPerMillion, fable51.cacheReadPerMillion)
+        XCTAssertEqual(pricing.supplement.canonicalName(for: "claude-fable-5-thinking-high"), "claude-fable-5")
     }
 
     /// Claude Fable 5 (carried over from the old manifest tests): priced at 2x standard Claude 4.8
@@ -196,6 +225,8 @@ final class PricingBundledResourceTests: XCTestCase {
             "Opus 4.8 (Auto)": "claude-opus-4-8",
             "Sonnet 5 (Auto Intelligence)": "claude-sonnet-5",
             "Fable 5 (Auto Balanced)": "claude-fable-5",
+            "Fable 5.1 (Auto Balanced)": "claude-fable-5.1",
+            "Claude Fable 5.1 (Auto)": "claude-fable-5.1",
             "Haiku 4.5 (Auto Cost)": "claude-haiku-4-5",
             "Composer 2.5 (Auto)": "composer-2.5",
             "Composer 2.5 Fast (Auto)": "composer-2.5-fast",
@@ -344,6 +375,12 @@ final class PricingBundledResourceTests: XCTestCase {
             }
             XCTAssertEqual(pricing.supplement.canonicalName(for: "cursor-grok-\(version)-high"), "grok-\(version)")
             XCTAssertEqual(pricing.supplement.canonicalName(for: "cursor-grok-\(version)-high-fast"), "grok-\(version)-fast")
+        }
+
+        let grok46 = try XCTUnwrap(pricing.resolve(model: "grok-4.6"))
+        for bot in ["grok-bot-automation", "grok-bot-cua", "grok-bot-default"] {
+            XCTAssertEqual(pricing.supplement.canonicalName(for: bot), "grok-4.6", bot)
+            XCTAssertEqual(pricing.resolve(model: bot), grok46, bot)
         }
     }
 


### PR DESCRIPTION
## TL;DR

Price Claude Fable 5.1 and alias Cursor's `grok-bot-*` slugs to Grok 4.6 so those unknown-model warnings stop eating spend.

## What was happening

- Cursor usage listed unpriced models: `claude-fable-5-1-thinking-{low,medium,high}` and `grok-bot-{automation,cua,default}`.
- The existing Fable 5 alias only matches `claude-fable-5`, so the new 5.1 thinking slugs never resolved.
- Neither bundled LiteLLM nor models.dev snapshot carries Fable 5.1 yet.
- The Grok bot slugs had no alias at all.

## What this changes

- Add a `claude-fable-5.1` supplement entry from [Cursor models & pricing](https://cursor.com/docs/models-and-pricing.md) and [Anthropic's pricing page](https://platform.claude.com/docs/en/about-claude/pricing):
  - input $10
  - cache write $12.50
  - cache read $0.25 (0.025x; 75% below Fable 5's $1)
  - output $50
- Alias `claude-fable-5-1` / `claude-fable-5.1` plus thinking, effort, `[1m]`, and Cursor Router labels (`Fable 5.1 (Auto …)`) to that entry. Fable 5 stays on its own catalog rates.
- Alias `grok-bot-automation`, `grok-bot-cua`, and `grok-bot-default` to `grok-4.6` ($2 / $2 / $0.50 / $6).
- Bump `updated_at` so installed apps pick this up from the feed.

## Heads-up

- Left other Cursor-page diffs alone for a later pass: Grok 4.5 Fast output is now $18 on Cursor's table (we still have $12); GPT-5.6 Sol is on promo $4/$20 there (we keep official $5/$30); Sonnet 5 is $2/$10 on Cursor (catalogs still $3/$15).
- `grok-bot-*` looks like Cursor-internal routing, not a published model. Priced as Grok 4.6 on purpose.

## Tests

- `swift test --filter "ModelPricing|PricingBundledResource"`: 57 tests passed.
- Supplement JSON / regex / multiplier validation passed.


Made with [Cursor](https://cursor.com)