### PR TITLE
Let one account own sessions with no owner marker

### DIFF
--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -49,13 +49,20 @@ struct ProviderAccountAssembly {
         return make(
             observer: DefaultAccountObserver(),
             accountsStore: ProviderAccountsStore(defaults: defaults),
-            families: families
+            families: families,
+            unattributedOwnerIdentityKey: defaults.string(forKey: Self.unattributedOwnerKey)
         )
     }
 
     /// The environment variable that relocates each family's default home — the fact whose
     /// invisibility (shell layers unreadable AND not in the process environment) makes that family's
     /// identity read unsafe on a first launch.
+    /// The account the user named as the owner of markerless sessions — transcripts written before
+    /// Claude Code stamped `ownerAccountUuid`, which no account can claim on evidence. Empty or
+    /// unset (the default) keeps the strict rule: markerless sessions count only while a single
+    /// Claude account has ever been known.
+    static let unattributedOwnerKey = "openusage.unattributedOwner.v1"
+
     private static let homeOverrideKeys: [String: String] = [
         "claude": "CLAUDE_CONFIG_DIR",
         "codex": "CODEX_HOME",
@@ -69,6 +76,7 @@ struct ProviderAccountAssembly {
         observer: DefaultAccountObserver,
         accountsStore: ProviderAccountsStore,
         families: Set<String> = ProviderAccountID.families,
+        unattributedOwnerIdentityKey: String? = nil,
         desktop: ClaudeDesktopAuthStore? = nil,
         listDesktopOrganizationDirectories: @escaping @Sendable (URL) -> [String] = { root in
             let urls = (try? FileManager.default.contentsOfDirectory(
@@ -149,7 +157,14 @@ struct ProviderAccountAssembly {
 
         let defaultClaudeIdentity = identityKeys["claude"]
         let records = accountsStore.reconcile(with: observations)
-        let allowsUnattributedPiUsage = records.count { $0.family == "claude" } == 1
+        // Markerless sessions belong to whoever the user named, or — while only one Claude account
+        // has ever been known — to that account. Never to a guess: at most one card can claim them,
+        // so a second account can neither hide the history nor double-count it.
+        let legacySingleAccount = records.count { $0.family == "claude" } == 1
+        let namedOwner = unattributedOwnerIdentityKey?.nilIfEmpty?.lowercased()
+        func allowsUnattributedPiUsage(_ identityKey: String) -> Bool {
+            legacySingleAccount || identityKey.lowercased() == namedOwner
+        }
         var cards: [ClaudeAccountCard] = []
         if let defaultIdentity = defaultClaudeIdentity,
            let organization = defaultIdentity.split(separator: "|").last,
@@ -165,7 +180,7 @@ struct ProviderAccountAssembly {
             cards.append(ClaudeAccountCard(
                 id: record.id, identityKey: defaultIdentity, organizationID: String(organization),
                 displayName: "Claude — \(label)", usesDesktopCredentials: false,
-                allowsUnattributedPiUsage: allowsUnattributedPiUsage
+                allowsUnattributedPiUsage: allowsUnattributedPiUsage(defaultIdentity)
             ))
             identityKeys.removeValue(forKey: "claude")
             identityKeys[record.id] = defaultIdentity
@@ -179,7 +194,8 @@ struct ProviderAccountAssembly {
             cards.append(ClaudeAccountCard(
                 id: cardID, identityKey: organization.identityKey, organizationID: organization.id,
                 displayName: "Claude — \(organizationLabel(record.label) ?? organization.label)",
-                usesDesktopCredentials: true, allowsUnattributedPiUsage: allowsUnattributedPiUsage
+                usesDesktopCredentials: true,
+                allowsUnattributedPiUsage: allowsUnattributedPiUsage(organization.identityKey)
             ))
             identityKeys[cardID] = organization.identityKey
         }

--- a/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
+++ b/Tests/OpenUsageTests/ClaudeDesktopAuthStoreTests.swift
@@ -181,6 +181,62 @@ final class ClaudeDesktopAuthStoreTests: XCTestCase {
         XCTAssertEqual(legacy.identityKeysByCard["claude"], accountUUID)
     }
 
+    /// The account the user names owns markerless sessions — the transcripts written before Claude
+    /// Code stamped `ownerAccountUuid`, which no account can claim on evidence. Exactly one card
+    /// claims them, so a second account neither hides that history nor double-counts it.
+    @MainActor
+    func testNamedUnattributedOwnerKeepsMarkerlessSessionsOnExactlyOneCard() throws {
+        let fixture = try makeFixture(
+            activeOrganization: organization,
+            v2: [
+                cacheKey(organization: organization): tokenEntry("personal-token", expiresIn: 3_600),
+                cacheKey(organization: otherOrganization): tokenEntry("work-token", expiresIn: 3_600),
+            ],
+            accountUUID: accountUUID
+        )
+        let personalIdentity = "\(accountUUID)|\(organization)"
+        let workIdentity = "\(accountUUID)|\(otherOrganization)"
+        let suite = "OpenUsageTests.UnattributedOwner.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let existing = ProviderAccountRecord(
+            id: "claude", family: "claude", identityKey: personalIdentity,
+            label: "Personal",
+            sources: [.init(kind: .defaultHome, anchor: "\(home.path)/.claude", holdsDefaultSource: true)]
+        )
+        defaults.set(try JSONEncoder().encode([existing]), forKey: ProviderAccountsStore.storageKey)
+        fixture.files.files["\(home.path)/.claude.json"] =
+            #"{"oauthAccount":{"accountUuid":"\#(accountUUID)","organizationUuid":"\#(otherOrganization)","emailAddress":"work@example.com","organizationName":"SUNSTORY"}}"#
+        let fixtureHome = home
+        let observer = DefaultAccountObserver(
+            environment: FakeEnvironment(), files: fixture.files, keychain: FakeKeychain(),
+            homeDirectory: { fixtureHome }
+        )
+        let organizations = [organization, otherOrganization]
+        func cards(owner: String?) -> [ClaudeAccountCard] {
+            ProviderAccountAssembly.make(
+                observer: observer, accountsStore: ProviderAccountsStore(defaults: defaults),
+                families: ["claude"], unattributedOwnerIdentityKey: owner,
+                desktop: fixture.store, listDesktopOrganizationDirectories: { _ in organizations }
+            ).claudeCards
+        }
+
+        // No owner named: two accounts, so nobody claims the markerless sessions.
+        XCTAssertFalse(cards(owner: nil).contains { $0.allowsUnattributedPiUsage })
+        XCTAssertFalse(cards(owner: "").contains { $0.allowsUnattributedPiUsage })
+
+        // Named owner: that card claims them, every sibling still doesn't. Case is irrelevant —
+        // identity keys are compared the same way everywhere else in the pass.
+        let named = cards(owner: personalIdentity.uppercased())
+        XCTAssertEqual(
+            named.filter(\.allowsUnattributedPiUsage).map(\.identityKey), [personalIdentity]
+        )
+        XCTAssertEqual(
+            cards(owner: workIdentity).filter(\.allowsUnattributedPiUsage).map(\.identityKey),
+            [workIdentity]
+        )
+    }
+
     func testV1FallbackDoesNotOverrideTombstonedV2Key() throws {
         let key = cacheKey(organization: organization)
         let selection = ClaudeDesktopAuthStore.selectCredential(


### PR DESCRIPTION
Fixes #1204

Transcripts written before Claude Code stamped `ownerAccountUuid` carry no ownership at all, so a second Claude account hides every one of them from both cards. On my machine that is 3523 of 3724 `.jsonl` files: Last 30 Days read $21,285.60 / 28.5B tokens with one account and $3,186.71 / 4.82B with two.

#1168 is right that ownership must never be guessed. This lets the user *state* it instead:

- `openusage.unattributedOwner.v1` holds one identity key, injected into the account pass as `unattributedOwnerIdentityKey` (no new launch-time work, no credential reads).
- That card counts markerless sessions; every other card keeps today's strict rule. At most one card can claim them, so nothing double-counts.
- Unset or empty — the default, and the state of every existing install — is byte-for-byte today's behavior, including the single-account legacy path.

No UI in this PR: it is the smallest change that makes the behavior expressible, and I did not want to guess at where the control belongs. Happy to add a single-choice control in the account settings (with before/after screenshots) if you tell me where you would want it.

**Testing**

- `swift build` and `swift test` clean: 1252 tests, 0 failures, 3 skipped.
- New test `testNamedUnattributedOwnerKeepsMarkerlessSessionsOnExactlyOneCard`: two accounts and no owner named → nobody claims markerless sessions; owner named → exactly that card claims them, case-insensitively, and naming the sibling moves the claim.
- Running locally in a signed build with two Claude accounts (personal default home + work `CLAUDE_CONFIG_DIR`): both cards live, personal Last 30 Days restored to $21,285.60.

I know the policy — the linked issue is not approved or assigned yet. Opening it so the change is visible next to the report; close it without ceremony if you would rather scope this differently, and I will follow the issue.
