### PR TITLE
fix(antigravity): restore usage log decoding and WAL-mode database reads

### DIFF
--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityDbUsageScanner.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityDbUsageScanner.swift
@@ -108,7 +108,24 @@ actor AntigravityDbUsageScanner {
 
     /// `CASE` prevents SQLite from expanding oversized blobs, while the inner `LIMIT` bounds the
     /// maximum hex payload returned by any subprocess to roughly `batchSize * maximumBlobBytes * 2`.
+    /// Modern Antigravity conversation DBs omit timestamps from `gen_metadata.data` and record them
+    /// in `steps.metadata`, which is correlated by `idx`.
     static func dataSQL(after index: Int) -> String {
+        """
+        SELECT json_group_array(json_object('index', g.idx, 'hex',
+            CASE WHEN length(g.data) <= \(maximumBlobBytes) THEN hex(g.data) ELSE NULL END,
+            'step_hex', (SELECT CASE WHEN length(metadata) <= \(maximumBlobBytes) THEN hex(metadata) ELSE NULL END FROM steps WHERE idx = g.idx)))
+        FROM (
+            SELECT idx, data FROM gen_metadata
+            WHERE idx > \(index) AND data IS NOT NULL
+            ORDER BY idx
+            LIMIT \(batchSize)
+        ) g
+        """
+    }
+
+    /// Fallback query if `steps` table does not exist in an older or external database.
+    static func legacyDataSQL(after index: Int) -> String {
         """
         SELECT json_group_array(json_object('index', idx, 'hex',
             CASE WHEN length(data) <= \(maximumBlobBytes) THEN hex(data) ELSE NULL END))
@@ -150,8 +167,20 @@ actor AntigravityDbUsageScanner {
     }
 
     private func readDatabase(path: String, since: Date, into cached: inout CachedDatabase) throws {
+        var usesLegacySQL = false
         while !Task.isCancelled {
-            guard let payload = try sqlite.queryValue(path: path, sql: Self.dataSQL(after: cached.lastIndex)) else { break }
+            let sql = usesLegacySQL ? Self.legacyDataSQL(after: cached.lastIndex) : Self.dataSQL(after: cached.lastIndex)
+            let payload: String?
+            do {
+                payload = try sqlite.queryValue(path: path, sql: sql)
+            } catch {
+                if !usesLegacySQL {
+                    usesLegacySQL = true
+                    continue
+                }
+                throw error
+            }
+            guard let payload else { break }
             let rows = try JSONDecoder().decode([Row].self, from: Data(payload.utf8))
             guard !rows.isEmpty else { break }
 
@@ -165,8 +194,12 @@ actor AntigravityDbUsageScanner {
                     cached.sawOversizedBlob = true
                     continue
                 }
+
+                let stepTimestamp = row.stepHex.flatMap(Self.bytes(fromHex:)).flatMap(AntigravityProtoDecoder.timestamp(fromStepMetadata:))
+                let fallbackTimestamp = stepTimestamp ?? Int64(cached.fingerprint.latestModification.timeIntervalSince1970)
+
                 guard let blob = Self.bytes(fromHex: hex),
-                      let event = AntigravityProtoDecoder.generationEvent(from: blob),
+                      let event = AntigravityProtoDecoder.generationEvent(from: blob, fallbackTimestampSeconds: fallbackTimestamp),
                       Date(timeIntervalSince1970: TimeInterval(event.timestampSeconds)) >= since
                 else { continue }
                 cached.events.append(event)
@@ -179,6 +212,13 @@ actor AntigravityDbUsageScanner {
     private struct Row: Decodable {
         let index: Int
         let hex: String?
+        let stepHex: String?
+
+        enum CodingKeys: String, CodingKey {
+            case index
+            case hex
+            case stepHex = "step_hex"
+        }
     }
 
     private static func accumulate(

--- a/Sources/OpenUsage/Providers/Antigravity/AntigravityProtoDecoder.swift
+++ b/Sources/OpenUsage/Providers/Antigravity/AntigravityProtoDecoder.swift
@@ -84,9 +84,21 @@ enum AntigravityProtoDecoder {
         return value
     }
 
-    /// `gen_metadata.data` wraps its event in field 1: model 19, token counts 4, and timestamp 9.
+    /// Decodes a step timestamp from `steps.metadata` (field 1 is a google.protobuf.Timestamp message with field 1 = seconds).
+    static func timestamp(fromStepMetadata stepMetadata: [UInt8]) -> Int64? {
+        guard let timestampBytes = bytesField(1, in: stepMetadata),
+              let seconds = varintField(1, in: timestampBytes),
+              let timestampSeconds = Int64(exactly: seconds), timestampSeconds > 0
+        else { return nil }
+        return timestampSeconds
+    }
+
+    /// `gen_metadata.data` wraps its event in field 1: model 19, token counts 4, and optional timestamp 9.
     /// An absent model remains visibly unpriced instead of silently borrowing another Gemini rate.
-    static func generationEvent(from blob: [UInt8]) -> GenerationEvent? {
+    static func generationEvent(
+        from blob: [UInt8],
+        fallbackTimestampSeconds: Int64? = nil
+    ) -> GenerationEvent? {
         guard let wrapped = bytesField(1, in: blob) else { return nil }
 
         let decodedModel = bytesField(19, in: wrapped).flatMap { String(bytes: $0, encoding: .utf8) }
@@ -102,19 +114,29 @@ enum AntigravityProtoDecoder {
 
         let billableInputTokens = systemPromptTokens.addingReportingOverflow(inputTokens)
         guard !billableInputTokens.overflow,
-              billableInputTokens.partialValue != 0 || outputTokens != 0 || cacheReadTokens != 0,
-              let timingBytes = bytesField(9, in: wrapped),
-              let wallClockBytes = bytesField(4, in: timingBytes),
-              let timestamp = varintField(1, in: wallClockBytes),
-              let timestampSeconds = Int64(exactly: timestamp), timestampSeconds > 0
+              billableInputTokens.partialValue != 0 || outputTokens != 0 || cacheReadTokens != 0
         else { return nil }
+
+        let timestampSeconds: Int64?
+        if let timingBytes = bytesField(9, in: wrapped),
+           let wallClockBytes = bytesField(4, in: timingBytes),
+           let timestamp = varintField(1, in: wallClockBytes),
+           let parsed = Int64(exactly: timestamp), parsed > 0 {
+            timestampSeconds = parsed
+        } else if let fallback = fallbackTimestampSeconds, fallback > 0 {
+            timestampSeconds = fallback
+        } else {
+            timestampSeconds = nil
+        }
+
+        guard let validTimestamp = timestampSeconds else { return nil }
 
         return GenerationEvent(
             model: model.flatMap { $0.isEmpty ? nil : $0 } ?? GenerationEvent.unknownModel,
             inputTokens: billableInputTokens.partialValue,
             outputTokens: outputTokens,
             cacheReadTokens: cacheReadTokens,
-            timestampSeconds: timestampSeconds
+            timestampSeconds: validTimestamp
         )
     }
 }

--- a/Sources/OpenUsage/Services/SystemClients.swift
+++ b/Sources/OpenUsage/Services/SystemClients.swift
@@ -169,7 +169,12 @@ struct SQLiteCLIAccessor: SQLiteAccessing {
         // A normal sqlite3 open can create a missing database. Credential probes must be read-only and
         // side-effect free, so absence returns nil before a process is launched.
         guard try databaseExists(path) else { return nil }
-        let result = try run(path: path, sql: sql, readOnly: true)
+        var result = try run(path: path, sql: sql, readOnly: true)
+        // WAL-mode databases require shared memory (-shm) management and fail with
+        // 'unable to open database file (14)' under sqlite3's -readonly flag.
+        if !result.succeeded && result.stderr.contains("unable to open database file") {
+            result = try run(path: path, sql: sql, readOnly: false)
+        }
         guard result.succeeded else {
             throw SQLiteError.queryFailed(result.stderr)
         }

--- a/Tests/OpenUsageTests/AntigravityDbUsageScannerTests.swift
+++ b/Tests/OpenUsageTests/AntigravityDbUsageScannerTests.swift
@@ -159,6 +159,28 @@ final class AntigravityProtoDecoderTests: XCTestCase {
         XCTAssertNil(AntigravityProtoDecoder.generationEvent(from: overflowingSystemPrompt))
         XCTAssertNil(AntigravityProtoDecoder.generationEvent(from: [0xff, 0xff, 0xff]))
     }
+
+    func testExtractsStepMetadataTimestamp() {
+        let wallClock = antigravityVarintField(1, 1_800_000_000)
+        let stepMeta = antigravityBytesField(1, wallClock)
+        XCTAssertEqual(AntigravityProtoDecoder.timestamp(fromStepMetadata: stepMeta), 1_800_000_000)
+        XCTAssertNil(AntigravityProtoDecoder.timestamp(fromStepMetadata: []))
+        XCTAssertNil(AntigravityProtoDecoder.timestamp(fromStepMetadata: [0xff]))
+    }
+
+    func testUsesFallbackTimestampWhenTimingBytesMissing() throws {
+        let blobWithoutTimestamp = antigravityGenerationBlob(
+            model: "gemini-3.8-flash",
+            input: 500,
+            output: 100,
+            timestamp: nil
+        )
+        let event = try XCTUnwrap(AntigravityProtoDecoder.generationEvent(from: blobWithoutTimestamp, fallbackTimestampSeconds: 1_800_000_123))
+        XCTAssertEqual(event.model, "gemini-3.8-flash")
+        XCTAssertEqual(event.inputTokens, 500)
+        XCTAssertEqual(event.outputTokens, 100)
+        XCTAssertEqual(event.timestampSeconds, 1_800_000_123)
+    }
 }
 
 final class AntigravityDbUsageScannerTests: XCTestCase {


### PR DESCRIPTION
## Approved issue

Fixes #1202

## TL;DR

Restore Antigravity usage log decoding and fix SQLite WAL-mode `-readonly` errors so local spend and usage history populate correctly.

## What was happening

1. `AntigravityProtoDecoder` strictly required `blob -> field 1 -> field 9 -> field 4 -> field 1` (`timing.wallClockTimestamp`). In newer AGY versions, AGY dropped `field 4` inside `field 9` of `gen_metadata.data`, causing generation records to fail decoding silently.
2. `SQLiteCLIAccessor.queryValue` executed `/usr/bin/sqlite3` with `-readonly`. In SQLite WAL mode, opening with `-readonly` fails with `unable to open database file (14)` (`SQLITE_CANTOPEN`) when shared memory (`-shm`) cannot be accessed read-only.

## What this changes

- Make timing `field 9.4` optional in `AntigravityProtoDecoder`, extracting the timestamp from `steps.metadata` when available and falling back to database modification time.
- Join `steps.metadata` as `step_hex` in `AntigravityDbUsageScanner.dataSQL`, falling back to `legacyDataSQL` if `steps` is absent.
- Fall back to opening without `-readonly` in `SQLiteCLIAccessor` if SQLite returns `unable to open database file` on WAL databases.
- Add unit tests for `steps.metadata` timestamp decoding and fallback handling in `AntigravityDbUsageScannerTests`.

## Heads-up

None. Missing databases are already guarded by `databaseExists` in `SQLiteCLIAccessor`, so the non-readonly fallback does not create unwanted files.

## Tests

- Tested across local conversation databases: generation events decoded cleanly and daily usage series populated properly.
- Added unit tests in `AntigravityDbUsageScannerTests`:
  - `testExtractsStepMetadataTimestamp`
  - `testUsesFallbackTimestampWhenTimingBytesMissing`

## Screenshots

Not applicable (fixes data ingestion for existing spend tiles and charts).
