### PR TITLE
Add Claude Cards setting to follow the active login

### DIFF
--- a/Sources/OpenUsage/App/AppContainer.swift
+++ b/Sources/OpenUsage/App/AppContainer.swift
@@ -33,6 +33,9 @@ final class AppContainer {
     /// plus the live capture signal. Read by `StatusItemImageUpdater` to swap the strip for the
     /// wordmark while the screen is shared or recorded.
     let privacy: MenuBarPrivacyStore
+    /// The Claude Cards choice the provider set was built from. Settings compares the live value
+    /// against it to say a change waits for the next launch.
+    let claudeAccountsAtLaunch: ClaudeAccountsSetting
     /// One-time onboarding state (the first-run Customize hint card). Only ever marked pending by
     /// `FirstRunSeeder` on a fresh install, so existing installs never see the card.
     let onboarding: OnboardingStore
@@ -69,6 +72,7 @@ final class AppContainer {
         self.shellEnvironmentSnapshotTask = ShellEnvironmentSnapshotStore(defaults: .standard).startRefreshTask()
         // The launch account pass: which account is signed in at each family's default home. Feeds
         // the snapshot cache's account stamp and reconciles the account registry.
+        self.claudeAccountsAtLaunch = ClaudeAccountsSetting.current()
         let accountAssembly = ProviderAccountAssembly.make(waitsForLoginShell: true)
 
         let providers = ProviderCatalog.make(
@@ -269,7 +273,7 @@ final class AppContainer {
         for key in [
             AppearanceSetting.key, TimeFormatSetting.key, DensitySetting.key,
             ReduceAnimationsSetting.key, LogLevelSetting.key, TotalSpendSetting.key,
-            TotalSpendSetting.periodKey, TotalSpendSetting.metricKey,
+            TotalSpendSetting.periodKey, TotalSpendSetting.metricKey, ClaudeAccountsSetting.key,
         ] {
             UserDefaults.standard.removeObject(forKey: key)
         }

--- a/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
+++ b/Sources/OpenUsage/Services/ProviderAccountAssembly.swift
@@ -37,14 +37,15 @@ struct ProviderAccountAssembly {
         let shellFactsReadable = !waitsForLoginShell
             || LoginShellEnvironment.shared.capturedSuccessfully
             || ShellEnvironmentSnapshotStore.launchSnapshot != nil
-        let families = shellFactsReadable
-            ? ProviderAccountID.families
-            : ProviderAccountID.families.filter { family in
-                guard let key = Self.homeOverrideKeys[family] else { return false }
-                return ProcessInfo.processInfo.environment[key]?.nilIfEmpty != nil
-            }
-        if families.count < ProviderAccountID.families.count {
-            AppLog.info(.config, "account identity read skipped for \(ProviderAccountID.families.subtracting(families).sorted().joined(separator: ", ")): login shell cold and no shell-environment snapshot exists yet")
+        let claudeAccounts = ClaudeAccountsSetting.current(defaults: defaults)
+        let families = observedFamilies(shellFactsReadable: shellFactsReadable, claudeAccounts: claudeAccounts)
+        var skippedForColdShell = ProviderAccountID.families.subtracting(families)
+        if claudeAccounts == .activeLogin {
+            skippedForColdShell.remove("claude")
+            AppLog.info(.config, "accounts: claude follows the active login (one card); account pass skipped for claude")
+        }
+        if !skippedForColdShell.isEmpty {
+            AppLog.info(.config, "account identity read skipped for \(skippedForColdShell.sorted().joined(separator: ", ")): login shell cold and no shell-environment snapshot exists yet")
         }
         return make(
             observer: DefaultAccountObserver(),
@@ -60,6 +61,26 @@ struct ProviderAccountAssembly {
         "claude": "CLAUDE_CONFIG_DIR",
         "codex": "CODEX_HOME",
     ]
+
+    /// The families this launch's account pass observes: every family while the shell facts are
+    /// readable, otherwise only those whose home override is already in the process environment —
+    /// minus Claude when the user chose one Claude card that follows the active login. Leaving Claude
+    /// out of the pass yields no Claude cards and no identity key, so `ProviderCatalog` builds the
+    /// single unpinned provider that reads whichever login is current on every refresh.
+    static func observedFamilies(
+        shellFactsReadable: Bool,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        claudeAccounts: ClaudeAccountsSetting
+    ) -> Set<String> {
+        var families = shellFactsReadable
+            ? ProviderAccountID.families
+            : ProviderAccountID.families.filter { family in
+                guard let key = Self.homeOverrideKeys[family] else { return false }
+                return environment[key]?.nilIfEmpty != nil
+            }
+        if claudeAccounts == .activeLogin { families.remove("claude") }
+        return families
+    }
 
     /// The environment-independent core, separated so tests inject a fixed observer and scratch
     /// store. `families` limits the pass to the families whose home facts are readable this launch

--- a/Sources/OpenUsage/Stores/ClaudeAccountsSetting.swift
+++ b/Sources/OpenUsage/Stores/ClaudeAccountsSetting.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// How Claude logins become dashboard cards. `separate` (default) gives each account and organization
+/// its own card, pinned to that identity. `activeLogin` keeps one Claude card that follows whichever
+/// login Claude Code holds right now — for people who swap accounts in place (`claude login` again, a
+/// switcher tool) and don't want a card per account, or a card stuck on a login that has since been
+/// swapped out. Cards are built once at launch, so a change applies the next time the app starts.
+enum ClaudeAccountsSetting: String, CaseIterable {
+    case separate
+    case activeLogin
+
+    static let key = "openusage.claude.accounts"
+
+    var label: String {
+        switch self {
+        case .separate: "Per Account"
+        case .activeLogin: "Active Login"
+        }
+    }
+
+    static func current(defaults: UserDefaults = .standard) -> ClaudeAccountsSetting {
+        defaults.string(forKey: key).flatMap(ClaudeAccountsSetting.init(rawValue:)) ?? .separate
+    }
+}

--- a/Sources/OpenUsage/Views/SettingsScreen.swift
+++ b/Sources/OpenUsage/Views/SettingsScreen.swift
@@ -22,6 +22,7 @@ struct SettingsScreen: View {
     @AppStorage(TimeFormatSetting.key) private var timeFormat = TimeFormatSetting.auto
     @AppStorage(DensitySetting.key) private var density = DensitySetting.regular
     @AppStorage(ReduceAnimationsSetting.key) private var reduceAnimations = ReduceAnimationsSetting.fallback
+    @AppStorage(ClaudeAccountsSetting.key) private var claudeAccounts = ClaudeAccountsSetting.separate
     @AppStorage(LogLevelSetting.key) private var logLevel = LogLevelSetting.fallback
     /// Surfaced under the Advanced rows when copying the path or revealing the file fails.
     @State private var logActionError: String?
@@ -197,6 +198,14 @@ struct SettingsScreen: View {
                 Toggle("", isOn: $store.alwaysShowPacing)
                     .settingsSwitchStyle()
                     .hoverTooltip("Show how you're pacing on every metric, not just ones near their limit")
+            }
+            // One card per Claude account (default), or a single card that follows whichever login
+            // Claude Code holds right now. Cards are built at launch, so a change needs a restart.
+            row("Claude Cards") {
+                picker($claudeAccounts, options: ClaudeAccountsSetting.allCases, label: \.label)
+            }
+            if claudeAccounts != container.claudeAccountsAtLaunch {
+                inlineNotice("Applies the next time OpenUsage starts")
             }
         }
     }

--- a/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
+++ b/Tests/OpenUsageTests/ProviderAccountAssemblyTests.swift
@@ -77,4 +77,39 @@ final class ProviderAccountAssemblyTests: XCTestCase {
         XCTAssertTrue(store.records.isEmpty)
         XCTAssertNil(defaults.data(forKey: ProviderAccountsStore.storageKey), "no observations, no write")
     }
+
+    /// Active Login leaves Claude out of the pass entirely: no identity key, no cards, so the
+    /// catalog builds the single unpinned Claude provider. Codex is unaffected either way.
+    func testActiveLoginOnlyLeavesClaudeOutOfThePass() {
+        XCTAssertEqual(
+            ProviderAccountAssembly.observedFamilies(shellFactsReadable: true, environment: [:], claudeAccounts: .activeLogin),
+            ["codex"]
+        )
+        XCTAssertEqual(
+            ProviderAccountAssembly.observedFamilies(shellFactsReadable: true, environment: [:], claudeAccounts: .separate),
+            ProviderAccountID.families
+        )
+        // A cold login shell still admits a family whose home override is in the process environment.
+        XCTAssertEqual(
+            ProviderAccountAssembly.observedFamilies(
+                shellFactsReadable: false, environment: ["CLAUDE_CONFIG_DIR": "/x"], claudeAccounts: .separate
+            ),
+            ["claude"]
+        )
+        XCTAssertEqual(
+            ProviderAccountAssembly.observedFamilies(
+                shellFactsReadable: false, environment: ["CLAUDE_CONFIG_DIR": "/x"], claudeAccounts: .activeLogin
+            ),
+            []
+        )
+    }
+
+    func testClaudeAccountsSettingDefaultsToOnePerAccount() {
+        let defaults = makeScratchDefaults()
+        XCTAssertEqual(ClaudeAccountsSetting.current(defaults: defaults), .separate)
+        defaults.set(ClaudeAccountsSetting.activeLogin.rawValue, forKey: ClaudeAccountsSetting.key)
+        XCTAssertEqual(ClaudeAccountsSetting.current(defaults: defaults), .activeLogin)
+        defaults.set("garbage", forKey: ClaudeAccountsSetting.key)
+        XCTAssertEqual(ClaudeAccountsSetting.current(defaults: defaults), .separate)
+    }
 }

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -5,6 +5,12 @@ Tracks your Claude subscription limits using the login you already have from Cla
 Each account and organization gets its own Claude card with separate limits and spending. Signing in to
 the same account and organization through both Claude Code and Claude Desktop still creates only one card.
 
+If you switch Claude Code between accounts in place (running `claude login` again, or a switcher tool),
+set **Claude Cards** to **Active Login** in Settings → Usage Display. OpenUsage then keeps one
+Claude card that reads whichever login is current on every refresh, instead of a card per account pinned
+to the login it saw at launch. In this mode the spend tiles count every Claude Code session log on this
+Mac, and Claude Desktop logins add no extra card. The change applies the next time OpenUsage starts.
+
 ## What it tracks
 
 | Metric | Meaning |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -38,6 +38,7 @@ time; it also reports unavailable iCloud, loading, write, and malformed-file sta
 | Show Usage As | Used / Left | Whether bounded metrics read "48% used" or "52% left" — same toggle as clicking a headline. |
 | Reset Times | Countdown / Exact time | "Resets in 3h 25m" vs "Resets today at 6:38 PM" — same toggle as clicking a reset label. |
 | Always Show Pacing | Off / On | Off (default) shows pacing only when a metric is close to or over its limit. On surfaces it on every metric with a reset window: on-track rows gain their projection ("~33% left at reset") and an even-pace tick marking where steady use would put you right now. Metrics without a reset window have no pace to show. |
+| Claude Cards | Per Account / Active Login | Per Account (default) gives every Claude account and organization its own card, each pinned to its login. Active Login keeps a single Claude card that follows whichever login Claude Code holds right now — for people who switch accounts in place. Applies the next time OpenUsage starts. See [Claude](providers/claude.md). |
 
 ## Notifications
 


### PR DESCRIPTION
Fixes #1209

**TL;DR** — New Settings → Usage Display → **Claude Cards** choice. **Active Login** keeps one Claude card that reads whichever login Claude Code holds right now, for people who switch accounts in place. **Per Account** (default) is unchanged.

**What was happening**

- Every Claude card is pinned to the account seen at launch. After an in-place account switch the card fails each refresh with "credential does not match its account or organization" and shows the amber Session expired warning until relaunch.
- Each account that rotates through the default home mints another `claude@<hash>` card on the next launch and is auto-enabled, so four accounts become four cards.

**What this changes**

- `ClaudeAccountsSetting` (`openusage.claude.accounts`): `separate` (default) or `activeLogin`.
- `ProviderAccountAssembly.observedFamilies` drops Claude from the launch account pass when Active Login is chosen. No identity key and no cards means `ProviderCatalog` builds the existing single unpinned `ClaudeProvider()`; nothing else changes. The registry is not touched in this mode.
- Settings row with a picker, plus an inline "Applies the next time OpenUsage starts" note when the live value differs from the launch value. Reset All Settings clears the key.
- Docs: `docs/settings.md`, `docs/providers/claude.md`.

**Heads-up**

- Cards are built once at launch, hence the restart note rather than live rebuilding of the provider set.
- In Active Login mode the spend tiles count every Claude Code log on the Mac (pre-#1164 behavior), and Claude Desktop adds no card.

**Tests**

- `swift build`, `swift test` (1253 tests, 0 failures) on Swift 6.3.3 / macOS 26.6.
- New: `testActiveLoginOnlyLeavesClaudeOutOfThePass`, `testClaudeAccountsSettingDefaultsToOnePerAccount`.
- Manual: dev build with the real registry (three Claude cards) → set Active Login → relaunch → one `claude` card; `openusage` CLI output went from `claude@9d8f8d80` + `claude@b3c1e8f1` to a single `claude`.

**Screenshots**

Before (two pinned cards, the first stuck on "Session expired" after an account switch):

![before](https://raw.githubusercontent.com/Shpigford/openusage/claude-cards-screenshots/before-two-cards.png)

After, with Claude Cards set to Active Login (one card following the current login):

![after](https://raw.githubusercontent.com/Shpigford/openusage/claude-cards-screenshots/after-one-card.png)

The new Settings row:

![settings](https://raw.githubusercontent.com/Shpigford/openusage/claude-cards-screenshots/settings-claude-cards.png)
